### PR TITLE
Correct posix_isatty warning with MEMORY type streams

### DIFF
--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -99,7 +99,7 @@ class StreamOutput extends Output
                 || 'ON' === getenv('ConEmuANSI')
                 || 'xterm' === getenv('TERM');
         }
-
-        return function_exists('posix_isatty') && @posix_isatty($this->stream);
+        $metadata = is_resource($this->stream) ? stream_get_meta_data($this->stream) : false;
+        return $metadata && $metadata['stream_type'] !== 'MEMORY' && function_exists('posix_isatty') && @posix_isatty($this->stream);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | ~

posix_isatty(): could not use stream of type 'MEMORY'
