### PR TITLE
[WebProfilerExtension] Fixes escaping for a safe output with multiple roles

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
@@ -66,7 +66,7 @@ class WebProfilerExtension extends \Twig_Extension_Profiler
     public function getFunctions()
     {
         $profilerDump = function (\Twig_Environment $env, $value, $maxDepth = 0) {
-            return $value instanceof Data ? $this->dumpData($env, $value, $maxDepth) : twig_escape_filter($env, $this->dumpValue($value));
+            return $value instanceof Data ? $this->dumpData($env, $value, $maxDepth) : $this->dumpValue($value);
         };
 
         return array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21384
| License       | MIT
| Doc PR        | ~

This fixes the issue reported about escaping the the roles if multiple are shown. I don't think this should be filtered by twig as this was not present in the old version in 3.1. /cc @wouterj 