### PR TITLE
[WebProfilerBundle] Readd Symfony version status in the toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -113,7 +113,7 @@
         </div>
     {% endset %}
 
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true, name: 'config', status: block_status, additional_classes: 'sf-toolbar-block-right' }) }}
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true, name: 'config', status: block_status, additional_classes: 'sf-toolbar-block-right', block_attrs: 'title="' ~ symfony_version_status ~ '"' }) }}
 {% endblock %}
 
 {% block menu %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
@@ -1,4 +1,4 @@
-<div class="sf-toolbar-block sf-toolbar-block-{{ name }} sf-toolbar-status-{{ status|default('normal') }} {{ additional_classes|default('') }}">
+<div class="sf-toolbar-block sf-toolbar-block-{{ name }} sf-toolbar-status-{{ status|default('normal') }} {{ additional_classes|default('') }}" {{ block_attrs|default('') }}>
     {% if link is not defined or link %}<a href="{{ path('_profiler', { token: token, panel: name }) }}">{% endif %}
         <div class="sf-toolbar-icon">{{ icon|default('') }}</div>
     {% if link is not defined or link %}</a>{% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The Symfony version status (*"This Symfony version will no longer receive security fixes."* and the like) was no longer shown in the toolbar. This was removed in https://github.com/symfony/symfony/commit/9d89841e3aaa708a0215db7ad866cfb52b6f2261 , but the commit description isn't that describing. I guess it's not done on purpose.

I think having this information is crucial for this feature to work: A yellow version doesn't mean anything specific, unless I see "This Symfony will only receive security fixes".

/cc @javiereguiluz 