### PR TITLE
[DI] Add a check on the getReflectionClass call

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -502,6 +502,11 @@ class PhpDumper extends Dumper
     private function addServiceOverriddenMethods($id, Definition $definition)
     {
         $class = $this->container->getReflectionClass($definition->getClass());
+
+        if (!$class) {
+            throw new RuntimeException(sprintf('Unable to configure service "%s": class "%s" not found.', $id, $definition->getClass()));
+        }
+
         if ($class->isFinal()) {
             throw new RuntimeException(sprintf('Unable to configure service "%s": class "%s" cannot be marked as final.', $id, $class->name));
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -408,6 +408,23 @@ class PhpDumperTest extends TestCase
         yield array('Cannot dump definition for service "baz": factories and overridden getters are incompatible with each other.', 'getParam', 'baz');
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to configure service "Acme\FooNonExistant": class "Acme\FooNonExistant" not found.
+     */
+    public function testDumpOverriddenGetterOnNonExistantClassTriggersException()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = $container->register('Acme\\FooNonExistant');
+        $definition->setOverriddenGetter('getFoo', array('foo'));
+
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dumper->dump(array('class' => 'Symfony_DI_PhpDumper_Test_Overriden_Getters_On_Non_Existent_Definition'));
+    }
+
     public function testEnvParameter()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

This prevents from doing a getter injection if the definition's idcannot be resolved to an existing class.