### PR TITLE
[Security] Saltless Encoder Interface

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -19,8 +19,8 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Encoder\SelfSaltingEncoderInterface;
 use Symfony\Component\Security\Core\User\User;
 
 /**
@@ -117,9 +117,9 @@ EOF
 
         $encoderFactory = $this->encoderFactory ?: $this->getContainer()->get('security.encoder_factory');
         $encoder = $encoderFactory->getEncoder($userClass);
-        $bcryptWithoutEmptySalt = !$emptySalt && $encoder instanceof BCryptPasswordEncoder;
+        $saltlessWithoutEmptySalt = !$emptySalt && $encoder instanceof SelfSaltingEncoderInterface;
 
-        if ($bcryptWithoutEmptySalt) {
+        if ($saltlessWithoutEmptySalt) {
             $emptySalt = true;
         }
 
@@ -161,8 +161,8 @@ EOF
 
         if (!$emptySalt) {
             $errorIo->note(sprintf('Make sure that your salt storage field fits the salt length: %s chars', strlen($salt)));
-        } elseif ($bcryptWithoutEmptySalt) {
-            $errorIo->note('Bcrypt encoder used: the encoder generated its own built-in salt.');
+        } elseif ($saltlessWithoutEmptySalt) {
+            $errorIo->note('Self-salting encoder used: the encoder generated its own built-in salt.');
         }
 
         $errorIo->success('Password encoding succeeded');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -120,13 +120,11 @@ class UserPasswordEncoderCommandTest extends WebTestCase
 
     public function testEncodePasswordBcryptOutput()
     {
-        $this->passwordEncoderCommandTester->execute(
-            array(
-                'command' => 'security:encode-password',
-                'password' => 'p@ssw0rd',
-                'user-class' => 'Custom\Class\Bcrypt\User',
-            )
-        );
+        $this->passwordEncoderCommandTester->execute(array(
+            'command' => 'security:encode-password',
+            'password' => 'p@ssw0rd',
+            'user-class' => 'Custom\Class\Bcrypt\User',
+        ), array('interactive' => false));
 
         $this->assertNotContains(' Generated salt ', $this->passwordEncoderCommandTester->getDisplay());
     }

--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
  * @author Elnur Abdurrakhimov <elnur@elnur.pro>
  * @author Terje Bråten <terje@braten.be>
  */
-class BCryptPasswordEncoder extends BasePasswordEncoder
+class BCryptPasswordEncoder extends BasePasswordEncoder implements SelfSaltingEncoderInterface
 {
     const MAX_PASSWORD_LENGTH = 72;
 

--- a/src/Symfony/Component/Security/Core/Encoder/SelfSaltingEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SelfSaltingEncoderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Encoder;
+
+/**
+ * SelfSaltingEncoderInterface is a marker interface for encoders that do not
+ * require a user-generated salt.
+ *
+ * @author Zan Baldwin <hello@zanbaldwin.com>
+ */
+interface SelfSaltingEncoderInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

A new interface for encoders that do not require a user-generated salt (generate their own built-in) as suggested by @stof ([comment](https://github.com/symfony/symfony/pull/21604/files#r101225470)), this will become useful as more password encoders are added in the future (such as symfony/symfony#21604). 