### PR TITLE
[FrameworkBundle] Wire ArrayCache for annotation reader at bootstrap

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAnnotationsCachedReaderPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAnnotationsCachedReaderPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @internal
@@ -27,7 +28,16 @@ class AddAnnotationsCachedReaderPass implements CompilerPassInterface
         // "annotations.cached_reader" is wired late so that any passes using
         // "annotation_reader" at build time don't get any cache
         if ($container->hasDefinition('annotations.cached_reader')) {
-            $container->setAlias('annotation_reader', 'annotations.cached_reader');
+            $reader = $container->getDefinition('annotations.cached_reader');
+            $tags = $reader->getTags();
+
+            if (isset($tags['annotations.cached_reader'][0]['provider'])) {
+                if ($container->hasAlias($provider = $tags['annotations.cached_reader'][0]['provider'])) {
+                    $provider = (string) $container->getAlias($provider);
+                }
+                $container->set('annotations.cached_reader', null);
+                $container->setDefinition('annotations.cached_reader', $reader->replaceArgument(1, new Reference($provider)));
+            }
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1039,10 +1039,11 @@ class FrameworkExtension extends Extension
 
             $container
                 ->getDefinition('annotations.cached_reader')
-                ->replaceArgument(1, new Reference($cacheService))
                 ->replaceArgument(2, $config['debug'])
+                ->addTag('annotations.cached_reader', array('provider' => $cacheService))
                 ->addAutowiringType(Reader::class)
             ;
+            $container->setAlias('annotation_reader', 'annotations.cached_reader');
         } else {
             $container->removeDefinition('annotations.cached_reader');
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -11,7 +11,9 @@
 
         <service id="annotations.cached_reader" class="Doctrine\Common\Annotations\CachedReader" public="false">
             <argument type="service" id="annotations.reader" />
-            <argument /><!-- Cache Implementation -->
+            <argument type="service">
+                <service class="Doctrine\Common\Cache\ArrayCache" />
+            </argument>
             <argument /><!-- Debug-Flag -->
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddAnnotationsCachedReaderPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
@@ -818,6 +819,7 @@ abstract class FrameworkExtensionTest extends TestCase
             $container->getCompilerPassConfig()->setOptimizationPasses(array());
             $container->getCompilerPassConfig()->setRemovingPasses(array());
         }
+        $container->getCompilerPassConfig()->setBeforeRemovingPasses(array(new AddAnnotationsCachedReaderPass()));
         $container->compile();
 
         return self::$containerCache[$cacheKey] = $container;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21549
| License       | MIT
| Doc PR        | -

Related to #21381 which disabled any cache at bootstrap.
Instead, this wires ArrayCache during bootstrapping, then swaps the cache provider for the real one.