### PR TITLE
[HttpKernel][FrameworkBundle] Lazy load argument value resolvers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ControllerArgumentValueResolverPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ControllerArgumentValueResolverPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -32,6 +33,6 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('argument_resolver');
         $argumentResolvers = $this->findAndSortTaggedServices('controller.argument_value_resolver', $container);
-        $definition->replaceArgument(1, $argumentResolvers);
+        $definition->replaceArgument(1, new IteratorArgument($argumentResolvers));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -21,7 +21,7 @@
 
         <service id="argument_resolver" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver" public="false">
             <argument type="service" id="argument_metadata_factory" />
-            <argument type="collection" />
+            <argument /> <!-- argument value resolvers -->
         </service>
 
         <service id="argument_resolver.request_attribute" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver" public="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ControllerArgumentValueResolverPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ControllerArgumentValueResolverPassTest.php
@@ -42,7 +42,7 @@ class ControllerArgumentValueResolverPassTest extends \PHPUnit_Framework_TestCas
         }
 
         (new ControllerArgumentValueResolverPass())->process($container);
-        $this->assertEquals($expected, $definition->getArgument(1));
+        $this->assertEquals($expected, $definition->getArgument(1)->getValues());
     }
 
     public function testReturningEmptyArrayWhenNoService()
@@ -52,7 +52,7 @@ class ControllerArgumentValueResolverPassTest extends \PHPUnit_Framework_TestCas
         $container->setDefinition('argument_resolver', $definition);
 
         (new ControllerArgumentValueResolverPass())->process($container);
-        $this->assertEquals(array(), $definition->getArgument(1));
+        $this->assertEquals(array(), $definition->getArgument(1)->getValues());
     }
 
     public function testNoArgumentResolver()

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -29,11 +29,11 @@ final class ArgumentResolver implements ArgumentResolverInterface
     private $argumentMetadataFactory;
 
     /**
-     * @var ArgumentValueResolverInterface[]
+     * @var iterable|ArgumentValueResolverInterface[]
      */
     private $argumentValueResolvers;
 
-    public function __construct(ArgumentMetadataFactoryInterface $argumentMetadataFactory = null, array $argumentValueResolvers = array())
+    public function __construct(ArgumentMetadataFactoryInterface $argumentMetadataFactory = null, $argumentValueResolvers = array())
     {
         $this->argumentMetadataFactory = $argumentMetadataFactory ?: new ArgumentMetadataFactory();
         $this->argumentValueResolvers = $argumentValueResolvers ?: self::getDefaultArgumentValueResolvers();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The ArgumentResolver resolves an arg using the first ArgumentValueResolver which `supports()` it (which can be complex, see e.g. [sensiolabs/SensioFrameworkExtraBundle#436](https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/436/files#diff-865d48d9369c4431bce36ba642834570R10)).