### PR TITLE
[DI] Create autowired private services for FQCN invalid references

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -223,7 +223,7 @@ class AutowirePassTest extends TestCase
         $this->assertEquals(CollisionInterface::class, (string) $container->getDefinition('a')->getArgument(0));
     }
 
-    public function testCreateDefinition()
+    public function testCreateDefinitionFromTypeHint()
     {
         $container = new ContainerBuilder();
 
@@ -234,16 +234,43 @@ class AutowirePassTest extends TestCase
         $pass->process($container);
 
         $this->assertCount(1, $container->getDefinition('coop_tilleuls')->getArguments());
-        $this->assertEquals('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Dunglas', $container->getDefinition('coop_tilleuls')->getArgument(0));
+        $this->assertEquals(Dunglas::class, $container->getDefinition('coop_tilleuls')->getArgument(0));
 
-        $dunglasDefinition = $container->getDefinition('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Dunglas');
+        $dunglasDefinition = $container->getDefinition(Dunglas::class);
         $this->assertEquals(__NAMESPACE__.'\Dunglas', $dunglasDefinition->getClass());
+        $this->assertTrue($dunglasDefinition->isAutowired());
         $this->assertFalse($dunglasDefinition->isPublic());
+        $this->assertSame(array('autoregistered' => array(array())), $dunglasDefinition->getTags());
         $this->assertCount(1, $dunglasDefinition->getArguments());
-        $this->assertEquals('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Lille', $dunglasDefinition->getArgument(0));
+        $this->assertEquals(Lille::class, $dunglasDefinition->getArgument(0));
 
-        $lilleDefinition = $container->getDefinition('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Lille');
-        $this->assertEquals(__NAMESPACE__.'\Lille', $lilleDefinition->getClass());
+        $lilleDefinition = $container->getDefinition(Lille::class);
+        $this->assertEquals(Lille::class, $lilleDefinition->getClass());
+    }
+
+    public function testCreateDefinitionFromReference()
+    {
+        $container = new ContainerBuilder();
+
+        $coopTilleulsDefinition = $container->register('coop_tilleuls', LesTilleuls::class)
+            ->addArgument(new Reference(Dunglas::class));
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $this->assertCount(1, $container->getDefinition('coop_tilleuls')->getArguments());
+        $this->assertEquals(new Reference(Dunglas::class), $container->getDefinition('coop_tilleuls')->getArgument(0));
+
+        $dunglasDefinition = $container->getDefinition(Dunglas::class);
+        $this->assertEquals(Dunglas::class, $dunglasDefinition->getClass());
+        $this->assertTrue($dunglasDefinition->isAutowired());
+        $this->assertFalse($dunglasDefinition->isPublic());
+        $this->assertSame(array('autoregistered' => array(array())), $dunglasDefinition->getTags());
+        $this->assertCount(1, $dunglasDefinition->getArguments());
+        $this->assertEquals(Lille::class, $dunglasDefinition->getArgument(0));
+
+        $lilleDefinition = $container->getDefinition(Lille::class);
+        $this->assertEquals(Lille::class, $lilleDefinition->getClass());
     }
 
     public function testResolveParameter()
@@ -535,7 +562,7 @@ class AutowirePassTest extends TestCase
 
         $overridenGetters = $container->getDefinition('getter_overriding')->getOverriddenGetters();
         $this->assertEquals(array(
-            'abstractgetfoo' => new Reference('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Foo'),
+            'abstractgetfoo' => new Reference(Foo::class),
         ), $overridenGetters);
     }
 
@@ -559,8 +586,8 @@ class AutowirePassTest extends TestCase
         $overridenGetters = $container->getDefinition('getter_overriding')->getOverriddenGetters();
         $this->assertEquals(array(
             'getexplicitlydefined' => new Reference('b'),
-            'getfoo' => new Reference('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Foo'),
-            'getbar' => new Reference('autowired.Symfony\Component\DependencyInjection\Tests\Compiler\Bar'),
+            'getfoo' => new Reference(Foo::class),
+            'getbar' => new Reference(Bar::class),
         ), $overridenGetters);
     }
 
@@ -670,7 +697,7 @@ class AutowirePassTest extends TestCase
      * @dataProvider provideAutodiscoveredAutowiringOrder
      *
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMEssage Unable to autowire argument of type "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" for the service "a". Multiple services exist for this interface (autowired.Symfony\Component\DependencyInjection\Tests\Compiler\CollisionA, autowired.Symfony\Component\DependencyInjection\Tests\Compiler\CollisionB).
+     * @expectedExceptionMEssage Unable to autowire argument of type "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" for the service "a". Multiple services exist for this interface (Symfony\Component\DependencyInjection\Tests\Compiler\CollisionA, Symfony\Component\DependencyInjection\Tests\Compiler\CollisionB).
      */
     public function testAutodiscoveredAutowiringOrder($class)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR leverages to convention we now have for discovering services based on aliases & ids (i.e. id === php-type instead of autowiring types).
It allows one to reference a class, and get it automatically registered as a private and autowired service.
That's the missing mirror part to class-type-hints that are already automatically registered as a such.
So, two things here:
- the existing autoregistered services are renamed to pure FQCN ids (`autowired.` prefix removed) to match the "id === php-type" convention
- when a reference points to a non existing service, and this service is a FQCN, then a similar service is autoregistered (exact same code existing as for the previous case)

To allow identifying these autoregistered services, they now have an `autoregistered` tag.

Example of the new feature:
```yaml
services:
    my_service: ['@App\Foo']
```
=> an `App\Foo` service is automatically created if it does not exist already - private and autowired.

A missing part of the recent experience really.