### PR TITLE
simple-phpunit requires the zip extension

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -43,6 +43,9 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
         @unlink("$PHPUNIT_VERSION.zip");
         passthru("wget https://github.com/sebastianbergmann/phpunit/archive/$PHPUNIT_VERSION.zip");
     }
+    if (!class_exists('ZipArchive')) {
+        throw new \Exception('simple-phpunit requires the "zip" PHP extension to be installed and enabled in order to uncompress the downloaded PHPUnit packages.');
+    }
     $zip = new ZipArchive();
     $zip->open("$PHPUNIT_VERSION.zip");
     $zip->extractTo(getcwd());

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -21,7 +21,8 @@
         "php": ">=5.3.3"
     },
     "suggest": {
-        "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+        "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader",
+        "ext-zip": "Zip support is required when using bin/simple-phpunit"
     },
     "autoload": {
         "files": [ "bootstrap.php" ],


### PR DESCRIPTION
without the zip extension enabled, i get `PHP Fatal error:  Uncaught Error: Class 'ZipArchive' not found in .../vendor/bin/simple-phpunit:46`

| Q             | A
| ------------- | ---
| Branch?       | 3.2 (first version containing the script)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21060
| License       | MIT
| Doc PR        | -
