### PR TITLE
Improve tracking of environment variables in the case of private services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
@@ -72,6 +72,7 @@ class RemoveUnusedDefinitionsPass implements RepeatablePassInterface
                 $compiler->addLogMessage($formatter->formatRemoveService($this, $id, 'replaces alias '.reset($referencingAliases)));
             } elseif (0 === count($referencingAliases) && false === $isReferenced) {
                 $container->removeDefinition($id);
+                $container->resolveEnvPlaceholders(serialize($definition));
                 $compiler->addLogMessage($formatter->formatRemoveService($this, $id, 'unused'));
                 $hasChanged = true;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21273
| License       | MIT

Recently, I stumbled upon an issue with environment variables that I had troubles to understand. Here it is:

I have two environment variables, defined in my `parameters.yml` with a default value of empty:

``` yaml
parameters:
    env(MAILJET_PUBLIC_KEY): ''
    env(MAILJET_PRIVATE_KEY): ''
```

I use these variables only in a private service:

``` xml
<service id="app.mailjet.transport" class="AppBundle\Mailjet\MailjetApiTransport" public="false">
    <argument type="service" id="csa_guzzle.client.mailjet_api"/>
    <argument>%env(MAILJET_PUBLIC_KEY)%</argument>
    <argument>%env(MAILJET_PRIVATE_KEY)%</argument>
</service>
```

This private service is not used by any other service for the moment.

As the service is private and not used by any other service, the `RemoveUnusedDefinitionsPass` removes it from the container. However, when the container dumper dumps the container, it checks if the environment variable was dumped. As the service is now gone, an expection is thrown (`EnvParameterException, Incompatible use of dynamic environment variables "MAILJET_PUBLIC_KEY", "MAILJET_PRIVATE_KEY" found in parameters.`).