### PR TITLE
Make it possible to supress the fastcgi_finish_request() call

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -114,7 +114,7 @@ class Response
     /**
      * @var bool
      */
-    private $allowEarlyFastCGIFinishRequest = TRUE;
+    private $allowEarlyFastCGIFinishRequest = true;
 
     /**
      * Status codes translation table.
@@ -391,13 +391,13 @@ class Response
         return $this;
     }
 
-    /**
-     * Allows to supress the call to fastcgi_finish_request() on send().
-     *
-     * @param bool $allow
-     *
-     * @return $this
-     */
+      /**
+       * Allows to supress the call to fastcgi_finish_request() on send().
+       *
+       * @param bool $allow
+       *
+       * @return $this
+       */
       public function allowEarlyFastcgiFinishRequest($allow)
       {
           $this->allowEarlyFastCGIFinishRequest = $allow;

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -392,7 +392,7 @@ class Response
     }
 
       /**
-       * Allows to supress the call to fastcgi_finish_request() on send().
+       * Allows to suppress the call to fastcgi_finish_request() on send().
        *
        * @param bool $allow
        *

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -112,6 +112,11 @@ class Response
     protected $charset;
 
     /**
+     * @var bool
+     */
+    private $allowEarlyFastCGIFinishRequest = TRUE;
+
+    /**
      * Status codes translation table.
      *
      * The list of codes is complete according to the
@@ -377,7 +382,7 @@ class Response
         $this->sendHeaders();
         $this->sendContent();
 
-        if (function_exists('fastcgi_finish_request')) {
+        if ($this->allowEarlyFastCGIFinishRequest && function_exists('fastcgi_finish_request')) {
             fastcgi_finish_request();
         } elseif ('cli' !== PHP_SAPI) {
             static::closeOutputBuffers(0, true);
@@ -385,6 +390,20 @@ class Response
 
         return $this;
     }
+
+    /**
+     * Allows to supress the call to fastcgi_finish_request() on send().
+     *
+     * @param bool $allow
+     *
+     * @return $this
+     */
+      public function allowEarlyFastcgiFinishRequest($allow)
+      {
+          $this->allowEarlyFastCGIFinishRequest = $allow;
+
+          return $this;
+      }
 
     /**
      * Sets the response content.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes|no (it fixes a problem but its a new feature for http-foundation)
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

```HttpFoundation::Response``` calls out to ```fastcgi_finish_request``` in order to send out an HTTP response before the kernel terminate event fires.

While this might be the expected / desired behaviour there are maybe usecases where you want to ensure a consistent behaviour, for example to have a better control over edge cases/race conditions.

Note: This would help Drupal to avoid subclasses the symfony response class: https://www.drupal.org/node/2851111