### PR TITLE
Refactored other PHPUnit method calls to work with namespaced PHPUnit 6

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
@@ -23,7 +23,7 @@ class PdoCacheTest extends CacheTestCase
     public static function setupBeforeClass()
     {
         if (!extension_loaded('pdo_sqlite')) {
-            throw new \PHPUnit_Framework_SkippedTestError('Extension pdo_sqlite required.');
+            self::markTestSkipped('Extension pdo_sqlite required.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
@@ -24,7 +24,7 @@ class PdoDbalCacheTest extends CacheTestCase
     public static function setupBeforeClass()
     {
         if (!extension_loaded('pdo_sqlite')) {
-            throw new \PHPUnit_Framework_SkippedTestError('Extension pdo_sqlite required.');
+            self::markTestSkipped('Extension pdo_sqlite required.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -221,7 +221,14 @@ class ApplicationTest extends TestCase
         $application->add(new \Foo2Command());
 
         $expectedMsg = "The namespace \"f\" is ambiguous.\nDid you mean one of these?\n    foo\n    foo1";
-        $this->setExpectedException(CommandNotFoundException::class, $expectedMsg);
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(CommandNotFoundException::class);
+            $this->expectExceptionMessage($expectedMsg);
+        } else {
+            $this->setExpectedException(CommandNotFoundException::class, $expectedMsg);
+        }
+
         $application->findNamespace('f');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -933,7 +933,13 @@ class ContainerBuilderTest extends TestCase
         $container = include __DIR__.'/Fixtures/containers/container30.php';
         $container->getDefinition($id)->setOverriddenGetter($getter, 123);
 
-        $this->setExpectedException(RuntimeException::class, $expectedMessage);
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage($expectedMessage);
+        } else {
+            $this->setExpectedException(RuntimeException::class, $expectedMessage);
+        }
+
         $container->get($id);
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -388,7 +388,13 @@ class PhpDumperTest extends TestCase
         $container->compile();
         $dumper = new PhpDumper($container);
 
-        $this->setExpectedException(RuntimeException::class, $expectedMessage);
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage($expectedMessage);
+        } else {
+            $this->setExpectedException(RuntimeException::class, $expectedMessage);
+        }
+
         $dumper->dump();
     }
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionFunctionTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionFunctionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\ExpressionLanguage\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunction;
  *
  * @author Dany Maillard <danymaillard93b@gmail.com>
  */
-class ExpressionFunctionTest extends \PHPUnit_Framework_TestCase
+class ExpressionFunctionTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -36,7 +36,7 @@ class SerializerPassTest extends TestCase
             ->with('serializer.normalizer')
             ->will($this->returnValue(array()));
 
-        $this->setExpectedException('RuntimeException');
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(\RuntimeException::class);
 
         $serializerPass = new SerializerPass();
         $serializerPass->process($container);
@@ -63,7 +63,7 @@ class SerializerPassTest extends TestCase
             ->method('getDefinition')
             ->will($this->returnValue($definition));
 
-        $this->setExpectedException('RuntimeException');
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(\RuntimeException::class);
 
         $serializerPass = new SerializerPass();
         $serializerPass->process($container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Continued work to make Symfony PHPUnit 6 compatible.