### PR TITLE
[HttpFoundation] Find the original request protocol version

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1536,6 +1536,24 @@ class Request
     }
 
     /**
+     * Returns the original protocol version.
+     *
+     * @return string
+     */
+    public function getOriginalProtocolVersion()
+    {
+        if ($this->isFromTrustedProxy()) {
+            preg_match('~^(HTTP/)?([1-9].[0-9]) ~', $this->headers->get('Via'), $matches);
+
+            if ($matches) {
+                return 'HTTP/'.$matches[2];
+            }
+        }
+
+        return $this->server->get('SERVER_PROTOCOL');
+    }
+
+    /**
      * Returns the request body content.
      *
      * @param bool $asResource If true, a resource will be returned

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1538,6 +1538,12 @@ class Request
     /**
      * Returns the original protocol version.
      *
+     * If the application is behind a proxy, the protocol version used in the
+     * requests between the client and the proxy and between the proxy and the
+     * server might be different. This returns the former (from the "Via" header)
+     * if the proxy is trusted (see "setTrustedProxies()"), otherwise it returns
+     * the latter (from the "SERVER_PROTOCOL" server parameter).
+     *
      * @return string
      */
     public function getOriginalProtocolVersion()

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1543,7 +1543,7 @@ class Request
     public function getOriginalProtocolVersion()
     {
         if ($this->isFromTrustedProxy()) {
-            preg_match('~^(HTTP/)?([1-9].[0-9]) ~', $this->headers->get('Via'), $matches);
+            preg_match('~^(HTTP/)?([1-9]\.[0-9]) ~', $this->headers->get('Via'), $matches);
 
             if ($matches) {
                 return 'HTTP/'.$matches[2];

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1536,7 +1536,7 @@ class Request
     }
 
     /**
-     * Returns the original protocol version.
+     * Returns the protocol version.
      *
      * If the application is behind a proxy, the protocol version used in the
      * requests between the client and the proxy and between the proxy and the
@@ -1546,7 +1546,7 @@ class Request
      *
      * @return string
      */
-    public function getOriginalProtocolVersion()
+    public function getProtocolVersion()
     {
         if ($this->isFromTrustedProxy()) {
             preg_match('~^(HTTP/)?([1-9]\.[0-9]) ~', $this->headers->get('Via'), $matches);

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2076,7 +2076,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             'trusted without via' => array('HTTP/2.0', true, '', 'HTTP/2.0'),
             'trusted with via' => array('HTTP/2.0', true, '1.0 fred, 1.1 nowhere.com (Apache/1.1)', 'HTTP/1.0'),
             'trusted with via and protocol name' => array('HTTP/2.0', true, 'HTTP/1.0 fred, HTTP/1.1 nowhere.com (Apache/1.1)', 'HTTP/1.0'),
-            'trusted with broken via' => array('HTTP/2.0', true, 'foo', 'HTTP/2.0'),
+            'trusted with broken via' => array('HTTP/2.0', true, 'HTTP/1^0 foo', 'HTTP/2.0'),
             'trusted with partially-broken via' => array('HTTP/2.0', true, '1.0 fred, foo', 'HTTP/1.0'),
         );
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2052,9 +2052,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider originalProtocolVersionProvider
+     * @dataProvider protocolVersionProvider
      */
-    public function testOriginalProtocolVersion($serverProtocol, $trustedProxy, $via, $expected)
+    public function testProtocolVersion($serverProtocol, $trustedProxy, $via, $expected)
     {
         if ($trustedProxy) {
             Request::setTrustedProxies(array('1.1.1.1'));
@@ -2065,10 +2065,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->server->set('REMOTE_ADDR', '1.1.1.1');
         $request->headers->set('Via', $via);
 
-        $this->assertSame($expected, $request->getOriginalProtocolVersion());
+        $this->assertSame($expected, $request->getProtocolVersion());
     }
 
-    public function originalProtocolVersionProvider()
+    public function protocolVersionProvider()
     {
         return array(
             'untrusted without via' => array('HTTP/2.0', false, '', 'HTTP/2.0'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21415
| License       | MIT
| Doc PR        | 

Adds a new method to `Request` to find the original protocol version from the `Via` header, if the request is from a trusted proxy.