### PR TITLE
[DependencyInjection] Always autowire the constructor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -440,7 +440,7 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         // manually configure *one* call, to override autowiring
         $container
             ->register('setter_injection', SetterInjection::class)
-            ->setAutowiredMethods(array('__construct', 'set*'))
+            ->setAutowiredMethods(array('set*'))
             ->addMethodCall('setWithCallsConfigured', array('manual_arg1', 'manual_arg2'))
         ;
 
@@ -557,7 +557,7 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         $container->register('c1', CollisionA::class);
         $container->register('c2', CollisionB::class);
         $aDefinition = $container->register('setter_injection_collision', SetterInjectionCollision::class);
-        $aDefinition->setAutowiredMethods(array('__construct', 'set*'));
+        $aDefinition->setAutowiredMethods(array('set*'));
 
         $pass = new AutowirePass();
         $pass->process($container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no (because method autowiring has been introduced in 3.3)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Always try to autowire the constructor even if it has not been configured explicitly. It doesn't make sense to autowire some methods but not the constructor. It will also allow to write shorter definitions when using method autowiring:

```yaml
services:
    Foo\Bar: { autowire: ['set*'] }
```

instead of

```yaml
services:
    Foo\Bar: { autowire: ['__construct', 'set*'] }
```


