### PR TITLE
[Debug] Fix fatal error when changing ErrorHandler loggers if an exception is buffered

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -225,7 +225,7 @@ class ErrorHandler
 
         if ($flush) {
             foreach ($this->bootstrappingLogger->cleanLogs() as $log) {
-                $type = $log[2]['exception']->getSeverity();
+                $type = $log[2]['exception'] instanceof \ErrorException ? $log[2]['exception']->getSeverity() : E_ERROR;
                 if (!isset($flush[$type])) {
                     $this->bootstrappingLogger->log($log[0], $log[1], $log[2]);
                 } elseif ($this->loggers[$type][0]) {

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -417,6 +417,25 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         $handler->setLoggers(array(E_DEPRECATED => array($mockLogger, LogLevel::WARNING)));
     }
 
+    public function testSettingLoggerWhenExceptionIsBuffered()
+    {
+        $bootLogger = new BufferingLogger();
+        $handler = new ErrorHandler($bootLogger);
+
+        $exception = new \Exception('Foo message');
+
+        $mockLogger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+        $mockLogger->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::CRITICAL, 'Uncaught Exception: Foo message', array('exception' => $exception));
+
+        $handler->setExceptionHandler(function () use ($handler, $mockLogger) {
+            $handler->setDefaultLogger($mockLogger);
+        });
+
+        $handler->handleException($exception);
+    }
+
     public function testHandleFatalError()
     {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21304
| License       | MIT
| Doc PR        | -

Prevents a fatal error when setting a new logger if the bootstrapping logger buffered an exception that does not extend `ErrorException`.

@nicolas-grekas The faulty behaviour was added by 8f245493f4f2841bcc38435774eec207aa8869d1, so this PR is against 3.2 and not 2.8.