### PR TITLE
Revert "feature #21792 [Security] deprecate multiple providers in context listener (xabbuh)"

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -105,9 +105,6 @@ Process
 Security
 --------
 
- * Deprecated the ability to pass multiple user providers to the `ContextListener`. Pass only the user provider responsible
-   for the active firewall instead.
-
  * The `RoleInterface` has been deprecated. Extend the `Symfony\Component\Security\Core\Role\Role`
    class in your custom role implementations instead.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -261,9 +261,6 @@ Process
 Security
 --------
 
- * Dropped support for passing multiple user providers to the `ContextListener`. Pass only the user provider responsible
-   for the active firewall instead.
-
  * The `RoleInterface` has been removed. Extend the `Symfony\Component\Security\Core\Role\Role`
    class instead.
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -434,7 +434,7 @@ class SecurityExtension extends Extension
 
         $listenerId = 'security.context_listener.'.count($this->contextListeners);
         $listener = $container->setDefinition($listenerId, new ChildDefinition('security.context_listener'));
-        $listener->replaceArgument(1, new Reference($providerId));
+        $listener->replaceArgument(1, array(new Reference($providerId)));
         $listener->replaceArgument(2, $contextKey);
 
         return $this->contextListeners[$contextKey] = $listenerId;

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -1,12 +1,6 @@
 CHANGELOG
 =========
 
-3.3.0
------
-
- * Deprecated the ability to pass multiple user providers to the `ContextListener`. Pass only the user provider responsible
-   for the active firewall instead.
-
 3.2.0
 -----
 

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -44,24 +44,10 @@ class ContextListener implements ListenerInterface
     private $registered;
     private $trustResolver;
 
-    /**
-     * @param TokenStorageInterface                         $tokenStorage
-     * @param UserProviderInterface|UserProviderInterface[] $userProviders
-     * @param string                                        $contextKey
-     * @param LoggerInterface|null                          $logger
-     * @param EventDispatcherInterface|null                 $dispatcher
-     * @param AuthenticationTrustResolverInterface|null     $trustResolver
-     */
-    public function __construct(TokenStorageInterface $tokenStorage, $userProviders, $contextKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, AuthenticationTrustResolverInterface $trustResolver = null)
+    public function __construct(TokenStorageInterface $tokenStorage, array $userProviders, $contextKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, AuthenticationTrustResolverInterface $trustResolver = null)
     {
         if (empty($contextKey)) {
             throw new \InvalidArgumentException('$contextKey must not be empty.');
-        }
-
-        if (is_array($userProviders)) {
-            @trigger_error(sprintf('Being able to pass multiple user providers to the constructor of %s is deprecated since version 3.3 and will not be supported anymore in 4.0. Only pass the user provider for the current firewall context instead.', __CLASS__), E_USER_DEPRECATED);
-        } else {
-            $userProviders = array($userProviders);
         }
 
         foreach ($userProviders as $userProvider) {

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -36,13 +35,12 @@ class ContextListenerTest extends TestCase
     {
         new ContextListener(
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock(),
-            $this->getMockBuilder(UserProviderInterface::class)->getMock(),
+            array(),
             ''
         );
     }
 
     /**
-     * @group legacy
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage User provider "stdClass" must implement "Symfony\Component\Security\Core\User\UserProviderInterface
      */
@@ -111,7 +109,7 @@ class ContextListenerTest extends TestCase
             new Response()
         );
 
-        $listener = new ContextListener($tokenStorage, $this->getMockBuilder(UserProviderInterface::class)->getMock(), 'session', null, new EventDispatcher());
+        $listener = new ContextListener($tokenStorage, array(), 'session', null, new EventDispatcher());
         $listener->onKernelResponse($event);
 
         $this->assertTrue($session->isStarted());
@@ -130,7 +128,7 @@ class ContextListenerTest extends TestCase
             new Response()
         );
 
-        $listener = new ContextListener(new TokenStorage(), $this->getMockBuilder(UserProviderInterface::class)->getMock(), 'session', null, new EventDispatcher());
+        $listener = new ContextListener(new TokenStorage(), array(), 'session', null, new EventDispatcher());
         $listener->onKernelResponse($event);
 
         $this->assertFalse($session->isStarted());
@@ -165,7 +163,7 @@ class ContextListenerTest extends TestCase
             ->method('setToken')
             ->with(null);
 
-        $listener = new ContextListener($tokenStorage, $this->getMockBuilder(UserProviderInterface::class)->getMock(), 'key123');
+        $listener = new ContextListener($tokenStorage, array(), 'key123');
         $listener->handle($event);
     }
 
@@ -186,7 +184,7 @@ class ContextListenerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $listener = new ContextListener($tokenStorage, $this->getMockBuilder(UserProviderInterface::class)->getMock(), 'key123', null, $dispatcher);
+        $listener = new ContextListener($tokenStorage, array(), 'key123', null, $dispatcher);
 
         $event->expects($this->any())
             ->method('isMasterRequest')
@@ -210,7 +208,7 @@ class ContextListenerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $listener = new ContextListener($tokenStorage, $this->getMockBuilder(UserProviderInterface::class)->getMock(), 'key123', null, $dispatcher);
+        $listener = new ContextListener($tokenStorage, array(), 'key123', null, $dispatcher);
 
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
         $request->expects($this->any())
@@ -244,7 +242,7 @@ class ContextListenerTest extends TestCase
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage->expects($this->once())->method('setToken')->with(null);
 
-        $listener = new ContextListener($tokenStorage, $this->getMockBuilder(UserProviderInterface::class)->getMock(), 'key123');
+        $listener = new ContextListener($tokenStorage, array(), 'key123');
         $listener->handle($event);
     }
 
@@ -270,7 +268,7 @@ class ContextListenerTest extends TestCase
             new Response()
         );
 
-        $listener = new ContextListener($tokenStorage, $this->getMockBuilder(UserProviderInterface::class)->getMock(), 'session', null, new EventDispatcher());
+        $listener = new ContextListener($tokenStorage, array(), 'session', null, new EventDispatcher());
         $listener->onKernelResponse($event);
 
         return $session;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21791
| License       | MIT
| Doc PR        | 

#21792 was a mistake as pointed out by @slaci (see https://github.com/symfony/symfony/pull/21791#issuecomment-282990746) and @stof (see https://github.com/symfony/symfony/pull/21792#issuecomment-282980046).