### PR TITLE
added support for glob loaders in Config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -36,6 +36,11 @@
             <argument type="service" id="file_locator" />
         </service>
 
+        <service id="routing.loader.glob" class="Symfony\Component\Config\Loader\GlobFileLoader" public="false">
+            <tag name="routing.loader" />
+            <argument type="service" id="file_locator" />
+        </service>
+
         <service id="routing.loader.directory" class="Symfony\Component\Routing\Loader\DirectoryLoader" public="false">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />

--- a/src/Symfony/Component/Config/Loader/GlobFileLoader.php
+++ b/src/Symfony/Component/Config/Loader/GlobFileLoader.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Loader;
+
+/**
+ * GlobFileLoader loads files from a glob pattern.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class GlobFileLoader extends FileLoader
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load($resource, $type = null)
+    {
+        return $this->import($resource, null, true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return 'glob' === $type;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpKernel\Config\EnvParametersResource;
 use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass;
 use Symfony\Component\HttpKernel\DependencyInjection\AddClassesToCachePass;
+use Symfony\Component\Config\Loader\GlobFileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\ConfigCache;
@@ -686,6 +687,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             new YamlFileLoader($container, $locator),
             new IniFileLoader($container, $locator),
             new PhpFileLoader($container, $locator),
+            new GlobFileLoader($locator),
             new DirectoryLoader($container, $locator),
             new ClosureLoader($container),
         ));

--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -61,21 +61,28 @@ class RouteCollectionBuilder
      */
     public function import($resource, $prefix = '/', $type = null)
     {
-        /** @var RouteCollection $collection */
-        $collection = $this->load($resource, $type);
+        /** @var RouteCollection[] $collection */
+        $collections = $this->load($resource, $type);
 
         // create a builder from the RouteCollection
         $builder = $this->createBuilder();
-        foreach ($collection->all() as $name => $route) {
-            $builder->addRoute($route, $name);
-        }
 
-        foreach ($collection->getResources() as $resource) {
-            $builder->addResource($resource);
-        }
+        foreach ($collections as $collection) {
+            if (null === $collection) {
+                continue;
+            }
 
-        // mount into this builder
-        $this->mount($prefix, $builder);
+            foreach ($collection->all() as $name => $route) {
+                $builder->addRoute($route, $name);
+            }
+
+            foreach ($collection->getResources() as $resource) {
+                $builder->addResource($resource);
+            }
+
+            // mount into this builder
+            $this->mount($prefix, $builder);
+        }
 
         return $builder;
     }
@@ -201,7 +208,7 @@ class RouteCollectionBuilder
     }
 
     /**
-     * Sets an opiton that will be added to all embedded routes (unless that
+     * Sets an option that will be added to all embedded routes (unless that
      * option is already set).
      *
      * @param string $key
@@ -345,7 +352,7 @@ class RouteCollectionBuilder
      * @param mixed       $resource A resource
      * @param string|null $type     The resource type or null if unknown
      *
-     * @return RouteCollection
+     * @return RouteCollection[]
      *
      * @throws FileLoaderLoadException If no loader is found
      */
@@ -356,7 +363,9 @@ class RouteCollectionBuilder
         }
 
         if ($this->loader->supports($resource, $type)) {
-            return $this->loader->load($resource, $type);
+            $collections = $this->loader->load($resource, $type);
+
+            return is_array($collections) ? $collections : array($collections);
         }
 
         if (null === $resolver = $this->loader->getResolver()) {
@@ -367,6 +376,8 @@ class RouteCollectionBuilder
             throw new FileLoaderLoadException($resource);
         }
 
-        return $loader->load($resource, $type);
+        $collections = $loader->load($resource, $type);
+
+        return is_array($collections) ? $collections : array($collections);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | not yet

In #21270, we added the possibility to use glob patterns to import (not load) config files, but it was restricted to the container. The same feature could be useful (and I actually have a use case) for the routing.

So, this PR moves the logic to the Config component. It also adds a new `GlobFileLoader` class that allows to load glob patterns (not just import them as in #21270).

Last, but not least, the new glob file loader is registered in both the routing and the container default loaders.

Here is a simple, but powerful example, using the Symfony micro kernel (actually, this is a snippet from the Kernel used in Symfony Flex :)):

```php
<?php

namespace Symfony\Flex;

use Symfony\Component\HttpKernel\Kernel as BaseKernel;

class Kernel extends BaseKernel
{
    use MicroKernelTrait;

    const CONFIG_EXTS = '.{php,xml,yaml,yml}';

    // ...

    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
    {
        $confDir = dirname($this->getRootDir()).'/etc';
        $loader->import($confDir.'/packages/*'.self::CONFIG_EXTS, 'glob');
        $loader->import($confDir.'/packages/'.$this->getEnvironment().'/**/*'.self::CONFIG_EXTS, 'glob');
        $loader->import($confDir.'/container'.self::CONFIG_EXTS, 'glob');
    }

    protected function configureRoutes(RouteCollectionBuilder $routes)
    {
        $confDir = dirname($this->getRootDir()).'/etc';
        $routes->import($confDir.'/routing/*'.self::CONFIG_EXTS, '/', 'glob');
        $routes->import($confDir.'/routing/'.$this->getEnvironment().'/**/*'.self::CONFIG_EXTS, '/', 'glob');
        $routes->import($confDir.'/routing'.self::CONFIG_EXTS, '/', 'glob');
    }
}
```
