### PR TITLE
[VarDumper] Fixed typo in new search input

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -462,14 +462,14 @@ return function (root, x) {
                 reveal(currentNode);
                 highlight(root, currentNode, state.nodes);
             }
-            counter.textContent = (state.isEmpty() ? 0 : state.idx + 1) + ' on ' + state.count();
+            counter.textContent = (state.isEmpty() ? 0 : state.idx + 1) + ' of ' + state.count();
         }
 
         var search = doc.createElement('div');
         search.className = 'sf-dump-search-wrapper sf-dump-search-hidden';
         search.innerHTML = '
             <input type="text" class="sf-dump-search-input">
-            <span class="sf-dump-search-count">0 on 0<\/span>
+            <span class="sf-dump-search-count">0 of 0<\/span>
             <button type="button" class="sf-dump-search-input-previous" tabindex="-1">
                 <svg viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
                     <path d="M1683 1331l-166 165q-19 19-45 19t-45-19l-531-531-531 531q-19 19-45 19t-45-19l-166-165q-19-19-19-45.5t19-45.5l742-741q19-19 45-19t45 19l742 741q19 19 19 45.5t-19 45.5z"\/>
@@ -501,7 +501,7 @@ return function (root, x) {
                 resetHighlightedNodes(root);
                 var searchQuery = e.target.value;
                 if ('' === searchQuery) {
-                    counter.textContent = '0 on 0';
+                    counter.textContent = '0 of 0';
 
                     return;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

I guess both work out.. but using `of` notation is way more common.

Btw chrome search doesnt show `0 of 0` (at least not initially).. maybe worth it?

/cc @ogizanagi 