### PR TITLE
[Lock] Scoped Lock

### DIFF
--- a/src/Symfony/Component/Lock/Factory.php
+++ b/src/Symfony/Component/Lock/Factory.php
@@ -37,7 +37,7 @@ class Factory implements LoggerAwareInterface
      * Creates a lock for the given resource.
      *
      * @param string $resource The resource to lock
-     * @param float  $ttl      maximum expected lock duration
+     * @param float  $ttl      Maximum expected lock duration in seconds
      *
      * @return Lock
      */
@@ -47,5 +47,18 @@ class Factory implements LoggerAwareInterface
         $lock->setLogger($this->logger);
 
         return $lock;
+    }
+
+    /**
+     * Create a scoped lock for the given resource.
+     *
+     * @param string $resource The resource to lock
+     * @param float  $ttl      Maximum expected lock duration in seconds
+     *
+     * @return ScopedLock
+     */
+    public function createScopedLock($resource, $ttl = 300.0)
+    {
+        return new ScopedLock($this->createLock($resource, $ttl));
     }
 }

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -33,9 +33,9 @@ final class Lock implements LockInterface, LoggerAwareInterface
     private $ttl;
 
     /**
-     * @param Key            $key
-     * @param StoreInterface $store
-     * @param float|null     $ttl
+     * @param Key            $key   Resource to lock
+     * @param StoreInterface $store Store used to handle lock persistence
+     * @param float|null     $ttl   Maximum expected lock duration in seconds
      */
     public function __construct(Key $key, StoreInterface $store, $ttl = null)
     {

--- a/src/Symfony/Component/Lock/ScopedLock.php
+++ b/src/Symfony/Component/Lock/ScopedLock.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock;
+
+/**
+ * ScopedLock encapsulates a LockInterface which is automatically released when destructed.
+ *
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ */
+final class ScopedLock implements LockInterface
+{
+    /**
+     * @var LockInterface
+     */
+    private $lock;
+
+    /**
+     * @param LockInterface $lock
+     */
+    public function __construct(LockInterface $lock)
+    {
+        $this->lock = $lock;
+    }
+
+    /**
+     * Automatically release the underlying lock when the object is destructed.
+     */
+    public function __destruct()
+    {
+        if ($this->isAcquired()) {
+            $this->release();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function acquire($blocking = false)
+    {
+        return $this->lock->acquire($blocking);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refresh()
+    {
+        $this->lock->refresh();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAcquired()
+    {
+        return $this->lock->isAcquired();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function release()
+    {
+        $this->lock->release();
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/FactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/FactoryTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Lock\ScopedLock;
 use Symfony\Component\Lock\StoreInterface;
 
 /**
@@ -32,5 +33,17 @@ class FactoryTest extends TestCase
         $lock = $factory->createLock('foo');
 
         $this->assertInstanceOf(LockInterface::class, $lock);
+    }
+
+    public function testCreateScopedLock()
+    {
+        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $factory = new Factory($store);
+        $factory->setLogger($logger);
+
+        $lock = $factory->createScopedLock('foo');
+
+        $this->assertInstanceOf(ScopedLock::class, $lock);
     }
 }

--- a/src/Symfony/Component/Lock/Tests/ScopedLockTest.php
+++ b/src/Symfony/Component/Lock/Tests/ScopedLockTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Lock\ScopedLock;
+
+/**
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ */
+class ScopedLockTest extends TestCase
+{
+    public function testReleaseWhenLeavingScope()
+    {
+        $lock = $this->getMockBuilder(LockInterface::class)->getMock();
+
+        $lock
+            ->method('isAcquired')
+            ->willReturn(true)
+        ;
+        $lock
+            ->expects($this->once())
+            ->method('release')
+        ;
+
+        new ScopedLock($lock);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | soon

This add to the just-born Lock component a scoped lock.

A scoped lock is a lock which will get automatically released when destructed.

## Usage

```php
class MyService
{
    private $lockFactory;

    public function __construct(LockFactoryInterface $lockFactory)
    {
        $this->lockFactory = $lockFactory;
    }

    public function run()
    {
        $lock = $this->lockFactory->createScopedLock(__METHOD__);
        $lock->acquire();

       // some locked job

        if (/* early return test*/) {
            return; //the lock will be released when leaving the function scope.
        }
        
        try {
             //some other locked job
        } catch (\Exception $e) {
             //no need to release the lock. it will be automatically released when leaving the function scope.
        }
        
    } //lock is automatically released here
}
```