### PR TITLE
[Config][DI] Add ComposerResource to track the runtime engine + deps

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -23,7 +23,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
@@ -994,8 +993,7 @@ class FrameworkExtension extends Extension
     {
         if (interface_exists('Symfony\Component\Form\FormInterface')) {
             $reflClass = new \ReflectionClass('Symfony\Component\Form\FormInterface');
-            $files['xml'][] = $file = dirname($reflClass->getFileName()).'/Resources/config/validation.xml';
-            $container->addResource(new FileResource($file));
+            $files['xml'][] = dirname($reflClass->getFileName()).'/Resources/config/validation.xml';
         }
 
         foreach ($container->getParameter('kernel.bundles_metadata') as $bundle) {

--- a/src/Symfony/Component/Config/Resource/ComposerResource.php
+++ b/src/Symfony/Component/Config/Resource/ComposerResource.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Resource;
+
+/**
+ * ComposerResource tracks the PHP version and Composer dependencies.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ComposerResource implements SelfCheckingResourceInterface, \Serializable
+{
+    private $versions;
+    private $vendors;
+
+    private static $runtimeVersion;
+    private static $runtimeVendors;
+
+    public function __construct()
+    {
+        self::refresh();
+        $this->versions = self::$runtimeVersion;
+        $this->vendors = self::$runtimeVendors;
+    }
+
+    public function getVendors()
+    {
+        return array_keys($this->vendors);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return __CLASS__;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFresh($timestamp)
+    {
+        self::refresh();
+
+        if (self::$runtimeVersion !== $this->versions) {
+            return false;
+        }
+
+        return self::$runtimeVendors === $this->vendors;
+    }
+
+    public function serialize()
+    {
+        return serialize(array($this->versions, $this->vendors));
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->versions, $this->vendors) = unserialize($serialized);
+    }
+
+    private static function refresh()
+    {
+        if (null !== self::$runtimeVersion) {
+            return;
+        }
+
+        self::$runtimeVersion = array();
+        self::$runtimeVendors = array();
+
+        foreach (get_loaded_extensions() as $ext) {
+            self::$runtimeVersion[$ext] = phpversion($ext);
+        }
+
+        foreach (get_declared_classes() as $class) {
+            if ('C' === $class[0] && 0 === strpos($class, 'ComposerAutoloaderInit')) {
+                $r = new \ReflectionClass($class);
+                $v = dirname(dirname($r->getFileName()));
+                if (file_exists($v.'/composer/installed.json')) {
+                    self::$runtimeVendors[$v] = @filemtime($v.'/composer/installed.json');
+                }
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Resource/ComposerResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ComposerResourceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Resource;
+
+use Composer\Autoload\ClassLoader;
+use Symfony\Component\Config\Resource\ComposerResource;
+
+class ComposerResourceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetVendor()
+    {
+        $res = new ComposerResource();
+
+        $r = new \ReflectionClass(ClassLoader::class);
+        $found = false;
+
+        foreach ($res->getVendors() as $vendor) {
+            if ($vendor && 0 === strpos($r->getFileName(), $vendor)) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found);
+    }
+
+    public function testSerializeUnserialize()
+    {
+        $res = new ComposerResource();
+        $ser = unserialize(serialize($res));
+
+        $this->assertTrue($res->isFresh(0));
+        $this->assertTrue($ser->isFresh(0));
+
+        $this->assertEquals($res, $ser);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/FactoryReturnTypePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/FactoryReturnTypePass.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -67,7 +66,7 @@ class FactoryReturnTypePass implements CompilerPassInterface
             try {
                 $m = new \ReflectionFunction($factory);
                 if (false !== $m->getFileName() && file_exists($m->getFileName())) {
-                    $container->addResource(new FileResource($m->getFileName()));
+                    $container->fileExists($m->getFileName());
                 }
             } catch (\ReflectionException $e) {
                 return;

--- a/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
@@ -27,7 +27,7 @@ class DirectoryLoader extends FileLoader
     {
         $file = rtrim($file, '/');
         $path = $this->locator->locate($file);
-        $this->container->addResource(new DirectoryResource($path));
+        $this->container->fileExists($path, false);
 
         foreach (scandir($path) as $dir) {
             if ('.' !== $dir[0]) {

--- a/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
@@ -29,7 +29,7 @@ class IniFileLoader extends FileLoader
     {
         $path = $this->locator->locate($resource);
 
-        $this->container->addResource(new FileResource($path));
+        $this->container->fileExists($path);
 
         // first pass to catch parsing errors
         $result = parse_ini_file($path, true);

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -34,7 +34,7 @@ class PhpFileLoader extends FileLoader
 
         $path = $this->locator->locate($resource);
         $this->setCurrentDir(dirname($path));
-        $this->container->addResource(new FileResource($path));
+        $this->container->fileExists($path);
 
         include $path;
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -42,7 +42,7 @@ class XmlFileLoader extends FileLoader
 
         $xml = $this->parseFileToDOM($path);
 
-        $this->container->addResource(new FileResource($path));
+        $this->container->fileExists($path);
 
         // anonymous services
         $this->processAnonymousServices($xml, $path);

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -72,7 +72,7 @@ class YamlFileLoader extends FileLoader
 
         $content = $this->loadFile($path);
 
-        $this->container->addResource(new FileResource($path));
+        $this->container->fileExists($path);
 
         // empty file
         if (null === $content) {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Tests;
 require_once __DIR__.'/Fixtures/includes/classes.php';
 require_once __DIR__.'/Fixtures/includes/ProjectExtension.php';
 
+use Symfony\Component\Config\Resource\ComposerResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\Alias;
@@ -614,7 +615,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
         $resources = $container->getResources();
 
-        $this->assertCount(1, $resources, '1 resource was registered');
+        $this->assertCount(2, $resources, '2 resources were registered');
 
         /* @var $resource \Symfony\Component\Config\Resource\FileResource */
         $resource = end($resources);
@@ -640,7 +641,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
         $resources = $container->getResources();
 
-        $this->assertCount(1, $resources, '1 resource was registered');
+        $this->assertCount(2, $resources, '2 resources were registered');
 
         /* @var $resource \Symfony\Component\Config\Resource\FileResource */
         $resource = end($resources);
@@ -669,9 +670,9 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
         $resources = $container->getResources();
 
-        $this->assertCount(2, $resources, '2 resources were registered');
+        $this->assertCount(3, $resources, '3 resources were registered');
 
-        $this->assertSame('reflection.BarClass', (string) $resources[0]);
+        $this->assertSame('reflection.BarClass', (string) $resources[1]);
         $this->assertSame('BarMissingClass', (string) end($resources));
     }
 
@@ -715,6 +716,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testFileExists()
     {
         $container = new ContainerBuilder();
+        $A = new ComposerResource();
         $a = new FileResource(__DIR__.'/Fixtures/xml/services1.xml');
         $b = new FileResource(__DIR__.'/Fixtures/xml/services2.xml');
         $c = new DirectoryResource($dir = dirname($b));
@@ -728,7 +730,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertEquals(array($a, $b, $c), $resources, '->getResources() returns an array of resources read for the current configuration');
+        $this->assertEquals(array($A, $a, $b, $c), $resources, '->getResources() returns an array of resources read for the current configuration');
     }
 
     public function testExtension()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

So that the container is invalidated whenever a new PHP runtime is used, a PHP-extension is added, or vendors are changed.