### PR TITLE
[lock] Rename Quorum into Strategy

### DIFF
--- a/src/Symfony/Component/Lock/Strategy/ConsensusStrategy.php
+++ b/src/Symfony/Component/Lock/Strategy/ConsensusStrategy.php
@@ -9,23 +9,21 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Lock\Quorum;
-
-use Symfony\Component\Lock\QuorumInterface;
+namespace Symfony\Component\Lock\Strategy;
 
 /**
- * UnanimousStrategy is a QuorumInterface implementation where 100% of elements should be successful.
+ * ConsensusStrategy is a StrategyInterface implementation where strictly more than 50% items should be successful.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class UnanimousStrategy implements QuorumInterface
+class ConsensusStrategy implements StrategyInterface
 {
     /**
      * {@inheritdoc}
      */
     public function isMet($numberOfSuccess, $numberOfItems)
     {
-        return $numberOfSuccess === $numberOfItems;
+        return $numberOfSuccess > ($numberOfItems / 2);
     }
 
     /**
@@ -33,6 +31,6 @@ class UnanimousStrategy implements QuorumInterface
      */
     public function canBeMet($numberOfFailure, $numberOfItems)
     {
-        return $numberOfFailure === 0;
+        return $numberOfFailure < ($numberOfItems / 2);
     }
 }

--- a/src/Symfony/Component/Lock/Strategy/StrategyInterface.php
+++ b/src/Symfony/Component/Lock/Strategy/StrategyInterface.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Lock;
+namespace Symfony\Component\Lock\Strategy;
 
 /**
- * QuorumInterface defines an interface to indicate when a quorum is met and can be met.
+ * StrategyInterface defines an interface to indicate when a quorum is met and can be met.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-interface QuorumInterface
+interface StrategyInterface
 {
     /**
      * Returns whether or not the quorum is met.

--- a/src/Symfony/Component/Lock/Strategy/UnanimousStrategy.php
+++ b/src/Symfony/Component/Lock/Strategy/UnanimousStrategy.php
@@ -9,23 +9,21 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Lock\Quorum;
-
-use Symfony\Component\Lock\QuorumInterface;
+namespace Symfony\Component\Lock\Strategy;
 
 /**
- * ConsensusStrategy is a QuorumInterface implementation where strictly more than 50% items should be successful.
+ * UnanimousStrategy is a StrategyInterface implementation where 100% of elements should be successful.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class ConsensusStrategy implements QuorumInterface
+class UnanimousStrategy implements StrategyInterface
 {
     /**
      * {@inheritdoc}
      */
     public function isMet($numberOfSuccess, $numberOfItems)
     {
-        return $numberOfSuccess > ($numberOfItems / 2);
+        return $numberOfSuccess === $numberOfItems;
     }
 
     /**
@@ -33,6 +31,6 @@ class ConsensusStrategy implements QuorumInterface
      */
     public function canBeMet($numberOfFailure, $numberOfItems)
     {
-        return $numberOfFailure < ($numberOfItems / 2);
+        return $numberOfFailure === 0;
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Strategy/ConsensusStrategyTest.php
+++ b/src/Symfony/Component/Lock/Tests/Strategy/ConsensusStrategyTest.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Lock\Tests\Quorum;
+namespace Symfony\Component\Lock\Tests\Strategy;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Lock\Quorum\ConsensusStrategy;
+use Symfony\Component\Lock\Strategy\ConsensusStrategy;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
@@ -20,11 +20,11 @@ use Symfony\Component\Lock\Quorum\ConsensusStrategy;
 class ConsensusStrategyTest extends TestCase
 {
     /** @var ConsensusStrategy */
-    private $quorum;
+    private $strategy;
 
     public function setup()
     {
-        $this->quorum = new ConsensusStrategy();
+        $this->strategy = new ConsensusStrategy();
     }
 
     public function provideMetResults()
@@ -76,7 +76,7 @@ class ConsensusStrategyTest extends TestCase
      */
     public function testMet($success, $failure, $total, $isMet)
     {
-        $this->assertSame($isMet, $this->quorum->isMet($success, $total));
+        $this->assertSame($isMet, $this->strategy->isMet($success, $total));
     }
 
     /**
@@ -84,6 +84,6 @@ class ConsensusStrategyTest extends TestCase
      */
     public function canBeMet($success, $failure, $total, $isMet)
     {
-        $this->assertSame($isMet, $this->quorum->canBeMet($failure, $total));
+        $this->assertSame($isMet, $this->strategy->canBeMet($failure, $total));
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Strategy/UnanimousStrategyTest.php
+++ b/src/Symfony/Component/Lock/Tests/Strategy/UnanimousStrategyTest.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Lock\Tests\Quorum;
+namespace Symfony\Component\Lock\Tests\Strategy;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Lock\Quorum\UnanimousStrategy;
+use Symfony\Component\Lock\Strategy\UnanimousStrategy;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
@@ -20,11 +20,11 @@ use Symfony\Component\Lock\Quorum\UnanimousStrategy;
 class UnanimousStrategyTest extends TestCase
 {
     /** @var UnanimousStrategy */
-    private $quorum;
+    private $strategy;
 
     public function setup()
     {
-        $this->quorum = new UnanimousStrategy();
+        $this->strategy = new UnanimousStrategy();
     }
 
     public function provideMetResults()
@@ -76,7 +76,7 @@ class UnanimousStrategyTest extends TestCase
      */
     public function testMet($success, $failure, $total, $isMet)
     {
-        $this->assertSame($isMet, $this->quorum->isMet($success, $total));
+        $this->assertSame($isMet, $this->strategy->isMet($success, $total));
     }
 
     /**
@@ -84,6 +84,6 @@ class UnanimousStrategyTest extends TestCase
      */
     public function canBeMet($success, $failure, $total, $isMet)
     {
-        $this->assertSame($isMet, $this->quorum->canBeMet($failure, $total));
+        $this->assertSame($isMet, $this->strategy->canBeMet($failure, $total));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes (not consistent naming)
| New feature?  | no
| BC breaks?    | yes (but version 3.4 not yet released)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | 

The term `Quorum` in Interface is confusing an not consistent with the Symfony project.
This PR switch to naming `Strategy\StrategyInterface` (like in adapter i `Cache` and `Ldap` component)