### PR TITLE
[DI] Add tail injection for methods + autowiring

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.3.0
 -----
 
+ * [EXPERIMENTAL] added support for tail-injection for methods + autowiring
  * [EXPERIMENTAL] added "TypedReference" and "ServiceClosureArgument" for creating service-locator services
  * [EXPERIMENTAL] added "instanceof" section for local interface-defined configs
  * added "service-locator" argument for lazy loading a set of identified values and services

--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -62,6 +62,7 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
             $value->setArguments($this->processValue($value->getArguments()));
             $value->setProperties($this->processValue($value->getProperties()));
             $value->setOverriddenGetters($this->processValue($value->getOverriddenGetters()));
+            $value->setOverridenTails($this->processValue($value->getOverridenTails()));
             $value->setMethodCalls($this->processValue($value->getMethodCalls()));
 
             if ($v = $value->getFactory()) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -111,6 +111,7 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass implements Repe
             $this->processValue($value->getProperties());
             $this->lazy = true;
             $this->processValue($value->getOverriddenGetters());
+            $this->processValue($value->getOverridenTails());
             $this->lazy = false;
             $this->processValue($value->getMethodCalls());
             $this->processValue($value->getConfigurator());

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -65,6 +65,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
             $value->setArguments($this->processValue($value->getArguments(), 0));
             $value->setProperties($this->processValue($value->getProperties(), 1));
             $value->setOverriddenGetters($this->processValue($value->getOverriddenGetters(), 1));
+            $value->setOverridenTails($this->processValue($value->getOverridenTails(), 1));
             $value->setMethodCalls($this->processValue($value->getMethodCalls(), 2));
         } elseif (is_array($value)) {
             $i = 0;

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -43,6 +43,7 @@ class ResolveReferencesToAliasesPass implements CompilerPassInterface
             $definition->setArguments($this->processArguments($definition->getArguments()));
             $definition->setMethodCalls($this->processArguments($definition->getMethodCalls()));
             $definition->setOverriddenGetters($this->processArguments($definition->getOverriddenGetters()));
+            $definition->setOverridenTails($this->processArguments($definition->getOverridenTails()));
             $definition->setProperties($this->processArguments($definition->getProperties()));
             $definition->setFactory($this->processFactory($definition->getFactory()));
         }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -31,6 +31,7 @@ class Definition
     private $calls = array();
     private $getters = array();
     private $instanceof = array();
+    private $tails = array();
     private $configurator;
     private $tags = array();
     private $public = true;
@@ -388,6 +389,49 @@ class Definition
     public function getInstanceofConditionals()
     {
         return $this->instanceof;
+    }
+
+    /**
+     * Sets the default values of tail arguments in a method.
+     *
+     * @return $this
+     *
+     * @experimental in version 3.3
+     */
+    public function setOverridenTail($name, array $defaultArgs)
+    {
+        if (!$name) {
+            throw new InvalidArgumentException(sprintf('Tail method name cannot be empty.'));
+        }
+        $this->tails[strtolower($name)] = $defaultArgs;
+
+        return $this;
+    }
+
+    /**
+     * Sets the default values of tail arguments in a list of methods.
+     *
+     * @return $this
+     *
+     * @experimental in version 3.3
+     */
+    public function setOverridenTails(array $tails)
+    {
+        $this->tails = array_change_key_case($tails, CASE_LOWER);
+
+        return $this;
+    }
+
+    /**
+     * Gets the default values of tail arguments for configured methods.
+     *
+     * @return array
+     *
+     * @experimental in version 3.3
+     */
+    public function getOverridenTails()
+    {
+        return $this->tails;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -84,7 +84,14 @@ class GraphvizDumper extends Dumper
             foreach ($definition->getOverriddenGetters() as $name => $value) {
                 $this->edges[$id] = array_merge(
                     $this->edges[$id],
-                    $this->findEdges($id, $value, false, $name.'()')
+                    $this->findEdges($id, $value, false, $name.'()', true)
+                );
+            }
+
+            foreach ($definition->getOverridenTails() as $name => $value) {
+                $this->edges[$id] = array_merge(
+                    $this->edges[$id],
+                    $this->findEdges($id, $value, false, $name.'()', true)
                 );
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -528,7 +528,7 @@ class PhpDumper extends Dumper
             $constructor = sprintf("\n    public function __construct(\$container%1\$s)\n    {\n        \$this->container%1\$s = \$container%1\$s;\n    }\n", $this->salt);
         }
 
-        return $constructor.$this->addServiceOverriddenGetters($id, $definition, $class);
+        return $constructor.$this->addServiceOverriddenGetters($id, $definition, $class).$this->addServiceOverridenTails($id, $definition, $class);
     }
 
     private function addServiceOverriddenGetters($id, Definition $definition, \ReflectionClass $class)
@@ -569,6 +569,57 @@ class PhpDumper extends Dumper
         }
 
         return $getters;
+    }
+
+    private function addServiceOverridenTails($id, Definition $definition, \ReflectionClass $class)
+    {
+        $tails = '';
+
+        foreach ($definition->getOverridenTails() as $name => $defaultArgs) {
+            $r = InheritanceProxyHelper::getReflector($class, $name, $id);
+            if (!$defaultArgs = InheritanceProxyHelper::getTailArgs($r, $defaultArgs, $id)) {
+                continue;
+            }
+
+            $tail = array();
+            $tail[] = sprintf('%s function %s', $r->isProtected() ? 'protected' : 'public', InheritanceProxyHelper::getSignature($r, $call, $defaultArgs));
+            $tail[] = '{';
+            $tail[] = '    switch (func_num_args()) {';
+
+            if ($numReqArgs = key($defaultArgs)) {
+                for ($i = 0; $i < $numReqArgs; ++$i) {
+                    $tail[] = "        case $i:";
+                }
+            }
+
+            foreach ($defaultArgs as $i => list($param, $value)) {
+                if (null === $value && !$param->allowsNull()) {
+                    throw new RuntimeException(sprintf('Unable to configure service "%s": argument %d ($%s) of method "%s::%s()" must be non-null.', $id, $i, $param->name, $class->name, $r->name));
+                }
+                if (false === strpos($dumpedValue = $this->dumpValue($value), '$this')) {
+                    $tail[] = "        case $i: \${$param->name} = {$dumpedValue};";
+                } else {
+                    $s = $this->salt;
+                    $tail[] = "        case $i:";
+                    $tail[] = "            if (null === \$p{$s} = &\$this->tails{$s}[__FUNCTION__][{$i}]) {";
+                    $tail[] = "                \$p{$s} = \Closure::bind(function () { return {$dumpedValue}; }, \$this->container{$s}, \$this->container{$s});";
+                    $tail[] = '            }';
+                    $tail[] = "            \${$param->name} = \$p{$s}();";
+                }
+            }
+
+            $tail[] = '    }';
+            $tail[] = '';
+            $tail[] = "    return parent::{$call};";
+            $tail[] = '}';
+            $tail[] = '';
+
+            foreach ($tail as $code) {
+                $tails .= $code ? "\n    ".$code : "\n";
+            }
+        }
+
+        return $tails;
     }
 
     private function addServiceProperties($id, Definition $definition, $variableName = 'instance')
@@ -819,6 +870,9 @@ EOF;
             if ($definition->getOverriddenGetters()) {
                 throw new RuntimeException(sprintf('Cannot dump definition for service "%s": factories and overridden getters are incompatible with each other.', $id));
             }
+            if ($definition->getOverridenTails()) {
+                throw new RuntimeException(sprintf('Cannot dump definition for service "%s": factories and overridden tails are incompatible with each other.', $id));
+            }
             $callable = $definition->getFactory();
             if (is_array($callable)) {
                 if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $callable[1])) {
@@ -854,13 +908,20 @@ EOF;
             if ($definition->getOverriddenGetters()) {
                 throw new RuntimeException(sprintf('Cannot dump definition for service "%s": dynamic class names and overridden getters are incompatible with each other.', $id));
             }
+            if ($definition->getOverridenTails()) {
+                throw new RuntimeException(sprintf('Cannot dump definition for service "%s": dynamic class names and overridden tails are incompatible with each other.', $id));
+            }
 
             return sprintf("        \$class = %s;\n\n        $return{$instantiation}new \$class(%s);\n", $class, implode(', ', $arguments));
         }
         $class = $this->dumpLiteralClass($class);
 
-        if ($definition->getOverriddenGetters()) {
-            $inheritanceProxy = "    private \$container{$this->salt};\n    private \$getters{$this->salt};\n";
+        if ($definition->getOverriddenGetters() || $definition->getOverridenTails()) {
+            $inheritanceProxy = implode('', array(
+                "    private \$container{$this->salt};\n",
+                $definition->getOverriddenGetters() ? "    private \$getters{$this->salt};\n" : '',
+                $definition->getOverridenTails() ? "    private \$tails{$this->salt};\n" : '',
+            ));
             $inheritanceProxy = sprintf("%s implements \\%s\n{\n%s%s}\n", $class, InheritanceProxyInterface::class, $inheritanceProxy, $this->addServiceOverriddenMethods($id, $definition));
             $class = 'SymfonyProxy_'.md5($inheritanceProxy);
             $this->inheritanceProxies[$class] = $inheritanceProxy;
@@ -1437,6 +1498,7 @@ EOF;
                 $this->getDefinitionsFromArguments($definition->getArguments()),
                 $this->getDefinitionsFromArguments($definition->getMethodCalls()),
                 $this->getDefinitionsFromArguments($definition->getOverriddenGetters()),
+                $this->getDefinitionsFromArguments($definition->getOverridenTails()),
                 $this->getDefinitionsFromArguments($definition->getProperties()),
                 $this->getDefinitionsFromArguments(array($definition->getConfigurator())),
                 $this->getDefinitionsFromArguments(array($definition->getFactory()))
@@ -1584,6 +1646,9 @@ EOF;
             }
             if ($value->getOverriddenGetters()) {
                 throw new RuntimeException('Cannot dump definitions which have overridden getters.');
+            }
+            if ($value->getOverridenTails()) {
+                throw new RuntimeException('Cannot dump definitions which have overridden tails.');
             }
             if (null !== $value->getConfigurator()) {
                 throw new RuntimeException('Cannot dump definitions which have a configurator.');

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -173,6 +173,10 @@ class XmlDumper extends Dumper
             $this->convertParameters($parameters, 'getter', $service, 'name');
         }
 
+        if ($parameters = $definition->getOverridenTails()) {
+            $this->convertParameters($parameters, 'tail', $service, 'name');
+        }
+
         $this->addMethodCalls($definition->getMethodCalls(), $service);
 
         if ($callable = $definition->getFactory()) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -134,6 +134,10 @@ class YamlDumper extends Dumper
             $code .= sprintf("        getters:\n%s\n", $this->dumper->dump($this->dumpValue($definition->getOverriddenGetters()), 0));
         }
 
+        if ($definition->getOverridenTails()) {
+            $code .= sprintf("        tails:\n%s\n", $this->dumper->dump($this->dumpValue($definition->getOverridenTails()), 0));
+        }
+
         if ($definition->getMethodCalls()) {
             $code .= sprintf("        calls:\n%s\n", $this->dumper->dump($this->dumpValue($definition->getMethodCalls()), 1, 12));
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -294,6 +294,10 @@ class XmlFileLoader extends FileLoader
             }
         }
 
+        foreach ($this->getChildren($service, 'tail') as $call) {
+            $definition->setOverridenTail($call->getAttribute('method'), $this->getArgumentsAsPhp($call, 'argument', false, (bool) $parent));
+        }
+
         foreach ($this->getChildren($service, 'call') as $call) {
             $definition->addMethodCall($call->getAttribute('method'), $this->getArgumentsAsPhp($call, 'argument'));
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -52,6 +52,7 @@ class YamlFileLoader extends FileLoader
         'arguments' => 'arguments',
         'properties' => 'properties',
         'getters' => 'getters',
+        'tails' => 'tails',
         'configurator' => 'configurator',
         'calls' => 'calls',
         'tags' => 'tags',
@@ -429,6 +430,10 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['getters'])) {
             $definition->setOverriddenGetters($this->resolveServices($service['getters']));
+        }
+
+        if (isset($service['tails'])) {
+            $definition->setOverridenTails($this->resolveServices($service['tails']));
         }
 
         if (isset($service['calls'])) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -118,6 +118,7 @@
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="getter" type="getter" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="tail" type="tail" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="autowiring-type" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
     </xsd:choice>
     <xsd:attribute name="id" type="xsd:string" />
@@ -223,6 +224,13 @@
     <xsd:attribute name="key" type="xsd:string" />
     <xsd:attribute name="name" type="xsd:string" />
     <xsd:attribute name="on-invalid" type="invalid_sequence" />
+  </xsd:complexType>
+
+  <xsd:complexType name="tail" mixed="true">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="argument" type="argument" minOccurs="1" maxOccurs="unbounded" />
+    </xsd:choice>
+    <xsd:attribute name="method" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="argument" mixed="true">

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -364,6 +364,20 @@ class ResolveDefinitionTemplatesPassTest extends TestCase
         $this->assertSame('ParentClass', $def->getClass());
     }
 
+    public function testTails()
+    {
+        $container = new ContainerBuilder();
+        $container->register('parent', 'foo')->setOverridenTail('foo', array('moo', 'b'));
+        $container->setDefinition('child', new ChildDefinition('parent'))
+            ->setOverridenTail('foo', array('index_0' => 'a'))
+        ;
+
+        $this->process($container);
+
+        $def = $container->getDefinition('child');
+        $this->assertEquals(array('foo' => array('a', 'b')), $def->getOverridenTails());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new ResolveDefinitionTemplatesPass();

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -927,6 +927,18 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals(array($second, $first), $configs);
     }
 
+    public function testOverridenTail()
+    {
+        $builder = new ContainerBuilder();
+        $builder
+            ->register('foo', FooClass::class)
+            ->setOverridenTail('method1', array(1 => 123));
+
+        $foo = $builder->get('foo');
+
+        $this->assertSame(array(456, 123), $foo->method1(456));
+    }
+
     public function testOverriddenGetter()
     {
         $builder = new ContainerBuilder();
@@ -1182,6 +1194,10 @@ class ContainerBuilderTest extends TestCase
 
 class FooClass
 {
+    public function method1($a1, $a2)
+    {
+        return func_get_args();
+    }
 }
 
 class A

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_tails.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_tails.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Tails;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+if (!class_exists(Foo::class, false)) {
+    class Foo
+    {
+        public function method0($bar)
+        {
+            return func_get_args();
+        }
+
+        public function method1($arg)
+        {
+            return func_get_args();
+        }
+    }
+
+    class Baz
+    {
+        final public function __construct()
+        {
+        }
+
+        protected function method1($arg1, $arg2)
+        {
+            return func_get_args();
+        }
+    }
+}
+
+$container = new ContainerBuilder();
+
+$container
+    ->register('foo', Foo::class)
+    ->setOverridenTail('method1', array(123))
+;
+
+$container
+    ->register('baz', Baz::class)
+    ->setOverridenTail('method1', array(1 => new Reference('foo')))
+;
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tails.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tails.php
@@ -1,0 +1,157 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * Symfony_DI_PhpDumper_Test_Tail_Methods.
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final since Symfony 3.3
+ */
+class Symfony_DI_PhpDumper_Test_Tail_Methods extends Container
+{
+    private $parameters;
+    private $targetDirs = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->services = array();
+        $this->normalizedIds = array(
+            'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
+            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
+            'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
+        );
+        $this->methodMap = array(
+            'baz' => 'getBazService',
+            'foo' => 'getFooService',
+        );
+
+        $this->aliases = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped frozen container.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFrozen()
+    {
+        return true;
+    }
+
+    /**
+     * Gets the 'baz' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\Tails\Baz A Symfony\Component\DependencyInjection\Tests\Fixtures\Tails\Baz instance
+     */
+    protected function getBazService()
+    {
+        return $this->services['baz'] = $this->instantiateProxy(SymfonyProxy_8c73474cb8141efea9d50aa6c4f80fa0::class, array(), true);
+    }
+
+    /**
+     * Gets the 'foo' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\Tails\Foo A Symfony\Component\DependencyInjection\Tests\Fixtures\Tails\Foo instance
+     */
+    protected function getFooService()
+    {
+        return $this->services['foo'] = new SymfonyProxy_9ff17673d1eeac1c1e97759e44f2e76e($this);
+    }
+
+    private function instantiateProxy($class, $args, $useConstructor)
+    {
+        static $reflectionCache;
+
+        if (null === $r = &$reflectionCache[$class]) {
+            $r[0] = new \ReflectionClass($class);
+            $r[1] = $r[0]->getProperty('containeru1sCxo6vGxZrp0Vla5q50A');
+            $r[1]->setAccessible(true);
+            $r[2] = $r[0]->getConstructor();
+        }
+        $service = $useConstructor ? $r[0]->newInstanceWithoutConstructor() : $r[0]->newInstanceArgs($args);
+        $r[1]->setValue($service, $this);
+        if ($r[2] && $useConstructor) {
+            $r[2]->invokeArgs($service, $args);
+        }
+
+        return $service;
+    }
+}
+
+class SymfonyProxy_8c73474cb8141efea9d50aa6c4f80fa0 extends \Symfony\Component\DependencyInjection\Tests\Fixtures\Tails\Baz implements \Symfony\Component\DependencyInjection\LazyProxy\InheritanceProxyInterface
+{
+    private $containeru1sCxo6vGxZrp0Vla5q50A;
+    private $tailsu1sCxo6vGxZrp0Vla5q50A;
+
+    protected function method1($arg1, $arg2 = null)
+    {
+        switch (func_num_args()) {
+            case 0:
+            case 1:
+                if (null === $pu1sCxo6vGxZrp0Vla5q50A = &$this->tailsu1sCxo6vGxZrp0Vla5q50A[__FUNCTION__][1]) {
+                    $pu1sCxo6vGxZrp0Vla5q50A = \Closure::bind(function () { return ${($_ = isset($this->services['foo']) ? $this->services['foo'] : $this->get('foo')) && false ?: '_'}; }, $this->containeru1sCxo6vGxZrp0Vla5q50A, $this->containeru1sCxo6vGxZrp0Vla5q50A);
+                }
+                $arg2 = $pu1sCxo6vGxZrp0Vla5q50A();
+        }
+
+        return parent::method1($arg1, $arg2);
+    }
+}
+
+class SymfonyProxy_9ff17673d1eeac1c1e97759e44f2e76e extends \Symfony\Component\DependencyInjection\Tests\Fixtures\Tails\Foo implements \Symfony\Component\DependencyInjection\LazyProxy\InheritanceProxyInterface
+{
+    private $containeru1sCxo6vGxZrp0Vla5q50A;
+    private $tailsu1sCxo6vGxZrp0Vla5q50A;
+
+    public function __construct($containeru1sCxo6vGxZrp0Vla5q50A)
+    {
+        $this->containeru1sCxo6vGxZrp0Vla5q50A = $containeru1sCxo6vGxZrp0Vla5q50A;
+    }
+
+    public function method1($arg = null)
+    {
+        switch (func_num_args()) {
+            case 0: $arg = 123;
+        }
+
+        return parent::method1($arg);
+    }
+
+    public function method0($bar = null)
+    {
+        switch (func_num_args()) {
+            case 0:
+                if (null === $pu1sCxo6vGxZrp0Vla5q50A = &$this->tailsu1sCxo6vGxZrp0Vla5q50A[__FUNCTION__][0]) {
+                    $pu1sCxo6vGxZrp0Vla5q50A = \Closure::bind(function () { return $this->get('bar', ContainerInterface::NULL_ON_INVALID_REFERENCE); }, $this->containeru1sCxo6vGxZrp0Vla5q50A, $this->containeru1sCxo6vGxZrp0Vla5q50A);
+                }
+                $bar = $pu1sCxo6vGxZrp0Vla5q50A();
+        }
+
+        return parent::method0($bar);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_tails.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_tails.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="foo" class="Foo">
+            <tail method="method1">
+                <argument index="1">bar</argument>
+                <argument type="service" id="bar" />
+            </tail>
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_tails.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_tails.yml
@@ -1,0 +1,7 @@
+services:
+    foo:
+        class: Foo
+        autowire: true
+        tails:
+            method1: { 1: 'bar', 2: '@bar' }
+

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -591,6 +591,15 @@ class XmlFileLoaderTest extends TestCase
         $this->assertTrue($container->getDefinition('bar')->isAutowired());
     }
 
+    public function testTails()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_tails.xml');
+
+        $this->assertEquals(array('method1' => array(1 => 'bar', 2 => new Reference('bar'))), $container->getDefinition('foo')->getOverridenTails());
+    }
+
     public function testGetter()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -441,6 +441,15 @@ class YamlFileLoaderTest extends TestCase
         $this->assertFalse($container->getDefinition('no_defaults_child')->isAutowired());
     }
 
+    public function testTails()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_tails.yml');
+
+        $this->assertEquals(array('method1' => array(1 => 'bar', 2 => new Reference('bar'))), $container->getDefinition('foo')->getOverridenTails());
+    }
+
     public function testGetter()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

A definition like:

```yaml
services:
    foo:
        class: Foo
        tails:
            method1: { 1: 'bar', 2: '@bar' }
```

will create an inheritance proxy overriding `Foo::method1`, making its args 2 & 3 optional, with the configured values being used as defaults, keeping only argument 1 mandatory (if it was in the original declaration of course).

This allows one to write an implementation of some interface and wire some optional args at the end of the signature.

```php
interface FooInterface { function foo(); }

class MyFoo implements Foo { function foo(LoggerInterface $logger = null); }

// and in some other code that care only about FooInterface

$myFooInstance->foo();
```

that is tail injection.

IoC is about the inner of things, the outer being just wiring.

From the outer, it looks like tail injection allows one to remove some arguments while the type system requires them. Looks like conflicting.
From the inner of things, tail injection allows to *add* extra (optional) arguments.
 If you look at the implementation, it just fits everything well. The code is straightforward.