### PR TITLE
[FrameworkBundle] Lazy configuration of annotations' loader and `@required`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -5,7 +5,19 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="annotations.reader" class="Doctrine\Common\Annotations\AnnotationReader" public="false" />
+        <service id="annotations.reader" class="Doctrine\Common\Annotations\AnnotationReader" public="false">
+            <call method="addGlobalIgnoredName">
+                <argument>required</argument>
+                <argument type="service">
+                    <!-- dummy arg to register class_exists as annotation loader only when required -->
+                    <service class="Doctrine\Common\Annotations\AnnotationRegistry">
+                        <call method="registerLoader">
+                            <argument>class_exists</argument>
+                        </call>
+                    </service>
+                </argument>
+            </call>
+        </service>
         <service id="Doctrine\Common\Annotations\Reader" alias="annotations.reader" public="false" />
 
         <service id="annotations.cached_reader" class="Doctrine\Common\Annotations\CachedReader" public="false">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This would remove the need for https://github.com/symfony/symfony-standard/pull/1052 and for the `autoload.php` file altogether.

Tested on symfony-demo with great success so far.