### PR TITLE
Router: Optimize catch-all routes

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -245,7 +245,7 @@ EOF;
                 $hasTrailingSlash = true;
             }
             
-            if(!preg_match('#^'.preg_quote('#^/(?P<', '#').'([A-Za-z0-9_]+)'.preg_quote('>.*)?$#s', '#').'$#', $regex)) {
+            if (!preg_match('#^'.preg_quote('#^/(?P<', '#').'([A-Za-z0-9_]+)'.preg_quote('>.*)?$#s', '#').'$#', $regex)) {
                 $conditions[] = sprintf('preg_match(%s, $pathinfo, $matches)', var_export($regex, true));
 
                 $matches = true;

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -244,7 +244,7 @@ EOF;
                 $regex = substr($regex, 0, $pos).'/?$'.substr($regex, $pos + 2);
                 $hasTrailingSlash = true;
             }
-            
+
             if (!preg_match('#^'.preg_quote('#^/(?P<', '#').'([A-Za-z0-9_]+)'.preg_quote('>.*)?$#s', '#').'$#', $regex)) {
                 $conditions[] = sprintf('preg_match(%s, $pathinfo, $matches)', var_export($regex, true));
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -245,12 +245,11 @@ EOF;
                 $hasTrailingSlash = true;
             }
             
-            if(!preg_match('#^' . preg_quote('#^/(?P<', '#') . '([A-Za-z0-9_]+)' . preg_quote('>.*)?$#s', '#') . '$#', $regex)) {
+            if(!preg_match('#^'.preg_quote('#^/(?P<', '#').'([A-Za-z0-9_]+)'.preg_quote('>.*)?$#s', '#').'$#', $regex)) {
                 $conditions[] = sprintf('preg_match(%s, $pathinfo, $matches)', var_export($regex, true));
 
                 $matches = true;
-            }
-            else {
+            } else {
                 $conditions[] = 'true';
             }
         }

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -244,9 +244,15 @@ EOF;
                 $regex = substr($regex, 0, $pos).'/?$'.substr($regex, $pos + 2);
                 $hasTrailingSlash = true;
             }
-            $conditions[] = sprintf('preg_match(%s, $pathinfo, $matches)', var_export($regex, true));
+            
+            if(!preg_match('#^' . preg_quote('#^/(?P<', '#') . '([A-Za-z0-9_]+)' . preg_quote('>.*)?$#s', '#') . '$#', $regex)) {
+                $conditions[] = sprintf('preg_match(%s, $pathinfo, $matches)', var_export($regex, true));
 
-            $matches = true;
+                $matches = true;
+            }
+            else {
+                $conditions[] = 'true';
+            }
         }
 
         if ($compiledRoute->getHostVariables()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | unsure - not quite finished yet
| License       | MIT

The typical catch-all route (example: `@Route("/{url}", requirements={"url" = ".*"})`) still leads to a preg_match being executed, even though the route will always match. When using Symfony with a catch-all route to "pass along" the request to another system or part of the application this preg_match gets executed on every request without any added benefit.

I attempted to improve this with the changes in this pull request (condition "true" instead of the regex), although it still has flaws:

- The named catch-all parameter (for example "url" in `@Route("/{url}", requirements={"url" = ".*"})`) is empty instead of containing the whole URL because I was not sure where to get the URL or how to add it to the Dumper. I thought it more sensible to just post a partial solution instead of no solution or going through the Router code for a lot longer.
- The regex to find a "catch-all" route is a bit crude, and I was not sure if `[A-Za-z0-9_]+` actually contains all allowed characters for placeholders in routes.
- Tests probably need to be modified too, but I thought it better to just post something small to see if this is even a feature which Symfony wants to implement in this manner.

Hope this still helps, and would be glad to improve it further after some feedback!