### PR TITLE
[Form] Hardened form type tests

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -29,13 +29,16 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Forms;
-use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTest;
+use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleAssociationToIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity;
 
-class EntityTypeTest extends TypeTestCase
+class EntityTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'entity';
+
     const ITEM_GROUP_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\GroupableEntity';
     const SINGLE_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity';
     const SINGLE_IDENT_NO_TO_STRING_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity';
@@ -116,7 +119,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testClassOptionIsRequired()
     {
-        $this->factory->createNamed('name', 'entity');
+        $this->factory->createNamed('name', static::TESTED_TYPE);
     }
 
     /**
@@ -124,7 +127,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testInvalidClassOption()
     {
-        $this->factory->createNamed('name', 'entity', null, array(
+        $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'class' => 'foo',
         ));
     }
@@ -136,7 +139,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -153,13 +156,14 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
-        ));
+        ))
+            ->createView();
 
-        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $view->vars['choices']);
     }
 
     public function testSetDataToUninitializedEntityWithNonRequiredQueryBuilder()
@@ -170,15 +174,16 @@ class EntityTypeTest extends TypeTestCase
         $this->persist(array($entity1, $entity2));
         $qb = $this->em->createQueryBuilder()->select('e')->from(self::SINGLE_IDENT_CLASS, 'e');
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
             'choice_label' => 'name',
             'query_builder' => $qb,
-        ));
+        ))
+            ->createView();
 
-        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $view->vars['choices']);
     }
 
     /**
@@ -186,7 +191,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testConfigureQueryBuilderWithNonQueryBuilderAndNonClosure()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => new \stdClass(),
@@ -198,7 +203,7 @@ class EntityTypeTest extends TypeTestCase
      */
     public function testConfigureQueryBuilderWithClosureReturningNonQueryBuilder()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function () {
@@ -211,7 +216,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSetDataSingleNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => false,
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
@@ -224,7 +229,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSetDataMultipleExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'em' => 'default',
@@ -238,7 +243,7 @@ class EntityTypeTest extends TypeTestCase
 
     public function testSetDataMultipleNonExpandedNull()
     {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -250,47 +255,6 @@ class EntityTypeTest extends TypeTestCase
         $this->assertSame(array(), $field->getViewData());
     }
 
-    public function testSubmitSingleExpandedNull()
-    {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
-            'multiple' => false,
-            'expanded' => true,
-            'em' => 'default',
-            'class' => self::SINGLE_IDENT_CLASS,
-        ));
-        $field->submit(null);
-
-        $this->assertNull($field->getData());
-        $this->assertSame('', $field->getViewData(), 'View data is always a string');
-    }
-
-    public function testSubmitSingleNonExpandedNull()
-    {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
-            'multiple' => false,
-            'expanded' => false,
-            'em' => 'default',
-            'class' => self::SINGLE_IDENT_CLASS,
-        ));
-        $field->submit(null);
-
-        $this->assertNull($field->getData());
-        $this->assertSame('', $field->getViewData());
-    }
-
-    public function testSubmitMultipleNull()
-    {
-        $field = $this->factory->createNamed('name', 'entity', null, array(
-            'multiple' => true,
-            'em' => 'default',
-            'class' => self::SINGLE_IDENT_CLASS,
-        ));
-        $field->submit(null);
-
-        $this->assertEquals(new ArrayCollection(), $field->getData());
-        $this->assertSame(array(), $field->getViewData());
-    }
-
     public function testSubmitSingleNonExpandedSingleIdentifier()
     {
         $entity1 = new SingleIntIdEntity(1, 'Foo');
@@ -298,7 +262,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -323,7 +287,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($innerEntity1, $innerEntity2, $entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -345,7 +309,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -369,7 +333,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -398,7 +362,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($innerEntity1, $innerEntity2, $innerEntity3, $entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -423,7 +387,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -454,7 +418,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -480,7 +444,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -510,7 +474,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'em' => 'default',
@@ -536,7 +500,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'em' => 'default',
@@ -565,7 +529,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'em' => 'default',
@@ -590,7 +554,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -612,7 +576,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'em' => 'default',
@@ -638,7 +602,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -669,7 +633,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => 'default',
@@ -694,7 +658,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'em' => 'default',
@@ -724,7 +688,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             // not all persisted entities should be displayed
@@ -747,7 +711,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'choice_label' => 'name',
@@ -769,7 +733,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::ITEM_GROUP_CLASS,
             'choice_label' => 'name',
@@ -800,7 +764,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'choice_label' => 'name',
@@ -826,7 +790,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($item1, $item2, $item3, $item4));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::ITEM_GROUP_CLASS,
             'choices' => array($item1, $item2, $item3, $item4),
@@ -857,7 +821,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'preferred_choices' => array($entity3, $entity2),
@@ -876,7 +840,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'choices' => array($entity2, $entity3),
@@ -896,7 +860,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'choices' => array($entity1, $entity2),
@@ -919,7 +883,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($innerEntity1, $innerEntity2, $entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_ASSOC_IDENT_CLASS,
             'choices' => array($entity1, $entity2),
@@ -940,7 +904,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::COMPOSITE_IDENT_CLASS,
             'choices' => array($entity1, $entity2),
@@ -963,7 +927,7 @@ class EntityTypeTest extends TypeTestCase
 
         $repository = $this->em->getRepository(self::SINGLE_IDENT_CLASS);
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => $repository->createQueryBuilder('e')
@@ -991,7 +955,7 @@ class EntityTypeTest extends TypeTestCase
 
         $repository = $this->em->getRepository(self::SINGLE_ASSOC_IDENT_CLASS);
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_ASSOC_IDENT_CLASS,
             'query_builder' => $repository->createQueryBuilder('e')
@@ -1013,10 +977,10 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
-            'query_builder' => function ($repository) {
+            'query_builder' => function (EntityRepository $repository) {
                 return $repository->createQueryBuilder('e')
                     ->where('e.id IN (1, 2)');
             },
@@ -1037,10 +1001,10 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::COMPOSITE_IDENT_CLASS,
-            'query_builder' => function ($repository) {
+            'query_builder' => function (EntityRepository $repository) {
                 return $repository->createQueryBuilder('e')
                     ->where('e.id1 IN (10, 50)');
             },
@@ -1059,7 +1023,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -1080,7 +1044,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => 'default',
@@ -1106,7 +1070,7 @@ class EntityTypeTest extends TypeTestCase
             ->with(self::SINGLE_IDENT_CLASS)
             ->will($this->returnValue($this->em));
 
-        $this->factory->createNamed('name', 'entity', null, array(
+        $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
             'choice_label' => 'name',
@@ -1121,7 +1085,7 @@ class EntityTypeTest extends TypeTestCase
         $this->emRegistry->expects($this->never())
             ->method('getManagerForClass');
 
-        $this->factory->createNamed('name', 'entity', null, array(
+        $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             'choice_label' => 'name',
@@ -1150,15 +1114,15 @@ class EntityTypeTest extends TypeTestCase
             ->addTypeGuesser($entityTypeGuesser)
             ->getFormFactory();
 
-        $formBuilder = $factory->createNamedBuilder('form', 'form');
+        $formBuilder = $factory->createNamedBuilder('form', FormTypeTest::TESTED_TYPE);
 
-        $formBuilder->add('property1', 'entity', array(
+        $formBuilder->add('property1', static::TESTED_TYPE, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => $repo->createQueryBuilder('e')->where('e.id IN (1, 2)'),
         ));
 
-        $formBuilder->add('property2', 'entity', array(
+        $formBuilder->add('property2', static::TESTED_TYPE, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function (EntityRepository $repo) {
@@ -1166,7 +1130,7 @@ class EntityTypeTest extends TypeTestCase
             },
         ));
 
-        $formBuilder->add('property3', 'entity', array(
+        $formBuilder->add('property3', static::TESTED_TYPE, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function (EntityRepository $repo) {
@@ -1213,15 +1177,15 @@ class EntityTypeTest extends TypeTestCase
             ->addTypeGuesser($entityTypeGuesser)
             ->getFormFactory();
 
-        $formBuilder = $factory->createNamedBuilder('form', 'form');
+        $formBuilder = $factory->createNamedBuilder('form', FormTypeTest::TESTED_TYPE);
 
-        $formBuilder->add('property1', 'entity', array(
+        $formBuilder->add('property1', static::TESTED_TYPE, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => $repo->createQueryBuilder('e')->where('e.id = :id')->setParameter('id', 1),
         ));
 
-        $formBuilder->add('property2', 'entity', array(
+        $formBuilder->add('property2', static::TESTED_TYPE, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function (EntityRepository $repo) {
@@ -1229,7 +1193,7 @@ class EntityTypeTest extends TypeTestCase
             },
         ));
 
-        $formBuilder->add('property3', 'entity', array(
+        $formBuilder->add('property3', static::TESTED_TYPE, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function (EntityRepository $repo) {
@@ -1260,14 +1224,14 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1));
 
-        $field1 = $this->factory->createNamed('name', 'entity', null, array(
+        $field1 = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
             'choice_label' => 'name',
         ));
 
-        $field2 = $this->factory->createNamed('name', 'entity', null, array(
+        $field2 = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
@@ -1288,14 +1252,15 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'entity', null, array(
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'required' => false,
             'property' => 'name',
-        ));
+        ))
+            ->createView();
 
-        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $view->vars['choices']);
     }
 
     protected function createRegistryMock($name, $em)
@@ -1307,5 +1272,214 @@ class EntityTypeTest extends TypeTestCase
             ->will($this->returnValue($em));
 
         return $registry;
+    }
+
+    public function testPassDisabledAsOption()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'disabled' => true,
+            'class' => self::SINGLE_IDENT_CLASS,
+        ));
+
+        $this->assertTrue($form->isDisabled());
+    }
+
+    public function testPassIdAndNameToView()
+    {
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+        ))
+            ->createView();
+
+        $this->assertEquals('name', $view->vars['id']);
+        $this->assertEquals('name', $view->vars['name']);
+        $this->assertEquals('name', $view->vars['full_name']);
+    }
+
+    public function testStripLeadingUnderscoresAndDigitsFromId()
+    {
+        $view = $this->factory->createNamed('_09name', static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+        ))
+            ->createView();
+
+        $this->assertEquals('name', $view->vars['id']);
+        $this->assertEquals('_09name', $view->vars['name']);
+        $this->assertEquals('_09name', $view->vars['full_name']);
+    }
+
+    public function testPassIdAndNameToViewWithParent()
+    {
+        $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
+            ->add('child', static::TESTED_TYPE, array(
+                'em' => 'default',
+                'class' => self::SINGLE_IDENT_CLASS,
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals('parent_child', $view['child']->vars['id']);
+        $this->assertEquals('child', $view['child']->vars['name']);
+        $this->assertEquals('parent[child]', $view['child']->vars['full_name']);
+    }
+
+    public function testPassIdAndNameToViewWithGrandParent()
+    {
+        $builder = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
+            ->add('child', FormTypeTest::TESTED_TYPE);
+        $builder->get('child')->add('grand_child', static::TESTED_TYPE, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+        ));
+        $view = $builder->getForm()->createView();
+
+        $this->assertEquals('parent_child_grand_child', $view['child']['grand_child']->vars['id']);
+        $this->assertEquals('grand_child', $view['child']['grand_child']->vars['name']);
+        $this->assertEquals('parent[child][grand_child]', $view['child']['grand_child']->vars['full_name']);
+    }
+
+    public function testPassTranslationDomainToView()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'translation_domain' => 'domain',
+        ))
+            ->createView();
+
+        $this->assertSame('domain', $view->vars['translation_domain']);
+    }
+
+    public function testInheritTranslationDomainFromParent()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
+                'translation_domain' => 'domain',
+            ))
+            ->add('child', static::TESTED_TYPE, array(
+                'em' => 'default',
+                'class' => self::SINGLE_IDENT_CLASS,
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals('domain', $view['child']->vars['translation_domain']);
+    }
+
+    public function testPreferOwnTranslationDomain()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
+                'translation_domain' => 'parent_domain',
+            ))
+            ->add('child', static::TESTED_TYPE, array(
+                'em' => 'default',
+                'class' => self::SINGLE_IDENT_CLASS,
+                'translation_domain' => 'domain',
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals('domain', $view['child']->vars['translation_domain']);
+    }
+
+    public function testDefaultTranslationDomain()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
+            ->add('child', static::TESTED_TYPE, array(
+                'em' => 'default',
+                'class' => self::SINGLE_IDENT_CLASS,
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertNull($view['child']->vars['translation_domain']);
+    }
+
+    public function testPassLabelToView()
+    {
+        $view = $this->factory->createNamed('__test___field', static::TESTED_TYPE, null, array(
+            'label' => 'My label',
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+        ))
+            ->createView();
+
+        $this->assertSame('My label', $view->vars['label']);
+    }
+
+    public function testPassMultipartFalseToView()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+        ))
+            ->createView();
+
+        $this->assertFalse($view->vars['multipart']);
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+        ));
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
+        $this->assertSame('', $form->getViewData(), 'View data is always a string');
+    }
+
+    public function testSubmitNullExpanded()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'expanded' => true,
+        ));
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
+        $this->assertSame('', $form->getViewData(), 'View data is always a string');
+    }
+
+    public function testSubmitNullMultiple()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'multiple' => true,
+        ));
+        $form->submit(null);
+
+        $collection = new ArrayCollection();
+
+        $this->assertEquals($collection, $form->getData());
+        $this->assertEquals($collection, $form->getNormData());
+        $this->assertSame(array(), $form->getViewData(), 'View data is always an array');
+    }
+
+    public function testSubmitNullExpandedMultiple()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'expanded' => true,
+            'multiple' => true,
+        ));
+        $form->submit(null);
+
+        $collection = new ArrayCollection();
+
+        $this->assertEquals($collection, $form->getData());
+        $this->assertEquals($collection, $form->getNormData());
+        $this->assertSame(array(), $form->getViewData(), 'View data is always an array');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\Test\TypeTestCase;
  */
 abstract class BaseTypeTest extends TypeTestCase
 {
+    const TESTED_TYPE = '';
+
     public function testPassDisabledAsOption()
     {
         $form = $this->factory->create($this->getTestedType(), null, array('disabled' => true));
@@ -47,7 +49,7 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassIdAndNameToViewWithParent()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
+        $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
             ->add('child', $this->getTestedType())
             ->getForm()
             ->createView();
@@ -59,8 +61,8 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassIdAndNameToViewWithGrandParent()
     {
-        $builder = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form');
+        $builder = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
+            ->add('child', FormTypeTest::TESTED_TYPE);
         $builder->get('child')->add('grand_child', $this->getTestedType());
         $view = $builder->getForm()->createView();
 
@@ -71,10 +73,10 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassTranslationDomainToView()
     {
-        $form = $this->factory->create($this->getTestedType(), null, array(
+        $view = $this->factory->create($this->getTestedType(), null, array(
             'translation_domain' => 'domain',
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame('domain', $view->vars['translation_domain']);
     }
@@ -82,7 +84,7 @@ abstract class BaseTypeTest extends TypeTestCase
     public function testInheritTranslationDomainFromParent()
     {
         $view = $this->factory
-            ->createNamedBuilder('parent', 'form', null, array(
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
                 'translation_domain' => 'domain',
             ))
             ->add('child', $this->getTestedType())
@@ -95,7 +97,7 @@ abstract class BaseTypeTest extends TypeTestCase
     public function testPreferOwnTranslationDomain()
     {
         $view = $this->factory
-            ->createNamedBuilder('parent', 'form', null, array(
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
                 'translation_domain' => 'parent_domain',
             ))
             ->add('child', $this->getTestedType(), array(
@@ -109,7 +111,7 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testDefaultTranslationDomain()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
+        $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
             ->add('child', $this->getTestedType())
             ->getForm()
             ->createView();
@@ -119,19 +121,32 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassLabelToView()
     {
-        $form = $this->factory->createNamed('__test___field', $this->getTestedType(), null, array('label' => 'My label'));
-        $view = $form->createView();
+        $view = $this->factory->createNamed('__test___field', $this->getTestedType(), null, array('label' => 'My label'))
+            ->createView();
 
         $this->assertSame('My label', $view->vars['label']);
     }
 
     public function testPassMultipartFalseToView()
     {
-        $form = $this->factory->create($this->getTestedType());
-        $view = $form->createView();
+        $view = $this->factory->create($this->getTestedType())
+            ->createView();
 
         $this->assertFalse($view->vars['multipart']);
     }
 
-    abstract protected function getTestedType();
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        $form = $this->factory->create($this->getTestedType());
+        $form->submit(null);
+
+        $this->assertSame($expected, $form->getData());
+        $this->assertSame($norm, $form->getNormData());
+        $this->assertSame($view, $form->getViewData());
+    }
+
+    protected function getTestedType()
+    {
+        return static::TESTED_TYPE;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -14,20 +14,17 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 /**
  * @author Stepan Anchugov <kixxx1@gmail.com>
  */
-class BirthdayTypeTest extends BaseTypeTest
+class BirthdayTypeTest extends DateTypeTest
 {
+    const TESTED_TYPE = 'birthday';
+
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testSetInvalidYearsOption()
     {
-        $this->factory->create('birthday', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'years' => 'bad value',
         ));
-    }
-
-    protected function getTestedType()
-    {
-        return 'birthday';
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
@@ -16,13 +16,10 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
  */
 class ButtonTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'button';
+
     public function testCreateButtonInstances()
     {
-        $this->assertInstanceOf('Symfony\Component\Form\Button', $this->factory->create('button'));
-    }
-
-    protected function getTestedType()
-    {
-        return 'button';
+        $this->assertInstanceOf('Symfony\Component\Form\Button', $this->factory->create(static::TESTED_TYPE));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -12,13 +12,14 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\CallbackTransformer;
-use Symfony\Component\Form\Test\TypeTestCase;
 
-class CheckboxTypeTest extends TypeTestCase
+class CheckboxTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'checkbox';
+
     public function testDataIsFalseByDefault()
     {
-        $form = $this->factory->create('checkbox');
+        $form = $this->factory->create(static::TESTED_TYPE);
 
         $this->assertFalse($form->getData());
         $this->assertFalse($form->getNormData());
@@ -27,42 +28,42 @@ class CheckboxTypeTest extends TypeTestCase
 
     public function testPassValueToView()
     {
-        $form = $this->factory->create('checkbox', null, array('value' => 'foobar'));
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE, null, array('value' => 'foobar'))
+            ->createView();
 
         $this->assertEquals('foobar', $view->vars['value']);
     }
 
     public function testCheckedIfDataTrue()
     {
-        $form = $this->factory->create('checkbox');
-        $form->setData(true);
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE)
+            ->setData(true)
+            ->createView();
 
         $this->assertTrue($view->vars['checked']);
     }
 
     public function testCheckedIfDataTrueWithEmptyValue()
     {
-        $form = $this->factory->create('checkbox', null, array('value' => ''));
-        $form->setData(true);
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE, null, array('value' => ''))
+            ->setData(true)
+            ->createView();
 
         $this->assertTrue($view->vars['checked']);
     }
 
     public function testNotCheckedIfDataFalse()
     {
-        $form = $this->factory->create('checkbox');
-        $form->setData(false);
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE)
+            ->setData(false)
+            ->createView();
 
         $this->assertFalse($view->vars['checked']);
     }
 
     public function testSubmitWithValueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'value' => 'foobar',
         ));
         $form->submit('foobar');
@@ -73,7 +74,7 @@ class CheckboxTypeTest extends TypeTestCase
 
     public function testSubmitWithRandomValueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'value' => 'foobar',
         ));
         $form->submit('krixikraxi');
@@ -84,7 +85,7 @@ class CheckboxTypeTest extends TypeTestCase
 
     public function testSubmitWithValueUnchecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'value' => 'foobar',
         ));
         $form->submit(null);
@@ -95,7 +96,7 @@ class CheckboxTypeTest extends TypeTestCase
 
     public function testSubmitWithEmptyValueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'value' => '',
         ));
         $form->submit('');
@@ -106,7 +107,7 @@ class CheckboxTypeTest extends TypeTestCase
 
     public function testSubmitWithEmptyValueUnchecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'value' => '',
         ));
         $form->submit(null);
@@ -117,7 +118,7 @@ class CheckboxTypeTest extends TypeTestCase
 
     public function testSubmitWithEmptyValueAndFalseUnchecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'value' => '',
         ));
         $form->submit(false);
@@ -128,7 +129,7 @@ class CheckboxTypeTest extends TypeTestCase
 
     public function testSubmitWithEmptyValueAndTrueChecked()
     {
-        $form = $this->factory->create('checkbox', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'value' => '',
         ));
         $form->submit(true);
@@ -152,7 +153,7 @@ class CheckboxTypeTest extends TypeTestCase
             }
         );
 
-        $form = $this->factory->createBuilder('checkbox')
+        $form = $this->factory->createBuilder(static::TESTED_TYPE)
             ->addModelTransformer($transformer)
             ->getForm();
 
@@ -170,5 +171,10 @@ class CheckboxTypeTest extends TypeTestCase
             array('checked', true),
             array('unchecked', false),
         );
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull(false, false, null);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -14,11 +14,12 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Tests\Fixtures\ChoiceSubType;
 
-class ChoiceTypeTest extends TypeTestCase
+class ChoiceTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'choice';
+
     private $choices = array(
         'Bernhard' => 'a',
         'Fabien' => 'b',
@@ -98,7 +99,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testChoicesOptionExpectsArrayOrTraversable()
     {
-        $this->factory->create('choice', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => new \stdClass(),
         ));
     }
@@ -108,7 +109,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testChoiceListOptionExpectsChoiceListInterface()
     {
-        $this->factory->create('choice', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'choice_list' => array('foo' => 'foo'),
         ));
     }
@@ -118,19 +119,21 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testChoiceLoaderOptionExpectsChoiceLoaderInterface()
     {
-        $this->factory->create('choice', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'choice_loader' => new \stdClass(),
         ));
     }
 
     public function testChoiceListAndChoicesCanBeEmpty()
     {
-        $this->factory->create('choice');
+        $this->factory->create(static::TESTED_TYPE, null, array(
+            'choices_as_values' => true,
+        ));
     }
 
     public function testExpandedChoicesOptionsTurnIntoChildren()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'expanded' => true,
             'choices' => $this->choices,
             'choices_as_values' => true,
@@ -144,7 +147,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testExpandedFlippedChoicesOptionsTurnIntoChildren()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'expanded' => true,
             'choices' => array_flip($this->choices),
         ));
@@ -154,7 +157,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testChoiceListWithScalarValues()
     {
-        $view = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $this->scalarChoices,
             'choices_as_values' => true,
         ))->createView();
@@ -169,7 +172,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testChoiceListWithScalarValuesAndFalseAsPreSetData()
     {
-        $view = $this->factory->create('choice', false, array(
+        $view = $this->factory->create(static::TESTED_TYPE, false, array(
             'choices' => $this->scalarChoices,
             'choices_as_values' => true,
         ))->createView();
@@ -179,7 +182,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testExpandedChoiceListWithScalarValues()
     {
-        $view = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $this->scalarChoices,
             'choices_as_values' => true,
             'expanded' => true,
@@ -192,7 +195,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testExpandedChoiceListWithBooleanAndNullValues()
     {
-        $view = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $this->booleanChoicesWithNull,
             'choices_as_values' => true,
             'expanded' => true,
@@ -205,7 +208,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testExpandedChoiceListWithScalarValuesAndFalseAsPreSetData()
     {
-        $view = $this->factory->create('choice', false, array(
+        $view = $this->factory->create(static::TESTED_TYPE, false, array(
             'choices' => $this->scalarChoices,
             'choices_as_values' => true,
             'expanded' => true,
@@ -219,7 +222,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testExpandedChoiceListWithBooleanAndNullValuesAndFalseAsPreSetData()
     {
-        $view = $this->factory->create('choice', false, array(
+        $view = $this->factory->create(static::TESTED_TYPE, false, array(
             'choices' => $this->booleanChoicesWithNull,
             'choices_as_values' => true,
             'expanded' => true,
@@ -232,7 +235,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPlaceholderPresentOnNonRequiredExpandedSingleChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -246,7 +249,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPlaceholderNotPresentIfRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -260,7 +263,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPlaceholderNotPresentIfMultiple()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'required' => false,
@@ -274,7 +277,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPlaceholderNotPresentIfEmptyChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -291,7 +294,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPlaceholderWithBooleanChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'required' => false,
@@ -301,9 +304,8 @@ class ChoiceTypeTest extends TypeTestCase
             ),
             'placeholder' => 'Select an option',
             'choices_as_values' => true,
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame('', $view->vars['value'], 'Value should be empty');
         $this->assertSame('1', $view->vars['choices'][0]->value);
@@ -313,7 +315,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPlaceholderWithBooleanChoicesWithFalseAsPreSetData()
     {
-        $form = $this->factory->create('choice', false, array(
+        $view = $this->factory->create(static::TESTED_TYPE, false, array(
             'multiple' => false,
             'expanded' => false,
             'required' => false,
@@ -323,9 +325,8 @@ class ChoiceTypeTest extends TypeTestCase
             ),
             'placeholder' => 'Select an option',
             'choices_as_values' => true,
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame('0', $view->vars['value'], 'Value should be "0"');
         $this->assertSame('1', $view->vars['choices'][0]->value);
@@ -335,7 +336,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPlaceholderWithExpandedBooleanChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -360,7 +361,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPlaceholderWithExpandedBooleanChoicesAndWithFalseAsPreSetData()
     {
-        $form = $this->factory->create('choice', false, array(
+        $form = $this->factory->create(static::TESTED_TYPE, false, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -385,7 +386,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testExpandedChoicesOptionsAreFlattened()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'expanded' => true,
             'choices' => $this->groupedChoices,
             'choices_as_values' => true,
@@ -408,7 +409,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testExpandedChoicesFlippedOptionsAreFlattened()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'expanded' => true,
             'choices' => $this->groupedChoicesFlipped,
         ));
@@ -433,7 +434,7 @@ class ChoiceTypeTest extends TypeTestCase
         $obj4 = (object) array('id' => 4, 'name' => 'Jon');
         $obj5 = (object) array('id' => 5, 'name' => 'Roman');
 
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'expanded' => true,
             'choices' => array(
                 'Symfony' => array($obj1, $obj2, $obj3),
@@ -453,7 +454,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testExpandedCheckboxesAreNeverRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'required' => true,
@@ -468,7 +469,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testExpandedRadiosAreRequiredIfChoiceChildIsRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -483,7 +484,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testExpandedRadiosAreNotRequiredIfChoiceChildIsNotRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -498,7 +499,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleNonExpanded()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -514,7 +515,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleNonExpandedInvalidChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -530,7 +531,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleNonExpandedNull()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -547,9 +548,9 @@ class ChoiceTypeTest extends TypeTestCase
     // In edge cases (for example, when choices are loaded dynamically by a
     // loader), the choices may be empty. Make sure to behave the same as when
     // choices are available.
-    public function testSubmitSingleNonExpandedNullNoChoices()
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(),
@@ -559,13 +560,14 @@ class ChoiceTypeTest extends TypeTestCase
         $form->submit(null);
 
         $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
         $this->assertSame('', $form->getViewData());
         $this->assertTrue($form->isSynchronized());
     }
 
     public function testSubmitSingleNonExpandedEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -581,7 +583,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleNonExpandedEmptyExplicitEmptyChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(
@@ -605,7 +607,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitSingleNonExpandedEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(),
@@ -621,7 +623,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleNonExpandedFalse()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -640,7 +642,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitSingleNonExpandedFalseNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array(),
@@ -656,7 +658,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->objectChoices,
@@ -675,7 +677,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleChoiceWithEmptyData()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => array('test'),
@@ -690,7 +692,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleChoiceWithEmptyData()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => array('test'),
@@ -705,7 +707,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleChoiceExpandedWithEmptyData()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'choices' => array('test'),
@@ -720,7 +722,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleChoiceExpandedWithEmptyData()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => array('test'),
@@ -738,7 +740,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testLegacyNullChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => null,
@@ -753,7 +755,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testLegacySubmitSingleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choice_list' => new ObjectChoiceList(
@@ -777,7 +779,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleNonExpanded()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -793,7 +795,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleNonExpandedEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -812,7 +814,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitMultipleNonExpandedEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => array(),
@@ -828,7 +830,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleNonExpandedInvalidScalarChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -844,7 +846,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleNonExpandedInvalidArrayChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -860,7 +862,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->objectChoices,
@@ -881,7 +883,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testLegacySubmitMultipleNonExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choice_list' => new ObjectChoiceList(
@@ -904,7 +906,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -933,7 +935,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedRequiredInvalidChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -962,7 +964,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedNonRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -993,7 +995,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredInvalidChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -1022,7 +1024,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedRequiredNull()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -1054,7 +1056,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedRequiredNullNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -1072,7 +1074,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedRequiredEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -1104,7 +1106,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedRequiredEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -1122,7 +1124,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedRequiredFalse()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -1154,7 +1156,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedRequiredFalseNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -1172,7 +1174,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredNull()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -1206,7 +1208,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedNonRequiredNullNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -1224,7 +1226,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -1258,7 +1260,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedNonRequiredEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -1276,7 +1278,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedNonRequiredFalse()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -1310,7 +1312,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitSingleExpandedNonRequiredFalseNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -1328,7 +1330,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedWithEmptyChild()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'choices' => array(
@@ -1351,7 +1353,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitSingleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'choices' => $this->objectChoices,
@@ -1382,7 +1384,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testLegacySubmitSingleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'choice_list' => new ObjectChoiceList(
@@ -1418,7 +1420,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testSubmitSingleExpandedNumericChoicesFlipped()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => true,
             'choices' => $this->numericChoicesFlipped,
@@ -1443,7 +1445,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleExpanded()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1471,7 +1473,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleExpandedInvalidScalarChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1499,7 +1501,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleExpandedInvalidArrayChoice()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1527,7 +1529,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleExpandedEmpty()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -1556,7 +1558,7 @@ class ChoiceTypeTest extends TypeTestCase
     // choices are available.
     public function testSubmitMultipleExpandedEmptyNoChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => array(),
@@ -1571,7 +1573,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleExpandedWithEmptyChild()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => array(
@@ -1597,7 +1599,7 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSubmitMultipleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->objectChoices,
@@ -1628,7 +1630,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testLegacySubmitMultipleExpandedObjectChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choice_list' => new ObjectChoiceList(
@@ -1664,7 +1666,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testSubmitMultipleExpandedNumericChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->numericChoicesFlipped,
@@ -1689,16 +1691,17 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testSingleSelectedObjectChoices()
     {
-        $form = $this->factory->create('choice', $this->objectChoices[3], array(
+        $view = $this->factory->create(static::TESTED_TYPE, $this->objectChoices[3], array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->objectChoices,
             'choices_as_values' => true,
             'choice_label' => 'name',
             'choice_value' => 'id',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
+        /** @var callable $selectedChecker */
         $selectedChecker = $view->vars['is_selected'];
 
         $this->assertTrue($selectedChecker($view->vars['choices'][3]->value, $view->vars['value']));
@@ -1707,16 +1710,17 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testMultipleSelectedObjectChoices()
     {
-        $form = $this->factory->create('choice', array($this->objectChoices[3]), array(
+        $view = $this->factory->create(static::TESTED_TYPE, array($this->objectChoices[3]), array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->objectChoices,
             'choices_as_values' => true,
             'choice_label' => 'name',
             'choice_value' => 'id',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
+        /** @var callable $selectedChecker */
         $selectedChecker = $view->vars['is_selected'];
 
         $this->assertTrue($selectedChecker($view->vars['choices'][3]->value, $view->vars['value']));
@@ -1731,7 +1735,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testSetDataSingleNonExpandedAcceptsBoolean()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->numericChoicesFlipped,
@@ -1749,7 +1753,7 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testSetDataMultipleNonExpandedAcceptsBoolean()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->numericChoicesFlipped,
@@ -1764,82 +1768,82 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPassRequiredToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertTrue($view->vars['required']);
     }
 
     public function testPassNonRequiredToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => false,
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertFalse($view->vars['required']);
     }
 
     public function testPassMultipleToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertTrue($view->vars['multiple']);
     }
 
     public function testPassExpandedToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'expanded' => true,
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertTrue($view->vars['expanded']);
     }
 
     public function testPassChoiceTranslationDomainToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertNull($view->vars['choice_translation_domain']);
     }
 
     public function testChoiceTranslationDomainWithTrueValueToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $this->choices,
             'choices_as_values' => true,
             'choice_translation_domain' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertNull($view->vars['choice_translation_domain']);
     }
 
     public function testDefaultChoiceTranslationDomainIsSameAsTranslationDomainToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $this->choices,
             'choices_as_values' => true,
             'translation_domain' => 'foo',
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals('foo', $view->vars['choice_translation_domain']);
     }
@@ -1847,10 +1851,12 @@ class ChoiceTypeTest extends TypeTestCase
     public function testInheritChoiceTranslationDomainFromParent()
     {
         $view = $this->factory
-            ->createNamedBuilder('parent', 'form', null, array(
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
                 'translation_domain' => 'domain',
             ))
-            ->add('child', 'choice')
+            ->add('child', static::TESTED_TYPE, array(
+                'choices_as_values' => true,
+            ))
             ->getForm()
             ->createView();
 
@@ -1859,26 +1865,26 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPlaceholderIsNullByDefaultIfRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'required' => true,
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertNull($view->vars['placeholder']);
     }
 
     public function testPlaceholderIsEmptyStringByDefaultIfNotRequired()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'required' => false,
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame('', $view->vars['placeholder']);
     }
@@ -1888,15 +1894,15 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testPassPlaceholderToView($multiple, $expanded, $required, $placeholder, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
             'placeholder' => $placeholder,
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame($viewValue, $view->vars['placeholder']);
         $this->assertFalse($view->vars['placeholder_in_choices']);
@@ -1908,15 +1914,15 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testPassEmptyValueBC($multiple, $expanded, $required, $placeholder, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
             'empty_value' => $placeholder,
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame($viewValue, $view->vars['placeholder']);
         $this->assertFalse($view->vars['placeholder_in_choices']);
@@ -1929,15 +1935,15 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testDontPassPlaceholderIfContainedInChoices($multiple, $expanded, $required, $placeholder, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
             'placeholder' => $placeholder,
             'choices' => array('Empty' => '', 'A' => 'a'),
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertNull($view->vars['placeholder']);
         $this->assertTrue($view->vars['placeholder_in_choices']);
@@ -1993,15 +1999,15 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testPlaceholderOptionWithEmptyValueOption($multiple, $expanded, $required, $placeholder, $emptyValue, $viewValue)
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => $multiple,
             'expanded' => $expanded,
             'required' => $required,
             'placeholder' => $placeholder,
             'empty_value' => $emptyValue,
             'choices' => $this->choices,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame($viewValue, $view->vars['placeholder']);
         $this->assertFalse($view->vars['placeholder_in_choices']);
@@ -2115,11 +2121,11 @@ class ChoiceTypeTest extends TypeTestCase
     public function testPassChoicesToView()
     {
         $choices = array('A' => 'a', 'B' => 'b', 'C' => 'c', 'D' => 'd');
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals(array(
             new ChoiceView('a', 'a', 'A'),
@@ -2132,12 +2138,12 @@ class ChoiceTypeTest extends TypeTestCase
     public function testPassPreferredChoicesToView()
     {
         $choices = array('A' => 'a', 'B' => 'b', 'C' => 'c', 'D' => 'd');
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $choices,
             'choices_as_values' => true,
             'preferred_choices' => array('b', 'd'),
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals(array(
             0 => new ChoiceView('a', 'a', 'A'),
@@ -2151,12 +2157,12 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testPassHierarchicalChoicesToView()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $this->groupedChoices,
             'choices_as_values' => true,
             'preferred_choices' => array('b', 'd'),
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals(array(
             'Symfony' => new ChoiceGroupView('Symfony', array(
@@ -2183,13 +2189,13 @@ class ChoiceTypeTest extends TypeTestCase
         $obj2 = (object) array('value' => 'b', 'label' => 'B');
         $obj3 = (object) array('value' => 'c', 'label' => 'C');
         $obj4 = (object) array('value' => 'd', 'label' => 'D');
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => array($obj1, $obj2, $obj3, $obj4),
             'choices_as_values' => true,
             'choice_label' => 'label',
             'choice_value' => 'value',
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals(array(
             new ChoiceView($obj1, 'a', 'A'),
@@ -2204,10 +2210,10 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testDuplicateChoiceLabels()
     {
-        $form = $this->factory->create('choice', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => array('a' => 'A', 'b' => 'B', 'c' => 'A'),
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals(array(
             new ChoiceView('a', 'a', 'A'),
@@ -2218,13 +2224,13 @@ class ChoiceTypeTest extends TypeTestCase
 
     public function testAdjustFullNameForMultipleNonExpanded()
     {
-        $form = $this->factory->createNamed('name', 'choice', null, array(
+        $view = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
             'choices_as_values' => true,
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame('name[]', $view->vars['full_name']);
     }
@@ -2232,7 +2238,7 @@ class ChoiceTypeTest extends TypeTestCase
     // https://github.com/symfony/symfony/issues/3298
     public function testInitializeWithEmptyChoices()
     {
-        $this->factory->createNamed('name', 'choice', null, array(
+        $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'choices' => array(),
             'choices_as_values' => true,
         ));
@@ -2245,7 +2251,7 @@ class ChoiceTypeTest extends TypeTestCase
         $obj3 = (object) array('value' => 'c', 'label' => 'C');
         $obj4 = (object) array('value' => 'd', 'label' => 'D');
 
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => array($obj1, $obj2, $obj3, $obj4),
             'choices_as_values' => true,
             'choice_label' => 'label',
@@ -2256,7 +2262,7 @@ class ChoiceTypeTest extends TypeTestCase
         ));
 
         // Trigger data initialization
-        $form->getViewData();
+        $this->assertSame('c', $form->getViewData());
     }
 
     /**
@@ -2269,11 +2275,12 @@ class ChoiceTypeTest extends TypeTestCase
     public function testCustomChoiceTypeDoesNotInheritChoiceLabels()
     {
         $builder = $this->factory->createBuilder();
-        $builder->add('choice', 'choice', array(
+        $builder->add('choice', static::TESTED_TYPE, array(
                 'choices' => array(
                     '1' => '1',
                     '2' => '2',
                 ),
+                'choices_as_values' => true,
             )
         );
         $builder->add('subChoice', new ChoiceSubType());
@@ -2290,10 +2297,11 @@ class ChoiceTypeTest extends TypeTestCase
      */
     public function testSubmitInvalidNestedValue($multiple, $expanded, $submissionData)
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'choices' => $this->choices,
             'multiple' => $multiple,
             'expanded' => $expanded,
+            'choices_as_values' => true,
         ));
 
         $form->submit($submissionData);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -11,16 +11,17 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\AuthorType;
 
-class CollectionTypeTest extends TypeTestCase
+class CollectionTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'collection';
+
     public function testContainsNoChildByDefault()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
         ));
 
         $this->assertCount(0, $form);
@@ -28,8 +29,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testSetDataAdjustsSize()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'options' => array(
                 'attr' => array('maxlength' => 20),
             ),
@@ -57,8 +58,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testThrowsExceptionIfObjectIsNotTraversable()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
         ));
         $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $form->setData(new \stdClass());
@@ -66,8 +67,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testNotResizedIfSubmittedWithMissingData()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
         $form->submit(array('foo@bar.com'));
@@ -80,8 +81,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testResizedDownIfSubmittedWithMissingDataAndAllowDelete()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'allow_delete' => true,
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
@@ -95,8 +96,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testResizedDownIfSubmittedWithEmptyDataAndDeleteEmpty()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'allow_delete' => true,
             'delete_empty' => true,
         ));
@@ -112,8 +113,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testDontAddEmptyDataIfDeleteEmpty()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'delete_empty' => true,
         ));
@@ -129,8 +130,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testNoDeleteEmptyIfDeleteNotAllowed()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'allow_delete' => false,
             'delete_empty' => true,
         ));
@@ -144,7 +145,7 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testResizedDownIfSubmittedWithCompoundEmptyDataAndDeleteEmpty()
     {
-        $form = $this->factory->create('collection', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'type' => new AuthorType(),
             // If the field is not required, no new Author will be created if the
             // form is completely empty
@@ -167,8 +168,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testNotResizedIfSubmittedWithExtraData()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
         ));
         $form->setData(array('foo@bar.com'));
         $form->submit(array('foo@foo.com', 'bar@bar.com'));
@@ -180,8 +181,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testResizedUpIfSubmittedWithExtraDataAndAllowAdd()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'allow_add' => true,
         ));
         $form->setData(array('foo@bar.com'));
@@ -196,8 +197,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testAllowAddButNoPrototype()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => FormTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => false,
         ));
@@ -208,8 +209,8 @@ class CollectionTypeTest extends TypeTestCase
     public function testPrototypeMultipartPropagation()
     {
         $form = $this->factory
-            ->create('collection', null, array(
-                'type' => 'file',
+            ->create(static::TESTED_TYPE, null, array(
+                'type' => FileTypeTest::TESTED_TYPE,
                 'allow_add' => true,
                 'prototype' => true,
             ))
@@ -220,8 +221,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testGetDataDoesNotContainsPrototypeNameBeforeDataAreSet()
     {
-        $form = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $form = $this->factory->create(static::TESTED_TYPE, array(), array(
+            'type' => FileTypeTest::TESTED_TYPE,
             'prototype' => true,
             'allow_add' => true,
         ));
@@ -232,8 +233,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testGetDataDoesNotContainsPrototypeNameAfterDataAreSet()
     {
-        $form = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $form = $this->factory->create(static::TESTED_TYPE, array(), array(
+            'type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
         ));
@@ -245,16 +246,16 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testPrototypeNameOption()
     {
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => FormTypeTest::TESTED_TYPE,
             'prototype' => true,
             'allow_add' => true,
         ));
 
         $this->assertSame('__name__', $form->getConfig()->getAttribute('prototype')->getName(), '__name__ is the default');
 
-        $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => FormTypeTest::TESTED_TYPE,
             'prototype' => true,
             'allow_add' => true,
             'prototype_name' => '__test__',
@@ -265,8 +266,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testPrototypeDefaultLabel()
     {
-        $form = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $form = $this->factory->create(static::TESTED_TYPE, array(), array(
+            'type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
             'prototype_name' => '__test__',
@@ -277,8 +278,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testPrototypeDefaultRequired()
     {
-        $form = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $form = $this->factory->create(static::TESTED_TYPE, array(), array(
+            'type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
             'prototype_name' => '__test__',
@@ -289,8 +290,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testPrototypeSetNotRequired()
     {
-        $form = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $form = $this->factory->create(static::TESTED_TYPE, array(), array(
+            'type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
             'prototype_name' => '__test__',
@@ -303,14 +304,14 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testPrototypeSetNotRequiredIfParentNotRequired()
     {
-        $child = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $child = $this->factory->create(static::TESTED_TYPE, array(), array(
+            'type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
             'prototype_name' => '__test__',
         ));
 
-        $parent = $this->factory->create('form', array(), array(
+        $parent = $this->factory->create(FormTypeTest::TESTED_TYPE, array(), array(
             'required' => false,
         ));
 
@@ -322,8 +323,8 @@ class CollectionTypeTest extends TypeTestCase
 
     public function testPrototypeNotOverrideRequiredByEntryOptionsInFavorOfParent()
     {
-        $child = $this->factory->create('collection', array(), array(
-            'type' => 'file',
+        $child = $this->factory->create(static::TESTED_TYPE, array(), array(
+            'type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
             'prototype_name' => '__test__',
@@ -332,7 +333,7 @@ class CollectionTypeTest extends TypeTestCase
             ),
         ));
 
-        $parent = $this->factory->create('form', array(), array(
+        $parent = $this->factory->create(FormTypeTest::TESTED_TYPE, array(), array(
             'required' => false,
         ));
 
@@ -341,5 +342,10 @@ class CollectionTypeTest extends TypeTestCase
         $this->assertFalse($parent->createView()->vars['required'], 'Parent is not required');
         $this->assertFalse($child->createView()->vars['required'], 'Child is not required');
         $this->assertFalse($child->createView()->vars['prototype']->vars['required'], '"Prototype" should not be required');
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull(array(), array(), array());
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class CountryTypeTest extends TestCase
+class CountryTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'country';
+
     protected function setUp()
     {
         IntlTestHelper::requireIntl($this, false);
@@ -26,9 +27,8 @@ class CountryTypeTest extends TestCase
 
     public function testCountriesAreSelectable()
     {
-        $form = $this->factory->create('country');
-        $view = $form->createView();
-        $choices = $view->vars['choices'];
+        $choices = $this->factory->create(static::TESTED_TYPE)
+            ->createView()->vars['choices'];
 
         // Don't check objects for identity
         $this->assertContains(new ChoiceView('DE', 'DE', 'Germany'), $choices, '', false, false);
@@ -40,14 +40,18 @@ class CountryTypeTest extends TestCase
 
     public function testUnknownCountryIsNotIncluded()
     {
-        $form = $this->factory->create('country', 'country');
-        $view = $form->createView();
-        $choices = $view->vars['choices'];
+        $choices = $this->factory->create(static::TESTED_TYPE, 'country')
+            ->createView()->vars['choices'];
 
         foreach ($choices as $choice) {
             if ('ZZ' === $choice->value) {
                 $this->fail('Should not contain choice "ZZ"');
             }
         }
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class CurrencyTypeTest extends TestCase
+class CurrencyTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'currency';
+
     protected function setUp()
     {
         IntlTestHelper::requireIntl($this, false);
@@ -26,12 +27,16 @@ class CurrencyTypeTest extends TestCase
 
     public function testCurrenciesAreSelectable()
     {
-        $form = $this->factory->create('currency');
-        $view = $form->createView();
-        $choices = $view->vars['choices'];
+        $choices = $this->factory->create(static::TESTED_TYPE)
+            ->createView()->vars['choices'];
 
         $this->assertContains(new ChoiceView('EUR', 'EUR', 'Euro'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('USD', 'USD', 'US Dollar'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('SIT', 'SIT', 'Slovenian Tolar'), $choices, '', false, false);
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -12,10 +12,11 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 
-class DateTimeTypeTest extends TestCase
+class DateTimeTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'datetime';
+
     protected function setUp()
     {
         \Locale::setDefault('en');
@@ -25,7 +26,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDateTime()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -53,7 +54,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitString()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -79,7 +80,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitTimestamp()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -107,7 +108,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitWithoutMinutes()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -137,7 +138,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitWithSeconds()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -169,7 +170,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDifferentTimezones()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'date_widget' => 'choice',
@@ -201,7 +202,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDifferentTimezonesDateTime()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'widget' => 'single_text',
@@ -220,7 +221,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitStringSingleText()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -235,7 +236,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitStringSingleTextWithSeconds()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -251,7 +252,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testSubmitDifferentPattern()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'date_format' => 'MM*yyyy*dd',
             'date_widget' => 'single_text',
             'time_widget' => 'single_text',
@@ -272,27 +273,27 @@ class DateTimeTypeTest extends TestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->factory->create('datetime', new \DateTime());
+        $this->factory->create(static::TESTED_TYPE, new \DateTime());
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertEquals('datetime', $view->vars['type']);
     }
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => false,
             'with_seconds' => true,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('', $view['date']['year']->vars['placeholder']);
         $this->assertSame('', $view['date']['month']->vars['placeholder']);
         $this->assertSame('', $view['date']['day']->vars['placeholder']);
@@ -303,12 +304,12 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => true,
             'with_seconds' => true,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertNull($view['date']['year']->vars['placeholder']);
         $this->assertNull($view['date']['month']->vars['placeholder']);
         $this->assertNull($view['date']['day']->vars['placeholder']);
@@ -319,12 +320,12 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'placeholder' => 'Empty',
             'with_seconds' => true,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty', $view['date']['year']->vars['placeholder']);
         $this->assertSame('Empty', $view['date']['month']->vars['placeholder']);
         $this->assertSame('Empty', $view['date']['day']->vars['placeholder']);
@@ -338,12 +339,12 @@ class DateTimeTypeTest extends TestCase
      */
     public function testPassEmptyValueBC()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'empty_value' => 'Empty',
             'with_seconds' => true,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty', $view['date']['year']->vars['placeholder']);
         $this->assertSame('Empty', $view['date']['month']->vars['placeholder']);
         $this->assertSame('Empty', $view['date']['day']->vars['placeholder']);
@@ -360,7 +361,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
@@ -370,9 +371,9 @@ class DateTimeTypeTest extends TestCase
                 'second' => 'Empty second',
             ),
             'with_seconds' => true,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty year', $view['date']['year']->vars['placeholder']);
         $this->assertSame('Empty month', $view['date']['month']->vars['placeholder']);
         $this->assertSame('Empty day', $view['date']['day']->vars['placeholder']);
@@ -383,7 +384,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => false,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -392,9 +393,9 @@ class DateTimeTypeTest extends TestCase
                 'second' => 'Empty second',
             ),
             'with_seconds' => true,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty year', $view['date']['year']->vars['placeholder']);
         $this->assertSame('', $view['date']['month']->vars['placeholder']);
         $this->assertSame('Empty day', $view['date']['day']->vars['placeholder']);
@@ -405,7 +406,7 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => true,
             'placeholder' => array(
                 'year' => 'Empty year',
@@ -414,9 +415,9 @@ class DateTimeTypeTest extends TestCase
                 'second' => 'Empty second',
             ),
             'with_seconds' => true,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty year', $view['date']['year']->vars['placeholder']);
         $this->assertNull($view['date']['month']->vars['placeholder']);
         $this->assertSame('Empty day', $view['date']['day']->vars['placeholder']);
@@ -427,50 +428,50 @@ class DateTimeTypeTest extends TestCase
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('datetime', $view->vars['type']);
     }
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
             'html5' => false,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertFalse(isset($view->vars['type']));
     }
 
     public function testDontPassHtml5TypeIfNotHtml5Format()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
             'format' => 'yyyy-MM-dd HH:mm',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertFalse(isset($view->vars['type']));
     }
 
     public function testDontPassHtml5TypeIfNotSingleText()
     {
-        $form = $this->factory->create('datetime', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'text',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertFalse(isset($view->vars['type']));
     }
 
     public function testDateTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null);
+        $form = $this->factory->create(static::TESTED_TYPE, null);
 
         $form['date']->addError($error);
 
@@ -481,7 +482,7 @@ class DateTimeTypeTest extends TestCase
     public function testDateTypeSingleTextErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'date_widget' => 'single_text',
         ));
 
@@ -494,7 +495,7 @@ class DateTimeTypeTest extends TestCase
     public function testTimeTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null);
+        $form = $this->factory->create(static::TESTED_TYPE, null);
 
         $form['time']->addError($error);
 
@@ -505,7 +506,7 @@ class DateTimeTypeTest extends TestCase
     public function testTimeTypeSingleTextErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('datetime', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'time_widget' => 'single_text',
         ));
 
@@ -513,5 +514,42 @@ class DateTimeTypeTest extends TestCase
 
         $this->assertSame(array(), iterator_to_array($form['time']->getErrors()));
         $this->assertSame(array($error), iterator_to_array($form->getErrors()));
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, array(
+            // View data is an array of choice values array
+            'date' => array('year' => '', 'month' => '', 'day' => ''),
+            'time' => array('hour' => '', 'minute' => ''),
+        ));
+    }
+
+    public function testSubmitNullWithText()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'widget' => 'text',
+        ));
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
+        $this->assertSame(array(
+            // View data is an array of choice values array
+            'date' => array('year' => '', 'month' => '', 'day' => ''),
+            'time' => array('hour' => '', 'minute' => ''),
+        ), $form->getViewData());
+    }
+
+    public function testSubmitNullWithSingleText()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'widget' => 'single_text',
+        ));
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
+        $this->assertSame('', $form->getViewData());
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -13,11 +13,12 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class DateTypeTest extends TestCase
+class DateTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'date';
+
     private $defaultTimezone;
 
     protected function setUp()
@@ -37,7 +38,7 @@ class DateTypeTest extends TestCase
      */
     public function testInvalidWidgetOption()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'fake_widget',
         ));
     }
@@ -47,14 +48,14 @@ class DateTypeTest extends TestCase
      */
     public function testInvalidInputOption()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'input' => 'fake_input',
         ));
     }
 
     public function testSubmitFromSingleTextDateTimeWithDefaultFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
@@ -69,7 +70,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromSingleTextDateTimeWithCustomFormat()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
@@ -90,7 +91,7 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -111,7 +112,7 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -132,7 +133,7 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -155,7 +156,7 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
@@ -177,7 +178,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromText()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'text',
@@ -199,7 +200,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromChoice()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -222,7 +223,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromChoiceEmpty()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -243,7 +244,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputDateTimeDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -259,7 +260,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputStringDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -275,7 +276,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputTimestampDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -293,7 +294,7 @@ class DateTypeTest extends TestCase
 
     public function testSubmitFromInputRawDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -318,11 +319,10 @@ class DateTypeTest extends TestCase
      */
     public function testDatePatternWithFormatOption($format, $pattern)
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => $format,
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals($pattern, $view->vars['date_pattern']);
     }
@@ -344,7 +344,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatIsNoPattern()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => '0',
             'widget' => 'single_text',
             'input' => 'string',
@@ -357,7 +357,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatDoesNotContainYearMonthAndDay()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'months' => array(6, 7),
             'format' => 'yy',
         ));
@@ -369,7 +369,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatMissesYearMonthAndDayWithSingleTextWidget()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
             'format' => 'wrong',
         ));
@@ -380,7 +380,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatIsNoConstant()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => 105,
         ));
     }
@@ -390,7 +390,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfFormatIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => array(),
         ));
     }
@@ -400,7 +400,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfYearsIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'years' => 'bad value',
         ));
     }
@@ -410,7 +410,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfMonthsIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'months' => 'bad value',
         ));
     }
@@ -420,7 +420,7 @@ class DateTypeTest extends TestCase
      */
     public function testThrowExceptionIfDaysIsInvalid()
     {
-        $this->factory->create('date', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'days' => 'bad value',
         ));
     }
@@ -432,7 +432,7 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'America/New_York',
@@ -454,7 +454,7 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'America/New_York',
@@ -474,7 +474,7 @@ class DateTypeTest extends TestCase
 
     public function testYearsOption()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'years' => array(2010, 2011),
         ));
 
@@ -488,7 +488,7 @@ class DateTypeTest extends TestCase
 
     public function testMonthsOption()
     {
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'months' => array(6, 7),
             'format' => \IntlDateFormatter::SHORT,
         ));
@@ -508,7 +508,7 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_AT');
 
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'months' => array(1, 4),
             'format' => 'dd.MMM.yy',
         ));
@@ -528,12 +528,11 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_AT');
 
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'months' => array(1, 4),
             'format' => 'dd.MMMM.yy',
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals(array(
             new ChoiceView(1, '1', 'Jänner'),
@@ -548,12 +547,11 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_AT');
 
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'months' => array(1, 4),
             'format' => 'dd.MMMM.yy',
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals(array(
             new ChoiceView(1, '1', 'Jänner'),
@@ -563,11 +561,10 @@ class DateTypeTest extends TestCase
 
     public function testIsDayWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'days' => array(6, 7),
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals(array(
             new ChoiceView(6, '6', '06'),
@@ -575,26 +572,9 @@ class DateTypeTest extends TestCase
         ), $view['day']->vars['choices']);
     }
 
-    public function testIsPartiallyFilledReturnsFalseIfSingleText()
+    public function testIsSynchronizedReturnsTrueIfChoiceAndCompletelyEmpty()
     {
-        $this->markTestIncomplete('Needs to be reimplemented using validators');
-
-        $form = $this->factory->create('date', null, array(
-            'model_timezone' => 'UTC',
-            'view_timezone' => 'UTC',
-            'widget' => 'single_text',
-        ));
-
-        $form->submit('7.6.2010');
-
-        $this->assertFalse($form->isPartiallyFilled());
-    }
-
-    public function testIsPartiallyFilledReturnsFalseIfChoiceAndCompletelyEmpty()
-    {
-        $this->markTestIncomplete('Needs to be reimplemented using validators');
-
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -606,33 +586,29 @@ class DateTypeTest extends TestCase
             'year' => '',
         ));
 
-        $this->assertFalse($form->isPartiallyFilled());
+        $this->assertTrue($form->isSynchronized());
     }
 
-    public function testIsPartiallyFilledReturnsFalseIfChoiceAndCompletelyFilled()
+    public function testIsSynchronizedReturnsTrueIfChoiceAndCompletelyFilled()
     {
-        $this->markTestIncomplete('Needs to be reimplemented using validators');
-
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, new \DateTime(), array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
         $form->submit(array(
-            'day' => '2',
+            'day' => '0',
             'month' => '6',
             'year' => '2010',
         ));
 
-        $this->assertFalse($form->isPartiallyFilled());
+        $this->assertTrue($form->isSynchronized());
     }
 
-    public function testIsPartiallyFilledReturnsTrueIfChoiceAndDayEmpty()
+    public function testIsSynchronizedReturnsFalseIfChoiceAndDayEmpty()
     {
-        $this->markTestIncomplete('Needs to be reimplemented using validators');
-
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -644,7 +620,7 @@ class DateTypeTest extends TestCase
             'year' => '2010',
         ));
 
-        $this->assertTrue($form->isPartiallyFilled());
+        $this->assertFalse($form->isSynchronized());
     }
 
     public function testPassDatePatternToView()
@@ -654,8 +630,8 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_AT');
 
-        $form = $this->factory->create('date');
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE)
+            ->createView();
 
         $this->assertSame('{{ day }}{{ month }}{{ year }}', $view->vars['date_pattern']);
     }
@@ -667,43 +643,40 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('de_AT');
 
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => \IntlDateFormatter::LONG,
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame('{{ day }}{{ month }}{{ year }}', $view->vars['date_pattern']);
     }
 
     public function testPassDatePatternToViewDifferentPattern()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => 'MMyyyydd',
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame('{{ month }}{{ year }}{{ day }}', $view->vars['date_pattern']);
     }
 
     public function testPassDatePatternToViewDifferentPatternWithSeparators()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'format' => 'MM*yyyy*dd',
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame('{{ month }}*{{ year }}*{{ day }}', $view->vars['date_pattern']);
     }
 
     public function testDontPassDatePatternIfText()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertFalse(isset($view->vars['date_pattern']));
     }
@@ -715,22 +688,21 @@ class DateTypeTest extends TestCase
 
         \Locale::setDefault('es_ES');
 
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             // EEEE, d 'de' MMMM 'de' y
             'format' => \IntlDateFormatter::FULL,
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertEquals('{{ day }}{{ month }}{{ year }}', $view->vars['date_pattern']);
     }
 
     public function testPassWidgetToView()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
-        ));
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $this->assertSame('single_text', $view->vars['widget']);
     }
@@ -739,26 +711,26 @@ class DateTypeTest extends TestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->factory->create('date', new \DateTime());
+        $this->factory->create(static::TESTED_TYPE, new \DateTime());
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertEquals('date', $view->vars['type']);
     }
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => false,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('', $view['year']->vars['placeholder']);
         $this->assertSame('', $view['month']->vars['placeholder']);
         $this->assertSame('', $view['day']->vars['placeholder']);
@@ -766,11 +738,11 @@ class DateTypeTest extends TestCase
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => true,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertNull($view['year']->vars['placeholder']);
         $this->assertNull($view['month']->vars['placeholder']);
         $this->assertNull($view['day']->vars['placeholder']);
@@ -778,11 +750,11 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'placeholder' => 'Empty',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty', $view['year']->vars['placeholder']);
         $this->assertSame('Empty', $view['month']->vars['placeholder']);
         $this->assertSame('Empty', $view['day']->vars['placeholder']);
@@ -793,11 +765,11 @@ class DateTypeTest extends TestCase
      */
     public function testPassEmptyValueBC()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'empty_value' => 'Empty',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty', $view['year']->vars['placeholder']);
         $this->assertSame('Empty', $view['month']->vars['placeholder']);
         $this->assertSame('Empty', $view['day']->vars['placeholder']);
@@ -808,15 +780,15 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
                 'day' => 'Empty day',
             ),
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty year', $view['year']->vars['placeholder']);
         $this->assertSame('Empty month', $view['month']->vars['placeholder']);
         $this->assertSame('Empty day', $view['day']->vars['placeholder']);
@@ -824,15 +796,15 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => false,
             'placeholder' => array(
                 'year' => 'Empty year',
                 'day' => 'Empty day',
             ),
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty year', $view['year']->vars['placeholder']);
         $this->assertSame('', $view['month']->vars['placeholder']);
         $this->assertSame('Empty day', $view['day']->vars['placeholder']);
@@ -840,15 +812,15 @@ class DateTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => true,
             'placeholder' => array(
                 'year' => 'Empty year',
                 'day' => 'Empty day',
             ),
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('Empty year', $view['year']->vars['placeholder']);
         $this->assertNull($view['month']->vars['placeholder']);
         $this->assertSame('Empty day', $view['day']->vars['placeholder']);
@@ -856,43 +828,43 @@ class DateTypeTest extends TestCase
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertSame('date', $view->vars['type']);
     }
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
             'html5' => false,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertFalse(isset($view->vars['type']));
     }
 
     public function testDontPassHtml5TypeIfNotHtml5Format()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
             'format' => \IntlDateFormatter::MEDIUM,
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertFalse(isset($view->vars['type']));
     }
 
     public function testDontPassHtml5TypeIfNotSingleText()
     {
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'text',
-        ));
+        ))
+            ->createView();
 
-        $view = $form->createView();
         $this->assertFalse(isset($view->vars['type']));
     }
 
@@ -910,7 +882,7 @@ class DateTypeTest extends TestCase
     public function testYearErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => $widget,
         ));
         $form['year']->addError($error);
@@ -925,7 +897,7 @@ class DateTypeTest extends TestCase
     public function testMonthErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => $widget,
         ));
         $form['month']->addError($error);
@@ -940,7 +912,7 @@ class DateTypeTest extends TestCase
     public function testDayErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('date', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => $widget,
         ));
         $form['day']->addError($error);
@@ -955,11 +927,10 @@ class DateTypeTest extends TestCase
             $this->markTestSkipped('PHP 32 bit is required.');
         }
 
-        $form = $this->factory->create('date', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
             'years' => range(1900, 2040),
-        ));
-
-        $view = $form->createView();
+        ))
+            ->createView();
 
         $listChoices = array();
         foreach (range(1902, 2037) as $y) {
@@ -967,5 +938,22 @@ class DateTypeTest extends TestCase
         }
 
         $this->assertEquals($listChoices, $view['year']->vars['choices']);
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, array('year' => '', 'month' => '', 'day' => ''));
+    }
+
+    public function testSubmitNullWithSingleText()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'widget' => 'single_text',
+        ));
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
+        $this->assertSame('', $form->getViewData());
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -51,27 +51,29 @@ class FormTest_AuthorWithoutRefSetter
 
 class FormTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'form';
+
     public function testCreateFormInstances()
     {
-        $this->assertInstanceOf('Symfony\Component\Form\Form', $this->factory->create('form'));
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $this->factory->create(static::TESTED_TYPE));
     }
 
     public function testPassRequiredAsOption()
     {
-        $form = $this->factory->create('form', null, array('required' => false));
+        $form = $this->factory->create(static::TESTED_TYPE, null, array('required' => false));
 
         $this->assertFalse($form->isRequired());
 
-        $form = $this->factory->create('form', null, array('required' => true));
+        $form = $this->factory->create(static::TESTED_TYPE, null, array('required' => true));
 
         $this->assertTrue($form->isRequired());
     }
 
     public function testSubmittedDataIsTrimmedBeforeTransforming()
     {
-        $form = $this->factory->createBuilder('form')
+        $form = $this->factory->createBuilder(static::TESTED_TYPE)
             ->addViewTransformer(new FixedDataTransformer(array(
-                null => '',
+                '' => '',
                 'reverse[a]' => 'a',
             )))
             ->setCompound(false)
@@ -85,9 +87,9 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmittedDataIsNotTrimmedBeforeTransformingIfNoTrimming()
     {
-        $form = $this->factory->createBuilder('form', null, array('trim' => false))
+        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, array('trim' => false))
             ->addViewTransformer(new FixedDataTransformer(array(
-                null => '',
+                '' => '',
                 'reverse[ a ]' => ' a ',
             )))
             ->setCompound(false)
@@ -101,8 +103,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form', null, array('read_only' => true))
-            ->add('child', 'form')
+        $view = $this->factory->createNamedBuilder('parent', static::TESTED_TYPE, null, array('read_only' => true))
+            ->add('child', static::TESTED_TYPE)
             ->getForm()
             ->createView();
 
@@ -111,8 +113,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
-            ->add('child', 'form', array('read_only' => true))
+        $view = $this->factory->createNamedBuilder('parent', static::TESTED_TYPE)
+            ->add('child', static::TESTED_TYPE, array('read_only' => true))
             ->getForm()
             ->createView();
 
@@ -121,8 +123,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', 'form')
-                ->add('child', 'form')
+        $view = $this->factory->createNamedBuilder('parent', static::TESTED_TYPE)
+                ->add('child', static::TESTED_TYPE)
                 ->getForm()
                 ->createView();
 
@@ -131,37 +133,37 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMaxLengthToView()
     {
-        $form = $this->factory->create('form', null, array('attr' => array('maxlength' => 10)));
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE, null, array('attr' => array('maxlength' => 10)))
+            ->createView();
 
         $this->assertSame(10, $view->vars['attr']['maxlength']);
     }
 
     public function testPassMaxLengthBCToView()
     {
-        $form = $this->factory->create('form', null, array('max_length' => 10));
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE, null, array('max_length' => 10))
+            ->createView();
 
         $this->assertSame(10, $view->vars['attr']['maxlength']);
     }
 
     public function testDataClassMayBeNull()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => null,
         ));
     }
 
     public function testDataClassMayBeAbstractClass()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\AbstractAuthor',
         ));
     }
 
     public function testDataClassMayBeInterface()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\AuthorInterface',
         ));
     }
@@ -171,22 +173,23 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testDataClassMustBeValidClassOrInterface()
     {
-        $this->factory->createBuilder('form', null, array(
+        $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => 'foobar',
         ));
     }
 
     public function testSubmitWithEmptyDataCreatesObjectIfClassAvailable()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
-        ));
-        $builder->add('firstName', 'text');
-        $builder->add('lastName', 'text');
-        $form = $builder->getForm();
+        ))
+            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->add('lastName', TextTypeTest::TESTED_TYPE)
+            ->getForm();
 
-        $form->setData(null);
+        $this->assertNull($form->getData());
+
         // partially empty, still an object is created
         $form->submit(array('firstName' => 'Bernhard', 'lastName' => ''));
 
@@ -197,19 +200,19 @@ class FormTypeTest extends BaseTypeTest
         $this->assertEquals($author, $form->getData());
     }
 
-    public function testSubmitWithEmptyDataCreatesObjectIfInitiallySubmittedWithObject()
+    public function testSubmitWithDefaultDataDontCreateObject()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $defaultAuthor = new Author();
+        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             // data class is inferred from the passed object
-            'data' => new Author(),
+            'data' => $defaultAuthor,
             'required' => false,
-        ));
-        $builder->add('firstName', 'text');
-        $builder->add('lastName', 'text');
-        $form = $builder->getForm();
+        ))
+            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->add('lastName', TextTypeTest::TESTED_TYPE)
+            ->getForm();
 
-        $form->setData(null);
-        // partially empty, still an object is created
+        // partially empty
         $form->submit(array('firstName' => 'Bernhard', 'lastName' => ''));
 
         $author = new Author();
@@ -217,34 +220,37 @@ class FormTypeTest extends BaseTypeTest
         $author->setLastName('');
 
         $this->assertEquals($author, $form->getData());
+        $this->assertSame($defaultAuthor, $form->getData());
     }
 
     public function testSubmitWithEmptyDataCreatesArrayIfDataClassIsNull()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => null,
             'required' => false,
-        ));
-        $builder->add('firstName', 'text');
-        $form = $builder->getForm();
+        ))
+            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->getForm();
 
-        $form->setData(null);
+        $this->assertNull($form->getData());
+
         $form->submit(array('firstName' => 'Bernhard'));
 
         $this->assertSame(array('firstName' => 'Bernhard'), $form->getData());
     }
 
-    public function testSubmitEmptyWithEmptyDataCreatesNoObjectIfNotRequired()
+    public function testSubmitEmptyWithEmptyDataDontCreateObjectIfNotRequired()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
-        ));
-        $builder->add('firstName', 'text');
-        $builder->add('lastName', 'text');
-        $form = $builder->getForm();
+        ))
+            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->add('lastName', TextTypeTest::TESTED_TYPE)
+            ->getForm();
 
-        $form->setData(null);
+        $this->assertNull($form->getData());
+
         $form->submit(array('firstName' => '', 'lastName' => ''));
 
         $this->assertNull($form->getData());
@@ -252,15 +258,16 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitEmptyWithEmptyDataCreatesObjectIfRequired()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => true,
-        ));
-        $builder->add('firstName', 'text');
-        $builder->add('lastName', 'text');
-        $form = $builder->getForm();
+        ))
+            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->add('lastName', TextTypeTest::TESTED_TYPE)
+            ->getForm();
 
-        $form->setData(null);
+        $this->assertNull($form->getData());
+
         $form->submit(array('firstName' => '', 'lastName' => ''));
 
         $this->assertEquals(new Author(), $form->getData());
@@ -271,11 +278,12 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testSubmitWithEmptyDataStoresArrayIfNoClassAvailable()
     {
-        $form = $this->factory->createBuilder('form')
-            ->add('firstName', 'text')
+        $form = $this->factory->createBuilder(static::TESTED_TYPE)
+            ->add('firstName', TextTypeTest::TESTED_TYPE)
             ->getForm();
 
-        $form->setData(null);
+        $this->assertNull($form->getData());
+
         $form->submit(array('firstName' => 'Bernhard'));
 
         $this->assertSame(array('firstName' => 'Bernhard'), $form->getData());
@@ -283,31 +291,40 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitWithEmptyDataPassesEmptyStringToTransformerIfNotCompound()
     {
-        $form = $this->factory->createBuilder('form')
+        $form = $this->factory->createBuilder(static::TESTED_TYPE)
             ->addViewTransformer(new FixedDataTransformer(array(
                 // required for the initial, internal setData(null)
-                null => 'null',
+                '' => 'null',
                 // required to test that submit(null) is converted to ''
                 'empty' => '',
             )))
             ->setCompound(false)
             ->getForm();
 
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
+        $this->assertSame('null', $form->getViewData());
+
         $form->submit(null);
 
         $this->assertSame('empty', $form->getData());
+        $this->assertSame('empty', $form->getNormData());
+        $this->assertSame('', $form->getViewData());
     }
 
     public function testSubmitWithEmptyDataUsesEmptyDataOption()
     {
         $author = new Author();
 
-        $builder = $this->factory->createBuilder('form', null, array(
+        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'empty_data' => $author,
-        ));
-        $builder->add('firstName', 'text');
-        $form = $builder->getForm();
+        ))
+            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->getForm();
+
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getViewData());
 
         $form->submit(array('firstName' => 'Bernhard'));
 
@@ -315,62 +332,34 @@ class FormTypeTest extends BaseTypeTest
         $this->assertEquals('Bernhard', $author->firstName);
     }
 
-    public function provideZeros()
-    {
-        return array(
-            array(0, '0'),
-            array('0', '0'),
-            array('00000', '00000'),
-        );
-    }
-
-    /**
-     * @dataProvider provideZeros
-     *
-     * @see https://github.com/symfony/symfony/issues/1986
-     */
-    public function testSetDataThroughParamsWithZero($data, $dataAsString)
-    {
-        $form = $this->factory->create('form', null, array(
-            'data' => $data,
-            'compound' => false,
-        ));
-        $view = $form->createView();
-
-        $this->assertFalse($form->isEmpty());
-
-        $this->assertSame($dataAsString, $view->vars['value']);
-        $this->assertSame($dataAsString, $form->getData());
-    }
-
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testAttributesException()
     {
-        $this->factory->create('form', null, array('attr' => ''));
+        $this->factory->create(static::TESTED_TYPE, null, array('attr' => ''));
     }
 
     public function testNameCanBeEmptyString()
     {
-        $form = $this->factory->createNamed('', 'form');
+        $form = $this->factory->createNamed('', static::TESTED_TYPE);
 
         $this->assertEquals('', $form->getName());
     }
 
-    public function testSubformDoesntCallSetters()
+    public function testSubformDoesntCallSettersForReferences()
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder('form', $author);
-        $builder->add('reference', 'form', array(
+        $builder = $this->factory->createBuilder(static::TESTED_TYPE, $author);
+        $builder->add('reference', static::TESTED_TYPE, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
         ));
-        $builder->get('reference')->add('firstName', 'text');
+        $builder->get('reference')->add('firstName', TextTypeTest::TESTED_TYPE);
         $form = $builder->getForm();
 
         $form->submit(array(
-            // reference has a getter, but not setter
+            // reference has a getter, but no setter
             'reference' => array(
                 'firstName' => 'Foo',
             ),
@@ -385,17 +374,17 @@ class FormTypeTest extends BaseTypeTest
         $author = new FormTest_AuthorWithoutRefSetter(null);
         $newReference = new Author();
 
-        $builder = $this->factory->createBuilder('form', $author);
-        $builder->add('referenceCopy', 'form', array(
+        $builder = $this->factory->createBuilder(static::TESTED_TYPE, $author);
+        $builder->add('referenceCopy', static::TESTED_TYPE, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
         ));
-        $builder->get('referenceCopy')->add('firstName', 'text');
+        $builder->get('referenceCopy')->add('firstName', TextTypeTest::TESTED_TYPE);
         $form = $builder->getForm();
 
         $form['referenceCopy']->setData($newReference); // new author object
 
         $form->submit(array(
-        // referenceCopy has a getter that returns a copy
+            // referenceCopy has a getter that returns a copy
             'referenceCopy' => array(
                 'firstName' => 'Foo',
         ),
@@ -408,12 +397,12 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder('form', $author);
-        $builder->add('referenceCopy', 'form', array(
+        $builder = $this->factory->createBuilder(static::TESTED_TYPE, $author);
+        $builder->add('referenceCopy', static::TESTED_TYPE, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'by_reference' => false,
         ));
-        $builder->get('referenceCopy')->add('firstName', 'text');
+        $builder->get('referenceCopy')->add('firstName', TextTypeTest::TESTED_TYPE);
         $form = $builder->getForm();
 
         $form->submit(array(
@@ -431,8 +420,8 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter('scalar');
 
-        $builder = $this->factory->createBuilder('form', $author);
-        $builder->add('referenceCopy', 'form');
+        $builder = $this->factory->createBuilder(static::TESTED_TYPE, $author);
+        $builder->add('referenceCopy', static::TESTED_TYPE);
         $builder->get('referenceCopy')->addViewTransformer(new CallbackTransformer(
             function () {},
             function ($value) { // reverseTransform
@@ -455,9 +444,9 @@ class FormTypeTest extends BaseTypeTest
         $ref2 = new Author();
         $author = array('referenceCopy' => $ref1);
 
-        $builder = $this->factory->createBuilder('form');
+        $builder = $this->factory->createBuilder(static::TESTED_TYPE);
         $builder->setData($author);
-        $builder->add('referenceCopy', 'form');
+        $builder->add('referenceCopy', static::TESTED_TYPE);
         $builder->get('referenceCopy')->addViewTransformer(new CallbackTransformer(
             function () {},
             function ($value) use ($ref2) { // reverseTransform
@@ -467,7 +456,7 @@ class FormTypeTest extends BaseTypeTest
         $form = $builder->getForm();
 
         $form->submit(array(
-            'referenceCopy' => array('a' => 'b'), // doesn't matter actually
+            'referenceCopy' => array(), // doesn't matter actually
         ));
 
         // the new reference was inserted into the array
@@ -477,9 +466,9 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMultipartTrueIfAnyChildIsMultipartToView()
     {
-        $view = $this->factory->createBuilder('form')
-            ->add('foo', 'text')
-            ->add('bar', 'file')
+        $view = $this->factory->createBuilder(static::TESTED_TYPE)
+            ->add('foo', TextTypeTest::TESTED_TYPE)
+            ->add('bar', FileTypeTest::TESTED_TYPE)
             ->getForm()
             ->createView();
 
@@ -488,8 +477,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewIsNotRenderedByDefault()
     {
-        $view = $this->factory->createBuilder('form')
-                ->add('foo', 'form')
+        $view = $this->factory->createBuilder(static::TESTED_TYPE)
+                ->add('foo', static::TESTED_TYPE)
                 ->getForm()
                 ->createView();
 
@@ -498,16 +487,14 @@ class FormTypeTest extends BaseTypeTest
 
     public function testErrorBubblingIfCompound()
     {
-        $form = $this->factory->create('form', null, array(
-            'compound' => true,
-        ));
+        $form = $this->factory->create(static::TESTED_TYPE);
 
         $this->assertTrue($form->getConfig()->getErrorBubbling());
     }
 
     public function testNoErrorBubblingIfNotCompound()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'compound' => false,
         ));
 
@@ -516,7 +503,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testOverrideErrorBubbling()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'compound' => false,
             'error_bubbling' => true,
         ));
@@ -526,7 +513,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPropertyPath()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'property_path' => 'foo',
         ));
 
@@ -536,7 +523,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPropertyPathNullImpliesDefault()
     {
-        $form = $this->factory->createNamed('name', 'form', null, array(
+        $form = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
             'property_path' => null,
         ));
 
@@ -546,7 +533,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNotMapped()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'property_path' => 'foo',
             'mapped' => false,
         ));
@@ -557,39 +544,52 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewValidNotSubmitted()
     {
-        $form = $this->factory->create('form');
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE)
+            ->createView();
+
         $this->assertTrue($view->vars['valid']);
     }
 
     public function testViewNotValidSubmitted()
     {
-        $form = $this->factory->create('form');
+        $form = $this->factory->create(static::TESTED_TYPE);
         $form->submit(array());
         $form->addError(new FormError('An error'));
-        $view = $form->createView();
-        $this->assertFalse($view->vars['valid']);
+
+        $this->assertFalse($form->createView()->vars['valid']);
     }
 
     public function testViewSubmittedNotSubmitted()
     {
-        $form = $this->factory->create('form');
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE)
+            ->createView();
+
         $this->assertFalse($view->vars['submitted']);
     }
 
     public function testViewSubmittedSubmitted()
     {
-        $form = $this->factory->create('form');
+        $form = $this->factory->create(static::TESTED_TYPE);
         $form->submit(array());
-        $view = $form->createView();
-        $this->assertTrue($view->vars['submitted']);
+
+        $this->assertTrue($form->createView()->vars['submitted']);
     }
 
     public function testDataOptionSupersedesSetDataCalls()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'data' => 'default',
+            'compound' => false,
+        ));
+
+        $form->setData('foobar');
+
+        $this->assertSame('default', $form->getData());
+    }
+
+    public function testPassedDataSupersedesSetDataCalls()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, 'default', array(
             'compound' => false,
         ));
 
@@ -600,7 +600,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testDataOptionSupersedesSetDataCallsIfNull()
     {
-        $form = $this->factory->create('form', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'data' => null,
             'compound' => false,
         ));
@@ -612,22 +612,25 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNormDataIsPassedToView()
     {
-        $view = $this->factory->createBuilder('form')
-            ->addViewTransformer(new FixedDataTransformer(array(
+        $view = $this->factory->createBuilder(static::TESTED_TYPE)
+            ->addModelTransformer(new FixedDataTransformer(array(
                 'foo' => 'bar',
+            )))
+            ->addViewTransformer(new FixedDataTransformer(array(
+                'bar' => 'baz',
             )))
             ->setData('foo')
             ->getForm()
             ->createView();
 
-        $this->assertSame('foo', $view->vars['data']);
-        $this->assertSame('bar', $view->vars['value']);
+        $this->assertSame('bar', $view->vars['data']);
+        $this->assertSame('baz', $view->vars['value']);
     }
 
     // https://github.com/symfony/symfony/issues/6862
     public function testPassZeroLabelToView()
     {
-        $view = $this->factory->create('form', null, array(
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
                 'label' => '0',
             ))
             ->createView();
@@ -640,7 +643,7 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testCanGetErrorsWhenButtonInForm()
     {
-        $builder = $this->factory->createBuilder('form', null, array(
+        $builder = $this->factory->createBuilder(static::TESTED_TYPE, null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
         ));
@@ -652,8 +655,8 @@ class FormTypeTest extends BaseTypeTest
         $form->getErrorsAsString();
     }
 
-    protected function getTestedType()
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
-        return 'form';
+        parent::testSubmitNull(array(), array(), array());
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -11,11 +11,12 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class IntegerTypeTest extends TestCase
+class IntegerTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'integer';
+
     protected function setUp()
     {
         IntlTestHelper::requireIntl($this, false);
@@ -25,11 +26,16 @@ class IntegerTypeTest extends TestCase
 
     public function testSubmitCastsToInteger()
     {
-        $form = $this->factory->create('integer');
+        $form = $this->factory->create(static::TESTED_TYPE);
 
         $form->submit('1.678');
 
         $this->assertSame(1, $form->getData());
         $this->assertSame('1', $form->getViewData());
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class LanguageTypeTest extends TestCase
+class LanguageTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'language';
+
     protected function setUp()
     {
         IntlTestHelper::requireIntl($this, false);
@@ -26,9 +27,8 @@ class LanguageTypeTest extends TestCase
 
     public function testCountriesAreSelectable()
     {
-        $form = $this->factory->create('language');
-        $view = $form->createView();
-        $choices = $view->vars['choices'];
+        $choices = $this->factory->create(static::TESTED_TYPE)
+            ->createView()->vars['choices'];
 
         $this->assertContains(new ChoiceView('en', 'en', 'English'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'British English'), $choices, '', false, false);
@@ -39,10 +39,14 @@ class LanguageTypeTest extends TestCase
 
     public function testMultipleLanguagesIsNotIncluded()
     {
-        $form = $this->factory->create('language', 'language');
-        $view = $form->createView();
-        $choices = $view->vars['choices'];
+        $choices = $this->factory->create(static::TESTED_TYPE, 'language')
+            ->createView()->vars['choices'];
 
         $this->assertNotContains(new ChoiceView('mul', 'mul', 'Mehrsprachig'), $choices, '', false, false);
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class LocaleTypeTest extends TestCase
+class LocaleTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'locale';
+
     protected function setUp()
     {
         IntlTestHelper::requireIntl($this, false);
@@ -26,12 +27,16 @@ class LocaleTypeTest extends TestCase
 
     public function testLocalesAreSelectable()
     {
-        $form = $this->factory->create('locale');
-        $view = $form->createView();
-        $choices = $view->vars['choices'];
+        $choices = $this->factory->create(static::TESTED_TYPE)
+            ->createView()->vars['choices'];
 
         $this->assertContains(new ChoiceView('en', 'en', 'English'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'English (United Kingdom)'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('zh_Hant_MO', 'zh_Hant_MO', 'Chinese (Traditional, Macau SAR China)'), $choices, '', false, false);
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -11,11 +11,12 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class MoneyTypeTest extends TestCase
+class MoneyTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'money';
+
     protected function setUp()
     {
         // we test against different locales, so we need the full
@@ -29,8 +30,8 @@ class MoneyTypeTest extends TestCase
     {
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create('money');
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE)
+            ->createView();
 
         $this->assertSame('{{ widget }} €', $view->vars['money_pattern']);
     }
@@ -39,8 +40,9 @@ class MoneyTypeTest extends TestCase
     {
         \Locale::setDefault('en_US');
 
-        $form = $this->factory->create('money', null, array('currency' => 'JPY'));
-        $view = $form->createView();
+        $view = $this->factory->create(static::TESTED_TYPE, null, array('currency' => 'JPY'))
+            ->createView();
+
         $this->assertTrue((bool) strstr($view->vars['money_pattern'], '¥'));
     }
 
@@ -49,12 +51,15 @@ class MoneyTypeTest extends TestCase
     {
         \Locale::setDefault('de_DE');
 
-        $form1 = $this->factory->create('money', null, array('currency' => 'GBP'));
-        $form2 = $this->factory->create('money', null, array('currency' => 'EUR'));
-        $view1 = $form1->createView();
-        $view2 = $form2->createView();
+        $view1 = $this->factory->create(static::TESTED_TYPE, null, array('currency' => 'GBP'))->createView();
+        $view2 = $this->factory->create(static::TESTED_TYPE, null, array('currency' => 'EUR'))->createView();
 
         $this->assertSame('{{ widget }} £', $view1->vars['money_pattern']);
         $this->assertSame('{{ widget }} €', $view2->vars['money_pattern']);
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -11,11 +11,12 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
-class NumberTypeTest extends TestCase
+class NumberTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'number';
+
     protected function setUp()
     {
         parent::setUp();
@@ -28,37 +29,38 @@ class NumberTypeTest extends TestCase
 
     public function testDefaultFormatting()
     {
-        $form = $this->factory->create('number');
+        $form = $this->factory->create(static::TESTED_TYPE);
         $form->setData('12345.67890');
-        $view = $form->createView();
 
-        $this->assertSame('12345,679', $view->vars['value']);
+        $this->assertSame('12345,679', $form->createView()->vars['value']);
     }
 
     public function testDefaultFormattingWithGrouping()
     {
-        $form = $this->factory->create('number', null, array('grouping' => true));
+        $form = $this->factory->create(static::TESTED_TYPE, null, array('grouping' => true));
         $form->setData('12345.67890');
-        $view = $form->createView();
 
-        $this->assertSame('12.345,679', $view->vars['value']);
+        $this->assertSame('12.345,679', $form->createView()->vars['value']);
     }
 
     public function testDefaultFormattingWithScale()
     {
-        $form = $this->factory->create('number', null, array('scale' => 2));
+        $form = $this->factory->create(static::TESTED_TYPE, null, array('scale' => 2));
         $form->setData('12345.67890');
-        $view = $form->createView();
 
-        $this->assertSame('12345,68', $view->vars['value']);
+        $this->assertSame('12345,68', $form->createView()->vars['value']);
     }
 
     public function testDefaultFormattingWithRounding()
     {
-        $form = $this->factory->create('number', null, array('scale' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP));
+        $form = $this->factory->create(static::TESTED_TYPE, null, array('scale' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP));
         $form->setData('12345.54321');
-        $view = $form->createView();
 
-        $this->assertSame('12346', $view->vars['value']);
+        $this->assertSame('12346', $form->createView()->vars['value']);
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -11,43 +11,44 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase;
-
-class PasswordTypeTest extends TypeTestCase
+class PasswordTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'password';
+
     public function testEmptyIfNotSubmitted()
     {
-        $form = $this->factory->create('password');
+        $form = $this->factory->create(static::TESTED_TYPE);
         $form->setData('pAs5w0rd');
-        $view = $form->createView();
 
-        $this->assertSame('', $view->vars['value']);
+        $this->assertSame('', $form->createView()->vars['value']);
     }
 
     public function testEmptyIfSubmitted()
     {
-        $form = $this->factory->create('password');
+        $form = $this->factory->create(static::TESTED_TYPE);
         $form->submit('pAs5w0rd');
-        $view = $form->createView();
 
-        $this->assertSame('', $view->vars['value']);
+        $this->assertSame('', $form->createView()->vars['value']);
     }
 
     public function testNotEmptyIfSubmittedAndNotAlwaysEmpty()
     {
-        $form = $this->factory->create('password', null, array('always_empty' => false));
+        $form = $this->factory->create(static::TESTED_TYPE, null, array('always_empty' => false));
         $form->submit('pAs5w0rd');
-        $view = $form->createView();
 
-        $this->assertSame('pAs5w0rd', $view->vars['value']);
+        $this->assertSame('pAs5w0rd', $form->createView()->vars['value']);
     }
 
     public function testNotTrimmed()
     {
-        $form = $this->factory->create('password', null);
+        $form = $this->factory->create(static::TESTED_TYPE, null);
         $form->submit(' pAs5w0rd ');
-        $data = $form->getData();
 
-        $this->assertSame(' pAs5w0rd ', $data);
+        $this->assertSame(' pAs5w0rd ', $form->getData());
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -11,63 +11,67 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Form\Form;
 
-class RepeatedTypeTest extends TypeTestCase
+class RepeatedTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'repeated';
+
+    /**
+     * @var Form
+     */
     protected $form;
 
     protected function setUp()
     {
         parent::setUp();
 
-        $this->form = $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $this->form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
         ));
-        $this->form->setData(null);
     }
 
     public function testSetData()
     {
         $this->form->setData('foobar');
 
-        $this->assertEquals('foobar', $this->form['first']->getData());
-        $this->assertEquals('foobar', $this->form['second']->getData());
+        $this->assertSame('foobar', $this->form['first']->getData());
+        $this->assertSame('foobar', $this->form['second']->getData());
     }
 
     public function testSetOptions()
     {
-        $form = $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'options' => array('label' => 'Global'),
         ));
 
-        $this->assertEquals('Global', $form['first']->getConfig()->getOption('label'));
-        $this->assertEquals('Global', $form['second']->getConfig()->getOption('label'));
+        $this->assertSame('Global', $form['first']->getConfig()->getOption('label'));
+        $this->assertSame('Global', $form['second']->getConfig()->getOption('label'));
         $this->assertTrue($form['first']->isRequired());
         $this->assertTrue($form['second']->isRequired());
     }
 
     public function testSetOptionsPerChild()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             // the global required value cannot be overridden
-            'type' => 'text',
+            'type' => TextTypeTest::TESTED_TYPE,
             'first_options' => array('label' => 'Test', 'required' => false),
             'second_options' => array('label' => 'Test2'),
         ));
 
-        $this->assertEquals('Test', $form['first']->getConfig()->getOption('label'));
-        $this->assertEquals('Test2', $form['second']->getConfig()->getOption('label'));
+        $this->assertSame('Test', $form['first']->getConfig()->getOption('label'));
+        $this->assertSame('Test2', $form['second']->getConfig()->getOption('label'));
         $this->assertTrue($form['first']->isRequired());
         $this->assertTrue($form['second']->isRequired());
     }
 
     public function testSetRequired()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => false,
-            'type' => 'text',
+            'type' => TextTypeTest::TESTED_TYPE,
         ));
 
         $this->assertFalse($form['first']->isRequired());
@@ -79,8 +83,8 @@ class RepeatedTypeTest extends TypeTestCase
      */
     public function testSetInvalidOptions()
     {
-        $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'options' => 'bad value',
         ));
     }
@@ -90,8 +94,8 @@ class RepeatedTypeTest extends TypeTestCase
      */
     public function testSetInvalidFirstOptions()
     {
-        $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'first_options' => 'bad value',
         ));
     }
@@ -101,15 +105,15 @@ class RepeatedTypeTest extends TypeTestCase
      */
     public function testSetInvalidSecondOptions()
     {
-        $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'second_options' => 'bad value',
         ));
     }
 
     public function testSetErrorBubblingToTrue()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'error_bubbling' => true,
         ));
 
@@ -120,7 +124,7 @@ class RepeatedTypeTest extends TypeTestCase
 
     public function testSetErrorBubblingToFalse()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'error_bubbling' => false,
         ));
 
@@ -131,7 +135,7 @@ class RepeatedTypeTest extends TypeTestCase
 
     public function testSetErrorBubblingIndividually()
     {
-        $form = $this->factory->create('repeated', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'error_bubbling' => true,
             'options' => array('error_bubbling' => false),
             'second_options' => array('error_bubbling' => true),
@@ -144,14 +148,14 @@ class RepeatedTypeTest extends TypeTestCase
 
     public function testSetOptionsPerChildAndOverwrite()
     {
-        $form = $this->factory->create('repeated', null, array(
-            'type' => 'text',
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'type' => TextTypeTest::TESTED_TYPE,
             'options' => array('label' => 'Label'),
             'second_options' => array('label' => 'Second label'),
         ));
 
-        $this->assertEquals('Label', $form['first']->getConfig()->getOption('label'));
-        $this->assertEquals('Second label', $form['second']->getConfig()->getOption('label'));
+        $this->assertSame('Label', $form['first']->getConfig()->getOption('label'));
+        $this->assertSame('Second label', $form['second']->getConfig()->getOption('label'));
         $this->assertTrue($form['first']->isRequired());
         $this->assertTrue($form['second']->isRequired());
     }
@@ -162,10 +166,10 @@ class RepeatedTypeTest extends TypeTestCase
 
         $this->form->submit($input);
 
-        $this->assertEquals('foo', $this->form['first']->getViewData());
-        $this->assertEquals('bar', $this->form['second']->getViewData());
+        $this->assertSame('foo', $this->form['first']->getViewData());
+        $this->assertSame('bar', $this->form['second']->getViewData());
         $this->assertFalse($this->form->isSynchronized());
-        $this->assertEquals($input, $this->form->getViewData());
+        $this->assertSame($input, $this->form->getViewData());
         $this->assertNull($this->form->getData());
     }
 
@@ -175,10 +179,15 @@ class RepeatedTypeTest extends TypeTestCase
 
         $this->form->submit($input);
 
-        $this->assertEquals('foo', $this->form['first']->getViewData());
-        $this->assertEquals('foo', $this->form['second']->getViewData());
+        $this->assertSame('foo', $this->form['first']->getViewData());
+        $this->assertSame('foo', $this->form['second']->getViewData());
         $this->assertTrue($this->form->isSynchronized());
-        $this->assertEquals($input, $this->form->getViewData());
-        $this->assertEquals('foo', $this->form->getData());
+        $this->assertSame($input, $this->form->getViewData());
+        $this->assertSame('foo', $this->form->getData());
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, array('first' => null, 'second' => null));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
@@ -11,28 +11,28 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
-
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class SubmitTypeTest extends TestCase
+class SubmitTypeTest extends ButtonTypeTest
 {
+    const TESTED_TYPE = 'submit';
+
     public function testCreateSubmitButtonInstances()
     {
-        $this->assertInstanceOf('Symfony\Component\Form\SubmitButton', $this->factory->create('submit'));
+        $this->assertInstanceOf('Symfony\Component\Form\SubmitButton', $this->factory->create(static::TESTED_TYPE));
     }
 
     public function testNotClickedByDefault()
     {
-        $button = $this->factory->create('submit');
+        $button = $this->factory->create(static::TESTED_TYPE);
 
         $this->assertFalse($button->isClicked());
     }
 
     public function testNotClickedIfSubmittedWithNull()
     {
-        $button = $this->factory->create('submit');
+        $button = $this->factory->create(static::TESTED_TYPE);
         $button->submit(null);
 
         $this->assertFalse($button->isClicked());
@@ -40,7 +40,7 @@ class SubmitTypeTest extends TestCase
 
     public function testClickedIfSubmittedWithEmptyString()
     {
-        $button = $this->factory->create('submit');
+        $button = $this->factory->create(static::TESTED_TYPE);
         $button->submit('');
 
         $this->assertTrue($button->isClicked());
@@ -48,7 +48,7 @@ class SubmitTypeTest extends TestCase
 
     public function testClickedIfSubmittedWithUnemptyString()
     {
-        $button = $this->factory->create('submit');
+        $button = $this->factory->create(static::TESTED_TYPE);
         $button->submit('foo');
 
         $this->assertTrue($button->isClicked());
@@ -57,9 +57,9 @@ class SubmitTypeTest extends TestCase
     public function testSubmitCanBeAddedToForm()
     {
         $form = $this->factory
-            ->createBuilder('form')
+            ->createBuilder(FormTypeTest::TESTED_TYPE)
             ->getForm();
 
-        $this->assertSame($form, $form->add('send', 'submit'));
+        $this->assertSame($form, $form->add('send', static::TESTED_TYPE));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+class TextTypeTest extends BaseTypeTest
+{
+    const TESTED_TYPE = 'text';
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
+    }
+
+    public function testSubmitNullReturnsNullWithEmptyDataAsString()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, 'name', array(
+            'empty_data' => '',
+        ));
+
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+    }
+
+    public function provideZeros()
+    {
+        return array(
+            array(0, '0'),
+            array('0', '0'),
+            array('00000', '00000'),
+        );
+    }
+
+    /**
+     * @dataProvider provideZeros
+     *
+     * @see https://github.com/symfony/symfony/issues/1986
+     */
+    public function testSetDataThroughParamsWithZero($data, $dataAsString)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'data' => $data,
+        ));
+        $view = $form->createView();
+
+        $this->assertFalse($form->isEmpty());
+
+        $this->assertSame($dataAsString, $view->vars['value']);
+        $this->assertSame($dataAsString, $form->getData());
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -13,13 +13,14 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 
-class TimeTypeTest extends TestCase
+class TimeTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'time';
+
     public function testSubmitDateTime()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -40,7 +41,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitString()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -59,7 +60,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitTimestamp()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -80,7 +81,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArray()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -99,7 +100,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitDatetimeSingleText()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -114,7 +115,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitDatetimeSingleTextWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -130,7 +131,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArraySingleText()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -150,7 +151,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArraySingleTextWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -170,7 +171,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitArraySingleTextWithSeconds()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -192,7 +193,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitStringSingleText()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -207,7 +208,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitStringSingleTextWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -223,7 +224,7 @@ class TimeTypeTest extends TestCase
 
     public function testSubmitWithSecondsAndBrowserOmissionSeconds()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -239,7 +240,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataWithoutMinutes()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -253,7 +254,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataWithSeconds()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -267,7 +268,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataDifferentTimezones()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'string',
@@ -293,7 +294,7 @@ class TimeTypeTest extends TestCase
 
     public function testSetDataDifferentTimezonesDateTime()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'datetime',
@@ -320,7 +321,7 @@ class TimeTypeTest extends TestCase
 
     public function testHoursOption()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'hours' => array(6, 7),
         ));
 
@@ -334,7 +335,7 @@ class TimeTypeTest extends TestCase
 
     public function testIsMinuteWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'minutes' => array(6, 7),
         ));
 
@@ -348,7 +349,7 @@ class TimeTypeTest extends TestCase
 
     public function testIsSecondWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'seconds' => array(6, 7),
             'with_seconds' => true,
         ));
@@ -365,7 +366,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'choice',
         ));
 
@@ -381,7 +382,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -399,7 +400,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'choice',
         ));
 
@@ -415,7 +416,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -433,7 +434,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -451,7 +452,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -469,7 +470,7 @@ class TimeTypeTest extends TestCase
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -487,12 +488,12 @@ class TimeTypeTest extends TestCase
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->factory->create('time', new \DateTime());
+        $this->factory->create(static::TESTED_TYPE, new \DateTime());
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
         ));
 
@@ -502,7 +503,7 @@ class TimeTypeTest extends TestCase
 
     public function testSingleTextWidgetWithSecondsShouldHaveRightStepAttribute()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
             'with_seconds' => true,
         ));
@@ -514,7 +515,7 @@ class TimeTypeTest extends TestCase
 
     public function testSingleTextWidgetWithSecondsShouldNotOverrideStepAttribute()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
             'with_seconds' => true,
             'attr' => array(
@@ -529,7 +530,7 @@ class TimeTypeTest extends TestCase
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => 'single_text',
             'html5' => false,
         ));
@@ -540,7 +541,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => false,
             'with_seconds' => true,
         ));
@@ -553,7 +554,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => true,
             'with_seconds' => true,
         ));
@@ -566,7 +567,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'placeholder' => 'Empty',
             'with_seconds' => true,
         ));
@@ -582,7 +583,7 @@ class TimeTypeTest extends TestCase
      */
     public function testPassEmptyValueBC()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'empty_value' => 'Empty',
             'with_seconds' => true,
         ));
@@ -598,7 +599,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'placeholder' => array(
                 'hour' => 'Empty hour',
                 'minute' => 'Empty minute',
@@ -615,7 +616,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => false,
             'placeholder' => array(
                 'hour' => 'Empty hour',
@@ -632,7 +633,7 @@ class TimeTypeTest extends TestCase
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'required' => true,
             'placeholder' => array(
                 'hour' => 'Empty hour',
@@ -661,7 +662,7 @@ class TimeTypeTest extends TestCase
     public function testHourErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => $widget,
         ));
         $form['hour']->addError($error);
@@ -676,7 +677,7 @@ class TimeTypeTest extends TestCase
     public function testMinuteErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => $widget,
         ));
         $form['minute']->addError($error);
@@ -691,7 +692,7 @@ class TimeTypeTest extends TestCase
     public function testSecondErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create('time', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'widget' => $widget,
             'with_seconds' => true,
         ));
@@ -706,7 +707,7 @@ class TimeTypeTest extends TestCase
      */
     public function testInitializeWithSecondsAndWithoutMinutes()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'with_minutes' => false,
             'with_seconds' => true,
         ));
@@ -717,7 +718,7 @@ class TimeTypeTest extends TestCase
      */
     public function testThrowExceptionIfHoursIsInvalid()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'hours' => 'bad value',
         ));
     }
@@ -727,7 +728,7 @@ class TimeTypeTest extends TestCase
      */
     public function testThrowExceptionIfMinutesIsInvalid()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'minutes' => 'bad value',
         ));
     }
@@ -737,8 +738,15 @@ class TimeTypeTest extends TestCase
      */
     public function testThrowExceptionIfSecondsIsInvalid()
     {
-        $this->factory->create('time', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'seconds' => 'bad value',
         ));
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        $view = array('hour' => '', 'minute' => '');
+
+        parent::testSubmitNull($expected, $norm, $view);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -12,20 +12,25 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
-use Symfony\Component\Form\Test\TypeTestCase;
 
-class TimezoneTypeTest extends TypeTestCase
+class TimezoneTypeTest extends BaseTypeTest
 {
+    const TESTED_TYPE = 'timezone';
+
     public function testTimezonesAreSelectable()
     {
-        $form = $this->factory->create('timezone');
-        $view = $form->createView();
-        $choices = $view->vars['choices'];
+        $choices = $this->factory->create(static::TESTED_TYPE)
+            ->createView()->vars['choices'];
 
         $this->assertArrayHasKey('Africa', $choices);
         $this->assertContains(new ChoiceView('Africa/Kinshasa', 'Africa/Kinshasa', 'Kinshasa'), $choices['Africa'], '', false, false);
 
         $this->assertArrayHasKey('America', $choices);
         $this->assertContains(new ChoiceView('America/New_York', 'America/New_York', 'New York'), $choices['America'], '', false, false);
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        parent::testSubmitNull($expected, $norm, '');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Test\TypeTestCase as TestCase;
-
-class UrlTypeTest extends TestCase
+class UrlTypeTest extends TextTypeTest
 {
+    const TESTED_TYPE = 'url';
+
     public function testSubmitAddsDefaultProtocolIfNoneIsIncluded()
     {
-        $form = $this->factory->create('url', 'name');
+        $form = $this->factory->create(static::TESTED_TYPE, 'name');
 
         $form->submit('www.domain.com');
 
@@ -27,7 +27,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfAlreadyIncluded()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'default_protocol' => 'http',
         ));
 
@@ -39,7 +39,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfEmpty()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'default_protocol' => 'http',
         ));
 
@@ -51,7 +51,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfNull()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'default_protocol' => 'http',
         ));
 
@@ -63,7 +63,7 @@ class UrlTypeTest extends TestCase
 
     public function testSubmitAddsNoDefaultProtocolIfSetToNull()
     {
-        $form = $this->factory->create('url', null, array(
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'default_protocol' => null,
         ));
 
@@ -78,7 +78,7 @@ class UrlTypeTest extends TestCase
      */
     public function testThrowExceptionIfDefaultProtocolIsInvalid()
     {
-        $this->factory->create('url', null, array(
+        $this->factory->create(static::TESTED_TYPE, null, array(
             'default_protocol' => array(),
         ));
     }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -513,6 +513,24 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame('default', $form->getData());
     }
 
+    public function testPresSetDataChangesDataIfDataIsLocked()
+    {
+        $config = new FormConfigBuilder('name', null, $this->dispatcher);
+        $config
+            ->setData('default')
+            ->setDataLocked(true)
+            ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+                $event->setData('foobar');
+            });
+        $form = new Form($config);
+
+        $form->submit(false);
+
+        $this->assertTrue($form->isValid());
+
+        $this->assertSame('foobar', $form->getData());
+    }
+
     public function testSubmitConvertsEmptyToNullIfNoTransformer()
     {
         $form = $this->getBuilder()->getForm();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

This one the PRs to come targeting 2.7 needed to harden the code base before doing some changes in master.

It takes care of the form types tests part (even if some other tests will be added later, it will also be easier after it), and unlocks merging https://github.com/symfony/symfony/pull/21481.
It also back ports tests added in https://github.com/symfony/symfony/pull/18357 for the TextType.

Since it's very hard to merge branches when modifying tests because of BC, and making every test type extend the base type test would involve many function calls to get the tested type, the function `getTestedType` is no longer abstract and return a constant to override instead, it's much better for performance, I didn't change the call in the base type test to keep BC but I suggest to deprecate it in master. Even if those are tests I really think it is worth keeping BC here.

The constants also ease testing in the ecosystem of form related libraries that need to be compatible with Symfony 2.7 and 3. I think using "test" as both prefix and suffix on namespaces, classes and names of the constants should discourage using them in real application code. Since this is just about our test suite, I don't think this should be considered a feature, so tis change should be good for 2.7.

Two other PRs will follow to solve conflicts in 2.8 and 3.2.

I missed last month patches, I hope I won't this time :).