### PR TITLE
#21809 [SecurityBundle] bugfix: if security provider's name contains upper cases then container didn't compile

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -558,7 +558,7 @@ class SecurityExtension extends Extension
     // Parses a <provider> tag and returns the id for the related user provider service
     private function createUserDaoProvider($name, $provider, ContainerBuilder $container)
     {
-        $name = $this->getUserProviderId(strtolower($name));
+        $name = $this->getUserProviderId($name);
 
         // Doctrine Entity and In-memory DAO provider are managed by factories
         foreach ($this->userProviderFactories as $factory) {
@@ -582,7 +582,7 @@ class SecurityExtension extends Extension
         if (isset($provider['chain'])) {
             $providers = array();
             foreach ($provider['chain']['providers'] as $providerName) {
-                $providers[] = new Reference($this->getUserProviderId(strtolower($providerName)));
+                $providers[] = new Reference($this->getUserProviderId($providerName));
             }
 
             $container
@@ -597,7 +597,7 @@ class SecurityExtension extends Extension
 
     private function getUserProviderId($name)
     {
-        return 'security.user.provider.concrete.'.$name;
+        return 'security.user.provider.concrete.'.strtolower($name);
     }
 
     private function createExceptionListener($container, $config, $id, $defaultEntryPoint, $stateless)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CamelCasedProviders/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CamelCasedProviders/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return array(
+    new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+    new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CamelCasedProviders/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CamelCasedProviders/config.yml
@@ -1,0 +1,30 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+doctrine:
+    dbal:
+        driver:   pdo_sqlite
+        memory:   true
+        charset:  UTF8
+
+    orm:
+        entity_managers:
+            default:
+
+                auto_mapping: true
+
+security:
+    providers:
+        camelCasedName:
+            entity:
+                class: Symfony\Component\Security\Core\User\User
+
+    firewalls:
+        default:
+            anonymous: ~
+            provider: camelCasedName
+
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CamelCasedProvidersCausesExceptionsTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CamelCasedProvidersCausesExceptionsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+class CamelCasedProvidersCausesExceptionsTest extends WebTestCase
+{
+    public function testBugfixExceptionThenCamelCasedProviderIsGiven()
+    {
+        $client = $this->createClient(array('test_case' => 'CamelCasedProviders', 'root_config' => 'config.yml'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? no
| Tests pass?   | yes
| Fixed tickets | #21809
| License       | MIT

then security.yml  providers was with upper case, on container compile error was thrown:
````
[04:39:32][Ant output]      [exec]      [exec] > Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache
[04:39:32][Ant output]      [exec]      [exec] 
[04:39:32][Ant output]      [exec]      [exec] 
[04:39:32][Ant output]      [exec]      [exec]   [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]
[04:39:32][Ant output]      [exec]      [exec]   The service "security.authentication.provider.simple_form.default" has a de
[04:39:32][Ant output]      [exec]      [exec]   pendency on a non-existent service "security.user.provider.concrete.carrier
[04:39:32][Ant output]      [exec]      [exec]   User".

`````

Problem has occurred with this commit line:
https://github.com/symfony/symfony/commit/fbd9f88e312d03614b7e96ed3a1c8c993eb8c0b5#diff-2be909961a57bf75fbb600c1f5fc46e3R320

Issue fixes with this PR.

