### PR TITLE
[Config] Early return for DirectoryResource

### DIFF
--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -68,7 +68,10 @@ class DirectoryResource implements ResourceInterface, \Serializable
             return false;
         }
 
-        $newestMTime = filemtime($this->resource);
+        if ($timestamp <= filemtime($this->resource)) {
+            return false;
+        }
+
         foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->resource), \RecursiveIteratorIterator::SELF_FIRST) as $file) {
             // if regex filtering is enabled only check matching files
             if ($this->pattern && $file->isFile() && !preg_match($this->pattern, $file->getBasename())) {
@@ -81,10 +84,13 @@ class DirectoryResource implements ResourceInterface, \Serializable
                 continue;
             }
 
-            $newestMTime = max($file->getMTime(), $newestMTime);
+            // early return if a file's mtime exceeds the passed timestamp
+            if ($timestamp <= $file->getMTime()) {
+                return false;
+            }
         }
 
-        return $newestMTime < $timestamp;
+        return true;
     }
 
     public function serialize()

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -68,7 +68,7 @@ class DirectoryResource implements ResourceInterface, \Serializable
             return false;
         }
 
-        if ($timestamp <= filemtime($this->resource)) {
+        if ($timestamp < filemtime($this->resource)) {
             return false;
         }
 
@@ -85,7 +85,7 @@ class DirectoryResource implements ResourceInterface, \Serializable
             }
 
             // early return if a file's mtime exceeds the passed timestamp
-            if ($timestamp <= $file->getMTime()) {
+            if ($timestamp < $file->getMTime()) {
                 return false;
             }
         }

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -96,8 +96,10 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
     public function testIsFreshDeleteFile()
     {
         $resource = new DirectoryResource($this->directory);
+        $time = time();
+        sleep(1);
         unlink($this->directory.'/tmp.xml');
-        $this->assertFalse($resource->isFresh(time()), '->isFresh() returns false if an existing file is removed');
+        $this->assertFalse($resource->isFresh($time), '->isFresh() returns false if an existing file is removed');
     }
 
     public function testIsFreshDeleteDirectory()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | sure?
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| Related PRs | #21440
| License       | MIT
| Doc PR        | n/a

Alternate PR  that implements an early return for `DirectoryResource` to increase the speed on large file sets. We can never return early with `true` without checking all assets within the resource, as the aforementioned referenced PR did; hence this PR takes the counter approach and returns `false` early where appropriate.

_Conversation about possible bug at https://github.com/symfony/symfony/pull/21458#discussion_r98366339._
