### PR TITLE
Fix emacs link

### DIFF
--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -84,8 +84,15 @@ class DirectoryResource implements ResourceInterface, \Serializable
                 continue;
             }
 
+            // for broken links
+            try {
+                $fileMTime = $file->getMTime();
+            } catch (\RuntimeException $e) {
+                continue;
+            }
+
             // early return if a file's mtime exceeds the passed timestamp
-            if ($timestamp < $file->getMTime()) {
+            if ($timestamp < $fileMTime) {
                 return false;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes (minor)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

When an Emacs buffer is modified, by default Emacs automatically creates a
temporary symlink in the same directory as the file being edited (e.g. Controller.php):

```
.#Controller.php -> user@host.12345:1296583136
```

where '12345' is [the Emacs' PID][1].

In this case Symfony breaks with a RuntimeException:

```
SplFileInfo::getMTime(): stat failed for ...Bundle/Controller/.#APIController.php
```

in
vendor/symfony/symfony/src/Symfony/Component/Config/Resource/DirectoryResource.php
at line 89

```
$newestMTime = max($file->getMTime(), $newestMTime);
```


[1]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Interlocking.html