### PR TITLE
[Routing] Ignore hidden directories when loading routes from annotations

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -40,6 +40,22 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses');
     }
 
+    public function testLoadIgnoresHiddenDirectories()
+    {
+        $this->expectAnnotationsToBeReadFrom(array(
+            'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
+            'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\FooClass',
+        ));
+
+        $this->reader
+            ->expects($this->any())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue(array()))
+        ;
+
+        $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses');
+    }
+
     public function testSupports()
     {
         $fixturesDir = __DIR__.'/../Fixtures';
@@ -49,5 +65,14 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
 
         $this->assertTrue($this->loader->supports($fixturesDir, 'annotation'), '->supports() checks the resource type if specified');
         $this->assertFalse($this->loader->supports($fixturesDir, 'foo'), '->supports() checks the resource type if specified');
+    }
+
+    private function expectAnnotationsToBeReadFrom(array $classes)
+    {
+        $this->reader->expects($this->exactly(count($classes)))
+            ->method('getClassAnnotation')
+            ->with($this->callback(function (\ReflectionClass $class) use ($classes) {
+                return in_array($class->getName(), $classes);
+            }));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21497
| License       | MIT
| Doc PR        | -

The problem surfaced after implementing #18869. Therefore it doesn't exist on 2.7, but I'd still merge it there to avoid conflicts when merging between branches. Without this fix, the oldest branch the added test will fail is 3.2. 