### PR TITLE
[Console] Test inline styles with non-decorated formatter

### DIFF
--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -196,6 +196,9 @@ class OutputFormatterTest extends TestCase
         $this->assertEquals(
             'some question', $formatter->format('<question>some question</question>')
         );
+        $this->assertEquals(
+            'some text with inline style', $formatter->format('<fg=red>some text with inline style</>')
+        );
 
         $formatter->setDecorated(true);
 
@@ -210,6 +213,9 @@ class OutputFormatterTest extends TestCase
         );
         $this->assertEquals(
             "\033[30;46msome question\033[39;49m", $formatter->format('<question>some question</question>')
+        );
+        $this->assertEquals(
+            "\033[31msome text with inline style\033[39m", $formatter->format('<fg=red>some text with inline style</>')
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Small improvement of `OutputFormatter` test.