### PR TITLE
fix camelize function

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -392,7 +392,7 @@ class Container implements ResettableContainerInterface
      */
     public static function camelize($id)
     {
-        return strtr(ucwords(strtr($id, array('_' => ' ', '.' => '_ ', '\\' => '_ '))), array(' ' => ''));
+        return strtr(ucwords(strtr($id, array('_' => ' ', '.' => '_ ', '\\' => '_ '))), array(' ' => '', '_' => ''));
     }
 
     /**


### PR DESCRIPTION
camelize method wont probably camelize string when you use id like this '\\hello\\world' , this will output _Hello_World instead of HelloWorld

| Q             | A
| ------------- | ---
| Branch?       | master / 2.7, 2.8 or 3.2 <!--see comment below-->
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
