### PR TITLE
[FrameworkBundle] Remove useless checks in descriptors

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -217,28 +217,17 @@ class JsonDescriptor extends Descriptor
             'public' => $definition->isPublic(),
             'synthetic' => $definition->isSynthetic(),
             'lazy' => $definition->isLazy(),
+            'shared' => $definition->isShared(),
+            'synchronized' => $definition->isSynchronized(false),
+            'abstract' => $definition->isAbstract(),
+            'autowire' => $definition->isAutowired(),
+            'autowiring_types' => array(),
+            'file' => $definition->getFile(),
         );
 
-        if (method_exists($definition, 'isShared')) {
-            $data['shared'] = $definition->isShared();
+        foreach ($definition->getAutowiringTypes() as $autowiringType) {
+            $data['autowiring_types'][] = $autowiringType;
         }
-
-        if (method_exists($definition, 'isSynchronized')) {
-            $data['synchronized'] = $definition->isSynchronized(false);
-        }
-
-        $data['abstract'] = $definition->isAbstract();
-
-        if (method_exists($definition, 'isAutowired')) {
-            $data['autowire'] = $definition->isAutowired();
-
-            $data['autowiring_types'] = array();
-            foreach ($definition->getAutowiringTypes() as $autowiringType) {
-                $data['autowiring_types'][] = $autowiringType;
-            }
-        }
-
-        $data['file'] = $definition->getFile();
 
         if ($definition->getFactoryClass(false)) {
             $data['factory_class'] = $definition->getFactoryClass(false);
@@ -269,11 +258,9 @@ class JsonDescriptor extends Descriptor
 
         if (!$omitTags) {
             $data['tags'] = array();
-            if (count($definition->getTags())) {
-                foreach ($definition->getTags() as $tagName => $tagData) {
-                    foreach ($tagData as $parameters) {
-                        $data['tags'][] = array('name' => $tagName, 'parameters' => $parameters);
-                    }
+            foreach ($definition->getTags() as $tagName => $tagData) {
+                foreach ($tagData as $parameters) {
+                    $data['tags'][] = array('name' => $tagName, 'parameters' => $parameters);
                 }
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -183,24 +183,14 @@ class MarkdownDescriptor extends Descriptor
             ."\n".'- Public: '.($definition->isPublic() ? 'yes' : 'no')
             ."\n".'- Synthetic: '.($definition->isSynthetic() ? 'yes' : 'no')
             ."\n".'- Lazy: '.($definition->isLazy() ? 'yes' : 'no')
+            ."\n".'- Shared: '.($definition->isShared() ? 'yes' : 'no')
+            ."\n".'- Synchronized: '.($definition->isSynchronized(false) ? 'yes' : 'no')
+            ."\n".'- Abstract: '.($definition->isAbstract() ? 'yes' : 'no')
+            ."\n".'- Autowired: '.($definition->isAutowired() ? 'yes' : 'no')
         ;
 
-        if (method_exists($definition, 'isShared')) {
-            $output .= "\n".'- Shared: '.($definition->isShared() ? 'yes' : 'no');
-        }
-
-        if (method_exists($definition, 'isSynchronized')) {
-            $output .= "\n".'- Synchronized: '.($definition->isSynchronized(false) ? 'yes' : 'no');
-        }
-
-        $output .= "\n".'- Abstract: '.($definition->isAbstract() ? 'yes' : 'no');
-
-        if (method_exists($definition, 'isAutowired')) {
-            $output .= "\n".'- Autowired: '.($definition->isAutowired() ? 'yes' : 'no');
-
-            foreach ($definition->getAutowiringTypes() as $autowiringType) {
-                $output .= "\n".'- Autowiring Type: `'.$autowiringType.'`';
-            }
+        foreach ($definition->getAutowiringTypes() as $autowiringType) {
+            $output .= "\n".'- Autowiring Type: `'.$autowiringType.'`';
         }
 
         if ($definition->getFile()) {
@@ -371,7 +361,7 @@ class MarkdownDescriptor extends Descriptor
      */
     private function formatRouterConfig(array $array)
     {
-        if (!count($array)) {
+        if (!$array) {
             return 'NONE';
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -255,8 +255,7 @@ class TextDescriptor extends Descriptor
         $tableRows[] = array('Service ID', isset($options['id']) ? $options['id'] : '-');
         $tableRows[] = array('Class', $definition->getClass() ?: '-');
 
-        $tags = $definition->getTags();
-        if (count($tags)) {
+        if ($tags = $definition->getTags()) {
             $tagInformation = '';
             foreach ($tags as $tagName => $tagData) {
                 foreach ($tagData as $tagParameters) {
@@ -281,24 +280,12 @@ class TextDescriptor extends Descriptor
         $tableRows[] = array('Public', $definition->isPublic() ? 'yes' : 'no');
         $tableRows[] = array('Synthetic', $definition->isSynthetic() ? 'yes' : 'no');
         $tableRows[] = array('Lazy', $definition->isLazy() ? 'yes' : 'no');
-
-        if (method_exists($definition, 'isSynchronized')) {
-            $tableRows[] = array('Synchronized', $definition->isSynchronized(false) ? 'yes' : 'no');
-        }
+        $tableRows[] = array('Synchronized', $definition->isSynchronized(false) ? 'yes' : 'no');
         $tableRows[] = array('Abstract', $definition->isAbstract() ? 'yes' : 'no');
+        $tableRows[] = array('Autowired', $definition->isAutowired() ? 'yes' : 'no');
 
-        if (method_exists($definition, 'isAutowired')) {
-            $tableRows[] = array('Autowired', $definition->isAutowired() ? 'yes' : 'no');
-
-            $autowiringTypes = $definition->getAutowiringTypes();
-            if (count($autowiringTypes)) {
-                $autowiringTypesInformation = implode(', ', $autowiringTypes);
-            } else {
-                $autowiringTypesInformation = '-';
-            }
-
-            $tableRows[] = array('Autowiring Types', $autowiringTypesInformation);
-        }
+        $autowiringTypes = $definition->getAutowiringTypes();
+        $tableRows[] = array('Autowiring Types', $autowiringTypes ? implode(', ', $autowiringTypes) : '-');
 
         if ($definition->getFile()) {
             $tableRows[] = array('Required File', $definition->getFile() ? $definition->getFile() : '-');

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -187,7 +187,7 @@ class XmlDescriptor extends Descriptor
             $methodXML->appendChild(new \DOMText($method));
         }
 
-        if (count($route->getDefaults())) {
+        if ($route->getDefaults()) {
             $routeXML->appendChild($defaultsXML = $dom->createElement('defaults'));
             foreach ($route->getDefaults() as $attribute => $value) {
                 $defaultsXML->appendChild($defaultXML = $dom->createElement('default'));
@@ -198,7 +198,7 @@ class XmlDescriptor extends Descriptor
 
         $requirements = $route->getRequirements();
         unset($requirements['_scheme'], $requirements['_method']);
-        if (count($requirements)) {
+        if ($requirements) {
             $routeXML->appendChild($requirementsXML = $dom->createElement('requirements'));
             foreach ($requirements as $attribute => $pattern) {
                 $requirementsXML->appendChild($requirementXML = $dom->createElement('requirement'));
@@ -207,7 +207,7 @@ class XmlDescriptor extends Descriptor
             }
         }
 
-        if (count($route->getOptions())) {
+        if ($route->getOptions()) {
             $routeXML->appendChild($optionsXML = $dom->createElement('options'));
             foreach ($route->getOptions() as $name => $value) {
                 $optionsXML->appendChild($optionXML = $dom->createElement('option'));
@@ -331,18 +331,16 @@ class XmlDescriptor extends Descriptor
 
         $serviceXML->setAttribute('class', $definition->getClass());
 
-        if (method_exists($definition, 'getFactoryMethod')) {
-            if ($definition->getFactoryClass(false)) {
-                $serviceXML->setAttribute('factory-class', $definition->getFactoryClass(false));
-            }
+        if ($definition->getFactoryClass(false)) {
+            $serviceXML->setAttribute('factory-class', $definition->getFactoryClass(false));
+        }
 
-            if ($definition->getFactoryService(false)) {
-                $serviceXML->setAttribute('factory-service', $definition->getFactoryService(false));
-            }
+        if ($definition->getFactoryService(false)) {
+            $serviceXML->setAttribute('factory-service', $definition->getFactoryService(false));
+        }
 
-            if ($definition->getFactoryMethod(false)) {
-                $serviceXML->setAttribute('factory-method', $definition->getFactoryMethod(false));
-            }
+        if ($definition->getFactoryMethod(false)) {
+            $serviceXML->setAttribute('factory-method', $definition->getFactoryMethod(false));
         }
 
         if ($factory = $definition->getFactory()) {
@@ -366,24 +364,14 @@ class XmlDescriptor extends Descriptor
         $serviceXML->setAttribute('public', $definition->isPublic() ? 'true' : 'false');
         $serviceXML->setAttribute('synthetic', $definition->isSynthetic() ? 'true' : 'false');
         $serviceXML->setAttribute('lazy', $definition->isLazy() ? 'true' : 'false');
-        if (method_exists($definition, 'isShared')) {
-            $serviceXML->setAttribute('shared', $definition->isShared() ? 'true' : 'false');
-        }
-        if (method_exists($definition, 'isSynchronized')) {
-            $serviceXML->setAttribute('synchronized', $definition->isSynchronized(false) ? 'true' : 'false');
-        }
+        $serviceXML->setAttribute('shared', $definition->isShared() ? 'true' : 'false');
+        $serviceXML->setAttribute('synchronized', $definition->isSynchronized(false) ? 'true' : 'false');
         $serviceXML->setAttribute('abstract', $definition->isAbstract() ? 'true' : 'false');
-
-        if (method_exists($definition, 'isAutowired')) {
-            $serviceXML->setAttribute('autowired', $definition->isAutowired() ? 'true' : 'false');
-        }
-
+        $serviceXML->setAttribute('autowired', $definition->isAutowired() ? 'true' : 'false');
         $serviceXML->setAttribute('file', $definition->getFile());
 
         if (!$omitTags) {
-            $tags = $definition->getTags();
-
-            if (count($tags) > 0) {
+            if ($tags = $definition->getTags()) {
                 $serviceXML->appendChild($tagsXML = $dom->createElement('tags'));
                 foreach ($tags as $tagName => $tagData) {
                     foreach ($tagData as $parameters) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

As pointed out by @ogizanagi in https://github.com/symfony/symfony/pull/21315#discussion_r96476201, some code in FrameworkBundle's descriptors is useless because the bundle works only with DI 2.8.