### PR TITLE
[Form] Reproduce CountryType BC break

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -50,4 +50,12 @@ class CountryTypeTest extends TestCase
             }
         }
     }
+
+    public function testSubmitNull()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CountryType');
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -45,4 +45,12 @@ class LanguageTypeTest extends TestCase
 
         $this->assertNotContains(new ChoiceView('mul', 'mul', 'Mehrsprachig'), $choices, '', false, false);
     }
+
+    public function testSubmitNull()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\LanguageType');
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -34,4 +34,12 @@ class LocaleTypeTest extends TestCase
         $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'English (United Kingdom)'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('zh_Hant_MO', 'zh_Hant_MO', 'Chinese (Traditional, Macau SAR China)'), $choices, '', false, false);
     }
+
+    public function testSubmitNull()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\LocaleType');
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -57,4 +57,12 @@ class MoneyTypeTest extends TestCase
         $this->assertSame('{{ widget }} £', $view1->vars['money_pattern']);
         $this->assertSame('{{ widget }} €', $view2->vars['money_pattern']);
     }
+
+    public function testSubmitNull()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\MoneyType');
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #20759
| License       | MIT
| Doc PR        | 

Hi,

I've created test cases to reproduce #20759 . I've realized that not only the `CountryType` is affected by this problem but also the `MoneyType`, `LanguageType`, `LocaleType` ... in other words all types having `ChoiceType` as their parent. What's also interesting to point out is that most of those types are implementing the `ChoiceLoaderInterface` since version 3.2

To be honest, I'm a bit lost about where to look but I'm sure the test cases are going to prove useful.
