### PR TITLE
[Routing] Optimised dumped router matcher, prevent unneeded function calls.

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -109,7 +109,7 @@ EOF;
         \$context = \$this->context;
         \$request = \$this->request;
         \$requestMethod = \$isLikeGetMethod = \$context->getMethod();
-        
+
         if (\$requestMethod === 'HEAD') {
             \$isLikeGetMethod = 'GET';
         }

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -229,10 +229,10 @@ EOF;
 
         if (!count($compiledRoute->getPathVariables()) && false !== preg_match('#^(.)\^(?P<url>.*?)\$\1#'.(substr($regex, -1) === 'u' ? 'u' : ''), $regex, $m)) {
             if ($supportsTrailingSlash && substr($m['url'], -1) === '/') {
-                $conditions[] = sprintf('$trimmedPathinfo === %s', var_export(rtrim(str_replace('\\', '', $m['url']), '/'), true));
+                $conditions[] = sprintf('%s === $trimmedPathinfo', var_export(rtrim(str_replace('\\', '', $m['url']), '/'), true));
                 $hasTrailingSlash = true;
             } else {
-                $conditions[] = sprintf('$pathinfo === %s', var_export(str_replace('\\', '', $m['url']), true));
+                $conditions[] = sprintf('%s === $pathinfo', var_export(str_replace('\\', '', $m['url']), true));
             }
         } else {
             if ($compiledRoute->getStaticPrefix() && $compiledRoute->getStaticPrefix() !== $parentPrefix) {
@@ -270,7 +270,7 @@ EOF;
             if (1 === count($methods)) {
                 if ($methods[0] === 'HEAD') {
                     $code .= <<<EOF
-            if (\$requestMethod != 'HEAD') {
+            if ('HEAD' !== \$requestMethod) {
                 \$allow[] = 'HEAD';
                 goto $gotoname;
             }
@@ -279,7 +279,7 @@ EOF;
 EOF;
                 } else {
                     $code .= <<<EOF
-            if (\$isLikeGetMethod != '$methods[0]') {
+            if ('$methods[0]' !== \$isLikeGetMethod) {
                 \$allow[] = '$methods[0]';
                 goto $gotoname;
             }
@@ -293,7 +293,7 @@ EOF;
                 if (in_array('GET', $methods)) {
                     // Since we treat HEAD requests like GET requests we don't need to match it.
                     $methodVariable = 'isLikeGetMethod';
-                    $methods = array_filter($methods, function ($method) { return $method != 'HEAD'; });
+                    $methods = array_filter($methods, function ($method) { return 'HEAD' !== $method; });
                 }
 
                 $methods = implode("', '", $methods);

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -109,6 +109,7 @@ EOF;
         \$context = \$this->context;
         \$request = \$this->request;
         \$requestMethod = \$isLikeGetMethod = \$context->getMethod();
+        \$schema = \$context->getScheme();
 
         if (\$requestMethod === 'HEAD') {
             \$isLikeGetMethod = 'GET';
@@ -336,7 +337,7 @@ EOF;
             $schemes = str_replace("\n", '', var_export(array_flip($schemes), true));
             $code .= <<<EOF
             \$requiredSchemes = $schemes;
-            if (!isset(\$requiredSchemes[\$context->getScheme()])) {
+            if (!isset(\$requiredSchemes[\$schema])) {
                 return \$this->redirect(\$pathinfo, '$name', key(\$requiredSchemes));
             }
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -296,8 +296,18 @@ EOF;
                     $methods = array_filter($methods, function ($method) { return 'HEAD' !== $method; });
                 }
 
-                $methods = implode("', '", $methods);
-                $code .= <<<EOF
+                if (1 === count($methods)) {
+                        $code .= <<<EOF
+            if ('$methods[0]' !== \$$methodVariable) {
+                \$allow[] = '$methods[0]';
+                goto $gotoname;
+            }
+
+
+EOF;
+                } else {
+                    $methods = implode("', '", $methods);
+                    $code .= <<<EOF
             if (!in_array(\$$methodVariable, array('$methods'))) {
                 \$allow = array_merge(\$allow, array('$methods'));
                 goto $gotoname;
@@ -305,6 +315,7 @@ EOF;
 
 
 EOF;
+                }
             }
         }
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -297,7 +297,7 @@ EOF;
                 }
 
                 if (1 === count($methods)) {
-                        $code .= <<<EOF
+                    $code .= <<<EOF
             if ('$methods[0]' !== \$$methodVariable) {
                 \$allow[] = '$methods[0]';
                 goto $gotoname;

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -229,7 +229,7 @@ EOF;
 
         if (!count($compiledRoute->getPathVariables()) && false !== preg_match('#^(.)\^(?P<url>.*?)\$\1#'.(substr($regex, -1) === 'u' ? 'u' : ''), $regex, $m)) {
             if ($supportsTrailingSlash && substr($m['url'], -1) === '/') {
-                $conditions[] = sprintf("\$trimmedPathinfo === %s", var_export(rtrim(str_replace('\\', '', $m['url']), '/'), true));
+                $conditions[] = sprintf('$trimmedPathinfo === %s', var_export(rtrim(str_replace('\\', '', $m['url']), '/'), true));
                 $hasTrailingSlash = true;
             } else {
                 $conditions[] = sprintf('$pathinfo === %s', var_export(str_replace('\\', '', $m['url']), true));

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -111,7 +111,7 @@ EOF;
         \$requestMethod = \$isLikeGetMethod = \$context->getMethod();
         \$schema = \$context->getScheme();
 
-        if (\$requestMethod === 'HEAD') {
+        if ('HEAD' === \$requestMethod) {
             \$isLikeGetMethod = 'GET';
         }
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -109,7 +109,7 @@ EOF;
         \$context = \$this->context;
         \$request = \$this->request;
         \$requestMethod = \$canonicalMethod = \$context->getMethod();
-        \$schema = \$context->getScheme();
+        \$scheme = \$context->getScheme();
 
         if ('HEAD' === \$requestMethod) {
             \$canonicalMethod = 'GET';
@@ -337,7 +337,7 @@ EOF;
             $schemes = str_replace("\n", '', var_export(array_flip($schemes), true));
             $code .= <<<EOF
             \$requiredSchemes = $schemes;
-            if (!isset(\$requiredSchemes[\$schema])) {
+            if (!isset(\$requiredSchemes[\$scheme])) {
                 return \$this->redirect(\$pathinfo, '$name', key(\$requiredSchemes));
             }
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -108,11 +108,11 @@ EOF;
         \$trimmedPathinfo = rtrim(\$pathinfo, '/');
         \$context = \$this->context;
         \$request = \$this->request;
-        \$requestMethod = \$isLikeGetMethod = \$context->getMethod();
+        \$requestMethod = \$canonicalMethod = \$context->getMethod();
         \$schema = \$context->getScheme();
 
         if ('HEAD' === \$requestMethod) {
-            \$isLikeGetMethod = 'GET';
+            \$canonicalMethod = 'GET';
         }
 
 
@@ -280,7 +280,7 @@ EOF;
 EOF;
                 } else {
                     $code .= <<<EOF
-            if ('$methods[0]' !== \$isLikeGetMethod) {
+            if ('$methods[0]' !== \$canonicalMethod) {
                 \$allow[] = '$methods[0]';
                 goto $gotoname;
             }
@@ -293,7 +293,7 @@ EOF;
 
                 if (in_array('GET', $methods)) {
                     // Since we treat HEAD requests like GET requests we don't need to match it.
-                    $methodVariable = 'isLikeGetMethod';
+                    $methodVariable = 'canonicalMethod';
                     $methods = array_filter($methods, function ($method) { return 'HEAD' !== $method; });
                 }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -28,6 +28,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $isLikeGetMethod = $context->getMethod();
+        $schema = $context->getScheme();
 
         if ($requestMethod === 'HEAD') {
             $isLikeGetMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -27,7 +27,12 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
-        $requestMethod = $context->getMethod();
+        $requestMethod = $isLikeGetMethod = $context->getMethod();
+
+        if ($requestMethod === 'HEAD') {
+            $isLikeGetMethod = 'GET';
+        }
+
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
@@ -37,8 +42,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/bar')) {
             // bar
             if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($requestMethod, array('GET', 'HEAD'))) {
-                    $allow = array_merge($allow, array('GET', 'HEAD'));
+                if (!in_array($isLikeGetMethod, array('GET'))) {
+                    $allow = array_merge($allow, array('GET'));
                     goto not_bar;
                 }
 
@@ -48,8 +53,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // barhead
             if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($requestMethod, array('GET', 'HEAD'))) {
-                    $allow = array_merge($allow, array('GET', 'HEAD'));
+                if ($isLikeGetMethod != 'GET') {
+                    $allow[] = 'GET';
                     goto not_barhead;
                 }
 
@@ -85,7 +90,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($requestMethod != 'POST') {
+                if ($isLikeGetMethod != 'POST') {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -96,7 +101,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($requestMethod != 'PUT') {
+                if ($isLikeGetMethod != 'PUT') {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -42,8 +42,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/bar')) {
             // bar
             if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($isLikeGetMethod, array('GET'))) {
-                    $allow = array_merge($allow, array('GET'));
+                if ('GET' !== $isLikeGetMethod) {
+                    $allow[] = 'GET';
                     goto not_bar;
                 }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -24,8 +24,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($pathinfo);
+        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
+        $requestMethod = $context->getMethod();
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
@@ -35,7 +37,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/bar')) {
             // bar
             if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                if (!in_array($requestMethod, array('GET', 'HEAD'))) {
                     $allow = array_merge($allow, array('GET', 'HEAD'));
                     goto not_bar;
                 }
@@ -46,7 +48,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // barhead
             if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                if (!in_array($requestMethod, array('GET', 'HEAD'))) {
                     $allow = array_merge($allow, array('GET', 'HEAD'));
                     goto not_barhead;
                 }
@@ -83,7 +85,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() != 'POST') {
+                if ($requestMethod != 'POST') {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -94,7 +96,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() != 'PUT') {
+                if ($requestMethod != 'PUT') {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }
@@ -195,7 +197,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         }
 
-        $host = $this->context->getHost();
+        $host = $context->getHost();
 
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route1

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -53,7 +53,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // barhead
             if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if ($isLikeGetMethod != 'GET') {
+                if ('GET' !== $isLikeGetMethod) {
                     $allow[] = 'GET';
                     goto not_barhead;
                 }
@@ -67,17 +67,17 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/test')) {
             if (0 === strpos($pathinfo, '/test/baz')) {
                 // baz
-                if ($pathinfo === '/test/baz') {
+                if ('/test/baz' === $pathinfo) {
                     return array('_route' => 'baz');
                 }
 
                 // baz2
-                if ($pathinfo === '/test/baz.html') {
+                if ('/test/baz.html' === $pathinfo) {
                     return array('_route' => 'baz2');
                 }
 
                 // baz3
-                if ($pathinfo === '/test/baz3/') {
+                if ('/test/baz3/' === $pathinfo) {
                     return array('_route' => 'baz3');
                 }
 
@@ -90,7 +90,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($isLikeGetMethod != 'POST') {
+                if ('POST' !== $isLikeGetMethod) {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -101,7 +101,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($isLikeGetMethod != 'PUT') {
+                if ('PUT' !== $isLikeGetMethod) {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }
@@ -113,7 +113,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // foofoo
-        if ($pathinfo === '/foofoo') {
+        if ('/foofoo' === $pathinfo) {
             return array (  'def' => 'test',  '_route' => 'foofoo',);
         }
 
@@ -123,7 +123,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // space
-        if ($pathinfo === '/spa ce') {
+        if ('/spa ce' === $pathinfo) {
             return array('_route' => 'space');
         }
 
@@ -168,12 +168,12 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             }
 
             // overridden2
-            if ($pathinfo === '/multi/new') {
+            if ('/multi/new' === $pathinfo) {
                 return array('_route' => 'overridden2');
             }
 
             // hey
-            if ($pathinfo === '/multi/hey/') {
+            if ('/multi/hey/' === $pathinfo) {
                 return array('_route' => 'hey');
             }
 
@@ -191,7 +191,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         if (0 === strpos($pathinfo, '/aba')) {
             // ababa
-            if ($pathinfo === '/ababa') {
+            if ('/ababa' === $pathinfo) {
                 return array('_route' => 'ababa');
             }
 
@@ -206,12 +206,12 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route1
-            if ($pathinfo === '/route1') {
+            if ('/route1' === $pathinfo) {
                 return array('_route' => 'route1');
             }
 
             // route2
-            if ($pathinfo === '/c2/route2') {
+            if ('/c2/route2' === $pathinfo) {
                 return array('_route' => 'route2');
             }
 
@@ -219,7 +219,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         if (preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
             // route3
-            if ($pathinfo === '/c2/route3') {
+            if ('/c2/route3' === $pathinfo) {
                 return array('_route' => 'route3');
             }
 
@@ -227,7 +227,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route4
-            if ($pathinfo === '/route4') {
+            if ('/route4' === $pathinfo) {
                 return array('_route' => 'route4');
             }
 
@@ -235,26 +235,26 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route5
-            if ($pathinfo === '/route5') {
+            if ('/route5' === $pathinfo) {
                 return array('_route' => 'route5');
             }
 
         }
 
         // route6
-        if ($pathinfo === '/route6') {
+        if ('/route6' === $pathinfo) {
             return array('_route' => 'route6');
         }
 
         if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#si', $host, $hostMatches)) {
             if (0 === strpos($pathinfo, '/route1')) {
                 // route11
-                if ($pathinfo === '/route11') {
+                if ('/route11' === $pathinfo) {
                     return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
                 }
 
                 // route12
-                if ($pathinfo === '/route12') {
+                if ('/route12' === $pathinfo) {
                     return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
                 }
 
@@ -287,7 +287,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             }
 
             // route17
-            if ($pathinfo === '/route17') {
+            if ('/route17' === $pathinfo) {
                 return array('_route' => 'route17');
             }
 
@@ -295,7 +295,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         if (0 === strpos($pathinfo, '/a')) {
             // a
-            if ($pathinfo === '/a/a...') {
+            if ('/a/a...' === $pathinfo) {
                 return array('_route' => 'a');
             }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -28,7 +28,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $canonicalMethod = $context->getMethod();
-        $schema = $context->getScheme();
+        $scheme = $context->getScheme();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -30,7 +30,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $requestMethod = $isLikeGetMethod = $context->getMethod();
         $schema = $context->getScheme();
 
-        if ($requestMethod === 'HEAD') {
+        if ('HEAD' === $requestMethod) {
             $isLikeGetMethod = 'GET';
         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -27,11 +27,11 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
-        $requestMethod = $isLikeGetMethod = $context->getMethod();
+        $requestMethod = $canonicalMethod = $context->getMethod();
         $schema = $context->getScheme();
 
         if ('HEAD' === $requestMethod) {
-            $isLikeGetMethod = 'GET';
+            $canonicalMethod = 'GET';
         }
 
 
@@ -43,7 +43,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/bar')) {
             // bar
             if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if ('GET' !== $isLikeGetMethod) {
+                if ('GET' !== $canonicalMethod) {
                     $allow[] = 'GET';
                     goto not_bar;
                 }
@@ -54,7 +54,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // barhead
             if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if ('GET' !== $isLikeGetMethod) {
+                if ('GET' !== $canonicalMethod) {
                     $allow[] = 'GET';
                     goto not_barhead;
                 }
@@ -91,7 +91,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ('POST' !== $isLikeGetMethod) {
+                if ('POST' !== $canonicalMethod) {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -102,7 +102,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ('PUT' !== $isLikeGetMethod) {
+                if ('PUT' !== $canonicalMethod) {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -24,8 +24,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
     {
         $allow = array();
         $pathinfo = rawurldecode($pathinfo);
+        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
+        $requestMethod = $context->getMethod();
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
@@ -35,7 +37,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (0 === strpos($pathinfo, '/bar')) {
             // bar
             if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                if (!in_array($requestMethod, array('GET', 'HEAD'))) {
                     $allow = array_merge($allow, array('GET', 'HEAD'));
                     goto not_bar;
                 }
@@ -46,7 +48,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // barhead
             if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                if (!in_array($requestMethod, array('GET', 'HEAD'))) {
                     $allow = array_merge($allow, array('GET', 'HEAD'));
                     goto not_barhead;
                 }
@@ -70,7 +72,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                 }
 
                 // baz3
-                if (rtrim($pathinfo, '/') === '/test/baz3') {
+                if ($trimmedPathinfo === '/test/baz3') {
                     if (substr($pathinfo, -1) !== '/') {
                         return $this->redirect($pathinfo.'/', 'baz3');
                     }
@@ -91,7 +93,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() != 'POST') {
+                if ($requestMethod != 'POST') {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -102,7 +104,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() != 'PUT') {
+                if ($requestMethod != 'PUT') {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }
@@ -174,7 +176,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             }
 
             // hey
-            if (rtrim($pathinfo, '/') === '/multi/hey') {
+            if ($trimmedPathinfo === '/multi/hey') {
                 if (substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'hey');
                 }
@@ -207,7 +209,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         }
 
-        $host = $this->context->getHost();
+        $host = $context->getHost();
 
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route1
@@ -322,7 +324,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         // secure
         if ($pathinfo === '/secure') {
             $requiredSchemes = array (  'https' => 0,);
-            if (!isset($requiredSchemes[$this->context->getScheme()])) {
+            if (!isset($requiredSchemes[$context->getScheme()])) {
                 return $this->redirect($pathinfo, 'secure', key($requiredSchemes));
             }
 
@@ -332,7 +334,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         // nonsecure
         if ($pathinfo === '/nonsecure') {
             $requiredSchemes = array (  'http' => 0,);
-            if (!isset($requiredSchemes[$this->context->getScheme()])) {
+            if (!isset($requiredSchemes[$context->getScheme()])) {
                 return $this->redirect($pathinfo, 'nonsecure', key($requiredSchemes));
             }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -27,7 +27,12 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
-        $requestMethod = $context->getMethod();
+        $requestMethod = $isLikeGetMethod = $context->getMethod();
+
+        if ($requestMethod === 'HEAD') {
+            $isLikeGetMethod = 'GET';
+        }
+
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
@@ -37,8 +42,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (0 === strpos($pathinfo, '/bar')) {
             // bar
             if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($requestMethod, array('GET', 'HEAD'))) {
-                    $allow = array_merge($allow, array('GET', 'HEAD'));
+                if (!in_array($isLikeGetMethod, array('GET'))) {
+                    $allow = array_merge($allow, array('GET'));
                     goto not_bar;
                 }
 
@@ -48,8 +53,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // barhead
             if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($requestMethod, array('GET', 'HEAD'))) {
-                    $allow = array_merge($allow, array('GET', 'HEAD'));
+                if ($isLikeGetMethod != 'GET') {
+                    $allow[] = 'GET';
                     goto not_barhead;
                 }
 
@@ -93,7 +98,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($requestMethod != 'POST') {
+                if ($isLikeGetMethod != 'POST') {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -104,7 +109,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($requestMethod != 'PUT') {
+                if ($isLikeGetMethod != 'PUT') {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -28,6 +28,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $isLikeGetMethod = $context->getMethod();
+        $schema = $context->getScheme();
 
         if ($requestMethod === 'HEAD') {
             $isLikeGetMethod = 'GET';
@@ -329,7 +330,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         // secure
         if ('/secure' === $pathinfo) {
             $requiredSchemes = array (  'https' => 0,);
-            if (!isset($requiredSchemes[$context->getScheme()])) {
+            if (!isset($requiredSchemes[$schema])) {
                 return $this->redirect($pathinfo, 'secure', key($requiredSchemes));
             }
 
@@ -339,7 +340,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         // nonsecure
         if ('/nonsecure' === $pathinfo) {
             $requiredSchemes = array (  'http' => 0,);
-            if (!isset($requiredSchemes[$context->getScheme()])) {
+            if (!isset($requiredSchemes[$schema])) {
                 return $this->redirect($pathinfo, 'nonsecure', key($requiredSchemes));
             }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -42,8 +42,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (0 === strpos($pathinfo, '/bar')) {
             // bar
             if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if (!in_array($isLikeGetMethod, array('GET'))) {
-                    $allow = array_merge($allow, array('GET'));
+                if ('GET' !== $isLikeGetMethod) {
+                    $allow[] = 'GET';
                     goto not_bar;
                 }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -53,7 +53,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // barhead
             if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if ($isLikeGetMethod != 'GET') {
+                if ('GET' !== $isLikeGetMethod) {
                     $allow[] = 'GET';
                     goto not_barhead;
                 }
@@ -67,17 +67,17 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (0 === strpos($pathinfo, '/test')) {
             if (0 === strpos($pathinfo, '/test/baz')) {
                 // baz
-                if ($pathinfo === '/test/baz') {
+                if ('/test/baz' === $pathinfo) {
                     return array('_route' => 'baz');
                 }
 
                 // baz2
-                if ($pathinfo === '/test/baz.html') {
+                if ('/test/baz.html' === $pathinfo) {
                     return array('_route' => 'baz2');
                 }
 
                 // baz3
-                if ($trimmedPathinfo === '/test/baz3') {
+                if ('/test/baz3' === $trimmedPathinfo) {
                     if (substr($pathinfo, -1) !== '/') {
                         return $this->redirect($pathinfo.'/', 'baz3');
                     }
@@ -98,7 +98,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($isLikeGetMethod != 'POST') {
+                if ('POST' !== $isLikeGetMethod) {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -109,7 +109,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($isLikeGetMethod != 'PUT') {
+                if ('PUT' !== $isLikeGetMethod) {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }
@@ -121,7 +121,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // foofoo
-        if ($pathinfo === '/foofoo') {
+        if ('/foofoo' === $pathinfo) {
             return array (  'def' => 'test',  '_route' => 'foofoo',);
         }
 
@@ -131,7 +131,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // space
-        if ($pathinfo === '/spa ce') {
+        if ('/spa ce' === $pathinfo) {
             return array('_route' => 'space');
         }
 
@@ -176,12 +176,12 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             }
 
             // overridden2
-            if ($pathinfo === '/multi/new') {
+            if ('/multi/new' === $pathinfo) {
                 return array('_route' => 'overridden2');
             }
 
             // hey
-            if ($trimmedPathinfo === '/multi/hey') {
+            if ('/multi/hey' === $trimmedPathinfo) {
                 if (substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'hey');
                 }
@@ -203,7 +203,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         if (0 === strpos($pathinfo, '/aba')) {
             // ababa
-            if ($pathinfo === '/ababa') {
+            if ('/ababa' === $pathinfo) {
                 return array('_route' => 'ababa');
             }
 
@@ -218,12 +218,12 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route1
-            if ($pathinfo === '/route1') {
+            if ('/route1' === $pathinfo) {
                 return array('_route' => 'route1');
             }
 
             // route2
-            if ($pathinfo === '/c2/route2') {
+            if ('/c2/route2' === $pathinfo) {
                 return array('_route' => 'route2');
             }
 
@@ -231,7 +231,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         if (preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
             // route3
-            if ($pathinfo === '/c2/route3') {
+            if ('/c2/route3' === $pathinfo) {
                 return array('_route' => 'route3');
             }
 
@@ -239,7 +239,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route4
-            if ($pathinfo === '/route4') {
+            if ('/route4' === $pathinfo) {
                 return array('_route' => 'route4');
             }
 
@@ -247,26 +247,26 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route5
-            if ($pathinfo === '/route5') {
+            if ('/route5' === $pathinfo) {
                 return array('_route' => 'route5');
             }
 
         }
 
         // route6
-        if ($pathinfo === '/route6') {
+        if ('/route6' === $pathinfo) {
             return array('_route' => 'route6');
         }
 
         if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#si', $host, $hostMatches)) {
             if (0 === strpos($pathinfo, '/route1')) {
                 // route11
-                if ($pathinfo === '/route11') {
+                if ('/route11' === $pathinfo) {
                     return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
                 }
 
                 // route12
-                if ($pathinfo === '/route12') {
+                if ('/route12' === $pathinfo) {
                     return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
                 }
 
@@ -299,7 +299,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             }
 
             // route17
-            if ($pathinfo === '/route17') {
+            if ('/route17' === $pathinfo) {
                 return array('_route' => 'route17');
             }
 
@@ -307,7 +307,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         if (0 === strpos($pathinfo, '/a')) {
             // a
-            if ($pathinfo === '/a/a...') {
+            if ('/a/a...' === $pathinfo) {
                 return array('_route' => 'a');
             }
 
@@ -327,7 +327,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // secure
-        if ($pathinfo === '/secure') {
+        if ('/secure' === $pathinfo) {
             $requiredSchemes = array (  'https' => 0,);
             if (!isset($requiredSchemes[$context->getScheme()])) {
                 return $this->redirect($pathinfo, 'secure', key($requiredSchemes));
@@ -337,7 +337,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // nonsecure
-        if ($pathinfo === '/nonsecure') {
+        if ('/nonsecure' === $pathinfo) {
             $requiredSchemes = array (  'http' => 0,);
             if (!isset($requiredSchemes[$context->getScheme()])) {
                 return $this->redirect($pathinfo, 'nonsecure', key($requiredSchemes));

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -30,7 +30,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $requestMethod = $isLikeGetMethod = $context->getMethod();
         $schema = $context->getScheme();
 
-        if ($requestMethod === 'HEAD') {
+        if ('HEAD' === $requestMethod) {
             $isLikeGetMethod = 'GET';
         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -27,11 +27,11 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
-        $requestMethod = $isLikeGetMethod = $context->getMethod();
+        $requestMethod = $canonicalMethod = $context->getMethod();
         $schema = $context->getScheme();
 
         if ('HEAD' === $requestMethod) {
-            $isLikeGetMethod = 'GET';
+            $canonicalMethod = 'GET';
         }
 
 
@@ -43,7 +43,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (0 === strpos($pathinfo, '/bar')) {
             // bar
             if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if ('GET' !== $isLikeGetMethod) {
+                if ('GET' !== $canonicalMethod) {
                     $allow[] = 'GET';
                     goto not_bar;
                 }
@@ -54,7 +54,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // barhead
             if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                if ('GET' !== $isLikeGetMethod) {
+                if ('GET' !== $canonicalMethod) {
                     $allow[] = 'GET';
                     goto not_barhead;
                 }
@@ -99,7 +99,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ('POST' !== $isLikeGetMethod) {
+                if ('POST' !== $canonicalMethod) {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -110,7 +110,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ('PUT' !== $isLikeGetMethod) {
+                if ('PUT' !== $canonicalMethod) {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -28,7 +28,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $canonicalMethod = $context->getMethod();
-        $schema = $context->getScheme();
+        $scheme = $context->getScheme();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';
@@ -330,7 +330,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         // secure
         if ('/secure' === $pathinfo) {
             $requiredSchemes = array (  'https' => 0,);
-            if (!isset($requiredSchemes[$schema])) {
+            if (!isset($requiredSchemes[$scheme])) {
                 return $this->redirect($pathinfo, 'secure', key($requiredSchemes));
             }
 
@@ -340,7 +340,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         // nonsecure
         if ('/nonsecure' === $pathinfo) {
             $requiredSchemes = array (  'http' => 0,);
-            if (!isset($requiredSchemes[$schema])) {
+            if (!isset($requiredSchemes[$scheme])) {
                 return $this->redirect($pathinfo, 'nonsecure', key($requiredSchemes));
             }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -27,7 +27,12 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
-        $requestMethod = $context->getMethod();
+        $requestMethod = $isLikeGetMethod = $context->getMethod();
+
+        if ($requestMethod === 'HEAD') {
+            $isLikeGetMethod = 'GET';
+        }
+
 
         if (0 === strpos($pathinfo, '/rootprefix')) {
             // static

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -28,6 +28,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $isLikeGetMethod = $context->getMethod();
+        $schema = $context->getScheme();
 
         if ($requestMethod === 'HEAD') {
             $isLikeGetMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -24,8 +24,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($pathinfo);
+        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
+        $requestMethod = $context->getMethod();
 
         if (0 === strpos($pathinfo, '/rootprefix')) {
             // static

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -36,7 +36,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         if (0 === strpos($pathinfo, '/rootprefix')) {
             // static
-            if ($pathinfo === '/rootprefix/test') {
+            if ('/rootprefix/test' === $pathinfo) {
                 return array('_route' => 'static');
             }
 
@@ -48,7 +48,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // with-condition
-        if ($pathinfo === '/with-condition' && ($context->getMethod() == "GET")) {
+        if ('/with-condition' === $pathinfo && ($context->getMethod() == "GET")) {
             return array('_route' => 'with-condition');
         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -27,11 +27,11 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
-        $requestMethod = $isLikeGetMethod = $context->getMethod();
+        $requestMethod = $canonicalMethod = $context->getMethod();
         $schema = $context->getScheme();
 
         if ('HEAD' === $requestMethod) {
-            $isLikeGetMethod = 'GET';
+            $canonicalMethod = 'GET';
         }
 
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -28,7 +28,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $canonicalMethod = $context->getMethod();
-        $schema = $context->getScheme();
+        $scheme = $context->getScheme();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -30,7 +30,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $requestMethod = $isLikeGetMethod = $context->getMethod();
         $schema = $context->getScheme();
 
-        if ($requestMethod === 'HEAD') {
+        if ('HEAD' === $requestMethod) {
             $isLikeGetMethod = 'GET';
         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -1,0 +1,101 @@
+<?php
+
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * ProjectUrlMatcher.
+ *
+ * This class has been auto-generated
+ * by the Symfony Routing Component.
+ */
+class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(RequestContext $context)
+    {
+        $this->context = $context;
+    }
+
+    public function match($pathinfo)
+    {
+        $allow = array();
+        $pathinfo = rawurldecode($pathinfo);
+        $trimmedPathinfo = rtrim($pathinfo, '/');
+        $context = $this->context;
+        $request = $this->request;
+        $requestMethod = $isLikeGetMethod = $context->getMethod();
+        $schema = $context->getScheme();
+
+        if ($requestMethod === 'HEAD') {
+            $isLikeGetMethod = 'GET';
+        }
+
+
+        // just_head
+        if ('/just_head' === $pathinfo) {
+            if ('HEAD' !== $requestMethod) {
+                $allow[] = 'HEAD';
+                goto not_just_head;
+            }
+
+            return array('_route' => 'just_head');
+        }
+        not_just_head:
+
+        // head_and_get
+        if ('/head_and_get' === $pathinfo) {
+            if ('GET' !== $isLikeGetMethod) {
+                $allow[] = 'GET';
+                goto not_head_and_get;
+            }
+
+            return array('_route' => 'head_and_get');
+        }
+        not_head_and_get:
+
+        if (0 === strpos($pathinfo, '/p')) {
+            // post_and_head
+            if ('/post_and_get' === $pathinfo) {
+                if (!in_array($requestMethod, array('POST', 'HEAD'))) {
+                    $allow = array_merge($allow, array('POST', 'HEAD'));
+                    goto not_post_and_head;
+                }
+
+                return array('_route' => 'post_and_head');
+            }
+            not_post_and_head:
+
+            if (0 === strpos($pathinfo, '/put_and_post')) {
+                // put_and_post
+                if ('/put_and_post' === $pathinfo) {
+                    if (!in_array($requestMethod, array('PUT', 'POST'))) {
+                        $allow = array_merge($allow, array('PUT', 'POST'));
+                        goto not_put_and_post;
+                    }
+
+                    return array('_route' => 'put_and_post');
+                }
+                not_put_and_post:
+
+                // put_and_get_and_head
+                if ('/put_and_post' === $pathinfo) {
+                    if (!in_array($isLikeGetMethod, array('PUT', 'GET'))) {
+                        $allow = array_merge($allow, array('PUT', 'GET'));
+                        goto not_put_and_get_and_head;
+                    }
+
+                    return array('_route' => 'put_and_get_and_head');
+                }
+                not_put_and_get_and_head:
+
+            }
+
+        }
+
+        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -27,11 +27,11 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
-        $requestMethod = $isLikeGetMethod = $context->getMethod();
+        $requestMethod = $canonicalMethod = $context->getMethod();
         $schema = $context->getScheme();
 
         if ('HEAD' === $requestMethod) {
-            $isLikeGetMethod = 'GET';
+            $canonicalMethod = 'GET';
         }
 
 
@@ -48,7 +48,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         // head_and_get
         if ('/head_and_get' === $pathinfo) {
-            if ('GET' !== $isLikeGetMethod) {
+            if ('GET' !== $canonicalMethod) {
                 $allow[] = 'GET';
                 goto not_head_and_get;
             }
@@ -83,7 +83,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
                 // put_and_get_and_head
                 if ('/put_and_post' === $pathinfo) {
-                    if (!in_array($isLikeGetMethod, array('PUT', 'GET'))) {
+                    if (!in_array($canonicalMethod, array('PUT', 'GET'))) {
                         $allow = array_merge($allow, array('PUT', 'GET'));
                         goto not_put_and_get_and_head;
                     }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -28,7 +28,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $canonicalMethod = $context->getMethod();
-        $schema = $context->getScheme();
+        $scheme = $context->getScheme();
 
         if ('HEAD' === $requestMethod) {
             $canonicalMethod = 'GET';

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -30,7 +30,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $requestMethod = $isLikeGetMethod = $context->getMethod();
         $schema = $context->getScheme();
 
-        if ($requestMethod === 'HEAD') {
+        if ('HEAD' === $requestMethod) {
             $isLikeGetMethod = 'GET';
         }
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -279,10 +279,59 @@ class PhpMatcherDumperTest extends TestCase
         $route->setCondition('context.getMethod() == "GET"');
         $rootprefixCollection->add('with-condition', $route);
 
+        /* test case 4 */
+        $headMatchCasesCollection = new RouteCollection();
+        $headMatchCasesCollection->add('just_head', new Route(
+            '/just_head',
+            array(),
+            array(),
+            array(),
+            '',
+            array(),
+            array('HEAD')
+        ));
+        $headMatchCasesCollection->add('head_and_get', new Route(
+            '/head_and_get',
+            array(),
+            array(),
+            array(),
+            '',
+            array(),
+            array('GET', 'HEAD')
+        ));
+        $headMatchCasesCollection->add('post_and_head', new Route(
+            '/post_and_get',
+            array(),
+            array(),
+            array(),
+            '',
+            array(),
+            array('POST', 'HEAD')
+        ));
+        $headMatchCasesCollection->add('put_and_post', new Route(
+            '/put_and_post',
+            array(),
+            array(),
+            array(),
+            '',
+            array(),
+            array('PUT', 'POST')
+        ));
+        $headMatchCasesCollection->add('put_and_get_and_head', new Route(
+            '/put_and_post',
+            array(),
+            array(),
+            array(),
+            '',
+            array(),
+            array('PUT', 'GET', 'HEAD')
+        ));
+
         return array(
            array($collection, 'url_matcher1.php', array()),
            array($redirectCollection, 'url_matcher2.php', array('base_class' => 'Symfony\Component\Routing\Tests\Fixtures\RedirectableUrlMatcher')),
            array($rootprefixCollection, 'url_matcher3.php', array()),
+           array($headMatchCasesCollection, 'url_matcher4.php', array()),
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | does not apply

The application I'm working on is fairly large. Because we had a routing issue (not caused by the framework) I looked through the dumped routing code. I spotted some easy wins. These changes brought down the time for the `match` method to run from ~ 7.5ms to ~2.5ms. It's not a lot, but it's something. I've profiled it several times with blackfire to confirm. The results were very consistent. Mind you, our application has quite a serious amount of routes, a little over 900.