### PR TITLE
[Controller] Replace AccessDeniedException by AccessDeniedHttpException

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -20,8 +20,8 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Form;
@@ -186,7 +186,7 @@ abstract class Controller implements ContainerAwareInterface
      * @param mixed  $object     The object
      * @param string $message    The message passed to the exception
      *
-     * @throws AccessDeniedException
+     * @throws AccessDeniedHttpException
      */
     protected function denyAccessUnlessGranted($attributes, $object = null, $message = 'Access Denied.')
     {
@@ -302,7 +302,7 @@ abstract class Controller implements ContainerAwareInterface
     }
 
     /**
-     * Returns an AccessDeniedException.
+     * Returns an AccessDeniedHttpException.
      *
      * This will result in a 403 response code. Usage example:
      *
@@ -311,11 +311,11 @@ abstract class Controller implements ContainerAwareInterface
      * @param string          $message  A message
      * @param \Exception|null $previous The previous exception
      *
-     * @return AccessDeniedException
+     * @return AccessDeniedHttpException
      */
     protected function createAccessDeniedException($message = 'Access Denied.', \Exception $previous = null)
     {
-        return new AccessDeniedException($message, $previous);
+        return new AccessDeniedHttpException($message, $previous);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -191,11 +191,7 @@ abstract class Controller implements ContainerAwareInterface
     protected function denyAccessUnlessGranted($attributes, $object = null, $message = 'Access Denied.')
     {
         if (!$this->isGranted($attributes, $object)) {
-            $exception = $this->createAccessDeniedException($message);
-            $exception->setAttributes($attributes);
-            $exception->setSubject($object);
-
-            throw $exception;
+            throw $this->createAccessDeniedException($message);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -348,7 +348,7 @@ class ControllerTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
      */
     public function testdenyAccessUnlessGranted()
     {
@@ -450,7 +450,7 @@ class ControllerTest extends TestCase
     {
         $controller = new TestController();
 
-        $this->assertInstanceOf('Symfony\Component\Security\Core\Exception\AccessDeniedException', $controller->createAccessDeniedException());
+        $this->assertInstanceOf('Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException', $controller->createAccessDeniedException());
     }
 
     public function testIsCsrfTokenValid()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs

**!!Not sure if this is actually a bug or on purpose!!**

The `Symfony\Bundle\FrameworkBundle\Controller\Controller::createAccessDeniedException()` method currently throws a instance of `Symfony\Component\Security\Core\Exception\AccessDeniedException`, and not a `Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException`.

It results in an HTTP 500 status code instead of an HTTP 403.

As the `createNotFoundException()` of the same class currently results in a 404 error code,
IMHO I think it would be more consistent to result in a 403 here, using the `AccessDeniedHttpException` instead.

@see [Controller.php#L316][1]

(If this is actually on purpose, I would love to hear more about it :))

  [1]: https://github.com/symfony/framework-bundle/blob/v3.2.0/Controller/Controller.php#L316