### PR TITLE
Refactored other PHPUnit method calls to work with namespaced PHPUnit 6

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
@@ -227,7 +227,12 @@ class FormPassTest extends TestCase
         $container->setDefinition('form.extension', $extDefinition);
         $container->register($id, 'stdClass')->setPublic(false)->addTag($tagName);
 
-        $this->setExpectedException('\InvalidArgumentException', $expectedExceptionMessage);
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('\InvalidArgumentException');
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        } else {
+            $this->setExpectedException('\InvalidArgumentException', $expectedExceptionMessage);
+        }
 
         $container->compile();
     }

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -55,7 +55,12 @@ class ArrayNodeTest extends TestCase
     public function testIgnoreAndRemoveBehaviors($ignore, $remove, $expected, $message = '')
     {
         if ($expected instanceof \Exception) {
-            $this->setExpectedException(get_class($expected), $expected->getMessage());
+            if (method_exists($this, 'expectException')) {
+                $this->expectException(get_class($expected));
+                $this->expectExceptionMessage($expected->getMessage());
+            } else {
+                $this->setExpectedException(get_class($expected), $expected->getMessage());
+            }
         }
         $node = new ArrayNode('root');
         $node->setIgnoreExtraKeys($ignore, $remove);

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2424,6 +2424,8 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         // compare plain HTML to check the whitespace
         try {
             $this->assertSame('<input type="text" id="text" name="text" readonly="readonly" disabled="disabled" required="required" maxlength="10" pattern="\d+" class="foobar" data-foo="bar" value="value" />', $html);
+        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" readonly="readonly" maxlength="10" pattern="\d+" class="foobar" data-foo="bar" value="value" />', $html);
         } catch (\PHPUnit_Framework_AssertionFailedError $e) {
             $this->assertSame('<input type="text" id="text" name="text" disabled="disabled" required="required" readonly="readonly" maxlength="10" pattern="\d+" class="foobar" data-foo="bar" value="value" />', $html);
         }

--- a/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
@@ -20,7 +20,11 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
+        if (class_exists('PHPUnit_Util_XML')) {
+            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
+        } else {
+            \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
+        }
     }
 
     public function provideTranslationFiles()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Continued work to make Symfony PHPUnit 6 compatible.