### PR TITLE
[Security][Firewall] Passing the newly generated security token to the event during user switching

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.4.0
 -----
 
+ * added a `setToken()` method to the `SwitchUserEvent` class to allow to replace the created token while switching users
+   when custom token generation is required by application. 
  * Using voters that do not implement the `VoterInterface`is now deprecated in
    the `AccessDecisionManager` and this functionality will be removed in 4.0.
 

--- a/src/Symfony/Component/Security/Http/Event/SwitchUserEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/SwitchUserEvent.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Event;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -24,11 +25,13 @@ class SwitchUserEvent extends Event
 {
     private $request;
     private $targetUser;
+    private $token;
 
-    public function __construct(Request $request, UserInterface $targetUser)
+    public function __construct(Request $request, UserInterface $targetUser, TokenInterface $token = null)
     {
         $this->request = $request;
         $this->targetUser = $targetUser;
+        $this->token = $token;
     }
 
     /**
@@ -45,5 +48,18 @@ class SwitchUserEvent extends Event
     public function getTargetUser()
     {
         return $this->targetUser;
+    }
+
+    /**
+     * @return TokenInterface|null
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    public function setToken(TokenInterface $token)
+    {
+        $this->token = $token;
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -145,8 +145,10 @@ class SwitchUserListener implements ListenerInterface
         $token = new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey, $roles);
 
         if (null !== $this->dispatcher) {
-            $switchEvent = new SwitchUserEvent($request, $token->getUser());
+            $switchEvent = new SwitchUserEvent($request, $token->getUser(), $token);
             $this->dispatcher->dispatch(SecurityEvents::SWITCH_USER, $switchEvent);
+            // use the token from the event in case any listeners have replaced it.
+            $token = $switchEvent->getToken();
         }
 
         return $token;
@@ -169,8 +171,9 @@ class SwitchUserListener implements ListenerInterface
 
         if (null !== $this->dispatcher && $original->getUser() instanceof UserInterface) {
             $user = $this->provider->refreshUser($original->getUser());
-            $switchEvent = new SwitchUserEvent($request, $user);
+            $switchEvent = new SwitchUserEvent($request, $user, $original);
             $this->dispatcher->dispatch(SecurityEvents::SWITCH_USER, $switchEvent);
+            $original = $switchEvent->getToken();
         }
 
         return $original;


### PR DESCRIPTION
Event allows listeners to easily switch out the token if custom token updates are required

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Updated SwitchUserEvent to include the generated security Token. Allows the listeners to replace the token with their own (in case an application has some custom logic for token generation). The SwitchUserListener will now use the token returned by the event, so if token was not changed the self generated token will be used. If token was changed in the event then the new token would get used.

Reasons for this feature
--------------------------

In our current project users can have different Role sets depending on which organization they switch to. Our `User->getRoles()` always returns ["ROLE_USER"] and after login user is presented with choice of organizations they want to work in. Based on selected organization roles get updated with then stored token.  

Without the change proposed in this PR. The only way we can setup the proper roles during user switch is by replacing `security.authentication.switchuser_listener` service with our own implementation of the listener. 

With the proposed change, we can replace the security token with the one having all the roles we require directly inside our listener for `security.switch_user` event that gets thrown by Symfony's `SwitchUserListener`

