### PR TITLE
add missing changelog for deprecated strict attribute

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -44,6 +44,9 @@ DependencyInjection
  * The `DefinitionDecorator` class is deprecated and will be removed in 4.0, use
    the `ChildDefinition` class instead.
 
+ * The ``strict`` attribute in service arguments has been deprecated and will be removed in 4.0.
+   The attribute is ignored since 3.0, so you can simply remove it.
+
 EventDispatcher
 ---------------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -68,6 +68,9 @@ DependencyInjection
  * Requesting a private service with the `Container::get()` method is no longer
    supported.
 
+ * The ``strict`` attribute in service arguments has been removed.
+   The attribute is ignored since 3.0, so you can simply remove it.
+
 EventDispatcher
 ---------------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

since #21058, 3.3 triggers a deprecation when using the strict attribute. luckily wouter managed to find the reason and we figured out we can simply delete the attribute. having an upgrade file entry would make it easier to find the reason for the deprecation and be sure what to do. (assuming i understood the implications correctly)