### PR TITLE
[FrameworkBundle] Document removal of server:* commands

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -172,6 +172,11 @@ FrameworkBundle
    class has been deprecated and will be removed in 4.0. Use the 
    `Symfony\Component\Routing\DependencyInjection\RoutingResolverPass` class instead.
 
+ * The `server:run`, `server:start`, `server:stop` and 
+   `server:status` console commands have been moved to a dedicated bundle. 
+   Require `symfony/web-server-bundle` in your composer.json and register 
+   `Symfony\Bundle\WebServerBundle\WebServerBundle` in your AppKernel to use them.
+
 HttpKernel
 -----------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -30,6 +30,10 @@ CHANGELOG
  * Deprecated `ControllerArgumentValueResolverPass`. Use
    `Symfony\Component\HttpKernel\DependencyInjection\ControllerArgumentValueResolverPass` instead
  * Deprecated `RoutingResolverPass`, use `Symfony\Component\Routing\DependencyInjection\RoutingResolverPass` instead
+ * [BC BREAK] The `server:run`, `server:start`, `server:stop` and 
+   `server:status` console commands have been moved to a dedicated bundle. 
+   Require `symfony/web-server-bundle` in your composer.json and register 
+   `Symfony\Bundle\WebServerBundle\WebServerBundle` in your AppKernel to use them.
 
 3.2.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21373 
| License       | MIT
| Doc PR        | n/a

To ease upgrading.

We could also add something like that in the framework application:
```php
public function findNamespace($namespace)
{
    try {
        return parent::findNamespace($namespace);
    } catch (CommandNotFoundException $e) {
        if ('server' === $namespace) {
            throw new CommandNotFoundException('The "server:start", "server:stop", "server:status" and "server:run" commands have been moved...');
        }
    }
}
```
But AFAIK we never did so in the past, tell me if we should.