### PR TITLE
Static code analysis with Php Inspections (EA Extended)

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -138,7 +138,7 @@ class CodeExtension extends \Twig_Extension
             $code = @highlight_file($file, true);
             // remove main code/span tags
             $code = preg_replace('#^<code.*?>\s*<span.*?>(.*)</span>\s*</code>#s', '\\1', $code);
-            $content = preg_split('#<br />#', $code);
+            $content = explode('<br />', $code);
 
             $lines = array();
             for ($i = max($line - 3, 1), $max = min($line + 3, count($content)); $i <= $max; ++$i) {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -62,9 +62,7 @@ class HttpKernelExtensionTest extends \PHPUnit_Framework_TestCase
 
         $context->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
 
-        $renderer = new FragmentHandler(array($strategy), false, $context);
-
-        return $renderer;
+        return new FragmentHandler(array($strategy), false, $context);
     }
 
     protected function renderTemplate(FragmentHandler $renderer, $template = '{{ render("foo") }}')

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -132,7 +132,7 @@ class CodeHelper extends Helper
             $code = @highlight_file($file, true);
             // remove main code/span tags
             $code = preg_replace('#^<code.*?>\s*<span.*?>(.*)</span>\s*</code>#s', '\\1', $code);
-            $content = preg_split('#<br />#', $code);
+            $content = explode('<br />', $code);
 
             $lines = array();
             for ($i = max($line - 3, 1), $max = min($line + 3, count($content)); $i <= $max; ++$i) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
@@ -46,4 +46,4 @@ EOF
 
 <?php echo $view['translator']->trans('typecast', ['a' => (int) '123'], 'not_messages'); ?>
 <?php echo $view['translator']->transChoice('msg1', 10 + 1, [], 'not_messages'); ?>
-<?php echo $view['translator']->transChoice('msg2', (int)4.5, [], 'not_messages'); ?>
+<?php echo $view['translator']->transChoice('msg2', ceil(4.5), [], 'not_messages'); ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php
@@ -46,4 +46,4 @@ EOF
 
 <?php echo $view['translator']->trans('typecast', ['a' => (int) '123'], 'not_messages'); ?>
 <?php echo $view['translator']->transChoice('msg1', 10 + 1, [], 'not_messages'); ?>
-<?php echo $view['translator']->transChoice('msg2', intval(4.5), [], 'not_messages'); ?>
+<?php echo $view['translator']->transChoice('msg2', (int)4.5, [], 'not_messages'); ?>

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimpleFormFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimpleFormFactory.php
@@ -77,17 +77,4 @@ class SimpleFormFactory extends FormLoginFactory
 
         return $listenerId;
     }
-
-    protected function createEntryPoint($container, $id, $config, $defaultEntryPoint)
-    {
-        $entryPointId = 'security.authentication.form_entry_point.'.$id;
-        $container
-            ->setDefinition($entryPointId, new DefinitionDecorator('security.authentication.form_entry_point'))
-            ->addArgument(new Reference('security.http_utils'))
-            ->addArgument($config['login_path'])
-            ->addArgument($config['use_forward'])
-        ;
-
-        return $entryPointId;
-    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
@@ -36,7 +36,7 @@ class CrossCheckTest extends \PHPUnit_Framework_TestCase
 
         $tmp = tempnam(sys_get_temp_dir(), 'sf');
 
-        file_put_contents($tmp, file_get_contents(self::$fixturesPath.'/'.$type.'/'.$fixture));
+        copy(self::$fixturesPath.'/'.$type.'/'.$fixture, $tmp);
 
         $container1 = new ContainerBuilder();
         $loader1 = new $loaderClass($container1, new FileLocator());

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1044,6 +1044,8 @@ class Crawler extends \SplObjectStorage
      */
     private function createSubCrawler($nodes)
     {
-        return new static($nodes, $this->uri, $this->baseHref);
+        $crawler = new static($nodes, $this->uri, $this->baseHref);
+
+        return $crawler;
     }
 }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1044,8 +1044,6 @@ class Crawler extends \SplObjectStorage
      */
     private function createSubCrawler($nodes)
     {
-        $crawler = new static($nodes, $this->uri, $this->baseHref);
-
-        return $crawler;
+        return new static($nodes, $this->uri, $this->baseHref);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -164,7 +164,8 @@ class BinaryFileResponse extends Response
         if ('' === $filenameFallback && (!preg_match('/^[\x20-\x7e]*$/', $filename) || false !== strpos($filename, '%'))) {
             $encoding = mb_detect_encoding($filename, null, true);
 
-            for ($i = 0; $i < mb_strlen($filename, $encoding); ++$i) {
+            $filenameLength = mb_strlen($filename, $encoding);
+            for ($i = 0; $i < $filenameLength; ++$i) {
                 $char = mb_substr($filename, $i, 1, $encoding);
 
                 if ('%' === $char || ord($char) < 32 || ord($char) > 126) {

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -164,8 +164,7 @@ class BinaryFileResponse extends Response
         if ('' === $filenameFallback && (!preg_match('/^[\x20-\x7e]*$/', $filename) || false !== strpos($filename, '%'))) {
             $encoding = mb_detect_encoding($filename, null, true);
 
-            $filenameLength = mb_strlen($filename, $encoding);
-            for ($i = 0; $i < $filenameLength; ++$i) {
+            for ($i = 0, $filenameLength = mb_strlen($filename, $encoding); $i < $filenameLength; ++$i) {
                 $char = mb_substr($filename, $i, 1, $encoding);
 
                 if ('%' === $char || ord($char) < 32 || ord($char) > 126) {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -108,7 +108,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
                 if (phpversion('mongodb')) {
                     $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $criteria[$that->options['expiry_field']]['$gte']);
-                    $that->assertGreaterThanOrEqual(round((int)((string) $criteria[$that->options['expiry_field']]['$gte']) / 1000), $testTimeout);
+                    $that->assertGreaterThanOrEqual(round((int) ((string) $criteria[$that->options['expiry_field']]['$gte']) / 1000), $testTimeout);
                 } else {
                     $that->assertInstanceOf('MongoDate', $criteria[$that->options['expiry_field']]['$gte']);
                     $that->assertGreaterThanOrEqual($criteria[$that->options['expiry_field']]['$gte']->sec, $testTimeout);
@@ -167,7 +167,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             $that->assertEquals('bar', $data[$that->options['data_field']]->getData());
             $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $data[$that->options['time_field']]);
             $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $data[$that->options['expiry_field']]);
-            $that->assertGreaterThanOrEqual($expectedExpiry, round((int)((string) $data[$that->options['expiry_field']]) / 1000));
+            $that->assertGreaterThanOrEqual($expectedExpiry, round((int) ((string) $data[$that->options['expiry_field']]) / 1000));
         } else {
             $that->assertEquals('bar', $data[$that->options['data_field']]->bin);
             $that->assertInstanceOf('MongoDate', $data[$that->options['time_field']]);
@@ -293,7 +293,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnCallback(function ($criteria) use ($that) {
                 if (phpversion('mongodb')) {
                     $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $criteria[$that->options['expiry_field']]['$lt']);
-                    $that->assertGreaterThanOrEqual(time() - 1, round((int)((string) $criteria[$that->options['expiry_field']]['$lt']) / 1000));
+                    $that->assertGreaterThanOrEqual(time() - 1, round((int) ((string) $criteria[$that->options['expiry_field']]['$lt']) / 1000));
                 } else {
                     $that->assertInstanceOf('MongoDate', $criteria[$that->options['expiry_field']]['$lt']);
                     $that->assertGreaterThanOrEqual(time() - 1, $criteria[$that->options['expiry_field']]['$lt']->sec);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -108,7 +108,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
                 if (phpversion('mongodb')) {
                     $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $criteria[$that->options['expiry_field']]['$gte']);
-                    $that->assertGreaterThanOrEqual(round((int) ((string) $criteria[$that->options['expiry_field']]['$gte']) / 1000), $testTimeout);
+                    $that->assertGreaterThanOrEqual(round(((int) $criteria[$that->options['expiry_field']]['$gte']) / 1000), $testTimeout);
                 } else {
                     $that->assertInstanceOf('MongoDate', $criteria[$that->options['expiry_field']]['$gte']);
                     $that->assertGreaterThanOrEqual($criteria[$that->options['expiry_field']]['$gte']->sec, $testTimeout);
@@ -167,7 +167,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             $that->assertEquals('bar', $data[$that->options['data_field']]->getData());
             $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $data[$that->options['time_field']]);
             $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $data[$that->options['expiry_field']]);
-            $that->assertGreaterThanOrEqual($expectedExpiry, round((int) ((string) $data[$that->options['expiry_field']]) / 1000));
+            $that->assertGreaterThanOrEqual($expectedExpiry, round(((int) $data[$that->options['expiry_field']]) / 1000));
         } else {
             $that->assertEquals('bar', $data[$that->options['data_field']]->bin);
             $that->assertInstanceOf('MongoDate', $data[$that->options['time_field']]);
@@ -293,7 +293,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnCallback(function ($criteria) use ($that) {
                 if (phpversion('mongodb')) {
                     $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $criteria[$that->options['expiry_field']]['$lt']);
-                    $that->assertGreaterThanOrEqual(time() - 1, round((int) ((string) $criteria[$that->options['expiry_field']]['$lt']) / 1000));
+                    $that->assertGreaterThanOrEqual(time() - 1, round(((int) $criteria[$that->options['expiry_field']]['$lt']) / 1000));
                 } else {
                     $that->assertInstanceOf('MongoDate', $criteria[$that->options['expiry_field']]['$lt']);
                     $that->assertGreaterThanOrEqual(time() - 1, $criteria[$that->options['expiry_field']]['$lt']->sec);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -108,7 +108,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
                 if (phpversion('mongodb')) {
                     $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $criteria[$that->options['expiry_field']]['$gte']);
-                    $that->assertGreaterThanOrEqual(round(intval((string) $criteria[$that->options['expiry_field']]['$gte']) / 1000), $testTimeout);
+                    $that->assertGreaterThanOrEqual(round((int)((string) $criteria[$that->options['expiry_field']]['$gte']) / 1000), $testTimeout);
                 } else {
                     $that->assertInstanceOf('MongoDate', $criteria[$that->options['expiry_field']]['$gte']);
                     $that->assertGreaterThanOrEqual($criteria[$that->options['expiry_field']]['$gte']->sec, $testTimeout);
@@ -167,7 +167,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             $that->assertEquals('bar', $data[$that->options['data_field']]->getData());
             $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $data[$that->options['time_field']]);
             $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $data[$that->options['expiry_field']]);
-            $that->assertGreaterThanOrEqual($expectedExpiry, round(intval((string) $data[$that->options['expiry_field']]) / 1000));
+            $that->assertGreaterThanOrEqual($expectedExpiry, round((int)((string) $data[$that->options['expiry_field']]) / 1000));
         } else {
             $that->assertEquals('bar', $data[$that->options['data_field']]->bin);
             $that->assertInstanceOf('MongoDate', $data[$that->options['time_field']]);
@@ -293,7 +293,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnCallback(function ($criteria) use ($that) {
                 if (phpversion('mongodb')) {
                     $that->assertInstanceOf('MongoDB\BSON\UTCDateTime', $criteria[$that->options['expiry_field']]['$lt']);
-                    $that->assertGreaterThanOrEqual(time() - 1, round(intval((string) $criteria[$that->options['expiry_field']]['$lt']) / 1000));
+                    $that->assertGreaterThanOrEqual(time() - 1, round((int)((string) $criteria[$that->options['expiry_field']]['$lt']) / 1000));
                 } else {
                     $that->assertInstanceOf('MongoDate', $criteria[$that->options['expiry_field']]['$lt']);
                     $that->assertGreaterThanOrEqual(time() - 1, $criteria[$that->options['expiry_field']]['$lt']->sec);

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -48,26 +48,6 @@ class Client extends BaseClient
     }
 
     /**
-     * {@inheritdoc}
-     *
-     * @return Request|null A Request instance
-     */
-    public function getRequest()
-    {
-        return parent::getRequest();
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return Response|null A Response instance
-     */
-    public function getResponse()
-    {
-        return parent::getResponse();
-    }
-
-    /**
      * Makes a request.
      *
      * @param Request $request A Request instance

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -25,6 +25,9 @@ use Symfony\Component\HttpFoundation\Response;
  * Client simulates a browser and makes requests to a Kernel object.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method Request|null getRequest() A Request instance
+ * @method Response|null getResponse() A Response instance
  */
 class Client extends BaseClient
 {

--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -33,8 +33,7 @@ class ValueExporter
 
         if (is_object($value)) {
             if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
-                // note: \DateTime::ISO8601 is not ISO8601 compatible; \DateTime::ATOM IS ISO8601 compatible
-                return sprintf('Object(%s) - %s', get_class($value), $value->format(\DateTime::ISO8601));
+                return sprintf('Object(%s) - %s', get_class($value), $value->format(\DateTime::ATOM));
             }
 
             return sprintf('Object(%s)', get_class($value));

--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -33,6 +33,7 @@ class ValueExporter
 
         if (is_object($value)) {
             if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
+                // note: \DateTime::ISO8601 is not ISO8601 compatible; \DateTime::ATOM IS ISO8601 compatible
                 return sprintf('Object(%s) - %s', get_class($value), $value->format(\DateTime::ISO8601));
             }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
@@ -41,7 +41,7 @@ class MemcacheProfilerStorage extends BaseMemcacheProfilerStorage
             $port = $matches[3];
 
             $memcache = new \Memcache();
-            $memcache->addserver($host, $port);
+            $memcache->addServer($host, $port);
 
             $this->memcache = $memcache;
         }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/Util/ValueExporterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/Util/ValueExporterTest.php
@@ -28,7 +28,7 @@ class ValueExporterTest extends \PHPUnit_Framework_TestCase
     public function testDateTime()
     {
         $dateTime = new \DateTime('2014-06-10 07:35:40', new \DateTimeZone('UTC'));
-        $this->assertSame('Object(DateTime) - 2014-06-10T07:35:40+0000', $this->valueExporter->exportValue($dateTime));
+        $this->assertSame('Object(DateTime) - 2014-06-10T07:35:40+00:00', $this->valueExporter->exportValue($dateTime));
     }
 
     /**
@@ -37,7 +37,7 @@ class ValueExporterTest extends \PHPUnit_Framework_TestCase
     public function testDateTimeImmutable()
     {
         $dateTime = new \DateTimeImmutable('2014-06-10 07:35:40', new \DateTimeZone('UTC'));
-        $this->assertSame('Object(DateTimeImmutable) - 2014-06-10T07:35:40+0000', $this->valueExporter->exportValue($dateTime));
+        $this->assertSame('Object(DateTimeImmutable) - 2014-06-10T07:35:40+00:00', $this->valueExporter->exportValue($dateTime));
     }
 
     public function testIncompleteClass()

--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -662,9 +662,7 @@ QUERY;
     protected function getDeleteSecurityIdentityIdSql(SecurityIdentityInterface $sid)
     {
         $select = $this->getSelectSecurityIdentityIdSql($sid);
-        $delete = preg_replace('/^SELECT id FROM/', 'DELETE FROM', $select);
-
-        return $delete;
+        return preg_replace('/^SELECT id FROM/', 'DELETE FROM', $select);
     }
 
     /**

--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -662,6 +662,7 @@ QUERY;
     protected function getDeleteSecurityIdentityIdSql(SecurityIdentityInterface $sid)
     {
         $select = $this->getSelectSecurityIdentityIdSql($sid);
+
         return preg_replace('/^SELECT id FROM/', 'DELETE FROM', $select);
     }
 

--- a/src/Symfony/Component/Translation/Tests/DataCollectorTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/DataCollectorTranslatorTest.php
@@ -68,8 +68,6 @@ class DataCollectorTranslatorTest extends \PHPUnit_Framework_TestCase
         $translator->addResource('array', array('bar' => 'bar (fr)'), 'fr');
         $translator->addResource('array', array('bar_ru' => 'bar (ru)'), 'ru');
 
-        $collector = new DataCollectorTranslator($translator);
-
-        return $collector;
+        return new DataCollectorTranslator($translator);
     }
 }

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -610,7 +610,8 @@ class Parser
             $previousLineIndented = false;
             $previousLineBlank = false;
 
-            for ($i = 0; $i < count($blockLines); ++$i) {
+            $blockLinesCount = count($blockLines);
+            for ($i = 0; $i < $blockLinesCount; ++$i) {
                 if ('' === $blockLines[$i]) {
                     $text .= "\n";
                     $previousLineIndented = false;

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -610,8 +610,7 @@ class Parser
             $previousLineIndented = false;
             $previousLineBlank = false;
 
-            $blockLinesCount = count($blockLines);
-            for ($i = 0; $i < $blockLinesCount; ++$i) {
+            for ($i = 0, $blockLinesCount = count($blockLines); $i < $blockLinesCount; ++$i) {
                 if ('' === $blockLines[$i]) {
                     $text .= "\n";
                     $previousLineIndented = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | --
| License       | MIT
| Doc PR        | --

- Unnecessary proxy methods and methods duplicating  parents ones removed;
- Type casings instead of PHP4 functions;
- Usage of copy instead of file combining file get/put contents;
- One time use variables cleaned up;
- Superfluous functions calls in loop termination conditions fixed;