### PR TITLE
[Cache] Be able to set indefinite lifetime on CacheItem independent from default value

### DIFF
--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -105,7 +105,7 @@ final class CacheItem implements CacheItemInterface
     public function clearExpiry()
     {
         $this->expiry = null;
-        
+
         return $this;
     }
 

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -68,9 +68,7 @@ final class CacheItem implements CacheItemInterface
      */
     public function expiresAt($expiration)
     {
-        if (0 === $expiration) {
-            $this->expiry = null;
-        } elseif (null === $expiration) {
+        if (null === $expiration) {
             $this->expiry = $this->defaultLifetime > 0 ? time() + $this->defaultLifetime : null;
         } elseif ($expiration instanceof \DateTimeInterface) {
             $this->expiry = (int) $expiration->format('U');
@@ -86,9 +84,7 @@ final class CacheItem implements CacheItemInterface
      */
     public function expiresAfter($time)
     {
-        if (0 === $time) {
-            $this->expiry = null;
-        } elseif (null === $time) {
+        if (null === $time) {
             $this->expiry = $this->defaultLifetime > 0 ? time() + $this->defaultLifetime : null;
         } elseif ($time instanceof \DateInterval) {
             $this->expiry = (int) \DateTime::createFromFormat('U', time())->add($time)->format('U');
@@ -98,6 +94,18 @@ final class CacheItem implements CacheItemInterface
             throw new InvalidArgumentException(sprintf('Expiration date must be an integer, a DateInterval, null, false or omitted, "%s" given', is_object($time) ? get_class($time) : gettype($time)));
         }
 
+        return $this;
+    }
+    
+    /**
+     * Remove the expiry time.
+     *
+     * @return static
+     */
+    public function clearExpiry()
+    {
+        $this->expiry = null;
+        
         return $this;
     }
 

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -66,9 +66,9 @@ final class CacheItem implements CacheItemInterface
     /**
      * {@inheritdoc}
      */
-    public function expiresAt($expiration = null)
+    public function expiresAt($expiration)
     {
-        if (0 === func_num_args()) {
+        if (0 === $expiration) {
             $this->expiry = null;
         } elseif (null === $expiration) {
             $this->expiry = $this->defaultLifetime > 0 ? time() + $this->defaultLifetime : null;
@@ -84,9 +84,9 @@ final class CacheItem implements CacheItemInterface
     /**
      * {@inheritdoc}
      */
-    public function expiresAfter($time = null)
+    public function expiresAfter($time)
     {
-        if (0 === func_num_args()) {
+        if (0 === $time) {
             $this->expiry = null;
         } elseif (null === $time) {
             $this->expiry = $this->defaultLifetime > 0 ? time() + $this->defaultLifetime : null;

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -73,7 +73,7 @@ final class CacheItem implements CacheItemInterface
         } elseif ($expiration instanceof \DateTimeInterface) {
             $this->expiry = (int) $expiration->format('U');
         } else {
-            throw new InvalidArgumentException(sprintf('Expiration date must implement DateTimeInterface, be null, be false, be omitted, "%s" given', is_object($expiration) ? get_class($expiration) : gettype($expiration)));
+            throw new InvalidArgumentException(sprintf('Expiration date must implement DateTimeInterface or be null, "%s" given', is_object($expiration) ? get_class($expiration) : gettype($expiration)));
         }
 
         return $this;
@@ -91,7 +91,7 @@ final class CacheItem implements CacheItemInterface
         } elseif (is_int($time)) {
             $this->expiry = $time + time();
         } else {
-            throw new InvalidArgumentException(sprintf('Expiration date must be an integer, a DateInterval, null, false or omitted, "%s" given', is_object($time) ? get_class($time) : gettype($time)));
+            throw new InvalidArgumentException(sprintf('Expiration date must be an integer, a DateInterval or null, "%s" given', is_object($time) ? get_class($time) : gettype($time)));
         }
 
         return $this;

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -96,7 +96,7 @@ final class CacheItem implements CacheItemInterface
 
         return $this;
     }
-    
+
     /**
      * Remove the expiry time.
      *

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -66,14 +66,16 @@ final class CacheItem implements CacheItemInterface
     /**
      * {@inheritdoc}
      */
-    public function expiresAt($expiration)
+    public function expiresAt($expiration = null)
     {
-        if (null === $expiration) {
+        if (0 === func_num_args()) {
+            $this->expiry = null;
+        } elseif (null === $expiration) {
             $this->expiry = $this->defaultLifetime > 0 ? time() + $this->defaultLifetime : null;
         } elseif ($expiration instanceof \DateTimeInterface) {
             $this->expiry = (int) $expiration->format('U');
         } else {
-            throw new InvalidArgumentException(sprintf('Expiration date must implement DateTimeInterface or be null, "%s" given', is_object($expiration) ? get_class($expiration) : gettype($expiration)));
+            throw new InvalidArgumentException(sprintf('Expiration date must implement DateTimeInterface, be null, be false, be omitted, "%s" given', is_object($expiration) ? get_class($expiration) : gettype($expiration)));
         }
 
         return $this;
@@ -82,16 +84,18 @@ final class CacheItem implements CacheItemInterface
     /**
      * {@inheritdoc}
      */
-    public function expiresAfter($time)
+    public function expiresAfter($time = null)
     {
-        if (null === $time) {
+        if (0 === func_num_args()) {
+            $this->expiry = null;
+        } elseif (null === $time) {
             $this->expiry = $this->defaultLifetime > 0 ? time() + $this->defaultLifetime : null;
         } elseif ($time instanceof \DateInterval) {
             $this->expiry = (int) \DateTime::createFromFormat('U', time())->add($time)->format('U');
         } elseif (is_int($time)) {
             $this->expiry = $time + time();
         } else {
-            throw new InvalidArgumentException(sprintf('Expiration date must be an integer, a DateInterval or null, "%s" given', is_object($time) ? get_class($time) : gettype($time)));
+            throw new InvalidArgumentException(sprintf('Expiration date must be an integer, a DateInterval, null, false or omitted, "%s" given', is_object($time) ? get_class($time) : gettype($time)));
         }
 
         return $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

One cannot set a cache item to be stored with an indefinite lifetime if it has a non-indefinite default value, at the moment. 