### PR TITLE
[EventDispatcher] Added EventTrait

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\EventDispatcher\Debug;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -118,7 +119,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, EventInterface $event = null)
     {
         if (null === $event) {
             $event = new Event();
@@ -220,20 +221,20 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     /**
      * Called before dispatching the event.
      *
-     * @param string $eventName The event name
-     * @param Event  $event     The event
+     * @param string         $eventName The event name
+     * @param EventInterface $event     The event
      */
-    protected function preDispatch($eventName, Event $event)
+    protected function preDispatch($eventName, EventInterface $event)
     {
     }
 
     /**
      * Called after dispatching the event.
      *
-     * @param string $eventName The event name
-     * @param Event  $event     The event
+     * @param string         $eventName The event name
+     * @param EventInterface $event     The event
      */
-    protected function postDispatch($eventName, Event $event)
+    protected function postDispatch($eventName, EventInterface $event)
     {
     }
 

--- a/src/Symfony/Component/EventDispatcher/Event.php
+++ b/src/Symfony/Component/EventDispatcher/Event.php
@@ -25,34 +25,7 @@ namespace Symfony\Component\EventDispatcher;
  * @author Roman Borschel <roman@code-factory.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class Event
+class Event implements EventInterface
 {
-    /**
-     * @var bool Whether no further event listeners should be triggered
-     */
-    private $propagationStopped = false;
-
-    /**
-     * Returns whether further event listeners should be triggered.
-     *
-     * @see Event::stopPropagation()
-     *
-     * @return bool Whether propagation was already stopped for this event
-     */
-    public function isPropagationStopped()
-    {
-        return $this->propagationStopped;
-    }
-
-    /**
-     * Stops the propagation of the event to further event listeners.
-     *
-     * If multiple event listeners are connected to the same event, no
-     * further event listener will be triggered once any trigger calls
-     * stopPropagation().
-     */
-    public function stopPropagation()
-    {
-        $this->propagationStopped = true;
-    }
+    use EventTrait;
 }

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -33,7 +33,7 @@ class EventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, EventInterface $event = null)
     {
         if (null === $event) {
             $event = new Event();
@@ -161,11 +161,11 @@ class EventDispatcher implements EventDispatcherInterface
      * This method can be overridden to add functionality that is executed
      * for each listener.
      *
-     * @param callable[] $listeners The event listeners
-     * @param string     $eventName The name of the event to dispatch
-     * @param Event      $event     The event object to pass to the event handlers/listeners
+     * @param callable[]     $listeners The event listeners
+     * @param string         $eventName The name of the event to dispatch
+     * @param EventInterface $event     The event object to pass to the event handlers/listeners
      */
-    protected function doDispatch($listeners, $eventName, Event $event)
+    protected function doDispatch($listeners, $eventName, EventInterface $event)
     {
         foreach ($listeners as $listener) {
             if ($event->isPropagationStopped()) {

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -23,15 +23,15 @@ interface EventDispatcherInterface
     /**
      * Dispatches an event to all registered listeners.
      *
-     * @param string $eventName The name of the event to dispatch. The name of
-     *                          the event is the name of the method that is
-     *                          invoked on listeners.
-     * @param Event  $event     The event to pass to the event handlers/listeners
-     *                          If not supplied, an empty Event instance is created.
+     * @param string          $eventName The name of the event to dispatch. The name of
+     *                                   the event is the name of the method that is
+     *                                   invoked on listeners.
+     * @param EventInterface  $event     The event to pass to the event handlers/listeners
+     *                                   If not supplied, an empty Event instance is created.
      *
-     * @return Event
+     * @return EventInterface
      */
-    public function dispatch($eventName, Event $event = null);
+    public function dispatch($eventName, EventInterface $event = null);
 
     /**
      * Adds an event listener that listens on the specified events.

--- a/src/Symfony/Component/EventDispatcher/EventInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+
+interface EventInterface
+{
+    /**
+     * Returns whether further event listeners should be triggered.
+     *
+     * @see EventInterface::stopPropagation()
+     *
+     * @return bool Whether propagation was already stopped for this event
+     */
+    public function isPropagationStopped();
+
+    /**
+     * Stops the propagation of the event to further event listeners.
+     *
+     * If multiple event listeners are connected to the same event, no
+     * further event listener will be triggered once any trigger calls
+     * stopPropagation().
+     */
+    public function stopPropagation();
+}

--- a/src/Symfony/Component/EventDispatcher/EventTrait.php
+++ b/src/Symfony/Component/EventDispatcher/EventTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+
+trait EventTrait
+{
+    /**
+     * @var bool Whether no further event listeners should be triggered
+     */
+    private $propagationStopped = false;
+
+    /**
+     * @return bool
+     */
+    public function isPropagationStopped()
+    {
+        return $this->propagationStopped;
+    }
+
+    /**
+     * @return void
+     */
+    public function stopPropagation()
+    {
+        $this->propagationStopped = true;
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
@@ -38,7 +38,7 @@ class ImmutableEventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, EventInterface $event = null)
     {
         return $this->dispatcher->dispatch($eventName, $event);
     }

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\HttpKernel\Debug;
 
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher as BaseTraceableEventDispatcher;
+use Symfony\Component\EventDispatcher\EventInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Collects some data about event listeners.
@@ -27,7 +27,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     /**
      * {@inheritdoc}
      */
-    protected function preDispatch($eventName, Event $event)
+    protected function preDispatch($eventName, EventInterface $event)
     {
         switch ($eventName) {
             case KernelEvents::REQUEST:
@@ -58,7 +58,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     /**
      * {@inheritdoc}
      */
-    protected function postDispatch($eventName, Event $event)
+    protected function postDispatch($eventName, EventInterface $event)
     {
         switch ($eventName) {
             case KernelEvents::CONTROLLER_ARGUMENTS:

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -305,7 +305,7 @@ class EventDispatcherMock implements \Symfony\Component\EventDispatcher\EventDis
 {
     public $dispatchedEvents = array();
 
-    public function dispatch($eventName, \Symfony\Component\EventDispatcher\Event $event = null)
+    public function dispatch($eventName, \Symfony\Component\EventDispatcher\EventInterface $event = null)
     {
         $this->dispatchedEvents[] = $eventName;
     }


### PR DESCRIPTION
This allows to easily make any custom class fit for EventDispatcher

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes/no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I would like to use this to make some of our Doctrine entities (or some other object) events. Currently we have to encapsulate them to some Event class which means we cannot easily typehint against them in our listeners.

Let me know your suggestions regarding deprecations, this patch touching multiple components, backporting and changing the implementation also for current children of Event class. I will change the patch accordingly.