### PR TITLE
[Serializer] Xml encoder throws exception for valid data

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -369,7 +369,10 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         if (is_array($data) || ($data instanceof \Traversable && !$this->serializer->supportsNormalization($data, $this->format))) {
             foreach ($data as $key => $data) {
                 //Ah this is the magic @ attribute types.
-                if (0 === strpos($key, '@') && is_scalar($data) && $this->isElementNameValid($attributeName = substr($key, 1))) {
+                if (0 === strpos($key, '@') && $this->isElementNameValid($attributeName = substr($key, 1))) {
+                    if (!is_scalar($data)) {
+                        $data = $this->serializer->normalize($data, $this->format, $this->context);
+                    }
                     $parentNode->setAttribute($attributeName, $data);
                 } elseif ($key === '#') {
                     $append = $this->selectNodeType($parentNode, $data);
@@ -474,7 +477,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         } elseif ($val instanceof \Traversable) {
             $this->buildXml($node, $val);
         } elseif (is_object($val)) {
-            return $this->buildXml($node, $this->serializer->normalize($val, $this->format, $this->context));
+            return $this->selectNodeType($node, $this->serializer->normalize($val, $this->format, $this->context));
         } elseif (is_numeric($val)) {
             return $this->appendText($node, (string) $val);
         } elseif (is_string($val) && $this->needsCdataWrapping($val)) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
-use DateTime;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
@@ -29,9 +28,6 @@ class XmlEncoderTest extends TestCase
      */
     private $encoder;
 
-    /**
-     * @var string
-     */
     private $exampleDateTimeString = '2017-02-19T15:16:08+0300';
 
     protected function setUp()
@@ -535,40 +531,33 @@ XML;
         return $obj;
     }
 
-    /**
-     * @test
-     */
     public function testEncodeXmlWithBoolValue()
     {
-        $expectedXml = '<?xml version="1.0"?>
+        $expectedXml = <<<'XML'
+<?xml version="1.0"?>
 <response><foo>1</foo><bar>0</bar></response>
-';
+
+XML;
 
         $actualXml = $this->encoder->encode(array('foo' => true, 'bar' => false), 'xml');
 
         $this->assertEquals($expectedXml, $actualXml);
     }
 
-    /**
-     * @test
-     */
     public function testEncodeXmlWithDateTimeObjectValue()
     {
         $xmlEncoder = $this->createXmlEncoderWithDateTimeNormalizer();
 
-        $actualXml = $xmlEncoder->encode(array('dateTime' => new DateTime($this->exampleDateTimeString)), 'xml');
+        $actualXml = $xmlEncoder->encode(array('dateTime' => new \DateTime($this->exampleDateTimeString)), 'xml');
 
         $this->assertEquals($this->createXmlWithDateTime(), $actualXml);
     }
 
-    /**
-     * @test
-     */
     public function testEncodeXmlWithDateTimeObjectField()
     {
         $xmlEncoder = $this->createXmlEncoderWithDateTimeNormalizer();
 
-        $actualXml = $xmlEncoder->encode(array('foo' => array('@dateTime' => new DateTime($this->exampleDateTimeString))), 'xml');
+        $actualXml = $xmlEncoder->encode(array('foo' => array('@dateTime' => new \DateTime($this->exampleDateTimeString))), 'xml');
 
         $this->assertEquals($this->createXmlWithDateTimeField(), $actualXml);
     }
@@ -595,13 +584,13 @@ XML;
         $mock
             ->expects($this->once())
             ->method('normalize')
-            ->with(new DateTime($this->exampleDateTimeString), 'xml', array())
+            ->with(new \DateTime($this->exampleDateTimeString), 'xml', array())
             ->willReturn($this->exampleDateTimeString);
 
         $mock
             ->expects($this->once())
             ->method('supportsNormalization')
-            ->with(new DateTime($this->exampleDateTimeString), 'xml')
+            ->with(new \DateTime($this->exampleDateTimeString), 'xml')
             ->willReturn(true);
 
         return $mock;

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -12,14 +12,14 @@
 namespace Symfony\Component\Serializer\Tests\Encoder;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Serializer\Encoder\XmlEncoder;
-use Symfony\Component\Serializer\Exception\UnexpectedValueException;
-use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\ScalarDummy;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class XmlEncoderTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21617 
| License       | MIT
| Doc PR        | None

#21617  Xml encoder throws exception for valid data
    
- add tests for bool and object encoding
- fix encoding for object in array and field

