### PR TITLE
[Security] deprecate the Role and SwitchUserRole classes

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -53,6 +53,13 @@ HttpFoundation
 Security
 --------
 
+ * The `Role` and `SwitchUserRole` classes are deprecated and will be removed in 5.0. Use strings for roles
+   instead.
+ * The `RoleHierarchyInterface` is deprecated and will be removed in 5.0.
+ * The `getReachableRoles()` method of the `RoleHierarchy` class is deprecated and will be removed in 5.0.
+   Use the `getReachableRoleNames()` method instead.
+ * The `getRoles()` method of the `TokenInterface` is deprecated. Tokens must implement the `getRoleNames()`
+   method instead and return roles as strings.
  * The `AbstractToken::serialize()`, `AbstractToken::unserialize()`,
    `AuthenticationException::serialize()` and `AuthenticationException::unserialize()`
    methods are now final, use `getState()` and `setState()` instead.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -226,6 +226,11 @@ Process
 Security
 --------
 
+ * The `Role` and `SwitchUserRole` classes have been removed.
+ * The `RoleHierarchyInterface` has been removed.
+ * The `getReachableRoles()` method of the `RoleHierarchy` class has been removed.
+ * The `getRoles()` method has been removed from the `TokenInterface`. It has been replaced by the new
+   `getRoleNames()` method.
  * The `ContextListener::setLogoutOnUserChange()` method has been removed.
  * The `Symfony\Component\Security\Core\User\AdvancedUserInterface` has been removed.
  * The `ExpressionVoter::addExpressionLanguageProvider()` method has been removed.

--- a/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
@@ -31,10 +31,16 @@ class TokenProcessor
     {
         $records['extra']['token'] = null;
         if (null !== $token = $this->tokenStorage->getToken()) {
+            if (method_exists($token, 'getRoleNames')) {
+                $roles = $token->getRoleNames();
+            } else {
+                $roles = array_map(function ($role) { return $role->getRole(); }, $token->getRoles(false));
+            }
+
             $records['extra']['token'] = [
                 'username' => $token->getUsername(),
                 'authenticated' => $token->isAuthenticated(),
-                'roles' => array_map(function ($role) { return $role->getRole(); }, $token->getRoles()),
+                'roles' => $roles,
             ];
         }
 

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
@@ -36,7 +36,6 @@ class TokenProcessorTest extends TestCase
         $this->assertArrayHasKey('token', $record['extra']);
         $this->assertEquals($token->getUsername(), $record['extra']['token']['username']);
         $this->assertEquals($token->isAuthenticated(), $record['extra']['token']['authenticated']);
-        $roles = array_map(function ($role) { return $role->getRole(); }, $token->getRoles());
-        $this->assertEquals($roles, $record['extra']['token']['roles']);
+        $this->assertEquals(['ROLE_USER'], $record['extra']['token']['roles']);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -98,6 +98,7 @@
             <argument>%security.role_hierarchy.roles%</argument>
         </service>
         <service id="Symfony\Component\Security\Core\Role\RoleHierarchyInterface" alias="security.role_hierarchy" />
+        <service id="Symfony\Component\Security\Core\Role\RoleHierarchy" alias="security.role_hierarchy" />
 
 
         <!-- Security Voters -->

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -21,7 +21,7 @@
         "symfony/config": "^4.2",
         "symfony/dependency-injection": "^4.2",
         "symfony/http-kernel": "^4.1",
-        "symfony/security-core": "~4.2",
+        "symfony/security-core": "~4.3",
         "symfony/security-csrf": "~4.2",
         "symfony/security-guard": "~4.2",
         "symfony/security-http": "~4.2"

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,13 @@ CHANGELOG
 4.3.0
 -----
 
+* The `Role` and `SwitchUserRole` classes are deprecated and will be removed in 5.0. Use strings for roles
+  instead.
+* The `RoleHierarchyInterface` is deprecated and will be removed in 5.0.
+* The `getReachableRoles()` method of the `RoleHierarchy` class is deprecated and will be removed in 5.0.
+  Use the `getReachableRoleNames()` method instead.
+* The `getRoles()` method of the `TokenInterface` is deprecated. Tokens must implement the `getRoleNames()`
+  method instead and return roles as strings.
 * Made the `serialize()` and `unserialize()` methods of `AbstractToken` and
   `AuthenticationException` final, use `getState()`/`setState()` instead
 

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Provider;
 
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -87,7 +88,12 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
             throw $e;
         }
 
-        $authenticatedToken = new UsernamePasswordToken($user, $token->getCredentials(), $this->providerKey, $this->getRoles($user, $token));
+        if ($token instanceof SwitchUserToken) {
+            $authenticatedToken = new SwitchUserToken($user, $token->getCredentials(), $this->providerKey, $this->getRoles($user, $token), $token->getOriginalToken());
+        } else {
+            $authenticatedToken = new UsernamePasswordToken($user, $token->getCredentials(), $this->providerKey, $this->getRoles($user, $token));
+        }
+
         $authenticatedToken->setAttributes($token->getAttributes());
 
         return $authenticatedToken;
@@ -110,7 +116,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
     {
         $roles = $user->getRoles();
 
-        foreach ($token->getRoles() as $role) {
+        foreach ($token->getRoles(false) as $role) {
             if ($role instanceof SwitchUserRole) {
                 $roles[] = $role;
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -26,11 +26,12 @@ abstract class AbstractToken implements TokenInterface
 {
     private $user;
     private $roles = [];
+    private $roleNames = [];
     private $authenticated = false;
     private $attributes = [];
 
     /**
-     * @param (Role|string)[] $roles An array of roles
+     * @param string[] $roles An array of roles
      *
      * @throws \InvalidArgumentException
      */
@@ -38,13 +39,19 @@ abstract class AbstractToken implements TokenInterface
     {
         foreach ($roles as $role) {
             if (\is_string($role)) {
-                $role = new Role($role);
+                $role = new Role($role, false);
             } elseif (!$role instanceof Role) {
                 throw new \InvalidArgumentException(sprintf('$roles must be an array of strings, or Role instances, but got %s.', \gettype($role)));
             }
 
             $this->roles[] = $role;
+            $this->roleNames[] = (string) $role;
         }
+    }
+
+    public function getRoleNames(): array
+    {
+        return $this->roleNames;
     }
 
     /**
@@ -52,6 +59,10 @@ abstract class AbstractToken implements TokenInterface
      */
     public function getRoles()
     {
+        if (0 === \func_num_args() || func_get_arg(0)) {
+            @trigger_error(sprintf('The %s() method is deprecated since Symfony 4.3. Use the getRoleNames() method instead.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         return $this->roles;
     }
 
@@ -172,7 +183,7 @@ abstract class AbstractToken implements TokenInterface
      */
     protected function getState(): array
     {
-        return [$this->user, $this->authenticated, $this->roles, $this->attributes];
+        return [$this->user, $this->authenticated, $this->roles, $this->attributes, $this->roleNames];
     }
 
     /**
@@ -193,7 +204,7 @@ abstract class AbstractToken implements TokenInterface
      */
     protected function setState(array $data)
     {
-        [$this->user, $this->authenticated, $this->roles, $this->attributes] = $data;
+        [$this->user, $this->authenticated, $this->roles, $this->attributes, $this->roleNames] = $data;
     }
 
     /**
@@ -225,7 +236,7 @@ abstract class AbstractToken implements TokenInterface
      */
     public function hasAttribute($name)
     {
-        return array_key_exists($name, $this->attributes);
+        return \array_key_exists($name, $this->attributes);
     }
 
     /**
@@ -239,7 +250,7 @@ abstract class AbstractToken implements TokenInterface
      */
     public function getAttribute($name)
     {
-        if (!array_key_exists($name, $this->attributes)) {
+        if (!\array_key_exists($name, $this->attributes)) {
             throw new \InvalidArgumentException(sprintf('This token has no "%s" attribute.', $name));
         }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
-use Symfony\Component\Security\Core\Role\Role;
-
 /**
  * AnonymousToken represents an anonymous token.
  *
@@ -25,7 +23,7 @@ class AnonymousToken extends AbstractToken
     /**
      * @param string        $secret A secret used to make sure the token is created by the app and not by a malicious client
      * @param string|object $user   The user can be a UserInterface instance, or an object implementing a __toString method or the username as a regular string
-     * @param Role[]        $roles  An array of roles
+     * @param string[]      $roles  An array of roles
      */
     public function __construct(string $secret, $user, array $roles = [])
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
-use Symfony\Component\Security\Core\Role\Role;
-
 /**
  * PreAuthenticatedToken implements a pre-authenticated token.
  *
@@ -24,10 +22,10 @@ class PreAuthenticatedToken extends AbstractToken
     private $providerKey;
 
     /**
-     * @param string|object   $user        The user can be a UserInterface instance, or an object implementing a __toString method or the username as a regular string
-     * @param mixed           $credentials The user credentials
-     * @param string          $providerKey The provider key
-     * @param (Role|string)[] $roles       An array of roles
+     * @param string|object $user        The user can be a UserInterface instance, or an object implementing a __toString method or the username as a regular string
+     * @param mixed         $credentials The user credentials
+     * @param string        $providerKey The provider key
+     * @param string[]      $roles       An array of roles
      */
     public function __construct($user, $credentials, string $providerKey, array $roles = [])
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
@@ -39,6 +39,10 @@ class TokenStorage implements TokenStorageInterface, ResetInterface
      */
     public function setToken(TokenInterface $token = null)
     {
+        if (null !== $token && !method_exists($token, 'getRoleNames')) {
+            @trigger_error(sprintf('Not implementing the getRoleNames() method in %s which implements %s is deprecated since Symfony 4.3.', \get_class($token), TokenInterface::class), E_USER_DEPRECATED);
+        }
+
         $this->token = $token;
     }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * Token representing a user who temporarily impersonates another one.
+ *
+ * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
+ */
+class SwitchUserToken extends UsernamePasswordToken
+{
+    private $originalToken;
+
+    /**
+     * @param string|object  $user          The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method
+     * @param mixed          $credentials   This usually is the password of the user
+     * @param string         $providerKey   The provider key
+     * @param string[]       $roles         An array of roles
+     * @param TokenInterface $originalToken The token of the user who switched to the current user
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($user, $credentials, string $providerKey, array $roles = [], TokenInterface $originalToken)
+    {
+        parent::__construct($user, $credentials, $providerKey, $roles);
+
+        $this->originalToken = $originalToken;
+    }
+
+    public function getOriginalToken(): TokenInterface
+    {
+        return $this->originalToken;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getState(): array
+    {
+        return [$this->originalToken, parent::getState()];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setState(array $data)
+    {
+        [$this->originalToken, $parentData] = $data;
+        parent::setState($parentData);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\Security\Core\Role\Role;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @method string[] getRoleNames() The associated roles - not implementing it is deprecated since Symfony 4.3
  */
 interface TokenInterface extends \Serializable
 {
@@ -34,6 +36,8 @@ interface TokenInterface extends \Serializable
      * Returns the user roles.
      *
      * @return Role[] An array of Role instances
+     *
+     * @deprecated since Symfony 4.3, use the getRoleNames() method instead
      */
     public function getRoles();
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
-use Symfony\Component\Security\Core\Role\Role;
-
 /**
  * UsernamePasswordToken implements a username and password token.
  *
@@ -24,10 +22,10 @@ class UsernamePasswordToken extends AbstractToken
     private $providerKey;
 
     /**
-     * @param string|object   $user        The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method
-     * @param mixed           $credentials This usually is the password of the user
-     * @param string          $providerKey The provider key
-     * @param (Role|string)[] $roles       An array of roles
+     * @param string|object $user        The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method
+     * @param mixed         $credentials This usually is the password of the user
+     * @param string        $providerKey The provider key
+     * @param string[]      $roles       An array of roles
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
@@ -47,7 +47,7 @@ class RoleVoter implements VoterInterface
 
             $result = VoterInterface::ACCESS_DENIED;
             foreach ($roles as $role) {
-                if ($attribute === $role->getRole()) {
+                if ($attribute === $role) {
                     return VoterInterface::ACCESS_GRANTED;
                 }
             }
@@ -58,6 +58,12 @@ class RoleVoter implements VoterInterface
 
     protected function extractRoles(TokenInterface $token)
     {
-        return $token->getRoles();
+        if (method_exists($token, 'getRoleNames')) {
+            return $token->getRoleNames();
+        }
+
+        @trigger_error(sprintf('Not implementing the getRoleNames() method in %s which implements %s is deprecated since Symfony 4.3.', \get_class($token), TokenInterface::class), E_USER_DEPRECATED);
+
+        return array_map(function (Role $role) { return $role->getRole(); }, $token->getRoles(false));
     }
 }

--- a/src/Symfony/Component/Security/Core/Role/Role.php
+++ b/src/Symfony/Component/Security/Core/Role/Role.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Security\Core\Role;
  * Role is a simple implementation representing a role identified by a string.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 4.3, to be removed in 5.0. Use strings as roles instead.
  */
 class Role
 {
@@ -22,6 +24,10 @@ class Role
 
     public function __construct(string $role)
     {
+        if (\func_num_args() < 2 || func_get_arg(1)) {
+            @trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.3 and will be removed in 5.0. Use strings as roles instead.', __CLASS__), E_USER_DEPRECATED);
+        }
+
         $this->role = $role;
     }
 
@@ -31,6 +37,11 @@ class Role
      * @return string
      */
     public function getRole()
+    {
+        return $this->role;
+    }
+
+    public function __toString(): string
     {
         return $this->role;
     }

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
@@ -36,6 +36,8 @@ class RoleHierarchy implements RoleHierarchyInterface
      */
     public function getReachableRoles(array $roles)
     {
+        @trigger_error(sprintf('The %s() method is deprecated since Symfony 4.3 and will be removed in 5.0. Use roles as strings and the getReachableRoleNames() method instead.', __METHOD__), E_USER_DEPRECATED);
+
         $reachableRoles = $roles;
         foreach ($roles as $role) {
             if (!isset($this->map[$role->getRole()])) {
@@ -44,6 +46,37 @@ class RoleHierarchy implements RoleHierarchyInterface
 
             foreach ($this->map[$role->getRole()] as $r) {
                 $reachableRoles[] = new Role($r);
+            }
+        }
+
+        return $reachableRoles;
+    }
+
+    /**
+     * @param string[] $roles
+     *
+     * @return string[]
+     */
+    public function getReachableRoleNames(array $roles): array
+    {
+        $reachableRoles = $roles = array_map(
+            function ($role) {
+                if ($role instanceof Role) {
+                    return $role->getRole();
+                }
+
+                return $role;
+            },
+            $roles
+        );
+
+        foreach ($roles as $role) {
+            if (!isset($this->map[$role])) {
+                continue;
+            }
+
+            foreach ($this->map[$role] as $r) {
+                $reachableRoles[] = $r;
             }
         }
 

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Security\Core\Role;
  * RoleHierarchyInterface is the interface for a role hierarchy.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 4.3, to be removed in 5.0.
  */
 interface RoleHierarchyInterface
 {

--- a/src/Symfony/Component/Security/Core/Role/SwitchUserRole.php
+++ b/src/Symfony/Component/Security/Core/Role/SwitchUserRole.php
@@ -18,9 +18,12 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * another one.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 4.3, to be removed in 5.0. Use strings as roles instead.
  */
 class SwitchUserRole extends Role
 {
+    private $deprecationTriggered = false;
     private $source;
 
     /**
@@ -29,7 +32,13 @@ class SwitchUserRole extends Role
      */
     public function __construct(string $role, TokenInterface $source)
     {
-        parent::__construct($role);
+        if ($triggerDeprecation = \func_num_args() < 3 || func_get_arg(2)) {
+            @trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.3 and will be removed in 5.0. Use strings as roles instead.', __CLASS__), E_USER_DEPRECATED);
+
+            $this->deprecationTriggered = true;
+        }
+
+        parent::__construct($role, $triggerDeprecation);
 
         $this->source = $source;
     }
@@ -41,6 +50,12 @@ class SwitchUserRole extends Role
      */
     public function getSource()
     {
+        if (!$this->deprecationTriggered && (\func_num_args() < 1 || func_get_arg(0))) {
+            @trigger_error(sprintf('The "%s" class is deprecated since version 4.3 and will be removed in 5.0. Use strings as roles instead.', __CLASS__), E_USER_DEPRECATED);
+
+            $this->deprecationTriggered = true;
+        }
+
         return $this->source;
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -70,7 +70,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', $token);
         $this->assertEquals('pass', $token->getCredentials());
         $this->assertEquals('key', $token->getProviderKey());
-        $this->assertEquals([], $token->getRoles());
+        $this->assertEquals([], $token->getRoleNames());
         $this->assertEquals(['foo' => 'bar'], $token->getAttributes(), '->authenticate() copies token attributes');
         $this->assertSame($user, $token->getUser());
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider;
 use Symfony\Component\Security\Core\Exception\DisabledException;
-use Symfony\Component\Security\Core\Role\Role;
 
 class RememberMeAuthenticationProviderTest extends TestCase
 {
@@ -78,7 +77,7 @@ class RememberMeAuthenticationProviderTest extends TestCase
 
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', $authToken);
         $this->assertSame($user, $authToken->getUser());
-        $this->assertEquals([new Role('ROLE_FOO')], $authToken->getRoles());
+        $this->assertEquals(['ROLE_FOO'], $authToken->getRoleNames());
         $this->assertEquals('', $authToken->getCredentials());
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AnonymousTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AnonymousTokenTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Role\Role;
 
 class AnonymousTokenTest extends TestCase
 {
@@ -23,7 +22,7 @@ class AnonymousTokenTest extends TestCase
         $this->assertTrue($token->isAuthenticated());
 
         $token = new AnonymousToken('foo', 'bar', ['ROLE_FOO']);
-        $this->assertEquals([new Role('ROLE_FOO')], $token->getRoles());
+        $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
     }
 
     public function testGetKey()

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/PreAuthenticatedTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/PreAuthenticatedTokenTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
-use Symfony\Component\Security\Core\Role\Role;
 
 class PreAuthenticatedTokenTest extends TestCase
 {
@@ -24,7 +23,7 @@ class PreAuthenticatedTokenTest extends TestCase
 
         $token = new PreAuthenticatedToken('foo', 'bar', 'key', ['ROLE_FOO']);
         $this->assertTrue($token->isAuthenticated());
-        $this->assertEquals([new Role('ROLE_FOO')], $token->getRoles());
+        $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
         $this->assertEquals('key', $token->getProviderKey());
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
-use Symfony\Component\Security\Core\Role\Role;
 
 class RememberMeTokenTest extends TestCase
 {
@@ -24,7 +23,7 @@ class RememberMeTokenTest extends TestCase
 
         $this->assertEquals('fookey', $token->getProviderKey());
         $this->assertEquals('foo', $token->getSecret());
-        $this->assertEquals([new Role('ROLE_FOO')], $token->getRoles());
+        $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
         $this->assertSame($user, $token->getUser());
         $this->assertTrue($token->isAuthenticated());
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/TokenStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/TokenStorageTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Token\Storage;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class TokenStorageTest extends TestCase
 {
@@ -20,7 +21,7 @@ class TokenStorageTest extends TestCase
     {
         $tokenStorage = new TokenStorage();
         $this->assertNull($tokenStorage->getToken());
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $token = new UsernamePasswordToken('username', 'password', 'provider');
         $tokenStorage->setToken($token);
         $this->assertSame($token, $tokenStorage->getToken());
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class SwitchUserTokenTest extends TestCase
+{
+    public function testSerialize()
+    {
+        $originalToken = new UsernamePasswordToken('user', 'foo', 'provider-key', ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
+        $token = new SwitchUserToken('admin', 'bar', 'provider-key', ['ROLE_USER'], $originalToken);
+
+        $unserializedToken = unserialize(serialize($token));
+
+        $this->assertInstanceOf(SwitchUserToken::class, $unserializedToken);
+        $this->assertSame('admin', $unserializedToken->getUsername());
+        $this->assertSame('bar', $unserializedToken->getCredentials());
+        $this->assertSame('provider-key', $unserializedToken->getProviderKey());
+        $this->assertEquals(['ROLE_USER'], $unserializedToken->getRoleNames());
+
+        $unserializedOriginalToken = $unserializedToken->getOriginalToken();
+
+        $this->assertInstanceOf(UsernamePasswordToken::class, $unserializedOriginalToken);
+        $this->assertSame('user', $unserializedOriginalToken->getUsername());
+        $this->assertSame('foo', $unserializedOriginalToken->getCredentials());
+        $this->assertSame('provider-key', $unserializedOriginalToken->getProviderKey());
+        $this->assertEquals(['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'], $unserializedOriginalToken->getRoleNames());
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\Role\Role;
 
 class UsernamePasswordTokenTest extends TestCase
 {
@@ -23,7 +22,7 @@ class UsernamePasswordTokenTest extends TestCase
         $this->assertFalse($token->isAuthenticated());
 
         $token = new UsernamePasswordToken('foo', 'bar', 'key', ['ROLE_FOO']);
-        $this->assertEquals([new Role('ROLE_FOO')], $token->getRoles());
+        $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
         $this->assertTrue($token->isAuthenticated());
         $this->assertEquals('key', $token->getProviderKey());
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
 
 class AuthorizationCheckerTest extends TestCase
@@ -37,10 +38,10 @@ class AuthorizationCheckerTest extends TestCase
 
     public function testVoteAuthenticatesTokenIfNecessary()
     {
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $token = new UsernamePasswordToken('username', 'password', 'provider');
         $this->tokenStorage->setToken($token);
 
-        $newToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $newToken = new UsernamePasswordToken('username', 'password', 'provider');
 
         $this->authenticationManager
             ->expects($this->once())
@@ -79,11 +80,7 @@ class AuthorizationCheckerTest extends TestCase
      */
     public function testIsGranted($decide)
     {
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
-        $token
-            ->expects($this->once())
-            ->method('isAuthenticated')
-            ->will($this->returnValue(true));
+        $token = new UsernamePasswordToken('username', 'password', 'provider', ['ROLE_USER']);
 
         $this->accessDecisionManager
             ->expects($this->once())

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\ExpressionVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
@@ -20,6 +21,7 @@ use Symfony\Component\Security\Core\Role\Role;
 class ExpressionVoterTest extends TestCase
 {
     /**
+     * @group legacy
      * @dataProvider getVoteTests
      */
     public function testVote($roles, $attributes, $expected, $tokenExpectsGetRoles = true, $expressionLanguageExpectsEvaluate = true)
@@ -27,6 +29,16 @@ class ExpressionVoterTest extends TestCase
         $voter = new ExpressionVoter($this->createExpressionLanguage($expressionLanguageExpectsEvaluate), $this->createTrustResolver(), $this->createAuthorizationChecker());
 
         $this->assertSame($expected, $voter->vote($this->getToken($roles, $tokenExpectsGetRoles), null, $attributes));
+    }
+
+    /**
+     * @dataProvider getVoteTests
+     */
+    public function testVoteWithTokenThatReturnsRoleNames($roles, $attributes, $expected, $tokenExpectsGetRoles = true, $expressionLanguageExpectsEvaluate = true)
+    {
+        $voter = new ExpressionVoter($this->createExpressionLanguage($expressionLanguageExpectsEvaluate), $this->createTrustResolver(), $this->createAuthorizationChecker());
+
+        $this->assertSame($expected, $voter->vote($this->getTokenWithRoleNames($roles, $tokenExpectsGetRoles), null, $attributes));
     }
 
     public function getVoteTests()
@@ -52,6 +64,19 @@ class ExpressionVoterTest extends TestCase
         if ($tokenExpectsGetRoles) {
             $token->expects($this->once())
                 ->method('getRoles')
+                ->will($this->returnValue($roles));
+        }
+
+        return $token;
+    }
+
+    protected function getTokenWithRoleNames(array $roles, $tokenExpectsGetRoles = true)
+    {
+        $token = $this->getMockBuilder(AbstractToken::class)->getMock();
+
+        if ($tokenExpectsGetRoles) {
+            $token->expects($this->once())
+                ->method('getRoleNames')
                 ->will($this->returnValue($roles));
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleHierarchyVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleHierarchyVoterTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Core\Role\RoleHierarchy;
 class RoleHierarchyVoterTest extends RoleVoterTest
 {
     /**
+     * @group legacy
      * @dataProvider getVoteTests
      */
     public function testVote($roles, $attributes, $expected)
@@ -25,6 +26,16 @@ class RoleHierarchyVoterTest extends RoleVoterTest
         $voter = new RoleHierarchyVoter(new RoleHierarchy(['ROLE_FOO' => ['ROLE_FOOBAR']]));
 
         $this->assertSame($expected, $voter->vote($this->getToken($roles), null, $attributes));
+    }
+
+    /**
+     * @dataProvider getVoteTests
+     */
+    public function testVoteUsingTokenThatReturnsRoleNames($roles, $attributes, $expected)
+    {
+        $voter = new RoleHierarchyVoter(new RoleHierarchy(['ROLE_FOO' => ['ROLE_FOOBAR']]));
+
+        $this->assertSame($expected, $voter->vote($this->getTokenWithRoleNames($roles), null, $attributes));
     }
 
     public function getVoteTests()
@@ -35,6 +46,18 @@ class RoleHierarchyVoterTest extends RoleVoterTest
     }
 
     /**
+     * @group legacy
+     * @dataProvider getLegacyVoteOnRoleObjectsTests
+     */
+    public function testVoteOnRoleObjects($roles, $attributes, $expected)
+    {
+        $voter = new RoleHierarchyVoter(new RoleHierarchy(['ROLE_FOO' => ['ROLE_FOOBAR']]));
+
+        $this->assertSame($expected, $voter->vote($this->getToken($roles), null, $attributes));
+    }
+
+    /**
+     * @group legacy
      * @dataProvider getVoteWithEmptyHierarchyTests
      */
     public function testVoteWithEmptyHierarchy($roles, $attributes, $expected)
@@ -42,6 +65,16 @@ class RoleHierarchyVoterTest extends RoleVoterTest
         $voter = new RoleHierarchyVoter(new RoleHierarchy([]));
 
         $this->assertSame($expected, $voter->vote($this->getToken($roles), null, $attributes));
+    }
+
+    /**
+     * @dataProvider getVoteWithEmptyHierarchyTests
+     */
+    public function testVoteWithEmptyHierarchyUsingTokenThatReturnsRoleNames($roles, $attributes, $expected)
+    {
+        $voter = new RoleHierarchyVoter(new RoleHierarchy([]));
+
+        $this->assertSame($expected, $voter->vote($this->getTokenWithRoleNames($roles), null, $attributes));
     }
 
     public function getVoteWithEmptyHierarchyTests()

--- a/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\Security\Core\Role\RoleHierarchy;
 
 class RoleHierarchyTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testGetReachableRoles()
     {
         $role = new RoleHierarchy([
@@ -29,5 +32,19 @@ class RoleHierarchyTest extends TestCase
         $this->assertEquals([new Role('ROLE_ADMIN'), new Role('ROLE_USER')], $role->getReachableRoles([new Role('ROLE_ADMIN')]));
         $this->assertEquals([new Role('ROLE_FOO'), new Role('ROLE_ADMIN'), new Role('ROLE_USER')], $role->getReachableRoles([new Role('ROLE_FOO'), new Role('ROLE_ADMIN')]));
         $this->assertEquals([new Role('ROLE_SUPER_ADMIN'), new Role('ROLE_ADMIN'), new Role('ROLE_FOO'), new Role('ROLE_USER')], $role->getReachableRoles([new Role('ROLE_SUPER_ADMIN')]));
+    }
+
+    public function testGetReachableRoleNames()
+    {
+        $role = new RoleHierarchy(array(
+            'ROLE_ADMIN' => array('ROLE_USER'),
+            'ROLE_SUPER_ADMIN' => array('ROLE_ADMIN', 'ROLE_FOO'),
+        ));
+
+        $this->assertEquals(array('ROLE_USER'), $role->getReachableRoleNames(array('ROLE_USER')));
+        $this->assertEquals(array('ROLE_FOO'), $role->getReachableRoleNames(array('ROLE_FOO')));
+        $this->assertEquals(array('ROLE_ADMIN', 'ROLE_USER'), $role->getReachableRoleNames(array('ROLE_ADMIN')));
+        $this->assertEquals(array('ROLE_FOO', 'ROLE_ADMIN', 'ROLE_USER'), $role->getReachableRoleNames(array('ROLE_FOO', 'ROLE_ADMIN')));
+        $this->assertEquals(array('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'), $role->getReachableRoleNames(array('ROLE_SUPER_ADMIN')));
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Role/RoleTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/RoleTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Security\Core\Tests\Role;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Role\Role;
 
+/**
+ * @group legacy
+ */
 class RoleTest extends TestCase
 {
     public function testGetRole()

--- a/src/Symfony/Component/Security/Core/Tests/Role/SwitchUserRoleTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/SwitchUserRoleTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Security\Core\Tests\Role;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Role\SwitchUserRole;
 
+/**
+ * @group legacy
+ */
 class SwitchUserRoleTest extends TestCase
 {
     public function testGetSource()

--- a/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Guard\Token;
 
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
-use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -28,9 +27,9 @@ class PostAuthenticationGuardToken extends AbstractToken implements GuardTokenIn
     private $providerKey;
 
     /**
-     * @param UserInterface   $user        The user!
-     * @param string          $providerKey The provider (firewall) key
-     * @param (Role|string)[] $roles       An array of roles
+     * @param UserInterface $user        The user!
+     * @param string        $providerKey The provider (firewall) key
+     * @param string[]      $roles       An array of roles
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverIn
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
@@ -189,10 +190,14 @@ class ContextListener implements ListenerInterface
                 if (null !== $this->logger) {
                     $context = ['provider' => \get_class($provider), 'username' => $refreshedUser->getUsername()];
 
-                    foreach ($token->getRoles() as $role) {
-                        if ($role instanceof SwitchUserRole) {
-                            $context['impersonator_username'] = $role->getSource()->getUsername();
-                            break;
+                    if ($token instanceof SwitchUserToken) {
+                        $context['impersonator_username'] = $token->getOriginalToken()->getUsername();
+                    } else {
+                        foreach ($token->getRoles(false) as $role) {
+                            if ($role instanceof SwitchUserRole) {
+                                $context['impersonator_username'] = $role->getSource(false)->getUsername();
+                                break;
+                            }
                         }
                     }
 

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -17,8 +17,8 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
@@ -122,7 +122,7 @@ class SwitchUserListener implements ListenerInterface
         $token = $this->tokenStorage->getToken();
         $originalToken = $this->getOriginalToken($token);
 
-        if (false !== $originalToken) {
+        if (null !== $originalToken) {
             if ($token->getUsername() === $username) {
                 return $token;
             }
@@ -146,9 +146,9 @@ class SwitchUserListener implements ListenerInterface
         $this->userChecker->checkPostAuth($user);
 
         $roles = $user->getRoles();
-        $roles[] = new SwitchUserRole('ROLE_PREVIOUS_ADMIN', $this->tokenStorage->getToken());
+        $roles[] = new SwitchUserRole('ROLE_PREVIOUS_ADMIN', $this->tokenStorage->getToken(), false);
 
-        $token = new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey, $roles);
+        $token = new SwitchUserToken($user, $user->getPassword(), $this->providerKey, $roles, $token);
 
         if (null !== $this->dispatcher) {
             $switchEvent = new SwitchUserEvent($request, $token->getUser(), $token);
@@ -169,7 +169,7 @@ class SwitchUserListener implements ListenerInterface
      */
     private function attemptExitUser(Request $request)
     {
-        if (false === $original = $this->getOriginalToken($this->tokenStorage->getToken())) {
+        if (null === ($currentToken = $this->tokenStorage->getToken()) || null === $original = $this->getOriginalToken($currentToken)) {
             throw new AuthenticationCredentialsNotFoundException('Could not find original Token object.');
         }
 
@@ -183,19 +183,18 @@ class SwitchUserListener implements ListenerInterface
         return $original;
     }
 
-    /**
-     * Gets the original Token from a switched one.
-     *
-     * @return TokenInterface|false The original TokenInterface instance, false if the current TokenInterface is not switched
-     */
-    private function getOriginalToken(TokenInterface $token)
+    private function getOriginalToken(TokenInterface $token): ?TokenInterface
     {
-        foreach ($token->getRoles() as $role) {
+        if ($token instanceof SwitchUserToken) {
+            return $token->getOriginalToken();
+        }
+
+        foreach ($token->getRoles(false) as $role) {
             if ($role instanceof SwitchUserRole) {
                 return $role->getSource();
             }
         }
 
-        return false;
+        return null;
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolve
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
 
@@ -35,7 +36,7 @@ class UserValueResolverTest extends TestCase
     public function testResolveNoUser()
     {
         $mock = $this->getMockBuilder(UserInterface::class)->getMock();
-        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $token = new UsernamePasswordToken('username', 'password', 'provider');
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);
 
@@ -57,8 +58,7 @@ class UserValueResolverTest extends TestCase
     public function testResolve()
     {
         $user = $this->getMockBuilder(UserInterface::class)->getMock();
-        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
-        $token->expects($this->any())->method('getUser')->willReturn($user);
+        $token = new UsernamePasswordToken($user, 'password', 'provider');
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);
 
@@ -72,8 +72,7 @@ class UserValueResolverTest extends TestCase
     public function testIntegration()
     {
         $user = $this->getMockBuilder(UserInterface::class)->getMock();
-        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
-        $token->expects($this->any())->method('getUser')->willReturn($user);
+        $token = new UsernamePasswordToken($user, 'password', 'provider');
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);
 
@@ -83,7 +82,7 @@ class UserValueResolverTest extends TestCase
 
     public function testIntegrationNoUser()
     {
-        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $token = new UsernamePasswordToken('username', 'password', 'provider');
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($token);
 

--- a/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
@@ -95,7 +95,7 @@ class LogoutUrlGeneratorTest extends TestCase
 
     public function testGuessFromTokenWithoutProviderKeyFallbacksToCurrentFirewall()
     {
-        $this->tokenStorage->setToken($this->getMockBuilder(TokenInterface::class)->getMock());
+        $this->tokenStorage->setToken(new UsernamePasswordToken('username', 'password', 'provider'));
         $this->generator->registerListener('secured_area', '/logout', null, null);
         $this->generator->setCurrentFirewall('secured_area');
 

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/security-core": "~3.4|~4.0",
+        "symfony/security-core": "~4.3",
         "symfony/event-dispatcher": "~3.4|~4.0",
         "symfony/http-foundation": "~3.4|~4.0",
         "symfony/http-kernel": "~3.4|~4.0",

--- a/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
+++ b/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -35,8 +36,7 @@ class GuardListenerTest extends TestCase
             ],
         ];
         $expressionLanguage = new ExpressionLanguage();
-        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
-        $token->expects($this->any())->method('getRoles')->willReturn([new Role('ROLE_USER')]);
+        $token = new UsernamePasswordToken('username', 'credentials', 'provider', ['ROLE_USER']);
         $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
         $tokenStorage->expects($this->any())->method('getToken')->willReturn($token);
         $this->authenticationChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #20824
| License       | MIT
| Doc PR        | symfony/symfony-docs#11047

In #20801, we deprecated the `RoleInterface`. The next logical step would be to also deprecate the `Role` class. However, we currently have the `SwitchUserRole` class (a sub-class of `Role`) that acts as an indicator to check whether or not the authenticated user switched to another user.

This PR proposes an alternative solution to the usage of the special `SwitchUserRole` class by storing the original token inside the `UsernamePasswordToken`. This PR is not complete, but rather acts as a proof of concept of how we could get rid of the `Role` and the `SwitchUserRole` classes.

Please share your opinions whether you think this is a valid approach and I will be happy to finalise the PR.