### PR TITLE
[Validator] Improved error message for missing upload_tmp_dir

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51">
                 <source>No temporary folder was configured in php.ini.</source>
-                <target>No temporary folder was configured in php.ini.</target>
+                <target>No temporary folder was configured in php.ini, or the configured folder does not exist.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51">
                 <source>No temporary folder was configured in php.ini.</source>
-                <target>Er is geen tijdelijke map geconfigureerd in php.ini.</target>
+                <target>Er is geen tijdelijke map geconfigureerd in php.ini, of de gespecificeerde map bestaat niet.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51">
                 <source>No temporary folder was configured in php.ini.</source>
-                <target>Nie skonfigurowano folderu tymczasowego w php.ini.</target>
+                <target>Nie skonfigurowano folderu tymczasowego w php.ini, lub skonfigurowany folder nie istnieje.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

I ran into a problem in which the value for upload_tmp_dir was set in php.ini, but PHP was unable to write to the specified location. PHP returns an UPLOAD_ERR_NO_TMP_DIR in $_FILES when it can't find or use the tmp dir, and my application displayed the error for $uploadNoTmpDirErrorMessage, from which I drew the conclusion that the ini setting was missing or emtpy. 

This conclusion was based on the wording in the error message, which explicitly states that 'no temporary folder was configured', which is not actually correct. According to the [PHP documentation](http://php.net/manual/en/features.file-upload.errors.php):

> UPLOAD_ERR_NO_TMP_DIR
> Value: 6; Missing a temporary folder. Introduced in PHP 5.0.3.

'Missing' might be interpreted as 'the value for the ini setting is missing', but also as 'the configured folder is missing'.

I thought it might save someone some time if the error message from the Symfony Validator makes this explicit, which is what this PR aims to do.

I also updated the Dutch and Polish translations, because those, in addition to English, are the languages spoken in my team.
