### PR TITLE
[HttpKernel] Bundle Requirement Checker

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -227,7 +227,7 @@ abstract class Bundle implements BundleInterface
      */
     protected function getRequiredBundles()
     {
-        return [];
+        return array();
     }
 
     private function parseClassName()

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -59,6 +59,7 @@ abstract class Bundle implements BundleInterface
      */
     public function build(ContainerBuilder $container)
     {
+        $this->checkRequiredBundles($container);
     }
 
     /**
@@ -219,12 +220,43 @@ abstract class Bundle implements BundleInterface
         }
     }
 
+    /**
+     * Lists the required bundles.
+     *
+     * @return string[]
+     */
+    protected function getRequiredBundles()
+    {
+        return [];
+    }
+
     private function parseClassName()
     {
         $pos = strrpos(static::class, '\\');
         $this->namespace = false === $pos ? '' : substr(static::class, 0, $pos);
         if (null === $this->name) {
             $this->name = false === $pos ? static::class : substr(static::class, $pos + 1);
+        }
+    }
+
+    /**
+     * Checks if the required bundles are enabled.
+     *
+     * @param ContainerBuilder $container
+     *
+     * @throws \LogicException
+     */
+    private function checkRequiredBundles(ContainerBuilder $container)
+    {
+        $requiredBundles = $this->getRequiredBundles();
+        if (empty($requiredBundles)) {
+            return;
+        }
+        $enabledBundles = $container->getParameter('kernel.bundles');
+        $disabledBundles = array_diff($requiredBundles, array_keys($enabledBundles));
+
+        if (!empty($disabledBundles)) {
+            throw new \LogicException(sprintf('%s requires the following bundle(s): %s', $this->getName(), implode(', ', $disabledBundles)));
         }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -94,7 +94,7 @@ class BundleTest extends TestCase
     {
         $bundle = new DependencyBundle();
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', []);
+        $container->setParameter('kernel.bundles', array());
         $bundle->build($container);
     }
 
@@ -102,7 +102,7 @@ class BundleTest extends TestCase
     {
         $bundle = new DependencyBundle();
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.bundles', ['OtherBundle' => 'Fake\Namespace\For\OtherBundle']);
+        $container->setParameter('kernel.bundles', array('OtherBundle' => 'Fake\Namespace\For\OtherBundle'));
         $bundle->build($container);
     }
 }
@@ -123,6 +123,6 @@ class DependencyBundle extends Bundle
 {
     protected function getRequiredBundles()
     {
-        return ['OtherBundle'];
+        return array('OtherBundle');
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -85,6 +85,26 @@ class BundleTest extends TestCase
         $this->assertSame('Symfony\Component\HttpKernel\Tests\Bundle', $bundle->getNamespace());
         $this->assertSame('ExplicitlyNamedBundle', $bundle->getName());
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage DependencyBundle requires the following bundle(s): OtherBundle
+     */
+    public function testRequiredBundleIsNotEnabledClass()
+    {
+        $bundle = new DependencyBundle();
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', []);
+        $bundle->build($container);
+    }
+
+    public function testRequiredBundleIsEnabledClass()
+    {
+        $bundle = new DependencyBundle();
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', ['OtherBundle' => 'Fake\Namespace\For\OtherBundle']);
+        $bundle->build($container);
+    }
 }
 
 class NamedBundle extends Bundle
@@ -97,4 +117,12 @@ class NamedBundle extends Bundle
 
 class GuessedNameBundle extends Bundle
 {
+}
+
+class DependencyBundle extends Bundle
+{
+    protected function getRequiredBundles()
+    {
+        return ['OtherBundle'];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | *to be written*

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

A bundle may need other bundle(s) to be used.
This PR adds an easy way to check if those required bundles are enabled or not.

The documentation is not yet available.
Example

```php
<?php

namespace Acme\MyProjectBundle;

use Symfony\Component\HttpKernel\Bundle\Bundle;

class MyProjectBundle extends Bundle
{
    /**
     * {@inheritdoc}
     */
    protected function getRequiredBundles()
    {
        return ['MyProjectNeedsThisBundle'];
    }
}
```