### PR TITLE
[HttpKernel] Allow signing URIs with a custom query string parameter

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -50,4 +50,15 @@ class UriSignerTest extends TestCase
         );
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
     }
+
+    public function testCheckWithDifferentParameter()
+    {
+        $signer = new UriSigner('foobar', 'qux');
+
+        $this->assertSame(
+            'http://example.com/foo?baz=bay&foo=bar&qux=rIOcC%2FF3DoEGo%2FvnESjSp7uU9zA9S%2F%2BOLhxgMexoPUM%3D',
+            $signer->sign('http://example.com/foo?foo=bar&baz=bay')
+        );
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&baz=bay')));
+    }
 }

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -19,21 +19,24 @@ namespace Symfony\Component\HttpKernel;
 class UriSigner
 {
     private $secret;
+    private $parameter;
 
     /**
      * Constructor.
      *
-     * @param string $secret A secret
+     * @param string $secret    A secret
+     * @param string $parameter Query string parameter to use
      */
-    public function __construct($secret)
+    public function __construct($secret, $parameter = '_hash')
     {
         $this->secret = $secret;
+        $this->parameter = $parameter;
     }
 
     /**
      * Signs a URI.
      *
-     * The given URI is signed by adding a _hash query string parameter
+     * The given URI is signed by adding the query string parameter
      * which value depends on the URI and the secret.
      *
      * @param string $uri A URI to sign
@@ -51,13 +54,13 @@ class UriSigner
 
         $uri = $this->buildUrl($url, $params);
 
-        return $uri.(false === strpos($uri, '?') ? '?' : '&').'_hash='.$this->computeHash($uri);
+        return $uri.(false === strpos($uri, '?') ? '?' : '&').$this->parameter.'='.$this->computeHash($uri);
     }
 
     /**
      * Checks that a URI contains the correct hash.
      *
-     * The _hash query string parameter must be the last one
+     * The query string parameter must be the last one
      * (as it is generated that way by the sign() method, it should
      * never be a problem).
      *
@@ -74,12 +77,12 @@ class UriSigner
             $params = array();
         }
 
-        if (empty($params['_hash'])) {
+        if (empty($params[$this->parameter])) {
             return false;
         }
 
-        $hash = urlencode($params['_hash']);
-        unset($params['_hash']);
+        $hash = urlencode($params[$this->parameter]);
+        unset($params[$this->parameter]);
 
         return $this->computeHash($this->buildUrl($url, $params)) === $hash;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

`UriSigner` is currently restricting to using `_hash` as the query string parameter, this makes is customisable.