### PR TITLE
[Security] fix Composer constraint

### DIFF
--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/security-core": "~2.6",
+        "symfony/security-core": "^2.7.13|^2.8.6",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": "~2.4",
         "symfony/http-kernel": "~2.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The `MAX_USERNAME_LENGTH` constant introduced by #18733 that is used in the `UsernamePasswordFormAuthenticationListener` was first part of Symfony 2.7.13 and 2.8.6.