### PR TITLE
[Workflow] Remove unnecessary method calls 

### DIFF
--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -62,7 +62,7 @@ class Workflow
             }
             $marking->mark($this->definition->getInitialPlace());
 
-            // Because the marking could have been initialized, we update the subject
+            // update the subject with the new marking
             $this->markingStore->setMarking($subject, $marking);
         }
 

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -61,6 +61,9 @@ class Workflow
                 throw new LogicException(sprintf('The Marking is empty and there is no initial place for workflow "%s".', $this->name));
             }
             $marking->mark($this->definition->getInitialPlace());
+            
+            // Because the marking could have been initialized, we update the subject
+            $this->markingStore->setMarking($subject, $marking);
         }
 
         // check that the subject has a known place
@@ -75,9 +78,6 @@ class Workflow
                 throw new LogicException($message);
             }
         }
-
-        // Because the marking could have been initialized, we update the subject
-        $this->markingStore->setMarking($subject, $marking);
 
         return $marking;
     }

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -92,7 +92,7 @@ class Workflow
      */
     public function can($subject, $transitionName)
     {
-        $transitions = $this->getEnabledTransitions($subject, $this->getMarking($subject));
+        $transitions = $this->getEnabledTransitions($subject);
 
         foreach ($transitions as $transition) {
             if ($transitionName === $transition->getName()) {
@@ -116,7 +116,7 @@ class Workflow
      */
     public function apply($subject, $transitionName)
     {
-        $transitions = $this->getEnabledTransitions($subject, $this->getMarking($subject));
+        $transitions = $this->getEnabledTransitions($subject);
 
         // We can shortcut the getMarking method in order to boost performance,
         // since the "getEnabledTransitions" method already checks the Marking

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -61,7 +61,7 @@ class Workflow
                 throw new LogicException(sprintf('The Marking is empty and there is no initial place for workflow "%s".', $this->name));
             }
             $marking->mark($this->definition->getInitialPlace());
-            
+
             // Because the marking could have been initialized, we update the subject
             $this->markingStore->setMarking($subject, $marking);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

getEnabledTransitions() method only requires 1 parameter "$subject". 

Removed places where a second parameter "$this->getMarking($subject)" is being passed to getEnabledTransitions().

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
