### PR TITLE
[DependencyInjection] fix support of inherited tags in child services definitions.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -42,6 +42,7 @@ class PassConfig
         $this->beforeOptimizationPasses = array(
             100 => array(
                 $resolveClassPass = new ResolveClassPass(),
+                new ResolveDefinitionTemplatesPass(),
             ),
         );
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
@@ -30,7 +30,7 @@ class PassConfigTest extends \PHPUnit_Framework_TestCase
         $config->addPass($pass2, PassConfig::TYPE_BEFORE_OPTIMIZATION, 30);
 
         $passes = $config->getBeforeOptimizationPasses();
-        $this->assertSame($pass2, $passes[1]);
-        $this->assertSame($pass1, $passes[2]);
+        $this->assertSame($pass2, $passes[2]);
+        $this->assertSame($pass1, $passes[3]);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -363,6 +363,38 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('ParentClass', $def->getClass());
     }
 
+    public function testProcessInheritTags()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('parent', 'ParentClass')->addTag('some.tag', array('foo' => 'bar'));
+
+        $definition = (new ChildDefinition('parent'))
+            ->setInheritTags(true)
+            ->addTag('other.tag')
+            ->addTag('some.tag', array('bar' => 'foo'));
+
+        $container->setDefinition('child', $definition);
+
+        $this->process($container);
+
+        $definition = $container->getDefinition('child');
+        $this->assertSame('ParentClass', $definition->getClass());
+        $this->assertCount(2, $definition->getTags());
+        $this->assertSame(
+            array(
+                'other.tag' => array(
+                    array(),
+                ),
+                'some.tag' => array(
+                    array('bar' => 'foo'),
+                    array('foo' => 'bar'),
+                ),
+            ),
+            $definition->getTags()
+        );
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new ResolveDefinitionTemplatesPass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~
