### PR TITLE
Enable dump() in autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,9 @@
             "**/Tests/"
         ]
     },
+    "autoload-dev": {
+        "files": [ "src/Symfony/Component/VarDumper/Resources/functions/dump.php" ]
+    },
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I miss `dump()` badly when working on Symfony itself.