### PR TITLE
[DoctrineBridge] Fixed validating custom doctrine type columns

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdStringWrapperNameEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdStringWrapperNameEntity.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\Type\StringWrapper;
+
+/** @Entity */
+class SingleIntIdStringWrapperNameEntity
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /** @Column(type="string_wrapper", nullable=true) */
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapper.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapper.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\Type;
+
+class StringWrapper
+{
+    /**
+     * @var string
+     */
+    private $string;
+
+    /**
+     * @param string $string
+     */
+    public function __construct($string = null)
+    {
+        $this->string = $string;
+    }
+
+    /**
+     * @return string
+     */
+    public function getString()
+    {
+        return $this->string;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapperType.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapperType.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\StringType;
+
+class StringWrapperType extends StringType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return $value instanceof StringWrapper ? $value->getString() : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return new StringWrapper($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'string_wrapper';
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -176,9 +176,15 @@ class UniqueEntityValidator extends ConstraintValidator
             return $this->formatValue($value, self::PRETTY_DATE);
         }
 
-        // non unique value is a composite PK
         if ($class->getName() !== $idClass = get_class($value)) {
-            $identifiers = $em->getClassMetadata($idClass)->getIdentifierValues($value);
+            // non unique value might be a composite PK that consists of other entity objects
+            if ($em->getMetadataFactory()->hasMetadataFor($idClass)) {
+                $identifiers = $em->getClassMetadata($idClass)->getIdentifierValues($value);
+            } else {
+                // this case might happen if the non unique column has a custom doctrine type and its value is an object
+                // in which case we cannot get any identifiers for it
+                $identifiers = array();
+            }
         } else {
             $identifiers = $class->getIdentifierValues($value);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21619
| License       | MIT
| Doc PR        | -

This fixes #21619 by not assuming the invalid `$value` is a Doctrine entity if its an object
