### PR TITLE
[DI][DX] Do not map id to class for global classes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
@@ -30,7 +30,7 @@ class ResolveClassPass implements CompilerPassInterface
             if ($definition instanceof ChildDefinition || $definition->isSynthetic() || null !== $definition->getClass()) {
                 continue;
             }
-            if (preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+$/', $id)) {
+            if (preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $id)) {
                 $this->changes[strtolower($id)] = $id;
                 $definition->setClass($id);
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveClassPassTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
+
+class ResolveClassPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideValidClassId
+     */
+    public function testResolveClassFromId($serviceId)
+    {
+        $pass = new ResolveClassPass();
+        $container = new ContainerBuilder();
+        $def = $container->register($serviceId);
+
+        $pass->process($container);
+
+        $this->assertSame($serviceId, $def->getClass());
+    }
+
+    public function provideValidClassId()
+    {
+        yield array('Acme\UnknownClass');
+        yield array(CaseSensitiveClass::class);
+    }
+
+    /**
+     * @dataProvider provideInvalidClassId
+     */
+    public function testWontResolveClassFromId($serviceId)
+    {
+        $pass = new ResolveClassPass();
+        $container = new ContainerBuilder();
+        $def = $container->register($serviceId);
+
+        $pass->process($container);
+
+        $this->assertNull($def->getClass());
+    }
+
+    public function provideInvalidClassId()
+    {
+        yield array(\stdClass::class);
+        yield array('bar');
+        yield array('\DateTime');
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -932,14 +932,24 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $unknown = $container->register('unknown_class');
-        $class = $container->register(\stdClass::class);
+        $unknown = $container->register('Acme\UnknownClass');
         $autoloadClass = $container->register(CaseSensitiveClass::class);
         $container->compile();
 
-        $this->assertSame('unknown_class', $unknown->getClass());
-        $this->assertEquals(\stdClass::class, $class->getClass());
+        $this->assertSame('Acme\UnknownClass', $unknown->getClass());
         $this->assertEquals(CaseSensitiveClass::class, $autoloadClass->getClass());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage The definition for "DateTime" has no class.
+     */
+    public function testNoClassFromGlobalNamespaceClassId()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = $container->register(\DateTime::class);
+        $container->compile();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
@@ -40,4 +40,4 @@ services:
 
     with_defaults_aliased_short: '@with_defaults'
 
-    with_shortcut_args: [foo]
+    Acme\WithShortCutArgs: [foo]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -40,4 +40,4 @@ services:
     new_factory2: { class: FooBarClass, factory: ['@baz', getClass]}
     new_factory3: { class: FooBarClass, factory: [BazClass, getInstance]}
     new_factory4: { class: BazClass, factory: [~, getInstance]}
-    with_shortcut_args: [foo, '@baz']
+    Acme\WithShortCutArgs: [foo, '@baz']

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -154,7 +154,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(new Reference('baz'), 'getClass'), $services['new_factory2']->getFactory(), '->load() parses the factory tag');
         $this->assertEquals(array('BazClass', 'getInstance'), $services['new_factory3']->getFactory(), '->load() parses the factory tag');
         $this->assertSame(array(null, 'getInstance'), $services['new_factory4']->getFactory(), '->load() accepts factory tag without class');
-        $this->assertEquals(array('foo', new Reference('baz')), $services['with_shortcut_args']->getArguments(), '->load() parses short service definition');
+        $this->assertEquals(array('foo', new Reference('baz')), $services['Acme\WithShortCutArgs']->getArguments(), '->load() parses short service definition');
 
         $aliases = $container->getAliases();
         $this->assertTrue(isset($aliases['alias_for_foo']), '->load() parses aliases');
@@ -385,9 +385,9 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('public', $container->getDefinition('no_defaults_child')->getChanges());
         $this->assertArrayNotHasKey('autowire', $container->getDefinition('no_defaults_child')->getChanges());
 
-        $this->assertFalse($container->getDefinition('with_shortcut_args')->isPublic());
-        $this->assertSame(array('foo' => array(array())), $container->getDefinition('with_shortcut_args')->getTags());
-        $this->assertTrue($container->getDefinition('with_shortcut_args')->isAutowired());
+        $this->assertFalse($container->getDefinition('Acme\WithShortCutArgs')->isPublic());
+        $this->assertSame(array('foo' => array(array())), $container->getDefinition('Acme\WithShortCutArgs')->getTags());
+        $this->assertTrue($container->getDefinition('Acme\WithShortCutArgs')->isAutowired());
 
         $container->compile();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yesish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21380
| License       | MIT
| Doc PR        | N/A

Using a global classname as service id without specifying the definition class attribute won't work anymore after this, in the benefit of properly throwing an exception at compilation time for a misconfigured service. Service ids could previously be wrongly interpreted as a class name.

So:
```yml
services:
    app_bar:
        arguments: ['foo']
```

will now properly result into:
> Fatal error: Uncaught Symfony\Component\DependencyInjection\Exception\RuntimeException: The definition for "app_bar" has no class.

at compilation time.