### PR TITLE
Fix ICU dependant tests

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -108,10 +108,10 @@ class IntegerToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCas
 
     public function testReverseTransformWithGrouping()
     {
-        // Since we test against "de_AT", we need the full implementation
+        // Since we test against "de_DE", we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('de_DE');
 
         $transformer = new IntegerToLocalizedStringTransformer(null, true);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -54,8 +54,8 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
     public function provideTransformationsWithGrouping()
     {
         return array(
-            array(1234.5, '1.234,5', 'de_AT'),
-            array(12345.912, '12.345,912', 'de_AT'),
+            array(1234.5, '1.234,5', 'de_DE'),
+            array(12345.912, '12.345,912', 'de_DE'),
             array(1234.5, '1 234,5', 'fr'),
             array(1234.5, '1 234,5', 'ru'),
             array(1234.5, '1 234,5', 'fi'),
@@ -410,10 +410,10 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
     {
-        // Since we test against "de_AT", we need the full implementation
+        // Since we test against "de_DE", we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('de_DE');
 
         $transformer = new NumberToLocalizedStringTransformer(null, true);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -69,10 +69,10 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextDateTime()
     {
-        // we test against "de_AT", so we need the full implementation
+        // we test against "de_DE", so we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('de_DE');
 
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
@@ -90,10 +90,10 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextString()
     {
-        // we test against "de_AT", so we need the full implementation
+        // we test against "de_DE", so we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('de_DE');
 
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
@@ -111,10 +111,10 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextTimestamp()
     {
-        // we test against "de_AT", so we need the full implementation
+        // we test against "de_DE", so we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('de_DE');
 
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
@@ -134,10 +134,10 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextRaw()
     {
-        // we test against "de_AT", so we need the full implementation
+        // we test against "de_DE", so we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('de_DE');
 
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
@@ -398,10 +398,10 @@ class DateTypeTest extends TestCase
 
     public function testSetDataWithNegativeTimezoneOffsetStringInput()
     {
-        // we test against "de_AT", so we need the full implementation
+        // we test against "de_DE", so we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('de_DE');
 
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
@@ -420,10 +420,10 @@ class DateTypeTest extends TestCase
 
     public function testSetDataWithNegativeTimezoneOffsetDateTimeInput()
     {
-        // we test against "de_AT", so we need the full implementation
+        // we test against "de_DE", so we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
 
-        \Locale::setDefault('de_AT');
+        \Locale::setDefault('de_DE');
 
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,

--- a/src/Symfony/Component/Intl/Util/IntlTestHelper.php
+++ b/src/Symfony/Component/Intl/Util/IntlTestHelper.php
@@ -41,7 +41,7 @@ class IntlTestHelper
         //   * the intl extension is loaded with version Intl::getIcuStubVersion()
         //   * the intl extension is not loaded
 
-        if (($minimumIcuVersion || defined('HHVM_VERSION_ID')) && IcuVersion::compare(Intl::getIcuVersion(), $minimumIcuVersion, '!=', 1)) {
+        if (($minimumIcuVersion || defined('HHVM_VERSION_ID')) && IcuVersion::compare(Intl::getIcuVersion(), $minimumIcuVersion, '<', 1)) {
             $testCase->markTestSkipped('ICU version '.$minimumIcuVersion.' is required.');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

#20551 changed the condition checking if the ICU version matches the stubbed data. The change intended to enable tests on more ICU versions, but it actually has limited them. I'm still not convinced it should've been done but let's at least fix the condition. Ideal solution would be to have the latest ICU data available on travis (still not there https://github.com/travis-ci/travis-ci/issues/3616).

I also needed to fix several tests.

Currently skipped tests in components depending on ICU data:

|            | 4.8.1.1 | 54.1 | 55.1 | 57.1 |
|---|---|--|--|--|
| Intl       | 488     | 488  | 7    | 6    |
| Locale     | 0       | 0    | 0    | 0    |
| Translation| 0       | 0    | 0    | 0    |
| Validator  | 69      | 69   | 69   | 0    |
| Form       | 75      | 75   | 75   | 1    |
