### PR TITLE
[DependencyInjection] Fix manual ordering of arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -49,8 +49,12 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
                 if (is_int($key) || '' === $key || '$' !== $key[0]) {
                     if (!is_int($key)) {
                         @trigger_error(sprintf('Using key "%s" for defining arguments of method "%s" for service "%s" is deprecated since Symfony 3.3 and will throw an exception in 4.0. Use no keys or $named arguments instead.', $key, $method, $this->currentId), E_USER_DEPRECATED);
+
+                        $resolvedArguments[] = $argument;
+                        continue;
                     }
-                    $resolvedArguments[] = $argument;
+
+                    $resolvedArguments[$key] = $argument;
                     continue;
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -45,16 +45,20 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
             $parameters = null;
             $resolvedArguments = array();
 
+            $previousIndex = null;
             foreach ($arguments as $key => $argument) {
                 if (is_int($key) || '' === $key || '$' !== $key[0]) {
                     if (!is_int($key)) {
                         @trigger_error(sprintf('Using key "%s" for defining arguments of method "%s" for service "%s" is deprecated since Symfony 3.3 and will throw an exception in 4.0. Use no keys or $named arguments instead.', $key, $method, $this->currentId), E_USER_DEPRECATED);
-
-                        $resolvedArguments[] = $argument;
-                        continue;
+                    } else {
+                        if (null !== $previousIndex && $key < $previousIndex) {
+                            @trigger_error(sprintf('Using key "%s" after the key "%s" for defining arguments of method "%s" for service "%s" is deprecated since Symfony 3.3. They will be automatically reordered in 4.0.', $key, $previousIndex, $method, $this->currentId), E_USER_DEPRECATED);
+                        } else {
+                            $previousIndex = $key;
+                        }
                     }
 
-                    $resolvedArguments[$key] = $argument;
+                    $resolvedArguments[] = $argument;
                     continue;
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -106,6 +106,19 @@ class ResolveNamedArgumentsPassTest extends \PHPUnit_Framework_TestCase
         $pass = new ResolveNamedArgumentsPass();
         $pass->process($container);
     }
+
+    public function testCase()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
+        $definition->setArguments(array('$apiKey' => '123', 0 => new Reference('foo')));
+
+        $pass = new ResolveNamedArgumentsPass();
+        $pass->process($container);
+
+        $this->assertEquals(array(1 => '123', 2 => new Reference('foo')), $definition->getArguments());
+    }
 }
 
 class NoConstructor

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -91,6 +91,19 @@ class ResolveNamedArgumentsPassTest extends \PHPUnit_Framework_TestCase
         $pass = new ResolveNamedArgumentsPass();
         $pass->process($container);
     }
+
+    public function testArgumentsWithManualIndexes()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
+        $definition->setArguments(array(1 => '123', 0 => new Reference('foo')));
+
+        $pass = new ResolveNamedArgumentsPass();
+        $pass->process($container);
+
+        $this->assertEquals(array(new Reference('foo'), '123'), $definition->getArguments());
+    }
 }
 
 class NoConstructor

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -92,6 +92,10 @@ class ResolveNamedArgumentsPassTest extends \PHPUnit_Framework_TestCase
         $pass->process($container);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Using key "0" after the key "1" for defining arguments of method "__construct" for service "Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy" is deprecated since Symfony 3.3. They will be automatically reordered in 4.0.
+     */
     public function testArgumentsWithManualIndexes()
     {
         $container = new ContainerBuilder();
@@ -101,8 +105,6 @@ class ResolveNamedArgumentsPassTest extends \PHPUnit_Framework_TestCase
 
         $pass = new ResolveNamedArgumentsPass();
         $pass->process($container);
-
-        $this->assertEquals(array(new Reference('foo'), '123'), $definition->getArguments());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

I think we expect arguments to be reordered when the keys are numeric so here is the fix :)

ping @nicolas-grekas 