### PR TITLE
[PhpUnitBridge] include expected deprecations in assertion counter

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -240,6 +240,10 @@ class SymfonyTestsListenerTrait
         }
 
         if ($this->expectedDeprecations) {
+            if (!in_array($test->getStatus(), array($BaseTestRunner::STATUS_SKIPPED, $BaseTestRunner::STATUS_INCOMPLETE), true)) {
+                $test->addToAssertionCount(count($this->expectedDeprecations));
+            }
+
             restore_error_handler();
 
             if (!in_array($test->getStatus(), array($BaseTestRunner::STATUS_SKIPPED, $BaseTestRunner::STATUS_INCOMPLETE, $BaseTestRunner::STATUS_FAILURE, $BaseTestRunner::STATUS_ERROR), true)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21786#issuecomment-283074426
| License       | MIT
| Doc PR        | 

We still need to include the changes from #21786 as we cannot increment the number of assertions in the `startTest()` method (the PHPUnit test runner resets the counter after the listeners have been executed).
