### PR TITLE
[Serializer] Add missing conflict for property-info<3.1

### DIFF
--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -30,7 +30,8 @@
         "phpdocumentor/reflection-docblock": "~3.0"
     },
     "conflict": {
-        "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4"
+        "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
+        "symfony/property-info": "<3.1"
     },
     "suggest": {
         "psr/cache-implementation": "For using the metadata cache.",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21293#discussion_r96254245
| License       | MIT
| Doc PR        | n/a