### PR TITLE
[3.4] Deprecations regarding use of service locators/getter injection

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -70,12 +70,21 @@ FrameworkBundle
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass` class has been
    deprecated and will be removed in 4.0. Use the `Symfony\Component\Form\DependencyInjection\FormPass`
    class instead.
+   
+ * The `Symfony\Bundle\FrameworkBundle\EventListener\SessionListener` class has been deprecated
+   and will be removed in 4.0. Use the `Symfony\Component\HttpKernel\EventListener\SessionListener` instead.
+   
+ * The `Symfony\Bundle\FrameworkBundle\EventListener\TestSessionListener` class has been deprecated
+   and will be removed in 4.0. Use the `Symfony\Component\HttpKernel\EventListener\TestSessionListener` instead.
 
 HttpKernel
 -----------
 
  * The `Psr6CacheClearer::addPool()` method has been deprecated. Pass an array of pools indexed
    by name to the constructor instead.
+   
+ * The `LazyLoadingFragmentHandler::addRendererService()` method has been deprecated and
+   will be removed in 4.0.
 
 Process
 -------
@@ -124,6 +133,12 @@ TwigBridge
 
  * The `TwigRendererEngine::setEnvironment()` method has been deprecated and will be removed
    in 4.0. Pass the Twig Environment as second argument of the constructor instead.
+
+TwigBundle
+----------
+
+* The `ContainerAwareRuntimeLoader` class has been deprecated and will be removed in 4.0.
+  Use the Twig `Twig_ContainerRuntimeLoader` class instead.
 
 Workflow
 --------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -187,6 +187,12 @@ FrameworkBundle
 
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass` class has been
    removed. Use the `Symfony\Component\Form\DependencyInjection\FormPass` class instead.
+   
+ * The `Symfony\Bundle\FrameworkBundle\EventListener\SessionListener` class has been removed. 
+   Use the `Symfony\Component\HttpKernel\EventListener\SessionListener` instead.
+   
+ * The `Symfony\Bundle\FrameworkBundle\EventListener\TestSessionListener` class has been removed.
+   Use the `Symfony\Component\HttpKernel\EventListener\TestSessionListener` instead.
 
 SecurityBundle
 --------------
@@ -236,6 +242,9 @@ HttpKernel
 
  * The `Psr6CacheClearer::addPool()` method has been removed. Pass an array of pools indexed
    by name to the constructor instead.
+   
+ * The `LazyLoadingFragmentHandler::addRendererService()` method has been removed.
+
 
 Process
 -------
@@ -275,6 +284,12 @@ Translation
 -----------
 
  * Removed the backup feature from the file dumper classes.
+
+TwigBundle
+----------
+
+* The `ContainerAwareRuntimeLoader` class has been removed. Use the 
+  Twig `Twig_ContainerRuntimeLoader` class instead.
 
 TwigBridge
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/SessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/SessionListener.php
@@ -14,10 +14,14 @@ namespace Symfony\Bundle\FrameworkBundle\EventListener;
 use Symfony\Component\HttpKernel\EventListener\SessionListener as BaseSessionListener;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+@trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use %s instead.', SessionListener::class, BaseSessionListener::class), E_USER_DEPRECATED);
+
 /**
  * Sets the session in the request.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 3.3, to be removed in 4.0.
  */
 class SessionListener extends BaseSessionListener
 {

--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
@@ -14,10 +14,14 @@ namespace Symfony\Bundle\FrameworkBundle\EventListener;
 use Symfony\Component\HttpKernel\EventListener\TestSessionListener as BaseTestSessionListener;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+@trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use %s instead.', TestSessionListener::class, BaseTestSessionListener::class), E_USER_DEPRECATED);
+
 /**
  * TestSessionListener.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 3.3, to be removed in 4.0.
  */
 class TestSessionListener extends BaseTestSessionListener
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
@@ -11,7 +11,7 @@
 
     <services>
         <service id="fragment.handler" class="Symfony\Component\HttpKernel\DependencyInjection\LazyLoadingFragmentHandler">
-            <argument type="service" id="service_container" />
+            <argument /> <!-- fragment renderer locator -->
             <argument type="service" id="request_stack" />
             <argument>%kernel.debug%</argument>
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -47,9 +47,9 @@
 
         <service id="session.handler.write_check" class="Symfony\Component\HttpFoundation\Session\Storage\Handler\WriteCheckSessionHandler" public="false" />
 
-        <service id="session_listener" class="Symfony\Bundle\FrameworkBundle\EventListener\SessionListener">
+        <service id="session_listener" class="Symfony\Component\HttpKernel\EventListener\SessionListener">
             <tag name="kernel.event_subscriber" />
-            <argument type="service" id="service_container" />
+            <getter name="getSession" type="service" id="session" on-invalid="null" />
         </service>
 
         <service id="session.save_listener" class="Symfony\Component\HttpKernel\EventListener\SaveSessionListener">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -20,9 +20,9 @@
 
         <service id="test.client.cookiejar" class="Symfony\Component\BrowserKit\CookieJar" shared="false" />
 
-        <service id="test.session.listener" class="Symfony\Bundle\FrameworkBundle\EventListener\TestSessionListener">
-            <argument type="service" id="service_container" />
+        <service id="test.session.listener" class="Symfony\Component\HttpKernel\EventListener\TestSessionListener">
             <tag name="kernel.event_subscriber" />
+            <getter name="getSession" type="service" id="session" on-invalid="null" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/ContainerAwareRuntimeLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/ContainerAwareRuntimeLoader.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\TwigBundle;
 
+@trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use the Twig_ContainerRuntimeLoader class instead.'), ContainerAwareRuntimeLoader::class);
+
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -18,6 +20,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Loads Twig extension runtimes via the service container.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 3.3, will be removed in 4.0. Use \Twig_ContainerRuntimeLoader instead.
  */
 class ContainerAwareRuntimeLoader implements \Twig_RuntimeLoaderInterface
 {

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/RuntimeLoaderPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/RuntimeLoaderPass.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Bundle\TwigBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Registers Twig runtime services.
@@ -31,17 +33,13 @@ class RuntimeLoaderPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('twig.runtime') as $id => $attributes) {
             $def = $container->getDefinition($id);
 
-            if (!$def->isPublic()) {
-                throw new InvalidArgumentException(sprintf('The service "%s" must be public as it can be lazy-loaded.', $id));
-            }
-
             if ($def->isAbstract()) {
                 throw new InvalidArgumentException(sprintf('The service "%s" must not be abstract as it can be lazy-loaded.', $id));
             }
 
-            $mapping[$def->getClass()] = $id;
+            $mapping[$def->getClass()] = new Reference($id);
         }
 
-        $definition->replaceArgument(1, $mapping);
+        $definition->replaceArgument(0, new ServiceLocatorArgument($mapping));
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -138,10 +138,8 @@
             <argument /> <!-- thousands separator, set in TwigExtension -->
         </service>
 
-        <service id="twig.runtime_loader" class="Symfony\Bundle\TwigBundle\ContainerAwareRuntimeLoader" public="false">
-            <argument type="service" id="service_container" />
-            <argument type="collection" /> <!-- the mapping between class names and service names -->
-            <argument type="service" id="logger" on-invalid="null" />
+        <service id="twig.runtime_loader" class="Twig_ContainerRuntimeLoader" public="false">
+            <argument /> <!-- runtime locator -->
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Tests/ContainerAwareRuntimeLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/ContainerAwareRuntimeLoaderTest.php
@@ -15,6 +15,9 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\TwigBundle\ContainerAwareRuntimeLoader;
 
+/**
+ * @group legacy
+ */
 class ContainerAwareRuntimeLoaderTest extends TestCase
 {
     public function testLoad()

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -244,7 +244,7 @@ class TwigExtensionTest extends TestCase
         $container->compile();
 
         $loader = $container->getDefinition('twig.runtime_loader');
-        $args = $loader->getArgument(1);
+        $args = $loader->getArgument(0)->getValues();
         $this->assertArrayHasKey('Symfony\Bridge\Twig\Form\TwigRenderer', $args);
         $this->assertArrayHasKey('FooClass', $args);
         $this->assertContains('twig.form.renderer', $args);

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -21,7 +21,7 @@
         "symfony/twig-bridge": "^3.2.1",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/http-kernel": "~2.8.16|~3.1.9|^3.2.2",
-        "twig/twig": "~1.28|~2.0"
+        "twig/twig": "^1.32|^2.2"
     },
     "require-dev": {
         "symfony/asset": "~2.8|~3.0",

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/LazyLoadingFragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/LazyLoadingFragmentHandler.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 
@@ -23,7 +23,11 @@ use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 class LazyLoadingFragmentHandler extends FragmentHandler
 {
     private $container;
+    /**
+     * @deprecated since version 3.3, to be removed in 4.0
+     */
     private $rendererIds = array();
+    private $initialized = array();
 
     /**
      * Constructor.
@@ -44,9 +48,13 @@ class LazyLoadingFragmentHandler extends FragmentHandler
      *
      * @param string $name     The service name
      * @param string $renderer The render service id
+     *
+     * @deprecated since version 3.3, to be removed in 4.0
      */
     public function addRendererService($name, $renderer)
     {
+        @trigger_error(sprintf('The %s() method is deprecated since version 3.3 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+
         $this->rendererIds[$name] = $renderer;
     }
 
@@ -55,10 +63,17 @@ class LazyLoadingFragmentHandler extends FragmentHandler
      */
     public function render($uri, $renderer = 'inline', array $options = array())
     {
+        // BC 3.x, to be removed in 4.0
         if (isset($this->rendererIds[$renderer])) {
             $this->addRenderer($this->container->get($this->rendererIds[$renderer]));
-
             unset($this->rendererIds[$renderer]);
+
+            return parent::render($uri, $renderer, $options);
+        }
+
+        if (!isset($this->initialized[$renderer]) && $this->container->has($renderer)) {
+            $this->addRenderer($this->container->get($renderer));
+            $this->initialized[$renderer] = true;
         }
 
         return parent::render($uri, $renderer, $options);

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
@@ -60,19 +62,13 @@ class FragmentRendererPassTest extends TestCase
         $renderer = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock();
         $renderer
             ->expects($this->once())
-            ->method('addMethodCall')
-            ->with('addRendererService', array('foo', 'my_content_renderer'))
-        ;
+            ->method('replaceArgument')
+            ->with(0, $this->equalTo(new ServiceLocatorArgument(array('foo' => new Reference('my_content_renderer')))));
 
         $definition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock();
         $definition->expects($this->atLeastOnce())
             ->method('getClass')
             ->will($this->returnValue('Symfony\Component\HttpKernel\Tests\DependencyInjection\RendererService'));
-        $definition
-            ->expects($this->once())
-            ->method('isPublic')
-            ->will($this->returnValue(true))
-        ;
 
         $builder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('hasDefinition', 'findTaggedServiceIds', 'getDefinition', 'getReflectionClass'))->getMock();
         $builder->expects($this->any())

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LazyLoadingFragmentHandlerTest.php
@@ -18,7 +18,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LazyLoadingFragmentHandlerTest extends TestCase
 {
-    public function test()
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\DependencyInjection\LazyLoadingFragmentHandler::addRendererService() method is deprecated since version 3.3 and will be removed in 4.0.
+     */
+    public function testRenderWithLegacyMapping()
     {
         $renderer = $this->getMockBuilder('Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface')->getMock();
         $renderer->expects($this->once())->method('getName')->will($this->returnValue('foo'));
@@ -32,6 +36,27 @@ class LazyLoadingFragmentHandlerTest extends TestCase
 
         $handler = new LazyLoadingFragmentHandler($container, $requestStack, false);
         $handler->addRendererService('foo', 'foo');
+
+        $handler->render('/foo', 'foo');
+
+        // second call should not lazy-load anymore (see once() above on the get() method)
+        $handler->render('/foo', 'foo');
+    }
+
+    public function testRender()
+    {
+        $renderer = $this->getMockBuilder('Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface')->getMock();
+        $renderer->expects($this->once())->method('getName')->will($this->returnValue('foo'));
+        $renderer->expects($this->any())->method('render')->will($this->returnValue(new Response()));
+
+        $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
+        $requestStack->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+
+        $container = $this->getMockBuilder('Psr\Container\ContainerInterface')->getMock();
+        $container->expects($this->once())->method('has')->with('foo')->willReturn(true);
+        $container->expects($this->once())->method('get')->will($this->returnValue($renderer));
+
+        $handler = new LazyLoadingFragmentHandler($container, $requestStack, false);
 
         $handler->render('/foo', 'foo');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

In order to don't do it twice, this includes the deprecations for #21625. 
Targets 3.4 (or more if the experimental period for service locators/getter injection is prolonged).