### PR TITLE
Use proper error message when session write fails #20807

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
@@ -35,6 +35,14 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
         $this->saveHandlerName = $this->wrapper ? ini_get('session.save_handler') : 'user';
     }
 
+    /**
+     * @return \SessionHandlerInterface
+     */
+    public function getHandler(): \SessionHandlerInterface
+    {
+        return $this->handler;
+    }
+
     // \SessionHandlerInterface
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
@@ -38,7 +38,7 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
     /**
      * @return \SessionHandlerInterface
      */
-    public function getHandler(): \SessionHandlerInterface
+    public function getHandler()
     {
         return $this->handler;
     }


### PR DESCRIPTION
This improves the error message that is thrown if a session write fails (see #20807)

As there was no way to get the actual handler, I introduced a method on the SessionHandlerProxy. I hope that's okay, otherwise please give me a hint on what to do.

| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20807
| License       | MIT