### PR TITLE
[Form] Fixed typo in a test after #21877

### DIFF
--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -513,22 +513,20 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame('default', $form->getData());
     }
 
-    public function testPresSetDataChangesDataIfDataIsLocked()
+    public function testPreSetDataChangesDataIfDataIsLocked()
     {
         $config = new FormConfigBuilder('name', null, $this->dispatcher);
         $config
             ->setData('default')
             ->setDataLocked(true)
-            ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
                 $event->setData('foobar');
             });
         $form = new Form($config);
 
-        $form->submit(false);
-
-        $this->assertTrue($form->isValid());
-
         $this->assertSame('foobar', $form->getData());
+        $this->assertSame('foobar', $form->getNormData());
+        $this->assertSame('foobar', $form->getViewData());
     }
 
     public function testSubmitConvertsEmptyToNullIfNoTransformer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Reviewing the diff on GitHub, I realized I've missed some typos in a new test of #21877. Sorry!