### PR TITLE
[Yaml] deprecate parsing mappings without keys

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -119,6 +119,8 @@ Workflow
 Yaml
 ----
 
+ * Omitting the key of a mapping is deprecated and will throw a `ParseException` in Symfony 4.0.
+
  * The constructor arguments `$offset`, `$totalNumberOfLines` and
    `$skippedLineNumbers` of the `Parser` class are deprecated and will be
    removed in 4.0

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -340,6 +340,8 @@ Validator
 Yaml
 ----
 
+ * Omitting the key of a mapping is not supported anymore and throws a `ParseException`.
+
  * Mappings with a colon (`:`) that is not followed by a whitespace are not
    supported anymore and lead to a `ParseException`(e.g. `foo:bar` must be
    `foo: bar`).

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.3.0
+-----
+
+ * Omitting the key of a mapping is deprecated and will throw a `ParseException` in Symfony 4.0.
+
 3.2.0
 -----
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -481,6 +481,10 @@ class Inline
                 break;
             }
 
+            if (':' === $key) {
+                @trigger_error('Omitting the key of a mapping is deprecated and will throw a ParseException in 4.0.', E_USER_DEPRECATED);
+            }
+
             if (':' !== $key && (!isset($mapping[$i + 1]) || !in_array($mapping[$i + 1], array(' ', ',', '[', ']', '{', '}'), true))) {
                 @trigger_error('Using a colon that is not followed by an indication character (i.e. " ", ",", "[", "]", "{", "}" is deprecated since version 3.2 and will throw a ParseException in 4.0.', E_USER_DEPRECATED);
             }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -687,6 +687,10 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($longStringWithQuotes, $arrayFromYaml['longStringWithQuotes']);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Omitting the key of a mapping is deprecated and will throw a ParseException in 4.0.
+     */
     public function testOmittedMappingKeyIsParsedAsColon()
     {
         $this->assertSame(array(':' => 'foo'), Inline::parse('{: foo}'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 