### PR TITLE
[Routing] Fix BC break in AnnotationClassLoader defaults attributes handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,8 @@
         "ircmaxell/password-compat": "~1.0",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "symfony/phpunit-bridge": "~3.2",
-        "egulias/email-validator": "~1.2,>=1.2.1"
+        "egulias/email-validator": "~1.2,>=1.2.1",
+        "sensio/framework-extra-bundle": "^3.0.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AnnotatedControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AnnotatedControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+class AnnotatedControllerTest extends WebTestCase
+{
+    /**
+     * @dataProvider getRoutes
+     */
+    public function testAnnotatedController($path, $expectedValue)
+    {
+        $client = $this->createClient(array('test_case' => 'AnnotatedController', 'root_config' => 'config.yml'));
+        $client->request('GET', '/annotated'.$path);
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame($expectedValue, $client->getResponse()->getContent());
+    }
+
+    public function getRoutes()
+    {
+        return array(
+            array('/null_request', 'Symfony\Component\HttpFoundation\Request'),
+            array('/null_argument', ''),
+            array('/null_argument_with_route_param', ''),
+            array('/null_argument_with_route_param/value', 'value'),
+            array('/argument_with_route_param_and_default', 'value'),
+            array('/argument_with_route_param_and_default/custom', 'custom'),
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/AnnotatedController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/AnnotatedController.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class AnnotatedController
+{
+    /**
+     * @Route("/null_request", name="null_request")
+     */
+    public function requestDefaultNullAction(Request $request = null)
+    {
+        return new Response($request ? get_class($request) : null);
+    }
+
+    /**
+     * @Route("/null_argument", name="null_argument")
+     */
+    public function argumentDefaultNullWithoutRouteParamAction($value = null)
+    {
+        return new Response($value);
+    }
+
+    /**
+     * @Route("/null_argument_with_route_param/{value}", name="null_argument_with_route_param")
+     */
+    public function argumentDefaultNullWithRouteParamAction($value = null)
+    {
+        return new Response($value);
+    }
+
+    /**
+     * @Route("/argument_with_route_param_and_default/{value}", defaults={"value": "value"}, name="argument_with_route_param_and_default")
+     */
+    public function argumentWithoutDefaultWithRouteParamAndDefaultAction($value)
+    {
+        return new Response($value);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/bundles.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
+
+return array(
+    new FrameworkBundle(),
+    new TestBundle(),
+    new SensioFrameworkExtraBundle(),
+);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/config.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: ../config/default.yml }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/routing.yml
@@ -1,0 +1,4 @@
+annotated_controller:
+    prefix:   /annotated
+    resource: "@TestBundle/Controller/AnnotatedController.php"
+    type:     annotation

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -25,7 +25,7 @@
         "symfony/http-foundation": "~2.7",
         "symfony/http-kernel": "~2.7.23|~2.8.16",
         "symfony/filesystem": "~2.3",
-        "symfony/routing": "~2.6,>2.6.4",
+        "symfony/routing": "~2.7.24|~2.8.17",
         "symfony/security-core": "~2.6.13|~2.7.9|~2.8",
         "symfony/security-csrf": "~2.6",
         "symfony/stopwatch": "~2.3",
@@ -45,7 +45,8 @@
         "symfony/expression-language": "~2.6",
         "symfony/process": "~2.0,>=2.0.5",
         "symfony/validator": "~2.5",
-        "symfony/yaml": "~2.0,>=2.0.5"
+        "symfony/yaml": "~2.0,>=2.0.5",
+        "sensio/framework-extra-bundle": "^3.0.2"
     },
     "suggest": {
         "symfony/console": "For using the console commands",

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -138,6 +138,11 @@ abstract class AnnotationClassLoader implements LoaderInterface
         }
 
         $defaults = array_replace($globals['defaults'], $annot->getDefaults());
+        foreach ($method->getParameters() as $param) {
+            if (false !== strpos($globals['path'].$annot->getPath(), sprintf('{%s}', $param->getName())) && !isset($defaults[$param->getName()]) && $param->isDefaultValueAvailable()) {
+                $defaults[$param->getName()] = $param->getDefaultValue();
+            }
+        }
         $requirements = array_replace($globals['requirements'], $annot->getRequirements());
         $options = array_replace($globals['options'], $annot->getOptions());
         $schemes = array_merge($globals['schemes'], $annot->getSchemes());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/commit/77289b902352adeefa6e7ec6bc09fe2565a9d9c7#commitcomment-20572462
| License       | MIT
| Doc PR        | n/a

This fixes a BC break introduced in #21333. Instead of removing the automatic request attributes creation, we keep it but only for attributes that are mandatory (i.e. present in the route path).

Thanks to @iltar for the idea.