### PR TITLE
[DI] Resolve invalid refs embedded in autowired defs by autoregistered services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -518,6 +518,22 @@ class AutowirePassTest extends TestCase
         );
     }
 
+    public function testInvalidReference()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('bar', Bar::class)
+            ->setAutowired(true)
+            ->setProperty('a', array(new Reference(A::class)))
+        ;
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $this->assertSame(A::class, $container->getDefinition('autowired.'.A::class)->getClass());
+    }
+
     /**
      * @requires PHP 7.0
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Best reviewed ignoring whitespaces:
https://github.com/symfony/symfony/pull/21873/files?w=1

With this, any "invalid" reference embedded in an autowired definition will trigger the creation of an autoregistered service, in the same way than discovered type hints create them.

This PR provides the same experience than #21859, but in a more focused way, respecting a core principle: if you don't ask explicitly for autowiring, you don't get any :)