### PR TITLE
[DI][FrameworkBundle] ServiceLocator: fix XmlDescriptor to use dashes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -437,7 +437,7 @@ class XmlDescriptor extends Descriptor
                     $argumentXML->appendChild($childArgumentXML);
                 }
             } elseif ($argument instanceof ServiceLocatorArgument) {
-                $argumentXML->setAttribute('type', 'service_locator');
+                $argumentXML->setAttribute('type', 'service-locator');
 
                 foreach ($this->getArgumentNodes($argument->getValues(), $dom) as $childArgumentXML) {
                     $argumentXML->appendChild($childArgumentXML);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
@@ -24,7 +24,7 @@
       <argument type="service" id="definition_2"/>
     </argument>
     <argument type="closure-proxy" id="definition1" method="get"/>
-    <argument type="service_locator">
+    <argument type="service-locator">
       <argument key="def1" type="service" id="definition_1"/>
       <argument key="def2" type="service" id="definition_2"/>
     </argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
@@ -21,7 +21,7 @@
     <argument type="service" id="definition_2"/>
   </argument>
   <argument type="closure-proxy" id="definition1" method="get"/>
-  <argument type="service_locator">
+  <argument type="service-locator">
     <argument key="def1" type="service" id="definition_1"/>
     <argument key="def2" type="service" id="definition_2"/>
   </argument>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21600#discussion_r101126540
| License       | MIT
| Doc PR        | N/A

As reported by @stof, I should have used dashes, not underscores. My bad...