### PR TITLE
[DependencyInjection] Fixed variadic method parameter in autowired classes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -341,7 +341,7 @@ class AutowirePass implements CompilerPassInterface
             $methodArgumentsMetadata[] = array(
                 'class' => $class,
                 'isOptional' => $parameter->isOptional(),
-                'defaultValue' => $parameter->isOptional() ? $parameter->getDefaultValue() : null,
+                'defaultValue' => ($parameter->isOptional() && !$parameter->isVariadic()) ? $parameter->getDefaultValue() : null,
             );
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -338,10 +338,11 @@ class AutowirePass implements CompilerPassInterface
                 $class = false;
             }
 
+            $isVariadic = method_exists($parameter, 'isVariadic') && $parameter->isVariadic();
             $methodArgumentsMetadata[] = array(
                 'class' => $class,
                 'isOptional' => $parameter->isOptional(),
-                'defaultValue' => ($parameter->isOptional() && !$parameter->isVariadic()) ? $parameter->getDefaultValue() : null,
+                'defaultValue' => ($parameter->isOptional() && !$isVariadic) ? $parameter->getDefaultValue() : null,
             );
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -35,6 +35,20 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', (string) $container->getDefinition('bar')->getArgument(0));
     }
 
+    public function testProcessVariadic()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', __NAMESPACE__.'\Foo');
+        $definition = $container->register('fooVariadic', __NAMESPACE__.'\FooVariadic');
+        $definition->setAutowired(true);
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $this->assertCount(1, $container->getDefinition('fooVariadic')->getArguments());
+        $this->assertEquals('foo', (string) $container->getDefinition('fooVariadic')->getArgument(0));
+    }
+
     public function testProcessAutowireParent()
     {
         $container = new ContainerBuilder();
@@ -651,6 +665,17 @@ class IdenticalClassResource extends ClassForResource
 class ClassChangedConstructorArgs extends ClassForResource
 {
     public function __construct($foo, Bar $bar, $baz)
+    {
+    }
+}
+
+class FooVariadic
+{
+    public function __construct(Foo $foo)
+    {
+    }
+
+    public function bar(...$arguments)
     {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\AutowirePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\FooVariadic;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -35,11 +36,14 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', (string) $container->getDefinition('bar')->getArgument(0));
     }
 
+    /**
+     * @requires PHP 5.6
+     */
     public function testProcessVariadic()
     {
         $container = new ContainerBuilder();
         $container->register('foo', __NAMESPACE__.'\Foo');
-        $definition = $container->register('fooVariadic', __NAMESPACE__.'\FooVariadic');
+        $definition = $container->register('fooVariadic', FooVariadic::class);
         $definition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -665,17 +669,6 @@ class IdenticalClassResource extends ClassForResource
 class ClassChangedConstructorArgs extends ClassForResource
 {
     public function __construct($foo, Bar $bar, $baz)
-    {
-    }
-}
-
-class FooVariadic
-{
-    public function __construct(Foo $foo)
-    {
-    }
-
-    public function bar(...$arguments)
     {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -42,7 +42,7 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     public function testProcessVariadic()
     {
         $container = new ContainerBuilder();
-        $container->register('foo', __NAMESPACE__.'\Foo');
+        $container->register('foo', Foo::class);
         $definition = $container->register('fooVariadic', FooVariadic::class);
         $definition->setAutowired(true);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/FooVariadic.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/FooVariadic.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\includes;
+
+use Symfony\Component\DependencyInjection\Tests\Compiler\Foo;
+
+class FooVariadic
+{
+    public function __construct(Foo $foo)
+    {
+    }
+
+    public function bar(...$arguments)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | --
| License       | MIT

Autowiring classes containing methods with variadic method parameter throws a ReflectionException in compile process:

```
PHP Fatal error:  Uncaught ReflectionException: Internal error: Failed to retrieve the default value in /.../vendor/symfony/dependency-injection/Compiler/AutowirePass.php:437
Stack trace:
#0 /.../vendor/symfony/dependency-injection/Compiler/AutowirePass.php(437): ReflectionParameter->getDefaultValue()
#1 /.../vendor/symfony/dependency-injection/Compiler/AutowirePass.php(80): Symfony\Component\DependencyInjection\Compiler\AutowirePass::getResourceMetadataForMethod(Object(ReflectionMethod))
#2 /.../vendor/symfony/dependency-injection/Compiler/AutowirePass.php(105): Symfony\Component\DependencyInjection\Compiler\AutowirePass::createResourceForClass(Object(ReflectionClass))
#3 /.../vendor/symfony/dependency-injection/Compiler/AutowirePass.php(48): Symfony\Component\DependencyInjection\Compiler\AutowirePass->completeDefinition('__controller.Sw...', Object(Symfony\Component\DependencyInjection\Definition), Array)
#4 /.../vendor/symfony/dependency-injection/Compiler/Compiler in /.../vendor/symfony/dependency-injection/Compiler/AutowirePass.php on line 437
```

**Example:**
```
<?php
class FooVariadic
{
    public function bar(...$arguments)
    {
    }
}

$method = new ReflectionMethod(FooVariadic::class, 'bar');
$parameter = $method->getParameters()[0];
$parameter->getDefaultValue(); // -> ReflectionException: Internal error: Failed to retrieve the default value in ...
```
