### PR TITLE
Release v2.8.17

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,27 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.17 (2017-02-06)
+
+ * bug #20844 [Config] Fix checking cache for non existing meta file (hason)
+ * bug #21063 [Form] Fixed DateType format option for single text widget (HeahDude)
+ * bug #21430 Casting TableCell value to string. (jaydiablo)
+ * bug #21359 [FrameworkBundle] fixed custom domain for translations in php templates (robinlehrmann)
+ * bug #21485 [Process] Non ASCII characters disappearing during the escapeshellarg (GuillaumeVerdon)
+ * bug #21370 [FrameworkBundle] Execute the PhpDocExtractor earlier (GuilhemN)
+ * bug #21462 [BrowserKit] ignore invalid cookies expires date format (xabbuh)
+ * bug #21438 [Console] Fix TableCell issues with decoration (ogizanagi)
+ * bug #21431 [DoctrineBridge] always check for all fields to be mapped (xabbuh)
+ * bug #21360 [PropertyAccess] Handle interfaces in the invalid argument exception (fancyweb)
+ * bug #21403 [DI] Fix defaults overriding empty strings in AutowirePass (nicolas-grekas)
+ * bug #21401 [Debug] Workaround "null" $context (nicolas-grekas)
+ * bug #21333 [HttpKernel] Fix ArgumentValueResolver for arguments default null (chalasr)
+ * bug #20871 [HttpKernel] Give higher priority to adding request formats (akeeman)
+ * bug #21332 [PropertyInfo] Don't try to access a property thru a static method (dunglas)
+ * bug #21331 [PropertyInfo] Exclude static methods form properties guessing (dunglas)
+ * bug #21285 [TwigBundle] do not lose already set method calls (xabbuh)
+ * bug #21279 #20411 fix Yaml parsing for very long quoted strings (RichardBradley)
+
 * 2.8.16 (2017-01-12)
 
  * bug #21218 [Form] DateTimeToLocalizedStringTransformer does not use timezone when using date only (magnetik)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.17-DEV';
+    const VERSION = '2.8.17';
     const VERSION_ID = 20817;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
     const RELEASE_VERSION = 17;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';
     const END_OF_LIFE = '11/2019';


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.8.16...4ddbaec

**Changelog**

 * bug #20844 [Config] Fix checking cache for non existing meta file (@hason)
 * bug #21063 [Form] Fixed DateType format option for single text widget (@HeahDude)
 * bug #21430 Casting TableCell value to string. (@jaydiablo)
 * bug #21359 [FrameworkBundle] fixed custom domain for translations in php templates (@robinlehrmann)
 * bug #21485 [Process] Non ASCII characters disappearing during the escapeshellarg (@GuillaumeVerdon)
 * bug #21370 [FrameworkBundle] Execute the PhpDocExtractor earlier (@GuilhemN)
 * bug #21462 [BrowserKit] ignore invalid cookies expires date format (@xabbuh)
 * bug #21438 [Console] Fix TableCell issues with decoration (@ogizanagi)
 * bug #21431 [DoctrineBridge] always check for all fields to be mapped (@xabbuh)
 * bug #21360 [PropertyAccess] Handle interfaces in the invalid argument exception (@fancyweb)
 * bug #21403 [DI] Fix defaults overriding empty strings in AutowirePass (@nicolas-grekas)
 * bug #21401 [Debug] Workaround "null" $context (@nicolas-grekas)
 * bug #21333 [HttpKernel] Fix ArgumentValueResolver for arguments default null (@chalasr)
 * bug #20871 [HttpKernel] Give higher priority to adding request formats (@akeeman)
 * bug #21332 [PropertyInfo] Don't try to access a property thru a static method (@dunglas)
 * bug #21331 [PropertyInfo] Exclude static methods form properties guessing (@dunglas)
 * bug #21285 [TwigBundle] do not lose already set method calls (@xabbuh)
 * bug #21279 #20411 fix Yaml parsing for very long quoted strings (@RichardBradley)
