### PR TITLE
[DI] Allow extensions to create ServiceLocator as services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Console\Descriptor;
 
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -386,6 +387,10 @@ class JsonDescriptor extends Descriptor
             }
 
             return $data;
+        }
+
+        if ($value instanceof ServiceClosureArgument) {
+            $value = $value->getValues()[0];
         }
 
         if ($value instanceof Reference) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -324,6 +325,9 @@ class TextDescriptor extends Descriptor
         $argumentsInformation = array();
         if ($showArguments && ($arguments = $definition->getArguments())) {
             foreach ($arguments as $argument) {
+                if ($argument instanceof ServiceClosureArgument) {
+                    $argument = $argument->getValues()[0];
+                }
                 if ($argument instanceof Reference) {
                     $argumentsInformation[] = sprintf('Service(%s)', (string) $argument);
                 } elseif ($argument instanceof IteratorArgument) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Console\Descriptor;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -423,6 +424,10 @@ class XmlDescriptor extends Descriptor
 
             if (is_string($argumentKey)) {
                 $argumentXML->setAttribute('key', $argumentKey);
+            }
+
+            if ($argument instanceof ServiceClosureArgument) {
+                $argument = $argument->getValues()[0];
             }
 
             if ($argument instanceof Reference) {

--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceClosureArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceClosureArgument.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Argument;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * Represents a service wrapped in a memoizing closure.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @experimental in version 3.3
+ */
+class ServiceClosureArgument implements ArgumentInterface
+{
+    private $values;
+
+    public function __construct(Reference $reference)
+    {
+        $this->values = array($reference);
+    }
+
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    public function setValues(array $values)
+    {
+        if (array(0) !== array_keys($values) || !($values[0] instanceof Reference || null === $values[0])) {
+            throw new InvalidArgumentException('A ServiceClosureArgument must hold one and only one Reference.');
+        }
+
+        $this->values = $values;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.3.0
 -----
 
+ * [EXPERIMENTAL] added "TypedReference" and "ServiceClosureArgument" for creating service-locator services
  * [EXPERIMENTAL] added "instanceof" section for local interface-defined configs
  * added "service-locator" argument for lazy loading a set of identified values and services
  * [EXPERIMENTAL] added prototype services for PSR4-based discovery and registration

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -53,7 +54,9 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
      */
     private function processValue($value, $rootLevel = 0, $level = 0)
     {
-        if ($value instanceof ArgumentInterface) {
+        if ($value instanceof ServiceClosureArgument) {
+            $value->setValues($this->processValue($value->getValues(), 1, 1));
+        } elseif ($value instanceof ArgumentInterface) {
             $value->setValues($this->processValue($value->getValues(), $rootLevel, 1 + $level));
         } elseif ($value instanceof Definition) {
             if ($value->isSynthetic() || $value->isAbstract()) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Dumper;
 
 use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Parameter;
@@ -289,6 +290,9 @@ class XmlDumper extends Dumper
                 $element->setAttribute($keyAttribute, $key);
             }
 
+            if ($value instanceof ServiceClosureArgument) {
+                $value = $value->getValues()[0];
+            }
             if (is_array($value)) {
                 $element->setAttribute('type', 'collection');
                 $this->convertParameters($value, $type, $element, 'key');

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -254,6 +255,9 @@ class YamlDumper extends Dumper
      */
     private function dumpValue($value)
     {
+        if ($value instanceof ServiceClosureArgument) {
+            $value = $value->getValues()[0];
+        }
         if ($value instanceof ArgumentInterface) {
             if ($value instanceof IteratorArgument) {
                 $tag = 'iterator';

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AbstractGetterOverriding;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\FooVariadic;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\GetterOverriding;
+use Symfony\Component\DependencyInjection\TypedReference;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -516,6 +517,22 @@ class AutowirePassTest extends TestCase
             array(new Reference('app_a')),
             $methodCalls[0][1]
         );
+    }
+
+    public function testTtypedReference()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('bar', Bar::class)
+            ->setAutowired(true)
+            ->setProperty('a', array(new TypedReference(A::class, A::class)))
+        ;
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $this->assertSame(A::class, $container->getDefinition('autowired.'.A::class)->getClass());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInvalidReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInvalidReferencesPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Compiler\ResolveInvalidReferencesPass;
@@ -119,6 +120,24 @@ class ResolveInvalidReferencesPassTest extends TestCase
         $this->process($container);
 
         $this->assertEquals(array(), $def->getOverriddenGetters());
+    }
+
+    public function testProcessRemovesArgumentsOnInvalid()
+    {
+        $container = new ContainerBuilder();
+        $def = $container
+            ->register('foo')
+            ->addArgument(array(
+                array(
+                    new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+                    new ServiceClosureArgument(new Reference('baz', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
+                ),
+            ))
+        ;
+
+        $this->process($container);
+
+        $this->assertSame(array(array(array())), $def->getArguments());
     }
 
     protected function process(ContainerBuilder $container)

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator_php55.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator_php55.php
@@ -1,0 +1,110 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * ProjectServiceContainer.
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final since Symfony 3.3
+ */
+class ProjectServiceContainer extends Container
+{
+    private $parameters;
+    private $targetDirs = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->services = array();
+        $this->normalizedIds = array(
+            'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
+            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
+            'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
+        );
+        $this->methodMap = array(
+            'bar_service' => 'getBarServiceService',
+            'baz_service' => 'getBazServiceService',
+            'foo_service' => 'getFooServiceService',
+        );
+        $this->privates = array(
+            'baz_service' => true,
+        );
+
+        $this->aliases = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped frozen container.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFrozen()
+    {
+        return true;
+    }
+
+    /**
+     * Gets the 'bar_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getBarServiceService()
+    {
+        return $this->services['bar_service'] = new \stdClass(${($_ = isset($this->services['baz_service']) ? $this->services['baz_service'] : $this->getBazServiceService()) && false ?: '_'});
+    }
+
+    /**
+     * Gets the 'foo_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\ServiceLocator A Symfony\Component\DependencyInjection\ServiceLocator instance
+     */
+    protected function getFooServiceService()
+    {
+        return $this->services['foo_service'] = new \Symfony\Component\DependencyInjection\ServiceLocator(array('bar' => function () {
+            return ${($_ = isset($this->services['bar_service']) ? $this->services['bar_service'] : $this->get('bar_service')) && false ?: '_'};
+        }, 'baz' => function () {
+            return ${($_ = isset($this->services['baz_service']) ? $this->services['baz_service'] : $this->getBazServiceService()) && false ?: '_'};
+        }));
+    }
+
+    /**
+     * Gets the 'baz_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * This service is private.
+     * If you want to be able to request this service from the container directly,
+     * make it public, otherwise you might end up with broken code.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getBazServiceService()
+    {
+        return $this->services['baz_service'] = new \stdClass();
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator_php70.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator_php70.php
@@ -1,0 +1,110 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * ProjectServiceContainer.
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final since Symfony 3.3
+ */
+class ProjectServiceContainer extends Container
+{
+    private $parameters;
+    private $targetDirs = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->services = array();
+        $this->normalizedIds = array(
+            'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
+            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
+            'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
+        );
+        $this->methodMap = array(
+            'bar_service' => 'getBarServiceService',
+            'baz_service' => 'getBazServiceService',
+            'foo_service' => 'getFooServiceService',
+        );
+        $this->privates = array(
+            'baz_service' => true,
+        );
+
+        $this->aliases = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped frozen container.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFrozen()
+    {
+        return true;
+    }
+
+    /**
+     * Gets the 'bar_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getBarServiceService()
+    {
+        return $this->services['bar_service'] = new \stdClass(${($_ = isset($this->services['baz_service']) ? $this->services['baz_service'] : $this->getBazServiceService()) && false ?: '_'});
+    }
+
+    /**
+     * Gets the 'foo_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\ServiceLocator A Symfony\Component\DependencyInjection\ServiceLocator instance
+     */
+    protected function getFooServiceService()
+    {
+        return $this->services['foo_service'] = new \Symfony\Component\DependencyInjection\ServiceLocator(array('bar' => function () {
+            return ${($_ = isset($this->services['bar_service']) ? $this->services['bar_service'] : $this->get('bar_service')) && false ?: '_'};
+        }, 'baz' => function (): \stdClass {
+            return ${($_ = isset($this->services['baz_service']) ? $this->services['baz_service'] : $this->getBazServiceService()) && false ?: '_'};
+        }));
+    }
+
+    /**
+     * Gets the 'baz_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * This service is private.
+     * If you want to be able to request this service from the container directly,
+     * make it public, otherwise you might end up with broken code.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getBazServiceService()
+    {
+        return $this->services['baz_service'] = new \stdClass();
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator_php71.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator_php71.php
@@ -1,0 +1,110 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * ProjectServiceContainer.
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final since Symfony 3.3
+ */
+class ProjectServiceContainer extends Container
+{
+    private $parameters;
+    private $targetDirs = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->services = array();
+        $this->normalizedIds = array(
+            'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
+            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
+            'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
+        );
+        $this->methodMap = array(
+            'bar_service' => 'getBarServiceService',
+            'baz_service' => 'getBazServiceService',
+            'foo_service' => 'getFooServiceService',
+        );
+        $this->privates = array(
+            'baz_service' => true,
+        );
+
+        $this->aliases = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped frozen container.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFrozen()
+    {
+        return true;
+    }
+
+    /**
+     * Gets the 'bar_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getBarServiceService()
+    {
+        return $this->services['bar_service'] = new \stdClass(${($_ = isset($this->services['baz_service']) ? $this->services['baz_service'] : $this->getBazServiceService()) && false ?: '_'});
+    }
+
+    /**
+     * Gets the 'foo_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\ServiceLocator A Symfony\Component\DependencyInjection\ServiceLocator instance
+     */
+    protected function getFooServiceService()
+    {
+        return $this->services['foo_service'] = new \Symfony\Component\DependencyInjection\ServiceLocator(array('bar' => function () {
+            return ${($_ = isset($this->services['bar_service']) ? $this->services['bar_service'] : $this->get('bar_service')) && false ?: '_'};
+        }, 'baz' => function (): \stdClass {
+            return ${($_ = isset($this->services['baz_service']) ? $this->services['baz_service'] : $this->getBazServiceService()) && false ?: '_'};
+        }));
+    }
+
+    /**
+     * Gets the 'baz_service' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * This service is private.
+     * If you want to be able to request this service from the container directly,
+     * make it public, otherwise you might end up with broken code.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getBazServiceService()
+    {
+        return $this->services['baz_service'] = new \stdClass();
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/TypedReference.php
+++ b/src/Symfony/Component/DependencyInjection/TypedReference.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+/**
+ * Represents a PHP type-hinted service reference.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @experimental in version 3.3
+ */
+class TypedReference extends Reference
+{
+    private $type;
+    private $canBeAutoregistered;
+
+    /**
+     * @param string $id                  The service identifier
+     * @param string $type                The PHP type of the identified service
+     * @param int    $invalidBehavior     The behavior when the service does not exist
+     * @param bool   $canBeAutoregistered Whether autowiring can autoregister the referenced service when it's a FQCN or not
+     */
+    public function __construct($id, $type, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $canBeAutoregistered = true)
+    {
+        parent::__construct($id, $invalidBehavior);
+        $this->type = $type;
+        $this->canBeAutoregistered = $canBeAutoregistered;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function canBeAutoregistered()
+    {
+        return $this->canBeAutoregistered;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/pull/21770/files?w=1

With this PR, DI extensions are able to create "service locator" services.
They are easily created as such:
```php
$container->register('my_service_locator', ServiceLocator::class)
    ->addArgument(array(
        'exposed_id' => new ServiceClosureArgument(new Reference('internal_id')),
    ))
```
I already need this in two different PRs to come.
