### PR TITLE
[TwigBundle] Fix the name of the cache warming test class

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 
-class NewCacheWamingTest extends \PHPUnit_Framework_TestCase
+class CacheWarmingTest extends \PHPUnit_Framework_TestCase
 {
     public function testCacheIsProperlyWarmedWhenTemplatingIsAvailable()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Rename the test class according to PSR-4.