### PR TITLE
[Twig Bridge] A simpler way to retrieve flash messages

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -166,7 +166,7 @@ class AppVariable
             return array();
         }
 
-        if (null === $types || array() === $types) {
+        if (null === $types || '' === $types || array() === $types) {
             return $session->getFlashBag()->all();
         }
 

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -159,23 +159,21 @@ class AppVariable
         // needed to avoid starting the session automatically when looking for flash messages
         try {
             $session = $this->getSession();
-            if (null !== $session && !$session->isStarted()) {
+            if (null === $session || !$session->isStarted()) {
                 return array();
             }
         } catch (\RuntimeException $e) {
             return array();
         }
 
-        if (null === $types || empty($types)) {
+        if (empty($types)) {
             return $session->getFlashBag()->all();
         }
 
-        $types = (array) $types;
-
-        if (1 === count($types)) {
-            return $session->getFlashBag()->get($types[0]);
+        if (is_string($types)) {
+            return $session->getFlashBag()->get($types);
         }
 
-        return array_intersect($session->getFlashBag()->all(), array_flip($types));
+        return array_intersect_key($session->getFlashBag()->all(), array_flip($types));
     }
 }

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -166,7 +166,7 @@ class AppVariable
             return array();
         }
 
-        if (null !== $type || array() === $types) {
+        if (null === $types || array() === $types) {
             return $session->getFlashBag()->all();
         }
 

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -150,7 +150,7 @@ class AppVariable
      * Returns some or all the existing flash messages:
      *  * getFlashes() returns all the flash messages
      *  * getFlashes('notice') returns a simple array with flash messages of that type
-     *  * getFlashes(array('notice', 'error')) returns a nested array of type => messages
+     *  * getFlashes(array('notice', 'error')) returns a nested array of type => messages.
      *
      * @return array
      */

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -147,15 +147,16 @@ class AppVariable
     }
 
     /**
-     * Returns some or all the existing flash messages. The method is variadic:
-     * if no arguments are passed, all flashes are returned; if one or more
-     * arguments are passed, only the flashes that belong to that category are
-     * returned; e.g. getFlashes('notice') or getFlashes('notice', 'error').
+     * Returns some or all the existing flash messages:
+     *  * getFlashes() returns all the flash messages
+     *  * getFlashes('notice') returns a simple array with flash messages of that type
+     *  * getFlashes(array('notice', 'error')) returns a nested array of type => messages
      *
      * @return array
      */
-    public function getFlashes()
+    public function getFlashes($types = null)
     {
+        // needed to avoid starting the session automatically when looking for flash messages
         try {
             $session = $this->getSession();
             if (null !== $session && !$session->isStarted()) {
@@ -165,21 +166,14 @@ class AppVariable
             return array();
         }
 
-        if (0 === func_num_args()) {
+        if (null === $types) {
             return $session->getFlashBag()->all();
         }
 
-        if (1 === func_num_args()) {
-            return $session->getFlashBag()->get(func_get_arg(0));
+        if (1 === count($types)) {
+            return $session->getFlashBag()->get($types[0]);
         }
 
-        $flashes = array();
-        foreach ($session->getFlashBag()->all() as $key => $message) {
-            if (in_array($key, func_get_args())) {
-                $flashes[$key][] = $message;
-            }
-        }
-
-        return $flashes;
+        return array_intersect($session->getFlashBag()->all(), array_flip($types));
     }
 }

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -166,9 +166,11 @@ class AppVariable
             return array();
         }
 
-        if (null === $types) {
+        if (null === $types || empty($types)) {
             return $session->getFlashBag()->all();
         }
+
+        $types = (array) $types;
 
         if (1 === count($types)) {
             return $session->getFlashBag()->get($types[0]);

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -161,7 +161,7 @@ class AppVariable
             if (null !== $session && !$session->isStarted()) {
                 return array();
             }
-        } catch(\RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             return array();
         }
 

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -145,4 +145,37 @@ class AppVariable
 
         return $this->debug;
     }
+
+    /**
+     * Returns some or all the existing flash messages. The method is variadic:
+     * if no arguments are passed, all flashes are returned; if one or more
+     * arguments are passed, only the flashes that belong to that category are
+     * returned; e.g. getFlashes('notice') or getFlashes('notice', 'error').
+     *
+     * @return array
+     */
+    public function getFlashes()
+    {
+        try {
+            $session = $this->getSession();
+            if (null !== $session && !$session->isStarted()) {
+                return array();
+            }
+        } catch(\RuntimeException $e) {
+            return array();
+        }
+
+        if (0 === func_num_args()) {
+            return $session->getFlashBag()->all();
+        }
+
+        $flashes = array();
+        foreach ($session->getFlashBag()->all() as $key => $message) {
+            if (in_array($key, func_get_args())) {
+                $flashes[$key][] = $message;
+            }
+        }
+
+        return $flashes;
+    }
 }

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -166,7 +166,7 @@ class AppVariable
             return array();
         }
 
-        if (empty($types)) {
+        if (null !== $type || array() === $types) {
             return $session->getFlashBag()->all();
         }
 

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -169,6 +169,10 @@ class AppVariable
             return $session->getFlashBag()->all();
         }
 
+        if (1 === func_num_args()) {
+            return $session->getFlashBag()->get(func_get_arg(0));
+        }
+
         $flashes = array();
         foreach ($session->getFlashBag()->all() as $key => $message) {
             if (in_array($key, func_get_args())) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Getting flash messages in templates is more complex than it could be. Main problems:

1. It's too low level: you need to get the "flash bag" (and first, learn what a "flash bag" is) and then you need to call the internal method: `all()`, `get()`, etc.
2. You need to be careful because the session will start automatically when you ask for flashes (even if there are no flashes). You can prevent this with the `{% if app.session is not null and app.session.started %}` code, but it's boring to always use that.

So, I propose to add a new `app.flashes` helper that works as follows.

---

## Get all the flash messages

### Before

```twig
{% if app.session is not null and app.session.started %}
    {% for label, messages in app.session.flashbag.all %}
        {% for message in messages %}
            <div class="alert alert-{{ label }}">
                {{ message }}
            </div>
        {% endfor %}
    {% endfor %}
{% endif %}
```

### After

```twig
{% for label, messages in app.flashes %}
    {% for message in messages %}
        <div class="alert alert-{{ label }}">
            {{ message }}
        </div>
    {% endfor %}
{% endfor %}
```

---

## Get only the flashes of type `notice`

```twig
{% if app.session is not null and app.session.started %}
    {% for message in app.session.flashbag.get('notice') %}
        <div class="alert alert-notice">
            {{ message }}
        </div>
    {% endfor %}
{% endif %}
```

### After

```twig
{% for message in app.flashes('notice') %}
    <div class="alert alert-notice">
        {{ message }}
    </div>
{% endfor %}
```

---

As an added bonus, you can get any number of flash messages because the method allows to pass an array of flash types:

```twig
{% for label, messages in app.flashes(['warning', 'error']) %}
    {% for message in messages %}
        <div class="alert alert-{{ label }}">
            {{ message }}
        </div>
    {% endfor %}
{% endfor %}
```
