### PR TITLE
[PHPUnit Bridge]Implement poor man's error handler

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -112,7 +112,7 @@ class DeprecationErrorHandler
             $trace = debug_backtrace(true);
             $group = 'other';
 
-            $isWeak = DeprecationErrorHandler::MODE_WEAK === $mode || (DeprecationErrorHandler::MODE_WEAK_VENDORS === $mode && $isVendor = $inVendors($file));
+            $isWeak = DeprecationErrorHandler::MODE_WEAK === $mode || (self::MODE_WEAK_VENDORS === $mode && $isVendor = $inVendors($file));
 
             $i = count($trace);
             while (1 < $i && (!isset($trace[--$i]['class']) || ('ReflectionMethod' === $trace[$i]['class'] || 0 === strpos($trace[$i]['class'], 'PHPUnit_') || 0 === strpos($trace[$i]['class'], 'PHPUnit\\')))) {
@@ -196,7 +196,7 @@ class DeprecationErrorHandler
                     $colorize = function ($str) { return $str; };
                 }
                 if ($currErrorHandler !== $deprecationHandler) {
-                    echo "\n", $colorize('THE ERROR HANDLER HAS CHANGED!', true), "\n";
+                    echo "\n", $colorize("THE ERROR HANDLER HAS CHANGED!\n".var_export(error_get_last(), true), true), "\n";
                 }
 
                 $cmp = function ($a, $b) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/failure.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/failure.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test DeprecationErrorHandler failure
+--FILE--
+<?php
+namespace Symfony\Bridge\PhpUnit;
+function error_get_last()
+{
+    return array(
+        'type' => E_ERROR,
+        'message' => 'failed to load flux capacitor',
+        'file' => '/wherever/the/deprecation_handler_is',
+        'line' => 42
+    );
+}
+
+putenv('SYMFONY_DEPRECATIONS_HELPER');
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+trigger_error('test failure', E_USER_DEPRECATED);
+set_error_handler('var_dump');
+
+--EXPECTF--
+THE ERROR HANDLER HAS CHANGED!
+array (
+  'type' => 1,
+  'message' => 'failed to load flux capacitor',
+  'file' => '/wherever/the/deprecation_handler_is',
+  'line' => 42,
+)
+
+Other deprecation notices (1)
+
+test failure: 1x


### PR DESCRIPTION
This line of code is hit when the error handler has failed. In that
case, we want to get errors in the most reliable possible way, with very
simple code. I think var_export and error_get_last are good candidates
for that.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
[Here is what it looks like](https://travis-ci.org/symfony/symfony/jobs/206115949#L3792). I will remove the purposefully wrong commit once everyone is ok with the output. Please not that in that case, it's a `phpt`, so it's a bit special.
Also, to elaborate a bit on the why, if you feel like people developing on the deprecation error handler could easily add these lines and remove them after debugging their problem, bear in mind that some problems, just like the one I introduced to test this, occur on some builds only.

The problem I introduced was a mistake I made in #21539 .
To debug it I had to find the right Travis container from quay.io, set up [travis-build](https://github.com/travis-ci/travis-build) on it, which is quite an ordeal, and then run the generated `ci.sh` script.