### PR TITLE
Adding use statement for InvalidArgumentException

### DIFF
--- a/src/Symfony/Component/Translation/TranslatorBagInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorBagInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Translation;
 
+use Symfony\Component\Translation\Exception\InvalidArgumentException;
+
 /**
  * TranslatorBagInterface.
  *

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Translation;
 
+use Symfony\Component\Translation\Exception\InvalidArgumentException;
+
 /**
  * TranslatorInterface.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This is a super minor bugfix. We should tell what InvalidArgumentException we throw. I consider this a bugfix and not a BC break because `Symfony\Component\Translation\Exception\InvalidArgumentException` has always been the intention.