### PR TITLE
[FrameworkBundle][TwigBundle] Require PSR-11 container instead of Symfony container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/DelegatingEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/DelegatingEngine.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Templating;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Templating\DelegatingEngine as BaseDelegatingEngine;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Templating;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Templating\PhpEngine as BasePhpEngine;
 use Symfony\Component\Templating\Loader\LoaderInterface;
 use Symfony\Component\Templating\TemplateNameParserInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TimedPhpEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TimedPhpEngine.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Templating;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Templating\TemplateNameParserInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Templating\Loader\LoaderInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Times the time spent to render a template.

--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Bundle\TwigBundle\CacheWarmer;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinderInterface;
 use Symfony\Component\Templating\TemplateReference;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

As discussed in #21978 here is the second PR.