### PR TITLE
Fix double escaping of the decision attributes in the profiler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -257,7 +257,13 @@
                                 : '<span class="label status-error same-width">DENIED</span>'
                             }}
                         </td>
-                        <td>{{ decision.attributes|length == 1 ? decision.attributes|first : profiler_dump(decision.attributes) }}</td>
+                        <td>
+                            {% if decision.attributes|length == 1 %}
+                                {{ decision.attributes|first }}
+                            {% else %}
+                                {{ profiler_dump(decision.attributes) }}
+                            {% endif %}
+                        </td>
                         <td>{{ profiler_dump(decision.object) }}</td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21384
| License       | MIT
| Doc PR        | n/a

A ternary operator is considered safe by the Twig auto-escaping only when both branches are safe. But this ternary was safe only in the ELSE branch, causing it to be unsafe. This triggered a double-escaping of the value (escaping the output of the dump). The fix is to use a {% if %} and 2 separate output statements, allowing them to be auto-escaped separately.

