### PR TITLE
[debug] Hide vendor stack traces from UI unless exception originates from vendor

### DIFF
--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -215,7 +215,14 @@ class ExceptionHandler
             try {
                 $count = count($exception->getAllPrevious());
                 $total = $count + 1;
-                foreach ($exception->toArray() as $position => $e) {
+                $exceptionArray = $exception->toArray();
+                $skipVendorTraces = true;
+
+                if (strpos($exceptionArray[0]['trace'][0]['file'], '/vendor/') > -1) {
+                    $skipVendorTraces = false;
+                }
+
+                foreach ($exceptionArray as $position => $e) {
                     $ind = $count - $position + 1;
                     $class = $this->formatClass($e['class']);
                     $message = nl2br($this->escapeHtml($e['message']));
@@ -231,6 +238,9 @@ class ExceptionHandler
 EOF
                         , $ind, $total, $class, $this->formatPath($e['trace'][0]['file'], $e['trace'][0]['line']), $message);
                     foreach ($e['trace'] as $trace) {
+                        if ($skipVendorTraces === true && strpos($trace['file'], '/vendor/') > -1) {
+                            continue;
+                        }
                         $content .= '       <li>';
                         if ($trace['function']) {
                             $content .= sprintf('at %s%s%s(%s)', $this->formatClass($trace['class']), $trace['type'], $trace['function'], $this->formatArgs($trace['args']));


### PR DESCRIPTION
Figured seeing vendor traces in each stack trace would not necessarily be relevant if the terminating trace originates in the app. 

This may need an update to the ExceptionCaster as console output, etc should follow same logic. Also may want to environmentalize this behavior. Figured there would be some discussion about this. 

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->


