### PR TITLE
[Yaml] Allow dumping empty array as YAML sequence

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-3.2.3
+3.3.0
 -----
 
  * Added support for dumping empty PHP arrays as YAML sequences:

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+3.2.3
+-----
+
+ * Added support for dumping empty PHP arrays as YAML sequences:
+
+   ```php
+   Yaml::dump([], 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+   ```
+
 3.2.0
 -----
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -164,7 +164,7 @@ class Inline
                 }
 
                 if (Yaml::DUMP_OBJECT_AS_MAP & $flags && ($value instanceof \stdClass || $value instanceof \ArrayObject)) {
-                    return self::dumpArray((array) $value, $flags);
+                    return self::dumpArray((array) $value, $flags & ~Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
                 }
 
                 if (Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE & $flags) {

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -252,7 +252,7 @@ class Inline
     private static function dumpArray($value, $flags)
     {
         // array
-        if ($value && !self::isHash($value)) {
+        if (($value || Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE & $flags) && !self::isHash($value)) {
             $output = array();
             foreach ($value as $val) {
                 $output[] = self::dump($val, $flags);

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -258,10 +258,10 @@ EOF;
         $this->assertEquals('[]', $dump);
 
         $dump = $this->dumper->dump(new \ArrayObject(), 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_OBJECT_AS_MAP);
-        $this->assertEquals('[]', $dump);
+        $this->assertEquals('{  }', $dump);
 
         $dump = $this->dumper->dump(new \stdClass(), 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_OBJECT_AS_MAP);
-        $this->assertEquals('[]', $dump);
+        $this->assertEquals('{  }', $dump);
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -246,6 +246,24 @@ EOF;
         $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, true);
     }
 
+    public function testEmptyArray()
+    {
+        $dump = $this->dumper->dump(array());
+        $this->assertEquals('{  }', $dump);
+
+        $dump = $this->dumper->dump(array(), 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+        $this->assertEquals('[]', $dump);
+
+        $dump = $this->dumper->dump(array(), 9, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+        $this->assertEquals('[]', $dump);
+
+        $dump = $this->dumper->dump(new \ArrayObject(), 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_OBJECT_AS_MAP);
+        $this->assertEquals('[]', $dump);
+
+        $dump = $this->dumper->dump(new \stdClass(), 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_OBJECT_AS_MAP);
+        $this->assertEquals('[]', $dump);
+    }
+
     /**
      * @dataProvider getEscapeSequences
      */

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -29,6 +29,7 @@ class Yaml
     const DUMP_OBJECT_AS_MAP = 64;
     const DUMP_MULTI_LINE_LITERAL_BLOCK = 128;
     const PARSE_CONSTANT = 256;
+    const DUMP_EMPTY_ARRAY_AS_SEQUENCE = 512;
 
     /**
      * Parses YAML into a PHP value.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #9870, #15937, #16266
| License       | MIT
| Doc PR        | 

PHP arrays are dumped as either YAML sequences or mappings, depending on whether the array has continuos integer keys or not.

An empty array is always dumped as a YAML mapping. Sometimes you want it dumped as a YAML sequence instead.