### PR TITLE
[Config][FrameworkBundle] Lazy load resource checkers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -61,7 +61,7 @@
         </service>
 
         <service id="config_cache_factory" class="Symfony\Component\Config\ResourceCheckerConfigCacheFactory">
-            <argument type="collection"></argument>
+            <argument /> <!-- resource checkers -->
         </service>
 
         <service class="Symfony\Component\Config\Resource\SelfCheckingResourceChecker" public="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ConfigCachePassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ConfigCachePassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConfigCachePass;
 
@@ -41,11 +42,11 @@ class ConfigCachePassTest extends TestCase
 
         $definition->expects($this->once())
             ->method('replaceArgument')
-            ->with(0, array(
+            ->with(0, new IteratorArgument(array(
                     new Reference('checker_1'),
                     new Reference('checker_2'),
                     new Reference('checker_3'),
-                ));
+                )));
 
         $pass = new ConfigCachePass();
         $pass->process($container);

--- a/src/Symfony/Component/Config/DependencyInjection/ConfigCachePass.php
+++ b/src/Symfony/Component/Config/DependencyInjection/ConfigCachePass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Config\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -42,6 +43,6 @@ class ConfigCachePass implements CompilerPassInterface
             return;
         }
 
-        $container->getDefinition($this->factoryServiceId)->replaceArgument(0, $resourceCheckers);
+        $container->getDefinition($this->factoryServiceId)->replaceArgument(0, new IteratorArgument($resourceCheckers));
     }
 }

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -29,15 +29,15 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
     private $file;
 
     /**
-     * @var ResourceCheckerInterface[]
+     * @var iterable|ResourceCheckerInterface[]
      */
     private $resourceCheckers;
 
     /**
-     * @param string                     $file             The absolute cache path
-     * @param ResourceCheckerInterface[] $resourceCheckers The ResourceCheckers to use for the freshness check
+     * @param string                              $file             The absolute cache path
+     * @param iterable|ResourceCheckerInterface[] $resourceCheckers The ResourceCheckers to use for the freshness check
      */
-    public function __construct($file, array $resourceCheckers = array())
+    public function __construct($file, $resourceCheckers = array())
     {
         $this->file = $file;
         $this->resourceCheckers = $resourceCheckers;

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCacheFactory.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCacheFactory.php
@@ -20,14 +20,14 @@ namespace Symfony\Component\Config;
 class ResourceCheckerConfigCacheFactory implements ConfigCacheFactoryInterface
 {
     /**
-     * @var ResourceCheckerInterface[]
+     * @var iterable|ResourceCheckerInterface[]
      */
     private $resourceCheckers = array();
 
     /**
-     * @param ResourceCheckerInterface[] $resourceCheckers
+     * @param iterable|ResourceCheckerInterface[] $resourceCheckers
      */
-    public function __construct(array $resourceCheckers = array())
+    public function __construct($resourceCheckers = array())
     {
         $this->resourceCheckers = $resourceCheckers;
     }

--- a/src/Symfony/Component/Config/Tests/DependencyInjection/ConfigCachePassTest.php
+++ b/src/Symfony/Component/Config/Tests/DependencyInjection/ConfigCachePassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\DependencyInjection\ConfigCachePass;
 
@@ -38,11 +39,11 @@ class ConfigCachePassTest extends TestCase
 
         $definition->expects($this->once())
             ->method('replaceArgument')
-            ->with(0, array(
+            ->with(0, new IteratorArgument(array(
                     new Reference('checker_1'),
                     new Reference('checker_2'),
                     new Reference('checker_3'),
-                ));
+                )));
 
         $pass = new ConfigCachePass();
         $pass->process($container);

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -21,10 +21,10 @@
     },
     "require-dev": {
         "symfony/yaml": "~3.0",
-        "symfony/dependency-injection": "~3.2"
+        "symfony/dependency-injection": "~3.3"
     },
     "conflict": {
-        "symfony/dependency-injection": "<3.2"
+        "symfony/dependency-injection": "<3.3"
     },
     "suggest": {
         "symfony/yaml": "To use the yaml reference dumper"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

`ResourceCheckerConfigCache::isFresh()` stops on the first resource checker supporting a resource (considered authoritative). Thus no need to instantiate other checkers.