### PR TITLE
[HttpCache] purge both http and https from http cache

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -317,14 +317,30 @@ class Store implements StoreInterface
     /**
      * Purges data for the given URL.
      *
+     * This method purges both the HTTP and the HTTPS version of the cache entry.
+     *
+     * @param string $url A URL
+     *
+     * @return bool true if the URL exists with either HTTP or HTTPS scheme and has been purged, false otherwise
+     */
+    public function purge($url)
+    {
+        $http = preg_replace('#^https#', 'http', $url);
+        $https = preg_replace('#^http#', 'https', $url);
+
+        return $this->doPurge($http) || $this->doPurge($https);
+    }
+
+    /**
+     * Purges data for the given URL.
+     *
      * @param string $url A URL
      *
      * @return bool true if the URL exists and has been purged, false otherwise
      */
-    public function purge($url)
+    private function doPurge($url)
     {
         $key = $this->getCacheKey(Request::create($url));
-
         if (isset($this->locks[$key])) {
             flock($this->locks[$key], LOCK_UN);
             fclose($this->locks[$key]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | => travis
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The HTTP cache store of HttpCache respects the scheme for cache entries, which is the expected behaviour. however, Store::purge($url) also respects the scheme when invalidating the cache. This seems wrong to me.

This PR is rather rough for now, and i did not even look at the tests. Do the maintainers agree with my assumption? Should it be a bugfix against 2.8? Any input on the code?