### PR TITLE
[DependencyInjection] Optimized initializing container parameters by using immutable arrays

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -829,7 +829,7 @@ EOF;
         $bagClass = $this->container->isFrozen() ? 'use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;' : 'use Symfony\Component\DependencyInjection\ParameterBag\\ParameterBag;';
         $namespaceLine = $namespace ? "namespace $namespace;\n" : '';
 
-        // We inject the parameters as a static propery so opcache can optimize it for speed and memory
+        // Inject the parameters as a static property so OPcache can optimize it for speed and memory
         if ($this->container->getParameterBag()->all()) {
             $parametersArray = $this->exportParameters($this->container->getParameterBag()->all());
             $parameters = "\n    private static \$parameters = $parametersArray;";

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -151,7 +151,7 @@ class PhpDumper extends Dumper
 
         $code .=
             $this->addServices().
-            $this->addDefaultParametersMethod().
+            $this->addParametersMethods().
             $this->endClass().
             $this->addProxyClasses()
         ;
@@ -829,6 +829,14 @@ EOF;
         $bagClass = $this->container->isFrozen() ? 'use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;' : 'use Symfony\Component\DependencyInjection\ParameterBag\\ParameterBag;';
         $namespaceLine = $namespace ? "namespace $namespace;\n" : '';
 
+        // We inject the parameters as a static propery so opcache can optimize it for speed and memory
+        if ($this->container->getParameterBag()->all()) {
+            $parametersArray = $this->exportParameters($this->container->getParameterBag()->all());
+            $parameters = "\n    private static \$parameters = $parametersArray;";
+        } else {
+            $parameters = '';
+        }
+
         return <<<EOF
 <?php
 $namespaceLine
@@ -847,9 +855,7 @@ $bagClass
  * by the Symfony Dependency Injection Component.
  */
 class $class extends $baseClass
-{
-    private \$parameters;
-    private \$targetDirs = array();
+{{$parameters}
 
 EOF;
     }
@@ -861,8 +867,7 @@ EOF;
      */
     private function addConstructor()
     {
-        $targetDirs = $this->exportTargetDirs();
-        $arguments = $this->container->getParameterBag()->all() ? 'new ParameterBag($this->getDefaultParameters())' : null;
+        $arguments = $this->container->getParameterBag()->all() ? 'new ParameterBag(self::$parameters)' : null;
 
         $code = <<<EOF
 
@@ -870,7 +875,7 @@ EOF;
      * Constructor.
      */
     public function __construct()
-    {{$targetDirs}
+    {
         parent::__construct($arguments);
 
 EOF;
@@ -899,20 +904,14 @@ EOF;
      */
     private function addFrozenConstructor()
     {
-        $targetDirs = $this->exportTargetDirs();
-
         $code = <<<EOF
 
     /*{$this->docStar}
      * Constructor.
      */
     public function __construct()
-    {{$targetDirs}
+    {
 EOF;
-
-        if ($this->container->getParameterBag()->all()) {
-            $code .= "\n        \$this->parameters = \$this->getDefaultParameters();\n";
-        }
 
         $code .= <<<'EOF'
 
@@ -1030,13 +1029,11 @@ EOF;
      *
      * @return string
      */
-    private function addDefaultParametersMethod()
+    private function addParametersMethods()
     {
         if (!$this->container->getParameterBag()->all()) {
             return '';
         }
-
-        $parameters = $this->exportParameters($this->container->getParameterBag()->all());
 
         $code = '';
         if ($this->container->isFrozen()) {
@@ -1049,11 +1046,11 @@ EOF;
     {
         $name = strtolower($name);
 
-        if (!(isset($this->parameters[$name]) || array_key_exists($name, $this->parameters))) {
+        if (!(isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters))) {
             throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
         }
 
-        return $this->parameters[$name];
+        return self::$parameters[$name];
     }
 
     /**
@@ -1063,7 +1060,7 @@ EOF;
     {
         $name = strtolower($name);
 
-        return isset($this->parameters[$name]) || array_key_exists($name, $this->parameters);
+        return isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters);
     }
 
     /**
@@ -1080,7 +1077,7 @@ EOF;
     public function getParameterBag()
     {
         if (null === $this->parameterBag) {
-            $this->parameterBag = new FrozenParameterBag($this->parameters);
+            $this->parameterBag = new FrozenParameterBag(self::$parameters);
         }
 
         return $this->parameterBag;
@@ -1091,20 +1088,6 @@ EOF;
                 $code = str_replace('/**', '/*', $code);
             }
         }
-
-        $code .= <<<EOF
-
-    /*{$this->docStar}
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return $parameters;
-    }
-
-EOF;
 
         return $code;
     }
@@ -1575,17 +1558,6 @@ EOF;
         return $this->expressionLanguage;
     }
 
-    private function exportTargetDirs()
-    {
-        return null === $this->targetDirRegex ? '' : <<<EOF
-
-        \$dir = __DIR__;
-        for (\$i = 1; \$i <= {$this->targetDirMaxMatches}; ++\$i) {
-            \$this->targetDirs[\$i] = \$dir = dirname(\$dir);
-        }
-EOF;
-    }
-
     private function export($value)
     {
         if (null !== $this->targetDirRegex && is_string($value) && preg_match($this->targetDirRegex, $value, $matches, PREG_OFFSET_CAPTURE)) {
@@ -1594,8 +1566,9 @@ EOF;
             $suffix = isset($value[$suffix]) ? '.'.var_export(substr($value, $suffix), true) : '';
             $dirname = '__DIR__';
 
-            if (0 < $offset = 1 + $this->targetDirMaxMatches - count($matches)) {
-                $dirname = sprintf('$this->targetDirs[%d]', $offset);
+            if (0 < $pathDepth = 1 + $this->targetDirMaxMatches - count($matches)) {
+                // Using __DIR__ and ../ makes this an immutable array which opcache can optimize
+                $dirname = "__DIR__.'".str_repeat('/..', $pathDepth)."'";
             }
 
             if ($prefix || $suffix) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
@@ -17,8 +17,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class Container extends AbstractContainer
 {
-    private $parameters;
-    private $targetDirs = array();
 
     /**
      * Constructor.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
@@ -16,8 +16,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
-    private $targetDirs = array();
 
     /**
      * Constructor.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -16,16 +16,16 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
-    private $targetDirs = array();
+    private static $parameters = array(
+            'empty_value' => '',
+            'some_string' => '-',
+        );
 
     /**
      * Constructor.
      */
     public function __construct()
     {
-        $this->parameters = $this->getDefaultParameters();
-
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
@@ -74,11 +74,11 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        if (!(isset($this->parameters[$name]) || array_key_exists($name, $this->parameters))) {
+        if (!(isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters))) {
             throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
         }
 
-        return $this->parameters[$name];
+        return self::$parameters[$name];
     }
 
     /**
@@ -88,7 +88,7 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        return isset($this->parameters[$name]) || array_key_exists($name, $this->parameters);
+        return isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters);
     }
 
     /**
@@ -105,22 +105,9 @@ class ProjectServiceContainer extends Container
     public function getParameterBag()
     {
         if (null === $this->parameterBag) {
-            $this->parameterBag = new FrozenParameterBag($this->parameters);
+            $this->parameterBag = new FrozenParameterBag(self::$parameters);
         }
 
         return $this->parameterBag;
-    }
-
-    /**
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return array(
-            'empty_value' => '',
-            'some_string' => '-',
-        );
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -16,20 +16,18 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
-    private $targetDirs = array();
+    private static $parameters = array(
+            'foo' => ('wiz'.__DIR__.'/..'),
+            'bar' => __DIR__,
+            'baz' => (__DIR__.'/PhpDumperTest.php'),
+            'buz' => __DIR__.'/../..',
+        );
 
     /**
      * Constructor.
      */
     public function __construct()
     {
-        $dir = __DIR__;
-        for ($i = 1; $i <= 5; ++$i) {
-            $this->targetDirs[$i] = $dir = dirname($dir);
-        }
-        $this->parameters = $this->getDefaultParameters();
-
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
@@ -68,7 +66,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getTestService()
     {
-        return $this->services['test'] = new \stdClass(('wiz'.$this->targetDirs[1]), array(('wiz'.$this->targetDirs[1]) => ($this->targetDirs[2].'/')));
+        return $this->services['test'] = new \stdClass(('wiz'.__DIR__.'/..'), array(('wiz'.__DIR__.'/..') => (__DIR__.'/../..'.'/')));
     }
 
     /**
@@ -78,11 +76,11 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        if (!(isset($this->parameters[$name]) || array_key_exists($name, $this->parameters))) {
+        if (!(isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters))) {
             throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
         }
 
-        return $this->parameters[$name];
+        return self::$parameters[$name];
     }
 
     /**
@@ -92,7 +90,7 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        return isset($this->parameters[$name]) || array_key_exists($name, $this->parameters);
+        return isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters);
     }
 
     /**
@@ -109,24 +107,9 @@ class ProjectServiceContainer extends Container
     public function getParameterBag()
     {
         if (null === $this->parameterBag) {
-            $this->parameterBag = new FrozenParameterBag($this->parameters);
+            $this->parameterBag = new FrozenParameterBag(self::$parameters);
         }
 
         return $this->parameterBag;
-    }
-
-    /**
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return array(
-            'foo' => ('wiz'.$this->targetDirs[1]),
-            'bar' => __DIR__,
-            'baz' => (__DIR__.'/PhpDumperTest.php'),
-            'buz' => $this->targetDirs[2],
-        );
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -16,8 +16,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
-    private $targetDirs = array();
 
     /**
      * Constructor.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -16,8 +16,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
-    private $targetDirs = array();
 
     /**
      * Constructor.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services20.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services20.php
@@ -16,8 +16,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
-    private $targetDirs = array();
 
     /**
      * Constructor.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -16,25 +16,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
-    private $targetDirs = array();
-
-    /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        parent::__construct(new ParameterBag($this->getDefaultParameters()));
-    }
-
-    /**
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return array(
+    private static $parameters = array(
             'foo' => '%baz%',
             'baz' => 'bar',
             'bar' => 'foo is %%foo bar',
@@ -50,5 +32,12 @@ class ProjectServiceContainer extends Container
                 7 => 'null',
             ),
         );
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct(new ParameterBag(self::$parameters));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -16,15 +16,18 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
-    private $targetDirs = array();
+    private static $parameters = array(
+            'baz_class' => 'BazClass',
+            'foo_class' => 'Bar\\FooClass',
+            'foo' => 'bar',
+        );
 
     /**
      * Constructor.
      */
     public function __construct()
     {
-        parent::__construct(new ParameterBag($this->getDefaultParameters()));
+        parent::__construct(new ParameterBag(self::$parameters));
         $this->methodMap = array(
             'bar' => 'getBarService',
             'baz' => 'getBazService',
@@ -358,19 +361,5 @@ class ProjectServiceContainer extends Container
         $instance->foo = 'bar';
 
         return $instance;
-    }
-
-    /**
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return array(
-            'baz_class' => 'BazClass',
-            'foo_class' => 'Bar\\FooClass',
-            'foo' => 'bar',
-        );
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -16,16 +16,17 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  */
 class ProjectServiceContainer extends Container
 {
-    private $parameters;
-    private $targetDirs = array();
+    private static $parameters = array(
+            'baz_class' => 'BazClass',
+            'foo_class' => 'Bar\\FooClass',
+            'foo' => 'bar',
+        );
 
     /**
      * Constructor.
      */
     public function __construct()
     {
-        $this->parameters = $this->getDefaultParameters();
-
         $this->services =
         $this->scopedServices =
         $this->scopeStacks = array();
@@ -312,11 +313,11 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        if (!(isset($this->parameters[$name]) || array_key_exists($name, $this->parameters))) {
+        if (!(isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters))) {
             throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
         }
 
-        return $this->parameters[$name];
+        return self::$parameters[$name];
     }
 
     /**
@@ -326,7 +327,7 @@ class ProjectServiceContainer extends Container
     {
         $name = strtolower($name);
 
-        return isset($this->parameters[$name]) || array_key_exists($name, $this->parameters);
+        return isset(self::$parameters[$name]) || array_key_exists($name, self::$parameters);
     }
 
     /**
@@ -343,23 +344,9 @@ class ProjectServiceContainer extends Container
     public function getParameterBag()
     {
         if (null === $this->parameterBag) {
-            $this->parameterBag = new FrozenParameterBag($this->parameters);
+            $this->parameterBag = new FrozenParameterBag(self::$parameters);
         }
 
         return $this->parameterBag;
-    }
-
-    /**
-     * Gets the default parameters.
-     *
-     * @return array An array of the default parameters
-     */
-    protected function getDefaultParameters()
-    {
-        return array(
-            'baz_class' => 'BazClass',
-            'foo_class' => 'Bar\\FooClass',
-            'foo' => 'bar',
-        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR was inspired by 
https://github.com/composer/composer/pull/5174
which immproved composer's autoloader performance with a large class map by making the class map use constants instead of variable so opcache could optimize the array.

For dumped containers instead of calculating $targetPaths in the contructor we use the constant ``__DIR__`` with the appropriate number of '/..' to create immutable values that can be used in a static array. Because it is constant opcache will not need to execute the array everytime but can copy it from shared memory.

A quick and easy benchmark of a large container of 26000+ lines for parameters shows that this is 5% faster and uses 3% less memory.
```php
$start = microtime(true);
require '../app/cache/dev/appDevDebugProjectContainer.php'; var_dump('new container');

$container = new appDevDebugProjectContainer();

echo ((memory_get_peak_usage() / 1024 )/1024).'mb';
echo 'end time '. ((microtime(true) -$start) * 1000).'ms';
```
Old container:
2.8640975952148mb
end time 1.7151832580566ms
New Container
2.7830810546875mb
end time 1.6288757324219ms

Savings are significantly more when multiple copies of a container are made. Which I have seen happen in poorly written programs. 