### PR TITLE
Refactor stale-while-revalidate code in HttpCache, add a (first?) test for it

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -549,49 +549,38 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         // try to acquire a lock to call the backend
         $lock = $this->store->lock($request);
 
+        if (true === $lock) {
+            // we have the lock, call the backend
+            return false;
+        }
+
         // there is already another process calling the backend
-        if (true !== $lock) {
-            // check if we can serve the stale entry
-            if (null === $age = $entry->headers->getCacheControlDirective('stale-while-revalidate')) {
-                $age = $this->options['stale_while_revalidate'];
-            }
 
-            if (abs($entry->getTtl()) < $age) {
-                $this->record($request, 'stale-while-revalidate');
-
-                // server the stale response while there is a revalidation
-                return true;
-            }
-
-            // wait for the lock to be released
-            $wait = 0;
-            while ($this->store->isLocked($request) && $wait < 5000000) {
-                usleep(50000);
-                $wait += 50000;
-            }
-
-            if ($wait < 5000000) {
-                // replace the current entry with the fresh one
-                $new = $this->lookup($request);
-                $entry->headers = $new->headers;
-                $entry->setContent($new->getContent());
-                $entry->setStatusCode($new->getStatusCode());
-                $entry->setProtocolVersion($new->getProtocolVersion());
-                foreach ($new->headers->getCookies() as $cookie) {
-                    $entry->headers->setCookie($cookie);
-                }
-            } else {
-                // backend is slow as hell, send a 503 response (to avoid the dog pile effect)
-                $entry->setStatusCode(503);
-                $entry->setContent('503 Service Unavailable');
-                $entry->headers->set('Retry-After', 10);
-            }
-
+        // May we serve a stale response?
+        if ($this->mayServeStaleWhileRevalidate($entry)) {
+            $this->record($request, 'stale-while-revalidate');
             return true;
         }
 
-        // we have the lock, call the backend
-        return false;
+        // wait for the lock to be released
+        if ($this->waitForLock($request)) {
+            // replace the current entry with the fresh one
+            $new = $this->lookup($request);
+            $entry->headers = $new->headers;
+            $entry->setContent($new->getContent());
+            $entry->setStatusCode($new->getStatusCode());
+            $entry->setProtocolVersion($new->getProtocolVersion());
+            foreach ($new->headers->getCookies() as $cookie) {
+                $entry->headers->setCookie($cookie);
+            }
+        } else {
+            // backend is slow as hell, send a 503 response (to avoid the dog pile effect)
+            $entry->setStatusCode(503);
+            $entry->setContent('503 Service Unavailable');
+            $entry->headers->set('Retry-After', 10);
+        }
+
+        return true;
     }
 
     /**
@@ -709,5 +698,42 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             $path .= '?'.$qs;
         }
         $this->traces[$request->getMethod().' '.$path][] = $event;
+    }
+
+    /**
+     * Checks whether the given (cached) response may be served as "stale" when a revalidation
+     * is currently in progress.
+     *
+     * @param Response $entry
+     *
+     * @return bool True when the stale response may be served, false otherwise.
+     */
+    private function mayServeStaleWhileRevalidate(Response $entry)
+    {
+        $timeout = $entry->headers->getCacheControlDirective('stale-while-revalidate');
+
+        if ($timeout === null) {
+            $timeout = $this->options['stale_while_revalidate'];
+        }
+
+        return abs($entry->getTtl()) < $timeout;
+    }
+
+    /**
+     * Waits for the store to release a locked entry.
+     *
+     * @param Request $request The request to wait for
+     *
+     * @return bool True if the lock was released before the internal timeout was hit; false if the wait timeout was exceeded.
+     */
+    private function waitForLock(Request $request)
+    {
+        $wait = 0;
+        while ($this->store->isLocked($request) && $wait < 5000000) {
+            usleep(50000);
+            $wait += 50000;
+        }
+
+        return $wait < 5000000;
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -559,6 +559,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         // May we serve a stale response?
         if ($this->mayServeStaleWhileRevalidate($entry)) {
             $this->record($request, 'stale-while-revalidate');
+
             return true;
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -29,6 +29,10 @@ class HttpCacheTestCase extends TestCase
     protected $responses;
     protected $catch;
     protected $esi;
+
+    /**
+     * @var Store
+     */
     protected $store;
 
     protected function setUp()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I came up with this while trying to hunt a production bug related to handling of stale cache entries under the condition of a busy backend (also see #22033).

It's just a refactoring to make the code more readable plus a new test.
