### PR TITLE
[DI] Fix ServiceLocatorArgument::setValues() for non-reference values

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceLocatorArgument.php
@@ -39,7 +39,7 @@ class ServiceLocatorArgument implements ArgumentInterface
     public function setValues(array $values)
     {
         foreach ($values as $v) {
-            if (!$v instanceof Reference) {
+            if (!$v instanceof Reference && null !== $v) {
                 throw new InvalidArgumentException('Values of a ServiceLocatorArgument must be Reference objects.');
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Argument/ServiceLocatorArgumentTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Argument/ServiceLocatorArgumentTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Argument;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ServiceLocatorArgumentTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Values of a ServiceLocatorArgument must be Reference objects.
+     */
+    public function testThrowsOnNonReferenceValues()
+    {
+        new ServiceLocatorArgument(array('foo' => 'bar'));
+    }
+
+    public function testAcceptsReferencesOrNulls()
+    {
+        $locator = new ServiceLocatorArgument($values = array('foo' => new Reference('bar'), 'bar' => null));
+
+        $this->assertSame($values, $locator->getValues());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Fixed tickets | https://github.com/symfony/symfony/pull/21625#issuecomment-282938336
| Tests pass?   | yes
| License       | MIT

`ResolveInvalidReferencesPass` [calls `setValues()`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php#L91) with resolved invalid reference (null), the `Reference` type check should occurs at construction only.