### PR TITLE
[Form] Added test to show that delete_empty don't work for embedded forms without data_class

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -177,6 +177,29 @@ class CollectionTypeTest extends BaseTypeTest
         $this->assertEquals(array(new Author('s_first', 's_last')), $form->getData());
     }
 
+    public function testResizedDownIfSubmittedWithCompoundEmptyDataDeleteEmptyAndNoDataClass()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'entry_type' => 'Symfony\Component\Form\Tests\Fixtures\AuthorType',
+            // If the field is not required, no new Author will be created if the
+            // form is completely empty
+            'entry_options' => array('data_class' => null),
+            'allow_add' => true,
+            'delete_empty' => true,
+        ));
+
+        $form->setData(array(array('firstName' => 'first', 'lastName' => 'last')));
+        $form->submit(array(
+            array('firstName' => 's_first', 'lastName' => 's_last'),
+            array('firstName' => '', 'lastName' => ''),
+        ));
+
+        $this->assertTrue($form->has('0'));
+        $this->assertFalse($form->has('1'));
+        $this->assertEquals(array('s_first', 's_last'), $form[0]->getData());
+        $this->assertEquals(array(array('s_first', 's_last')), $form->getData());
+    }
+
     public function testNotResizedIfSubmittedWithExtraData()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -185,6 +185,7 @@ class CollectionTypeTest extends BaseTypeTest
             // form is completely empty
             'entry_options' => array('data_class' => null),
             'allow_add' => true,
+            'allow_delete' => true,
             'delete_empty' => true,
         ));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

This pull request creates a test, that fails showing the problem with delete_empty and embedded forms without data_class.

Something needs to be fixed in the ResizeSubscriber or somewhere else that I couldn't find, so this test can pass.

Related to #22008 