### PR TITLE
[FrameworkBundle] Fix translation dep constraint

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -136,6 +136,17 @@ class TranslatorTest extends TestCase
         $this->assertSame('en', $translator->getLocale());
     }
 
+    /**
+     * @expectedException \Symfony\Component\Translation\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The Translator does not support the following options: 'foo'
+     */
+    public function testInvalidOptions()
+    {
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+
+        (new Translator($container, new MessageSelector(), array(), array('foo' => 'bar')));
+    }
+
     protected function getCatalogue($locale, $messages, $resources = array())
     {
         $catalogue = new MessageCatalogue($locale);

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -47,7 +47,7 @@
         "symfony/security-core": "~3.2",
         "symfony/security-csrf": "~2.8|~3.0",
         "symfony/serializer": "~2.8|~3.0",
-        "symfony/translation": "~2.8|~3.0",
+        "symfony/translation": "~3.2",
         "symfony/templating": "~2.8|~3.0",
         "symfony/validator": "~3.2",
         "symfony/yaml": "~3.2",
@@ -60,7 +60,8 @@
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0",
         "phpdocumentor/type-resolver": "<0.2.0",
-        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+        "symfony/translations": "<3.2"
     },
     "suggest": {
         "ext-apcu": "For best performance of the system caches",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a

The framework Translator makes use of the Translator component domain exceptions which exist since 3.2 only, leading to a fatal error when one of these exceptions is thrown in the framework using `symfony/translations:<3.2`. Bug introduced in https://github.com/symfony/symfony/pull/20012