### PR TITLE
button_widget add filter raw in label if use html

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -226,7 +226,7 @@
             {% set label = name|humanize %}
         {%- endif -%}
     {%- endif -%}
-    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</button>
+    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ (translation_domain is same as(false) ? label : label|trans({}, translation_domain))|raw }}</button>
 {%- endblock button_widget -%}
 
 {%- block submit_widget -%}


### PR DESCRIPTION
If it is necessary to include html for example an icon, this way it is possible.

| Q             | A
| ------------- | ---
| Branch?       | master / 2.7, 2.8 or 3.2 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

If it is necessary to include html for example an icon, this way it is possible.
