### PR TITLE
[FrameworkBundle][Console] Fix descriptors to support IteratorArgument, ClosureProxy and arrays

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -14,6 +14,8 @@ namespace Symfony\Bundle\FrameworkBundle\Console\Descriptor;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -325,8 +327,13 @@ class TextDescriptor extends Descriptor
                     $argumentsInformation[] = sprintf('Service(%s)', (string) $argument);
                 } elseif ($argument instanceof Definition) {
                     $argumentsInformation[] = 'Inlined Service';
+                } elseif ($argument instanceof IteratorArgument) {
+                    $argumentsInformation[] = 'Iterator';
+                } elseif ($argument instanceof ClosureProxyArgument) {
+                    list($reference, $method) = $argument->getValues();
+                    $argumentsInformation[] = sprintf('ClosureProxy(Service(%s)::%s())', $reference, $method);
                 } else {
-                    $argumentsInformation[] = $argument;
+                    $argumentsInformation[] = is_array($argument) ? 'Array' : $argument;
                 }
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bundle\FrameworkBundle\Console\Descriptor;
 
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -427,6 +429,17 @@ class XmlDescriptor extends Descriptor
                 $argumentXML->setAttribute('id', (string) $argument);
             } elseif ($argument instanceof Definition) {
                 $argumentXML->appendChild($dom->importNode($this->getContainerDefinitionDocument($argument, null, false, true)->childNodes->item(0), true));
+            } elseif ($argument instanceof IteratorArgument) {
+                $argumentXML->setAttribute('type', 'iterator');
+
+                foreach ($this->getArgumentNodes($argument->getValues(), $dom) as $childArgumentXML) {
+                    $argumentXML->appendChild($childArgumentXML);
+                }
+            } elseif ($argument instanceof ClosureProxyArgument) {
+                list($reference, $method) = $argument->getValues();
+                $argumentXML->setAttribute('type', 'closure-proxy');
+                $argumentXML->setAttribute('id', (string) $reference);
+                $argumentXML->setAttribute('method', $method);
             } elseif (is_array($argument)) {
                 $argumentXML->setAttribute('type', 'collection');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -108,6 +110,16 @@ class ObjectsProvider
                 ->addArgument(new Reference('definition2'))
                 ->addArgument('%parameter%')
                 ->addArgument(new Definition('inline_service', array('arg1', 'arg2')))
+                ->addArgument(array(
+                    'foo',
+                    new Reference('definition2'),
+                    new Definition('inline_service'),
+                ))
+                ->addArgument(new IteratorArgument(array(
+                    new Reference('definition_1'),
+                    new Reference('definition_2'),
+                )))
+                ->addArgument(new ClosureProxyArgument('definition1', 'get'))
                 ->setFactory(array('Full\\Qualified\\FactoryClass', 'get')),
             'definition_2' => $definition2
                 ->setPublic(false)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
@@ -34,7 +34,43 @@
                     ],
                     "file": null,
                     "tags": []
-                }
+                },
+                [
+                    "foo",
+                    {
+                        "type": "service",
+                        "id": "definition2"
+                    },
+                    {
+                        "class": "inline_service",
+                        "public": true,
+                        "synthetic": false,
+                        "lazy": false,
+                        "shared": true,
+                        "abstract": false,
+                        "autowire": false,
+                        "arguments": [],
+                        "file": null,
+                        "tags": []
+                    }
+                ],
+                [
+                    {
+                        "type": "service",
+                        "id": "definition_1"
+                    },
+                    {
+                        "type": "service",
+                        "id": "definition_2"
+                    }
+                ],
+                [
+                    {
+                        "type": "service",
+                        "id": "definition1"
+                    },
+                    "get"
+                ]
             ]
         }
     },

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
@@ -12,6 +12,18 @@
         <argument>arg2</argument>
       </definition>
     </argument>
+    <argument type="collection">
+      <argument>foo</argument>
+      <argument type="service" id="definition2"/>
+      <argument>
+        <definition class="inline_service" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file=""/>
+      </argument>
+    </argument>
+    <argument type="iterator">
+      <argument type="service" id="definition_1"/>
+      <argument type="service" id="definition_2"/>
+    </argument>
+    <argument type="closure-proxy" id="definition1" method="get"/>
   </definition>
   <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.json
@@ -26,7 +26,43 @@
             ],
             "file": null,
             "tags": []
-        }
+        },
+        [
+            "foo",
+            {
+                "type": "service",
+                "id": "definition2"
+            },
+            {
+                "class": "inline_service",
+                "public": true,
+                "synthetic": false,
+                "lazy": false,
+                "shared": true,
+                "abstract": false,
+                "autowire": false,
+                "arguments": [],
+                "file": null,
+                "tags": []
+            }
+        ],
+        [
+            {
+                "type": "service",
+                "id": "definition_1"
+            },
+            {
+                "type": "service",
+                "id": "definition_2"
+            }
+        ],
+        [
+            {
+                "type": "service",
+                "id": "definition1"
+            },
+            "get"
+        ]
     ],
     "file": null,
     "factory_class": "Full\\Qualified\\FactoryClass",

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
@@ -1,19 +1,22 @@
- ---------------- ----------------------------- 
- [32m Option         [39m [32m Value                       [39m 
- ---------------- ----------------------------- 
-  Service ID       -                            
-  Class            Full\Qualified\Class1        
-  Tags             -                            
-  Public           yes                          
-  Synthetic        no                           
-  Lazy             yes                          
-  Shared           yes                          
-  Abstract         yes                          
-  Autowired        no                           
-  Factory Class    Full\Qualified\FactoryClass  
-  Factory Method   get                          
-  Arguments        Service(definition2)         
-                   %parameter%                  
-                   Inlined Service              
- ---------------- ----------------------------- 
+ ---------------- ------------------------------------------- 
+ [32m Option         [39m [32m Value                                     [39m 
+ ---------------- ------------------------------------------- 
+  Service ID       -                                          
+  Class            Full\Qualified\Class1                      
+  Tags             -                                          
+  Public           yes                                        
+  Synthetic        no                                         
+  Lazy             yes                                        
+  Shared           yes                                        
+  Abstract         yes                                        
+  Autowired        no                                         
+  Factory Class    Full\Qualified\FactoryClass                
+  Factory Method   get                                        
+  Arguments        Service(definition2)                       
+                   %parameter%                                
+                   Inlined Service                            
+                   Array                                      
+                   Iterator                                   
+                   ClosureProxy(Service(definition1)::get())  
+ ---------------- ------------------------------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
@@ -9,4 +9,16 @@
       <argument>arg2</argument>
     </definition>
   </argument>
+  <argument type="collection">
+    <argument>foo</argument>
+    <argument type="service" id="definition2"/>
+    <argument>
+      <definition class="inline_service" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file=""/>
+    </argument>
+  </argument>
+  <argument type="iterator">
+    <argument type="service" id="definition_1"/>
+    <argument type="service" id="definition_2"/>
+  </argument>
+  <argument type="closure-proxy" id="definition1" method="get"/>
 </definition>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Fixes both array and iterator/closure-proxy arguments support in descriptors when using `--show-arguments`
