### PR TITLE
[Form] Add validate method to mockec validator in form TypeTestCase

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TypeTestCase.php
@@ -23,6 +23,7 @@ abstract class TypeTestCase extends BaseTypeTestCase
         $this->validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')->getMock();
         $metadata = $this->getMockBuilder('Symfony\Component\Validator\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
         $this->validator->expects($this->once())->method('getMetadataFor')->will($this->returnValue($metadata));
+        $this->validator->expects($this->any())->method('validate')->will($this->returnValue(array()));
 
         parent::setUp();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

When using the `Symfony\Component\Form\Tests\Extension\Validator\Type\TypeTestCase` class to unit test forms, the `validate` method is not mocked, which causes errors when the unit tests run.