### PR TITLE
[Cache] [PdoAdapter] Fix MySQL 1170 error (blob as primary key)

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -109,16 +109,16 @@ class PdoAdapter extends AbstractAdapter
 
         if ($conn instanceof Connection) {
             $types = array(
-                'mysql'  => 'binary',
+                'mysql' => 'binary',
                 'sqlite' => 'text',
-                'pgsql'  => 'string',
-                'oci'    => 'string',
+                'pgsql' => 'string',
+                'oci' => 'string',
                 'sqlsrv' => 'string',
             );
             if (!isset($types[$this->driver])) {
                 throw new \DomainException(sprintf('Creating the cache table is currently not implemented for PDO driver "%s".', $this->driver));
             }
-            
+
             $schema = new Schema();
             $table = $schema->createTable($this->table);
             $table->addColumn($this->idCol, $types[$this->driver], array('length' => 255));

--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -108,9 +108,20 @@ class PdoAdapter extends AbstractAdapter
         $conn = $this->getConnection();
 
         if ($conn instanceof Connection) {
+            $types = array(
+                'mysql'  => 'binary',
+                'sqlite' => 'text',
+                'pgsql'  => 'string',
+                'oci'    => 'string',
+                'sqlsrv' => 'string',
+            );
+            if (!isset($types[$this->driver])) {
+                throw new \DomainException(sprintf('Creating the cache table is currently not implemented for PDO driver "%s".', $this->driver));
+            }
+            
             $schema = new Schema();
             $table = $schema->createTable($this->table);
-            $table->addColumn($this->idCol, 'blob', array('length' => 255));
+            $table->addColumn($this->idCol, $types[$this->driver], array('length' => 255));
             $table->addColumn($this->dataCol, 'blob', array('length' => 16777215));
             $table->addColumn($this->lifetimeCol, 'integer', array('unsigned' => true, 'notnull' => false));
             $table->addColumn($this->timeCol, 'integer', array('unsigned' => true, 'foo' => 'bar'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When using a Doctrine\DBAL\Connection to initialize the PdoAdapter, PdoAdapter::createTable tries to create a table using a blob field as primary key. [This is not an option for MySQL](https://techjourney.net/mysql-error-1170-42000-blobtext-column-used-in-key-specification-without-a-key-length/), resulting in an exeption: `Syntax error or access violation: 1170 BLOB/TEXT column 'item_id' used in key specification without a key length`. This commit supplies a way to act like the non-Connection way creates the table does.
