### PR TITLE
[DependencyInjection] AutowirePass: remove a useless method call

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -88,7 +88,7 @@ class AutowirePass extends AbstractRecursivePass implements CompilerPassInterfac
         }
 
         $autowiredMethods = $this->getMethodsToAutowire($reflectionClass, $autowiredMethods);
-        $methodCalls = $value->getMethodCalls();
+        $originMethodCalls = $methodCalls = $value->getMethodCalls();
 
         if ($constructor = $reflectionClass->getConstructor()) {
             array_unshift($methodCalls, array($constructor->name, $value->getArguments()));
@@ -106,7 +106,7 @@ class AutowirePass extends AbstractRecursivePass implements CompilerPassInterfac
             }
         }
 
-        if ($methodCalls !== $value->getMethodCalls()) {
+        if ($methodCalls !== $originMethodCalls) {
             $value->setMethodCalls($methodCalls);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a
