### PR TITLE
[FrameworkBundle][Router][DX] Invalidate routing cache when container has changed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Routing;
 
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Routing\Router as BaseRouter;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -52,6 +53,10 @@ class Router extends BaseRouter implements WarmableInterface
     {
         if (null === $this->collection) {
             $this->collection = $this->container->get('routing.loader')->load($this->resource, $this->options['resource_type']);
+
+            $containerClassPath = sprintf('%s/%s.php', $this->container->getParameter('kernel.cache_dir'), $this->container->getParameter('kernel.container_class'));
+            $this->collection->addResource(new FileResource($containerClassPath));
+
             $this->resolveParameters($this->collection);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21426
| License       | MIT
| Doc PR        | N/A

This tries to fix #21426 by adding the container class as a resource of the main `RouteCollection`, allowing the router to invalidate its cache if the container has changed.

There are many places & ways this could have been done:

1. From the component `Router` class, by adding a router option/method to accept arbitrary resources to add.
1. From the framework bundle `Router` class, by adding a specific `container_class` option.
1. From the framework bundle `DelegatingLoader` class.
1. From the framework bundle `Router` class, directly from the container parameters (current implementation)

WDYT?

~~I consider this as a DX enhancement rather than a real bug fix though, hence this PR targets master.~~