### PR TITLE
[Workflow] Allow transition when many places in transition froms

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -313,8 +313,9 @@ class WorkflowTest extends TestCase
 
         $subject->marking = array('c' => 1, 'e' => 1);
         $transitions = $workflow->getEnabledTransitions($subject);
-        $this->assertCount(1, $transitions);
-        $this->assertSame('t5', $transitions[0]->getName());
+        $this->assertCount(2, $transitions);
+        $this->assertSame('t2', $transitions[0]->getName());
+        $this->assertSame('t5', $transitions[1]->getName());
     }
 
     public function testGetEnabledTransitionsWithSameNameTransition()

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -187,8 +187,8 @@ class Workflow
     }
 
     /**
-     * Check if this marking has at least one place in the froms transition
-     * Check also if the transition is guarded for this marking
+     * Check if this marking has at least one place in the froms transition.
+     * Check also if the transition is guarded for this marking.
      *
      * @param object     $subject
      * @param Marking    $marking

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -186,19 +186,25 @@ class Workflow
         return $this->definition;
     }
 
+    /**
+     * Check if this marking has at least one place in the froms transition
+     * Check also if the transition is guarded for this marking
+     *
+     * @param object     $subject
+     * @param Marking    $marking
+     * @param Transition $transition
+     *
+     * @return bool
+     */
     private function doCan($subject, Marking $marking, Transition $transition)
     {
         foreach ($transition->getFroms() as $place) {
-            if (!$marking->has($place)) {
-                return false;
+            if ($marking->has($place) && true !== $this->guardTransition($subject, $marking, $transition)) {
+                return true;
             }
         }
 
-        if (true === $this->guardTransition($subject, $marking, $transition)) {
-            return false;
-        }
-
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | 

It is about the workflow component
Actually a permission with multiple places in froms can not be applied
This PR solve that
