### PR TITLE
[HttpFoundation] fix path info when request path is not sent

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1846,7 +1846,7 @@ class Request
         }
 
         // Remove the query string from REQUEST_URI
-        if ($pos = strpos($requestUri, '?')) {
+        if (false !== $pos = strpos($requestUri, '?')) {
             $requestUri = substr($requestUri, 0, $pos);
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1138,6 +1138,16 @@ class RequestTest extends TestCase
         $this->disableHttpMethodParameterOverride();
     }
 
+    public function testQueryStringIsRemovedFromRequestUriIfNoRequestPathIsGiven()
+    {
+        $_SERVER['QUERY_STRING'] = 'a=b';
+        $_SERVER['REQUEST_URI'] = '?a=b';
+
+        $request = Request::createFromGlobals();
+
+        $this->assertSame('/', $request->getPathInfo());
+    }
+
     public function testOverrideGlobals()
     {
         $request = new Request();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21967
| License       | MIT
| Doc PR        | 