### PR TITLE
[Workflow] Added fluent interface to the DefinitionBuilder

### DIFF
--- a/src/Symfony/Component/Workflow/DefinitionBuilder.php
+++ b/src/Symfony/Component/Workflow/DefinitionBuilder.php
@@ -46,19 +46,31 @@ class DefinitionBuilder
 
     /**
      * Clear all data in the builder.
+     *
+     * @return $this
      */
     public function reset()
     {
         $this->places = array();
         $this->transitions = array();
         $this->initialPlace = null;
+
+        return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function setInitialPlace($place)
     {
         $this->initialPlace = $place;
+
+        return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function addPlace($place)
     {
         if (!preg_match('{^[\w\d_-]+$}', $place)) {
@@ -70,27 +82,43 @@ class DefinitionBuilder
         }
 
         $this->places[$place] = $place;
+
+        return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function addPlaces(array $places)
     {
         foreach ($places as $place) {
             $this->addPlace($place);
         }
+
+        return $this;
     }
 
     /**
      * @param Transition[] $transitions
+     *
+     * @return $this
      */
     public function addTransitions(array $transitions)
     {
         foreach ($transitions as $transition) {
             $this->addTransition($transition);
         }
+
+        return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function addTransition(Transition $transition)
     {
         $this->transitions[] = $transition;
+
+        return $this;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

---

It seems more logic to me to have this fluent interface.