### PR TITLE
[Console] Do not squash input changes made from console.command event

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -859,6 +859,10 @@ class Application
             // ignore invalid options/arguments for now, to allow the event listeners to customize the InputDefinition
         }
 
+        // don't bind the input again as it would override any input argument/option set from the command event in
+        // addition to being useless
+        $command->setInputBound(true);
+
         $event = new ConsoleCommandEvent($command, $input, $output);
         $this->dispatcher->dispatch(ConsoleEvents::COMMAND, $event);
 

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -42,6 +42,7 @@ class Command
     private $ignoreValidationErrors = false;
     private $applicationDefinitionMerged = false;
     private $applicationDefinitionMergedWithArgs = false;
+    private $inputBound = false;
     private $code;
     private $synopsis = array();
     private $usages = array();
@@ -218,11 +219,13 @@ class Command
         $this->mergeApplicationDefinition();
 
         // bind the input against the command specific arguments/options
-        try {
-            $input->bind($this->definition);
-        } catch (ExceptionInterface $e) {
-            if (!$this->ignoreValidationErrors) {
-                throw $e;
+        if (!$this->inputBound) {
+            try {
+                $input->bind($this->definition);
+            } catch (ExceptionInterface $e) {
+                if (!$this->ignoreValidationErrors) {
+                    throw $e;
+                }
             }
         }
 
@@ -676,6 +679,14 @@ class Command
         $descriptor->describe($output, $this);
 
         return $output->fetch();
+    }
+
+    /**
+     * @internal
+     */
+    public function setInputBound($inputBound)
+    {
+        $this->inputBound = $inputBound;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1113,6 +1113,31 @@ class ApplicationTest extends TestCase
         $this->assertEquals('some test value', $extraValue);
     }
 
+    public function testUpdateInputFromConsoleCommandEvent()
+    {
+        $dispatcher = $this->getDispatcher();
+        $dispatcher->addListener('console.command', function (ConsoleCommandEvent $event) {
+            $event->getInput()->setOption('extra', 'overriden');
+        });
+
+        $application = new Application();
+        $application->setDispatcher($dispatcher);
+        $application->setAutoExit(false);
+
+        $application
+            ->register('foo')
+            ->addOption('extra', null, InputOption::VALUE_REQUIRED)
+            ->setCode(function (InputInterface $input, OutputInterface $output) {
+                $output->write('foo.');
+            })
+        ;
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'foo', '--extra' => 'original'));
+
+        $this->assertEquals('overriden', $tester->getInput()->getOption('extra'));
+    }
+
     public function testTerminalDimensions()
     {
         $application = new Application();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/19441
| License       | MIT
| Doc PR        | n/a

Setting arguments/options from the `console.command` event is expected to work since https://github.com/symfony/symfony/pull/15938