### PR TITLE
[DI] Remove experimental status from service-locator argument type

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
@@ -18,8 +18,6 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  * Represents a service locator able to lazy load a given range of services.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
- *
- * @experimental in version 3.3
  */
 class ServiceLocatorArgument implements ArgumentInterface
 {

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * [EXPERIMENTAL] added "instanceof" section for local interface-defined configs
- * [EXPERIMENTAL] added "service-locator" argument for lazy loading a set of identified values and services
+ * added "service-locator" argument for lazy loading a set of identified values and services
  * [EXPERIMENTAL] added prototype services for PSR4-based discovery and registration
  * added `ContainerBuilder::getReflectionClass()` for retrieving and tracking reflection class info
  * deprecated `ContainerBuilder::getClassResource()`, use `ContainerBuilder::getReflectionClass()` or `ContainerBuilder::addObjectResource()` instead

--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
@@ -18,8 +18,6 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 /**
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
- *
- * @experimental in version 3.3
  */
 class ServiceLocator implements PsrContainerInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21625#issuecomment-282483374, https://github.com/symfony/symfony/pull/21625#discussion_r102232221, #21710
| License       | MIT

The `service-locator` argument type is not controversial to me. We know its scope, nothing really surprising, just a map of services to be lazily loaded like `iterator` is (which is not experimental) but keyed.
About its api, it's just PSR-11 restricted to objects, nothing that can't be changed safely in the future.

As stated in https://github.com/symfony/symfony/pull/21625#issuecomment-282483374, it proven its usefulness already. I think what we were looking for by flagging it experimental is just to see it in action, we've 3 opened PRs for that (#21625, #21690, #21730).

This allows introducing deprecations for making use of the feature in the core, thus unlocks #21625 and #21690.