### PR TITLE
[FrameworkBundle][Translator] Make the Translator works with any PSR-11 container

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -180,6 +180,9 @@ FrameworkBundle
    Require `symfony/web-server-bundle` in your composer.json and register 
    `Symfony\Bundle\WebServerBundle\WebServerBundle` in your AppKernel to use them.
 
+ * The `Symfony\Bundle\FrameworkBundle\Translation\Translator` constructor now takes the
+   default locale as 3rd argument. Not passing it will trigger an error in 4.0.
+
 HttpKernel
 -----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -274,6 +274,9 @@ FrameworkBundle
    class has been removed. Use the
    `Symfony\Component\Routing\DependencyInjection\RoutingResolverPass` class instead.
 
+ * The `Symfony\Bundle\FrameworkBundle\Translation\Translator` constructor now takes the
+   default locale as mandatory 3rd argument.
+
 HttpFoundation
 ---------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -35,6 +35,8 @@ CHANGELOG
    `server:status` console commands have been moved to a dedicated bundle. 
    Require `symfony/web-server-bundle` in your composer.json and register 
    `Symfony\Bundle\WebServerBundle\WebServerBundle` in your AppKernel to use them.
+ * Added `$defaultLocale` as 3rd argument of `Translator::__construct()`
+   making `Translator` works with any PSR-11 container
 
 3.2.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslatorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslatorPass.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class TranslatorPass implements CompilerPassInterface
 {
@@ -24,7 +26,9 @@ class TranslatorPass implements CompilerPassInterface
         }
 
         $loaders = array();
+        $loaderRefs = array();
         foreach ($container->findTaggedServiceIds('translation.loader') as $id => $attributes) {
+            $loaderRefs[$id] = new Reference($id);
             $loaders[$id][] = $attributes[0]['alias'];
             if (isset($attributes[0]['legacy-alias'])) {
                 $loaders[$id][] = $attributes[0]['legacy-alias'];
@@ -35,11 +39,15 @@ class TranslatorPass implements CompilerPassInterface
             $definition = $container->getDefinition('translation.loader');
             foreach ($loaders as $id => $formats) {
                 foreach ($formats as $format) {
-                    $definition->addMethodCall('addLoader', array($format, new Reference($id)));
+                    $definition->addMethodCall('addLoader', array($format, $loaderRefs[$id]));
                 }
             }
         }
 
-        $container->findDefinition('translator.default')->replaceArgument(2, $loaders);
+        $container
+            ->findDefinition('translator.default')
+            ->replaceArgument(0, (new Definition(ServiceLocator::class, array($loaderRefs)))->addTag('container.service_locator'))
+            ->replaceArgument(3, $loaders)
+        ;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -954,11 +954,11 @@ class FrameworkExtension extends Extension
             }
 
             $options = array_merge(
-                $translator->getArgument(3),
+                $translator->getArgument(4),
                 array('resource_files' => $files)
             );
 
-            $translator->replaceArgument(3, $options);
+            $translator->replaceArgument(4, $options);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -6,14 +6,14 @@
 
     <services>
         <service id="translator.default" class="Symfony\Bundle\FrameworkBundle\Translation\Translator">
-            <argument type="service" id="service_container" />
+            <argument /> <!-- translation loaders locator -->
             <argument type="service" id="translator.selector" />
-            <argument type="collection" /> <!-- translation loaders -->
+            <argument>%kernel.default_locale%</argument>
+            <argument type="collection" /> <!-- translation loaders ids -->
             <argument type="collection">
                 <argument key="cache_dir">%kernel.cache_dir%/translations</argument>
                 <argument key="debug">%kernel.debug%</argument>
             </argument>
-            <argument type="collection" /> <!-- translation resources -->
             <call method="setConfigCacheFactory">
                 <argument type="service" id="config_cache_factory" />
             </call>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslatorPass;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class TranslatorPassTest extends TestCase
 {
@@ -39,7 +41,15 @@ class TranslatorPassTest extends TestCase
             ->will($this->returnValue(array('xliff' => array(array('alias' => 'xliff', 'legacy-alias' => 'xlf')))));
         $container->expects($this->once())
             ->method('findDefinition')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock()));
+            ->will($this->returnValue($translator = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock()));
+        $translator->expects($this->at(0))
+            ->method('replaceArgument')
+            ->with(0, $this->equalTo((new Definition(ServiceLocator::class, array(array('xliff' => new Reference('xliff')))))->addTag('container.service_locator')))
+            ->willReturn($translator);
+        $translator->expects($this->at(1))
+            ->method('replaceArgument')
+            ->with(3, array('xliff' => array('xliff', 'xlf')))
+            ->willReturn($translator);
         $pass = new TranslatorPass();
         $pass->process($container);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
 use Doctrine\Common\Annotations\Annotation;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslatorPass;
 use Symfony\Bundle\FullStack;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddAnnotationsCachedReaderPass;
@@ -417,7 +418,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('full');
         $this->assertTrue($container->hasDefinition('translator.default'), '->registerTranslatorConfiguration() loads translation.xml');
         $this->assertEquals('translator.default', (string) $container->getAlias('translator'), '->registerTranslatorConfiguration() redefines translator service from identity to real translator');
-        $options = $container->getDefinition('translator.default')->getArgument(3);
+        $options = $container->getDefinition('translator.default')->getArgument(4);
 
         $files = array_map('realpath', $options['resource_files']['en']);
         $ref = new \ReflectionClass('Symfony\Component\Validator\Validation');
@@ -922,7 +923,7 @@ abstract class FrameworkExtensionTest extends TestCase
             $container->getCompilerPassConfig()->setOptimizationPasses(array());
             $container->getCompilerPassConfig()->setRemovingPasses(array());
         }
-        $container->getCompilerPassConfig()->setBeforeRemovingPasses(array(new AddAnnotationsCachedReaderPass(), new AddConstraintValidatorsPass()));
+        $container->getCompilerPassConfig()->setBeforeRemovingPasses(array(new AddAnnotationsCachedReaderPass(), new AddConstraintValidatorsPass(), new TranslatorPass()));
         $container->compile();
 
         return self::$containerCache[$cacheKey] = $container;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Uses a service-locator for collected translation loaders and replace the single call of `getParameter()` by an optional constructor argument.