### PR TITLE
[2.8][WebProfilerBundle] Drop dead code

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -43,7 +43,7 @@ class ProfilerController
      * @param array                 $templates       The templates
      * @param string                $toolbarPosition The toolbar position (top, bottom, normal, or null -- use the configuration)
      */
-    public function __construct(UrlGeneratorInterface $generator, Profiler $profiler = null, \Twig_Environment $twig, array $templates, $toolbarPosition = 'normal')
+    public function __construct(UrlGeneratorInterface $generator, Profiler $profiler = null, \Twig_Environment $twig, array $templates, $toolbarPosition = 'bottom')
     {
         $this->generator = $generator;
         $this->profiler = $profiler;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -1,28 +1,26 @@
 <!-- START of Symfony Web Debug Toolbar -->
-{% if 'normal' != position %}
-    <div id="sfMiniToolbar-{{ token }}" class="sf-minitoolbar" data-no-turbolink>
-        <a href="javascript:void(0);" title="Show Symfony toolbar" tabindex="-1" accesskey="D" onclick="
-            var elem = this.parentNode;
-            if (elem.style.display == 'none') {
-                document.getElementById('sfToolbarMainContent-{{ token }}').style.display = 'none';
-                document.getElementById('sfToolbarClearer-{{ token }}').style.display = 'none';
-                elem.style.display = 'block';
-            } else {
-                document.getElementById('sfToolbarMainContent-{{ token }}').style.display = 'block';
-                document.getElementById('sfToolbarClearer-{{ token }}').style.display = 'block';
-                elem.style.display = 'none'
-            }
+<div id="sfMiniToolbar-{{ token }}" class="sf-minitoolbar" data-no-turbolink>
+    <a href="javascript:void(0);" title="Show Symfony toolbar" tabindex="-1" accesskey="D" onclick="
+        var elem = this.parentNode;
+        if (elem.style.display == 'none') {
+            document.getElementById('sfToolbarMainContent-{{ token }}').style.display = 'none';
+            document.getElementById('sfToolbarClearer-{{ token }}').style.display = 'none';
+            elem.style.display = 'block';
+        } else {
+            document.getElementById('sfToolbarMainContent-{{ token }}').style.display = 'block';
+            document.getElementById('sfToolbarClearer-{{ token }}').style.display = 'block';
+            elem.style.display = 'none'
+        }
 
-            Sfjs.setPreference('toolbar/displayState', 'block');
-        ">
-            {{ include('@WebProfiler/Icon/symfony.svg') }}
-        </a>
-    </div>
-    <style>
-        {{ include('@WebProfiler/Profiler/toolbar.css.twig', { 'position': position, 'floatable': true }) }}
-    </style>
-    <div id="sfToolbarClearer-{{ token }}" style="clear: both; height: 36px;"></div>
-{% endif %}
+        Sfjs.setPreference('toolbar/displayState', 'block');
+    ">
+        {{ include('@WebProfiler/Icon/symfony.svg') }}
+    </a>
+</div>
+<style>
+    {{ include('@WebProfiler/Profiler/toolbar.css.twig', { 'position': position, 'floatable': true }) }}
+</style>
+<div id="sfToolbarClearer-{{ token }}" style="clear: both; height: 36px;"></div>
 
 <div id="sfToolbarMainContent-{{ token }}" class="sf-toolbarreset clear-fix" data-no-turbolink>
     {% for name, template in templates %}
@@ -39,16 +37,14 @@
         {% endif %}
     {% endfor %}
 
-    {% if 'normal' != position %}
-        <a class="hide-button" title="Close Toolbar" tabindex="-1" accesskey="D" onclick="
-            var p = this.parentNode;
-            p.style.display = 'none';
-            (p.previousElementSibling || p.previousSibling).style.display = 'none';
-            document.getElementById('sfMiniToolbar-{{ token }}').style.display = 'block';
-            Sfjs.setPreference('toolbar/displayState', 'none');
-        ">
-            {{ include('@WebProfiler/Icon/close.svg') }}
-        </a>
-    {% endif %}
+    <a class="hide-button" title="Close Toolbar" tabindex="-1" accesskey="D" onclick="
+        var p = this.parentNode;
+        p.style.display = 'none';
+        (p.previousElementSibling || p.previousSibling).style.display = 'none';
+        document.getElementById('sfMiniToolbar-{{ token }}').style.display = 'block';
+        Sfjs.setPreference('toolbar/displayState', 'none');
+    ">
+        {{ include('@WebProfiler/Icon/close.svg') }}
+    </a>
 </div>
 <!-- END of Symfony Web Debug Toolbar -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| License       | MIT

As you can read in https://github.com/symfony/symfony/blob/2.8/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php#L40-L46 the `position` can only be `top` or `bottom`. I don't see any reference anywhere to a `normal` position.
The removed tests are always true.
