### PR TITLE
missing javascript block definition

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
@@ -15,5 +15,6 @@
     </head>
     <body>
         {% block body '' %}
+        {% block javascript %}{% endblock javascript %}
     </body>
 </html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | na


fix bug in webprofiler base.html.twig.

open profiler, click 'blocks'.
   produces this error:

> Block "javascript" on template "@WebProfiler/Profiler/base.html.twig" does not exist.
