### PR TITLE
[EventDispatcher] Allow EventDispatcher to dispatch anonymous events

### DIFF
--- a/src/Symfony/Component/EventDispatcher/AnonymousEventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/AnonymousEventDispatcherInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+/**
+ * Dispatch events without the need to specify an event name.
+ *
+ * @author Daniel Santamaría <santaka87@gmail.com>
+ */
+interface AnonymousEventDispatcherInterface
+{
+    /**
+     * Dispatches an event to all registered listeners.
+     *
+     * @param object $event The event to pass to the event handlers/listeners
+     */
+    public function dispatchAnonymousEvent($event);
+}

--- a/src/Symfony/Component/EventDispatcher/EventPropagationTrackerInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventPropagationTrackerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+/**
+ * Keeps track of events whose propagation has been stopped.
+ *
+ * @author Daniel Santamaría <santaka87@gmail.com>
+ */
+interface EventPropagationTrackerInterface
+{
+    /**
+     * Checks if the event propagation has been stopped.
+     *
+     * @param object $event
+     *
+     * @return bool
+     */
+    public function isPropagationStopped($event);
+
+    /**
+     * Stops the event the propagation.
+     *
+     * @param object $event
+     */
+    public function stopPropagation($event);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | pending

- [ ] submit changes to the documentation

**Feture description**

This PR allows `EventDispatcher` to dispatch anonymous events. Internally the fully qualified event object class name is used.

To add a listener or subscribe to an anonymous event, simply use the event object fully qualified name:

```php
// EventSubscriber

public function getSubscribedEvents()
{
    return [CustomEvent::class => 'onCustomEvent']
}
```

```php
// EventListener

$dispatcher->addListener(CustomEvent::class, $listener);
```

To dispatch an anonymous event:

```php
class CustomEvent
{
    // ...
}

$dispatcher->dispatchAnonymousEvent(new CustomEvent());
```
To stop event propagation:

```php
$dispatcher->stopPropagation($event);
```


I have removed the coupling to `Event` class for these reasons:
- To remove client code coupling to this component.
- To allow clients to design immutable events.
- To move the stop propagation responsability to another object.


> **ORIGINAL PULL REQUEST - Allow EventDispatcher to dispatch any object**
> 
> **Feture description**
> 
> This PR allows `EventDispatcher` to dispatch any `object`. This way, clients of this component are not forced to couple to `Event` class.
> 
> I have deprecated `Event` class, because it would not be the base class for all events anymore. Also, I have created a clone of this class named `StoppableEvent`. This would be the new class which clients should use in order to make "stop propagation" feature available for that event.
> 
> **Motivation**
> 
> - In my opinion, the stop propagation feature is not always desirable. 
> - From de DDD/EventSourcing prespective, in order to use this component, you are forced to couple your Domain Events to the Event class. This can be fixed by creating a Wrapper object, but then you loose the type hinting in the listeners.
> 