### PR TITLE
[Validator] property constraints can be added in child classes

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -346,10 +346,6 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
         }
 
         foreach ($source->getConstrainedProperties() as $property) {
-            if ($this->hasPropertyMetadata($property)) {
-                continue;
-            }
-
             foreach ($source->getPropertyMetadata($property) as $member) {
                 $member = clone $member;
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCar.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCar.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Constraints\Length;
+
+class EntityStaticCar extends EntityStaticVehicle
+{
+    public static function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        $metadata->addPropertyConstraint('wheels', new Length(array('max' => 99)));
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCarTurbo.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticCarTurbo.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Constraints\Length;
+
+class EntityStaticCarTurbo extends EntityStaticCar
+{
+    public static function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        $metadata->addPropertyConstraint('wheels', new Length(array('max' => 99)));
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticVehicle.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityStaticVehicle.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Constraints\Length;
+
+class EntityStaticVehicle
+{
+    public $wheels;
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        $metadata->addPropertyConstraint('wheels', new Length(array('max' => 99)));
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Validator\Tests\Mapping;
 
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
@@ -303,21 +302,6 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
     public function testGetPropertyMetadataReturnsEmptyArrayWithoutConfiguredMetadata()
     {
         $this->assertCount(0, $this->metadata->getPropertyMetadata('foo'), '->getPropertyMetadata() returns an empty collection if no metadata is configured for the given property');
-    }
-
-    public function testMergeDoesOverrideConstraintsFromParentClassIfPropertyIsOverriddenInChildClass()
-    {
-        $parentMetadata = new ClassMetadata('\Symfony\Component\Validator\Tests\Mapping\ParentClass');
-        $parentMetadata->addPropertyConstraint('example', new GreaterThan(0));
-
-        $childMetadata = new ClassMetadata('\Symfony\Component\Validator\Tests\Mapping\ChildClass');
-        $childMetadata->addPropertyConstraint('example', new GreaterThan(1));
-        $childMetadata->mergeConstraints($parentMetadata);
-
-        $expectedMetadata = new ClassMetadata('\Symfony\Component\Validator\Tests\Mapping\ChildClass');
-        $expectedMetadata->addPropertyConstraint('example', new GreaterThan(1));
-
-        $this->assertEquals($expectedMetadata, $childMetadata);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -174,10 +174,14 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $reader = new \Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader();
         $factory = new LazyLoadingMetadataFactory($reader);
         $metadata = $factory->getMetadataFor('Symfony\Component\Validator\Tests\Fixtures\EntityStaticCarTurbo');
-        $classMetaData = $metadata->getPropertyMetadata('wheels');
-        $constraints = $classMetaData[0]->getConstraints();
-        $groups = $constraints[0]->groups;
+        $groups = array();
 
+        foreach ($metadata->getPropertyMetadata('wheels') as $propertyMetadata) {
+            $constraints = $propertyMetadata->getConstraints();
+            $groups = array_replace($groups, $constraints[0]->groups);
+        }
+
+        $this->assertCount(4, $groups);
         $this->assertContains('Default', $groups);
         $this->assertContains('EntityStaticCarTurbo', $groups);
         $this->assertContains('EntityStaticCar', $groups);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -168,6 +168,21 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
 
         $metadata = $factory->getMetadataFor(self::CLASS_NAME);
     }
+
+    public function testGroupsFromParent()
+    {
+        $reader = new \Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader();
+        $factory = new LazyLoadingMetadataFactory($reader);
+        $metadata = $factory->getMetadataFor('Symfony\Component\Validator\Tests\Fixtures\EntityStaticCarTurbo');
+        $classMetaData = $metadata->getPropertyMetadata('wheels');
+        $constraints = $classMetaData[0]->getConstraints();
+        $groups = $constraints[0]->groups;
+
+        $this->assertContains('Default', $groups);
+        $this->assertContains('EntityStaticCarTurbo', $groups);
+        $this->assertContains('EntityStaticCar', $groups);
+        $this->assertContains('EntityStaticVehicle', $groups);
+    }
 }
 
 class TestLoader implements LoaderInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21538, #21567
| License       | MIT
| Doc PR        | 

This reverts the changes done in #21053 (and applies the test written by @angelk in #21538). I think trying to "fix" #15950 with the changes from #21053 was a mistake. Child classes should be able to refine validation constraints (I basically agree with @ro0NL's reasoning in https://github.com/symfony/symfony/issues/21567#issuecomment-278729990.