### PR TITLE
[FrameworkBundle] Fix annotations cache folder path

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1278,7 +1278,6 @@ class FrameworkExtension extends Extension
     private function registerCacheConfiguration(array $config, ContainerBuilder $container)
     {
         $version = substr(str_replace('/', '-', base64_encode(hash('sha256', uniqid(mt_rand(), true), true))), 0, 22);
-        $container->getDefinition('cache.annotations')->replaceArgument(2, $version);
         $container->getDefinition('cache.adapter.apcu')->replaceArgument(2, $version);
         $container->getDefinition('cache.adapter.system')->replaceArgument(2, $version);
         $container->getDefinition('cache.adapter.filesystem')->replaceArgument(2, $config['directory']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The argument at index 2 sets a cache path as it extends the file system adapter by default since https://github.com/symfony/symfony/commit/e59f0e0fd7323902fa025e2eae96ce9eb91b24c5, where it did set the version before that. This change now results in annotation cache folders showing up in the project root (because of the overwritten cache root folder).
Because cache.annotations has a parent now, this line is not needed anymore and fixes the problem.