### PR TITLE
[PropertyAccess] Fix phpDoc typo

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccess.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccess.php
@@ -31,7 +31,7 @@ final class PropertyAccess
     /**
      * Creates a property accessor builder.
      *
-     * @return PropertyAccessor
+     * @return PropertyAccessorBuilder
      */
     public static function createPropertyAccessorBuilder()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Fix a phpDoc typo disallowing to manipulate the builder