### PR TITLE
[Console] Use proper line endings in BufferedOutput

### DIFF
--- a/src/Symfony/Component/Console/Output/BufferedOutput.php
+++ b/src/Symfony/Component/Console/Output/BufferedOutput.php
@@ -42,7 +42,7 @@ class BufferedOutput extends Output
         $this->buffer .= $message;
 
         if ($newline) {
-            $this->buffer .= "\n";
+            $this->buffer .= PHP_EOL;
         }
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/DummyOutput.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/DummyOutput.php
@@ -26,7 +26,7 @@ class DummyOutput extends BufferedOutput
     public function getLogs()
     {
         $logs = array();
-        foreach (explode("\n", trim($this->fetch())) as $message) {
+        foreach (explode(PHP_EOL, trim($this->fetch())) as $message) {
             preg_match('/^\[(.*)\] (.*)/', $message, $matches);
             $logs[] = sprintf('%s %s', $matches[1], $matches[2]);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

`BufferOutput` should be consistent with `StreamOutput` when writing newlines.

I faced an issue using this class in tests where the expected output was platform dependent (using `PHP_EOL` too).