### PR TITLE
Fix symlinks on Windows.

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -332,24 +332,24 @@ class Filesystem
         }
 
         if (!$ok) {
-            if (strncasecmp(PHP_OS, 'WIN', 3) == 0) {
-                // Creating symlinks on windows through PHP's symlink function
-                // is totally broken with relative paths.
-                // @see https://github.com/php/php-src/pull/1243
-                // @see https://bugs.php.net/bug.php?id=69473
-                $exitCode = 1;
-                $output = array();
-                // Without this cleanup for backslashes symlink will
-                // be created but completely broken.
-                $originDir = str_replace('/', DIRECTORY_SEPARATOR, $originDir);
-                $targetDir = str_replace('/', DIRECTORY_SEPARATOR, $targetDir);
-                // Careful as parameters here are ordered differently
-                // compared to PHP's symlink function.
-                @exec(sprintf('mklink /d %s %s', escapeshellarg($targetDir), escapeshellarg($originDir)), $ouptput, $exitCode);
-                $ok = $exitCode == 0;
-            } else {
-                $ok = @symlink($originDir, $targetDir);
-            }
+            $ok = @symlink($originDir, $targetDir);
+        }
+
+        if (!$ok && strncasecmp(PHP_OS, 'WIN', 3) == 0) {
+            // Creating symlinks on windows through PHP's symlink function
+            // is totally broken with relative paths.
+            // @see https://github.com/php/php-src/pull/1243
+            // @see https://bugs.php.net/bug.php?id=69473
+            $exitCode = 1;
+            $output = array();
+            // Without this cleanup for backslashes symlink will
+            // be created but completely broken.
+            $originDir = str_replace('/', DIRECTORY_SEPARATOR, $originDir);
+            $targetDir = str_replace('/', DIRECTORY_SEPARATOR, $targetDir);
+            // Careful as parameters here are ordered differently
+            // compared to PHP's symlink function.
+            @exec(sprintf('mklink /d %s %s', escapeshellarg($targetDir), escapeshellarg($originDir)), $ouptput, $exitCode);
+            $ok = $exitCode == 0;
         }
 
         if (!$ok) {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -331,7 +331,28 @@ class Filesystem
             }
         }
 
-        if (!$ok && true !== @symlink($originDir, $targetDir)) {
+        if (!$ok) {
+            if (strncasecmp(PHP_OS, 'WIN', 3) == 0) {
+                // Creating symlinks on windows through PHP's symlink function
+                // is totally broken with relative paths.
+                // @see https://github.com/php/php-src/pull/1243
+                // @see https://bugs.php.net/bug.php?id=69473
+                $exitCode = 1;
+                $output = array();
+                // Without this cleanup for backslashes symlink will
+                // be created but completely broken.
+                $originDir = str_replace('/', DIRECTORY_SEPARATOR, $originDir);
+                $targetDir = str_replace('/', DIRECTORY_SEPARATOR, $targetDir);
+                // Careful as parameters here are ordered differently
+                // compared to PHP's symlink function.
+                @exec(sprintf('mklink /d %s %s', escapeshellarg($targetDir), escapeshellarg($originDir)), $ouptput, $exitCode);
+                $ok = $exitCode == 0;
+            } else {
+                $ok = @symlink($originDir, $targetDir);
+            }
+        }
+
+        if (!$ok) {
             $this->linkException($originDir, $targetDir, 'symbolic');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Php's symlink function on Windows is completely broken, see:

https://github.com/php/php-src/pull/1243
https://bugs.php.net/bug.php?id=69473

Looks like there is little to no intention to fix this in core. An alternative way to achieve symlinks (properly) on Windows is to use the command line.

I submitted a similar PR for the composer/composer project, where they use symfony's filesystem + a manual junction based fallback for windows:

https://github.com/composer/composer/pull/6213

This patch adds additional fallback to try and create the symlink on windows environments using exec()





