### PR TITLE
LazyLoadingMetadataFactory looks broken

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCar.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCar.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+use Symfony\Component\Validator\Constraints\Length;
+
+/**
+ * Description of EntityStatic
+ *
+ * @author po_taka <angel.koilov@gmail.com>
+ */
+class EntityStaticCar extends EntityStaticVehicle
+{
+    public static function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        $metadata->addPropertyConstraint('wheels', new Length(array ('max' => 99,)));
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCar.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCar.php
@@ -1,16 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Validator\Tests\Fixtures;
 
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 use Symfony\Component\Validator\Constraints\Length;
 
-/**
- * Description of EntityStatic
- *
- * @author po_taka <angel.koilov@gmail.com>
- */
 class EntityStaticCar extends EntityStaticVehicle
 {
     public static function loadValidatorMetadata(ClassMetadata $metadata)

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCarTurbo.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCarTurbo.php
@@ -1,16 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Validator\Tests\Fixtures;
 
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 use Symfony\Component\Validator\Constraints\Length;
 
-/**
- * Description of EntityStaticParent
- *
- * @author po_taka <angel.koilov@gmail.com>
- */
 class EntityStaticCarTurbo extends EntityStaticCar
 {
     public static function loadValidatorMetadata(ClassMetadata $metadata)

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCarTurbo.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCarTurbo.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+use Symfony\Component\Validator\Constraints\Length;
+
+/**
+ * Description of EntityStaticParent
+ *
+ * @author po_taka <angel.koilov@gmail.com>
+ */
+class EntityStaticCarTurbo extends EntityStaticCar
+{
+    public static function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        $metadata->addPropertyConstraint('wheels', new Length(array ('max' => 99,)));
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticVehicle.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticVehicle.php
@@ -1,16 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Validator\Tests\Fixtures;
 
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 use Symfony\Component\Validator\Constraints\Length;
 
-/**
- * Description of EntityStaticVehicle
- *
- * @author po_taka <angel.koilov@gmail.com>
- */
 class EntityStaticVehicle
 {
     public $wheels;

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticVehicle.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticVehicle.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+use Symfony\Component\Validator\Constraints\Length;
+
+/**
+ * Description of EntityStaticVehicle
+ *
+ * @author po_taka <angel.koilov@gmail.com>
+ */
+class EntityStaticVehicle
+{
+    public $wheels;
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        $metadata->addPropertyConstraint('wheels', new Length(array ('max' => 99,)));
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -175,7 +175,8 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new LazyLoadingMetadataFactory($reader);
         $metadata = $factory->getMetadataFor('Symfony\Component\Validator\Tests\Fixtures\EntityStaticCarTurbo');
         $classMetaData = $metadata->getPropertyMetadata('wheels');
-        $groups = $classMetaData[0]->getConstraints()[0]->groups;
+        $constraints = $classMetaData[0]->getConstraints();
+        $groups = $constraints[0]->groups;
 
         $this->assertContains('Default', $groups);
         $this->assertContains('EntityStaticCarTurbo', $groups);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -168,6 +168,21 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
 
         $metadata = $factory->getMetadataFor(self::CLASS_NAME);
     }
+
+    public function testGroupsFromParent()
+    {
+        $reader = new \Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader();
+        $factory = new LazyLoadingMetadataFactory($reader);
+        $metadata = $factory->getMetadataFor('Symfony\Component\Validator\Tests\Fixtures\EntityStaticCarTurbo');
+        $classMetaData = $metadata->getPropertyMetadata('wheels');
+        $groups = $classMetaData[0]->getConstraints()[0]->groups;
+
+        $this->assertContains('Default', $groups);
+        $this->assertContains('EntityStaticCarTurbo', $groups);
+        $this->assertContains('EntityStaticCar', $groups);
+        $this->assertContains('EntityStaticVehicle', $groups);
+    }
+
 }
 
 class TestLoader implements LoaderInterface


### PR DESCRIPTION
| Q               | A
| ------------- | ---
| Branch?       |  3.2
| Bug fix?      | no (tests only)
| New feature?  | no
| BC breaks?    | yes/no
| Deprecations? | no
| Tests pass?   | no
| License       | MIT


I'm expecting to have all parent classes in constraint group. By the [docs] (http://symfony.com/doc/current/validation/groups.html) 
> If you have inheritance (e.g. User extends BaseUser) and you validate with the class name of the subclass (i.e. User), then all constraints in the User and BaseUser will be validated. However, if you validate using the base class (i.e. BaseUser), then only the default constraints in the BaseUser class will be validated.

Testing with LazyLoadingMetadataFactory from v3.2.1 works fine.