### PR TITLE
[Form] Compare fields inside a RepeatedType through compare option

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG
  * added `Symfony\Component\Form\FormErrorIterator::findByCodes()`
  * added `getTypedExtensions`, `getTypes`, and `getTypeGuessers` to `Symfony\Component\Form\Test\FormIntegrationTestCase`
  * added `FormPass`
- * added `compare` option to `RepeatedType`
+ * added `comparator` option to `RepeatedType`
 
 3.2.0
 -----

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -9,11 +9,11 @@ CHANGELOG
  * added `Symfony\Component\Form\FormErrorIterator::findByCodes()`
  * added `getTypedExtensions`, `getTypes`, and `getTypeGuessers` to `Symfony\Component\Form\Test\FormIntegrationTestCase`
  * added `FormPass`
+ * added `compare` option to `RepeatedType`
 
 3.2.0
 -----
 
- * added `compare` option to `RepeatedType`
  * added `CallbackChoiceLoader`
  * implemented `ChoiceLoaderInterface` in children of `ChoiceType`
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 3.2.0
 -----
 
+ * added `compare` option to `RepeatedType`
  * added `CallbackChoiceLoader`
  * implemented `ChoiceLoaderInterface` in children of `ChoiceType`
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -70,7 +70,7 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
 
         foreach ($this->keys as $key) {
             if (isset($array[$key]) && '' !== $array[$key] && false !== $array[$key] && array() !== $array[$key]) {
-                if (!$compare($array[$key], $result)) {
+                if (!$compare($result, $array[$key], $key)) {
                     throw new TransformationFailedException(
                         'All values in the array should be the same'
                     );

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -20,12 +20,12 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 class ValueToDuplicatesTransformer implements DataTransformerInterface
 {
     private $keys;
-    private $compare;
+    private $comparator;
 
-    public function __construct(array $keys, callable $compare = null)
+    public function __construct(array $keys, callable $comparator = null)
     {
         $this->keys = $keys;
-        $this->compare = $compare;
+        $this->comparator = $comparator;
     }
 
     /**
@@ -64,13 +64,13 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
 
         $result = current($array);
         $emptyKeys = array();
-        $compare = is_callable($this->compare) ? $this->compare : function ($value1, $value2) {
+        $comparator = is_callable($this->comparator) ? $this->comparator : function ($value1, $value2) {
             return $value1 === $value2;
         };
 
         foreach ($this->keys as $key) {
             if (isset($array[$key]) && '' !== $array[$key] && false !== $array[$key] && array() !== $array[$key]) {
-                if (!$compare($result, $array[$key], $key)) {
+                if (!$comparator($result, $array[$key], $key)) {
                     throw new TransformationFailedException(
                         'All values in the array should be the same'
                     );

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -22,6 +22,12 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
     private $keys;
     private $comparator;
 
+    /**
+     * Constructor.
+     *
+     * @param array    $keys       The compared keys
+     * @param callable $comparator The comparator callable to compare values
+     */
     public function __construct(array $keys, callable $comparator = null)
     {
         $this->keys = $keys;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -20,10 +20,12 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 class ValueToDuplicatesTransformer implements DataTransformerInterface
 {
     private $keys;
+    private $compare;
 
-    public function __construct(array $keys)
+    public function __construct(array $keys, callable $compare = null)
     {
         $this->keys = $keys;
+        $this->compare = $compare;
     }
 
     /**
@@ -62,10 +64,13 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
 
         $result = current($array);
         $emptyKeys = array();
+        $compare = is_callable($this->compare) ? $this->compare : function ($value1, $value2) {
+            return $value1 === $value2;
+        };
 
         foreach ($this->keys as $key) {
             if (isset($array[$key]) && '' !== $array[$key] && false !== $array[$key] && array() !== $array[$key]) {
-                if ($array[$key] !== $result) {
+                if (!$compare($array[$key], $result)) {
                     throw new TransformationFailedException(
                         'All values in the array should be the same'
                     );

--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -35,7 +35,7 @@ class RepeatedType extends AbstractType
             ->addViewTransformer(new ValueToDuplicatesTransformer(array(
                 $options['first_name'],
                 $options['second_name'],
-            )))
+            ), $options['compare']))
             ->add($options['first_name'], $options['type'], array_merge($options['options'], $options['first_options']))
             ->add($options['second_name'], $options['type'], array_merge($options['options'], $options['second_options']))
         ;
@@ -54,11 +54,13 @@ class RepeatedType extends AbstractType
             'first_name' => 'first',
             'second_name' => 'second',
             'error_bubbling' => false,
+            'compare' => null,
         ));
 
         $resolver->setAllowedTypes('options', 'array');
         $resolver->setAllowedTypes('first_options', 'array');
         $resolver->setAllowedTypes('second_options', 'array');
+        $resolver->setAllowedTypes('compare', array('callable','null'));
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -60,7 +60,7 @@ class RepeatedType extends AbstractType
         $resolver->setAllowedTypes('options', 'array');
         $resolver->setAllowedTypes('first_options', 'array');
         $resolver->setAllowedTypes('second_options', 'array');
-        $resolver->setAllowedTypes('compare', array('callable','null'));
+        $resolver->setAllowedTypes('compare', array('callable', 'null'));
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -60,7 +60,7 @@ class RepeatedType extends AbstractType
         $resolver->setAllowedTypes('options', 'array');
         $resolver->setAllowedTypes('first_options', 'array');
         $resolver->setAllowedTypes('second_options', 'array');
-        $resolver->setAllowedTypes('compare', array('callable', 'null'));
+        $resolver->setAllowedTypes('compare', array('null', 'callable'));
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -35,7 +35,7 @@ class RepeatedType extends AbstractType
             ->addViewTransformer(new ValueToDuplicatesTransformer(array(
                 $options['first_name'],
                 $options['second_name'],
-            ), $options['compare']))
+            ), $options['comparator']))
             ->add($options['first_name'], $options['type'], array_merge($options['options'], $options['first_options']))
             ->add($options['second_name'], $options['type'], array_merge($options['options'], $options['second_options']))
         ;
@@ -54,13 +54,13 @@ class RepeatedType extends AbstractType
             'first_name' => 'first',
             'second_name' => 'second',
             'error_bubbling' => false,
-            'compare' => null,
+            'comparator' => null,
         ));
 
         $resolver->setAllowedTypes('options', 'array');
         $resolver->setAllowedTypes('first_options', 'array');
         $resolver->setAllowedTypes('second_options', 'array');
-        $resolver->setAllowedTypes('compare', array('null', 'callable'));
+        $resolver->setAllowedTypes('comparator', array('null', 'callable'));
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
@@ -109,6 +109,7 @@ class ValueToDuplicatesTransformerTest extends TestCase
 
         $this->assertNull($this->transformer->reverseTransform($input));
     }
+    
     public function testReverseTransformCompletelyEmptyWithSimpleCallable()
     {
         $input = array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
@@ -17,15 +17,20 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\ValueToDuplicatesTrans
 class ValueToDuplicatesTransformerTest extends TestCase
 {
     private $transformer;
+    private $transformerWithSimpleCallable;
 
     protected function setUp()
     {
         $this->transformer = new ValueToDuplicatesTransformer(array('a', 'b', 'c'));
+        $this->transformerWithSimpleCallable = new ValueToDuplicatesTransformer(array('a', 'b', 'c'), function ($value1, $value2) {
+            return $value1 === $value2;
+        });
     }
 
     protected function tearDown()
     {
         $this->transformer = null;
+        $this->transformerWithSimpleCallable = null;
     }
 
     public function testTransform()
@@ -39,6 +44,17 @@ class ValueToDuplicatesTransformerTest extends TestCase
         $this->assertSame($output, $this->transformer->transform('Foo'));
     }
 
+    public function testTransformWithSimpleCallable()
+    {
+        $output = array(
+            'a' => 'Foo',
+            'b' => 'Foo',
+            'c' => 'Foo',
+        );
+
+        $this->assertSame($output, $this->transformerWithSimpleCallable->transform('Foo'));
+    }
+
     public function testTransformEmpty()
     {
         $output = array(
@@ -48,6 +64,17 @@ class ValueToDuplicatesTransformerTest extends TestCase
         );
 
         $this->assertSame($output, $this->transformer->transform(null));
+    }
+
+    public function testTransformEmptyWithSimpleCallable()
+    {
+        $output = array(
+            'a' => null,
+            'b' => null,
+            'c' => null,
+        );
+
+        $this->assertSame($output, $this->transformerWithSimpleCallable->transform(null));
     }
 
     public function testReverseTransform()
@@ -61,6 +88,17 @@ class ValueToDuplicatesTransformerTest extends TestCase
         $this->assertSame('Foo', $this->transformer->reverseTransform($input));
     }
 
+    public function testReverseTransformWithSimpleCallable()
+    {
+        $input = array(
+            'a' => 'Foo',
+            'b' => 'Foo',
+            'c' => 'Foo',
+        );
+
+        $this->assertSame('Foo', $this->transformerWithSimpleCallable->reverseTransform($input));
+    }
+
     public function testReverseTransformCompletelyEmpty()
     {
         $input = array(
@@ -70,6 +108,16 @@ class ValueToDuplicatesTransformerTest extends TestCase
         );
 
         $this->assertNull($this->transformer->reverseTransform($input));
+    }
+    public function testReverseTransformCompletelyEmptyWithSimpleCallable()
+    {
+        $input = array(
+            'a' => '',
+            'b' => '',
+            'c' => '',
+        );
+
+        $this->assertNull($this->transformerWithSimpleCallable->reverseTransform($input));
     }
 
     public function testReverseTransformCompletelyNull()
@@ -83,6 +131,17 @@ class ValueToDuplicatesTransformerTest extends TestCase
         $this->assertNull($this->transformer->reverseTransform($input));
     }
 
+    public function testReverseTransformCompletelyNullWithSimpleCallable()
+    {
+        $input = array(
+            'a' => null,
+            'b' => null,
+            'c' => null,
+        );
+
+        $this->assertNull($this->transformerWithSimpleCallable->reverseTransform($input));
+    }
+
     public function testReverseTransformEmptyArray()
     {
         $input = array(
@@ -94,6 +153,17 @@ class ValueToDuplicatesTransformerTest extends TestCase
         $this->assertNull($this->transformer->reverseTransform($input));
     }
 
+    public function testReverseTransformEmptyArrayWithSimpleCallable()
+    {
+        $input = array(
+            'a' => array(),
+            'b' => array(),
+            'c' => array(),
+        );
+
+        $this->assertNull($this->transformerWithSimpleCallable->reverseTransform($input));
+    }
+
     public function testReverseTransformZeroString()
     {
         $input = array(
@@ -103,6 +173,17 @@ class ValueToDuplicatesTransformerTest extends TestCase
         );
 
         $this->assertSame('0', $this->transformer->reverseTransform($input));
+    }
+
+    public function testReverseTransformZeroStringWithSimpleCallable()
+    {
+        $input = array(
+            'a' => '0',
+            'b' => '0',
+            'c' => '0',
+        );
+
+        $this->assertSame('0', $this->transformerWithSimpleCallable->reverseTransform($input));
     }
 
     /**
@@ -122,6 +203,20 @@ class ValueToDuplicatesTransformerTest extends TestCase
     /**
      * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      */
+    public function testReverseTransformPartiallyNullWithSimpleCallable()
+    {
+        $input = array(
+            'a' => 'Foo',
+            'b' => 'Foo',
+            'c' => null,
+        );
+
+        $this->transformerWithSimpleCallable->reverseTransform($input);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
     public function testReverseTransformDifferences()
     {
         $input = array(
@@ -136,8 +231,30 @@ class ValueToDuplicatesTransformerTest extends TestCase
     /**
      * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      */
+    public function testReverseTransformDifferencesWithSimpleCallable()
+    {
+        $input = array(
+            'a' => 'Foo',
+            'b' => 'Bar',
+            'c' => 'Foo',
+        );
+
+        $this->transformerWithSimpleCallable->reverseTransform($input);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
     public function testReverseTransformRequiresArray()
     {
         $this->transformer->reverseTransform('12345');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformRequiresArrayWithSimpleCallable()
+    {
+        $this->transformerWithSimpleCallable->reverseTransform('12345');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
@@ -109,7 +109,7 @@ class ValueToDuplicatesTransformerTest extends TestCase
 
         $this->assertNull($this->transformer->reverseTransform($input));
     }
-    
+
     public function testReverseTransformCompletelyEmptyWithSimpleCallable()
     {
         $input = array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -194,44 +194,44 @@ class RepeatedTypeTest extends BaseTypeTest
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
-    public function testSetOptionsForCompareNotCallableOrNull()
+    public function testSetOptionsForComparatorNotCallableOrNull()
     {
         $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
-            'compare' => 'test',
+            'comparator' => 'test',
         ));
     }
 
-    public function testSetOptionsForCompareCallableAsNull()
+    public function testSetOptionsForComparatorCallableAsNull()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
-            'compare' => null,
+            'comparator' => null,
         ));
 
-        $this->assertNull($form->getConfig()->getOption('compare'));
+        $this->assertNull($form->getConfig()->getOption('comparator'));
     }
 
-    public function testSetOptionsForCompareCallableAsCallable()
+    public function testSetOptionsForComparatorCallableAsCallable()
     {
         $callable = function ($value1, $value2) {
             return $value1 === $value2;
         };
 
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
-            'compare' => $callable,
+            'comparator' => $callable,
         ));
 
-        $this->assertSame($callable, $form->getConfig()->getOption('compare'));
+        $this->assertSame($callable, $form->getConfig()->getOption('comparator'));
     }
 
-    public function compare($value1, $value2)
+    public function comparator($value1, $value2)
     {
         return 0 === strcmp($value1, $value2);
     }
 
-    public function testSetOptionsForCompareNativeFunction()
+    public function testSetOptionsForComparatorNativeFunction()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
-            'compare' => array($this, 'compare'),
+            'comparator' => array($this, 'comparator'),
         ));
 
         $input = array('first' => 'foo', 'second' => 'foo');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -212,15 +212,15 @@ class RepeatedTypeTest extends BaseTypeTest
 
     public function testSetOptionsForCompareCallableAsCallable()
     {
+        $callable = function ($value1, $value2) {
+            return $value1 === $value2;
+        };
+
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, array(
-            'compare' => function ($value1, $value2) {
-                return $value1 === $value2;
-            },
+            'compare' => $callable,
         ));
 
-        $this->assertEquals(function ($value1, $value2) {
-            return $value1 === $value2;
-        }, $form->getConfig()->getOption('compare'));
+        $this->assertEquals($callable, $form->getConfig()->getOption('compare'));
     }
 
     public function compare($value1, $value2)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -220,7 +220,7 @@ class RepeatedTypeTest extends BaseTypeTest
             'compare' => $callable,
         ));
 
-        $this->assertEquals($callable, $form->getConfig()->getOption('compare'));
+        $this->assertSame($callable, $form->getConfig()->getOption('compare'));
     }
 
     public function compare($value1, $value2)
@@ -238,10 +238,10 @@ class RepeatedTypeTest extends BaseTypeTest
 
         $form->submit($input);
 
-        $this->assertEquals('foo', $form['first']->getViewData());
-        $this->assertEquals('foo', $form['second']->getViewData());
+        $this->assertSame('foo', $form['first']->getViewData());
+        $this->assertSame('foo', $form['second']->getViewData());
         $this->assertTrue($form->isSynchronized());
-        $this->assertEquals($input, $form->getViewData());
-        $this->assertEquals('foo', $form->getData());
+        $this->assertSame($input, $form->getViewData());
+        $this->assertSame('foo', $form->getData());
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -223,7 +223,8 @@ class RepeatedTypeTest extends BaseTypeTest
         }, $form->getConfig()->getOption('compare'));
     }
 
-    public function compare($value1, $value2) {
+    public function compare($value1, $value2)
+    {
         return 0 === strcmp($value1, $value2);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#7484

This adds the possibility to overwrite the way the comparison between the fields is done. The default behavior keeps the string comparison, but you could overwrite it to for example use `password_verify` to compare two password hashes created by `password_hash`.
