### PR TITLE
Fix dotenv documentation link

### DIFF
--- a/src/Symfony/Component/Dotenv/README.md
+++ b/src/Symfony/Component/Dotenv/README.md
@@ -7,7 +7,7 @@ accessible via `getenv()`, `$_ENV`, or `$_SERVER`.
 Resources
 ---------
 
-  * [Documentation](https://symfony.com/doc/current/components/dotenv/index.html)
+  * [Documentation](https://symfony.com/doc/current/components/dotenv.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | master <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!--highly recommended for new features-->

Replaces the Documentation link for the DotEnv component with the correct link.

Context: https://github.com/symfony/symfony-docs/issues/7526#issuecomment-287095159
