### PR TITLE
[PhpUnitBride] disable global test listener when not registered

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListener.php
@@ -27,6 +27,11 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
         $this->trait = new SymfonyTestsListenerTrait($mockedNamespaces);
     }
 
+    public function globalListenerDisabled()
+    {
+        $this->trait->globalListenerDisabled();
+    }
+
     public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
     {
         return $this->trait->startTestSuite($suite);

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -93,6 +93,12 @@ class SymfonyTestsListenerTrait
         }
     }
 
+    public function globalListenerDisabled()
+    {
+        self::$globallyEnabled = false;
+        $this->state = -1;
+    }
+
     public function startTestSuite($suite)
     {
         if (class_exists('PHPUnit_Util_Blacklist', false)) {

--- a/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
@@ -38,7 +38,17 @@ class TestRunner extends BaseRunner
 
         $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
 
-        if (!array_filter($arguments['listeners'], function ($listener) { return $listener instanceof SymfonyTestsListener; })) {
+        $registeredLocally = false;
+
+        foreach ($arguments['listeners'] as $registeredListener) {
+            if ($registeredListener instanceof SymfonyTestsListener) {
+                $registeredListener->globalListenerDisabled();
+                $registeredLocally = true;
+                break;
+            }
+        }
+
+        if (!$registeredLocally) {
             $arguments['listeners'][] = $listener;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The global test listener is always initialized to register the clock
mock and DNS mock as soon as possible. However, when the listener is
registered locally through the PHPUnit config, it will never be
registered as a listener. In thise case, the state of the local
listener must be reset to correctly report expected deprecation test
results.
