### PR TITLE
[FrameworkBundle] Fix cleaning of test dirs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
@@ -134,18 +134,4 @@ class SessionTest extends WebTestCase
             array('config.yml', false),
         );
     }
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->deleteTmpDir('SessionTest');
-    }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $this->deleteTmpDir('SessionTest');
-    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\Kernel;
 
 class WebTestCase extends BaseWebTestCase
 {
@@ -23,9 +22,19 @@ class WebTestCase extends BaseWebTestCase
         self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
-    protected function deleteTmpDir($testCase)
+    public static function setUpBeforeClass()
     {
-        if (!file_exists($dir = sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$testCase)) {
+        static::deleteTmpDir();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        static::deleteTmpDir();
+    }
+
+    protected static function deleteTmpDir()
+    {
+        if (!file_exists($dir = sys_get_temp_dir().'/'.static::getVarDir())) {
             return;
         }
 
@@ -49,10 +58,16 @@ class WebTestCase extends BaseWebTestCase
         }
 
         return new $class(
+            static::getVarDir(),
             $options['test_case'],
             isset($options['root_config']) ? $options['root_config'] : 'config.yml',
-            isset($options['environment']) ? $options['environment'] : 'frameworkbundletest'.strtolower($options['test_case']),
+            isset($options['environment']) ? $options['environment'] : strtolower(static::getVarDir().$options['test_case']),
             isset($options['debug']) ? $options['debug'] : true
         );
+    }
+
+    protected static function getVarDir()
+    {
+        return substr(strrchr(get_called_class(), '\\'), 1);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -46,14 +46,16 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class AppKernel extends Kernel
 {
+    private $varDir;
     private $testCase;
     private $rootConfig;
 
-    public function __construct($testCase, $rootConfig, $environment, $debug)
+    public function __construct($varDir, $testCase, $rootConfig, $environment, $debug)
     {
         if (!is_dir(__DIR__.'/'.$testCase)) {
             throw new \InvalidArgumentException(sprintf('The test case "%s" does not exist.', $testCase));
         }
+        $this->varDir = $varDir;
         $this->testCase = $testCase;
 
         $fs = new Filesystem();
@@ -81,12 +83,12 @@ class AppKernel extends Kernel
 
     public function getCacheDir()
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$this->testCase.'/cache/'.$this->environment;
+        return sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/cache/'.$this->environment;
     }
 
     public function getLogDir()
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$this->testCase.'/logs';
+        return sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/logs';
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)
@@ -96,13 +98,13 @@ class AppKernel extends Kernel
 
     public function serialize()
     {
-        return serialize(array($this->testCase, $this->rootConfig, $this->getEnvironment(), $this->isDebug()));
+        return serialize(array($this->varDir, $this->testCase, $this->rootConfig, $this->getEnvironment(), $this->isDebug()));
     }
 
     public function unserialize($str)
     {
         $a = unserialize($str);
-        $this->__construct($a[0], $a[1], $a[2], $a[3]);
+        $this->__construct($a[0], $a[1], $a[2], $a[3], $a[4]);
     }
 
     protected function getKernelParameters()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
@@ -108,14 +108,4 @@ class CsrfFormLoginTest extends WebTestCase
             array('routes_as_path.yml'),
         );
     }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('CsrfFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('CsrfFormLogin');
-    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
@@ -43,14 +43,4 @@ class FirewallEntryPointTest extends WebTestCase
             "Custom entry point wasn't started"
         );
     }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('FirewallEntryPoint');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('FirewallEntryPoint');
-    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -113,14 +113,4 @@ class FormLoginTest extends WebTestCase
             array('routes_as_path.yml'),
         );
     }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LocalizedRoutesAsPathTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LocalizedRoutesAsPathTest.php
@@ -76,14 +76,4 @@ class LocalizedRoutesAsPathTest extends WebTestCase
     {
         return array(array('en'), array('de'));
     }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
@@ -116,14 +116,4 @@ class SecurityRoutingIntegrationTest extends WebTestCase
     {
         return array(array('config.yml'), array('routes_as_path.yml'));
     }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SetAclCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SetAclCommandTest.php
@@ -40,20 +40,6 @@ class SetAclCommandTest extends WebTestCase
     const OBJECT_CLASS = 'Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AclBundle\Entity\Car';
     const SECURITY_CLASS = 'Symfony\Component\Security\Core\User\User';
 
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->deleteTmpDir('Acl');
-    }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $this->deleteTmpDir('Acl');
-    }
-
     public function testSetAclUser()
     {
         $objectId = 1;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
@@ -70,14 +70,4 @@ class SwitchUserTest extends WebTestCase
 
         return $client;
     }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\Kernel;
 
 class WebTestCase extends BaseWebTestCase
 {
@@ -23,9 +22,19 @@ class WebTestCase extends BaseWebTestCase
         self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
-    protected static function deleteTmpDir($testCase)
+    public static function setUpBeforeClass()
     {
-        if (defined('HHVM_VERSION_ID') || !file_exists($dir = sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$testCase)) {
+        static::deleteTmpDir();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        static::deleteTmpDir();
+    }
+
+    protected static function deleteTmpDir()
+    {
+        if (!file_exists($dir = sys_get_temp_dir().'/'.static::getVarDir())) {
             return;
         }
 
@@ -49,10 +58,16 @@ class WebTestCase extends BaseWebTestCase
         }
 
         return new $class(
+            static::getVarDir(),
             $options['test_case'],
             isset($options['root_config']) ? $options['root_config'] : 'config.yml',
-            isset($options['environment']) ? $options['environment'] : 'securitybundletest'.strtolower($options['test_case']),
+            isset($options['environment']) ? $options['environment'] : strtolower(static::getVarDir().$options['test_case']),
             isset($options['debug']) ? $options['debug'] : true
         );
+    }
+
+    protected static function getVarDir()
+    {
+        return substr(strrchr(get_called_class(), '\\'), 1);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
@@ -46,14 +46,16 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class AppKernel extends Kernel
 {
+    private $varDir;
     private $testCase;
     private $rootConfig;
 
-    public function __construct($testCase, $rootConfig, $environment, $debug)
+    public function __construct($varDir, $testCase, $rootConfig, $environment, $debug)
     {
         if (!is_dir(__DIR__.'/'.$testCase)) {
             throw new \InvalidArgumentException(sprintf('The test case "%s" does not exist.', $testCase));
         }
+        $this->varDir = $varDir;
         $this->testCase = $testCase;
 
         $fs = new Filesystem();
@@ -71,7 +73,7 @@ class AppKernel extends Kernel
     public function getName()
     {
         if (null === $this->name) {
-            $this->name = parent::getName().md5($this->rootConfig);
+            $this->name = parent::getName().substr(md5($this->rootConfig), -16);
         }
 
         return $this->name;
@@ -93,12 +95,12 @@ class AppKernel extends Kernel
 
     public function getCacheDir()
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$this->testCase.'/cache/'.$this->environment;
+        return sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/cache/'.$this->environment;
     }
 
     public function getLogDir()
     {
-        return sys_get_temp_dir().'/'.Kernel::VERSION.'/'.$this->testCase.'/logs';
+        return sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/logs';
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)
@@ -108,13 +110,13 @@ class AppKernel extends Kernel
 
     public function serialize()
     {
-        return serialize(array($this->testCase, $this->rootConfig, $this->getEnvironment(), $this->isDebug()));
+        return serialize(array($this->varDir, $this->testCase, $this->rootConfig, $this->getEnvironment(), $this->isDebug()));
     }
 
     public function unserialize($str)
     {
         $a = unserialize($str);
-        $this->__construct($a[0], $a[1], $a[2], $a[3]);
+        $this->__construct($a[0], $a[1], $a[2], $a[3], $a[4]);
     }
 
     protected function getKernelParameters()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I spent an hour or two today debugging a non existent issue that was related to a non removed temporary file.
Let's cleanup properly now in the base WebTestCase.