### PR TITLE
[Serializer] Reduce nesting in YamlFileLoader

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -60,39 +60,39 @@ class YamlFileLoader extends FileLoader
             $this->classes = $classes;
         }
 
-        if (isset($this->classes[$classMetadata->getName()])) {
-            $yaml = $this->classes[$classMetadata->getName()];
+        if (!isset($this->classes[$classMetadata->getName()])) {
+            return false;
+        }
 
-            if (isset($yaml['attributes']) && is_array($yaml['attributes'])) {
-                $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $yaml = $this->classes[$classMetadata->getName()];
 
-                foreach ($yaml['attributes'] as $attribute => $data) {
-                    if (isset($attributesMetadata[$attribute])) {
-                        $attributeMetadata = $attributesMetadata[$attribute];
-                    } else {
-                        $attributeMetadata = new AttributeMetadata($attribute);
-                        $classMetadata->addAttributeMetadata($attributeMetadata);
+        if (isset($yaml['attributes']) && is_array($yaml['attributes'])) {
+            $attributesMetadata = $classMetadata->getAttributesMetadata();
+
+            foreach ($yaml['attributes'] as $attribute => $data) {
+                if (isset($attributesMetadata[$attribute])) {
+                    $attributeMetadata = $attributesMetadata[$attribute];
+                } else {
+                    $attributeMetadata = new AttributeMetadata($attribute);
+                    $classMetadata->addAttributeMetadata($attributeMetadata);
+                }
+
+                if (isset($data['groups'])) {
+                    if (!is_array($data['groups'])) {
+                        throw new MappingException('The "groups" key must be an array of strings in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName());
                     }
 
-                    if (isset($data['groups'])) {
-                        if (!is_array($data['groups'])) {
-                            throw new MappingException('The "groups" key must be an array of strings in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName());
+                    foreach ($data['groups'] as $group) {
+                        if (!is_string($group)) {
+                            throw new MappingException('Group names must be strings in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName());
                         }
 
-                        foreach ($data['groups'] as $group) {
-                            if (!is_string($group)) {
-                                throw new MappingException('Group names must be strings in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName());
-                            }
-
-                            $attributeMetadata->addGroup($group);
-                        }
+                        $attributeMetadata->addGroup($group);
                     }
                 }
             }
-
-            return true;
         }
 
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

We don't need to check if $this->classes is empty, because isset takes care of it in next call anyway


Diffs on GH are hard to read for this type of change, here is old and new code:


```php
public function loadClassMetadata(ClassMetadataInterface $classMetadata)
{
    if (null === $this->classes) {
        $this->classes = $this->getClassesFromYaml();
    }

    if (!$this->classes) {
        return false;
    }

    if (isset($this->classes[$classMetadata->getName()])) {
        $yaml = $this->classes[$classMetadata->getName()];

        if (isset($yaml['attributes']) && is_array($yaml['attributes'])) {
           ...
        }

        return true;
    }

    return false;
}
```

```php
public function loadClassMetadata(ClassMetadataInterface $classMetadata)
{
    if (null === $this->classes) {
        $this->classes = $this->getClassesFromYaml();
    }

    if (!isset($this->classes[$classMetadata->getName()])) {
        return false;
    }

    $yaml = $this->classes[$classMetadata->getName()];

    if (isset($yaml['attributes']) && is_array($yaml['attributes'])) {
        ...
    }

    return true;
}
```