### PR TITLE
[DependencyInjection] Add optional named arguments support

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -56,15 +56,27 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
 
                 $parameters = null !== $parameters ? $parameters : $this->getParameters($class, $method);
 
+                $key = substr($key, 1);
+
+                $optional = false;
+                if ($key && '?' === $key[0]) {
+                    $optional = true;
+                    $key = substr($key, 1);
+                }
+
                 foreach ($parameters as $j => $p) {
-                    if ($key === '$'.$p->name) {
+                    if ($key === $p->name) {
                         $resolvedArguments[$j] = $argument;
 
                         continue 2;
                     }
                 }
 
-                throw new InvalidArgumentException(sprintf('Unable to resolve service "%s": method "%s::%s" has no argument named "%s". Check your service definition.', $this->currentId, $class, $method, $key));
+                if ($optional) {
+                    continue;
+                }
+
+                throw new InvalidArgumentException(sprintf('Unable to resolve service "%s": method "%s::%s" has no argument named "$%s". Check your service definition.', $this->currentId, $class, $method, $key));
             }
 
             if ($resolvedArguments !== $call[1]) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -21,12 +21,15 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy;
  */
 class ResolveNamedArgumentsPassTest extends \PHPUnit_Framework_TestCase
 {
-    public function testProcess()
+    /**
+     * @dataProvider argumentsProvider
+     */
+    public function testProcess(array $arguments)
     {
         $container = new ContainerBuilder();
 
         $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
-        $definition->setArguments(array(0 => new Reference('foo'), '$apiKey' => '123'));
+        $definition->setArguments($arguments);
         $definition->addMethodCall('setApiKey', array('$apiKey' => '123'));
 
         $pass = new ResolveNamedArgumentsPass();
@@ -34,6 +37,14 @@ class ResolveNamedArgumentsPassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array(0 => new Reference('foo'), 1 => '123'), $definition->getArguments());
         $this->assertEquals(array(array('setApiKey', array('123'))), $definition->getMethodCalls());
+    }
+
+    public function argumentsProvider()
+    {
+        return array(
+            'mixed usual/named arguments' => array(array(0 => new Reference('foo'), '$apiKey' => '123')),
+            'optional arguments' => array(array('$c' => new Reference('foo'), '$apiKey' => '123', '$?optional' => 'optional')),
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Add optional named arguments support:
```yml
services:
    AppBundle\:
        # Register all classes in the src/AppBundle directory as services
        resource: '../../src/AppBundle/{EventListener,Form/Type,Security,Twig,Utils}'
        arguments:
            $?locale: '%app_locales%'
            $?sender: '%app.notifications.email_sender%'
```

The goal is to permit registering a bunch of services with a set of arguments that will be used only if necessary.
An example of use case: https://github.com/symfony/symfony-demo/pull/483/files