### PR TITLE
[DI] Restore skipping logic when autowiring getters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/GetterOverriding.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/GetterOverriding.php
@@ -36,8 +36,24 @@ class GetterOverriding
     }
 
     /** @required */
+    public function getUnknown(): NotExist
+    {
+        // should not be called
+    }
+
+    /** @required */
     public function getExplicitlyDefined(): B
     {
         // should be called but not autowired
+    }
+
+    final public function getFinal(): A
+    {
+        // should not be called
+    }
+
+    public function &getReference(): A
+    {
+        // should not be called
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Partial revert for #22030: the skipping logic is part of the getter injection experience, which provides laziness, thus shouldn't bother you until you actually call the getter, if you do.