### PR TITLE
[HttpFoundation] Precalculate expiry timestamp

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -43,26 +43,7 @@ FrameworkBundle
 HttpFoundation
 --------------
 
- * The schema of the `PdoSessionHandler` to store sessions in a database changed.
-   The following changes must be made to your `session` table:
-
-   - Create a new `sess_expiry` column. In MySQL this would be:
-
-      ```sql
-      ALTER TABLE `session` ADD `sess_expiry` INTEGER UNSIGNED NOT NULL;
-      ```
-
-   - Migrate the old data to the `sess_expiry` column. In MySQL this would be:
-
-      ```sql
-      UPDATE `session` SET `sess_expiry` = `sess_time` + `sess_lifetime`;
-      ```
-
-   - Remove the `sess_time` and `sess_lifetime` columns. In MySQL this would be:
-
-       ```sql
-       ALTER TABLE `session` DROP COLUMN `sess_time`, DROP COLUMN `sess_lifetime`;
-       ```
+ * The `PdoSessionHandler` option `db_lifetime_col` has been deprecated.
 
 HttpKernel
 -----------

--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -39,6 +39,30 @@ FrameworkBundle
 ---------------
 
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConsoleCommandPass` has been deprecated. Use `Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass` instead.
+ 
+HttpFoundation
+--------------
+
+ * The schema of the `PdoSessionHandler` to store sessions in a database changed.
+   The following changes must be made to your `session` table:
+
+   - Create a new `sess_expiry` column. In MySQL this would be:
+
+      ```sql
+      ALTER TABLE `session` ADD `sess_expiry` INTEGER UNSIGNED NOT NULL;
+      ```
+
+   - Migrate the old data to the `sess_expiry` column. In MySQL this would be:
+
+      ```sql
+      UPDATE `session` SET `sess_expiry` = `sess_time` + `sess_lifetime`;
+      ```
+
+   - Remove the `sess_time` and `sess_lifetime` columns. In MySQL this would be:
+
+       ```sql
+       ALTER TABLE `session` DROP COLUMN `sess_time`, DROP COLUMN `sess_lifetime`;
+       ```
 
 HttpKernel
 -----------

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
    disabling `Range` and `Content-Length` handling, switching to chunked encoding instead
  * added the `Cookie::fromString()` method that allows to create a cookie from a
    raw header string
- * PdoSessionHandler: [BC BREAK] removed the `lifetime` and `timestamp` columns in favor of `expiry` column
+ * PdoSessionHandler: Deprecated the the `lifetime` column
  
 3.1.0
 -----

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -8,7 +8,8 @@ CHANGELOG
    disabling `Range` and `Content-Length` handling, switching to chunked encoding instead
  * added the `Cookie::fromString()` method that allows to create a cookie from a
    raw header string
-
+ * PdoSessionHandler: [BC BREAK] removed the `lifetime` and `timestamp` columns in favor of `expiry` column
+ 
 3.1.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -97,8 +97,10 @@ class PdoSessionHandler implements \SessionHandlerInterface
 
     /**
      * @var string Column for lifetime
+     *
+     * @deprecated since version 3.3, to be removed in 4.0
      */
-    private $expiryCol = 'sess_expiry';
+    private $lifetimeCol = 'sess_lifetime';
 
     /**
      * @var string Column for timestamp
@@ -159,7 +161,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
      *  * db_table: The name of the table [default: sessions]
      *  * db_id_col: The column where to store the session id [default: sess_id]
      *  * db_data_col: The column where to store the session data [default: sess_data]
-     *  * db_expiry_col: The column where to store the expirytime [default: sess_expiry]
+     *  * db_lifetime_col: The column where to store the lifetime [default: sess_lifetime]
      *  * db_time_col: The column where to store the timestamp [default: sess_time]
      *  * db_username: The username when lazy-connect [default: '']
      *  * db_password: The password when lazy-connect [default: '']
@@ -187,12 +189,16 @@ class PdoSessionHandler implements \SessionHandlerInterface
         $this->table = isset($options['db_table']) ? $options['db_table'] : $this->table;
         $this->idCol = isset($options['db_id_col']) ? $options['db_id_col'] : $this->idCol;
         $this->dataCol = isset($options['db_data_col']) ? $options['db_data_col'] : $this->dataCol;
-        $this->expiryCol = isset($options['db_expiry_col']) ? $options['db_expiry_col'] : $this->expiryCol;
+        $this->lifetimeCol = isset($options['db_lifetime_col']) ? $options['db_lifetime_col'] : $this->lifetimeCol;
         $this->timeCol = isset($options['db_time_col']) ? $options['db_time_col'] : $this->timeCol;
         $this->username = isset($options['db_username']) ? $options['db_username'] : $this->username;
         $this->password = isset($options['db_password']) ? $options['db_password'] : $this->password;
         $this->connectionOptions = isset($options['db_connection_options']) ? $options['db_connection_options'] : $this->connectionOptions;
         $this->lockMode = isset($options['lock_mode']) ? $options['lock_mode'] : $this->lockMode;
+
+        if ($this->lifetimeCol !== false) {
+            @trigger_error('Using the "db_lifetime_col" option is deprecated since version 3.3 as it will be removed in 4.0.', E_USER_DEPRECATED);
+        }
     }
 
     /**
@@ -211,29 +217,56 @@ class PdoSessionHandler implements \SessionHandlerInterface
         // connect if we are not yet
         $this->getConnection();
 
-        switch ($this->driver) {
-            case 'mysql':
-                // We use varbinary for the ID column because it prevents unwanted conversions:
-                // - character set conversions between server and client
-                // - trailing space removal
-                // - case-insensitivity
-                // - language processing like é == e
-                $sql = "CREATE TABLE $this->table ($this->idCol VARBINARY(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->expiryCol MEDIUMINT NOT NULL, $this->timeCol INTEGER UNSIGNED NOT NULL) COLLATE utf8_bin, ENGINE = InnoDB";
-                break;
-            case 'sqlite':
-                $sql = "CREATE TABLE $this->table ($this->idCol TEXT NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->expiryCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
-                break;
-            case 'pgsql':
-                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BYTEA NOT NULL, $this->expiryCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
-                break;
-            case 'oci':
-                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR2(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->expiryCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
-                break;
-            case 'sqlsrv':
-                $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol VARBINARY(MAX) NOT NULL, $this->expiryCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
-                break;
-            default:
-                throw new \DomainException(sprintf('Creating the session table is currently not implemented for PDO driver "%s".', $this->driver));
+        if ($this->lifetimeCol === false) {
+            switch ($this->driver) {
+                case 'mysql':
+                    // We use varbinary for the ID column because it prevents unwanted conversions:
+                    // - character set conversions between server and client
+                    // - trailing space removal
+                    // - case-insensitivity
+                    // - language processing like é == e
+                    $sql = "CREATE TABLE $this->table ($this->idCol VARBINARY(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->timeCol INTEGER UNSIGNED NOT NULL) COLLATE utf8_bin, ENGINE = InnoDB";
+                    break;
+                case 'sqlite':
+                    $sql = "CREATE TABLE $this->table ($this->idCol TEXT NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                    break;
+                case 'pgsql':
+                    $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BYTEA NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                    break;
+                case 'oci':
+                    $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR2(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                    break;
+                case 'sqlsrv':
+                    $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol VARBINARY(MAX) NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                    break;
+                default:
+                    throw new \DomainException(sprintf('Creating the session table is currently not implemented for PDO driver "%s".', $this->driver));
+            }
+        } else {
+            switch ($this->driver) {
+                case 'mysql':
+                    // We use varbinary for the ID column because it prevents unwanted conversions:
+                    // - character set conversions between server and client
+                    // - trailing space removal
+                    // - case-insensitivity
+                    // - language processing like é == e
+                    $sql = "CREATE TABLE $this->table ($this->idCol VARBINARY(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol MEDIUMINT NOT NULL, $this->timeCol INTEGER UNSIGNED NOT NULL) COLLATE utf8_bin, ENGINE = InnoDB";
+                    break;
+                case 'sqlite':
+                    $sql = "CREATE TABLE $this->table ($this->idCol TEXT NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                    break;
+                case 'pgsql':
+                    $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol BYTEA NOT NULL, $this->lifetimeCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                    break;
+                case 'oci':
+                    $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR2(128) NOT NULL PRIMARY KEY, $this->dataCol BLOB NOT NULL, $this->lifetimeCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                    break;
+                case 'sqlsrv':
+                    $sql = "CREATE TABLE $this->table ($this->idCol VARCHAR(128) NOT NULL PRIMARY KEY, $this->dataCol VARBINARY(MAX) NOT NULL, $this->lifetimeCol INTEGER NOT NULL, $this->timeCol INTEGER NOT NULL)";
+                    break;
+                default:
+                    throw new \DomainException(sprintf('Creating the session table is currently not implemented for PDO driver "%s".', $this->driver));
+            }
         }
 
         try {
@@ -333,12 +366,11 @@ class PdoSessionHandler implements \SessionHandlerInterface
             }
 
             $updateStmt = $this->pdo->prepare(
-                "UPDATE $this->table SET $this->dataCol = :data, $this->expiryCol = :expiry, $this->timeCol = :time WHERE $this->idCol = :id"
+                "UPDATE $this->table SET $this->dataCol = :data, $this->timeCol = :time WHERE $this->idCol = :id"
             );
             $updateStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
             $updateStmt->bindParam(':data', $data, \PDO::PARAM_LOB);
-            $updateStmt->bindValue(':expiry', time() + $maxlifetime, \PDO::PARAM_INT);
-            $updateStmt->bindValue(':time', time(), \PDO::PARAM_INT);
+            $updateStmt->bindValue(':time', time() + $maxlifetime, \PDO::PARAM_INT);
             $updateStmt->execute();
 
             // When MERGE is not supported, like in Postgres < 9.5, we have to use this approach that can result in
@@ -348,13 +380,18 @@ class PdoSessionHandler implements \SessionHandlerInterface
             // false positives due to longer gap locking.
             if (!$updateStmt->rowCount()) {
                 try {
-                    $insertStmt = $this->pdo->prepare(
-                        "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->expiryCol, $this->timeCol) VALUES (:id, :data, :expiry, :time)"
-                    );
+                    if ($this->lifetimeCol === false) {
+                        $insertStmt = $this->pdo->prepare(
+                            "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time)"
+                        );
+                    } else {
+                        $insertStmt = $this->pdo->prepare(
+                            "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, 0, :time)"
+                        );
+                    }
                     $insertStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
                     $insertStmt->bindParam(':data', $data, \PDO::PARAM_LOB);
-                    $insertStmt->bindValue(':expiry', time() + $maxlifetime, \PDO::PARAM_INT);
-                    $insertStmt->bindValue(':time', time(), \PDO::PARAM_INT);
+                    $insertStmt->bindValue(':time', time() + $maxlifetime, \PDO::PARAM_INT);
                     $insertStmt->execute();
                 } catch (\PDOException $e) {
                     // Handle integrity violation SQLSTATE 23000 (or a subclass like 23505 in Postgres) for duplicate keys
@@ -389,7 +426,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
             $this->gcCalled = false;
 
             // delete the session records that have expired
-            $sql = "DELETE FROM $this->table WHERE $this->expiryCol < :time";
+            $sql = "DELETE FROM $this->table WHERE $this->timeCol < :time";
 
             $stmt = $this->pdo->prepare($sql);
             $stmt->bindValue(':time', time(), \PDO::PARAM_INT);
@@ -523,13 +560,19 @@ class PdoSessionHandler implements \SessionHandlerInterface
                 // Exclusive-reading of non-existent rows does not block, so we need to do an insert to block
                 // until other connections to the session are committed.
                 try {
-                    $insertStmt = $this->pdo->prepare(
-                        "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->expiryCol, $this->timeCol) VALUES (:id, :data, :expiry, :time)"
-                    );
+                    if ($this->lifetimeCol === false) {
+                        $insertStmt = $this->pdo->prepare(
+                            "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time)"
+                        );
+                    } else {
+                        $insertStmt = $this->pdo->prepare(
+                            "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, 0, :time)"
+                        );
+                    }
+
                     $insertStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
                     $insertStmt->bindValue(':data', '', \PDO::PARAM_LOB);
-                    $insertStmt->bindValue(':expiry', 0, \PDO::PARAM_INT);
-                    $insertStmt->bindValue(':time', time(), \PDO::PARAM_INT);
+                    $insertStmt->bindValue(':time', 0, \PDO::PARAM_INT);
                     $insertStmt->execute();
                 } catch (\PDOException $e) {
                     // Catch duplicate key error because other connection created the session already.
@@ -629,9 +672,9 @@ class PdoSessionHandler implements \SessionHandlerInterface
                 case 'mysql':
                 case 'oci':
                 case 'pgsql':
-                    return "SELECT $this->dataCol, $this->expiryCol, $this->timeCol FROM $this->table WHERE $this->idCol = :id FOR UPDATE";
+                    return "SELECT $this->dataCol, $this->timeCol FROM $this->table WHERE $this->idCol = :id FOR UPDATE";
                 case 'sqlsrv':
-                    return "SELECT $this->dataCol, $this->expiryCol, $this->timeCol FROM $this->table WITH (UPDLOCK, ROWLOCK) WHERE $this->idCol = :id";
+                    return "SELECT $this->dataCol, $this->timeCol FROM $this->table WITH (UPDLOCK, ROWLOCK) WHERE $this->idCol = :id";
                 case 'sqlite':
                     // we already locked when starting transaction
                     break;
@@ -640,7 +683,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
             }
         }
 
-        return "SELECT $this->dataCol, $this->expiryCol, $this->timeCol FROM $this->table WHERE $this->idCol = :id";
+        return "SELECT $this->dataCol, $this->timeCol FROM $this->table WHERE $this->idCol = :id";
     }
 
     /**
@@ -655,31 +698,61 @@ class PdoSessionHandler implements \SessionHandlerInterface
     private function getMergeStatement($sessionId, $data, $maxlifetime)
     {
         $mergeSql = null;
-        switch (true) {
-            case 'mysql' === $this->driver:
-                $mergeSql = "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->expiryCol, $this->timeCol) VALUES (:id, :data, :expiry, :time) ".
-                    "ON DUPLICATE KEY UPDATE $this->dataCol = VALUES($this->dataCol), $this->expiryCol = VALUES($this->expiryCol), $this->timeCol = VALUES($this->timeCol)";
-                break;
-            case 'oci' === $this->driver:
-                // DUAL is Oracle specific dummy table
-                $mergeSql = "MERGE INTO $this->table USING DUAL ON ($this->idCol = ?) ".
-                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->expiryCol, $this->timeCol) VALUES (?, ?, ?, ?) ".
-                    "WHEN MATCHED THEN UPDATE SET $this->dataCol = ?, $this->expiryCol = ?, $this->timeCol = ?";
-                break;
-            case 'sqlsrv' === $this->driver && version_compare($this->pdo->getAttribute(\PDO::ATTR_SERVER_VERSION), '10', '>='):
-                // MERGE is only available since SQL Server 2008 and must be terminated by semicolon
-                // It also requires HOLDLOCK according to http://weblogs.sqlteam.com/dang/archive/2009/01/31/UPSERT-Race-Condition-With-MERGE.aspx
-                $mergeSql = "MERGE INTO $this->table WITH (HOLDLOCK) USING (SELECT 1 AS dummy) AS src ON ($this->idCol = ?) ".
-                    "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->expiryCol, $this->timeCol) VALUES (?, ?, ?, ?) ".
-                    "WHEN MATCHED THEN UPDATE SET $this->dataCol = ?, $this->expiryCol = ?, $this->timeCol = ?;";
-                break;
-            case 'sqlite' === $this->driver:
-                $mergeSql = "INSERT OR REPLACE INTO $this->table ($this->idCol, $this->dataCol, $this->expiryCol, $this->timeCol) VALUES (:id, :data, :expiry, :time)";
-                break;
-            case 'pgsql' === $this->driver && version_compare($this->pdo->getAttribute(\PDO::ATTR_SERVER_VERSION), '9.5', '>='):
-                $mergeSql = "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->expiryCol, $this->timeCol) VALUES (:id, :data, :expiry, :time) ".
-                    "ON CONFLICT ($this->idCol) DO UPDATE SET ($this->dataCol, $this->expiryCol, $this->timeCol) = (EXCLUDED.$this->dataCol, EXCLUDED.$this->expiryCol, EXCLUDED.$this->timeCol)";
-                break;
+
+        if ($this->lifetimeCol === false) {
+            switch (true) {
+                case 'mysql' === $this->driver:
+                    $mergeSql = "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time) ".
+                        "ON DUPLICATE KEY UPDATE $this->dataCol = VALUES($this->dataCol), $this->timeCol = VALUES($this->timeCol)";
+                    break;
+                case 'oci' === $this->driver:
+                    // DUAL is Oracle specific dummy table
+                    $mergeSql = "MERGE INTO $this->table USING DUAL ON ($this->idCol = ?) ".
+                        "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->timeCol) VALUES (?, ?, ?) ".
+                        "WHEN MATCHED THEN UPDATE SET $this->dataCol = ?, $this->timeCol = ?";
+                    break;
+                case 'sqlsrv' === $this->driver && version_compare($this->pdo->getAttribute(\PDO::ATTR_SERVER_VERSION), '10', '>='):
+                    // MERGE is only available since SQL Server 2008 and must be terminated by semicolon
+                    // It also requires HOLDLOCK according to http://weblogs.sqlteam.com/dang/archive/2009/01/31/UPSERT-Race-Condition-With-MERGE.aspx
+                    $mergeSql = "MERGE INTO $this->table WITH (HOLDLOCK) USING (SELECT 1 AS dummy) AS src ON ($this->idCol = ?) ".
+                        "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->timeCol) VALUES (?, ?, ?) ".
+                        "WHEN MATCHED THEN UPDATE SET $this->dataCol = ?, $this->timeCol = ?;";
+                    break;
+                case 'sqlite' === $this->driver:
+                    $mergeSql = "INSERT OR REPLACE INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time)";
+                    break;
+                case 'pgsql' === $this->driver && version_compare($this->pdo->getAttribute(\PDO::ATTR_SERVER_VERSION), '9.5', '>='):
+                    $mergeSql = "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->timeCol) VALUES (:id, :data, :time) ".
+                        "ON CONFLICT ($this->idCol) DO UPDATE SET ($this->dataCol, $this->timeCol) = (EXCLUDED.$this->dataCol, EXCLUDED.$this->timeCol)";
+                    break;
+            }
+        } else {
+            switch (true) {
+                case 'mysql' === $this->driver:
+                    $mergeSql = "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, 0, :time) ".
+                        "ON DUPLICATE KEY UPDATE $this->dataCol = VALUES($this->dataCol), $this->lifetimeCol = VALUES($this->lifetimeCol), $this->timeCol = VALUES($this->timeCol)";
+                    break;
+                case 'oci' === $this->driver:
+                    // DUAL is Oracle specific dummy table
+                    $mergeSql = "MERGE INTO $this->table USING DUAL ON ($this->idCol = ?) ".
+                        "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (?, ?, 0, ?) ".
+                        "WHEN MATCHED THEN UPDATE SET $this->dataCol = ?, $this->lifetimeCol = 0, $this->timeCol = ?";
+                    break;
+                case 'sqlsrv' === $this->driver && version_compare($this->pdo->getAttribute(\PDO::ATTR_SERVER_VERSION), '10', '>='):
+                    // MERGE is only available since SQL Server 2008 and must be terminated by semicolon
+                    // It also requires HOLDLOCK according to http://weblogs.sqlteam.com/dang/archive/2009/01/31/UPSERT-Race-Condition-With-MERGE.aspx
+                    $mergeSql = "MERGE INTO $this->table WITH (HOLDLOCK) USING (SELECT 1 AS dummy) AS src ON ($this->idCol = ?) ".
+                        "WHEN NOT MATCHED THEN INSERT ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (?, ?, 0, ?) ".
+                        "WHEN MATCHED THEN UPDATE SET $this->dataCol = ?, $this->lifetimeCol = 0, $this->timeCol = ?;";
+                    break;
+                case 'sqlite' === $this->driver:
+                    $mergeSql = "INSERT OR REPLACE INTO $this->table ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, 0, :time)";
+                    break;
+                case 'pgsql' === $this->driver && version_compare($this->pdo->getAttribute(\PDO::ATTR_SERVER_VERSION), '9.5', '>='):
+                    $mergeSql = "INSERT INTO $this->table ($this->idCol, $this->dataCol, $this->lifetimeCol, $this->timeCol) VALUES (:id, :data, 0, :time) ".
+                        "ON CONFLICT ($this->idCol) DO UPDATE SET ($this->dataCol, $this->lifetimeCol, $this->timeCol) = (EXCLUDED.$this->dataCol, EXCLUDED.$this->lifetimeCol, EXCLUDED.$this->timeCol)";
+                    break;
+            }
         }
 
         if (null !== $mergeSql) {
@@ -690,15 +763,12 @@ class PdoSessionHandler implements \SessionHandlerInterface
                 $mergeStmt->bindParam(2, $sessionId, \PDO::PARAM_STR);
                 $mergeStmt->bindParam(3, $data, \PDO::PARAM_LOB);
                 $mergeStmt->bindValue(4, time() + $maxlifetime, \PDO::PARAM_INT);
-                $mergeStmt->bindValue(5, time(), \PDO::PARAM_INT);
-                $mergeStmt->bindParam(6, $data, \PDO::PARAM_LOB);
-                $mergeStmt->bindValue(7, time() + $maxlifetime, \PDO::PARAM_INT);
-                $mergeStmt->bindValue(8, time(), \PDO::PARAM_INT);
+                $mergeStmt->bindParam(5, $data, \PDO::PARAM_LOB);
+                $mergeStmt->bindValue(6, time() + $maxlifetime, \PDO::PARAM_INT);
             } else {
                 $mergeStmt->bindParam(':id', $sessionId, \PDO::PARAM_STR);
                 $mergeStmt->bindParam(':data', $data, \PDO::PARAM_LOB);
-                $mergeStmt->bindValue(':expiry', time() + $maxlifetime, \PDO::PARAM_INT);
-                $mergeStmt->bindValue(':time', time(), \PDO::PARAM_INT);
+                $mergeStmt->bindValue(':time', time() + $maxlifetime, \PDO::PARAM_INT);
             }
 
             return $mergeStmt;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -146,7 +146,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $stream = $this->createStream($content);
 
         $pdo->prepareResult->expects($this->once())->method('fetchAll')
-            ->will($this->returnValue(array(array($stream, 42, time()))));
+            ->will($this->returnValue(array(array($stream, 42 + time()))));
 
         $storage = new PdoSessionHandler($pdo);
         $result = $storage->read('foo');
@@ -174,7 +174,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
         $selectStmt->expects($this->atLeast(2))->method('fetchAll')
             ->will($this->returnCallback(function () use (&$exception, $stream) {
-                return $exception ? array(array($stream, 42, time())) : array();
+                return $exception ? array(array($stream, 42 + time())) : array();
             }));
 
         $insertStmt->expects($this->once())->method('execute')

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -41,7 +41,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $storage = new PdoSessionHandler($pdo);
+        $storage = new PdoSessionHandler($pdo, array('db_lifetime_col' => false));
         $storage->createTable();
 
         return $pdo;
@@ -55,7 +55,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $pdo = $this->getMemorySqlitePdo();
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_SILENT);
 
-        $storage = new PdoSessionHandler($pdo);
+        $storage = new PdoSessionHandler($pdo, array('db_lifetime_col' => false));
     }
 
     /**
@@ -63,7 +63,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInexistentTable()
     {
-        $storage = new PdoSessionHandler($this->getMemorySqlitePdo(), array('db_table' => 'inexistent_table'));
+        $storage = new PdoSessionHandler($this->getMemorySqlitePdo(), array('db_table' => 'inexistent_table', 'db_lifetime_col' => false));
         $storage->open('', 'sid');
         $storage->read('id');
         $storage->write('id', 'data');
@@ -75,7 +75,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateTableTwice()
     {
-        $storage = new PdoSessionHandler($this->getMemorySqlitePdo());
+        $storage = new PdoSessionHandler($this->getMemorySqlitePdo(), array('db_lifetime_col' => false));
         $storage->createTable();
     }
 
@@ -83,7 +83,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $dsn = $this->getPersistentSqliteDsn();
 
-        $storage = new PdoSessionHandler($dsn);
+        $storage = new PdoSessionHandler($dsn, array('db_lifetime_col' => false));
         $storage->createTable();
         $storage->open('', 'sid');
         $data = $storage->read('id');
@@ -102,7 +102,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $dsn = $this->getPersistentSqliteDsn();
 
         // Open is called with what ini_set('session.save_path', $dsn) would mean
-        $storage = new PdoSessionHandler(null);
+        $storage = new PdoSessionHandler(null, array('db_lifetime_col' => false));
         $storage->open($dsn, 'sid');
         $storage->createTable();
         $data = $storage->read('id');
@@ -120,7 +120,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $sessionData = 'da'."\0".'ta';
 
-        $storage = new PdoSessionHandler($this->getMemorySqlitePdo());
+        $storage = new PdoSessionHandler($this->getMemorySqlitePdo(), array('db_lifetime_col' => false));
         $storage->open('', 'sid');
         $readData = $storage->read('id');
         $storage->write('id', $sessionData);
@@ -148,7 +148,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $pdo->prepareResult->expects($this->once())->method('fetchAll')
             ->will($this->returnValue(array(array($stream, 42 + time()))));
 
-        $storage = new PdoSessionHandler($pdo);
+        $storage = new PdoSessionHandler($pdo, array('db_lifetime_col' => false));
         $result = $storage->read('foo');
 
         $this->assertSame($content, $result);
@@ -182,7 +182,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
                 throw $exception = new \PDOException('', '23');
             }));
 
-        $storage = new PdoSessionHandler($pdo);
+        $storage = new PdoSessionHandler($pdo, array('db_lifetime_col' => false));
         $result = $storage->read('foo');
 
         $this->assertSame($content, $result);
@@ -190,7 +190,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testReadingRequiresExactlySameId()
     {
-        $storage = new PdoSessionHandler($this->getMemorySqlitePdo());
+        $storage = new PdoSessionHandler($this->getMemorySqlitePdo(), array('db_lifetime_col' => false));
         $storage->open('', 'sid');
         $storage->write('id', 'data');
         $storage->write('test', 'data');
@@ -215,7 +215,8 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testWriteDifferentSessionIdThanRead()
     {
-        $storage = new PdoSessionHandler($this->getMemorySqlitePdo());
+        $storage = new PdoSessionHandler($this->getMemorySqlitePdo(), array('db_lifetime_col' => false));
+        $storage->open('', 'sid');
         $storage->open('', 'sid');
         $storage->read('id');
         $storage->destroy('id');
@@ -232,7 +233,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
     public function testWrongUsageStillWorks()
     {
         // wrong method sequence that should no happen, but still works
-        $storage = new PdoSessionHandler($this->getMemorySqlitePdo());
+        $storage = new PdoSessionHandler($this->getMemorySqlitePdo(), array('db_lifetime_col' => false));
         $storage->write('id', 'data');
         $storage->write('other_id', 'other_data');
         $storage->destroy('inexistent');
@@ -248,7 +249,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
     public function testSessionDestroy()
     {
         $pdo = $this->getMemorySqlitePdo();
-        $storage = new PdoSessionHandler($pdo);
+        $storage = new PdoSessionHandler($pdo, array('db_lifetime_col' => false));
 
         $storage->open('', 'sid');
         $storage->read('id');
@@ -272,7 +273,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $previousLifeTime = ini_set('session.gc_maxlifetime', 1000);
         $pdo = $this->getMemorySqlitePdo();
-        $storage = new PdoSessionHandler($pdo);
+        $storage = new PdoSessionHandler($pdo, array('db_lifetime_col' => false));
 
         $storage->open('', 'sid');
         $storage->read('id');
@@ -299,7 +300,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetConnection()
     {
-        $storage = new PdoSessionHandler($this->getMemorySqlitePdo());
+        $storage = new PdoSessionHandler($this->getMemorySqlitePdo(), array('db_lifetime_col' => false));
 
         $method = new \ReflectionMethod($storage, 'getConnection');
         $method->setAccessible(true);
@@ -309,7 +310,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetConnectionConnectsIfNeeded()
     {
-        $storage = new PdoSessionHandler('sqlite::memory:');
+        $storage = new PdoSessionHandler('sqlite::memory:', array('db_lifetime_col' => false));
 
         $method = new \ReflectionMethod($storage, 'getConnection');
         $method->setAccessible(true);


### PR DESCRIPTION
Removed timestamp and lifetime columns in favor of expiry column.
Based on the work done in https://github.com/symfony/symfony/pull/14625.

Fix #13955.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13955
| License       | MIT
| Doc PR        | TBD

