### PR TITLE
[DI] Remove useless state from ServiceLocator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
@@ -22,7 +22,6 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 class ServiceLocator implements PsrContainerInterface
 {
     private $factories;
-    private $values = array();
 
     /**
      * @param callable[] $factories
@@ -53,13 +52,12 @@ class ServiceLocator implements PsrContainerInterface
             throw new ServiceCircularReferenceException($id, array($id, $id));
         }
 
-        if (false !== $factory) {
-            $this->factories[$id] = true;
-            $this->values[$id] = $factory();
-            $this->factories[$id] = false;
+        $this->factories[$id] = true;
+        try {
+            return $factory();
+        } finally {
+            $this->factories[$id] = $factory;
         }
-
-        return $this->values[$id];
     }
 
     public function __invoke($id)

--- a/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ServiceLocatorTest.php
@@ -40,15 +40,20 @@ class ServiceLocatorTest extends TestCase
         $this->assertSame('baz', $locator->get('bar'));
     }
 
-    public function testGetDoesNotExecuteTheSameCallableTwice()
+    public function testGetDoesNotMemoize()
     {
         $i = 0;
-        $locator = new ServiceLocator(array('foo' => function () use (&$i) { $i++; return 'bar'; }));
+        $locator = new ServiceLocator(array(
+            'foo' => function () use (&$i) {
+                ++$i;
+
+                return 'bar';
+            },
+        ));
 
         $this->assertSame('bar', $locator->get('foo'));
         $this->assertSame('bar', $locator->get('foo'));
-        $this->assertSame('bar', $locator->get('foo'));
-        $this->assertSame(1, $i);
+        $this->assertSame(2, $i);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no (master only)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

One less state to manage for the engine, and allows to deal with non-shared services.