### PR TITLE
[HttpKernel] DebugHandlersListener micro optimize

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -137,7 +137,7 @@ class DebugHandlersListener implements EventSubscriberInterface
     {
         $events = array(KernelEvents::REQUEST => array('configure', 2048));
 
-        if ('cli' === php_sapi_name() && defined('Symfony\Component\Console\ConsoleEvents::COMMAND')) {
+        if ('cli' === PHP_SAPI && defined('Symfony\Component\Console\ConsoleEvents::COMMAND')) {
             $events[ConsoleEvents::COMMAND] = array('configure', 2048);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2 (lowest version introduced)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

For ref.: [php_sapi_name()](http://php.net/manual/en/function.php-sapi-name.php) returns the const `PHP_SAPI`.

This a PR out of courtesy to see if the CS/Fixer/Rule that found this case should be added to the SF set by default.