### PR TITLE
Add new isExpirable() method and consider s-maxage=0 cacheable

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -530,7 +530,7 @@ class Response
             return false;
         }
 
-        return $this->isValidateable() || $this->isFresh();
+        return $this->isValidateable() || $this->isExpirable();
     }
 
     /**
@@ -545,6 +545,19 @@ class Response
     public function isFresh()
     {
         return $this->getTtl() > 0;
+    }
+
+    /**
+     * Returns true if the response includes headers that indicate time-based
+     * content expiration.
+     *
+     * @return bool true if the response expires when it reaches a particular age, false otherwise.
+     */
+    public function isExpirable()
+    {
+        return $this->headers->hasCacheControlDirective('s-maxage')
+            || $this->headers->hasCacheControlDirective('max-age')
+            || $this->headers->has('expires');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -258,6 +258,24 @@ class ResponseTest extends ResponseTestCase
         $this->assertFalse($response->isValidateable(), '->isValidateable() returns false when no validator is present');
     }
 
+    public function testIsExpirable()
+    {
+        $response = new Response('', 200);
+        $response->setSharedMaxAge(100);
+        $this->assertTrue($response->isExpirable(), '->isExpirable() returns true if a shared-maxage is set');
+
+        $response = new Response('', 200);
+        $response->setMaxAge(100);
+        $this->assertTrue($response->isExpirable(), '->isExpirable() returns true if a maxage is set');
+
+        $response = new Response('', 200);
+        $response->setExpires($this->createDateTimeOneHourLater());
+        $this->assertTrue($response->isExpirable(), '->isExpirable() returns true if an Expires date present');
+
+        $response = new Response();
+        $this->assertFalse($response->isExpirable(), '->isExpirable() returns false when no max-age or expire date is present');
+    }
+
     public function testGetDate()
     {
         $oneHourAgo = $this->createDateTimeOneHourAgo();
@@ -302,6 +320,14 @@ class ResponseTest extends ResponseTestCase
 
         $response = new Response();
         $this->assertNull($response->getMaxAge(), '->getMaxAge() returns null if no freshness information available');
+    }
+
+    public function testMaxAge0IsStillCacheable()
+    {
+        $response = new Response();
+        $response->setSharedMaxAge(0);
+
+        $this->assertTrue($response->isCacheable(), '->isCacheable() returns true even if the Response must always be revalidated');
     }
 
     public function testSetSharedMaxAge()

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -586,6 +586,27 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals('Hello World', $this->response->getContent());
     }
 
+    public function testCachesResponseWithSMaxAge0ButRevalidatesIt()
+    {
+        $this->setNextResponse(200, array('Cache-Control' => 's-maxage=0'), 'Hello World');
+
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsCalled();
+        $this->assertEquals(200, $this->response->getStatusCode());
+        $this->assertTraceContains('miss');
+        $this->assertTraceContains('store');
+        $this->assertEquals('Hello World', $this->response->getContent());
+
+        $this->setNextResponse(304, array('Cache-Control' => 's-maxage=0'));
+
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsCalled();
+        $this->assertEquals(200, $this->response->getStatusCode());
+        $this->assertTraceContains('stale');
+        $this->assertTraceContains('valid');
+        $this->assertEquals('Hello World', $this->response->getContent());
+    }
+
     public function testAssignsDefaultTtlWhenResponseHasNoFreshnessInformation()
     {
         $this->setNextResponse();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -595,7 +595,10 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals(200, $this->response->getStatusCode());
         $this->assertTraceContains('miss');
         $this->assertTraceContains('store');
+        $this->assertEquals(0, $this->response->getAge());
         $this->assertEquals('Hello World', $this->response->getContent());
+
+        sleep(2);
 
         $this->setNextResponse(304, array('Cache-Control' => 's-maxage=0'));
 
@@ -604,6 +607,7 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals(200, $this->response->getStatusCode());
         $this->assertTraceContains('stale');
         $this->assertTraceContains('valid');
+        $this->assertEquals(0, $this->response->getAge());
         $this->assertEquals('Hello World', $this->response->getContent());
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\Esi;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use Symfony\Component\HttpKernel\HttpCache\Store;
@@ -25,6 +26,8 @@ class HttpCacheTestCase extends TestCase
     protected $caches;
     protected $cacheConfig;
     protected $request;
+
+    /** @var  Response */
     protected $response;
     protected $responses;
     protected $catch;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -27,7 +27,7 @@ class HttpCacheTestCase extends TestCase
     protected $cacheConfig;
     protected $request;
 
-    /** @var  Response */
+    /** @var Response */
     protected $response;
     protected $responses;
     protected $catch;

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.9",
         "symfony/event-dispatcher": "^2.6.7|~3.0.0",
-        "symfony/http-foundation": "~2.7.20|~2.8.13|~3.1.6",
+        "symfony/http-foundation": "^2.8.19|~3.1.6",
         "symfony/debug": "^2.6.2",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

As in #22033, I am trying to find an issue with the `HttpCache` handling responses with `s-maxage=0`.

Though I cannot find a place in the RFCs that explicitly states it, I have always interpreted a `max-age` of zero to mean "you may cache this, but you must revalidate it before it is used the next time".

This is useful for example when using Symfony's `HttpCache` to keep the entire response but revalidate it every time using an `ETag` or `Last-Modified` information.