### PR TITLE
[Config] fixed glob file loader when there is an exception

### DIFF
--- a/src/Symfony/Component/Config/Loader/GlobFileLoader.php
+++ b/src/Symfony/Component/Config/Loader/GlobFileLoader.php
@@ -23,7 +23,7 @@ class GlobFileLoader extends FileLoader
      */
     public function load($resource, $type = null)
     {
-        return $this->import($resource, null, true);
+        return $this->import($resource);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Fixes a typo. When importing a glob, we definitely want to have errors like syntax errors in a YAML file.
