### PR TITLE
[DI] Don't try to instantiate reflection class if it doesn't exist

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -82,7 +82,7 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
         $class = $container->getReflectionClass($class);
         $constructor = $class ? $class->getConstructor() : null;
 
-        if (!$constructor || !$constructor->getNumberOfRequiredParameters()) {
+        if ($class && (!$constructor || !$constructor->getNumberOfRequiredParameters())) {
             return $class->newInstance();
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Introduced in https://github.com/symfony/symfony/pull/21419 so master only. 
It breaks on bundles that ~~do not use the convention for naming their `Configuration`~~ do not have configuration, e.g. SecurityBundle's FirewallEntryPointExtension for which tests are actually broken (see travis).
