### PR TITLE
[Security] LdapUserProvider should not throw an exception if the UID key does not exist in an LDAP entry

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
@@ -151,10 +151,7 @@ class LdapUserProviderTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\InvalidArgumentException
-     */
-    public function testLoadUserByUsernameFailsIfEntryHasNoUidKeyAttribute()
+    public function testLoadUserByUsernameShouldNotFailIfEntryHasNoUidKeyAttribute()
     {
         $result = $this->getMockBuilder(CollectionInterface::class)->getMock();
         $query = $this->getMockBuilder(QueryInterface::class)->getMock();

--- a/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
@@ -48,7 +48,7 @@ class LdapUserProvider implements UserProviderInterface
     public function __construct(LdapInterface $ldap, $baseDn, $searchDn = null, $searchPassword = null, array $defaultRoles = array(), $uidKey = 'sAMAccountName', $filter = '({uid_key}={username})', $passwordAttribute = null)
     {
         if (null === $uidKey) {
-            $uidKey = 'uid';
+            $uidKey = 'sAMAccountName';
         }
 
         $this->ldap = $ldap;
@@ -87,7 +87,13 @@ class LdapUserProvider implements UserProviderInterface
         }
 
         $entry = $entries[0];
-        $username = $this->getAttributeValue($entry, $this->uidKey);
+
+        try {
+            if (null !== $this->uidKey) {
+                $username = $this->getAttributeValue($entry, $this->uidKey);
+            }
+        } catch (InvalidArgumentException $e) {
+        }
 
         return $this->loadUser($username, $entry);
     }
@@ -123,6 +129,7 @@ class LdapUserProvider implements UserProviderInterface
     protected function loadUser($username, Entry $entry)
     {
         $password = null;
+
         if (null !== $this->passwordAttribute) {
             $password = $this->getAttributeValue($entry, $this->passwordAttribute);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1+
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21577
| License       | MIT
| Doc PR        | 

This ticket should fix #21577, which was introduced by commit 6641b79d582bece75e46235f414a9b1c8cb4fb57

LdapUserProvider should not throw an exception if the uid key does not exist in the entry.