### PR TITLE
[DI] Add ContainerBuilder::fileExists() for checking/tracking resource existence

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/DoctrineValidationPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/DoctrineValidationPass.php
@@ -13,7 +13,6 @@ namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\Config\Resource\FileResource;
 
 /**
  * Registers additional validators.
@@ -60,9 +59,8 @@ class DoctrineValidationPass implements CompilerPassInterface
 
         foreach ($container->getParameter('kernel.bundles') as $bundle) {
             $reflection = new \ReflectionClass($bundle);
-            if (is_file($file = dirname($reflection->getFileName()).'/'.$validationPath)) {
+            if ($container->fileExists($file = dirname($reflection->getFileName()).'/'.$validationPath)) {
                 $files[] = $file;
-                $container->addResource(new FileResource($file));
             }
         }
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\TwigBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -108,10 +107,9 @@ class TwigExtension extends Extension
             }
         }
 
-        if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/views')) {
+        if ($container->fileExists($dir = $container->getParameter('kernel.root_dir').'/Resources/views', false)) {
             $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir));
         }
-        $container->addResource(new FileExistenceResource($dir));
 
         if (!empty($config['globals'])) {
             $def = $container->getDefinition('twig');
@@ -164,15 +162,13 @@ class TwigExtension extends Extension
                 );
             }
 
-            if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$name.'/views')) {
+            if ($container->fileExists($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$name.'/views', false)) {
                 $bundleHierarchy[$name]['paths'][] = $dir;
             }
-            $container->addResource(new FileExistenceResource($dir));
 
-            if (is_dir($dir = $bundle['path'].'/Resources/views')) {
+            if ($container->fileExists($dir = $bundle['path'].'/Resources/views', false)) {
                 $bundleHierarchy[$name]['paths'][] = $dir;
             }
-            $container->addResource(new FileExistenceResource($dir));
 
             if (null === $bundle['parent']) {
                 continue;

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "symfony/asset": "~2.8|~3.0",
         "symfony/stopwatch": "~2.8|~3.0",
-        "symfony/dependency-injection": "~2.8|~3.0",
+        "symfony/dependency-injection": "~3.3",
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/finder": "~2.8|~3.0",
         "symfony/form": "~2.8|~3.0",
@@ -35,6 +35,9 @@
         "symfony/yaml": "~2.8|~3.0",
         "symfony/framework-bundle": "^3.2.2",
         "doctrine/annotations": "~1.0"
+    },
+    "conflict": {
+        "symfony/dependency-injection": "<3.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\TwigBundle\\": "" },

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.3.0
 -----
 
+ * added `ContainerBuilder::fileExists()` for checking and tracking file or directory existence
  * deprecated autowiring-types, use aliases instead
  * [EXPERIMENTAL] added support for getter-injection
  * added support for omitting the factory class name in a service definition if the definition class is set

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -15,6 +15,7 @@ require_once __DIR__.'/Fixtures/includes/classes.php';
 require_once __DIR__.'/Fixtures/includes/ProjectExtension.php';
 
 use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
@@ -680,6 +681,25 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array($a, $b), $resources, '->getResources() returns an array of resources read for the current configuration');
         $this->assertSame($container, $container->setResources(array()));
         $this->assertEquals(array(), $container->getResources());
+    }
+
+    public function testFileExists()
+    {
+        $container = new ContainerBuilder();
+        $a = new FileResource(__DIR__.'/Fixtures/xml/services1.xml');
+        $b = new FileResource(__DIR__.'/Fixtures/xml/services2.xml');
+        $c = new DirectoryResource($dir = dirname($b));
+
+        $this->assertTrue($container->fileExists((string) $a) && $container->fileExists((string) $b) && $container->fileExists($dir));
+
+        $resources = array();
+        foreach ($container->getResources() as $resource) {
+            if (false === strpos($resource, '.php')) {
+                $resources[] = $resource;
+            }
+        }
+
+        $this->assertEquals(array($a, $b, $c), $resources, '->getResources() returns an array of resources read for the current configuration');
     }
 
     public function testExtension()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20189, https://github.com/symfony/symfony/pull/20189#issuecomment-263077473
| License       | MIT
| Doc PR        | n/a

~~Finishes https://github.com/symfony/symfony/pull/20189~~ Adds a convenient `ContainerBuilder::fileExists()` method as suggested by Nicolas and use it to track resources in the FrameworkExtension, adding some missing ones. 