### PR TITLE
Casting TableCell value to string.

### DIFF
--- a/src/Symfony/Component/Console/Helper/TableCell.php
+++ b/src/Symfony/Component/Console/Helper/TableCell.php
@@ -30,12 +30,12 @@ class TableCell
     );
 
     /**
-     * @param string $value
+     * @param string|int|float $value
      * @param array  $options
      */
     public function __construct($value = '', array $options = array())
     {
-        $this->value = $value;
+        $this->value = (string) $value;
 
         // check option names
         if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
@@ -52,7 +52,7 @@ class TableCell
      */
     public function __toString()
     {
-        return (string) $this->value;
+        return $this->value;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/TableCell.php
+++ b/src/Symfony/Component/Console/Helper/TableCell.php
@@ -30,7 +30,7 @@ class TableCell
     );
 
     /**
-     * @param string|int|float $value
+     * @param string $value
      * @param array  $options
      */
     public function __construct($value = '', array $options = array())

--- a/src/Symfony/Component/Console/Helper/TableCell.php
+++ b/src/Symfony/Component/Console/Helper/TableCell.php
@@ -52,7 +52,7 @@ class TableCell
      */
     public function __toString()
     {
-        return $this->value;
+        return (string) $this->value;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/TableCell.php
+++ b/src/Symfony/Component/Console/Helper/TableCell.php
@@ -35,7 +35,11 @@ class TableCell
      */
     public function __construct($value = '', array $options = array())
     {
-        $this->value = (string) $value;
+        if (is_numeric($value) && !is_string($value)) {
+            $value = (string) $value;
+        }
+
+        $this->value = $value;
 
         // check option names
         if ($diff = array_diff(array_keys($options), array_keys($this->options))) {

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -514,6 +514,24 @@ TABLE;
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
+    public function testTableCellWithNumericValue()
+    {
+        $table = new Table($output = $this->getOutputStream());
+
+        $table->setRows([[new TableCell(12345)]]);
+        $table->render();
+
+        $expected =
+<<<'TABLE'
++-------+
+| 12345 |
++-------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
     public function testStyle()
     {
         $style = new TableStyle();

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -514,7 +514,7 @@ TABLE;
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
-    public function testTableCellWithNumericValue()
+    public function testTableCellWithNumericIntValue()
     {
         $table = new Table($output = $this->getOutputStream());
 
@@ -526,6 +526,24 @@ TABLE;
 +-------+
 | 12345 |
 +-------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    public function testTableCellWithNumericFloatValue()
+    {
+        $table = new Table($output = $this->getOutputStream());
+
+        $table->setRows(array(array(new TableCell(12345.01))));
+        $table->render();
+
+        $expected =
+<<<'TABLE'
++----------+
+| 12345.01 |
++----------+
 
 TABLE;
 

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -518,7 +518,7 @@ TABLE;
     {
         $table = new Table($output = $this->getOutputStream());
 
-        $table->setRows([[new TableCell(12345)]]);
+        $table->setRows(array(array(new TableCell(12345))));
         $table->render();
 
         $expected =


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21429
| License       | MIT
| Doc PR        | 

PHP throws a catchable fatal error when the value from this method is
used in strstr in the Table class. This fixes the error by casting to a string before returning the value.