### PR TITLE
[FrameworkBundle] Revert AbstractDescriptorTest output trimming

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -193,7 +193,7 @@ abstract class AbstractDescriptorTest extends \PHPUnit_Framework_TestCase
         if ('json' === $this->getFormat()) {
             $this->assertEquals(json_decode($expectedDescription), json_decode($output->fetch()));
         } else {
-            $this->assertEquals(trim(preg_replace('/[\s\t\r]+/', ' ', $expectedDescription)), trim(preg_replace('/[\s\t\r]+/', ' ', str_replace(PHP_EOL, "\n", $output->fetch()))));
+            $this->assertEquals(trim($expectedDescription), trim(str_replace(PHP_EOL, "\n", $output->fetch())));
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -15,6 +15,16 @@ use Symfony\Bundle\FrameworkBundle\Console\Descriptor\TextDescriptor;
 
 class TextDescriptorTest extends AbstractDescriptorTest
 {
+    protected function setUp()
+    {
+        putenv('COLUMNS=121');
+    }
+
+    protected function tearDown()
+    {
+        putenv('COLUMNS');
+    }
+
     protected function getDescriptor()
     {
         return new TextDescriptor();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no, but fixes an annoying/unhelping test output and fixes false positives
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21129/files#diff-0e52187cbf1067a310538287da74ddb5R178
| License       | MIT
| Doc PR        | N/A

#### Before output when having a failing test, for instance, in a `TextDescriptor` fixture:

```diff
There was 1 failure:

1) Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TextDescriptorTest::testDescribeContainerDefinitionWhichIsAnAlias with data set #1 (Symfony\Component\DependencyInjection\Alias Object (...), ' // This serv...------', Symfony\Component\DependencyInjection\ContainerBuilder Object (...), array('alias_2'))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-' // This service is an alias for the service service_2 Information for Service "service_2" =================================== ------------------ ---------------------------------  Option   Value  ------------------ --------------------------------- Class Full\Qualified\Class2 Tags tag1 (attr1: val1, attr2: val2) tag1 (attr3: val3) tag2 Calls setMailer Public no Synthetic yes Lazy no Shared yes Abstract no Autowired no Autowiring Types - Required File /path/to/file Factory Service factory.service Factory Method get ------------------ ---------------------------------'
+' // This service is an alias for the service service_2 Information for Service "service_2" =================================== ------------------ ---------------------------------  Option   Value  ------------------ --------------------------------- Service ID service_2 Class Full\Qualified\Class2 Tags tag1 (attr1: val1, attr2: val2) tag1 (attr3: val3) tag2 Calls setMailer Public no Synthetic yes Lazy no Shared yes Abstract no Autowired no Autowiring Types - Required File /path/to/file Factory Service factory.service Factory Method get ------------------ ---------------------------------'
```

#### After:

```diff
There was 1 failure:

1) Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TextDescriptorTest::testDescribeContainerDefinitionWhichIsAnAlias with data set #1 (Symfony\Component\DependencyInjection\Alias Object (...), ' // This serv...------', Symfony\Component\DependencyInjection\ContainerBuilder Object (...), array('alias_2'))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
  ------------------ --------------------------------- 
+  Service ID         service_2                        
   Class              Full\Qualified\Class2            
   Tags               tag1 (attr1: val1, attr2: val2)  
                      tag1 (attr3: val3)               
                      tag2                             
   Calls              setMailer                        
   Public             no                               
   Synthetic          yes                              
   Lazy               no                               
   Shared             yes                              
   Abstract           no                               
   Autowired          no                               
   Autowiring Types   -                                
   Required File      /path/to/file                    
   Factory Service    factory.service                  
   Factory Method     get                              
  ------------------ ---------------------------------'
```