### PR TITLE
[FrameworkBundle] Fix debug:container --show-arguments missing cases

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -86,7 +86,7 @@ class JsonDescriptor extends Descriptor
         if ($service instanceof Alias) {
             $this->describeContainerAlias($service, $options, $builder);
         } elseif ($service instanceof Definition) {
-            $this->writeData($this->getContainerDefinitionData($service), $options);
+            $this->writeData($this->getContainerDefinitionData($service, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments']), $options);
         } else {
             $this->writeData(get_class($service), $options);
         }
@@ -99,6 +99,7 @@ class JsonDescriptor extends Descriptor
     {
         $serviceIds = isset($options['tag']) && $options['tag'] ? array_keys($builder->findTaggedServiceIds($options['tag'])) : $builder->getServiceIds();
         $showPrivate = isset($options['show_private']) && $options['show_private'];
+        $omitTags = isset($options['omit_tags']) && $options['omit_tags'];
         $showArguments = isset($options['show_arguments']) && $options['show_arguments'];
         $data = array('definitions' => array(), 'aliases' => array(), 'services' => array());
 
@@ -109,7 +110,7 @@ class JsonDescriptor extends Descriptor
                 $data['aliases'][$serviceId] = $this->getContainerAliasData($service);
             } elseif ($service instanceof Definition) {
                 if (($showPrivate || $service->isPublic())) {
-                    $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, false, $showArguments);
+                    $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, $omitTags, $showArguments);
                 }
             } else {
                 $data['services'][$serviceId] = get_class($service);
@@ -124,7 +125,7 @@ class JsonDescriptor extends Descriptor
      */
     protected function describeContainerDefinition(Definition $definition, array $options = array())
     {
-        $this->writeData($this->getContainerDefinitionData($definition, isset($options['omit_tags']) && $options['omit_tags']), $options);
+        $this->writeData($this->getContainerDefinitionData($definition, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments']), $options);
     }
 
     /**
@@ -137,7 +138,7 @@ class JsonDescriptor extends Descriptor
         }
 
         $this->writeData(
-            array($this->getContainerAliasData($alias), $this->getContainerDefinitionData($builder->getDefinition((string) $alias))),
+            array($this->getContainerAliasData($alias), $this->getContainerDefinitionData($builder->getDefinition((string) $alias), isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments'])),
             array_merge($options, array('id' => (string) $alias))
         );
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -103,7 +103,7 @@ class MarkdownDescriptor extends Descriptor
             throw new \InvalidArgumentException('An "id" option must be provided.');
         }
 
-        $childOptions = array('id' => $options['id'], 'as_array' => true);
+        $childOptions = array_merge($options, array('id' => $options['id'], 'as_array' => true));
 
         if ($service instanceof Alias) {
             $this->describeContainerAlias($service, $childOptions, $builder);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -255,8 +255,8 @@ class TextDescriptor extends Descriptor
         $tableRows[] = array('Service ID', isset($options['id']) ? $options['id'] : '-');
         $tableRows[] = array('Class', $definition->getClass() ?: '-');
 
-        $tags = $definition->getTags();
-        if (count($tags)) {
+        $omitTags = isset($options['omit_tags']) && $options['omit_tags'];
+        if (!$omitTags && ($tags = $definition->getTags())) {
             $tagInformation = array();
             foreach ($tags as $tagName => $tagData) {
                 foreach ($tagData as $tagParameters) {
@@ -325,6 +325,22 @@ class TextDescriptor extends Descriptor
             } else {
                 $tableRows[] = array('Factory Function', $factory);
             }
+        }
+
+        $showArguments = isset($options['show_arguments']) && $options['show_arguments'];
+        $argumentsInformation = array();
+        if ($showArguments && ($arguments = $definition->getArguments())) {
+            foreach ($arguments as $argument) {
+                if ($argument instanceof Reference) {
+                    $argumentsInformation[] = sprintf('Service(%s)', (string) $argument);
+                } elseif ($argument instanceof Definition) {
+                    $argumentsInformation[] = 'Inlined Service';
+                } else {
+                    $argumentsInformation[] = $argument;
+                }
+            }
+
+            $tableRows[] = array('Arguments', implode("\n", $argumentsInformation));
         }
 
         $options['output']->table($tableHeaders, $tableRows);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -68,7 +68,7 @@ class XmlDescriptor extends Descriptor
             throw new \InvalidArgumentException('An "id" option must be provided.');
         }
 
-        $this->writeDocument($this->getContainerServiceDocument($service, $options['id'], $builder));
+        $this->writeDocument($this->getContainerServiceDocument($service, $options['id'], $builder, isset($options['show_arguments']) && $options['show_arguments']));
     }
 
     /**
@@ -84,7 +84,7 @@ class XmlDescriptor extends Descriptor
      */
     protected function describeContainerDefinition(Definition $definition, array $options = array())
     {
-        $this->writeDocument($this->getContainerDefinitionDocument($definition, isset($options['id']) ? $options['id'] : null, isset($options['omit_tags']) && $options['omit_tags']));
+        $this->writeDocument($this->getContainerDefinitionDocument($definition, isset($options['id']) ? $options['id'] : null, isset($options['omit_tags']) && $options['omit_tags'], isset($options['show_arguments']) && $options['show_arguments']));
     }
 
     /**
@@ -284,7 +284,7 @@ class XmlDescriptor extends Descriptor
         if ($service instanceof Alias) {
             $dom->appendChild($dom->importNode($this->getContainerAliasDocument($service, $id)->childNodes->item(0), true));
             if ($builder) {
-                $dom->appendChild($dom->importNode($this->getContainerDefinitionDocument($builder->getDefinition((string) $service), (string) $service)->childNodes->item(0), true));
+                $dom->appendChild($dom->importNode($this->getContainerDefinitionDocument($builder->getDefinition((string) $service), (string) $service, false, $showArguments)->childNodes->item(0), true));
             }
         } elseif ($service instanceof Definition) {
             $dom->appendChild($dom->importNode($this->getContainerDefinitionDocument($service, $id, false, $showArguments)->childNodes->item(0), true));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -79,6 +79,24 @@ abstract class AbstractDescriptorTest extends \PHPUnit_Framework_TestCase
         return $this->getDescriptionTestData(ObjectsProvider::getContainerDefinitions());
     }
 
+    /** @dataProvider getDescribeContainerDefinitionWithArgumentsShownTestData */
+    public function testDescribeContainerDefinitionWithArgumentsShown(Definition $definition, $expectedDescription)
+    {
+        $this->assertDescription($expectedDescription, $definition, array('show_arguments' => true));
+    }
+
+    public function getDescribeContainerDefinitionWithArgumentsShownTestData()
+    {
+        $definitions = ObjectsProvider::getContainerDefinitions();
+        $definitionsWithArgs = array();
+
+        foreach ($definitions as $key => $definition) {
+            $definitionsWithArgs[str_replace('definition_', 'definition_arguments_', $key)] = $definition;
+        }
+
+        return $this->getDescriptionTestData($definitionsWithArgs);
+    }
+
     /** @dataProvider getDescribeContainerAliasTestData */
     public function testDescribeContainerAlias(Alias $alias, $expectedDescription)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.json
@@ -1,0 +1,37 @@
+{
+    "class": "Full\\Qualified\\Class1",
+    "public": true,
+    "synthetic": false,
+    "lazy": true,
+    "shared": true,
+    "abstract": true,
+    "autowire": false,
+    "autowiring_types": [],
+    "arguments": [
+        {
+            "type": "service",
+            "id": "definition2"
+        },
+        "%parameter%",
+        {
+            "class": "inline_service",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autowiring_types": [],
+            "arguments": [
+                "arg1",
+                "arg2"
+            ],
+            "file": null,
+            "tags": []
+        }
+    ],
+    "file": null,
+    "factory_class": "Full\\Qualified\\FactoryClass",
+    "factory_method": "get",
+    "tags": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.md
@@ -1,0 +1,10 @@
+- Class: `Full\Qualified\Class1`
+- Public: yes
+- Synthetic: no
+- Lazy: yes
+- Shared: yes
+- Abstract: yes
+- Autowired: no
+- Arguments: yes
+- Factory Class: `Full\Qualified\FactoryClass`
+- Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
@@ -1,0 +1,20 @@
+ ------------------ ----------------------------- 
+ [32m Option           [39m [32m Value                       [39m 
+ ------------------ ----------------------------- 
+  Service ID         -                            
+  Class              Full\Qualified\Class1        
+  Tags               -                            
+  Public             yes                          
+  Synthetic          no                           
+  Lazy               yes                          
+  Shared             yes                          
+  Abstract           yes                          
+  Autowired          no                           
+  Autowiring Types   -                            
+  Factory Class      Full\Qualified\FactoryClass  
+  Factory Method     get                          
+  Arguments          Service(definition2)         
+                     %parameter%                  
+                     Inlined Service              
+ ------------------ ----------------------------- 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" file="">
+  <factory class="Full\Qualified\FactoryClass" method="get"/>
+  <argument type="service" id="definition2"/>
+  <argument>%parameter%</argument>
+  <argument>
+    <definition class="inline_service" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file="">
+      <argument>arg1</argument>
+      <argument>arg2</argument>
+    </definition>
+  </argument>
+</definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.json
@@ -1,0 +1,36 @@
+{
+    "class": "Full\\Qualified\\Class2",
+    "public": false,
+    "synthetic": true,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "autowire": false,
+    "autowiring_types": [],
+    "arguments": [],
+    "file": "\/path\/to\/file",
+    "factory_service": "factory.service",
+    "factory_method": "get",
+    "calls": [
+        "setMailer"
+    ],
+    "tags": [
+        {
+            "name": "tag1",
+            "parameters": {
+                "attr1": "val1",
+                "attr2": "val2"
+            }
+        },
+        {
+            "name": "tag1",
+            "parameters": {
+                "attr3": "val3"
+            }
+        },
+        {
+            "name": "tag2",
+            "parameters": []
+        }
+    ]
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.md
@@ -1,0 +1,18 @@
+- Class: `Full\Qualified\Class2`
+- Public: no
+- Synthetic: yes
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Arguments: no
+- File: `/path/to/file`
+- Factory Service: `factory.service`
+- Factory Method: `get`
+- Call: `setMailer`
+- Tag: `tag1`
+    - Attr1: val1
+    - Attr2: val2
+- Tag: `tag1`
+    - Attr3: val3
+- Tag: `tag2`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
@@ -1,0 +1,21 @@
+ ------------------ --------------------------------- 
+ [32m Option           [39m [32m Value                           [39m 
+ ------------------ --------------------------------- 
+  Service ID         -                                
+  Class              Full\Qualified\Class2            
+  Tags               tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
+                     tag1 ([32mattr3[39m: val3)               
+                     tag2                             
+  Calls              setMailer                        
+  Public             no                               
+  Synthetic          yes                              
+  Lazy               no                               
+  Shared             yes                              
+  Abstract           no                               
+  Autowired          no                               
+  Autowiring Types   -                                
+  Required File      /path/to/file                    
+  Factory Service    factory.service                  
+  Factory Method     get                              
+ ------------------ --------------------------------- 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="Full\Qualified\Class2" public="false" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" file="/path/to/file">
+  <factory service="factory.service" method="get"/>
+  <calls>
+    <call method="setMailer"/>
+  </calls>
+  <tags>
+    <tag name="tag1">
+      <parameter name="attr1">val1</parameter>
+      <parameter name="attr2">val2</parameter>
+    </tag>
+    <tag name="tag1">
+      <parameter name="attr3">val3</parameter>
+    </tag>
+    <tag name="tag2"/>
+  </tags>
+</definition>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20861#issuecomment-272628063 
| License       | MIT
| Doc PR        | n/a

Fixes the new `--show-arguments` option for per-service describing
(i.e. `debug:container foo_service --show-arguments`, doesn't work at all right now).
