### PR TITLE
[*Bundle] Add autowiring aliases for common services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -76,12 +77,9 @@ trait ControllerTrait
     }
 
     /**
-     * An instance of the Session implementation (and not the interface) is returned because getFlashBag is not part of
-     * the interface.
-     *
      * @required
      */
-    protected function getSession(): Session
+    protected function getSession(): SessionInterface
     {
     }
 
@@ -235,7 +233,11 @@ trait ControllerTrait
      */
     protected function addFlash(string $type, string $message)
     {
-        $this->getSession()->getFlashBag()->add($type, $message);
+        $session = $this->getSession();
+        if (!$session instanceof Session) {
+            throw new \LogicException(sprintf('You can not use the addFlash method: "%s" is not an instance of "%s".', get_class($session), Session::class));
+        }
+        $session->getFlashBag()->add($type, $message);
     }
 
     /**
@@ -245,8 +247,6 @@ trait ControllerTrait
      * @param mixed $object     The object
      *
      * @return bool
-     *
-     * @throws \LogicException
      */
     protected function isGranted($attributes, $object = null): bool
     {
@@ -395,8 +395,6 @@ trait ControllerTrait
      * Get a user from the Security Token Storage.
      *
      * @return mixed
-     *
-     * @throws \LogicException If SecurityBundle is not available
      *
      * @see TokenInterface::getUser()
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
@@ -10,6 +10,7 @@
             <argument type="service" id="assets.empty_package" /> <!-- default package -->
             <argument type="collection" /> <!-- named packages -->
         </service>
+        <service id="Symfony\Component\Asset\Packages" alias="assets.packages" public="false" />
 
         <service id="assets.empty_package" class="Symfony\Component\Asset\Package" public="false">
             <argument type="service" id="assets.empty_version_strategy" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -26,5 +26,6 @@
         <service id="debug.file_link_formatter" class="Symfony\Component\HttpKernel\Debug\FileLinkFormatter" public="false">
             <argument>%debug.file_link_format%</argument>
         </service>
+        <service id="Symfony\Component\HttpKernel\Debug\FileLinkFormatter" alias="debug.file_link_formatter" public="false" />
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -7,6 +7,7 @@
     <services>
         <!-- ResolvedFormTypeFactory -->
         <service id="form.resolved_type_factory" class="Symfony\Component\Form\ResolvedFormTypeFactory" />
+        <service id="Symfony\Component\Form\ResolvedFormTypeFactoryInterface" alias="form.resolved_type_factory" public="false" />
 
         <!-- FormRegistry -->
         <service id="form.registry" class="Symfony\Component\Form\FormRegistry">
@@ -21,12 +22,14 @@
             </argument>
             <argument type="service" id="form.resolved_type_factory" />
         </service>
+        <service id="Symfony\Component\Form\FormRegistryInterface" alias="form.registry" public="false" />
 
         <!-- FormFactory -->
         <service id="form.factory" class="Symfony\Component\Form\FormFactory">
             <argument type="service" id="form.registry" />
             <argument type="service" id="form.resolved_type_factory" />
         </service>
+        <service id="Symfony\Component\Form\FormFactoryInterface" alias="form.factory" public="false" />
 
         <!-- DependencyInjectionExtension -->
         <service id="form.extension" class="Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension" public="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/identity_translator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/identity_translator.xml
@@ -7,6 +7,7 @@
         <service id="translator" class="Symfony\Component\Translation\IdentityTranslator">
             <argument type="service" id="translator.selector" />
         </service>
+        <service id="Symfony\Component\Translation\TranslatorInterface" alias="translator" public="false" />
 
         <service id="translator.selector" class="Symfony\Component\Translation\MessageSelector" public="false" />
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.xml
@@ -10,5 +10,6 @@
             <argument /> <!-- throwExceptionOnInvalidIndex, set by the extension -->
             <argument type="service" id="cache.property_access" on-invalid="ignore" />
         </service>
+        <service id="Symfony\Component\PropertyAccess\PropertyAccessorInterface" alias="property_accessor" public="false" />
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
@@ -11,6 +11,7 @@
             <argument type="collection" />
             <argument type="collection" />
         </service>
+        <service id="Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface" alias="property_info" public="false" />
 
         <!-- Extractor -->
         <service id="property_info.reflection_extractor" class="Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor" public="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -80,6 +80,9 @@
         </service>
 
         <service id="router" alias="router.default" />
+        <service id="Symfony\Component\Routing\RouterInterface" alias="router" public="false" />
+        <service id="Symfony\Component\Routing\Generator\UrlGeneratorInterface" alias="router" public="false" />
+        <service id="Symfony\Component\Routing\Matcher\UrlMatcherInterface" alias="router" public="false" />
 
         <service id="router.request_context" class="Symfony\Component\Routing\RequestContext" public="false">
             <argument>%router.request_context.base_url%</argument>
@@ -89,6 +92,7 @@
             <argument>%request_listener.http_port%</argument>
             <argument>%request_listener.https_port%</argument>
         </service>
+        <service id="Symfony\Component\Routing\RequestContext" alias="router.request_context" public="false" />
 
         <service id="router.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer" public="false">
             <tag name="kernel.cache_warmer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.xml
@@ -6,14 +6,17 @@
 
     <services>
         <service id="security.csrf.token_generator" class="Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator" public="false" />
+        <service id="Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface" alias="security.csrf.token_generator" public="false" />
 
         <service id="security.csrf.token_storage" class="Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage" public="false">
             <argument type="service" id="session" />
         </service>
+        <service id="Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface" alias="security.csrf.token_storage" public="false" />
 
         <service id="security.csrf.token_manager" class="Symfony\Component\Security\Csrf\CsrfTokenManager">
             <argument type="service" id="security.csrf.token_generator" />
             <argument type="service" id="security.csrf.token_storage" />
         </service>
+        <service id="Symfony\Component\Security\Csrf\CsrfTokenManagerInterface" alias="security.csrf.token_manager" public="false" />
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -14,6 +14,11 @@
             <argument type="collection" />
             <argument type="collection" />
         </service>
+        <service id="Symfony\Component\Serializer\SerializerInterface" alias="serializer" public="false" />
+        <service id="Symfony\Component\Serializer\NormalizerInterface" alias="serializer" public="false" />
+        <service id="Symfony\Component\Serializer\DenormalizerInterface" alias="serializer" public="false" />
+        <service id="Symfony\Component\Serializer\EncoderInterface" alias="serializer" public="false" />
+        <service id="Symfony\Component\Serializer\DecoderInterface" alias="serializer" public="false" />
 
         <service id="serializer.property_accessor" alias="property_accessor" public="false" />
 
@@ -27,6 +32,7 @@
             <!-- Run after all custom normalizers -->
             <tag name="serializer.normalizer" priority="-1000" />
         </service>
+        <service id="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" alias="serializer.normalizer.object" public="false" />
 
         <service id="serializer.denormalizer.array" class="Symfony\Component\Serializer\Normalizer\ArrayDenormalizer" public="false">
             <!-- Run before the object normalizer -->

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -9,7 +9,6 @@
             <argument type="service" id="service_container" />
         </service>
         <service id="Symfony\Component\EventDispatcher\EventDispatcherInterface" alias="event_dispatcher" public="false" />
-        <service id="Symfony\Component\EventDispatcher\EventDispatcher" alias="event_dispatcher" public="false" />
 
         <service id="http_kernel" class="Symfony\Component\HttpKernel\HttpKernel">
             <argument type="service" id="event_dispatcher" />
@@ -17,8 +16,10 @@
             <argument type="service" id="request_stack" />
             <argument type="service" id="argument_resolver" />
         </service>
+        <service id="Symfony\Component\HttpKernel\HttpKernelInterface" alias="http_kernel" public="false" />
 
         <service id="request_stack" class="Symfony\Component\HttpFoundation\RequestStack" />
+        <service id="Symfony\Component\HttpFoundation\RequestStack" alias="request_stack" public="false" />
 
         <service id="cache_warmer" class="Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate">
             <argument type="collection" />
@@ -41,8 +42,10 @@
         </service>
 
         <service id="kernel" synthetic="true" />
+        <service id="Symfony\Component\HttpKernel\KernelInterface" alias="kernel" public="false" />
 
         <service id="filesystem" class="Symfony\Component\Filesystem\Filesystem" />
+        <service id="Symfony\Component\Filesystem\Filesystem" alias="filesystem" public="false" />
 
         <service id="file_locator" class="Symfony\Component\HttpKernel\Config\FileLocator">
             <argument type="service" id="kernel" />
@@ -51,6 +54,7 @@
                 <argument>%kernel.root_dir%</argument>
             </argument>
         </service>
+        <service id="Symfony\Component\HttpKernel\Config\FileLocator" alias="file_locator" public="false" />
 
         <service id="uri_signer" class="Symfony\Component\HttpKernel\UriSigner">
             <argument>%kernel.secret%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -15,6 +15,10 @@
             <argument type="service" id="session.flash_bag" />
         </service>
 
+        <service id="Symfony\Component\HttpFoundation\Session\SessionInterface" alias="session" public="false" />
+        <service id="Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface" alias="session.storage" public="false" />
+        <service id="SessionHandlerInterface" alias="session.handler" public="false" />
+
         <service id="session.storage.metadata_bag" class="Symfony\Component\HttpFoundation\Session\Storage\MetadataBag" public="false">
             <argument>%session.metadata.storage_key%</argument>
             <argument>%session.metadata.update_threshold%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -13,6 +13,7 @@
         <service id="validator" class="Symfony\Component\Validator\Validator\ValidatorInterface">
             <factory service="validator.builder" method="getValidator" />
         </service>
+        <service id="Symfony\Component\Validator\Validator\ValidatorInterface" alias="validator" public="false" />
 
         <service id="validator.builder" class="Symfony\Component\Validator\ValidatorBuilderInterface">
             <factory class="Symfony\Component\Validator\Validation" method="createValidatorBuilder" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.xml
@@ -22,6 +22,7 @@
         <service id="workflow.marking_store.single_state" class="Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore" abstract="true" />
 
         <service id="workflow.registry" class="Symfony\Component\Workflow\Registry" />
+        <service id="Symfony\Component\Workflow\Registry" alias="workflow.registry" public="false" />
 
         <service id="workflow.twig_extension" class="Symfony\Bridge\Twig\Extension\WorkflowExtension">
             <argument type="service" id="workflow.registry" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -17,8 +17,10 @@
             <argument type="service" id="security.access.decision_manager" />
             <argument>%security.access.always_authenticate_before_granting%</argument>
         </service>
+        <service id="Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface" alias="security.authorization_checker" />
 
         <service id="security.token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" />
+        <service id="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface" alias="security.token_storage" public="false" />
 
         <service id="security.user_value_resolver" class="Symfony\Bundle\SecurityBundle\SecurityUserValueResolver" public="false">
             <argument type="service" id="security.token_storage" />
@@ -48,12 +50,14 @@
         </service>
 
         <service id="security.encoder_factory" alias="security.encoder_factory.generic" />
+        <service id="Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface" alias="security.encoder_factory" public="false" />
 
         <service id="security.user_password_encoder.generic" class="Symfony\Component\Security\Core\Encoder\UserPasswordEncoder" public="false">
             <argument type="service" id="security.encoder_factory"></argument>
         </service>
 
-        <service id="security.password_encoder" alias="security.user_password_encoder.generic"></service>
+        <service id="security.password_encoder" alias="security.user_password_encoder.generic" />
+        <service id="Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface" alias="security.password_encoder" />
 
         <service id="security.user_checker" class="Symfony\Component\Security\Core\User\UserChecker" public="false" />
 
@@ -103,6 +107,7 @@
             <argument type="service" id="security.firewall.map" />
             <argument type="service" id="event_dispatcher" />
         </service>
+        <service id="Symfony\Component\Security\Http\Firewall" alias="security.firewall" public="false" />
 
         <service id="security.firewall.map" class="Symfony\Bundle\SecurityBundle\Security\FirewallMap" public="false">
             <argument /> <!-- Firewall context locator -->

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
@@ -35,6 +35,7 @@
         </service>
 
         <service id="security.acl.provider" alias="security.acl.dbal.provider" />
+        <service id="Symfony\Component\Security\Acl\Model\AclProviderInterface" alias="security.acl.provider" public="false" />
 
         <service id="security.acl.cache.doctrine" class="Symfony\Component\Security\Acl\Domain\DoctrineAclCache" public="false">
             <argument type="service" id="security.acl.cache.doctrine.cache_impl" />

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -17,6 +17,7 @@
             </call>
             <configurator service="twig.configurator.environment" method="configure" />
         </service>
+        <service id="Twig_Environment" alias="twig" public="false" />
 
         <service id="twig.app_variable" class="Symfony\Bridge\Twig\AppVariable" public="false">
             <call method="setEnvironment"><argument>%kernel.environment%</argument></call>

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -126,7 +126,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         $this->setDefinition('service_container', (new Definition(ContainerInterface::class))->setSynthetic(true));
         $this->setAlias(PsrContainerInterface::class, new Alias('service_container', false));
         $this->setAlias(ContainerInterface::class, new Alias('service_container', false));
-        $this->setAlias(Container::class, new Alias('service_container', false));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -26,7 +26,6 @@ use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -58,7 +57,6 @@ class ContainerBuilderTest extends TestCase
         $this->assertSame(ContainerInterface::class, $definition->getClass());
         $this->assertTrue($builder->hasAlias(PsrContainerInterface::class));
         $this->assertTrue($builder->hasAlias(ContainerInterface::class));
-        $this->assertTrue($builder->hasAlias(Container::class));
     }
 
     public function testDefinitions()
@@ -229,7 +227,6 @@ class ContainerBuilderTest extends TestCase
                 'bar',
                 'Psr\Container\ContainerInterface',
                 'Symfony\Component\DependencyInjection\ContainerInterface',
-                'Symfony\Component\DependencyInjection\Container',
             ),
             $builder->getServiceIds(),
             '->getServiceIds() returns all defined service ids'
@@ -281,7 +278,7 @@ class ContainerBuilderTest extends TestCase
 
         $builder->set('foobar', 'stdClass');
         $builder->set('moo', 'stdClass');
-        $this->assertCount(3, $builder->getAliases(), '->getAliases() does not return aliased services that have been overridden');
+        $this->assertCount(2, $builder->getAliases(), '->getAliases() does not return aliased services that have been overridden');
     }
 
     public function testSetAliases()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -82,7 +82,6 @@ class XmlDumperTest extends TestCase
     </service>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\Container" alias="service_container" public="false"/>
   </services>
 </container>
 ', $dumper->dump());
@@ -102,7 +101,6 @@ class XmlDumperTest extends TestCase
     </service>
     <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
     <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
-    <service id=\"Symfony\Component\DependencyInjection\Container\" alias=\"service_container\" public=\"false\"/>
   </services>
 </container>
 ", $dumper->dump());
@@ -129,7 +127,6 @@ class XmlDumperTest extends TestCase
     <service id=\"foo\" class=\"FooClass\Foo\" decorates=\"bar\" decoration-inner-name=\"bar.woozy\"/>
     <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
     <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
-    <service id=\"Symfony\Component\DependencyInjection\Container\" alias=\"service_container\" public=\"false\"/>
   </services>
 </container>
 ", include $fixturesPath.'/containers/container15.php'),
@@ -140,7 +137,6 @@ class XmlDumperTest extends TestCase
     <service id=\"foo\" class=\"FooClass\Foo\" decorates=\"bar\"/>
     <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
     <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
-    <service id=\"Symfony\Component\DependencyInjection\Container\" alias=\"service_container\" public=\"false\"/>
   </services>
 </container>
 ", include $fixturesPath.'/containers/container16.php'),

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services1.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services1.dot
@@ -3,5 +3,5 @@ digraph sc {
   node [fontsize="11" fontname="Arial" shape="record"];
   edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
 
-  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface, Symfony\Component\DependencyInjection\Container)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services10-1.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services10-1.dot
@@ -3,7 +3,7 @@ digraph sc {
   node [fontsize="13" fontname="Verdana" shape="square"];
   edge [fontsize="12" fontname="Verdana" color="white" arrowhead="closed" arrowsize="1"];
 
-  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface, Symfony\Component\DependencyInjection\Container)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=square, fillcolor="grey", style="filled"];
+  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=square, fillcolor="grey", style="filled"];
   node_foo [label="foo\nFooClass\n", shape=square, fillcolor="grey", style="filled"];
   node_bar [label="bar\n\n", shape=square, fillcolor="red", style="empty"];
   node_foo -> node_bar [label="" style="filled"];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services10.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services10.dot
@@ -3,7 +3,7 @@ digraph sc {
   node [fontsize="11" fontname="Arial" shape="record"];
   edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
 
-  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface, Symfony\Component\DependencyInjection\Container)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo [label="foo\nFooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_bar [label="bar\n\n", shape=record, fillcolor="#ff9999", style="filled"];
   node_foo -> node_bar [label="" style="filled"];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services14.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services14.dot
@@ -3,5 +3,5 @@ digraph sc {
   node [fontsize="11" fontname="Arial" shape="record"];
   edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
 
-  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface, Symfony\Component\DependencyInjection\Container)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services17.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services17.dot
@@ -3,6 +3,6 @@ digraph sc {
   node [fontsize="11" fontname="Arial" shape="record"];
   edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
 
-  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface, Symfony\Component\DependencyInjection\Container)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo [label="foo\n%foo.class%\n", shape=record, fillcolor="#eeeeee", style="filled"];
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
@@ -3,7 +3,7 @@ digraph sc {
   node [fontsize="11" fontname="Arial" shape="record"];
   edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
 
-  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface, Symfony\Component\DependencyInjection\Container)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo [label="foo (alias_for_foo)\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo_baz [label="foo.baz\nBazClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_bar [label="bar\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
@@ -30,7 +30,6 @@ class Container extends AbstractContainer
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -31,7 +31,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -35,7 +35,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
@@ -31,7 +31,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services29.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services29.php
@@ -29,7 +29,6 @@ class Symfony_DI_PhpDumper_Test_Overriden_Getters extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services31.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services31.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services32.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services32.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
             'symfony\\component\\dependencyinjection\\tests\\fixtures\\container33\\foo' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\Container33\\Foo',
         );

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -31,7 +31,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         parent::__construct(new ParameterBag($this->getDefaultParameters()));
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(
@@ -68,7 +67,6 @@ class ProjectServiceContainer extends Container
         );
         $this->aliases = array(
             'Psr\\Container\\ContainerInterface' => 'service_container',
-            'Symfony\\Component\\DependencyInjection\\Container' => 'service_container',
             'Symfony\\Component\\DependencyInjection\\ContainerInterface' => 'service_container',
             'alias_for_alias' => 'foo',
             'alias_for_foo' => 'foo',

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -31,7 +31,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dump_overriden_getters_with_constructor.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dump_overriden_getters_with_constructor.php
@@ -29,7 +29,6 @@ class Symfony_DI_PhpDumper_Test_Overriden_Getters_With_Constructor extends Conta
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dump_proxy_with_void_return_type.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_dump_proxy_with_void_return_type.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
@@ -29,7 +29,6 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->normalizedIds = array(
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'symfony\\component\\dependencyinjection\\container' => 'Symfony\\Component\\DependencyInjection\\Container',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
         );
         $this->methodMap = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services1.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services1.xml
@@ -4,6 +4,5 @@
         <service class="Symfony\Component\DependencyInjection\ContainerInterface" id="service_container" synthetic="true"/>
         <service alias="service_container" id="Psr\Container\ContainerInterface" public="false"/>
         <service alias="service_container" id="Symfony\Component\DependencyInjection\ContainerInterface" public="false"/>
-        <service alias="service_container" id="Symfony\Component\DependencyInjection\Container" public="false"/>
     </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
@@ -20,6 +20,5 @@
     </service>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\Container" alias="service_container" public="false"/>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
@@ -5,6 +5,5 @@
     <service id="foo" class="Foo" autowire="true"/>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\Container" alias="service_container" public="false"/>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
@@ -23,6 +23,5 @@
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\Container" alias="service_container" public="false"/>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -139,7 +139,6 @@
     </service>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\Container" alias="service_container" public="false"/>
     <service id="alias_for_foo" alias="foo"/>
     <service id="alias_for_alias" alias="foo"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
@@ -8,6 +8,3 @@ services:
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
-    Symfony\Component\DependencyInjection\Container:
-        alias: service_container
-        public: false

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
@@ -12,6 +12,3 @@ services:
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
-    Symfony\Component\DependencyInjection\Container:
-        alias: service_container
-        public: false

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
@@ -15,6 +15,3 @@ services:
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
-    Symfony\Component\DependencyInjection\Container:
-        alias: service_container
-        public: false

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -127,6 +127,3 @@ services:
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
-    Symfony\Component\DependencyInjection\Container:
-        alias: service_container
-        public: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As spotted while working on #22060, we're missing many aliases to prevent any autowiring ambiguities.
I also removed the "Symfony\Component\EventDispatcher\EventDispatcher" and "Symfony\Component\DependencyInjection\Container" aliases: we'd better encourage using the corresponding interfaces instead.
On ControllerTrait, we need to type hint against SessionInterface, because otherwise, when session support is disabled, autowiring still auto-registers an "autowired.Session" service, which defeats the purpose of being able to enable/disable it.