### PR TITLE
Stop relying on the $mode argument

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -90,17 +90,13 @@ class DeprecationErrorHandler
             'remainingCount' => 0,
             'legacyCount' => 0,
             'otherCount' => 0,
+            'remaining vendorCount' => 0,
             'unsilenced' => array(),
             'remaining' => array(),
             'legacy' => array(),
             'other' => array(),
+            'remaining vendor' => array(),
         );
-        if (self::MODE_WEAK_VENDORS === $mode) {
-            $deprecations += array(
-                'remaining vendorCount' => 0,
-                'remaining vendor' => array(),
-            );
-        }
         $deprecationHandler = function ($type, $msg, $file, $line, $context) use (&$deprecations, $getMode, $UtilPrefix, $inVendors) {
             $mode = $getMode();
             if ((E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) || DeprecationErrorHandler::MODE_DISABLED === $mode) {


### PR DESCRIPTION
When registering the error handler, simple-phpunit might be used, and in
that case, the bootstrap process will not have environment variables
defined inside phpunit.xml.dist . This means `$mode` might differ when
registering the error handler, and when an error is triggered.
This raises a question: should the $mode argument be removed to avoid
similar errors in the future?

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | yes/no
| Deprecations? | yes/no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes/no
| Fixed tickets | #21980 
| License       | MIT
| Doc PR        | n/a

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
