### PR TITLE
[Console] Fix bar width with multilines ProgressBar's format

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -603,13 +603,19 @@ class ProgressBar
         };
         $line = preg_replace_callback($regex, $callback, $this->format);
 
-        $lineLength = Helper::strlenWithoutDecoration($this->output->getFormatter(), $line);
+        // gets string length for each sub line with multiline format
+        $linesLength = array_map(function ($subLine) {
+            return Helper::strlenWithoutDecoration($this->output->getFormatter(), rtrim($subLine, "\r"));
+        }, explode("\n", $line));
+
+        $linesWidth = max($linesLength);
+
         $terminalWidth = $this->terminal->getWidth();
-        if ($lineLength <= $terminalWidth) {
+        if ($linesWidth <= $terminalWidth) {
             return $line;
         }
 
-        $this->setBarWidth($this->barWidth - $lineLength + $terminalWidth);
+        $this->setBarWidth($this->barWidth - $linesWidth + $terminalWidth);
 
         return preg_replace_callback($regex, $callback, $this->format);
     }

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -605,8 +605,8 @@ class ProgressBar
 
         // gets string length for each sub line with multiline format
         $linesLength = array_map(function ($subLine) {
-            return Helper::strlenWithoutDecoration($this->output->getFormatter(), rtrim($subLine, "\r"));
-        }, explode("\n", $line));
+            return Helper::strlenWithoutDecoration($this->output->getFormatter(), "\r");
+        }, explode(PHP_EOL, $line));
 
         $linesWidth = max($linesLength);
 

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -605,8 +605,8 @@ class ProgressBar
 
         // gets string length for each sub line with multiline format
         $linesLength = array_map(function ($subLine) {
-            return Helper::strlenWithoutDecoration($this->output->getFormatter(), "\r");
-        }, explode(PHP_EOL, $line));
+            return Helper::strlenWithoutDecoration($this->output->getFormatter(), rtrim($subLine, "\r"));
+        }, explode("\n", $line));
 
         $linesWidth = max($linesLength);
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -770,7 +770,6 @@ class ProgressBarTest extends TestCase
         $bar->start();
         rewind($output->getStream());
         $this->assertEquals(5, $bar->getBarWidth(), stream_get_contents($output->getStream()));
-        
         putenv('COLUMNS=120');
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -770,5 +770,7 @@ class ProgressBarTest extends TestCase
         $bar->start();
         rewind($output->getStream());
         $this->assertEquals(5, $bar->getBarWidth(), stream_get_contents($output->getStream()));
+        
+        putenv('COLUMNS=120');
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -754,4 +754,21 @@ class ProgressBarTest extends TestCase
 
         return "\x0D\x1B[2K".($count ? str_repeat("\x1B[1A\x1B[2K", $count) : '').$expected;
     }
+
+    public function testBarWidthWithMultilineFormat()
+    {
+        putenv('COLUMNS=10');
+
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->setFormat("%bar%\n0123456789");
+
+        // before starting
+        $bar->setBarWidth(5);
+        $this->assertEquals(5, $bar->getBarWidth());
+
+        // after starting
+        $bar->start();
+        rewind($output->getStream());
+        $this->assertEquals(5, $bar->getBarWidth(), stream_get_contents($output->getStream()));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The bar width is badly recalculated when we use multilines (``\n``) and bar placeholer (``%bar%``) in ProgressBar's format. The bar width is reduced because multilines is considered as a big oneline. This PR fixes this.