### PR TITLE
[Serializer] fix upper camel case conversion (see #21399)

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -44,14 +44,15 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
     public function normalize($propertyName)
     {
         if (null === $this->attributes || in_array($propertyName, $this->attributes)) {
+            $lcPropertyName = lcfirst($propertyName);
             $snakeCasedName = '';
 
-            $len = strlen($propertyName);
+            $len = strlen($lcPropertyName);
             for ($i = 0; $i < $len; ++$i) {
-                if (ctype_upper($propertyName[$i])) {
-                    $snakeCasedName .= '_'.strtolower($propertyName[$i]);
+                if (ctype_upper($lcPropertyName[$i])) {
+                    $snakeCasedName .= '_'.strtolower($lcPropertyName[$i]);
                 } else {
-                    $snakeCasedName .= strtolower($propertyName[$i]);
+                    $snakeCasedName .= strtolower($lcPropertyName[$i]);
                 }
             }
 

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
@@ -27,27 +27,30 @@ class CamelCaseToSnakeCaseNameConverterTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider attributeProvider
      */
-    public function testNormalize($underscored, $lowerCamelCased)
+    public function testNormalize($underscored, $camelCased, $useLowerCamelCase)
     {
-        $nameConverter = new CamelCaseToSnakeCaseNameConverter();
-        $this->assertEquals($nameConverter->normalize($lowerCamelCased), $underscored);
+        $nameConverter = new CamelCaseToSnakeCaseNameConverter(null, $useLowerCamelCase);
+        $this->assertEquals($nameConverter->normalize($camelCased), $underscored);
     }
 
     /**
      * @dataProvider attributeProvider
      */
-    public function testDenormalize($underscored, $lowerCamelCased)
+    public function testDenormalize($underscored, $camelCased, $useLowerCamelCase)
     {
-        $nameConverter = new CamelCaseToSnakeCaseNameConverter();
-        $this->assertEquals($nameConverter->denormalize($underscored), $lowerCamelCased);
+        $nameConverter = new CamelCaseToSnakeCaseNameConverter(null, $useLowerCamelCase);
+        $this->assertEquals($nameConverter->denormalize($underscored), $camelCased);
     }
 
     public function attributeProvider()
     {
         return array(
-            array('coop_tilleuls', 'coopTilleuls'),
-            array('_kevin_dunglas', '_kevinDunglas'),
-            array('this_is_a_test', 'thisIsATest'),
+            array('coop_tilleuls', 'coopTilleuls', true),
+            array('_kevin_dunglas', '_kevinDunglas', true),
+            array('this_is_a_test', 'thisIsATest', true),
+            array('coop_tilleuls', 'CoopTilleuls', false),
+            array('_kevin_dunglas', '_kevinDunglas', false),
+            array('this_is_a_test', 'ThisIsATest', false),
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21399 
| License       | MIT

Improve upper camel case support of CamelCaseToSnakeCaseConverter (`ThisIsATest` now converts to `this_is_a_test` instead of `_this_is_a_test`).