### PR TITLE
Release memory for the parsed data after parsing

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -121,6 +121,8 @@ final class Dotenv
             return $this->values;
         } finally {
             $this->values = array();
+            $this->data = null;
+            $this->path = null;
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

If the Dotenv instance outlives the parsing of the file (which is the case easily in the usage described in the documentation as it is used in the global scope and so the variable does not go out of scope until the end of the process), there is no reason to keep the parsed data in memory after the end of the parsing.

I have not reset the integer properties, as this would not save any memory anyway (integers are inline inside the ZVAL anyway)
