### PR TITLE
[WebProfilerBundle] Update license in composer.json from "MIT" to "(MIT and CC-BY-3.0)" because of icons license

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -4,7 +4,7 @@
     "description": "Symfony WebProfilerBundle",
     "keywords": [],
     "homepage": "https://symfony.com",
-    "license": "MIT",
+    "license": "(MIT and CC-BY-3.0)",
     "authors": [
         {
             "name": "Fabien Potencier",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Web profiler bundle contains a license for its' icons ([`Symfony/Bundle/WebProfilerBundle/Resources/ICONS_LICENSE.txt`](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/WebProfilerBundle/Resources/ICONS_LICENSE.txt)) which should be included in the `composer.json` license field.

Should the main [`composer.json`](https://github.com/symfony/symfony/blob/master/composer.json) file be updated as well?