### PR TITLE
[DoctrineBridge][Routing] Require PSR-11 container instead of Symfony container

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -13,7 +13,7 @@ namespace Symfony\Bridge\Doctrine;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\EventManager;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Allows lazy loading of listener services.

--- a/src/Symfony/Component/Routing/Loader/DependencyInjection/ServiceRouterLoader.php
+++ b/src/Symfony/Component/Routing/Loader/DependencyInjection/ServiceRouterLoader.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Routing\Loader\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Routing\Loader\ObjectRouteLoader;
 
 /**

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -23,13 +23,14 @@
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/yaml": "~3.3",
         "symfony/expression-language": "~2.8|~3.0",
-        "symfony/dependency-injection": "~2.8|~3.0",
+        "symfony/dependency-injection": "~3.3",
         "doctrine/annotations": "~1.0",
         "doctrine/common": "~2.2",
         "psr/log": "~1.0"
     },
     "conflict": {
         "symfony/config": "<2.8",
+        "symfony/dependency-injection": "<3.3",
         "symfony/yaml": "<3.3"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

The changed classes can easily use PSR-11 container instead of normal symfony container.

I didn't change any classes that have the `$container` property as protected (for example `Symfony\Bundle\FrameworkBundle\Translation\Translator`) because I'm unsure whether that would be considered a BC break. Let me know if you want me to change such classes as well.