### PR TITLE
Catch exceptions from posix_isatty

### DIFF
--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -100,6 +100,10 @@ class StreamOutput extends Output
                 || 'xterm' === getenv('TERM');
         }
 
-        return function_exists('posix_isatty') && @posix_isatty($this->stream);
+        try {
+            return function_exists('posix_isatty') && @posix_isatty($this->stream);
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Tests pass?   | yes
| License       | MIT


We are converting warnings to exceptions, which appears to not take into account @suppression.

This try-catch block does the same job, but allows for "upgraded" warnings.

`posix_isatty(): could not use stream of type 'TEMP'`
