### PR TITLE
[TwigBridge] Add docblocks for Twig url and path function to improve ide completion

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
@@ -40,11 +40,25 @@ class RoutingExtension extends \Twig_Extension
         );
     }
 
+    /**
+     * @param string $name
+     * @param array  $parameters
+     * @param bool   $relative
+     *
+     * @return string
+     */
     public function getPath($name, $parameters = array(), $relative = false)
     {
         return $this->generator->generate($name, $parameters, $relative ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
+    /**
+     * @param string $name
+     * @param array  $parameters
+     * @param bool   $schemeRelative
+     *
+     * @return string
+     */
     public function getUrl($name, $parameters = array(), $schemeRelative = false)
     {
         return $this->generator->generate($name, $parameters, $schemeRelative ? UrlGeneratorInterface::NETWORK_PATH : UrlGeneratorInterface::ABSOLUTE_URL);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

`RoutingExtension` missed docblock for Twig extension so `path` and `url` are not fully recognized by PhpStorm. 

https://github.com/Haehnchen/idea-php-symfony2-plugin/issues/864 will add more smarter completion 
`{{ p<caret> }} -> {{ path('<caret>') }}`, but string parameter is not detected. This will add the minimal docs


