### PR TITLE
[Filesystem] respect the umask argument in dumpFile()

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -516,8 +516,8 @@ class Filesystem
             }
 
             $this->chmod($tmpFile, $mode);
-        } else {
-            @chmod($tmpFile, file_exists($filename) ? fileperms($filename) : 0666 & ~umask());
+        } elseif (file_exists($filename)) {
+            @chmod($tmpFile, fileperms($filename));
         }
 
         $this->rename($tmpFile, $filename, true);

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1050,6 +1050,19 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertSame('bar', file_get_contents($filename));
     }
 
+    public function testDumpKeepsExistingPermissionsWhenOverwritingAnExistingFile()
+    {
+        $this->markAsSkippedIfChmodIsMissing();
+
+        $filename = $this->workspace.DIRECTORY_SEPARATOR.'foo.txt';
+        file_put_contents($filename, 'FOO BAR');
+        chmod($filename, 0745);
+
+        $this->filesystem->dumpFile($filename, 'bar', null);
+
+        $this->assertFilePermissions(745, $filename);
+    }
+
     public function testCopyShouldKeepExecutionPermission()
     {
         $this->markAsSkippedIfChmodIsMissing();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21823
| License       | MIT
| Doc PR        | 

In #21823 we introduced a small BC break: The `dumpFile()` method of the `Filesystem` class allowed to pass the desired file permissions (support for this feature was dropped in Symfony 3.0).