### PR TITLE
[DependencyInjection] Remove the "id" attribute of "callable"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -86,7 +86,6 @@
     <xsd:choice minOccurs="0" maxOccurs="1">
       <xsd:element name="service" type="service" minOccurs="0" maxOccurs="1" />
     </xsd:choice>
-    <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="service" type="xsd:string" />
     <xsd:attribute name="class" type="xsd:string" />
     <xsd:attribute name="method" type="xsd:string" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | ?
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets |  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | 

It seems like this attribute was added by mistake as it's used nowhere.
It should be removed but I don't think it's worth adding a bc layer.