### PR TITLE
[DI][Autowiring] Better resolve decorated services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -58,6 +58,7 @@ class DecoratorServicePass implements CompilerPassInterface
                 $decoratedDefinition->setPublic(false);
                 $decoratedDefinition->setTags(array());
                 $decoratedDefinition->setAutowiringTypes(array());
+                $decoratedDefinition->setDecorator($id);
                 $container->setDefinition($renamedId, $decoratedDefinition);
             }
 

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -36,6 +36,7 @@ class Definition
     private $abstract = false;
     private $lazy = false;
     private $decoratedService;
+    private $decorator;
     private $autowiredMethods = array();
     private $autowiringTypes = array();
 
@@ -113,6 +114,18 @@ class Definition
     public function getDecoratedService()
     {
         return $this->decoratedService;
+    }
+
+    public function setDecorator($id)
+    {
+        $this->decorator = $id;
+
+        return $this;
+    }
+
+    public function getDecorator()
+    {
+        return $this->decorator;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21351 
| License       | MIT
| Doc PR        | n/a

Given:
```yaml
services:
    App\Decorated: ~

    App\Decorator:
        decorates: App\Decorated
        arguments: ['@App\Decorator.inner']

    App\Autowired:
        autowire: true
```

```php
namespace App;

interface Common
{
}

class Decorated implements Common
{
}

class Decorator implements Common
{
    public function __construct(Common $inner)
    {
        $this->inner = $inner;
    }
}

class Autowired
{
    public function __construct(Common $service)
    {
        $this->service = $service;
    }
}
```

```php
dump($container->get(\App\Autowired::class));
```

__Before__
> Unable to autowire argument of type "AppBundle\Common" for the service "AppBundle\Autowired". Multiple services exist for this interface (AppBundle\Decorator, AppBundle\Decorator.inner).

__After__
```
Autowired {#4577 ▼
  +"service": Decorator {#2982 ▼
    +"inner": Decorated {#4324}
  }
}
```

It also works if the `App\Decorator` service is autowired.