### PR TITLE
[PhpUnitBridge] do not register the test listener twice

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
@@ -27,9 +27,16 @@ class TestRunner extends \PHPUnit_TextUI_TestRunner
      */
     protected function handleConfiguration(array &$arguments)
     {
-        $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
-        $arguments['listeners'][] = new SymfonyTestsListener();
+        $listener = new SymfonyTestsListener();
 
-        return parent::handleConfiguration($arguments);
+        $result = parent::handleConfiguration($arguments);
+
+        $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
+
+        if (!array_filter($arguments['listeners'], function ($listener) { return $listener instanceof SymfonyTestsListener; })) {
+            $arguments['listeners'][] = $listener;
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

If the listener is already configured through the PHPUnit config, there
is no need to also enable it explicitly in the test runner.