### PR TITLE
Subscribed event default method name based on the event name

### DIFF
--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -163,7 +163,21 @@ class ContainerAwareEventDispatcher extends EventDispatcher
         @trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use EventDispatcher with closure-proxy injection instead.', __CLASS__), E_USER_DEPRECATED);
 
         foreach ($class::getSubscribedEvents() as $eventName => $params) {
-            if (is_string($params)) {
+            if (is_int($eventName) && is_string($params)) {
+                $method = 'on'.preg_replace_callback(array(
+                        '/(?<=\b)[a-z]/i',
+                        '/[^a-z0-9]/i',
+                    ), function ($matches) { return strtoupper($matches[0]); }, $params);
+                $method = preg_replace('/[^a-z0-9]/i', '', $method);
+                $this->listenerIds[$params][] = array($serviceId, $method, 0);
+            } elseif (is_int($params)) {
+                $method = 'on'.preg_replace_callback(array(
+                        '/(?<=\b)[a-z]/i',
+                        '/[^a-z0-9]/i',
+                    ), function ($matches) { return strtoupper($matches[0]); }, $eventName);
+                $method = preg_replace('/[^a-z0-9]/i', '', $method);
+                $this->listenerIds[$eventName][] = array($serviceId, $method, $params);
+            } elseif (is_string($params)) {
                 $this->listenerIds[$eventName][] = array($serviceId, $params, 0);
             } elseif (is_string($params[0])) {
                 $this->listenerIds[$eventName][] = array($serviceId, $params[0], isset($params[1]) ? $params[1] : 0);

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -127,7 +127,21 @@ class EventDispatcher implements EventDispatcherInterface
     public function addSubscriber(EventSubscriberInterface $subscriber)
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
-            if (is_string($params)) {
+            if (is_int($eventName) && is_string($params)) {
+                $method = 'on'.preg_replace_callback(array(
+                        '/(?<=\b)[a-z]/i',
+                        '/[^a-z0-9]/i',
+                    ), function ($matches) { return strtoupper($matches[0]); }, $params);
+                $method = preg_replace('/[^a-z0-9]/i', '', $method);
+                $this->addListener($params, array($subscriber, $method));
+            } elseif (is_int($params)) {
+                $method = 'on'.preg_replace_callback(array(
+                        '/(?<=\b)[a-z]/i',
+                        '/[^a-z0-9]/i',
+                    ), function ($matches) { return strtoupper($matches[0]); }, $eventName);
+                $method = preg_replace('/[^a-z0-9]/i', '', $method);
+                $this->addListener($eventName, array($subscriber, $method), $params);
+            } elseif (is_string($params)) {
                 $this->addListener($eventName, array($subscriber, $params));
             } elseif (is_string($params[0])) {
                 $this->addListener($eventName, array($subscriber, $params[0]), isset($params[1]) ? $params[1] : 0);

--- a/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
@@ -196,6 +196,7 @@ abstract class AbstractEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->dispatcher->addSubscriber($eventSubscriber);
         $this->assertTrue($this->dispatcher->hasListeners(self::preFoo));
         $this->assertTrue($this->dispatcher->hasListeners(self::postFoo));
+        $this->assertTrue($this->dispatcher->hasListeners(self::postBar));
     }
 
     public function testAddSubscriberWithPriorities()
@@ -208,6 +209,9 @@ abstract class AbstractEventDispatcherTest extends \PHPUnit_Framework_TestCase
 
         $listeners = $this->dispatcher->getListeners('pre.foo');
         $this->assertTrue($this->dispatcher->hasListeners(self::preFoo));
+        $this->assertCount(2, $listeners);
+        $listeners = $this->dispatcher->getListeners('post.bar');
+        $this->assertTrue($this->dispatcher->hasListeners(self::postBar));
         $this->assertCount(2, $listeners);
         $this->assertInstanceOf('Symfony\Component\EventDispatcher\Tests\TestEventSubscriberWithPriorities', $listeners[0][0]);
     }
@@ -346,7 +350,7 @@ class TestEventSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents()
     {
-        return array('pre.foo' => 'preFoo', 'post.foo' => 'postFoo');
+        return array('pre.foo' => 'preFoo', 'post.foo' => 'postFoo', 'post.bar');
     }
 }
 
@@ -357,6 +361,7 @@ class TestEventSubscriberWithPriorities implements EventSubscriberInterface
         return array(
             'pre.foo' => array('preFoo', 10),
             'post.foo' => array('postFoo'),
+            'post.bar' => 10,
             );
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
@@ -193,6 +193,8 @@ class SubscriberService implements EventSubscriberInterface
             'onEvent' => 'onEvent',
             'onEventWithPriority' => array('onEventWithPriority', 10),
             'onEventNested' => array(array('onEventNested')),
+            'app.event',
+            'app.event.with.priority' => 10,
         );
     }
 
@@ -205,6 +207,14 @@ class SubscriberService implements EventSubscriberInterface
     }
 
     public function onEventNested(Event $e)
+    {
+    }
+
+    public function onAppEvent(Event $e)
+    {
+    }
+
+    public function onAppEventWithPriority(Event $e)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | 

Allow EventSubscriberInterface::getSubscribedEvents() to be as simple as :
`return [
    KernelEvents:: REQUEST,
    KernelEvents::CONTROLLER => 10, 
];`