### PR TITLE
[Workflow] Fixed marking state on leave and enter events

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -5,6 +5,7 @@ namespace Symfony\Component\Workflow\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\Event\Event;
 use Symfony\Component\Workflow\Event\GuardEvent;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
@@ -250,6 +251,41 @@ class WorkflowTest extends TestCase
         $marking = $workflow->apply($subject, 't1');
 
         $this->assertSame($eventNameExpected, $eventDispatcher->dispatchedEvents);
+    }
+
+    public function testMarkingStateOnApplyWithEventDispatcher()
+    {
+        $definition = new Definition(range('a', 'f'), array(new Transition('t', range('a', 'c'), range('d', 'f'))));
+
+        $subject = new \stdClass();
+        $subject->marking = array('a' => 1, 'b' => 1, 'c' => 1);
+
+        $dispatcher = new EventDispatcher();
+
+        $workflow = new Workflow($definition, new MultipleStateMarkingStore(), $dispatcher, 'test');
+
+        $assertInitialState = function (Event $event) {
+            $this->assertEquals(new Marking(array('a' => 1, 'b' => 1, 'c' => 1)), $event->getMarking());
+        };
+        $assertTransitionState = function (Event $event) {
+            $this->assertEquals(new Marking(array()), $event->getMarking());
+        };
+
+        $dispatcher->addListener('workflow.leave', $assertInitialState);
+        $dispatcher->addListener('workflow.test.leave', $assertInitialState);
+        $dispatcher->addListener('workflow.test.leave.a', $assertInitialState);
+        $dispatcher->addListener('workflow.test.leave.b', $assertInitialState);
+        $dispatcher->addListener('workflow.test.leave.c', $assertInitialState);
+        $dispatcher->addListener('workflow.transition', $assertTransitionState);
+        $dispatcher->addListener('workflow.test.transition', $assertTransitionState);
+        $dispatcher->addListener('workflow.test.transition.t', $assertTransitionState);
+        $dispatcher->addListener('workflow.enter', $assertTransitionState);
+        $dispatcher->addListener('workflow.test.enter', $assertTransitionState);
+        $dispatcher->addListener('workflow.test.enter.d', $assertTransitionState);
+        $dispatcher->addListener('workflow.test.enter.e', $assertTransitionState);
+        $dispatcher->addListener('workflow.test.enter.f', $assertTransitionState);
+
+        $workflow->apply($subject, 't');
     }
 
     public function testGetEnabledTransitions()

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -223,19 +223,21 @@ class Workflow
 
     private function leave($subject, Transition $transition, Marking $marking)
     {
+        $places = $transition->getFroms();
+
         if (null !== $this->dispatcher) {
             $event = new Event($subject, $marking, $transition);
 
             $this->dispatcher->dispatch('workflow.leave', $event);
             $this->dispatcher->dispatch(sprintf('workflow.%s.leave', $this->name), $event);
-        }
 
-        foreach ($transition->getFroms() as $place) {
-            $marking->unmark($place);
-
-            if (null !== $this->dispatcher) {
+            foreach ($places as $place) {
                 $this->dispatcher->dispatch(sprintf('workflow.%s.leave.%s', $this->name, $place), $event);
             }
+        }
+
+        foreach ($places as $place) {
+            $marking->unmark($place);
         }
     }
 
@@ -254,19 +256,21 @@ class Workflow
 
     private function enter($subject, Transition $transition, Marking $marking)
     {
+        $places = $transition->getTos();
+
         if (null !== $this->dispatcher) {
             $event = new Event($subject, $marking, $transition);
 
             $this->dispatcher->dispatch('workflow.enter', $event);
             $this->dispatcher->dispatch(sprintf('workflow.%s.enter', $this->name), $event);
-        }
 
-        foreach ($transition->getTos() as $place) {
-            $marking->mark($place);
-
-            if (null !== $this->dispatcher) {
+            foreach ($places as $place) {
                 $this->dispatcher->dispatch(sprintf('workflow.%s.enter.%s', $this->name, $place), $event);
             }
+        }
+
+        foreach ($places as $place) {
+            $marking->mark($place);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | related to https://github.com/symfony/symfony-docs/pull/7528

It seems weird to me to dispatch an event while the marking is not yet marked by the new places.
The event is still "marked" by old places when leaving occurs, my guess is that the symmetry should be mirrored.

Do you agree? Should I add a test?