### PR TITLE
[DI][FrameworkBundle] Show autowired methods in descriptors

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -220,8 +220,12 @@ class JsonDescriptor extends Descriptor
             'lazy' => $definition->isLazy(),
             'shared' => $definition->isShared(),
             'abstract' => $definition->isAbstract(),
-            'autowire' => $definition->isAutowired(),
         );
+
+        $autowiredCalls = array_values(array_filter($definition->getAutowiredCalls(), function ($method) {
+            return $method !== '__construct';
+        }));
+        $data['autowire'] = $definition->isAutowired() ? ($autowiredCalls ?: true) : false;
 
         foreach ($definition->getAutowiringTypes(false) as $autowiringType) {
             $data['autowiring_types'][] = $autowiringType;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -182,8 +182,15 @@ class MarkdownDescriptor extends Descriptor
             ."\n".'- Lazy: '.($definition->isLazy() ? 'yes' : 'no')
             ."\n".'- Shared: '.($definition->isShared() ? 'yes' : 'no')
             ."\n".'- Abstract: '.($definition->isAbstract() ? 'yes' : 'no')
-            ."\n".'- Autowired: '.($definition->isAutowired() ? 'yes' : 'no')
         ;
+
+        $autowiredCalls = array_filter($definition->getAutowiredCalls(), function ($method) {
+            return $method !== '__construct';
+        });
+        $output .= "\n".'- Autowire: ';
+        $output .= $definition->isAutowired() ? ($autowiredCalls ? implode(', ', array_map(function ($method) {
+            return "`$method`";
+        }, $autowiredCalls)) : 'yes') : 'no';
 
         foreach ($definition->getAutowiringTypes(false) as $autowiringType) {
             $output .= "\n".'- Autowiring Type: `'.$autowiringType.'`';

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -294,7 +294,11 @@ class TextDescriptor extends Descriptor
         $tableRows[] = array('Lazy', $definition->isLazy() ? 'yes' : 'no');
         $tableRows[] = array('Shared', $definition->isShared() ? 'yes' : 'no');
         $tableRows[] = array('Abstract', $definition->isAbstract() ? 'yes' : 'no');
-        $tableRows[] = array('Autowired', $definition->isAutowired() ? 'yes' : 'no');
+
+        $autowiredCalls = array_filter($definition->getAutowiredCalls(), function ($method) {
+            return $method !== '__construct';
+        });
+        $tableRows[] = array('Autowire', $definition->isAutowired() ? ($autowiredCalls ? implode("\n", $autowiredCalls) : 'yes') : 'no');
 
         if ($autowiringTypes = $definition->getAutowiringTypes(false)) {
             $tableRows[] = array('Autowiring Types', implode(', ', $autowiringTypes));

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -373,6 +373,18 @@ class XmlDescriptor extends Descriptor
         $serviceXML->setAttribute('autowired', $definition->isAutowired() ? 'true' : 'false');
         $serviceXML->setAttribute('file', $definition->getFile());
 
+        $autowiredCalls = array_filter($definition->getAutowiredCalls(), function ($method) {
+            return $method !== '__construct';
+        });
+        if ($autowiredCalls) {
+            $serviceXML->appendChild($autowiredMethodsXML = $dom->createElement('autowired-calls'));
+            foreach ($autowiredCalls as $autowiredMethod) {
+                $autowiredMethodXML = $dom->createElement('autowired-call');
+                $autowiredMethodXML->appendChild(new \DOMText($autowiredMethod));
+                $autowiredMethodsXML->appendChild($autowiredMethodXML);
+            }
+        }
+
         $calls = $definition->getMethodCalls();
         if (count($calls) > 0) {
             $serviceXML->appendChild($callsXML = $dom->createElement('calls'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -132,6 +132,9 @@ class ObjectsProvider
                 ->addTag('tag2')
                 ->addMethodCall('setMailer', array(new Reference('mailer')))
                 ->setFactory(array(new Reference('factory.service'), 'get')),
+            'definition_autowired' => (new Definition('AutowiredService'))->setAutowired(true),
+            'definition_autowired_with_methods' => (new Definition('AutowiredService'))
+                ->setAutowiredCalls(array('__construct', 'set*', 'addFoo')),
         );
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.md
@@ -11,6 +11,6 @@
 - Lazy: yes
 - Shared: yes
 - Abstract: yes
-- Autowired: no
+- Autowire: no
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
@@ -14,7 +14,7 @@
   Lazy             yes                          
   Shared           yes                          
   Abstract         yes                          
-  Autowired        no                           
+  Autowire         no                           
   Factory Class    Full\Qualified\FactoryClass  
   Factory Method   get                          
  ---------------- -----------------------------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.md
@@ -11,7 +11,7 @@
 - Lazy: no
 - Shared: yes
 - Abstract: no
-- Autowired: no
+- Autowire: no
 - File: `/path/to/file`
 - Factory Service: `factory.service`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
@@ -17,7 +17,7 @@
   Lazy              no                               
   Shared            yes                              
   Abstract          no                               
-  Autowired         no                               
+  Autowire          no                               
   Required File     /path/to/file                    
   Factory Service   factory.service                  
   Factory Method    get                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
@@ -70,6 +70,33 @@
             "factory_class": "Full\\Qualified\\FactoryClass",
             "factory_method": "get",
             "tags": []
+        },
+        "definition_autowired": {
+            "class": "AutowiredService",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": true,
+            "arguments": [],
+            "file": null,
+            "tags": []
+        },
+        "definition_autowired_with_methods": {
+            "class": "AutowiredService",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": [
+                "set*",
+                "addFoo"
+            ],
+            "arguments": [],
+            "file": null,
+            "tags": []
         }
     },
     "aliases": {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.md
@@ -12,10 +12,32 @@ Definitions
 - Lazy: yes
 - Shared: yes
 - Abstract: yes
-- Autowired: no
+- Autowire: no
 - Arguments: yes
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`
+
+### definition_autowired
+
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: yes
+- Arguments: no
+
+### definition_autowired_with_methods
+
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: `set*`, `addFoo`
+- Arguments: no
 
 
 Aliases

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.txt
@@ -2,12 +2,14 @@
 [33mSymfony Container Public Services[39m
 [33m=================================[39m
 
- ------------------- -------------------------------------------------------- 
- [32m Service ID        [39m [32m Class name                                             [39m 
- ------------------- -------------------------------------------------------- 
-  alias_1             alias for "service_1"                                   
-  alias_2             alias for "service_2"                                   
-  definition_1        Full\Qualified\Class1                                   
-  service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
- ------------------- -------------------------------------------------------- 
+ ----------------------------------- -------------------------------------------------------- 
+ [32m Service ID                        [39m [32m Class name                                             [39m 
+ ----------------------------------- -------------------------------------------------------- 
+  alias_1                             alias for "service_1"                                   
+  alias_2                             alias for "service_2"                                   
+  definition_1                        Full\Qualified\Class1                                   
+  definition_autowired                AutowiredService                                        
+  definition_autowired_with_methods   AutowiredService                                        
+  service_container                   Symfony\Component\DependencyInjection\ContainerBuilder  
+ ----------------------------------- -------------------------------------------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
@@ -25,5 +25,12 @@
     </argument>
     <argument type="closure-proxy" id="definition1" method="get"/>
   </definition>
+  <definition id="definition_autowired" class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file=""/>
+  <definition id="definition_autowired_with_methods" class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file="">
+    <autowired-calls>
+      <autowired-call>set*</autowired-call>
+      <autowired-call>addFoo</autowired-call>
+    </autowired-calls>
+  </definition>
   <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
@@ -12,6 +12,31 @@
             "factory_class": "Full\\Qualified\\FactoryClass",
             "factory_method": "get",
             "tags": []
+        },
+        "definition_autowired": {
+            "class": "AutowiredService",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": true,
+            "file": null,
+            "tags": []
+        },
+        "definition_autowired_with_methods": {
+            "class": "AutowiredService",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": [
+                "set*",
+                "addFoo"
+            ],
+            "file": null,
+            "tags": []
         }
     },
     "aliases": {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
@@ -12,9 +12,29 @@ Definitions
 - Lazy: yes
 - Shared: yes
 - Abstract: yes
-- Autowired: no
+- Autowire: no
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`
+
+### definition_autowired
+
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: yes
+
+### definition_autowired_with_methods
+
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: `set*`, `addFoo`
 
 
 Aliases

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.txt
@@ -2,12 +2,14 @@
 [33mSymfony Container Public Services[39m
 [33m=================================[39m
 
- ------------------- -------------------------------------------------------- 
- [32m Service ID        [39m [32m Class name                                             [39m 
- ------------------- -------------------------------------------------------- 
-  alias_1             alias for "service_1"                                   
-  alias_2             alias for "service_2"                                   
-  definition_1        Full\Qualified\Class1                                   
-  service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
- ------------------- -------------------------------------------------------- 
+ ----------------------------------- -------------------------------------------------------- 
+ [32m Service ID                        [39m [32m Class name                                             [39m 
+ ----------------------------------- -------------------------------------------------------- 
+  alias_1                             alias for "service_1"                                   
+  alias_2                             alias for "service_2"                                   
+  definition_1                        Full\Qualified\Class1                                   
+  definition_autowired                AutowiredService                                        
+  definition_autowired_with_methods   AutowiredService                                        
+  service_container                   Symfony\Component\DependencyInjection\ContainerBuilder  
+ ----------------------------------- -------------------------------------------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
@@ -5,5 +5,12 @@
   <definition id="definition_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" file="">
     <factory class="Full\Qualified\FactoryClass" method="get"/>
   </definition>
+  <definition id="definition_autowired" class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file=""/>
+  <definition id="definition_autowired_with_methods" class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file="">
+    <autowired-calls>
+      <autowired-call>set*</autowired-call>
+      <autowired-call>addFoo</autowired-call>
+    </autowired-calls>
+  </definition>
   <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
@@ -46,6 +46,31 @@
                     "parameters": []
                 }
             ]
+        },
+        "definition_autowired": {
+            "class": "AutowiredService",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": true,
+            "file": null,
+            "tags": []
+        },
+        "definition_autowired_with_methods": {
+            "class": "AutowiredService",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": [
+                "set*",
+                "addFoo"
+            ],
+            "file": null,
+            "tags": []
         }
     },
     "aliases": {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
@@ -12,7 +12,7 @@ Definitions
 - Lazy: yes
 - Shared: yes
 - Abstract: yes
-- Autowired: no
+- Autowire: no
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`
 
@@ -24,7 +24,7 @@ Definitions
 - Lazy: no
 - Shared: yes
 - Abstract: no
-- Autowired: no
+- Autowire: no
 - File: `/path/to/file`
 - Factory Service: `factory.service`
 - Factory Method: `get`
@@ -35,6 +35,26 @@ Definitions
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+
+### definition_autowired
+
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: yes
+
+### definition_autowired_with_methods
+
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: `set*`, `addFoo`
 
 
 Aliases

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.txt
@@ -2,13 +2,15 @@
 [33mSymfony Container Public and Private Services[39m
 [33m=============================================[39m
 
- ------------------- -------------------------------------------------------- 
- [32m Service ID        [39m [32m Class name                                             [39m 
- ------------------- -------------------------------------------------------- 
-  alias_1             alias for "service_1"                                   
-  alias_2             alias for "service_2"                                   
-  definition_1        Full\Qualified\Class1                                   
-  definition_2        Full\Qualified\Class2                                   
-  service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
- ------------------- -------------------------------------------------------- 
+ ----------------------------------- -------------------------------------------------------- 
+ [32m Service ID                        [39m [32m Class name                                             [39m 
+ ----------------------------------- -------------------------------------------------------- 
+  alias_1                             alias for "service_1"                                   
+  alias_2                             alias for "service_2"                                   
+  definition_1                        Full\Qualified\Class1                                   
+  definition_2                        Full\Qualified\Class2                                   
+  definition_autowired                AutowiredService                                        
+  definition_autowired_with_methods   AutowiredService                                        
+  service_container                   Symfony\Component\DependencyInjection\ContainerBuilder  
+ ----------------------------------- -------------------------------------------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
@@ -21,5 +21,12 @@
       <tag name="tag2"/>
     </tags>
   </definition>
+  <definition id="definition_autowired" class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file=""/>
+  <definition id="definition_autowired_with_methods" class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file="">
+    <autowired-calls>
+      <autowired-call>set*</autowired-call>
+      <autowired-call>addFoo</autowired-call>
+    </autowired-calls>
+  </definition>
   <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
@@ -12,7 +12,7 @@ Definitions
 - Lazy: no
 - Shared: yes
 - Abstract: no
-- Autowired: no
+- Autowire: no
 - File: `/path/to/file`
 - Factory Service: `factory.service`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.md
@@ -12,7 +12,7 @@ tag1
 - Lazy: no
 - Shared: yes
 - Abstract: no
-- Autowired: no
+- Autowire: no
 - File: `/path/to/file`
 - Factory Service: `factory.service`
 - Factory Method: `get`
@@ -30,7 +30,7 @@ tag2
 - Lazy: no
 - Shared: yes
 - Abstract: no
-- Autowired: no
+- Autowire: no
 - File: `/path/to/file`
 - Factory Service: `factory.service`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.md
@@ -4,6 +4,6 @@
 - Lazy: yes
 - Shared: yes
 - Abstract: yes
-- Autowired: no
+- Autowire: no
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.txt
@@ -9,7 +9,7 @@
   Lazy             yes                          
   Shared           yes                          
   Abstract         yes                          
-  Autowired        no                           
+  Autowire         no                           
   Factory Class    Full\Qualified\FactoryClass  
   Factory Method   get                          
  ---------------- ----------------------------- 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.md
@@ -4,7 +4,7 @@
 - Lazy: no
 - Shared: yes
 - Abstract: no
-- Autowired: no
+- Autowire: no
 - File: `/path/to/file`
 - Factory Service: `factory.service`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
@@ -12,7 +12,7 @@
   Lazy              no                               
   Shared            yes                              
   Abstract          no                               
-  Autowired         no                               
+  Autowire          no                               
   Required File     /path/to/file                    
   Factory Service   factory.service                  
   Factory Method    get                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.md
@@ -4,7 +4,7 @@
 - Lazy: yes
 - Shared: yes
 - Abstract: yes
-- Autowired: no
+- Autowire: no
 - Arguments: yes
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
@@ -9,7 +9,7 @@
   Lazy             yes                                        
   Shared           yes                                        
   Abstract         yes                                        
-  Autowired        no                                         
+  Autowire         no                                         
   Factory Class    Full\Qualified\FactoryClass                
   Factory Method   get                                        
   Arguments        Service(definition2)                       

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.md
@@ -4,7 +4,7 @@
 - Lazy: no
 - Shared: yes
 - Abstract: no
-- Autowired: no
+- Autowire: no
 - Arguments: no
 - File: `/path/to/file`
 - Factory Service: `factory.service`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
@@ -12,7 +12,7 @@
   Lazy              no                               
   Shared            yes                              
   Abstract          no                               
-  Autowired         no                               
+  Autowire          no                               
   Required File     /path/to/file                    
   Factory Service   factory.service                  
   Factory Method    get                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired.json
@@ -1,0 +1,12 @@
+{
+    "class": "AutowiredService",
+    "public": true,
+    "synthetic": false,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "autowire": true,
+    "arguments": [],
+    "file": null,
+    "tags": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired.md
@@ -1,0 +1,8 @@
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: yes
+- Arguments: no

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired.txt
@@ -1,0 +1,14 @@
+ ------------ ------------------ 
+ [32m Option     [39m [32m Value            [39m 
+ ------------ ------------------ 
+  Service ID   -                 
+  Class        AutowiredService  
+  Tags         -                 
+  Public       yes               
+  Synthetic    no                
+  Lazy         no                
+  Shared       yes               
+  Abstract     no                
+  Autowire     yes               
+ ------------ ------------------ 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file=""/>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired_with_methods.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired_with_methods.json
@@ -1,0 +1,15 @@
+{
+    "class": "AutowiredService",
+    "public": true,
+    "synthetic": false,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "autowire": [
+        "set*",
+        "addFoo"
+    ],
+    "arguments": [],
+    "file": null,
+    "tags": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired_with_methods.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired_with_methods.md
@@ -1,0 +1,8 @@
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: `set*`, `addFoo`
+- Arguments: no

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired_with_methods.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired_with_methods.txt
@@ -1,0 +1,15 @@
+ ------------ ------------------ 
+ [32m Option     [39m [32m Value            [39m 
+ ------------ ------------------ 
+  Service ID   -                 
+  Class        AutowiredService  
+  Tags         -                 
+  Public       yes               
+  Synthetic    no                
+  Lazy         no                
+  Shared       yes               
+  Abstract     no                
+  Autowire     set*              
+               addFoo            
+ ------------ ------------------ 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired_with_methods.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_autowired_with_methods.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file="">
+  <autowired-calls>
+    <autowired-call>set*</autowired-call>
+    <autowired-call>addFoo</autowired-call>
+  </autowired-calls>
+</definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired.json
@@ -1,0 +1,11 @@
+{
+    "class": "AutowiredService",
+    "public": true,
+    "synthetic": false,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "autowire": true,
+    "file": null,
+    "tags": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired.md
@@ -1,0 +1,7 @@
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: yes

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired.txt
@@ -1,0 +1,14 @@
+ ------------ ------------------ 
+ [32m Option     [39m [32m Value            [39m 
+ ------------ ------------------ 
+  Service ID   -                 
+  Class        AutowiredService  
+  Tags         -                 
+  Public       yes               
+  Synthetic    no                
+  Lazy         no                
+  Shared       yes               
+  Abstract     no                
+  Autowire     yes               
+ ------------ ------------------ 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file=""/>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired_with_methods.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired_with_methods.json
@@ -1,0 +1,14 @@
+{
+    "class": "AutowiredService",
+    "public": true,
+    "synthetic": false,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "autowire": [
+        "set*",
+        "addFoo"
+    ],
+    "file": null,
+    "tags": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired_with_methods.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired_with_methods.md
@@ -1,0 +1,7 @@
+- Class: `AutowiredService`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowire: `set*`, `addFoo`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired_with_methods.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired_with_methods.txt
@@ -1,0 +1,15 @@
+ ------------ ------------------ 
+ [32m Option     [39m [32m Value            [39m 
+ ------------ ------------------ 
+  Service ID   -                 
+  Class        AutowiredService  
+  Tags         -                 
+  Public       yes               
+  Synthetic    no                
+  Lazy         no                
+  Shared       yes               
+  Abstract     no                
+  Autowire     set*              
+               addFoo            
+ ------------ ------------------ 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired_with_methods.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_autowired_with_methods.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="AutowiredService" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="true" file="">
+  <autowired-calls>
+    <autowired-call>set*</autowired-call>
+    <autowired-call>addFoo</autowired-call>
+  </autowired-calls>
+</definition>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

so we can see the autowired methods using `debug:container`.