### PR TITLE
Fix invalid parent class reference with PhpUnit 6

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class KernelTestCase extends \PHPUnit_Framework_TestCase
+abstract class KernelTestCase extends \PHPUnit\Framework\TestCase
 {
     protected static $class;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | possible
| Deprecations? | no
| Tests pass?   | unknown
| Fixed tickets | #21534 
| License       | MIT
| Doc PR        | 

Reopening due to new PhpUnit [4.8.35](https://github.com/sebastianbergmann/phpunit/blob/4.8/ChangeLog-4.8.md#4835---2017-02-06) that introduces the new namespaces.

See https://github.com/symfony/symfony/issues/21534