### PR TITLE
[DependencyInjection] Use a service locator in AddConstraintValidatorsPass

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -146,6 +146,8 @@ FrameworkBundle
  * The `ConstraintValidatorFactory::$validators` and `$container` properties
    have been deprecated and will be removed in 4.0.
 
+ * Extending `ConstraintValidatorFactory` is deprecated and won't be supported in 4.0.
+
 HttpKernel
 -----------
 

--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -143,6 +143,9 @@ FrameworkBundle
    deprecated and will be removed in 4.0. Use the `Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoPass`
    class instead.
 
+ * The `ConstraintValidatorFactory::$validators` and `$container` properties
+   have been deprecated and will be removed in 4.0.
+
 HttpKernel
 -----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -188,7 +188,6 @@ FrameworkBundle
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass` class has been
    removed. Use the `Symfony\Component\Form\DependencyInjection\FormPass` class instead.
 
-<<<<<<< HEAD
  * The `Symfony\Bundle\FrameworkBundle\EventListener\SessionListener` class has been removed.
    Use the `Symfony\Component\HttpKernel\EventListener\SessionListener` class instead.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -188,6 +188,7 @@ FrameworkBundle
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass` class has been
    removed. Use the `Symfony\Component\Form\DependencyInjection\FormPass` class instead.
 
+<<<<<<< HEAD
  * The `Symfony\Bundle\FrameworkBundle\EventListener\SessionListener` class has been removed.
    Use the `Symfony\Component\HttpKernel\EventListener\SessionListener` class instead.
 
@@ -204,6 +205,8 @@ FrameworkBundle
 
  * The `ConstraintValidatorFactory::$validators` and `$container` properties
    have been removed.
+
+ * Extending `ConstraintValidatorFactory` is not supported anymore.
 
 HttpFoundation
 ---------------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -202,6 +202,9 @@ FrameworkBundle
    removed. Use the `Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoPass`
    class instead.
 
+ * The `ConstraintValidatorFactory::$validators` and `$container` properties
+   have been removed.
+
 HttpFoundation
 ---------------
 
@@ -243,7 +246,7 @@ HttpKernel
 
  * The `Psr6CacheClearer::addPool()` method has been removed. Pass an array of pools indexed
    by name to the constructor instead.
-   
+
  * The `LazyLoadingFragmentHandler::addRendererService()` method has been removed.
 
  * The `X-Status-Code` header method of setting a custom status code in the
@@ -310,7 +313,7 @@ Translation
 TwigBundle
 ----------
 
-* The `ContainerAwareRuntimeLoader` class has been removed. Use the 
+* The `ContainerAwareRuntimeLoader` class has been removed. Use the
   Twig `Twig_ContainerRuntimeLoader` class instead.
 
 TwigBridge

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -17,9 +17,10 @@ CHANGELOG
  * Deprecated `FormPass`, use `Symfony\Component\Form\DependencyInjection\FormPass` instead
  * Deprecated `SessionListener`
  * Deprecated `TestSessionListener`
- * Deprecated `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConfigCachePass`. 
+ * Deprecated `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConfigCachePass`.
    Use `Symfony\Component\Console\DependencyInjection\ConfigCachePass` instead.
  * Deprecated `PropertyInfoPass`, use `Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoPass` instead
+ * Deprecated extending `ConstraintValidatorFactory`
 
 3.2.0
 -----
@@ -31,7 +32,7 @@ CHANGELOG
  * Removed `symfony/asset` from the list of required dependencies in `composer.json`
  * The `Resources/public/images/*` files have been removed.
  * The `Resources/public/css/*.css` files have been removed (they are now inlined in TwigBundle).
- * Added possibility to prioritize form type extensions with `'priority'` attribute on tags `form.type_extension` 
+ * Added possibility to prioritize form type extensions with `'priority'` attribute on tags `form.type_extension`
 
 3.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
 
 class AddConstraintValidatorsPass implements CompilerPassInterface
 {
@@ -26,22 +27,13 @@ class AddConstraintValidatorsPass implements CompilerPassInterface
         $validators = array();
         foreach ($container->findTaggedServiceIds('validator.constraint_validator') as $id => $attributes) {
             if (isset($attributes[0]['alias'])) {
-                $validators[$attributes[0]['alias']] = $id;
+                $validators[$attributes[0]['alias']] = new Reference($id);
             }
 
             $definition = $container->getDefinition($id);
-
-            if (!$definition->isPublic()) {
-                throw new InvalidArgumentException(sprintf('The service "%s" must be public as it can be lazy-loaded.', $id));
-            }
-
-            if ($definition->isAbstract()) {
-                throw new InvalidArgumentException(sprintf('The service "%s" must not be abstract as it can be lazy-loaded.', $id));
-            }
-
-            $validators[$definition->getClass()] = $id;
+            $validators[$definition->getClass()] = new Reference($id);
         }
 
-        $container->getDefinition('validator.validator_factory')->replaceArgument(1, $validators);
+        $container->getDefinition('validator.validator_factory')->replaceArgument(0, new ServiceLocatorArgument($validators));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
@@ -26,11 +26,16 @@ class AddConstraintValidatorsPass implements CompilerPassInterface
 
         $validators = array();
         foreach ($container->findTaggedServiceIds('validator.constraint_validator') as $id => $attributes) {
+            $definition = $container->getDefinition($id);
+
+            if ($definition->isAbstract()) {
+                continue;
+            }
+
             if (isset($attributes[0]['alias'])) {
                 $validators[$attributes[0]['alias']] = new Reference($id);
             }
 
-            $definition = $container->getDefinition($id);
             $validators[$definition->getClass()] = new Reference($id);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -57,8 +57,7 @@
         </service>
 
         <service id="validator.validator_factory" class="Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory" public="false">
-            <argument type="service" id="service_container" />
-            <argument type="collection" />
+            <argument type="service-locator" /> <!-- Constraint validators locator -->
         </service>
 
         <service id="validator.expression" class="Symfony\Component\Validator\Constraints\ExpressionValidator">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConstraintValidatorsPass;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Reference;
 
 class AddConstraintValidatorsPassTest extends TestCase
 {
@@ -55,11 +57,11 @@ class AddConstraintValidatorsPassTest extends TestCase
 
         $validatorFactoryDefinition->expects($this->once())
             ->method('replaceArgument')
-            ->with(1, array(
-                'My\Fully\Qualified\Class\Named\Validator1' => 'my_constraint_validator_service1',
-                'my_constraint_validator_alias1' => 'my_constraint_validator_service1',
-                'My\Fully\Qualified\Class\Named\Validator2' => 'my_constraint_validator_service2',
-            ));
+            ->with(0, new ServiceLocatorArgument(array(
+                'My\Fully\Qualified\Class\Named\Validator1' => new Reference('my_constraint_validator_service1'),
+                'my_constraint_validator_alias1' => new Reference('my_constraint_validator_service1'),
+                'My\Fully\Qualified\Class\Named\Validator2' => new Reference('my_constraint_validator_service2'),
+            )));
 
         $addConstraintValidatorsPass = new AddConstraintValidatorsPass();
         $addConstraintValidatorsPass->process($container);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
@@ -14,57 +14,33 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConstraintValidatorsPass;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 class AddConstraintValidatorsPassTest extends TestCase
 {
     public function testThatConstraintValidatorServicesAreProcessed()
     {
-        $services = array(
-            'my_constraint_validator_service1' => array(0 => array('alias' => 'my_constraint_validator_alias1')),
-            'my_constraint_validator_service2' => array(),
-        );
+        $container = new ContainerBuilder();
+        $validatorFactory = $container->register('validator.validator_factory')
+            ->setArguments(array(new ServiceLocatorArgument()));
 
-        $validatorFactoryDefinition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock();
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds', 'getDefinition', 'hasDefinition'))->getMock();
-
-        $validatorDefinition1 = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->setMethods(array('getClass'))->getMock();
-        $validatorDefinition2 = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->setMethods(array('getClass'))->getMock();
-
-        $validatorDefinition1->expects($this->atLeastOnce())
-            ->method('getClass')
-            ->willReturn('My\Fully\Qualified\Class\Named\Validator1');
-        $validatorDefinition2->expects($this->atLeastOnce())
-            ->method('getClass')
-            ->willReturn('My\Fully\Qualified\Class\Named\Validator2');
-
-        $container->expects($this->any())
-            ->method('getDefinition')
-            ->with($this->anything())
-            ->will($this->returnValueMap(array(
-                array('my_constraint_validator_service1', $validatorDefinition1),
-                array('my_constraint_validator_service2', $validatorDefinition2),
-                array('validator.validator_factory', $validatorFactoryDefinition),
-            )));
-
-        $container->expects($this->atLeastOnce())
-            ->method('findTaggedServiceIds')
-            ->will($this->returnValue($services));
-        $container->expects($this->atLeastOnce())
-            ->method('hasDefinition')
-            ->with('validator.validator_factory')
-            ->will($this->returnValue(true));
-
-        $validatorFactoryDefinition->expects($this->once())
-            ->method('replaceArgument')
-            ->with(0, new ServiceLocatorArgument(array(
-                'My\Fully\Qualified\Class\Named\Validator1' => new Reference('my_constraint_validator_service1'),
-                'my_constraint_validator_alias1' => new Reference('my_constraint_validator_service1'),
-                'My\Fully\Qualified\Class\Named\Validator2' => new Reference('my_constraint_validator_service2'),
-            )));
+        $container->register('my_constraint_validator_service1', Validator1::class)
+            ->addTag('validator.constraint_validator', array('alias' => 'my_constraint_validator_alias1'));
+        $container->register('my_constraint_validator_service2', Validator2::class)
+            ->addTag('validator.constraint_validator');
+        $container->register('my_abstract_constraint_validator')
+            ->setAbstract(true)
+            ->addTag('validator.constraint_validator');
 
         $addConstraintValidatorsPass = new AddConstraintValidatorsPass();
         $addConstraintValidatorsPass->process($container);
+
+        $this->assertEquals(new ServiceLocatorArgument(array(
+            Validator1::class => new Reference('my_constraint_validator_service1'),
+            'my_constraint_validator_alias1' => new Reference('my_constraint_validator_service1'),
+            Validator2::class => new Reference('my_constraint_validator_service2'),
+        )), $validatorFactory->getArgument(0));
     }
 
     public function testThatCompilerPassIsIgnoredIfThereIsNoConstraintValidatorFactoryDefinition()

--- a/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php
@@ -40,7 +40,14 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
 {
+    /**
+     * @deprecated since version 3.3, to be removed in 4.0 alongside with magic methods below
+     */
     protected $container;
+
+    /**
+     * @deprecated since version 3.3, to be removed in 4.0 alongside with magic methods below
+     */
     protected $validators;
 
     /**
@@ -84,5 +91,53 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
         }
 
         return $this->validators[$name];
+    }
+
+    /**
+     * @internal
+     */
+    public function __get($name)
+    {
+        if ('validators' === $name || 'container' === $name) {
+            @trigger_error(sprintf('Using the "%s::$%s" property is deprecated since version 3.3 as it will be removed/private in 4.0.', __CLASS__, $name), E_USER_DEPRECATED);
+        }
+
+        return $this->$name;
+    }
+
+    /**
+     * @internal
+     */
+    public function __set($name, $value)
+    {
+        if ('validators' === $name || 'container' === $name) {
+            @trigger_error(sprintf('Using the "%s::$%s" property is deprecated since version 3.3 as it will be removed/private in 4.0.', __CLASS__, $name), E_USER_DEPRECATED);
+        }
+
+        $this->$name = $value;
+    }
+
+    /**
+     * @internal
+     */
+    public function __isset($name)
+    {
+        if ('validators' === $name || 'container' === $name) {
+            @trigger_error(sprintf('Using the "%s::$%s" property is deprecated since version 3.3 as it will be removed/private in 4.0.', __CLASS__, $name), E_USER_DEPRECATED);
+        }
+
+        return isset($this->$name);
+    }
+
+    /**
+     * @internal
+     */
+    public function __unset($name)
+    {
+        if ('validators' === $name || 'container' === $name) {
+            @trigger_error(sprintf('Using the "%s::$%s" property is deprecated since version 3.3 as it will be removed/private in 4.0.', __CLASS__, $name), E_USER_DEPRECATED);
+        }
+
+        unset($this->$name);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -49,7 +49,7 @@
         "symfony/serializer": "~3.3",
         "symfony/translation": "~2.8|~3.0",
         "symfony/templating": "~2.8|~3.0",
-        "symfony/validator": "~3.2",
+        "symfony/validator": "~3.3",
         "symfony/yaml": "~3.2",
         "symfony/property-info": "~3.3",
         "doctrine/annotations": "~1.0",
@@ -65,7 +65,8 @@
         "symfony/console": "<3.3",
         "symfony/serializer": "<3.3",
         "symfony/form": "<3.3",
-        "symfony/property-info": "<3.3"
+        "symfony/property-info": "<3.3",
+        "symfony/validator": "<3.3"
     },
     "suggest": {
         "ext-apcu": "For best performance of the system caches",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Use a service locator to load constraint validators: it allows them to be private.