### PR TITLE
[FrameworkBundle][Console] JsonDescriptor: Respect original output

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
@@ -11,9 +11,7 @@
             "file": null,
             "factory_class": "Full\\Qualified\\FactoryClass",
             "factory_method": "get",
-            "tags": [
-
-            ]
+            "tags": []
         }
     },
     "aliases": {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
@@ -11,9 +11,7 @@
             "file": null,
             "factory_class": "Full\\Qualified\\FactoryClass",
             "factory_method": "get",
-            "tags": [
-
-            ]
+            "tags": []
         },
         "definition_2": {
             "class": "Full\\Qualified\\Class2",
@@ -42,9 +40,7 @@
                 },
                 {
                     "name": "tag2",
-                    "parameters": [
-
-                    ]
+                    "parameters": []
                 }
             ]
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.json
@@ -27,17 +27,11 @@
                 },
                 {
                     "name": "tag2",
-                    "parameters": [
-
-                    ]
+                    "parameters": []
                 }
             ]
         }
     },
-    "aliases": [
-
-    ],
-    "services": [
-
-    ]
+    "aliases": [],
+    "services": []
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.json
@@ -9,7 +9,5 @@
     "file": null,
     "factory_class": "Full\\Qualified\\FactoryClass",
     "factory_method": "get",
-    "tags": [
-
-    ]
+    "tags": []
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.json
@@ -25,9 +25,7 @@
         },
         {
             "name": "tag2",
-            "parameters": [
-
-            ]
+            "parameters": []
         }
     ]
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2.json
@@ -6,9 +6,7 @@
     "scheme": "http|https",
     "method": "PUT|POST",
     "class": "Symfony\\Component\\Routing\\Route",
-    "defaults": [
-
-    ],
+    "defaults": [],
     "requirements": "NO CUSTOM",
     "options": {
         "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler",

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1.json
@@ -27,9 +27,7 @@
         "scheme": "http|https",
         "method": "PUT|POST",
         "class": "Symfony\\Component\\Routing\\Route",
-        "defaults": [
-
-        ],
+        "defaults": [],
         "requirements": "NO CUSTOM",
         "options": {
             "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

I'm suggesting this one, because I recently pushed some changes to the descriptors, and of course, I'm not editing expected output fixtures by hand, but by dumping the real output to fixture files. But it's tiring to get false positive diffs when reviewing it. Descriptor tests already are painful enough 😅 

This PR respects the way elements are actually output. If it's ok to you, I'll submit some other PRs to upper branches, because there are more issues regarding this (items order for instance).

If it causes too much troubles getting this in sync with upper branches, let's close this and never talk about it anymore 😄  