### PR TITLE
[DI] Add prototype services for PSR4-based discovery and registration

### DIFF
--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -32,7 +32,7 @@ abstract class FileLoader extends Loader
      */
     protected $locator;
 
-    private $currentDir;
+    protected $currentDir;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.3.0
 -----
 
+ * [EXPERIMENTAL] added prototype services for PSR4-based discovery and registration
  * added `ContainerBuilder::getReflectionClass()` for retrieving and tracking reflection class info
  * deprecated `ContainerBuilder::getClassResource()`, use `ContainerBuilder::getReflectionClass()` or `ContainerBuilder::addObjectResource()` instead
  * added `ContainerBuilder::fileExists()` for checking and tracking file or directory existence

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -12,8 +12,13 @@
 namespace Symfony\Component\DependencyInjection\Loader;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\Config\Loader\FileLoader as BaseFileLoader;
 use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\Glob;
 
 /**
  * FileLoader is the abstract class used by all built-in loaders that are file based.
@@ -33,5 +38,109 @@ abstract class FileLoader extends BaseFileLoader
         $this->container = $container;
 
         parent::__construct($locator);
+    }
+
+    /**
+     * Registers a set of classes as services using PSR-4 for discovery.
+     *
+     * @param Definition $prototype A definition to use as template
+     * @param string     $namespace The namespace prefix of classes in the scanned directory
+     * @param string     $resource  The directory to look for classes, glob-patterns allowed
+     *
+     * @experimental in version 3.3
+     */
+    public function registerClasses(Definition $prototype, $namespace, $resource)
+    {
+        if ('\\' !== substr($namespace, -1)) {
+            throw new InvalidArgumentException(sprintf('Namespace prefix must end with a "\\": %s.', $namespace));
+        }
+        if (!preg_match('/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+\\\\)++$/', $namespace)) {
+            throw new InvalidArgumentException(sprintf('Namespace is not a valid PSR-4 prefix: %s.', $namespace));
+        }
+
+        $classes = $this->findClasses($namespace, $resource);
+        // prepare for deep cloning
+        $prototype = serialize($prototype);
+
+        foreach ($classes as $class) {
+            $this->container->setDefinition($class, unserialize($prototype));
+        }
+    }
+
+    private function findClasses($namespace, $resource)
+    {
+        $classes = array();
+        $extRegexp = defined('HHVM_VERSION') ? '/\\.(?:php|hh)$/' : '/\\.php$/';
+
+        foreach ($this->glob($resource, true, $prefixLen) as $path => $info) {
+            if (!preg_match($extRegexp, $path, $m) || !$info->isFile() || !$info->isReadable()) {
+                continue;
+            }
+            $class = $namespace.ltrim(str_replace('/', '\\', substr($path, $prefixLen, -strlen($m[0]))), '\\');
+
+            if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+$/', $class)) {
+                continue;
+            }
+            if (!$r = $this->container->getReflectionClass($class, true)) {
+                continue;
+            }
+            if (!$r->isInterface() && !$r->isTrait()) {
+                $classes[] = $class;
+            }
+        }
+
+        return $classes;
+    }
+
+    private function glob($resource, $recursive, &$prefixLen = null)
+    {
+        if (strlen($resource) === $i = strcspn($resource, '*?{[')) {
+            $resourcePrefix = $resource;
+            $resource = '';
+        } elseif (0 === $i) {
+            $resourcePrefix = '.';
+            $resource = '/'.$resource;
+        } else {
+            $resourcePrefix = dirname(substr($resource, 0, 1 + $i));
+            $resource = substr($resource, strlen($resourcePrefix));
+        }
+
+        $resourcePrefix = $this->locator->locate($resourcePrefix, $this->currentDir, true);
+        $resourcePrefix = realpath($resourcePrefix) ?: $resourcePrefix;
+        $prefixLen = strlen($resourcePrefix);
+
+        // track directories only for new & removed files
+        $this->container->fileExists($resourcePrefix, '/^$/');
+
+        if (false === strpos($resource, '/**/') && (defined('GLOB_BRACE') || false === strpos($resource, '{'))) {
+            foreach (glob($resourcePrefix.$resource, defined('GLOB_BRACE') ? GLOB_BRACE : 0) as $path) {
+                if ($recursive && is_dir($path)) {
+                    $flags = \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS;
+                    foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, $flags)) as $path => $info) {
+                        yield $path => $info;
+                    }
+                } else {
+                    yield $path => new \SplFileInfo($path);
+                }
+            }
+
+            return;
+        }
+
+        if (!class_exists(Finder::class)) {
+            throw new LogicException(sprintf('Extended glob pattern "%s" cannot be used as the Finder component is not installed.', $resource));
+        }
+
+        $finder = new Finder();
+        $regex = Glob::toRegex($resource);
+        if ($recursive) {
+            $regex = substr_replace($regex, '(/|$)', -2, 1);
+        }
+
+        foreach ($finder->followLinks()->in($resourcePrefix) as $path => $info) {
+            if (preg_match($regex, substr($path, $prefixLen))) {
+                yield $path => $info;
+            }
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -121,14 +121,19 @@ class XmlFileLoader extends FileLoader
         $xpath = new \DOMXPath($xml);
         $xpath->registerNamespace('container', self::NS);
 
-        if (false === $services = $xpath->query('//container:services/container:service')) {
+        if (false === $services = $xpath->query('//container:services/container:service|//container:services/container:prototype')) {
             return;
         }
+        $this->setCurrentDir(dirname($file));
 
         $defaults = $this->getServiceDefaults($xml, $file);
         foreach ($services as $service) {
             if (null !== $definition = $this->parseDefinition($service, $file, $defaults)) {
-                $this->container->setDefinition((string) $service->getAttribute('id'), $definition);
+                if ('prototype' === $service->tagName) {
+                    $this->registerClasses($definition, (string) $service->getAttribute('namespace'), (string) $service->getAttribute('resource'));
+                } else {
+                    $this->container->setDefinition((string) $service->getAttribute('id'), $definition);
+                }
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -54,6 +54,7 @@
     </xsd:annotation>
     <xsd:choice maxOccurs="unbounded">
       <xsd:element name="service" type="service" minOccurs="1" />
+      <xsd:element name="prototype" type="prototype" minOccurs="0" />
       <xsd:element name="defaults" type="defaults" minOccurs="0" maxOccurs="1" />
     </xsd:choice>
   </xsd:complexType>
@@ -132,6 +133,29 @@
     <xsd:attribute name="decorates" type="xsd:string" />
     <xsd:attribute name="decoration-inner-name" type="xsd:string" />
     <xsd:attribute name="decoration-priority" type="xsd:integer" />
+    <xsd:attribute name="autowire" type="boolean" />
+    <xsd:attribute name="inherit-tags" type="boolean" />
+  </xsd:complexType>
+
+  <xsd:complexType name="prototype">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="argument" type="argument" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="configurator" type="callable" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="factory" type="callable" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="deprecated" type="xsd:string" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="getter" type="getter" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="autowire" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+    </xsd:choice>
+    <xsd:attribute name="namespace" type="xsd:string" use="required" />
+    <xsd:attribute name="resource" type="xsd:string" use="required" />
+    <xsd:attribute name="shared" type="boolean" />
+    <xsd:attribute name="public" type="boolean" />
+    <xsd:attribute name="lazy" type="boolean" />
+    <xsd:attribute name="abstract" type="boolean" />
+    <xsd:attribute name="parent" type="xsd:string" />
     <xsd:attribute name="autowire" type="boolean" />
     <xsd:attribute name="inherit-tags" type="boolean" />
   </xsd:complexType>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
+
+class Foo
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/MissingParent.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/MissingParent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
+
+class MissingParent extends NotExistingParent
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Sub/Bar.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Sub/Bar.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub;
+
+class Bar
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*" />
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype.yml
@@ -1,0 +1,3 @@
+services:
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\:
+        resource: ../Prototype

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -20,7 +20,10 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
@@ -606,6 +609,26 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $container->compile();
 
         $this->assertEquals(CaseSensitiveClass::class, $container->getDefinition(CaseSensitiveClass::class)->getClass());
+    }
+
+    public function testPrototype()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_prototype.xml');
+
+        $ids = array_keys($container->getDefinitions());
+        sort($ids);
+        $this->assertSame(array(Prototype\Foo::class, Prototype\Sub\Bar::class), $ids);
+
+        $resources = $container->getResources();
+
+        $fixturesDir = dirname(__DIR__).DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR;
+        $this->assertTrue(false !== array_search(new FileResource($fixturesDir.'xml'.DIRECTORY_SEPARATOR.'services_prototype.xml'), $resources));
+        $this->assertTrue(false !== array_search(new DirectoryResource($fixturesDir.'Prototype', '/^$/'), $resources));
+        $resources = array_map('strval', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -27,12 +27,14 @@
     "suggest": {
         "symfony/yaml": "",
         "symfony/config": "",
+        "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
         "symfony/expression-language": "For using expressions in service container configuration",
         "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
     },
     "conflict": {
-        "symfony/yaml": "<3.3",
-        "symfony/config": "<3.3"
+        "symfony/config": "<3.3",
+        "symfony/finder": "<3.3",
+        "symfony/yaml": "<3.3"
     },
     "provide": {
         "psr/container-implementation": "1.0"

--- a/src/Symfony/Component/Finder/Glob.php
+++ b/src/Symfony/Component/Finder/Glob.php
@@ -61,7 +61,7 @@ class Glob
             $firstByte = '/' === $car;
 
             if ($firstByte && $strictWildcardSlash && isset($glob[$i + 3]) && '**/' === $glob[$i + 1].$glob[$i + 2].$glob[$i + 3]) {
-                $car = $strictLeadingDot ? '/((?=[^\.])[^/]+/)*' : '/([^/]+/)*';
+                $car = $strictLeadingDot ? '/(?:(?=[^\.])[^/]++/)*' : '/(?:[^/]++/)*';
                 $i += 3;
                 if ('/' === $delimiter) {
                     $car = str_replace('/', '\\/', $car);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | to be done

Talking with @dunglas, we wondered if this could be a good idea, as a more general approach to folder-based service registration as done in [DunglasActionBundle](https://github.com/dunglas/DunglasActionBundle/blob/master/DependencyInjection/DunglasActionExtension.php).

So here is the implementation.

This allows one to define a set of services as such:
```yaml
services:
    App\:
        resource: ../src/{Controller,Command} # relative to the current file as usual
        autowire: true # or any other attributes really
```

This looks for php files in the "src" folder, derivates PSR-4 class names from them, and uses `class_exists` for final discovery. The resulting services are named after the classes found this way.

The "resource" attribute can be a glob to select only a subset of the classes/files.

This approach has several advantages over [DunglasActionBundle](https://github.com/dunglas/DunglasActionBundle/blob/master/DependencyInjection/DunglasActionExtension.php):
- it is resilient to missing parent classes (see test case)
- it loads classes using the normal code path (the autoloader), thus play well with them (e.g. if one registered a special autoloader).
- it is more predictable, because it uses discovered paths as the only source of ids/classes to register - vs relying on `get_declared_classes`, which would make things context sensitive.

Fits well with current initiatives to me.