### PR TITLE
[Workflow] Added more tests

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -104,6 +104,23 @@ class WorkflowTest extends TestCase
 
         $this->assertTrue($workflow->can($subject, 't1'));
         $this->assertFalse($workflow->can($subject, 't2'));
+
+        $subject->marking = array('b' => 1);
+
+        $this->assertFalse($workflow->can($subject, 't1'));
+        // In a workflow net, all "from" places should contain a token to enable
+        // the transition.
+        $this->assertFalse($workflow->can($subject, 't2'));
+
+        $subject->marking = array('b' => 1, 'c' => 1);
+
+        $this->assertFalse($workflow->can($subject, 't1'));
+        $this->assertTrue($workflow->can($subject, 't2'));
+
+        $subject->marking = array('f' => 1);
+
+        $this->assertFalse($workflow->can($subject, 't5'));
+        $this->assertTrue($workflow->can($subject, 't6'));
     }
 
     public function testCanWithGuard()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22017
| License       | MIT
| Doc PR        | -

---

It's not the first time that people try to fix the workflow because they don't understand how it works. Basically, it's because the default configuration is using the "workflow" and not the "state_machine" type. It was a mistake but it's too late because it will be BC break. May be we could solve that by triggering a deprecation if the type is not explicit. But nobody will see it because it will be triggered during the compilation. It could also be fixed with more documentation.

Anyway, I want to add more tests to cover that with a little comment in the test suite. Right now, only one tests failed. With this PR more tests are failing.