### PR TITLE
Make sure to deal with actual integers

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -93,17 +93,17 @@ class File extends Constraint
         if (ctype_digit((string) $maxSize)) {
             $this->maxSize = $sizeInt;
             $this->binaryFormat = null === $this->binaryFormat ? false : $this->binaryFormat;
-        } elseif (preg_match('/^\d++k$/i', $maxSize)) {
-            $this->maxSize = $sizeInt * 1000;
+        } elseif (preg_match('/^(\d++)k$/i', $maxSize, $matches)) {
+            $this->maxSize = $matches[1] * 1000;
             $this->binaryFormat = null === $this->binaryFormat ? false : $this->binaryFormat;
-        } elseif (preg_match('/^\d++M$/i', $maxSize)) {
-            $this->maxSize = $sizeInt * 1000000;
+        } elseif (preg_match('/^(\d++)M$/i', $maxSize, $matches)) {
+            $this->maxSize = $matches[1] * 1000000;
             $this->binaryFormat = null === $this->binaryFormat ? false : $this->binaryFormat;
-        } elseif (preg_match('/^\d++Ki$/i', $maxSize)) {
-            $this->maxSize = $sizeInt << 10;
+        } elseif (preg_match('/^(\d++)Ki$/i', $maxSize, $matches)) {
+            $this->maxSize = $matches[1] << 10;
             $this->binaryFormat = null === $this->binaryFormat ? true : $this->binaryFormat;
-        } elseif (preg_match('/^\d++Mi$/i', $maxSize)) {
-            $this->maxSize = $sizeInt << 20;
+        } elseif (preg_match('/^(\d++)Mi$/i', $maxSize, $matches)) {
+            $this->maxSize = $matches[1] << 20;
             $this->binaryFormat = null === $this->binaryFormat ? true : $this->binaryFormat;
         } else {
             throw new ConstraintDefinitionException(sprintf('"%s" is not a valid maximum size', $this->maxSize));

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -88,10 +88,8 @@ class File extends Constraint
 
     private function normalizeBinaryFormat($maxSize)
     {
-        $sizeInt = (int) $maxSize;
-
         if (ctype_digit((string) $maxSize)) {
-            $this->maxSize = $sizeInt;
+            $this->maxSize = (int) $maxSize;
             $this->binaryFormat = null === $this->binaryFormat ? false : $this->binaryFormat;
         } elseif (preg_match('/^(\d++)k$/i', $maxSize, $matches)) {
             $this->maxSize = $matches[1] * 1000;

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -88,21 +88,24 @@ class File extends Constraint
 
     private function normalizeBinaryFormat($maxSize)
     {
+        $factors = array(
+                'k' => 1000,
+                'ki' => 1 << 10,
+                'm' => 1000000,
+                'mi' => 1 << 20,
+        );
         if (ctype_digit((string) $maxSize)) {
             $this->maxSize = (int) $maxSize;
             $this->binaryFormat = null === $this->binaryFormat ? false : $this->binaryFormat;
-        } elseif (preg_match('/^(\d++)k$/i', $maxSize, $matches)) {
-            $this->maxSize = $matches[1] * 1000;
-            $this->binaryFormat = null === $this->binaryFormat ? false : $this->binaryFormat;
-        } elseif (preg_match('/^(\d++)M$/i', $maxSize, $matches)) {
-            $this->maxSize = $matches[1] * 1000000;
-            $this->binaryFormat = null === $this->binaryFormat ? false : $this->binaryFormat;
-        } elseif (preg_match('/^(\d++)Ki$/i', $maxSize, $matches)) {
-            $this->maxSize = $matches[1] << 10;
-            $this->binaryFormat = null === $this->binaryFormat ? true : $this->binaryFormat;
-        } elseif (preg_match('/^(\d++)Mi$/i', $maxSize, $matches)) {
-            $this->maxSize = $matches[1] << 20;
-            $this->binaryFormat = null === $this->binaryFormat ? true : $this->binaryFormat;
+        } elseif (preg_match(
+            '/^(\d++)('.implode('|', array_keys($factors)).')$/i',
+            $maxSize,
+            $matches
+        )) {
+            $this->maxSize = $matches[1] * $factors[$unit = strtolower($matches[2])];
+            $this->binaryFormat = null === $this->binaryFormat ?
+                2 === strlen($unit) :
+                $this->binaryFormat;
         } else {
             throw new ConstraintDefinitionException(sprintf('"%s" is not a valid maximum size', $this->maxSize));
         }


### PR DESCRIPTION
This fixes a bug where an attempt to make operations between numbers and
things like "100k" or "10M" is made, and fails when using php >= 7.1,
which no longer alows this, it seems.

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n / a

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->


The error message that arises is 

> A non well formed numeric value encountered