### PR TITLE
Prevent PHP from adding a default Content-Type

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -270,7 +270,11 @@ class Response
 
         if ($this->isInformational() || $this->isEmpty()) {
             $this->setContent(null);
-            $headers->remove('Content-Type');
+            // Remove the Content-Type header
+            // Apache, Nginx and PHP's built-in web server removes the header when it's set to empty
+            // If the header is not present, it results in a default being added
+            // see https://github.com/slimphp/Slim/issues/1612#issuecomment-159389799
+            $headers->set('Content-Type', '');
             $headers->remove('Content-Length');
         } else {
             // Content-type based on the Request


### PR DESCRIPTION
When we remove the Content-Type header

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12744
| License       | MIT
| Doc PR        | N/A
