### PR TITLE
Update attrribute id for XliffFileDumper

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -85,7 +85,7 @@ class XliffFileDumper extends FileDumper
         foreach ($messages->all($domain) as $source => $target) {
             $translation = $dom->createElement('trans-unit');
 
-            $translation->setAttribute('id', md5($source));
+            $translation->setAttribute('id', sha1($domain . '::' . $source));
             $translation->setAttribute('resname', $source);
 
             $s = $translation->appendChild($dom->createElement('source'));
@@ -145,7 +145,7 @@ class XliffFileDumper extends FileDumper
 
         foreach ($messages->all($domain) as $source => $target) {
             $translation = $dom->createElement('unit');
-            $translation->setAttribute('id', md5($source));
+            $translation->setAttribute('id', sha1($domain . '::' . $source));
 
             $segment = $translation->appendChild($dom->createElement('segment'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Currenty `md5($source)` is used as attribute id when dumping xliff files. This causes problems with at least one translation service, `PhraseApp` (www.phraseapp.com). In `PhraseApp` all translation ids have to be unique, this means a second translation from another domain is currently ignored.

This PR solves this by using `sha1($domain . '::' . $source)` as translation id, to ensure uniqueness accross all domains.