### PR TITLE
[Form] Choice type int values (BC Fix)

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -171,8 +171,8 @@ class ChoiceType extends AbstractType
             }
 
             foreach ($data as $v) {
-                if (null !== $v && !is_string($v)) {
-                    throw new TransformationFailedException('All choices submitted must be NULL or strings.');
+                if (null !== $v && !is_string($v) && !is_int($v)) {
+                    throw new TransformationFailedException('All choices submitted must be NULL, strings or ints.');
                 }
             }
         }, 256);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -2319,7 +2319,7 @@ class ChoiceTypeTest extends BaseTypeTest
 
         $form->submit($submissionData);
         $this->assertFalse($form->isSynchronized());
-        $this->assertEquals('All choices submitted must be NULL or strings.', $form->getTransformationFailure()->getMessage());
+        $this->assertEquals('All choices submitted must be NULL, strings or ints.', $form->getTransformationFailure()->getMessage());
     }
 
     public function invalidNestedValueTestMatrix()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1689,6 +1689,19 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->assertNull($form[4]->getViewData());
     }
 
+    public function testSubmitMultipleChoicesInts()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'multiple' => true,
+            'choices' => array_flip($this->numericChoicesFlipped),
+            'choices_as_values' => true,
+        ));
+
+        $form->submit(array(1, 2));
+
+        $this->assertTrue($form->isSynchronized());
+    }
+
     public function testSingleSelectedObjectChoices()
     {
         $view = $this->factory->create(static::TESTED_TYPE, $this->objectChoices[3], array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21952
| License       | MIT

#21267 unnecessarily forced all choice values to be strings, this was a BC braking change.

Everything can work fine if they are strings or ints. specifically the issue was because `array_flip` is used on the `choices` array, but this function will work fine with ints as well as strings.

Normally, when using HTML forms all data comes as strings, but the `symfony/form` component has use cases beyond this, specifically, I use it with JSON data, where valid values for a `ChoiceType` might not be strings.