### PR TITLE
[DI] Factorize compiler passes around new AbstractRecursivePass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+abstract class AbstractRecursivePass implements CompilerPassInterface
+{
+    protected $container;
+    protected $currentId;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->container = $container;
+
+        try {
+            $this->processValue($container->getDefinitions(), true);
+        } finally {
+            $this->container = null;
+        }
+    }
+
+    /**
+     * Processes a value found in a definition tree.
+     *
+     * @param mixed $value
+     * @param bool  $isRoot
+     *
+     * @return mixed The processed value
+     */
+    protected function processValue($value, $isRoot = false)
+    {
+        if (is_array($value)) {
+            foreach ($value as $k => $v) {
+                if ($isRoot) {
+                    $this->currentId = $k;
+                }
+                if ($v !== $processedValue = $this->processValue($v, $isRoot)) {
+                    $value[$k] = $processedValue;
+                }
+            }
+        } elseif ($value instanceof ArgumentInterface) {
+            $value->setValues($this->processValue($value->getValues()));
+        } elseif ($value instanceof Definition) {
+            $value->setArguments($this->processValue($value->getArguments()));
+            $value->setProperties($this->processValue($value->getProperties()));
+            $value->setMethodCalls($this->processValue($value->getMethodCalls()));
+
+            if ($v = $value->getFactory()) {
+                $value->setFactory($this->processValue($v));
+            }
+            if ($v = $value->getConfigurator()) {
+                $value->setConfigurator($this->processValue($v));
+            }
+        }
+
+        return $value;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -25,14 +25,13 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class AnalyzeServiceReferencesPass implements RepeatablePassInterface
+class AnalyzeServiceReferencesPass extends AbstractRecursivePass implements RepeatablePassInterface
 {
     private $graph;
-    private $container;
-    private $currentId;
     private $currentDefinition;
     private $repeatedPass;
     private $onlyConstructorArguments;
+    private $lazy;
 
     /**
      * @param bool $onlyConstructorArguments Sets this Service Reference pass to ignore method calls
@@ -60,68 +59,60 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
         $this->container = $container;
         $this->graph = $container->getCompiler()->getServiceReferenceGraph();
         $this->graph->clear();
-
-        foreach ($container->getDefinitions() as $id => $definition) {
-            if ($definition->isSynthetic() || $definition->isAbstract()) {
-                continue;
-            }
-
-            $this->currentId = $id;
-            $this->currentDefinition = $definition;
-
-            $this->processArguments($definition->getArguments());
-            if (is_array($definition->getFactory())) {
-                $this->processArguments($definition->getFactory());
-            }
-
-            if (!$this->onlyConstructorArguments) {
-                $this->processArguments($definition->getMethodCalls());
-                $this->processArguments($definition->getProperties());
-                if ($definition->getConfigurator()) {
-                    $this->processArguments(array($definition->getConfigurator()));
-                }
-            }
-        }
+        $this->lazy = false;
 
         foreach ($container->getAliases() as $id => $alias) {
             $this->graph->connect($id, $alias, (string) $alias, $this->getDefinition((string) $alias), null);
         }
+
+        parent::process($container);
     }
 
-    /**
-     * Processes service definitions for arguments to find relationships for the service graph.
-     *
-     * @param array $arguments An array of Reference or Definition objects relating to service definitions
-     * @param bool  $lazy      Whether the references nested in the arguments should be considered lazy or not
-     */
-    private function processArguments(array $arguments, $lazy = false)
+    protected function processValue($value, $isRoot = false)
     {
-        foreach ($arguments as $argument) {
-            if (is_array($argument)) {
-                $this->processArguments($argument, $lazy);
-            } elseif ($argument instanceof ArgumentInterface) {
-                $this->processArguments($argument->getValues(), true);
-            } elseif ($argument instanceof Reference) {
-                $targetDefinition = $this->getDefinition((string) $argument);
+        $lazy = $this->lazy;
 
-                $this->graph->connect(
-                    $this->currentId,
-                    $this->currentDefinition,
-                    $this->getDefinitionId((string) $argument),
-                    $targetDefinition,
-                    $argument,
-                    $lazy || ($targetDefinition && $targetDefinition->isLazy())
-                );
-            } elseif ($argument instanceof Definition) {
-                $this->processArguments($argument->getArguments());
-                $this->processArguments($argument->getMethodCalls());
-                $this->processArguments($argument->getProperties());
+        if ($value instanceof ArgumentInterface) {
+            $this->lazy = true;
+            parent::processValue($value);
+            $this->lazy = $lazy;
 
-                if (is_array($argument->getFactory())) {
-                    $this->processArguments($argument->getFactory());
-                }
-            }
+            return $value;
         }
+        if ($value instanceof Reference) {
+            $targetDefinition = $this->getDefinition((string) $value);
+
+            $this->graph->connect(
+                $this->currentId,
+                $this->currentDefinition,
+                $this->getDefinitionId((string) $value),
+                $targetDefinition,
+                $value,
+                $this->lazy || ($targetDefinition && $targetDefinition->isLazy())
+            );
+
+            return $value;
+        }
+        if (!$value instanceof Definition) {
+            return parent::processValue($value, $isRoot);
+        }
+        if ($isRoot) {
+            if ($value->isSynthetic() || $value->isAbstract()) {
+                return $value;
+            }
+            $this->currentDefinition = $value;
+        }
+        $this->lazy = false;
+
+        if ($this->onlyConstructorArguments) {
+            $this->processValue($value->getFactory());
+            $this->processValue($value->getArguments());
+        } else {
+            parent::processValue($value, $isRoot);
+        }
+        $this->lazy = $lazy;
+
+        return $value;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
@@ -11,56 +11,27 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Checks that all references are pointing to a valid service.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class CheckExceptionOnInvalidReferenceBehaviorPass implements CompilerPassInterface
+class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass implements CompilerPassInterface
 {
-    private $container;
-    private $sourceId;
-
-    public function process(ContainerBuilder $container)
+    protected function processValue($value, $isRoot = false)
     {
-        $this->container = $container;
+        if ($value instanceof Reference && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE === $value->getInvalidBehavior()) {
+            $destId = (string) $value;
 
-        foreach ($container->getDefinitions() as $id => $definition) {
-            $this->sourceId = $id;
-            $this->processDefinition($definition);
-        }
-    }
-
-    private function processDefinition(Definition $definition)
-    {
-        $this->processReferences($definition->getArguments());
-        $this->processReferences($definition->getMethodCalls());
-        $this->processReferences($definition->getProperties());
-    }
-
-    private function processReferences(array $arguments)
-    {
-        foreach ($arguments as $argument) {
-            if (is_array($argument)) {
-                $this->processReferences($argument);
-            } elseif ($argument instanceof ArgumentInterface) {
-                $this->processReferences($argument->getValues());
-            } elseif ($argument instanceof Definition) {
-                $this->processDefinition($argument);
-            } elseif ($argument instanceof Reference && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE === $argument->getInvalidBehavior()) {
-                $destId = (string) $argument;
-
-                if (!$this->container->has($destId)) {
-                    throw new ServiceNotFoundException($destId, $this->sourceId);
-                }
+            if (!$this->container->has($destId)) {
+                throw new ServiceNotFoundException($destId, $this->currentId);
             }
         }
+
+        return parent::processValue($value, $isRoot);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -11,10 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
@@ -25,75 +23,26 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class CheckReferenceValidityPass implements CompilerPassInterface
+class CheckReferenceValidityPass extends AbstractRecursivePass implements CompilerPassInterface
 {
-    private $container;
-    private $currentId;
-
-    /**
-     * Processes the ContainerBuilder to validate References.
-     *
-     * @param ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    protected function processValue($value, $isRoot = false)
     {
-        $this->container = $container;
-
-        foreach ($container->getDefinitions() as $id => $definition) {
-            if ($definition->isSynthetic() || $definition->isAbstract()) {
-                continue;
-            }
-
-            $this->currentId = $id;
-
-            $this->validateReferences($definition->getArguments());
-            $this->validateReferences($definition->getMethodCalls());
-            $this->validateReferences($definition->getProperties());
+        if ($isRoot && $value instanceof Definition && ($value->isSynthetic() || $value->isAbstract())) {
+            return $value;
         }
-    }
+        if ($value instanceof Reference && $this->container->hasDefinition((string) $value)) {
+            $targetDefinition = $this->container->getDefinition((string) $value);
 
-    /**
-     * Validates an array of References.
-     *
-     * @param array $arguments An array of Reference objects
-     *
-     * @throws RuntimeException when there is a reference to an abstract definition.
-     */
-    private function validateReferences(array $arguments)
-    {
-        foreach ($arguments as $argument) {
-            if (is_array($argument)) {
-                $this->validateReferences($argument);
-            } elseif ($argument instanceof ArgumentInterface) {
-                $this->validateReferences($argument->getValues());
-            } elseif ($argument instanceof Reference) {
-                $targetDefinition = $this->getDefinition((string) $argument);
-
-                if (null !== $targetDefinition && $targetDefinition->isAbstract()) {
-                    throw new RuntimeException(sprintf(
-                        'The definition "%s" has a reference to an abstract definition "%s". '
-                       .'Abstract definitions cannot be the target of references.',
-                       $this->currentId,
-                       $argument
-                    ));
-                }
+            if ($targetDefinition->isAbstract()) {
+                throw new RuntimeException(sprintf(
+                    'The definition "%s" has a reference to an abstract definition "%s". '
+                   .'Abstract definitions cannot be the target of references.',
+                   $this->currentId,
+                   $value
+                ));
             }
         }
-    }
 
-    /**
-     * Returns the Definition given an id.
-     *
-     * @param string $id Definition identifier
-     *
-     * @return Definition
-     */
-    private function getDefinition($id)
-    {
-        if (!$this->container->hasDefinition($id)) {
-            return;
-        }
-
-        return $this->container->getDefinition($id);
+        return parent::processValue($value, $isRoot);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -14,20 +14,15 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Inline service definitions where this is possible.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class InlineServiceDefinitionsPass implements RepeatablePassInterface
+class InlineServiceDefinitionsPass extends AbstractRecursivePass implements RepeatablePassInterface
 {
     private $repeatedPass;
-    private $graph;
-    private $compiler;
-    private $formatter;
-    private $currentId;
 
     /**
      * {@inheritdoc}
@@ -38,77 +33,38 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
     }
 
     /**
-     * Processes the ContainerBuilder for inline service definitions.
-     *
-     * @param ContainerBuilder $container
+     * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    protected function processValue($value, $isRoot = false)
     {
-        $this->compiler = $container->getCompiler();
-        $this->formatter = $this->compiler->getLoggingFormatter();
-        $this->graph = $this->compiler->getServiceReferenceGraph();
+        if ($value instanceof ArgumentInterface) {
+            $this->processValue($value->getValues());
 
-        $container->setDefinitions($this->inlineArguments($container, $container->getDefinitions(), true));
-    }
+            return $value;
+        }
+        if ($value instanceof Reference && $this->container->hasDefinition($id = (string) $value)) {
+            $compiler = $this->container->getCompiler();
+            $definition = $this->container->getDefinition($id);
 
-    /**
-     * Processes inline arguments.
-     *
-     * @param ContainerBuilder $container The ContainerBuilder
-     * @param array            $arguments An array of arguments
-     * @param bool             $isRoot    If we are processing the root definitions or not
-     *
-     * @return array
-     */
-    private function inlineArguments(ContainerBuilder $container, array $arguments, $isRoot = false)
-    {
-        foreach ($arguments as $k => $argument) {
-            if ($isRoot) {
-                $this->currentId = $k;
-            }
-            if (is_array($argument)) {
-                $arguments[$k] = $this->inlineArguments($container, $argument);
-            } elseif ($argument instanceof ArgumentInterface) {
-                $this->inlineArguments($container, $argument->getValues());
-            } elseif ($argument instanceof Reference) {
-                if (!$container->hasDefinition($id = (string) $argument)) {
-                    continue;
+            if ($this->isInlineableDefinition($id, $definition, $compiler->getServiceReferenceGraph())) {
+                $compiler->addLogMessage($compiler->getLoggingFormatter()->formatInlineService($this, $id, $this->currentId));
+
+                if ($definition->isShared()) {
+                    return $definition;
                 }
-
-                if ($this->isInlineableDefinition($id, $definition = $container->getDefinition($id))) {
-                    $this->compiler->addLogMessage($this->formatter->formatInlineService($this, $id, $this->currentId));
-
-                    if ($definition->isShared()) {
-                        $arguments[$k] = $definition;
-                    } else {
-                        $arguments[$k] = clone $definition;
-                    }
-                }
-            } elseif ($argument instanceof Definition) {
-                $argument->setArguments($this->inlineArguments($container, $argument->getArguments()));
-                $argument->setMethodCalls($this->inlineArguments($container, $argument->getMethodCalls()));
-                $argument->setProperties($this->inlineArguments($container, $argument->getProperties()));
-
-                $configurator = $this->inlineArguments($container, array($argument->getConfigurator()));
-                $argument->setConfigurator($configurator[0]);
-
-                $factory = $this->inlineArguments($container, array($argument->getFactory()));
-                $argument->setFactory($factory[0]);
+                $value = clone $definition;
             }
         }
 
-        return $arguments;
+        return parent::processValue($value, $isRoot);
     }
 
     /**
      * Checks if the definition is inlineable.
      *
-     * @param string     $id
-     * @param Definition $definition
-     *
      * @return bool If the definition is inlineable
      */
-    private function isInlineableDefinition($id, Definition $definition)
+    private function isInlineableDefinition($id, Definition $definition, ServiceReferenceGraph $graph)
     {
         if (!$definition->isShared()) {
             return true;
@@ -118,7 +74,7 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             return false;
         }
 
-        if (!$this->graph->hasNode($id)) {
+        if (!$graph->hasNode($id)) {
             return true;
         }
 
@@ -127,7 +83,7 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
         }
 
         $ids = array();
-        foreach ($this->graph->getNode($id)->getInEdges() as $edge) {
+        foreach ($graph->getNode($id)->getInEdges() as $edge) {
             $ids[] = $edge->getSourceNode()->getId();
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
@@ -22,10 +21,9 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class ReplaceAliasByActualDefinitionPass implements CompilerPassInterface
+class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass implements CompilerPassInterface
 {
-    private $compiler;
-    private $formatter;
+    private $replacements;
 
     /**
      * Process the Container to replace aliases with service definitions.
@@ -36,9 +34,6 @@ class ReplaceAliasByActualDefinitionPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        // Setup
-        $this->compiler = $container->getCompiler();
-        $this->formatter = $this->compiler->getLoggingFormatter();
         // First collect all alias targets that need to be replaced
         $seenAliasTargets = array();
         $replacements = array();
@@ -72,60 +67,25 @@ class ReplaceAliasByActualDefinitionPass implements CompilerPassInterface
             $container->removeDefinition($targetId);
             $replacements[$targetId] = $definitionId;
         }
+        $this->replacements = $replacements;
 
-        // Now replace target instances in all definitions
-        foreach ($container->getDefinitions() as $definitionId => $definition) {
-            $definition->setArguments($this->updateArgumentReferences($replacements, $definitionId, $definition->getArguments()));
-            $definition->setMethodCalls($this->updateArgumentReferences($replacements, $definitionId, $definition->getMethodCalls()));
-            $definition->setProperties($this->updateArgumentReferences($replacements, $definitionId, $definition->getProperties()));
-            $definition->setFactory($this->updateFactoryReference($replacements, $definition->getFactory()));
-        }
+        parent::process($container);
+        $this->replacements = array();
     }
 
     /**
-     * Recursively updates references in an array.
-     *
-     * @param array  $replacements Table of aliases to replace
-     * @param string $definitionId Identifier of this definition
-     * @param array  $arguments    Where to replace the aliases
-     *
-     * @return array
+     * {@inheritdoc}
      */
-    private function updateArgumentReferences(array $replacements, $definitionId, array $arguments)
+    protected function processValue($value, $isRoot = false)
     {
-        foreach ($arguments as $k => $argument) {
-            // Handle recursion step
-            if (is_array($argument)) {
-                $arguments[$k] = $this->updateArgumentReferences($replacements, $definitionId, $argument);
-                continue;
-            }
-            if ($argument instanceof ArgumentInterface) {
-                $argument->setValues($this->updateArgumentReferences($replacements, $definitionId, $argument->getValues()));
-                continue;
-            }
-            // Skip arguments that don't need replacement
-            if (!$argument instanceof Reference) {
-                continue;
-            }
-            $referenceId = (string) $argument;
-            if (!isset($replacements[$referenceId])) {
-                continue;
-            }
+        if ($value instanceof Reference && isset($this->replacements[$referenceId = (string) $value])) {
             // Perform the replacement
-            $newId = $replacements[$referenceId];
-            $arguments[$k] = new Reference($newId, $argument->getInvalidBehavior());
-            $this->compiler->addLogMessage($this->formatter->formatUpdateReference($this, $definitionId, $referenceId, $newId));
+            $newId = $this->replacements[$referenceId];
+            $value = new Reference($newId, $value->getInvalidBehavior());
+            $compiler = $this->container->getCompiler();
+            $compiler->addLogMessage($compiler->getLoggingFormatter()->formatUpdateReference($this, $this->currentId, $referenceId, $newId));
         }
 
-        return $arguments;
-    }
-
-    private function updateFactoryReference(array $replacements, $factory)
-    {
-        if (is_array($factory) && $factory[0] instanceof Reference && isset($replacements[$referenceId = (string) $factory[0]])) {
-            $factory[0] = new Reference($replacements[$referenceId], $factory[0]->getInvalidBehavior());
-        }
-
-        return $factory;
+        return parent::processValue($value, $isRoot);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -316,7 +316,7 @@ class ProjectServiceContainer extends Container
         return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function() {
             yield 0 => 'foo';
             yield 1 => ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
-            yield 2 => array('bar' => 'foo is '.'bar'.'', 'foobar' => 'bar');
+            yield 2 => array('bar' => 'foo is bar', 'foobar' => 'bar');
             yield 3 => true;
             yield 4 => $this;
         }));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR introduces an AbstractRecursivePass that is able to visit the definition tree recursively everywhere a Definition or a Reference can be nested.

All existing compiler passes that need recursivity are updated to leverage this new class.
This remove a bunch of boilerplate that was previously repeated all over.
It also fixes compiler passes that eg missed looking at configurators for no reason (this "fix" is a new feature really).
It then applies recursivity to AutowirePass, that does not handle it today, but should.

I'm happy that the net result is a loss of 153 lines :)