### PR TITLE
[phpunit-bridge] ext-zip is required

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=5.3.3 EVEN ON LATEST SYMFONY VERSIONS TO ALLOW USING",
         "php": "THIS BRIDGE WHEN TESTING LOWEST SYMFONY VERSIONS.",
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "ext-zip": "*"
     },
     "suggest": {
         "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"


### PR DESCRIPTION
without the zip extension enabled, i get `PHP Fatal error:  Uncaught Error: Class 'ZipArchive' not found in .../vendor/bin/simple-phpunit:46`

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
