### PR TITLE
[SecurityBundle] Don't normalize username of in-memory users

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -113,6 +113,8 @@ SecurityBundle
  * `UserPasswordEncoderCommand::getContainer()` is deprecated, and this class won't
     extend `ContainerAwareCommand` nor implement `ContainerAwareInterface` anymore in 4.0.
 
+ * [BC BREAK] Keys of the `users` node for `in_memory` user provider are no longer normalized.
+
 Serializer
 ----------
 

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecated `UserPasswordEncoderCommand::getContainer()` and relying on the
   `ContainerAwareInterface` interface for this command.
  * Deprecated the `FirewallMap::$map` and `$container` properties.
+ * [BC BREAK] Keys of the `users` node for `in_memory` user provider are no longer normalized.
 
 3.2.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
@@ -52,6 +52,7 @@ class InMemoryFactory implements UserProviderFactoryInterface
             ->children()
                 ->arrayNode('users')
                     ->useAttributeAsKey('name')
+                    ->normalizeKeys(false)
                     ->prototype('array')
                         ->children()
                             ->scalarNode('password')->defaultValue(uniqid('', true))->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

It's common to have e.g. emails as keys in `security.providers.in_memory.users` since keys are username. Actually they are normalized so `foo-bar@gmail.com` becomes `foo_bar@gmail.com` and authentication fails unexpectedly.