### PR TITLE
HttpCache: New test for revalidating responses with an expired TTL

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
-use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
@@ -803,7 +803,7 @@ class HttpCacheTest extends HttpCacheTestCase
     {
         $time = \DateTime::createFromFormat('U', time());
 
-        $this->setNextResponse(200, [], 'Hello World', function (Request $request, Response $response) use ($time) {
+        $this->setNextResponse(200, array(), 'Hello World', function (Request $request, Response $response) use ($time) {
             $response->setSharedMaxAge(10);
             $response->headers->set('Last-Modified', $time->format(DATE_RFC2822));
         });
@@ -820,7 +820,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
         sleep(15); // expire the cache
 
-        $this->setNextResponse(304, [], '', function (Request $request, Response $response) use ($time) {
+        $this->setNextResponse(304, array(), '', function (Request $request, Response $response) use ($time) {
             $this->assertEquals($time->format(DATE_RFC2822), $request->headers->get('IF_MODIFIED_SINCE'));
         });
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -799,6 +799,39 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertTraceNotContains('miss');
     }
 
+    public function testServesResponseWhileFreshAndRevalidatesWithLastModifiedInformation()
+    {
+        $time = \DateTime::createFromFormat('U', time());
+
+        $this->setNextResponse(200, [], 'Hello World', function (Request $request, Response $response) use ($time) {
+            $response->setSharedMaxAge(10);
+            $response->headers->set('Last-Modified', $time->format(DATE_RFC2822));
+        });
+
+        // prime the cache
+        $this->request('GET', '/');
+
+        // next request before s-maxage has expired: Serve from cache without hitting the backend
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsNotCalled();
+        $this->assertEquals(200, $this->response->getStatusCode());
+        $this->assertEquals('Hello World', $this->response->getContent());
+        $this->assertTraceContains('fresh');
+
+        sleep(15); // expire the cache
+
+        $this->setNextResponse(304, [], '', function (Request $request, Response $response) use ($time) {
+            $this->assertEquals($time->format(DATE_RFC2822), $request->headers->get('IF_MODIFIED_SINCE'));
+        });
+
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsCalled();
+        $this->assertEquals(200, $this->response->getStatusCode());
+        $this->assertEquals('Hello World', $this->response->getContent());
+        $this->assertTraceContains('stale');
+        $this->assertTraceContains('valid');
+    }
+
     public function testValidatesCachedResponsesUseSameHttpMethod()
     {
         $test = $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

See #22035, in particular [this and the following comments](https://github.com/symfony/symfony/pull/22035#issuecomment-287572234).