### PR TITLE
[HttpFoundation] Fix mime_type resolver strategy for API versioning. (Honor "Accept" header)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1320,7 +1320,15 @@ class Request
             static::initializeFormats();
         }
 
-        return isset(static::$formats[$format]) ? static::$formats[$format][0] : null;
+        if (!isset(static::$formats[$format])) {
+            return null;
+        }
+
+        if (in_array($this->headers->get('Accept'), static::$formats[$format], true)) {
+            return $this->headers->get('Accept');
+        }
+
+        return static::$formats[$format][0];
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -326,6 +326,23 @@ class RequestTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider getFormatToMimeTypeMapProviderForAccept
+     */
+    public function testGetMimeTypeFromFormatWithAccept($format, $mimeTypes, $accepts)
+    {
+        if (null !== $format) {
+            $request = new Request();
+            $request->setFormat($format, $mimeTypes);
+
+            $request->headers->set('Accept', $accepts);
+            // BC behavior.
+            // If accept is inside of the $format mime type array, return it, otherwise behave as you currently do.
+            $return = $accepts ?: $mimeTypes[0];
+            $this->assertEquals($return, $request->getMimeType($format));
+        }
+    }
+
     public function testGetFormatWithCustomMimeType()
     {
         $request = new Request();
@@ -344,6 +361,20 @@ class RequestTest extends TestCase
             array('xml', array('text/xml', 'application/xml', 'application/x-xml')),
             array('rdf', array('application/rdf+xml')),
             array('atom', array('application/atom+xml')),
+        );
+    }
+
+    public function getFormatToMimeTypeMapProviderForAccept()
+    {
+        return array(
+            array(null, array(null, 'unexistent-mime-type'), null),
+            array('txt', array('text/plain'), null),
+            array('js', array('application/javascript', 'application/x-javascript', 'text/javascript'), null),
+            array('css', array('text/css'), null),
+            array('json', array('application/json', 'application/x-json', 'application/json;version=1.0', 'application/json;version=1.1'), 'application/json;version=1.0'),
+            array('xml', array('text/xml', 'application/xml', 'application/x-xml', 'application/xml;version=1.0', 'application/xml;version=2.0'), 'application/xml;version=2.0'),
+            array('rdf', array('application/rdf+xml'), null),
+            array('atom', array('application/atom+xml'), null),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 +
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21974 
| License       | MIT
| Doc PR        | N/A

Media type in accept header not being honored when it is not the first element in the media_type array for the given format.

Check the "accept" header and see if the media_type is in the array, if it is, return it. Otherwise, perform operations as currently does.

This is non-intrusive, as it operates as it currently does if the request header does not match a mime-type listed.
