### PR TITLE
[PropertyInfo] Use iterators for PropertyInfoExtractor

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PropertyInfoPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PropertyInfoPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -36,15 +37,15 @@ class PropertyInfoPass implements CompilerPassInterface
         $definition = $container->getDefinition('property_info');
 
         $listExtractors = $this->findAndSortTaggedServices('property_info.list_extractor', $container);
-        $definition->replaceArgument(0, $listExtractors);
+        $definition->replaceArgument(0, new IteratorArgument($listExtractors));
 
         $typeExtractors = $this->findAndSortTaggedServices('property_info.type_extractor', $container);
-        $definition->replaceArgument(1, $typeExtractors);
+        $definition->replaceArgument(1, new IteratorArgument($typeExtractors));
 
         $descriptionExtractors = $this->findAndSortTaggedServices('property_info.description_extractor', $container);
-        $definition->replaceArgument(2, $descriptionExtractors);
+        $definition->replaceArgument(2, new IteratorArgument($descriptionExtractors));
 
         $accessExtractors = $this->findAndSortTaggedServices('property_info.access_extractor', $container);
-        $definition->replaceArgument(3, $accessExtractors);
+        $definition->replaceArgument(3, new IteratorArgument($accessExtractors));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -51,7 +51,7 @@
         "symfony/templating": "~2.8|~3.0",
         "symfony/validator": "~3.2",
         "symfony/yaml": "~3.2",
-        "symfony/property-info": "~3.1",
+        "symfony/property-info": "~3.3",
         "doctrine/annotations": "~1.0",
         "phpdocumentor/reflection-docblock": "^3.0",
         "twig/twig": "~1.26|~2.0",
@@ -62,7 +62,8 @@
         "phpdocumentor/type-resolver": "<0.2.0",
         "symfony/console": "<3.3",
         "symfony/serializer": "<3.3",
-        "symfony/form": "<3.3"
+        "symfony/form": "<3.3",
+        "symfony/property-info": "<3.3"
     },
     "suggest": {
         "ext-apcu": "For best performance of the system caches",

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -18,33 +18,18 @@ namespace Symfony\Component\PropertyInfo;
  */
 class PropertyInfoExtractor implements PropertyInfoExtractorInterface
 {
-    /**
-     * @var PropertyListExtractorInterface[]
-     */
     private $listExtractors;
-
-    /**
-     * @var PropertyTypeExtractorInterface[]
-     */
     private $typeExtractors;
-
-    /**
-     * @var PropertyDescriptionExtractorInterface[]
-     */
     private $descriptionExtractors;
-
-    /**
-     * @var PropertyAccessExtractorInterface[]
-     */
     private $accessExtractors;
 
     /**
-     * @param PropertyListExtractorInterface[]        $listExtractors
-     * @param PropertyTypeExtractorInterface[]        $typeExtractors
-     * @param PropertyDescriptionExtractorInterface[] $descriptionExtractors
-     * @param PropertyAccessExtractorInterface[]      $accessExtractors
+     * @param iterable|PropertyListExtractorInterface[]        $listExtractors
+     * @param iterable|PropertyTypeExtractorInterface[]        $typeExtractors
+     * @param iterable|PropertyDescriptionExtractorInterface[] $descriptionExtractors
+     * @param iterable|PropertyAccessExtractorInterface[]      $accessExtractors
      */
-    public function __construct(array $listExtractors = array(), array $typeExtractors = array(), array $descriptionExtractors = array(), array $accessExtractors = array())
+    public function __construct($listExtractors = array(), $typeExtractors = array(), $descriptionExtractors = array(), $accessExtractors = array())
     {
         $this->listExtractors = $listExtractors;
         $this->typeExtractors = $typeExtractors;
@@ -103,13 +88,13 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface
     /**
      * Iterates over registered extractors and return the first value found.
      *
-     * @param array  $extractors
-     * @param string $method
-     * @param array  $arguments
+     * @param iterable $extractors
+     * @param string   $method
+     * @param array    $arguments
      *
      * @return mixed
      */
-    private function extract(array $extractors, $method, array $arguments)
+    private function extract($extractors, $method, array $arguments)
     {
         foreach ($extractors as $extractor) {
             $value = call_user_func_array(array($extractor, $method), $arguments);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Most of the time, when using the cache, the property info extractors are not used: the new iterator feature looks perfect to prevent their instantiation.