### PR TITLE
[DI] Propagate instanceof-conditionals to autoregistered services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -518,6 +518,22 @@ class AutowirePassTest extends TestCase
         );
     }
 
+    public function testInstanceofConditionals()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('bar', Bar::class)
+            ->setAutowired(true)
+            ->setInstanceofConditionals(array(123 => 456))
+        ;
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $this->assertSame(array(123 => 456), $container->getDefinition('autowired.'.Foo::class)->getInstanceofConditionals());
+    }
+
     /**
      * @requires PHP 7.0
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Continuing my journey playing with upcoming 3.3 features, I noticed that "instanceof" conditionals should be propagated to the services that `AutowirePass` creates while discovering unreferenced type hints.

Best reviewed ignoring whitespaces:
https://github.com/symfony/symfony/pull/21872/files?w=1