### PR TITLE
[PropertyAccess] Handle interfaces in the invalid argument exception

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -246,7 +246,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     private static function throwInvalidArgumentException($message, $trace, $i)
     {
         if (isset($trace[$i]['file']) && __FILE__ === $trace[$i]['file']) {
-            $pos = strpos($message, $delim = 'must be of the type ') ?: strpos($message, $delim = 'must be an instance of ');
+            $pos = strpos($message, $delim = 'must be of the type ') ?: (strpos($message, $delim = 'must be an instance of ') ?: strpos($message, $delim = 'must implement interface '));
             $pos += strlen($delim);
             $type = $trace[$i]['args'][0];
             $type = is_object($type) ? get_class($type) : gettype($type);

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TypeHinted.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TypeHinted.php
@@ -18,6 +18,11 @@ class TypeHinted
 {
     private $date;
 
+    /**
+     * @var \Countable
+     */
+    private $countable;
+
     public function setDate(\DateTime $date)
     {
         $this->date = $date;
@@ -26,5 +31,21 @@ class TypeHinted
     public function getDate()
     {
         return $this->date;
+    }
+
+    /**
+     * @return \Countable
+     */
+    public function getCountable()
+    {
+        return $this->countable;
+    }
+
+    /**
+     * @param \Countable $countable
+     */
+    public function setCountable(\Countable $countable)
+    {
+        $this->countable = $countable;
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -554,4 +554,15 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('baz', $this->propertyAccessor->getValue($object, 'publicAccessor[value2]'));
         $this->assertSame(array('value1' => 'foo', 'value2' => 'baz'), $object->getPublicAccessor());
     }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Expected argument of type "Countable", "string" given
+     */
+    public function testThrowTypeErrorWithInterface()
+    {
+        $object = new TypeHinted();
+
+        $this->propertyAccessor->setValue($object, 'countable', 'This is a string, \Countable expected.');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Before : 
`Expected argument of type "dule\MenuBundle\Entity\AbstractMenu::setMenuElements() must implement interface Doctrine\Common\Collections\Collection", "array" given`

After : 
`Expected argument of type "Doctrine\Common\Collections\Collection", "array" given`