### PR TITLE
[DI] Fix undetected ambiguous service types in AutowiringPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -226,7 +226,7 @@ class AutowirePass implements CompilerPassInterface
      */
     private function createAutowiredDefinition(\ReflectionClass $typeHint, $id)
     {
-        if (isset($this->notGuessableTypes[$typeHint->name])) {
+        if (isset($this->notGuessableTypes[$typeHint->name]) && !isset($this->definedTypes[$typeHint->name])) {
             $classOrInterface = $typeHint->isInterface() ? 'interface' : 'class';
             $matchingServices = implode(', ', $this->types[$typeHint->name]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In AutowirePass, "createAutowiredDefinition" calls "populateAvailableType" *while* autowiring services.
This looks bugged to me, since it won't detect some conflicts and inject the firstly discovered class instead.

PR is unfinished on the topic.

ping @dunglas 