### PR TITLE
[PhpUnitBridge] disable global test listener when not registered

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -68,6 +68,12 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
         }
     }
 
+    public function globalListenerDisabled()
+    {
+        self::$globallyEnabled = false;
+        $this->state = -1;
+    }
+
     public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
     {
         $suiteName = $suite->getName();

--- a/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
@@ -33,7 +33,17 @@ class TestRunner extends \PHPUnit_TextUI_TestRunner
 
         $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
 
-        if (!array_filter($arguments['listeners'], function ($listener) { return $listener instanceof SymfonyTestsListener; })) {
+        $registeredLocally = false;
+
+        foreach ($arguments['listeners'] as $registeredListener) {
+            if ($registeredListener instanceof SymfonyTestsListener) {
+                $registeredListener->globalListenerDisabled();
+                $registeredLocally = true;
+                break;
+            }
+        }
+
+        if (!$registeredLocally) {
             $arguments['listeners'][] = $listener;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The global test listener is always initialized to register the clock
mock and DNS mock as soon as possible. However, when the listener is
registered locally through the PHPUnit config, it will never be
registered as a listener. In thise case, the state of the local
listener must be reset to correctly report expected deprecation test
results.