### PR TITLE
Added WebVTT to the list of MIME type extensions

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeExtensionGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeExtensionGuesser.php
@@ -744,6 +744,7 @@ class MimeTypeExtensionGuesser implements ExtensionGuesserInterface
         'text/vnd.sun.j2me.app-descriptor' => 'jad',
         'text/vnd.wap.wml' => 'wml',
         'text/vnd.wap.wmlscript' => 'wmls',
+        'text/vtt' => 'vtt',
         'text/x-asm' => 's',
         'text/x-c' => 'c',
         'text/x-fortran' => 'f',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20454
| License       | MIT
| Doc PR        | -

This is not included in the Apache list of MIME types ... but the related standard looks pretty serious:

* https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API
* https://w3c.github.io/webvtt/