### PR TITLE
[Security] allow default_target_path parameter be a route name

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -109,7 +109,7 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
     protected function determineTargetUrl(Request $request)
     {
         if ($this->options['always_use_default_target_path']) {
-            return $this->options['default_target_path'];
+            return $this->httpUtils->generateUri($request, $this->options['default_target_path']);
         }
 
         if ($targetUrl = ParameterBagUtils::getRequestParameterValue($request, $this->options['target_path_parameter'])) {
@@ -126,6 +126,6 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
             return $targetUrl;
         }
 
-        return $this->options['default_target_path'];
+        return $this->httpUtils->generateUri($request, $this->options['default_target_path']);
     }
 }


### PR DESCRIPTION
As of right now default_target_path can't be name of route, this commit will fix it

| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
