### PR TITLE
[HttpKernel] Fix ArgumentValueResolver for arguments default null

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -138,11 +138,6 @@ abstract class AnnotationClassLoader implements LoaderInterface
         }
 
         $defaults = array_replace($globals['defaults'], $annot->getDefaults());
-        foreach ($method->getParameters() as $param) {
-            if (!isset($defaults[$param->getName()]) && $param->isDefaultValueAvailable()) {
-                $defaults[$param->getName()] = $param->getDefaultValue();
-            }
-        }
         $requirements = array_replace($globals['requirements'], $annot->getRequirements());
         $options = array_replace($globals['options'], $annot->getOptions());
         $schemes = array_merge($globals['schemes'], $annot->getSchemes());

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -136,11 +136,10 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
             array_intersect_assoc($routeData['options'], $route->getOptions()),
             '->load preserves options annotation'
         );
-        $defaults = array_replace($methodArgs, $routeData['defaults']);
         $this->assertCount(
-            count($defaults),
-            array_intersect_assoc($defaults, $route->getDefaults()),
-            '->load preserves defaults annotation and merges them with default arguments in method signature'
+            count($routeData['defaults']),
+            $route->getDefaults(),
+            '->load preserves defaults annotation'
         );
         $this->assertEquals($routeData['schemes'], $route->getSchemes(), '->load preserves schemes annotation');
         $this->assertEquals($routeData['methods'], $route->getMethods(), '->load preserves methods annotation');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

If an argument has `null` as default value __and annotations are used for routing__, then it is not resolved by the ArgumentResolver e.g:

```php

public function showAction(Request $request) {
   dump($request); // Request object
}

public function showAction(?Request $request) {
   dump($request); // Request object
}

public function showAction(Request $request = null) {
   dump($request); // null
}
```
To me, the last example should have been a Request object too. 

Note that it is the same behavior when using `UserInterface` or whatever, I ran into this issue while trying to dump a user for a route accepting both anonymous and authenticated requests, the argument was always null while `$this->getUser()` returned the expected value. According to http://symfony.com/blog/new-in-symfony-3-2-user-value-resolver-for-controllers it should have worked through the argument.

I propose to make it works as a bugfix. 
Any suggestion for improving the patch will be really welcomed. ping @iltar 