### PR TITLE
[Routing] Add the ability to combine conditions when importing routes

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -30,6 +30,7 @@ class Route
     private $methods = array();
     private $schemes = array();
     private $condition;
+    private $combineConditions;
 
     /**
      * Constructor.
@@ -142,5 +143,15 @@ class Route
     public function getCondition()
     {
         return $this->condition;
+    }
+
+    public function setCombineConditions($combine = true)
+    {
+        $this->combineConditions = $combine;
+    }
+
+    public function getCombineConditions()
+    {
+        return $this->combineConditions;
     }
 }

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -139,6 +139,7 @@ class XmlFileLoader extends FileLoader
         $type = $node->getAttribute('type');
         $prefix = $node->getAttribute('prefix');
         $host = $node->hasAttribute('host') ? $node->getAttribute('host') : null;
+        $combineConditions = $node->hasAttribute('combine-conditions') ? $node->getAttribute('combine-conditions') : false;
         $schemes = $node->hasAttribute('schemes') ? preg_split('/[\s,\|]++/', $node->getAttribute('schemes'), -1, PREG_SPLIT_NO_EMPTY) : null;
         $methods = $node->hasAttribute('methods') ? preg_split('/[\s,\|]++/', $node->getAttribute('methods'), -1, PREG_SPLIT_NO_EMPTY) : null;
 
@@ -153,7 +154,7 @@ class XmlFileLoader extends FileLoader
             $subCollection->setHost($host);
         }
         if (null !== $condition) {
-            $subCollection->setCondition($condition);
+            $combineConditions ? $subCollection->addCondition($condition) : $subCollection->setCondition($condition);
         }
         if (null !== $schemes) {
             $subCollection->setSchemes($schemes);

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -27,7 +27,7 @@ use Symfony\Component\Config\Loader\FileLoader;
 class YamlFileLoader extends FileLoader
 {
     private static $availableKeys = array(
-        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition',
+        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'combine_conditions',
     );
     private $yamlParser;
 
@@ -137,6 +137,7 @@ class YamlFileLoader extends FileLoader
         $options = isset($config['options']) ? $config['options'] : array();
         $host = isset($config['host']) ? $config['host'] : null;
         $condition = isset($config['condition']) ? $config['condition'] : null;
+        $combineConditions = isset($config['combine_conditions']) ? $config['combine_conditions'] : false;
         $schemes = isset($config['schemes']) ? $config['schemes'] : null;
         $methods = isset($config['methods']) ? $config['methods'] : null;
 
@@ -149,7 +150,7 @@ class YamlFileLoader extends FileLoader
             $subCollection->setHost($host);
         }
         if (null !== $condition) {
-            $subCollection->setCondition($condition);
+            $combineConditions ? $subCollection->addCondition($condition) : $subCollection->setCondition($condition);
         }
         if (null !== $schemes) {
             $subCollection->setSchemes($schemes);

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -52,6 +52,7 @@
     <xsd:attribute name="host" type="xsd:string" />
     <xsd:attribute name="schemes" type="xsd:string" />
     <xsd:attribute name="methods" type="xsd:string" />
+    <xsd:attribute name="combine-conditions" type="xsd:boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="default" mixed="true">

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -550,6 +550,26 @@ class Route implements \Serializable
     }
 
     /**
+     * Adds a condition.
+     *
+     * This method implements a fluent interface.
+     *
+     * @param string $condition The condition to add
+     *
+     * @return $this
+     */
+    public function addCondition($condition)
+    {
+        if ($this->condition) {
+            $condition = sprintf('(%s) and (%s)', $this->condition, $condition);
+        }
+
+        $this->setCondition($condition);
+
+        return $this;
+    }
+
+    /**
      * Compiles the route.
      *
      * @return CompiledRoute A CompiledRoute instance

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -184,6 +184,18 @@ class RouteCollection implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Adds a condition on all routes.
+     *
+     * @param string $condition The condition
+     */
+    public function addCondition($condition)
+    {
+        foreach ($this->routes as $route) {
+            $route->addCondition($condition);
+        }
+    }
+
+    /**
      * Adds defaults to all routes.
      *
      * An existing default value under the same name in a route will be overridden.

--- a/src/Symfony/Component/Routing/Tests/Fixtures/combine_conditions.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/combine_conditions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import resource="combine_conditions_imported.xml" combine-conditions="true">
+        <condition>request.attributes.get("version") >= 1.0</condition>
+    </import>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/combine_conditions.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/combine_conditions.yml
@@ -1,0 +1,4 @@
+app_v1:
+    resource: 'combine_conditions_imported.yml'
+    condition: 'request.attributes.get("version") >= 1.0'
+    combine_conditions: true

--- a/src/Symfony/Component/Routing/Tests/Fixtures/combine_conditions_imported.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/combine_conditions_imported.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="with_condition" path="/with_condition">
+        <condition>context.getMethod() == "GET"</condition>
+    </route>
+
+    <route id="without_condition" path="/without_condition" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/combine_conditions_imported.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/combine_conditions_imported.yml
@@ -1,0 +1,6 @@
+with_condition:
+    path: /with_condition
+    condition: 'context.getMethod() == "GET"'
+
+without_condition:
+    path: /without_condition

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -287,4 +287,13 @@ class XmlFileLoaderTest extends TestCase
             $route->getDefault('map')
         );
     }
+
+    public function testLoadWithCombinedConditions()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $routeCollection = $loader->load('combine_conditions.xml');
+
+        $this->assertSame('request.attributes.get("version") >= 1.0', $routeCollection->get('without_condition')->getCondition());
+        $this->assertSame('(context.getMethod() == "GET") and (request.attributes.get("version") >= 1.0)', $routeCollection->get('with_condition')->getCondition());
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -108,4 +108,13 @@ class YamlFileLoaderTest extends TestCase
             $this->assertSame('context.getMethod() == "POST"', $route->getCondition());
         }
     }
+
+    public function testLoadWithCombinedConditions()
+    {
+        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $routeCollection = $loader->load('combine_conditions.yml');
+
+        $this->assertSame('request.attributes.get("version") >= 1.0', $routeCollection->get('without_condition')->getCondition());
+        $this->assertSame('(context.getMethod() == "GET") and (request.attributes.get("version") >= 1.0)', $routeCollection->get('with_condition')->getCondition());
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -258,6 +258,11 @@ class RouteCollectionTest extends TestCase
 
         $this->assertEquals('context.getMethod() == "POST"', $routea->getCondition());
         $this->assertEquals('context.getMethod() == "POST"', $routeb->getCondition());
+
+        $collection->addCondition('request.attributes.has(\'foo\')');
+
+        $this->assertSame('(context.getMethod() == "POST") and (request.attributes.has(\'foo\'))', $routea->getCondition());
+        $this->assertSame('(context.getMethod() == "POST") and (request.attributes.has(\'foo\'))', $routeb->getCondition());
     }
 
     public function testClone()

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -181,6 +181,8 @@ class RouteTest extends TestCase
         $this->assertSame('', $route->getCondition());
         $route->setCondition('context.getMethod() == "GET"');
         $this->assertSame('context.getMethod() == "GET"', $route->getCondition());
+        $route->addCondition('request.attributes.has(\'foo\')');
+        $this->assertSame('(context.getMethod() == "GET") and (request.attributes.has(\'foo\'))', $route->getCondition());
     }
 
     public function testCompile()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | todo

Allows to combine conditions when importing resources, instead of overriding conditions set on the imported routes:

```yml
app:
    resource: 'app.yml'
    condition: 'someGlobalCondition()'
    combine_conditions: true
```

```yml
# app.yml
foo:
    path: /foo
    # ...
    condition: 'someLocaleCondition()'

bar:
    path: /bar
    # ...
```

so the condition for the `foo` route becomes: `(someLocaleCondition) and (someGlobalCondition())`
Without the flag, it would have been: `someGlobalCondition()` (condition set on import overrides local route condition).

It also works on Route annotations defined on Controller classes:

```yml
app:
    resource: '@AppBundle/Controller/'
    type:     annotation
    condition: 'has("import")'
    combine_conditions: true
```

```php
namespace AppBundle\Controller;

use Symfony\Component\Routing\Annotation\Route;

/**
 * @Route(condition="has('controller')", combineConditions="true")
 */
class FooController
{
    /**
     * @Route(name="foo_index" condition="has('action')")
     */
    public function indexAction()
    {
    }
}
```

Condition for `foo_index` route becomes: `((has("action")) and (has("controller"))) and (has("import"))`.
If you omit the `combineConditions` attribute on the class Route annotation, the behavior stays as before: `((has("action")) and (has("import"))` (method Route condition wins over class one).

The current implementation just combines expressions using the `and` operator. 

We can imagine some other alternatives, like a `conditions_strategy` option along with enumerated values:

- `combine` (combine with `and`)
- `replace` (import condition wins, default)
- `set-if-null` (route condition wins)

But I'm not sure it'll be that much useful (the `and` combination solves most use-cases I think).
I don't have use-cases where combining expressions using `or` would be useful neither.

Ideally, I think the behavior should have been changed to always combine conditions (and thus won't require the `combine_conditions` flag). But that would be a BC break.
Perhaps introduce an application-wide flag and trigger a deprecation if the flag is not set to true?