### PR TITLE
[Cache] cache/integration-tests is now compatible with phpunit namespaces

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -13,18 +13,6 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Cache\IntegrationTests\CachePoolTest;
 
-if (!class_exists('PHPUnit_Framework_TestCase')) {
-    abstract class AdapterTestCase
-    {
-        public static function setUpBeforeClass()
-        {
-            self::markTestSkipped('cache/integration-tests is not yet compatible with namespaced phpunit versions.');
-        }
-    }
-
-    return;
-}
-
 abstract class AdapterTestCase extends CachePoolTest
 {
     protected function setUp()

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
@@ -16,7 +16,7 @@ class PredisClusterAdapterTest extends AbstractRedisAdapterTest
     public static function setupBeforeClass()
     {
         parent::setupBeforeClass();
-        self::$redis = new \Predis\Client(array(getenv('REDIS_HOST')));
+        self::$redis = new \Predis\Client(array(array('host' => getenv('REDIS_HOST'))));
     }
 
     public static function tearDownAfterClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -