### PR TITLE
dumpFile(), preserve existing file permissions

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -517,11 +517,7 @@ class Filesystem
 
             $this->chmod($tmpFile, $mode);
         } else {
-            if (file_exists($filename)) {
-                @chmod($tmpFile, fileperms($filename));
-            } else {
-                @chmod($tmpFile, 0666 & ~umask());
-            }
+            @chmod($tmpFile, file_exists($filename) ? fileperms($filename) : 0666 & ~umask());
         }
 
         $this->rename($tmpFile, $filename, true);

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -523,7 +523,7 @@ class Filesystem
                 @chmod($tmpFile, 0666 & ~umask());
             }
         }
-        
+
         $this->rename($tmpFile, $filename, true);
     }
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -516,7 +516,14 @@ class Filesystem
             }
 
             $this->chmod($tmpFile, $mode);
+        } else {
+            if (file_exists($filename)) {
+                @chmod($tmpFile, fileperms($filename));
+            } else {
+                @chmod($tmpFile, 0666 & ~umask());
+            }
         }
+        
         $this->rename($tmpFile, $filename, true);
     }
 


### PR DESCRIPTION
When calling Filesystem::dumpFile() on an already existing file, its permissions are lost.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
