### PR TITLE
[FrameworkBundle][Serializer] Add option to register a circular_reference_handler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -686,6 +686,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('enable_annotations')->{!class_exists(FullStack::class) && class_exists(Annotation::class) ? 'defaultTrue' : 'defaultFalse'}()->end()
                         ->scalarNode('cache')->end()
                         ->scalarNode('name_converter')->end()
+                        ->scalarNode('circular_reference_handler')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1281,6 +1281,10 @@ class FrameworkExtension extends Extension
         if (isset($config['name_converter']) && $config['name_converter']) {
             $container->getDefinition('serializer.normalizer.object')->replaceArgument(1, new Reference($config['name_converter']));
         }
+
+        if (isset($config['circular_reference_handler']) && $config['circular_reference_handler']) {
+            $container->getDefinition('serializer.normalizer.object')->addMethodCall('setCircularReferenceHandler', array(new Reference($config['circular_reference_handler'])));
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

--- 

Right now, it's quite hard (especially for new comers) to register a CircularReferenceHandler:

![screenshot1](https://cloud.githubusercontent.com/assets/408368/23959193/ce19bcec-09a4-11e7-82c7-80abd7b7f602.png)

---

This PR introduce an option to wire a service to the internal Object Normalizer.