### PR TITLE
[Process] Non ASCII characters disappearing during the escapeshellarg

### DIFF
--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -38,6 +38,7 @@ class ProcessUtils
      */
     public static function escapeArgument($argument)
     {
+        
         //Fix for PHP bug #43784 escapeshellarg removes % from given string
         //Fix for PHP bug #49446 escapeshellarg doesn't work on Windows
         //@see https://bugs.php.net/bug.php?id=43784
@@ -70,7 +71,10 @@ class ProcessUtils
 
             return $escapedArgument;
         }
-
+        // Avoid the disapeareance of non-ascii parameters when LC_CTYPE is not set as UTF-8
+        if (preg_match('/[^\x20-\x7f]/', $argument) && strpos("UTF-8", setlocale(LC_CTYPE, "0")) === false) {
+            throw new InvalidArgumentException("argument cannot contains non-ascii characters if the locale LC_CTYPE is not set as UTF-8");
+        }
         return escapeshellarg($argument);
     }
 

--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -38,7 +38,6 @@ class ProcessUtils
      */
     public static function escapeArgument($argument)
     {
-        
         //Fix for PHP bug #43784 escapeshellarg removes % from given string
         //Fix for PHP bug #49446 escapeshellarg doesn't work on Windows
         //@see https://bugs.php.net/bug.php?id=43784
@@ -71,7 +70,8 @@ class ProcessUtils
 
             return $escapedArgument;
         }
-        return "'" . str_replace("'", "'\\''", $argument) . "'";
+        
+        return "'".str_replace("'", "'\\''", $argument)."'";
     }
 
     /**

--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -71,11 +71,7 @@ class ProcessUtils
 
             return $escapedArgument;
         }
-        // Avoid the disapeareance of non-ascii parameters when LC_CTYPE is not set as UTF-8
-        if (preg_match('/[^\x20-\x7f]/', $argument) && strpos("UTF-8", setlocale(LC_CTYPE, "0")) === false) {
-            throw new InvalidArgumentException("argument cannot contains non-ascii characters if the locale LC_CTYPE is not set as UTF-8");
-        }
-        return escapeshellarg($argument);
+        return "'" . str_replace("'", "'\\''", $argument) . "'";
     }
 
     /**

--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -70,7 +70,7 @@ class ProcessUtils
 
             return $escapedArgument;
         }
-        
+
         return "'".str_replace("'", "'\\''", $argument)."'";
     }
 

--- a/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
@@ -43,7 +43,7 @@ class ProcessUtilsTest extends \PHPUnit_Framework_TestCase
             array("'<|>\" \"'\\''f'", '<|>" "\'f'),
             array("''", ''),
             array("'with\\trailingbs\\'", 'with\trailingbs\\'),
-        	array("'withNonAsciiAccentLikeéÉèÈàÀöä'", "withNonAsciiAccentLikeéÉèÈàÀöä")
+            array("'withNonAsciiAccentLikeéÉèÈàÀöä'", "withNonAsciiAccentLikeéÉèÈàÀöä"),
         );
     }
 }

--- a/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
@@ -43,6 +43,7 @@ class ProcessUtilsTest extends \PHPUnit_Framework_TestCase
             array("'<|>\" \"'\\''f'", '<|>" "\'f'),
             array("''", ''),
             array("'with\\trailingbs\\'", 'with\trailingbs\\'),
+        	array("'withNonAsciiAccentLikeéÉèÈàÀöä'", "withNonAsciiAccentLikeéÉèÈàÀöä")
         );
     }
 }

--- a/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
@@ -43,7 +43,7 @@ class ProcessUtilsTest extends \PHPUnit_Framework_TestCase
             array("'<|>\" \"'\\''f'", '<|>" "\'f'),
             array("''", ''),
             array("'with\\trailingbs\\'", 'with\trailingbs\\'),
-            array("'withNonAsciiAccentLikeéÉèÈàÀöä'", "withNonAsciiAccentLikeéÉèÈàÀöä"),
+            array("'withNonAsciiAccentLikeéÉèÈàÀöä'", 'withNonAsciiAccentLikeéÉèÈàÀöä'),
         );
     }
 }


### PR DESCRIPTION
If the LC_CTYPE is not set at UTF-8, the escapeshellarg() function will remove every non-ascii characters.

As it's usual in europe to have directories with non-ascii chars in their name (ex : ~/Vidéos) the function should throw an exception if we're trying to submit it an argument containing non-ascii param and the LC_CTYPE is not set to use UTF-8

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 


I had this issue while using the lib ffmpeg and giving it a path like "~/Vidéos" the "é" chars was disappearing from the command giving a RuntimeException.

The problem was my LC_CTYPE that wasn't set properly, I believe an exception should be raised before the RuntimeException to warn the user of that behavior