### PR TITLE
Deprecate accessing environment variables prefixed by SYMFONY__ as parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -100,6 +100,10 @@ class ParameterBag implements ParameterBagInterface
             throw new ParameterNotFoundException($name, null, null, null, $alternatives, $nonNestedAlternative);
         }
 
+        if (isset($_SERVER[$sfEnvVar = 'SYMFONY__'.strtoupper(str_replace('.', '__', $name))])) {
+            @trigger_error(sprintf('Defining parameters using special environment variables that start with "SYMFONY__" (such as "%s") is deprecated as of 3.3 and won\'t be supported in 4.0. Use the %%env()%% syntax to get the value of any environment variable from configuration files instead.', $sfEnvVar), E_USER_DEPRECATED);
+        }
+
         return $this->parameters[$name];
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -226,6 +226,16 @@ class ParameterBagTest extends TestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation Defining parameters using special environment variables that start with "SYMFONY__" (such as "SYMFONY__FOO__BAR") is deprecated as of 3.3 and won't be supported in 4.0. Use the %s syntax to get the value of any environment variable from configuration files instead.
+     */
+    public function testGetSymfonyEnvParameter()
+    {
+        $_SERVER['SYMFONY__FOO__BAR'] = 'foobar';
+        $this->assertSame('foobar', (new ParameterBag(array('foo.bar' => 'foobar')))->get('foo.bar'));
+    }
+
+    /**
      * @dataProvider stringsWithSpacesProvider
      */
     public function testResolveStringWithSpacesReturnsString($expected, $test, $description)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -560,7 +560,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 'kernel.charset' => $this->getCharset(),
                 'kernel.container_class' => $this->getContainerClass(),
             ),
-            $this->getEnvParameters()
+            $this->getEnvParameters(false)
         );
     }
 
@@ -570,9 +570,15 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      * Only the parameters starting with "SYMFONY__" are considered.
      *
      * @return array An array of parameters
+     *
+     * @deprecated since version 3.3, to be removed in 4.0
      */
     protected function getEnvParameters()
     {
+        if (0 === func_num_args() || func_get_arg(0)) {
+            @trigger_error(sprintf('The %s() method is deprecated as of 3.3 and will be removed in 4.0. Use the %%env()%% syntax to get the value of any environment variable from configuration files instead.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $parameters = array();
         foreach ($_SERVER as $key => $value) {
             if (0 === strpos($key, 'SYMFONY__')) {

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -735,6 +735,22 @@ EOF;
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Kernel::getEnvParameters() method is deprecated as of 3.3 and will be removed in 4.0. Use the %s syntax to get the value of any environment variable from configuration files instead.
+     */
+    public function testGetEnvParameters()
+    {
+        $_SERVER['SYMFONY__FOO__BAR'] = 'baz';
+
+        $kernel = $this->getKernel();
+        $method = new \ReflectionMethod($kernel, 'getEnvParameters');
+        $method->setAccessible(true);
+
+        $envParameters = $method->invoke($kernel);
+        $this->assertSame('baz', $envParameters['foo.bar']);
+    }
+
+    /**
      * Returns a mock for the BundleInterface.
      *
      * @return BundleInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/20089
| License       | MIT
| Doc PR        | n/a

Replaces #21889 