### PR TITLE
[DependencyInjection] ActionBundle integration: introduce _instanceof

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -34,4 +34,18 @@ abstract class FileLoader extends BaseFileLoader
 
         parent::__construct($locator);
     }
+
+    /**
+     * Generates the ID of an "instanceof" definition.
+     *
+     * @param string $id
+     * @param string $type
+     * @param string $file
+     *
+     * @return string
+     */
+    protected function generateInstanceofDefinitionId($id, $type, $file)
+    {
+        return sprintf("%s_%s_%s", $id, $type, hash('sha256', $file));
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -46,6 +46,6 @@ abstract class FileLoader extends BaseFileLoader
      */
     protected function generateInstanceofDefinitionId($id, $type, $file)
     {
-        return sprintf("%s_%s_%s", $id, $type, hash('sha256', $file));
+        return sprintf('%s_%s_%s', $id, $type, hash('sha256', $file));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -46,6 +46,6 @@ abstract class FileLoader extends BaseFileLoader
      */
     protected function generateInstanceofDefinitionId($id, $type, $file)
     {
-        return sprintf('%s_%s_%s', $id, $type, hash('sha256', $file));
+        return sprintf('0%s_%s_%s', $id, $type, hash('sha256', $file));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -221,6 +221,7 @@ class XmlFileLoader extends FileLoader
             }
 
             if ($parentId) {
+                $s = clone $s;
                 $s->setAttribute('parent', $parentId);
             }
             $parentId = $this->generateInstanceofDefinitionId($id, $type, $file);

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -223,8 +223,7 @@ class XmlFileLoader extends FileLoader
             if ($parentId) {
                 $s->setAttribute('parent', $parentId);
             }
-            // TODO: move the ID generation or maybe the whole block in the parent class
-            $parentId = md5("$file.$type.$id");
+            $parentId = $this->generateInstanceofDefinitionId($id, $type, $file);
             $parentDefinition = $this->getDefinition($s, $file);
             $parentDefinition->setAbstract(true);
             if ($parentDefinition instanceof ChildDefinition) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -298,8 +298,7 @@ class YamlFileLoader extends FileLoader
             if ($parentId) {
                 $value['parent'] = $parentId;
             }
-            // TODO: move the ID generation or maybe the whole block in the parent class
-            $parentId = md5("$file.$type.$id");
+            $parentId = $this->generateInstanceofDefinitionId($id, $type, $file);
             $parentDefinition = $this->getDefinition($parentId, $value, $file, array());
             $parentDefinition->setAbstract(true);
             if ($parentDefinition instanceof ChildDefinition) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -159,8 +159,16 @@ class YamlFileLoader extends FileLoader
         }
 
         $defaults = $this->parseDefaults($content, $file);
+
+        if ($this->isUnderscoredParamValid($content, '_instanceof', $file)) {
+            $instanceof = $content['services']['_instanceof'];
+            unset($content['services']['_instanceof']);
+        } else {
+            $instanceof = array();
+        }
+
         foreach ($content['services'] as $id => $service) {
-            $this->parseDefinition($id, $service, $file, $defaults);
+            $this->parseDefinition($id, $service, $file, $defaults, $instanceof);
         }
     }
 
@@ -174,20 +182,13 @@ class YamlFileLoader extends FileLoader
      */
     private function parseDefaults(array &$content, $file)
     {
-        if (!isset($content['services']['_defaults'])) {
-            return $content;
-        }
-        if (!is_array($defaults = $content['services']['_defaults'])) {
-            throw new InvalidArgumentException(sprintf('Service defaults must be an array, "%s" given in "%s".', gettype($defaults), $file));
-        }
-        if (isset($defaults['alias']) || isset($defaults['class']) || isset($defaults['factory'])) {
-            @trigger_error('Giving a service the "_defaults" name is deprecated since Symfony 3.3 and will be forbidden in 4.0. Rename your service.', E_USER_DEPRECATED);
-
-            return $content;
+        if (!$this->isUnderscoredParamValid($content, '_defaults', $file)) {
+            return array();
         }
 
-        $defaultKeys = array('public', 'tags', 'inherit_tags', 'autowire');
+        $defaults = $content['services']['_defaults'];
         unset($content['services']['_defaults']);
+        $defaultKeys = array('public', 'tags', 'inherit_tags', 'autowire');
 
         foreach ($defaults as $key => $default) {
             if (!in_array($key, $defaultKeys)) {
@@ -226,6 +227,25 @@ class YamlFileLoader extends FileLoader
         return $defaults;
     }
 
+    private function isUnderscoredParamValid($content, $name, $file)
+    {
+        if (!isset($content['services'][$name])) {
+            return false;
+        }
+
+        if (!is_array($underscoreParam = $content['services'][$name])) {
+            throw new InvalidArgumentException(sprintf('Service "%s" key must be an array, "%s" given in "%s".', $name, gettype($underscoreParam), $file));
+        }
+
+        if (isset($underscoreParam['alias']) || isset($underscoreParam['class']) || isset($underscoreParam['factory'])) {
+            @trigger_error(sprintf('Giving a service the "%s" name is deprecated since Symfony 3.3 and will be forbidden in 4.0. Rename your service.', $name), E_USER_DEPRECATED);
+
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * Parses a definition.
      *
@@ -233,10 +253,11 @@ class YamlFileLoader extends FileLoader
      * @param array|string $service
      * @param string       $file
      * @param array        $defaults
+     * @param array        $instanceof
      *
      * @throws InvalidArgumentException When tags are invalid
      */
-    private function parseDefinition($id, $service, $file, array $defaults)
+    private function parseDefinition($id, $service, $file, array $defaults, array $instanceof)
     {
         if (is_string($service) && 0 === strpos($service, '@')) {
             $public = isset($defaults['public']) ? $defaults['public'] : true;
@@ -253,12 +274,6 @@ class YamlFileLoader extends FileLoader
             $service = array();
         }
 
-        if (!is_array($service)) {
-            throw new InvalidArgumentException(sprintf('A service definition must be an array or a string starting with "@" but %s found for service "%s" in %s. Check your YAML syntax.', gettype($service), $id, $file));
-        }
-
-        static::checkDefinition($id, $service, $file);
-
         if (isset($service['alias'])) {
             $public = array_key_exists('public', $service) ? (bool) $service['public'] : (isset($defaults['public']) ? $defaults['public'] : true);
             $this->container->setAlias($id, new Alias($service['alias'], $public));
@@ -271,6 +286,44 @@ class YamlFileLoader extends FileLoader
 
             return;
         }
+
+        $definition = $this->getDefinition($id, $service, $file, $defaults);
+        $className = $definition->getClass() ?: $id;
+        $parentId = $definition instanceof ChildDefinition ? $definition->getParent() : null;
+        foreach ($instanceof as $type => $value) {
+            if (!is_a($className, $type, true)) {
+                continue;
+            }
+
+            if ($parentId) {
+                $value['parent'] = $parentId;
+            }
+            // TODO: move the ID generation or maybe the whole block in the parent class
+            $parentId = md5("$file.$type.$id");
+            $parentDefinition = $this->getDefinition($parentId, $value, $file, array());
+            $parentDefinition->setAbstract(true);
+            if ($parentDefinition instanceof ChildDefinition) {
+                $definition->setInheritTags(true);
+            }
+            $this->container->setDefinition($parentId, $parentDefinition);
+        }
+
+        if (null !== $parentId) {
+            $service['parent'] = $parentId;
+            $definition = $this->getDefinition($id, $service, $file, $defaults);
+            $definition->setInheritTags(true);
+        }
+
+        $this->container->setDefinition($id, $definition);
+    }
+
+    private function getDefinition($id, $service, $file, array $defaults)
+    {
+        if (!is_array($service)) {
+            throw new InvalidArgumentException(sprintf('A service definition must be an array or a string starting with "@" but %s found for service "%s" in %s. Check your YAML syntax.', gettype($service), $id, $file));
+        }
+
+        static::checkDefinition($id, $service, $file);
 
         if (isset($service['parent'])) {
             $definition = new ChildDefinition($service['parent']);
@@ -430,7 +483,7 @@ class YamlFileLoader extends FileLoader
             }
         }
 
-        $this->container->setDefinition($id, $definition);
+        return $definition;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -55,6 +55,7 @@
     <xsd:choice maxOccurs="unbounded">
       <xsd:element name="service" type="service" minOccurs="1" />
       <xsd:element name="defaults" type="defaults" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="instanceof" type="instanceof" minOccurs="0" maxOccurs="1" />
     </xsd:choice>
   </xsd:complexType>
 
@@ -133,6 +134,12 @@
     <xsd:attribute name="decoration-priority" type="xsd:integer" />
     <xsd:attribute name="autowire" type="boolean" />
     <xsd:attribute name="inherit-tags" type="boolean" />
+  </xsd:complexType>
+
+  <xsd:complexType name="instanceof">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="service" type="service" minOccurs="1" />
+    </xsd:choice>
   </xsd:complexType>
 
   <xsd:complexType name="tag">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services32.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services32.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <instanceof>
+            <service id="Symfony\Component\DependencyInjection\Tests\Loader\BarInterface" lazy="true">
+                <autowire>__construct</autowire>
+                <tag name="foo" />
+                <tag name="bar" />
+            </service>
+        </instanceof>
+
+        <service id="Symfony\Component\DependencyInjection\Tests\Loader\Bar" class="Symfony\Component\DependencyInjection\Tests\Loader\Bar" />
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services32.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services32.yml
@@ -1,0 +1,10 @@
+services:
+    _instanceof:
+        Symfony\Component\DependencyInjection\Tests\Loader\FooInterface:
+            autowire: true
+            lazy: true
+            tags:
+                - { name: foo }
+                - { name: bar }
+
+    Symfony\Component\DependencyInjection\Tests\Loader\Foo: ~

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -658,4 +659,32 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('setFoo'), $container->getDefinition('no_defaults_child')->getAutowiredMethods());
         $this->assertSame(array(), $container->getDefinition('with_defaults_child')->getAutowiredMethods());
     }
+
+    public function testInstanceof()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath . '/xml'));
+        $loader->load('services32.xml');
+
+        $parentDefinition = $container->getDefinition('97c529c8fec609499e1a920f6f064edb');
+        $this->assertNotInstanceOf(ChildDefinition::class, $parentDefinition);
+        $this->assertTrue($parentDefinition->isAutowired());
+        $this->assertTrue($parentDefinition->isLazy());
+        $this->assertEquals(array('foo' => array(array()), 'bar' => array(array())), $parentDefinition->getTags());
+
+        $container->compile();
+
+        $definition = $container->getDefinition(Bar::class);
+        $this->assertTrue($definition->isAutowired());
+        $this->assertTrue($definition->isLazy());
+        $this->assertEquals(array('foo' => array(array()), 'bar' => array(array())), $definition->getTags());
+    }
+}
+
+interface BarInterface
+{
+}
+
+class Bar implements BarInterface
+{
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -666,7 +666,8 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath . '/xml'));
         $loader->load('services32.xml');
 
-        $parentDefinition = $container->getDefinition('97c529c8fec609499e1a920f6f064edb');
+        $definitions = $container->getDefinitions();
+        $parentDefinition = array_shift($definitions);
         $this->assertNotInstanceOf(ChildDefinition::class, $parentDefinition);
         $this->assertTrue($parentDefinition->isAutowired());
         $this->assertTrue($parentDefinition->isLazy());

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -663,7 +663,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
     public function testInstanceof()
     {
         $container = new ContainerBuilder();
-        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath . '/xml'));
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('services32.xml');
 
         $definitions = $container->getDefinitions();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Loader;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -405,6 +406,26 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($container->getDefinition('no_defaults_child')->isAutowired());
     }
 
+    public function testInstanceof()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services32.yml');
+
+        $parentDefinition = $container->getDefinition('ab31379cf807a57ab10c13685f0ee619');
+        $this->assertNotInstanceOf(ChildDefinition::class, $parentDefinition);
+        $this->assertTrue($parentDefinition->isAutowired());
+        $this->assertTrue($parentDefinition->isLazy());
+        $this->assertEquals(array('foo' => array(array()), 'bar' => array(array())), $parentDefinition->getTags());
+
+        $container->compile();
+
+        $definition = $container->getDefinition(Foo::class);
+        $this->assertTrue($definition->isAutowired());
+        $this->assertTrue($definition->isLazy());
+        $this->assertEquals(array('foo' => array(array()), 'bar' => array(array())), $definition->getTags());
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @expectedExceptionMessage The value of the "decorates" option for the "bar" service must be the id of the service without the "@" prefix (replace "@foo" with "foo").
@@ -414,4 +435,12 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('bad_decorates.yml');
     }
+}
+
+interface FooInterface
+{
+}
+
+class Foo implements FooInterface
+{
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -412,7 +412,8 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('services32.yml');
 
-        $parentDefinition = $container->getDefinition('ab31379cf807a57ab10c13685f0ee619');
+        $definitions = $container->getDefinitions();
+        $parentDefinition = array_shift($definitions);
         $this->assertNotInstanceOf(ChildDefinition::class, $parentDefinition);
         $this->assertTrue($parentDefinition->isAutowired());
         $this->assertTrue($parentDefinition->isLazy());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

There is some work being done to include features of [DunglasActionBundle](https://github.com/dunglas/DunglasActionBundle) in the core of Symfony. The goal of all those PRs is to improve the developper experience of the framework, allow to develop faster while preserving all benefits of using Symfony (strictness, modularity, extensibility...) and make it easier to learn for newcomers.

This PR implements the tagging feature of ActionBundle in a more generic way. It will help to get rid of `AppBundle` in the the standard edition and to register automatically some classes including commands.

Here is an example of config (that can be embedded in the standard edition) to enable those features:

```yaml
# config/services.yml
services:
    _defaults:
        autowire: ['get*', 'set*'] # Enable constructor, getter and setter autowiring for all services defined in this file

    _instanceof:
        Symfony\Component\Console\Command: # Add the console.command tag to all services defined in this file having this type
            tags: ['console.command']
            # Set tags but also other settings like "public", "autowire" or "shared" here

        Twig_ExtensionInterface:
            tags: ['twig.extension']

        Symfony\Component\EventDispatcher\EventSubscriberInterface:
            tags: ['kernel.event_subscriber']

    App\: # Register all classes in the src/Controller directory as services
        psr4: ../src/{Controller,Command,Twig,EventSubscriber}
```

It's part of our 0 config initiative: controllers and commands will be automatically registered as services and "autowired", allowing the user to create and inject new services without having to write a single line of YAML or XML.
When refactoring changes are also automatically updated and don't require to update config files. It's a big win for rapid application development and prototyping.

Of course, this is fully compatible with the actual way of defining services and it's possible to switch (or mix) approaches very easily. It's even possible to start prototyping using 0config features then switch to explicit services definitions when the project becomes mature.

Thanks a lot to @nicolas-grekas for defining the `_instanceof` syntax and giving hints for the implementation.

- [ ] Remove some code duplication