### PR TITLE
fix some risky tests

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/HttpFoundation/DbalSessionHandlerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/HttpFoundation/DbalSessionHandlerTest.php
@@ -25,5 +25,7 @@ class DbalSessionHandlerTest extends TestCase
     {
         $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
         $handler = new DbalSessionHandler($connection);
+
+        $this->assertInstanceOf('Symfony\Bridge\Doctrine\HttpFoundation\DbalSessionHandler', $handler);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
@@ -118,36 +118,36 @@ class FormExtensionBootstrap3HorizontalLayoutTest extends AbstractBootstrap3Hori
 
     public function testRange()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testRangeWithMinMaxValues()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testLabelWithoutTranslationOnButton()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceExpandedWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testButtonlabelWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testAttributesNotTranslatedWhenTranslationDomainIsFalse()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -118,36 +118,36 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTest
 
     public function testRange()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testRangeWithMinMaxValues()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testLabelWithoutTranslationOnButton()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceExpandedWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testButtonlabelWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testAttributesNotTranslatedWhenTranslationDomainIsFalse()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -105,7 +105,11 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
 
         $renderer = $this->extension->renderer;
         $renderer->setTheme($view, array('page_dynamic_extends.html.twig'));
-        $renderer->searchAndRenderBlock($view, 'row');
+
+        $this->assertMatchesXpath(
+            $renderer->searchAndRenderBlock($view, 'row'),
+            '/div/label[text()="child"]'
+        );
     }
 
     public function isSelectedChoiceProvider()
@@ -211,36 +215,36 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
 
     public function testRange()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testRangeWithMinMaxValues()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testLabelWithoutTranslationOnButton()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceExpandedWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testButtonlabelWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testAttributesNotTranslatedWhenTranslationDomainIsFalse()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -119,36 +119,36 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
 
     public function testRange()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testRangeWithMinMaxValues()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testLabelWithoutTranslationOnButton()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceExpandedWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testButtonlabelWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testAttributesNotTranslatedWhenTranslationDomainIsFalse()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -131,36 +131,36 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
 
     public function testRange()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testRangeWithMinMaxValues()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testLabelWithoutTranslationOnButton()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceExpandedWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testButtonlabelWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testAttributesNotTranslatedWhenTranslationDomainIsFalse()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
@@ -118,36 +118,36 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
 
     public function testRange()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testRangeWithMinMaxValues()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testLabelWithoutTranslationOnButton()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testSingleChoiceExpandedWithPlaceholderWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testButtonlabelWithoutTranslation()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 
     public function testAttributesNotTranslatedWhenTranslationDomainIsFalse()
     {
-        // No-op for forward compatibility with AbstractLayoutTest 2.8
+        $this->markTestIncomplete('No-op for forward compatibility with AbstractLayoutTest 2.8');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/StopwatchHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/StopwatchHelperTest.php
@@ -30,11 +30,10 @@ class StopwatchHelperTest extends TestCase
     public function testProdEnvironment()
     {
         $helper = new StopwatchHelper(null);
+        $helper->start('foo');
 
-        try {
-            $helper->start('foo');
-        } catch (\BadMethodCallException $e) {
-            $this->fail('Assumed stopwatch is not called when not provided');
-        }
+        // add a dummy assertion here to satisfy PHPUnit, the only thing we want to test is that the code above
+        // can be executed without throwing any exceptions
+        $this->addToAssertionCount(1);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateTest.php
@@ -19,21 +19,9 @@ class TemplateTest extends TestCase
     /**
      * @dataProvider getTemplateToPathProvider
      */
-    public function testGetPathForTemplatesInABundle($template, $path)
+    public function testGetPathForTemplate($template, $path)
     {
-        if ($template->get('bundle')) {
-            $this->assertEquals($template->getPath(), $path);
-        }
-    }
-
-    /**
-     * @dataProvider getTemplateToPathProvider
-     */
-    public function testGetPathForTemplatesOutOfABundle($template, $path)
-    {
-        if (!$template->get('bundle')) {
-            $this->assertEquals($template->getPath(), $path);
-        }
+        $this->assertSame($template->getPath(), $path);
     }
 
     public function getTemplateToPathProvider()

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -704,8 +704,12 @@ class ApplicationTest extends TestCase
         $input = new ArgvInput(array('cli.php', '-v', 'foo:bar'));
         $application->run($input, $output);
 
+        $this->addToAssertionCount(1);
+
         $input = new ArgvInput(array('cli.php', '--verbose', 'foo:bar'));
         $application->run($input, $output);
+
+        $this->addToAssertionCount(1);
     }
 
     public function testRunReturnsIntegerExitCode()

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -34,7 +34,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * @dataProvider testRenderProvider
+     * @dataProvider renderProvider
      */
     public function testRender($headers, $rows, $style, $expected, $decorated = false)
     {
@@ -50,7 +50,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * @dataProvider testRenderProvider
+     * @dataProvider renderProvider
      */
     public function testRenderAddRows($headers, $rows, $style, $expected, $decorated = false)
     {
@@ -66,7 +66,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * @dataProvider testRenderProvider
+     * @dataProvider renderProvider
      */
     public function testRenderAddRowsOneByOne($headers, $rows, $style, $expected, $decorated = false)
     {
@@ -83,7 +83,7 @@ class TableTest extends TestCase
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
-    public function testRenderProvider()
+    public function renderProvider()
     {
         $books = array(
             array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
@@ -114,6 +114,8 @@ class CheckCircularReferencesPassTest extends TestCase
         $container->register('b')->addMethodCall('setA', array(new Reference('a')));
 
         $this->process($container);
+
+        $this->addToAssertionCount(1);
     }
 
     protected function process(ContainerBuilder $container)

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -72,6 +72,8 @@ class CheckDefinitionValidityPassTest extends TestCase
         $container->register('d', 'class')->setSynthetic(true);
 
         $this->process($container);
+
+        $this->addToAssertionCount(1);
     }
 
     public function testValidTags()
@@ -83,6 +85,8 @@ class CheckDefinitionValidityPassTest extends TestCase
         $container->register('d', 'class')->addTag('foo', array('bar' => 1.1));
 
         $this->process($container);
+
+        $this->addToAssertionCount(1);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
@@ -28,6 +28,10 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
             ->addArgument(new Reference('b'))
         ;
         $container->register('b', '\stdClass');
+
+        $this->process($container);
+
+        $this->addToAssertionCount(1);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckReferenceValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckReferenceValidityPassTest.php
@@ -27,6 +27,8 @@ class CheckReferenceValidityPassTest extends TestCase
         $container->register('b')->setScope('prototype');
 
         $this->process($container);
+
+        $this->addToAssertionCount(1);
     }
 
     /**
@@ -39,6 +41,8 @@ class CheckReferenceValidityPassTest extends TestCase
         $container->register('b')->setScope('prototype');
 
         $this->process($container);
+
+        $this->addToAssertionCount(1);
     }
 
     public function testProcessIgnoresCrossScopeHierarchyReferenceIfNotStrict()
@@ -51,6 +55,8 @@ class CheckReferenceValidityPassTest extends TestCase
         $container->register('b')->setScope('b');
 
         $this->process($container);
+
+        $this->addToAssertionCount(1);
     }
 
     /**
@@ -88,6 +94,8 @@ class CheckReferenceValidityPassTest extends TestCase
         $container->register('b');
 
         $this->process($container);
+
+        $this->addToAssertionCount(1);
     }
 
     protected function process(ContainerBuilder $container)

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -297,6 +297,8 @@ class PhpDumperTest extends TestCase
 
         $dumper = new PhpDumper($container);
         $dumper->dump();
+
+        $this->addToAssertionCount(1);
     }
 
     public function testCircularReferenceAllowanceForInlinedDefinitionsForLazyServices()
@@ -334,5 +336,7 @@ class PhpDumperTest extends TestCase
 
         $dumper->setProxyDumper(new DummyProxyDumper());
         $dumper->dump();
+
+        $this->addToAssertionCount(1);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -162,6 +162,8 @@ class XmlDumperTest extends TestCase
         $container->compile();
         $dumper = new XmlDumper($container);
         $dumper->dump();
+
+        $this->addToAssertionCount(1);
     }
 
     public function provideCompiledContainerData()

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -151,14 +151,20 @@ class TraceableEventDispatcherTest extends TestCase
     {
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
         $loop = 1;
+        $dispatchedEvents = 0;
         $dispatcher->addListener('foo', $listener1 = function () use ($dispatcher, &$loop) {
             ++$loop;
             if (2 == $loop) {
                 $dispatcher->dispatch('foo');
             }
         });
+        $dispatcher->addListener('foo', function () use (&$dispatchedEvents) {
+            ++$dispatchedEvents;
+        });
 
         $dispatcher->dispatch('foo');
+
+        $this->assertSame(2, $dispatchedEvents);
     }
 
     public function testDispatchReusedEventNested()

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -442,14 +442,22 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFilePermissions(400, $file);
     }
 
-    public function testChmodWrongMod()
+    public function testChmodWithWrongModLeavesPreviousPermissionsUntouched()
     {
         $this->markAsSkippedIfChmodIsMissing();
+
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('chmod() changes permissions even when passing invalid modes on HHVM');
+        }
 
         $dir = $this->workspace.DIRECTORY_SEPARATOR.'file';
         touch($dir);
 
+        $permissions = fileperms($dir);
+
         $this->filesystem->chmod($dir, 'Wrongmode');
+
+        $this->assertSame($permissions, fileperms($dir));
     }
 
     public function testChmodRecursive()
@@ -536,7 +544,10 @@ class FilesystemTest extends FilesystemTestCase
         $dir = $this->workspace.DIRECTORY_SEPARATOR.'dir';
         mkdir($dir);
 
-        $this->filesystem->chown($dir, $this->getFileOwner($dir));
+        $owner = $this->getFileOwner($dir);
+        $this->filesystem->chown($dir, $owner);
+
+        $this->assertSame($owner, $this->getFileOwner($dir));
     }
 
     public function testChownRecursive()
@@ -548,7 +559,10 @@ class FilesystemTest extends FilesystemTestCase
         $file = $dir.DIRECTORY_SEPARATOR.'file';
         touch($file);
 
-        $this->filesystem->chown($dir, $this->getFileOwner($dir), true);
+        $owner = $this->getFileOwner($dir);
+        $this->filesystem->chown($dir, $owner, true);
+
+        $this->assertSame($owner, $this->getFileOwner($file));
     }
 
     public function testChownSymlink()
@@ -562,7 +576,10 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->symlink($file, $link);
 
-        $this->filesystem->chown($link, $this->getFileOwner($link));
+        $owner = $this->getFileOwner($link);
+        $this->filesystem->chown($link, $owner);
+
+        $this->assertSame($owner, $this->getFileOwner($link));
     }
 
     /**
@@ -602,7 +619,10 @@ class FilesystemTest extends FilesystemTestCase
         $dir = $this->workspace.DIRECTORY_SEPARATOR.'dir';
         mkdir($dir);
 
-        $this->filesystem->chgrp($dir, $this->getFileGroup($dir));
+        $group = $this->getFileGroup($dir);
+        $this->filesystem->chgrp($dir, $group);
+
+        $this->assertSame($group, $this->getFileGroup($dir));
     }
 
     public function testChgrpRecursive()
@@ -614,7 +634,10 @@ class FilesystemTest extends FilesystemTestCase
         $file = $dir.DIRECTORY_SEPARATOR.'file';
         touch($file);
 
-        $this->filesystem->chgrp($dir, $this->getFileGroup($dir), true);
+        $group = $this->getFileGroup($dir);
+        $this->filesystem->chgrp($dir, $group, true);
+
+        $this->assertSame($group, $this->getFileGroup($file));
     }
 
     public function testChgrpSymlink()
@@ -628,7 +651,10 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->symlink($file, $link);
 
-        $this->filesystem->chgrp($link, $this->getFileGroup($link));
+        $group = $this->getFileGroup($link);
+        $this->filesystem->chgrp($link, $group);
+
+        $this->assertSame($group, $this->getFileGroup($link));
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -83,6 +83,8 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
                 // strip away <root> and </root>
                 substr($dom->saveHTML(), 6, -8)
             ));
+        } else {
+            $this->addToAssertionCount(1);
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -25,6 +25,8 @@ class TranslationFilesTest extends TestCase
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }
+
+        $this->addToAssertionCount(1);
     }
 
     public function provideTranslationFiles()

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -22,6 +22,18 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class InlineFragmentRendererTest extends TestCase
 {
+    private $originalTrustedHeaderName;
+
+    protected function setUp()
+    {
+        $this->originalTrustedHeaderName = Request::getTrustedHeaderName(Request::HEADER_CLIENT_IP);
+    }
+
+    protected function tearDown()
+    {
+        Request::setTrustedHeaderName(Request::HEADER_CLIENT_IP, $this->originalTrustedHeaderName);
+    }
+
     public function testRender()
     {
         $strategy = new InlineFragmentRenderer($this->getKernel($this->returnValue(new Response('foo'))));
@@ -47,7 +59,7 @@ class InlineFragmentRendererTest extends TestCase
 
         $strategy = new InlineFragmentRenderer($this->getKernelExpectingRequest($subRequest));
 
-        $strategy->render(new ControllerReference('main_controller', array('object' => $object), array()), Request::create('/'));
+        $this->assertSame('foo', $strategy->render(new ControllerReference('main_controller', array('object' => $object), array()), Request::create('/'))->getContent());
     }
 
     public function testRenderWithObjectsAsAttributesPassedAsObjectsInTheController()
@@ -70,14 +82,10 @@ class InlineFragmentRendererTest extends TestCase
 
     public function testRenderWithTrustedHeaderDisabled()
     {
-        $trustedHeaderName = Request::getTrustedHeaderName(Request::HEADER_CLIENT_IP);
-
         Request::setTrustedHeaderName(Request::HEADER_CLIENT_IP, '');
 
         $strategy = new InlineFragmentRenderer($this->getKernelExpectingRequest(Request::create('/')));
-        $strategy->render('/', Request::create('/'));
-
-        Request::setTrustedHeaderName(Request::HEADER_CLIENT_IP, $trustedHeaderName);
+        $this->assertSame('foo', $strategy->render('/', Request::create('/'))->getContent());
     }
 
     /**
@@ -120,22 +128,6 @@ class InlineFragmentRendererTest extends TestCase
             ->expects($this->any())
             ->method('handle')
             ->will($returnValue)
-        ;
-
-        return $kernel;
-    }
-
-    /**
-     * Creates a Kernel expecting a request equals to $request
-     * Allows delta in comparison in case REQUEST_TIME changed by 1 second.
-     */
-    private function getKernelExpectingRequest(Request $request)
-    {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel
-            ->expects($this->any())
-            ->method('handle')
-            ->with($this->equalTo($request, 1))
         ;
 
         return $kernel;
@@ -210,6 +202,22 @@ class InlineFragmentRendererTest extends TestCase
         $strategy = new InlineFragmentRenderer($this->getKernelExpectingRequest($expectedSubRequest));
         $request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_IF_MODIFIED_SINCE' => 'Fri, 01 Jan 2016 00:00:00 GMT', 'HTTP_IF_NONE_MATCH' => '*'));
         $strategy->render('/', $request);
+    }
+
+    /**
+     * Creates a Kernel expecting a request equals to $request
+     * Allows delta in comparison in case REQUEST_TIME changed by 1 second.
+     */
+    private function getKernelExpectingRequest(Request $request, $strict = false)
+    {
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
+        $kernel
+            ->expects($this->once())
+            ->method('handle')
+            ->with($this->equalTo($request, 1))
+            ->willReturn(new Response('foo'));
+
+        return $kernel;
     }
 }
 

--- a/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
@@ -89,9 +89,9 @@ class LegacyOptionsResolverTest extends TestCase
             'force' => 'boolean',
         ));
 
-        $this->resolver->resolve(array(
+        $this->assertSame(array('force' => true), $this->resolver->resolve(array(
             'force' => true,
-        ));
+        )));
     }
 
     public function testResolveLazyDependencyOnOptional()

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -1102,7 +1102,7 @@ class OptionsResolver2Dot6Test extends TestCase
         $this->resolver->resolve();
     }
 
-    public function testCatchedExceptionFromNormalizerDoesNotCrashOptionResolver()
+    public function testCaughtExceptionFromNormalizerDoesNotCrashOptionResolver()
     {
         $throw = true;
 
@@ -1116,7 +1116,7 @@ class OptionsResolver2Dot6Test extends TestCase
             }
         });
 
-        $this->resolver->setNormalizer('thrower', function (Options $options) use (&$throw) {
+        $this->resolver->setNormalizer('thrower', function () use (&$throw) {
             if ($throw) {
                 $throw = false;
                 throw new \UnexpectedValueException('throwing');
@@ -1125,10 +1125,10 @@ class OptionsResolver2Dot6Test extends TestCase
             return true;
         });
 
-        $this->resolver->resolve();
+        $this->assertSame(array('catcher' => false, 'thrower' => true), $this->resolver->resolve());
     }
 
-    public function testCatchedExceptionFromLazyDoesNotCrashOptionResolver()
+    public function testCaughtExceptionFromLazyDoesNotCrashOptionResolver()
     {
         $throw = true;
 
@@ -1149,7 +1149,7 @@ class OptionsResolver2Dot6Test extends TestCase
             return true;
         });
 
-        $this->resolver->resolve();
+        $this->assertSame(array('catcher' => false, 'thrower' => true), $this->resolver->resolve());
     }
 
     public function testInvokeEachNormalizerOnlyOnce()

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
@@ -87,7 +87,9 @@ class PropertyPathTest extends TestCase
 
     public function testZeroIsValidPropertyPath()
     {
-        new PropertyPath('0');
+        $propertyPath = new PropertyPath('0');
+
+        $this->assertSame('0', (string) $propertyPath);
     }
 
     public function testGetParentWithDot()

--- a/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
@@ -25,6 +25,8 @@ class TranslationFilesTest extends TestCase
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }
+
+        $this->addToAssertionCount(1);
     }
 
     public function provideTranslationFiles()

--- a/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
@@ -25,6 +25,8 @@ class TranslationFilesTest extends TestCase
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }
+
+        $this->addToAssertionCount(1);
     }
 
     public function provideTranslationFiles()

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\ScalarDummy;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -435,23 +434,12 @@ XML;
         $this->encoder->decode('<?xml version="1.0"?><invalid><xml>', 'xml');
     }
 
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
+     */
     public function testPreventsComplexExternalEntities()
     {
-        $oldCwd = getcwd();
-        chdir(__DIR__);
-
-        try {
-            $this->encoder->decode('<?xml version="1.0"?><!DOCTYPE scan[<!ENTITY test SYSTEM "php://filter/read=convert.base64-encode/resource=XmlEncoderTest.php">]><scan>&test;</scan>', 'xml');
-            chdir($oldCwd);
-
-            $this->fail('No exception was thrown.');
-        } catch (\Exception $e) {
-            chdir($oldCwd);
-
-            if (!$e instanceof UnexpectedValueException) {
-                $this->fail('Expected UnexpectedValueException');
-            }
-        }
+        $this->encoder->decode('<?xml version="1.0"?><!DOCTYPE scan[<!ENTITY test SYSTEM "php://filter/read=convert.base64-encode/resource=XmlEncoderTest.php">]><scan>&test;</scan>', 'xml');
     }
 
     public function testDecodeEmptyXml()

--- a/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
+++ b/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
@@ -65,7 +65,6 @@ class PluralizationRulesTest extends TestCase
             array('2', array('nl', 'fr', 'en', 'de', 'de_GE', 'hy', 'hy_AM')),
             array('3', array('be', 'bs', 'cs', 'hr')),
             array('4', array('cy', 'mt', 'sl')),
-            array('5', array()),
             array('6', array('ar')),
         );
     }
@@ -86,7 +85,6 @@ class PluralizationRulesTest extends TestCase
             array('3', array('cbs')),
             array('4', array('gd', 'kw')),
             array('5', array('ga')),
-            array('6', array()),
         );
     }
 

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -156,6 +156,7 @@ class TranslatorTest extends TestCase
         $translator = new Translator($locale, new MessageSelector());
         $translator->setFallbackLocales(array('fr', $locale));
         // no assertion. this method just asserts that no exception is thrown
+        $this->addToAssertionCount(1);
     }
 
     public function testTransWithFallbackLocale()
@@ -187,6 +188,7 @@ class TranslatorTest extends TestCase
         $translator = new Translator('fr', new MessageSelector());
         $translator->addResource('array', array('foo' => 'foofoo'), $locale);
         // no assertion. this method just asserts that no exception is thrown
+        $this->addToAssertionCount(1);
     }
 
     public function testAddResourceAfterTrans()
@@ -390,6 +392,7 @@ class TranslatorTest extends TestCase
 
         $translator->transChoice('foo', 1, array(), '', $locale);
         // no assertion. this method just asserts that no exception is thrown
+        $this->addToAssertionCount(1);
     }
 
     public function getTransFileTests()

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -115,7 +115,9 @@ class ConstraintTest extends TestCase
 
     public function testRequiredOptionsPassed()
     {
-        new ConstraintC(array('option1' => 'default'));
+        $constraint = new ConstraintC(array('option1' => 'default'));
+
+        $this->assertSame('default', $constraint->option1);
     }
 
     public function testGroupsAreConvertedToArray()
@@ -140,7 +142,9 @@ class ConstraintTest extends TestCase
 
     public function testCanCreateConstraintWithNoDefaultOptionAndEmptyArray()
     {
-        new ConstraintB(array());
+        $constraint = new ConstraintB(array());
+
+        $this->assertSame(array(Constraint::PROPERTY_CONSTRAINT, Constraint::CLASS_CONSTRAINT), $constraint->getTargets());
     }
 
     public function testGetTargetsCanBeString()

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
@@ -330,7 +330,9 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
     // Should succeed. Needed when defining constraints as annotations.
     public function testNoConstructorArguments()
     {
-        new Callback();
+        $constraint = new Callback();
+
+        $this->assertSame(array(Constraint::CLASS_CONSTRAINT, Constraint::PROPERTY_CONSTRAINT), $constraint->getTargets());
     }
 
     public function testAnnotationInvocationSingleValued()

--- a/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
@@ -94,5 +94,7 @@ class GroupSequenceTest extends TestCase
 
         // should not fail
         unset($sequence[2]);
+
+        $this->assertCount(2, $sequence);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -245,19 +245,23 @@ class ClassMetadataTest extends TestCase
     public function testGroupSequencesWorkIfContainingDefaultGroup()
     {
         $this->metadata->setGroupSequence(array('Foo', $this->metadata->getDefaultGroup()));
+
+        $this->assertInstanceOf('Symfony\Component\Validator\Constraints\GroupSequence', $this->metadata->getGroupSequence());
     }
 
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
+     */
     public function testGroupSequencesFailIfNotContainingDefaultGroup()
     {
-        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('Symfony\Component\Validator\Exception\GroupDefinitionException');
-
         $this->metadata->setGroupSequence(array('Foo', 'Bar'));
     }
 
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\GroupDefinitionException
+     */
     public function testGroupSequencesFailIfContainingDefault()
     {
-        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('Symfony\Component\Validator\Exception\GroupDefinitionException');
-
         $this->metadata->setGroupSequence(array('Foo', $this->metadata->getDefaultGroup(), Constraint::DEFAULT_GROUP));
     }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -167,7 +167,11 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
         $metadata->addConstraint(new Callback(function () {}));
 
+        $this->assertCount(3, $metadata->getConstraints());
+
         $metadata = $factory->getMetadataFor(self::CLASS_NAME);
+
+        $this->assertCount(6, $metadata->getConstraints());
     }
 
     public function testGroupsFromParent()

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -25,6 +25,8 @@ class TranslationFilesTest extends TestCase
         } else {
             \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
         }
+
+        $this->addToAssertionCount(1);
     }
 
     public function provideTranslationFiles()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

PHPUnit 6 marks tests as risky when they have no assertions (and are not marked as skipped or incomplete). This PR will update our test suite accordingly.

Component that still need to be covered:

- [ ] Config
- [ ] Form
- [ ] HttpFoundation
- [ ] Security
- [ ] Workflow