### PR TITLE
[Debug] Deprecate ContextErrorException

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -6,6 +6,11 @@ ClassLoader
 
  * The component is deprecated and will be removed in 4.0. Use Composer instead.
 
+Debug
+-----
+
+ * The `ContextErrorException` class is deprecated. `\ErrorException` will be used instead in 4.0.
+
 DependencyInjection
 -------------------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -15,6 +15,9 @@ Console
 Debug
 -----
 
+
+ * The `ContextErrorException` class has been removed. Use `\ErrorException` instead.
+
  * `FlattenException::getTrace()` now returns additional type descriptions
    `integer` and `float`.
 

--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.3.0
+-----
+
+* deprecated the `ContextErrorException` class: use \ErrorException directly now
+
 3.2.0
 -----
 

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -521,9 +521,6 @@ class ErrorHandler
                 }
             } elseif ($exception instanceof \ErrorException) {
                 $message = 'Uncaught '.$exception->getMessage();
-                if ($exception instanceof ContextErrorException) {
-                    $e['context'] = $exception->getContext();
-                }
             } else {
                 $message = 'Uncaught Exception: '.$exception->getMessage();
             }

--- a/src/Symfony/Component/Debug/Exception/ContextErrorException.php
+++ b/src/Symfony/Component/Debug/Exception/ContextErrorException.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Debug\Exception;
  * Error Exception with Variable Context.
  *
  * @author Christian Sciberras <uuf6429@gmail.com>
+ *
+ * @deprecated since version 3.3. Instead, \ErrorException will be used directly in 4.0.
  */
 class ContextErrorException extends \ErrorException
 {
@@ -31,6 +33,8 @@ class ContextErrorException extends \ErrorException
      */
     public function getContext()
     {
+        @trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0.', __CLASS__), E_USER_DEPRECATED);
+
         return $this->context;
     }
 }

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Debug\Tests;
 use Psr\Log\LogLevel;
 use Symfony\Component\Debug\BufferingLogger;
 use Symfony\Component\Debug\ErrorHandler;
-use Symfony\Component\Debug\Exception\ContextErrorException;
 use Symfony\Component\Debug\Exception\SilencedErrorContext;
 
 /**
@@ -71,13 +70,12 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
         try {
             self::triggerNotice($this);
-            $this->fail('ContextErrorException expected');
-        } catch (ContextErrorException $exception) {
+            $this->fail('ErrorException expected');
+        } catch (\ErrorException $exception) {
             // if an exception is thrown, the test passed
             $this->assertEquals(E_NOTICE, $exception->getSeverity());
             $this->assertEquals(__FILE__, $exception->getFile());
             $this->assertRegExp('/^Notice: Undefined variable: (foo|bar)/', $exception->getMessage());
-            $this->assertArrayHasKey('foobar', $exception->getContext());
 
             $trace = $exception->getTrace();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Since the `$context` argument is going to be deprecated in PHP 7.2 (see https://wiki.php.net/rfc/deprecations_php_7_2#errcontext_argument_of_error_handler), let's deprecate ContextErrorException altogether.