### PR TITLE
[FrameworkBundle] remove translator helper if Translator is disabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -96,6 +96,7 @@ class FrameworkExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $this->annotationsConfigEnabled = $this->isConfigEnabled($container, $config['annotations']);
+        $this->translationConfigEnabled = $this->isConfigEnabled($container, $config['translator']);
 
         // A translator must always be registered (as support is included by
         // default in the Form and Validator component). If disabled, an identity
@@ -752,6 +753,10 @@ class FrameworkExtension extends Extension
             } else {
                 $container->removeDefinition('templating.helper.assets');
             }
+
+            if (!$this->translationConfigEnabled) {
+                $container->removeDefinition('templating.helper.translator');
+            }
         }
     }
 
@@ -846,8 +851,6 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('translation.xml');
-
-        $this->translationConfigEnabled = true;
 
         // Use the "real" translator instead of the identity default
         $container->setAlias('translator', 'translator.default');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_php_translator_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_php_translator_disabled.php
@@ -1,0 +1,8 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'translator' => false,
+    'templating' => array(
+        'engines' => array('php'),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_php_translator_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_php_translator_enabled.php
@@ -1,0 +1,8 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'translator' => true,
+    'templating' => array(
+        'engines' => array('php'),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/templating_php_translator_disabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/templating_php_translator_disabled.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:translator enabled="false" />
+        <framework:templating>
+            <framework:engine>php</framework:engine>
+        </framework:templating>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/templating_php_translator_enabled.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/templating_php_translator_enabled.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:translator enabled="true" />
+        <framework:templating>
+            <framework:engine>php</framework:engine>
+        </framework:templating>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/templating_php_translator_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/templating_php_translator_disabled.yml
@@ -1,0 +1,4 @@
+framework:
+    translator: false
+    templating:
+        engines: [php]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/templating_php_translator_enabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/templating_php_translator_enabled.yml
@@ -1,0 +1,4 @@
+framework:
+    translator: true
+    templating:
+        engines: [php]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -455,6 +455,20 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals(array('en', 'fr'), $calls[1][1][0]);
     }
 
+    public function testTranslatorHelperIsRegisteredWhenTranslatorIsEnabled()
+    {
+        $container = $this->createContainerFromFile('templating_php_translator_enabled');
+
+        $this->assertTrue($container->has('templating.helper.translator'));
+    }
+
+    public function testTranslatorHelperIsNotRegisteredWhenTranslatorIsDisabled()
+    {
+        $container = $this->createContainerFromFile('templating_php_translator_disabled');
+
+        $this->assertFalse($container->has('templating.helper.translator'));
+    }
+
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20928#issuecomment-274293396, #21374
| License       | MIT
| Doc PR        | 