### PR TITLE
[FrameworkBundle] harden the config when using workflow guards

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -25,6 +25,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
@@ -508,6 +509,11 @@ class FrameworkExtension extends Extension
                 if (!isset($config['guard'])) {
                     continue;
                 }
+
+                if (!class_exists(ExpressionLanguage::class)) {
+                    throw new LogicException('Cannot guard workflows as the ExpressionLanguage component is not installed.');
+                }
+
                 $eventName = sprintf('workflow.%s.guard.%s', $name, $transitionName);
                 $guard->addTag('kernel.event_listener', array('event' => $eventName, 'method' => 'onTransition'));
                 $configuration[$eventName] = $config['guard'];

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -67,7 +67,8 @@
         "symfony/property-info": "<3.3",
         "symfony/serializer": "<3.3",
         "symfony/translations": "<3.2",
-        "symfony/validator": "<3.3"
+        "symfony/validator": "<3.3",
+        "symfony/workflow": "<3.3"
     },
     "suggest": {
         "ext-apcu": "For best performance of the system caches",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This will forbid using the FrameworkBundle in 3.3 with previous releases
of the Workflow to avoid issues related to the GuardListener class not
being present. Additionally, it provides a useful exception in case the
guard option is used without the ExpressionLanguage component being
installed.