### PR TITLE
[Routing] Mention AnnotationClassLoader BC break in changelog

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,35 @@
 CHANGELOG
 =========
 
+2.7.22
+-----
+
+ * [BC BREAK] The `AnnotationClassLoader` no longer sets request attributes from method arguments default values.
+   Define these attributes explicitly in the `@Route` annotation instead, as for other configuration formats.
+ 
+   Before:
+   
+   ```php
+    /**
+     * @Route("/hello/{name}", name="hello")
+     */
+    public function indexAction($name = null)
+    {
+        // ...
+    }
+   ```
+   
+   After:
+   ```php
+    /**
+     * @Route("/hello/{name}", name="hello", defaults={"name": null})
+     */
+    public function indexAction($name = null)
+    {
+        // ...
+    }
+   ```
+
 2.5.0
 -----
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Fixed tickets | https://github.com/symfony/symfony/commit/77289b902352adeefa6e7ec6bc09fe2565a9d9c7#commitcomment-20572720
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/7408

https://github.com/symfony/symfony/pull/21333 removed the autowiring of request attributes based on method arguments default values when using the `@Route` annotation. 
This feature was causing an annoying bug on argument resolvers and was inconsistent with other configuration formats which force to define the attributes explicitly.


