### PR TITLE
[DependencyInjection] Support anonymous services in Yaml

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.3.0
 -----
 
+ * added anonymous services support in YAML configuration files using the `!service` tag.
  * [EXPERIMENTAL] added "TypedReference" and "ServiceClosureArgument" for creating service-locator services
  * [EXPERIMENTAL] added "instanceof" section for local interface-defined configs
  * added "service-locator" argument for lazy loading a set of identified values and services

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/anonymous_services.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/anonymous_services.yml
@@ -1,0 +1,14 @@
+imports:
+    # Ensure the anonymous services count is reset after importing a file
+    - { resource: anonymous_services_in_instanceof.yml }
+
+services:
+    _defaults:
+        autowire: true
+
+    Foo:
+        arguments:
+            - !service
+                class: Bar
+                autowire: true
+        factory: [ !service { class: Quz }, 'constructFoo' ]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/anonymous_services_alias.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/anonymous_services_alias.yml
@@ -1,0 +1,7 @@
+services:
+    Bar: ~
+
+    Foo:
+        arguments:
+            - !service
+                alias: Bar

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/anonymous_services_in_instanceof.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/anonymous_services_in_instanceof.yml
@@ -1,0 +1,14 @@
+services:
+    _instanceof:
+        # Ensure previous conditionals aren't applied on anonymous services
+        Quz:
+            autowire: true
+
+        DummyInterface:
+            arguments: [ !service { class: Anonymous } ]
+
+        # Ensure next conditionals are not considered as services
+        Bar:
+            autowire: true
+
+    Dummy: ~

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/anonymous_services_in_parameters.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/anonymous_services_in_parameters.yml
@@ -1,0 +1,2 @@
+parameters:
+    foo: [ !service { } ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/16328
| License       | MIT
| Doc PR        | 

This PR allows creating anonymous services in yaml using the `!service` tag as proposed by @nicolas-grekas:
```yml
services:
    _instanceof:
        FooInterface:
            arguments:
                - !service
                    class: Bar
                    autowire: true

    Foo:
        factory: [ !service { class: Quz }, 'constructFoo' ]
```

Anonymous services are forbidden in parameters as in xml.
Defaults and instanceof conditionals aren't applied on anonymous services, as in xml too.
