### PR TITLE
Revert "[SecurityBundle] only pass relevant user provider"

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -234,6 +234,16 @@ class SecurityExtension extends Extension
         $firewalls = $config['firewalls'];
         $providerIds = $this->createUserProviders($config, $container);
 
+        // make the ContextListener aware of the configured user providers
+        $definition = $container->getDefinition('security.context_listener');
+        $arguments = $definition->getArguments();
+        $userProviders = array();
+        foreach ($providerIds as $userProviderId) {
+            $userProviders[] = new Reference($userProviderId);
+        }
+        $arguments[1] = $userProviders;
+        $definition->setArguments($arguments);
+
         // load firewall map
         $mapDef = $container->getDefinition('security.firewall.map');
         $map = $authenticationProviders = $contextRefs = array();
@@ -317,7 +327,7 @@ class SecurityExtension extends Extension
                 $contextKey = $firewall['context'];
             }
 
-            $listeners[] = new Reference($this->createContextListener($container, $contextKey, $defaultProvider));
+            $listeners[] = new Reference($this->createContextListener($container, $contextKey));
         }
 
         $config->replaceArgument(6, $contextKey);
@@ -426,7 +436,7 @@ class SecurityExtension extends Extension
         return array($matcher, $listeners, $exceptionListener);
     }
 
-    private function createContextListener($container, $contextKey, $providerId)
+    private function createContextListener($container, $contextKey)
     {
         if (isset($this->contextListeners[$contextKey])) {
             return $this->contextListeners[$contextKey];
@@ -434,7 +444,6 @@ class SecurityExtension extends Extension
 
         $listenerId = 'security.context_listener.'.count($this->contextListeners);
         $listener = $container->setDefinition($listenerId, new ChildDefinition('security.context_listener'));
-        $listener->replaceArgument(1, array(new Reference($providerId)));
         $listener->replaceArgument(2, $contextKey);
 
         return $this->contextListeners[$contextKey] = $listenerId;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21809, #21810
| License       | MIT
| Doc PR        | 

This reverts commit d97e07fd6a836985804f529191b99ea1915335e8 (applies #21798 on `master`). There is no merge commit that could be reverted.