### PR TITLE
Use PHPUnit 5.4 instead of 5.3

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -16,7 +16,7 @@
 error_reporting(-1);
 
 // PHPUnit 4.8 does not support PHP 7, while 5.1 requires PHP 5.6+
-$PHPUNIT_VERSION = PHP_VERSION_ID >= 50600 ? getenv('SYMFONY_PHPUNIT_VERSION') ?: '5.3' : '4.8';
+$PHPUNIT_VERSION = PHP_VERSION_ID >= 50600 ? getenv('SYMFONY_PHPUNIT_VERSION') ?: '5.4' : '4.8';
 $oldPwd = getcwd();
 $PHPUNIT_DIR = getenv('SYMFONY_PHPUNIT_DIR') ?: (__DIR__.'/.phpunit');
 $PHP = defined('PHP_BINARY') ? PHP_BINARY : 'php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

PHPUnit 5.3 doesn't have the forward compatibility layer for PHPUnit 6 so that `PHPUnit\Framework\TestCase` can be used instead of `PHPUnit_Framework_TestCase`.

This generates an error when upgrading to Symfony 3.2.5 without forcing the `SYMFONY_PHPUNIT_VERSION` const:

```
Class 'PHPUnit\Framework\TestCase' not found in vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php on line 25
```

This was introduced by https://github.com/symfony/symfony/commit/c9684ad31fd747df6c0dad495cddf0f596c39577 (from https://github.com/symfony/symfony/pull/21564) in 3.2.5

(Discussion started on Slack: https://symfony-devs.slack.com/archives/support/p1489058629011510)