### PR TITLE
[FrameworkBundle] Clean unnecessary method_exists calls in descriptors

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -219,9 +219,7 @@ class JsonDescriptor extends Descriptor
             'lazy' => $definition->isLazy(),
         );
 
-        if (method_exists($definition, 'isShared')) {
-            $data['shared'] = $definition->isShared();
-        }
+        $data['shared'] = $definition->isShared();
 
         if (method_exists($definition, 'isSynchronized')) {
             $data['synchronized'] = $definition->isSynchronized(false);
@@ -229,13 +227,11 @@ class JsonDescriptor extends Descriptor
 
         $data['abstract'] = $definition->isAbstract();
 
-        if (method_exists($definition, 'isAutowired')) {
-            $data['autowire'] = $definition->isAutowired();
+        $data['autowire'] = $definition->isAutowired();
 
-            $data['autowiring_types'] = array();
-            foreach ($definition->getAutowiringTypes() as $autowiringType) {
-                $data['autowiring_types'][] = $autowiringType;
-            }
+        $data['autowiring_types'] = array();
+        foreach ($definition->getAutowiringTypes() as $autowiringType) {
+            $data['autowiring_types'][] = $autowiringType;
         }
 
         $data['file'] = $definition->getFile();

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -185,9 +185,7 @@ class MarkdownDescriptor extends Descriptor
             ."\n".'- Lazy: '.($definition->isLazy() ? 'yes' : 'no')
         ;
 
-        if (method_exists($definition, 'isShared')) {
-            $output .= "\n".'- Shared: '.($definition->isShared() ? 'yes' : 'no');
-        }
+        $output .= "\n".'- Shared: '.($definition->isShared() ? 'yes' : 'no');
 
         if (method_exists($definition, 'isSynchronized')) {
             $output .= "\n".'- Synchronized: '.($definition->isSynchronized(false) ? 'yes' : 'no');
@@ -195,12 +193,10 @@ class MarkdownDescriptor extends Descriptor
 
         $output .= "\n".'- Abstract: '.($definition->isAbstract() ? 'yes' : 'no');
 
-        if (method_exists($definition, 'isAutowired')) {
-            $output .= "\n".'- Autowired: '.($definition->isAutowired() ? 'yes' : 'no');
+        $output .= "\n".'- Autowired: '.($definition->isAutowired() ? 'yes' : 'no');
 
-            foreach ($definition->getAutowiringTypes() as $autowiringType) {
-                $output .= "\n".'- Autowiring Type: `'.$autowiringType.'`';
-            }
+        foreach ($definition->getAutowiringTypes() as $autowiringType) {
+            $output .= "\n".'- Autowiring Type: `'.$autowiringType.'`';
         }
 
         if ($definition->getFile()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -287,18 +287,16 @@ class TextDescriptor extends Descriptor
         }
         $tableRows[] = array('Abstract', $definition->isAbstract() ? 'yes' : 'no');
 
-        if (method_exists($definition, 'isAutowired')) {
-            $tableRows[] = array('Autowired', $definition->isAutowired() ? 'yes' : 'no');
+        $tableRows[] = array('Autowired', $definition->isAutowired() ? 'yes' : 'no');
 
-            $autowiringTypes = $definition->getAutowiringTypes();
-            if (count($autowiringTypes)) {
-                $autowiringTypesInformation = implode(', ', $autowiringTypes);
-            } else {
-                $autowiringTypesInformation = '-';
-            }
-
-            $tableRows[] = array('Autowiring Types', $autowiringTypesInformation);
+        $autowiringTypes = $definition->getAutowiringTypes();
+        if (count($autowiringTypes)) {
+            $autowiringTypesInformation = implode(', ', $autowiringTypes);
+        } else {
+            $autowiringTypesInformation = '-';
         }
+
+        $tableRows[] = array('Autowiring Types', $autowiringTypesInformation);
 
         if ($definition->getFile()) {
             $tableRows[] = array('Required File', $definition->getFile() ? $definition->getFile() : '-');

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -366,17 +366,13 @@ class XmlDescriptor extends Descriptor
         $serviceXML->setAttribute('public', $definition->isPublic() ? 'true' : 'false');
         $serviceXML->setAttribute('synthetic', $definition->isSynthetic() ? 'true' : 'false');
         $serviceXML->setAttribute('lazy', $definition->isLazy() ? 'true' : 'false');
-        if (method_exists($definition, 'isShared')) {
-            $serviceXML->setAttribute('shared', $definition->isShared() ? 'true' : 'false');
-        }
+        $serviceXML->setAttribute('shared', $definition->isShared() ? 'true' : 'false');
         if (method_exists($definition, 'isSynchronized')) {
             $serviceXML->setAttribute('synchronized', $definition->isSynchronized(false) ? 'true' : 'false');
         }
         $serviceXML->setAttribute('abstract', $definition->isAbstract() ? 'true' : 'false');
 
-        if (method_exists($definition, 'isAutowired')) {
-            $serviceXML->setAttribute('autowired', $definition->isAutowired() ? 'true' : 'false');
-        }
+        $serviceXML->setAttribute('autowired', $definition->isAutowired() ? 'true' : 'false');
 
         $serviceXML->setAttribute('file', $definition->getFile());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no, only cleanup right now
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Those checks look useless as soon as the [FrameworkBundle v2.8 already requires the DI component 2.8 version](https://github.com/symfony/symfony/blob/v2.8.0/src/Symfony/Bundle/FrameworkBundle/composer.json#L22) in which were introduced these methods.

I also spotted the fact the `shared` property is missing from the `TextDescriptor` (at least should appear when a service is not shared IMHO) and the `autowiringTypes` are also missing from the `XmlDescriptor`.

WDYT about fixing this here too, as a bug fix? Or should we actually consider the whole thing (clean + missing info in descriptors) as an enhancement and target master instead?