### PR TITLE
[DO NOT MERGE][DependencyInjection] Resolve ChildDefinition ealier

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -43,6 +43,7 @@ class PassConfig
             100 => array(
                 $resolveClassPass = new ResolveClassPass(),
                 new ResolveDefinitionInheritancePass(),
+                new ResolveDefinitionTemplatesPass(),
             ),
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master?
| Bug fix?      | ?
| New feature?  | ?
| BC breaks?    |  ?
| Deprecations? | ?
| Tests pass?   | ?
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

---

I tried to register a service via a Bundle Extension. The service is a
ChildDefinition. And I added the tag `monolog.logger` on it with a channel. But
it did not worked. ie: The injected service is `logger` and not the custom logger
with the specified channel.

So I tried to debug the [LoggerChannelPass](https://github.com/symfony/monolog-bundle/blob/master/DependencyInjection/Compiler/LoggerChannelPass.php#L36).
And in this class, the service is not resolved yet. So the arguments list is empty.
So the pass could not work.

If I apply this patch, everything work as expected.

By the way, my use case is not isolated. Symfony itself does that, but with a
[workaround](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L661)