### PR TITLE
[Yaml] Remove internal arguments from the api

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -65,3 +65,10 @@ Workflow
 
  * Deprecated class name support in `WorkflowRegistry::add()` as second parameter.
    Wrap the class name in an instance of ClassInstanceSupportStrategy instead.
+
+Yaml
+----
+
+ * The constructor arguments `$offset`, `$totalNumberOfLines` and
+   `$skippedLineNumbers` of the `Parser` class are deprecated and will be
+   removed in 4.0

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -391,6 +391,9 @@ Yaml
 
  * Duplicate mapping keys lead to a `ParseException`.
 
+ * The constructor arguments `$offset`, `$totalNumberOfLines` and
+   `$skippedLineNumbers` of the `Parser` class were removed.
+
 Ldap
 ----
 

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -32,18 +32,19 @@ class Parser
     private $skippedLineNumbers = array();
     private $locallySkippedLineNumbers = array();
 
-    /**
-     * Constructor.
-     *
-     * @param int      $offset             The offset of YAML document (used for line numbers in error messages)
-     * @param int|null $totalNumberOfLines The overall number of lines being parsed
-     * @param int[]    $skippedLineNumbers Number of comment lines that have been skipped by the parser
-     */
     public function __construct($offset = 0, $totalNumberOfLines = null, array $skippedLineNumbers = array())
     {
-        $this->offset = $offset;
-        $this->totalNumberOfLines = $totalNumberOfLines;
-        $this->skippedLineNumbers = $skippedLineNumbers;
+        if (func_num_args() > 0) {
+            @trigger_error(sprintf('The constructor arguments $offset, $totalNumberOfLines, $skippedLineNumbers of %s are deprecated and will be removed in 4.0', self::class), E_USER_DEPRECATED);
+
+            $this->offset = func_get_arg(0);
+            if (func_num_args() > 1) {
+                $this->totalNumberOfLines = func_get_arg(1);
+            }
+            if (func_num_args() > 2) {
+                $this->skippedLineNumbers = func_get_arg(2);
+            }
+        }
     }
 
     /**
@@ -384,7 +385,11 @@ class Parser
             $skippedLineNumbers[] = $lineNumber;
         }
 
-        $parser = new self($offset, $this->totalNumberOfLines, $skippedLineNumbers);
+        $parser = new self();
+        $parser->offset = $offset;
+        $parser->totalNumberOfLines = $this->totalNumberOfLines;
+        $parser->skippedLineNumbers = $skippedLineNumbers;
+
         $parser->refs = &$this->refs;
 
         return $parser->parse($yaml, $flags);

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -32,7 +32,7 @@ class Parser
     private $skippedLineNumbers = array();
     private $locallySkippedLineNumbers = array();
 
-    public function __construct($offset = 0, $totalNumberOfLines = null, array $skippedLineNumbers = array())
+    public function __construct()
     {
         if (func_num_args() > 0) {
             @trigger_error(sprintf('The constructor arguments $offset, $totalNumberOfLines, $skippedLineNumbers of %s are deprecated and will be removed in 4.0', self::class), E_USER_DEPRECATED);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21230
| License       | MIT
| Doc PR        | 

Reopening of https://github.com/symfony/symfony/pull/21230 because of [@xabbuh's comment](https://github.com/symfony/symfony/pull/21194#discussion_r96732559).

> This PR removes internal constructor arguments of the `Parser` class.
> This should break nothing as they are only used to build errors message and are clearly meant for internal uses.
> 
> This would allow to have a nicer api for https://github.com/symfony/symfony/pull/21194#discussion_r95158384.