### PR TITLE
[FrameworkBundle] Fix third level headers for MarkdownDescriptor

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -233,7 +233,7 @@ class MarkdownDescriptor extends Descriptor
             }
         }
 
-        $this->write(isset($options['id']) ? sprintf("%s\n%s\n\n%s\n", $options['id'], str_repeat('~', strlen($options['id'])), $output) : $output);
+        $this->write(isset($options['id']) ? sprintf("### %s\n\n%s\n", $options['id'], $output) : $output);
     }
 
     /**
@@ -244,7 +244,7 @@ class MarkdownDescriptor extends Descriptor
         $output = '- Service: `'.$alias.'`'
             ."\n".'- Public: '.($alias->isPublic() ? 'yes' : 'no');
 
-        $this->write(isset($options['id']) ? sprintf("%s\n%s\n\n%s\n", $options['id'], str_repeat('~', strlen($options['id'])), $output) : $output);
+        $this->write(isset($options['id']) ? sprintf("### %s\n\n%s\n", $options['id'], $output) : $output);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
@@ -4,8 +4,7 @@ Public services
 Definitions
 -----------
 
-definition_1
-~~~~~~~~~~~~
+### definition_1
 
 - Class: `Full\Qualified\Class1`
 - Scope: `container`
@@ -21,14 +20,12 @@ definition_1
 Aliases
 -------
 
-alias_1
-~~~~~~~
+### alias_1
 
 - Service: `service_1`
 - Public: yes
 
-alias_2
-~~~~~~~
+### alias_2
 
 - Service: `service_2`
 - Public: no

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
@@ -4,8 +4,7 @@ Public and private services
 Definitions
 -----------
 
-definition_1
-~~~~~~~~~~~~
+### definition_1
 
 - Class: `Full\Qualified\Class1`
 - Scope: `container`
@@ -17,8 +16,7 @@ definition_1
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`
 
-definition_2
-~~~~~~~~~~~~
+### definition_2
 
 - Class: `Full\Qualified\Class2`
 - Scope: `container`
@@ -41,14 +39,12 @@ definition_2
 Aliases
 -------
 
-alias_1
-~~~~~~~
+### alias_1
 
 - Service: `service_1`
 - Public: yes
 
-alias_2
-~~~~~~~
+### alias_2
 
 - Service: `service_2`
 - Public: no

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
@@ -4,8 +4,7 @@ Public and private services with tag `tag1`
 Definitions
 -----------
 
-definition_2
-~~~~~~~~~~~~
+### definition_2
 
 - Class: `Full\Qualified\Class2`
 - Scope: `container`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.md
@@ -4,8 +4,7 @@ Container tags
 tag1
 ----
 
-definition_2
-~~~~~~~~~~~~
+### definition_2
 
 - Class: `Full\Qualified\Class2`
 - Scope: `container`
@@ -22,8 +21,7 @@ definition_2
 tag2
 ----
 
-definition_2
-~~~~~~~~~~~~
+### definition_2
 
 - Class: `Full\Qualified\Class2`
 - Scope: `container`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

`~` is not valid as an underlining char when using markdown on the contrary of reStructuredText.
See the rendering of [builder_1_public.md (before)](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md)  vs [builder_1_public.md (after)](https://github.com/ogizanagi/symfony/blob/fix/2.7/fwb/md_third_lvl_headers/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md) for instance.

This PR fixes it by using a third level header.

~~**EDIT:** There is no BC break. Wrong PR template information.~~