### PR TITLE
[DependencyInjection] clarify exception when no args are configured

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -302,6 +302,10 @@ class Definition
      */
     public function replaceArgument($index, $argument)
     {
+        if (0 === count($this->arguments)) {
+            throw new OutOfBoundsException('Cannot replace arguments if none have been configured yet.');
+        }
+
         if ($index < 0 || $index > count($this->arguments) - 1) {
             throw new OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d].', $index, count($this->arguments) - 1));
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -232,6 +232,7 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \OutOfBoundsException
+     * @expectedExceptionMessage The index "1" is not in the range [0, 0].
      */
     public function testReplaceArgumentShouldCheckBounds()
     {
@@ -239,6 +240,16 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
 
         $def->addArgument('foo');
         $def->replaceArgument(1, 'bar');
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     * @expectedExceptionMessage Cannot replace arguments if none have been configured yet.
+     */
+    public function testReplaceArgumentWithoutExistingArgumentsShouldCheckBounds()
+    {
+        $def = new Definition('stdClass');
+        $def->replaceArgument(0, 'bar');
     }
 
     public function testSetGetProperties()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21412
| License       | MIT
| Doc PR        | 