### PR TITLE
[FrameworkBundle] Execute the PhpDocExtractor earlier

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
@@ -15,7 +15,7 @@
         <!-- Extractor -->
         <service id="property_info.reflection_extractor" class="Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor" public="false">
             <tag name="property_info.list_extractor" priority="-1000" />
-            <tag name="property_info.type_extractor" priority="-1000" />
+            <tag name="property_info.type_extractor" priority="-1002" />
             <tag name="property_info.access_extractor" priority="-1000" />
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/PropertyInfoTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/PropertyInfoTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Component\PropertyInfo\Type;
+
+class PropertyInfoTest extends WebTestCase
+{
+    public function testPhpDocPriority()
+    {
+        static::bootKernel(array('test_case' => 'Serializer'));
+        $container = static::$kernel->getContainer();
+
+        $this->assertEquals(array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_INT))), $container->get('property_info')->getTypes(Dummy::class, 'codes'));
+    }
+}
+
+class Dummy
+{
+    /**
+     * @param int[] $codes
+     */
+    public function setCodes(array $codes)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes, but safer to apply on master
| New feature?  | no
| BC breaks?    | is changing a priority a bc break?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/21367
| License       | MIT
| Doc PR        | 

Fixes https://github.com/symfony/symfony/issues/21367.

> I wonder if this is logical to execute the PhpDocExtractor after the ReflectionExtractor: when you use phpdocs it's because they are more precise than php type hints.
This causes an issue in NelmioApiDocBundle, for example you can't use int[] with a setter as the type mixed[] will be returned instead of int[].
>
> ~~Would you accept bumping its priority to -999?~~

This PR changes the priority of the `ReflectionExtractor` to `-1002` to make sure it is executed after the `PhpDocExtractor`.