### PR TITLE
Ignore missing 'debug.file_link_formatter' service in Debug bundle

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -38,7 +38,7 @@
             <argument>0</argument> <!-- flags -->
             <call method="setDisplayOptions">
                 <argument type="collection">
-                    <argument key="fileLinkFormat" type="service" id="debug.file_link_formatter"></argument>
+                    <argument key="fileLinkFormat" type="service" id="debug.file_link_formatter" on-invalid="ignore"></argument>
                 </argument>
             </call>
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The new `HtmlDumper` requires the `debug.file_link_formatter` service which isn't available in older versions of the `DebugBundle`