### PR TITLE
Added setInputStream deprecation to UPGRADE guides

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -21,9 +21,9 @@ DependencyInjection
 ExpressionLanguage
 -------------------
 
-* Passing a `ParserCacheInterface` instance to the `ExpressionLanguage` has been
-  deprecated and will not be supported in Symfony 4.0. You should use the
-  `CacheItemPoolInterface` interface instead.
+ * Passing a `ParserCacheInterface` instance to the `ExpressionLanguage` has been
+   deprecated and will not be supported in Symfony 4.0. You should use the
+   `CacheItemPoolInterface` interface instead.
 
 Form
 ----

--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -11,6 +11,51 @@ Console
 
  * Setting unknown style options is deprecated and will throw an exception in
    Symfony 4.0.
+ * The `QuestionHelper::setInputStream()` method is deprecated and will be
+   removed in Symfony 4.0. Use `StreamableInputInterface::setStream()` or
+   `CommandTester::setInputs()` instead.
+
+   Before:
+
+   ```php
+   $input = new ArrayInput();
+
+   $questionHelper->setInputStream($stream);
+   $questionHelper->ask($input, $output, $question);
+   ```
+
+   After:
+
+   ```php
+   $input = new ArrayInput();
+   $input->setStream($stream);
+
+   $questionHelper->ask($input, $output, $question);
+   ```
+
+   Before:
+
+   ```php
+   $commandTester = new CommandTester($command);
+
+   $stream = fopen('php://memory', 'r+', false);
+   fputs($stream, "AppBundle\nYes");
+   rewind($stream);
+
+   $command->getHelper('question')->setInputStream($stream);
+
+   $commandTester->execute();
+   ```
+
+   After:
+
+   ```php
+   $commandTester = new CommandTester($command);
+
+   $commandTester->setInputs(array('AppBundle', 'Yes'));
+
+   $commandTester->execute();
+   ```
 
 DependencyInjection
 -------------------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -6,6 +6,51 @@ Console
 
  * Setting unknown style options is not supported anymore and throws an
    exception.
+ * The `QuestionHelper::setInputStream()` method is removed. Use
+   `StreamableInputInterface::setStream()` or `CommandTester::setInputs()`
+   instead.
+
+   Before:
+
+   ```php
+   $input = new ArrayInput();
+
+   $questionHelper->setInputStream($stream);
+   $questionHelper->ask($input, $output, $question);
+   ```
+
+   After:
+
+   ```php
+   $input = new ArrayInput();
+   $input->setStream($stream);
+
+   $questionHelper->ask($input, $output, $question);
+   ```
+
+   Before:
+
+   ```php
+   $commandTester = new CommandTester($command);
+
+   $stream = fopen('php://memory', 'r+', false);
+   fputs($stream, "AppBundle\nYes");
+   rewind($stream);
+
+   $command->getHelper('question')->setInputStream($stream);
+
+   $commandTester->execute();
+   ```
+
+   After:
+
+   ```php
+   $commandTester = new CommandTester($command);
+
+   $commandTester->setInputs(array('AppBundle', 'Yes'));
+
+   $commandTester->execute();
+   ```
 
 Debug
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The before/after examples of this deprecation is quite hard to figure out. Having them in the UPGRADE guides will significantly help the migration.