### PR TITLE
[WebProfilerBUndle] Improve toolbars ajax requests status visibility

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -118,10 +118,14 @@
                             rows.insertBefore(row, rows.firstChild);
 
                             var methodCell = document.createElement('td');
-                            if (request.error) {
+                            if (request.loading) {
+                                methodCell.innerHTML = '<span class="sf-toolbar-status sf-toolbar-status-loading">'+request.method+'</span>';
+                            } else if (request.error) {
                                 methodCell.className = 'sf-ajax-request-error';
+                                methodCell.innerHTML = '<span class="sf-toolbar-status sf-toolbar-status-red">'+request.method+'</span>';
+                            } else {
+                                methodCell.innerHTML = '<span class="sf-toolbar-status sf-toolbar-status-green">'+request.method+'</span>';
                             }
-                            methodCell.textContent = request.method;
                             row.appendChild(methodCell);
 
                             var pathCell = document.createElement('td');

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -195,6 +195,12 @@
     text-align: center;
 }
 
+.sf-toolbar-block .sf-toolbar-status-loading {
+    -webkit-animation: sf-blink .5s ease-in-out infinite;
+    -o-animation: sf-blink .5s ease-in-out infinite;
+    -moz-animation: sf-blink .5s ease-in-out infinite;
+    animation: sf-blink .5s ease-in-out infinite;
+}
 .sf-toolbar-block .sf-toolbar-status-green {
     background-color: {{ colors.success|raw }};
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR improves the ajax requests status visibility in Profiler's toolsbar. Shows which requests are still loading, and which ones are succeded or error.