### PR TITLE
[PhpUnitBridge] Assert missing deprecations

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -194,6 +194,10 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
                 try {
                     $prefix = "@expectedDeprecation:\n";
                     $test->assertStringMatchesFormat($prefix.'%A  '.implode("\n%A  ", $this->expectedDeprecations)."\n%A", $prefix.'  '.implode("\n  ", $this->gatheredDeprecations)."\n");
+
+                    if ($missing = array_diff($this->gatheredDeprecations, $this->expectedDeprecations)) {
+                        $test->assertStringMatchesFormat($prefix.'%A  '.implode("\n%A  ", $missing)."\n%A", $prefix.'  '.implode("\n  ", array())."\n");
+                    }
                 } catch (\PHPUnit_Framework_AssertionFailedError $e) {
                     $test->getTestResultObject()->addFailure($test, $e, $time);
                 }

--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\PhpUnit;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use SebastianBergmann\Diff\Differ;
 
 /**
  * Collects and replays skipped tests.
@@ -191,15 +192,11 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
             restore_error_handler();
 
             if (!in_array($test->getStatus(), array(\PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED, \PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE, \PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, \PHPUnit_Runner_BaseTestRunner::STATUS_ERROR), true)) {
-                try {
-                    $prefix = "@expectedDeprecation:\n";
-                    $test->assertStringMatchesFormat($prefix.'%A  '.implode("\n%A  ", $this->expectedDeprecations)."\n%A", $prefix.'  '.implode("\n  ", $this->gatheredDeprecations)."\n");
-
-                    if ($missing = array_diff($this->gatheredDeprecations, $this->expectedDeprecations)) {
-                        $test->assertStringMatchesFormat($prefix.'%A  '.implode("\n%A  ", $missing)."\n%A", $prefix.'  '.implode("\n  ", array())."\n");
-                    }
-                } catch (\PHPUnit_Framework_AssertionFailedError $e) {
-                    $test->getTestResultObject()->addFailure($test, $e, $time);
+                if ($this->gatheredDeprecations !== $this->expectedDeprecations) {
+                    $differ = new Differ("--- Expected\n+++ Actual\n");
+                    $test->getTestResultObject()->addFailure($test, new \PHPUnit_Framework_AssertionFailedError(
+                        "Failed asserting expected deprecations.\n\n".$differ->diff(implode("\n", $this->gatheredDeprecations), implode("\n", $this->expectedDeprecations))
+                    ), $time);
                 }
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | :scream: 
| Fixed tickets | https://github.com/symfony/symfony/pull/19668#discussion_r96112660
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

`assertStringMatchesFormat` is too tolerant here.

See also https://github.com/symfony/symfony/pull/21295

Given

```bash
$ ./phpunit src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php --filter testLegacyGet
```

Before

```
OK (1 test, 9 assertions)
```

After
```
1) Symfony\Component\DependencyInjection\Tests\ContainerTest::testLegacyGet
Failed asserting that format description matches text.
--- Expected
+++ Actual
@@ @@
 @expectedDeprecation:
-%A  Service identifiers will be made case sensitive in Symfony 4.0. Using "Foo" instead of "foo" is deprecated since version 3.3.
+

/var/www/html/symfony/vendor/symfony/symfony/.phpunit/phpunit-5.7/phpunit:5

FAILURES!
Tests: 1, Assertions: 9, Failures: 1.
```

ping @nicolas-grekas