### PR TITLE
[HttpFoundation] Allow HTTP/2.0 responses

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -190,8 +190,9 @@ class BinaryFileResponse extends Response
             $this->headers->set('Content-Type', $this->file->getMimeType() ?: 'application/octet-stream');
         }
 
-        if ('HTTP/1.0' !== $request->server->get('SERVER_PROTOCOL')) {
-            $this->setProtocolVersion('1.1');
+        preg_match('~^HTTP/([1-9]\.[0-9])$~', $request->server->get('SERVER_PROTOCOL'), $versionMatches);
+        if ($versionMatches) {
+            $this->setProtocolVersion($versionMatches[1]);
         }
 
         $this->ensureIEOverSSLCompatibility($request);

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -347,8 +347,9 @@ class Response
         }
 
         // Fix protocol
-        if ('HTTP/1.0' != $request->server->get('SERVER_PROTOCOL')) {
-            $this->setProtocolVersion('1.1');
+        preg_match('~^HTTP/([1-9]\.[0-9])$~', $request->server->get('SERVER_PROTOCOL'), $versionMatches);
+        if ($versionMatches) {
+            $this->setProtocolVersion($versionMatches[1]);
         }
 
         // Check if we need to send extra expire info headers
@@ -464,7 +465,7 @@ class Response
     }
 
     /**
-     * Sets the HTTP protocol version (1.0 or 1.1).
+     * Sets the HTTP protocol version.
      *
      * @param string $version The HTTP protocol version
      *

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -544,6 +544,29 @@ class ResponseTest extends ResponseTestCase
         $this->assertFalse($response->headers->has('Content-Length'));
     }
 
+    /**
+     * @dataProvider protocolVersionProvider
+     */
+    public function testPrepareSetsVersion($serverProtocol, $expected)
+    {
+        $request = Request::create('/', 'GET');
+        $request->server->set('SERVER_PROTOCOL', $serverProtocol);
+
+        $response = new Response('foo');
+        $response->prepare($request);
+        $this->assertEquals($expected, $response->getProtocolVersion());
+    }
+
+    public function protocolVersionProvider()
+    {
+        return array(
+            '1.0' => array('HTTP/1.0', '1.0'),
+            '1.1' => array('HTTP/1.1', '1.1'),
+            '2.0' => array('HTTP/2.0', '2.0'),
+            'broken' => array('foo', '1.0'),
+        );
+    }
+
     public function testPrepareSetsPragmaOnHttp10Only()
     {
         $request = Request::create('/', 'GET');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21415 (partially)
| License       | MIT
| Doc PR        | 

This removes the restriction on HTTP/1.0 or 1.1 responses.