### PR TITLE
Release v3.2.6

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -7,6 +7,12 @@ in 3.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.2.0...v3.2.1
 
+* 3.2.6 (2017-03-10)
+
+ * bug #21930 [Cache] Cached files rely on umask (4rthem)
+ * bug #21946 Use PHPUnit 5.4 instead of 5.3 (j0k3r)
+ * bug #21936 [PropertyAccess] Use ArrayAdapter in debug mode (chalasr)
+
 * 3.2.5 (2017-03-09)
 
  * bug #21923 [travis] Test with hhvm 3.18 (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '3.2.6-DEV';
+    const VERSION = '3.2.6';
     const VERSION_ID = 30206;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 2;
     const RELEASE_VERSION = 6;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '07/2017';
     const END_OF_LIFE = '01/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.2.5...v3.2.6)

 * bug #21930 [Cache] Cached files rely on umask (@4rthem)
 * bug #21946 Use PHPUnit 5.4 instead of 5.3 (@j0k3r)
 * bug #21936 [PropertyAccess] Use ArrayAdapter in debug mode (@chalasr)
