### PR TITLE
[Security] context listener: hardening user provider handling

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -150,6 +150,8 @@ class ContextListener implements ListenerInterface
             return $token;
         }
 
+        $userNotFoundByProvider = false;
+
         foreach ($this->userProviders as $provider) {
             try {
                 $refreshedUser = $provider->refreshUser($user);
@@ -167,8 +169,12 @@ class ContextListener implements ListenerInterface
                     $this->logger->warning('Username could not be found in the selected user provider.', array('username' => $e->getUsername(), 'provider' => get_class($provider)));
                 }
 
-                return;
+                $userNotFoundByProvider = true;
             }
+        }
+
+        if ($userNotFoundByProvider) {
+            return;
         }
 
         throw new \RuntimeException(sprintf('There is no user provider for user "%s".', get_class($user)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4498
| License       | MIT
| Doc PR        | 

After the wrong fix in #21791 this is the second attempt to solve #4498. If more than one user provider support the user for the current context, all of them will be applied instead of returning prematurely when the first user provider does not find the logged in user.