### PR TITLE
[HttpKernel] Resolve real class when failing on proxies

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Controller;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\LazyProxy\InheritanceProxyInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -233,6 +234,10 @@ class ControllerResolver implements ArgumentResolverInterface, ControllerResolve
         }
 
         $className = is_object($controller) ? get_class($controller) : $controller;
+
+        if (is_subclass_of($className, InheritanceProxyInterface::class)) {
+            $className = get_parent_class($className);
+        }
 
         if (method_exists($controller, $method)) {
             return sprintf('Method "%s" on class "%s" should be public and non-abstract.', $method, $className);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\Tests\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\LazyProxy\InheritanceProxyInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolver;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\NullableController;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\VariadicController;
@@ -277,6 +278,18 @@ class ControllerResolverTest extends TestCase
         $this->assertEquals(array(null, null, 'value', 'mandatory'), $resolver->getArguments($request, $controller));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The controller for URI "/" is not callable. Method "protectedAction" on class "Symfony\Component\HttpKernel\Tests\Controller\ControllerTest" should be public and non-abstract.
+     */
+    public function testGetControllerFailsUsingParentClassForProxies()
+    {
+        $resolver = new ControllerResolver();
+        $request = Request::create('/');
+        $request->attributes->set('_controller', 'Symfony\Component\HttpKernel\Tests\Controller\ControllerProxy::protectedAction');
+        $resolver->getController($request);
+    }
+
     protected function createControllerResolver(LoggerInterface $logger = null)
     {
         return new ControllerResolver($logger);
@@ -328,4 +341,8 @@ class ControllerTest
     public static function staticAction()
     {
     }
+}
+
+class ControllerProxy extends ControllerTest implements InheritanceProxyInterface
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/21969
| License       | MIT
| Doc PR        | n/a

__Before__
> The controller for URI "/" is not callable. Method "home" on class "SymfonyProxy_f6aad6c251e61ad4ae1fc5a561578cae" should be public and non-abstract.

__After__
> The controller for URI "/" is not callable. Method "home" on class "Actions" should be public and non-abstract.