### PR TITLE
[Lock] Adjust lock delay to avoid false error tests

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
@@ -34,7 +34,7 @@ trait BlockingStoreTestTrait
     public function testBlockingLocks()
     {
         // Amount a microsecond used to order async actions
-        $clockDelay = 30000;
+        $clockDelay = 50000;
 
         if (PHP_VERSION_ID < 50600 || defined('HHVM_VERSION_ID')) {
             $this->markTestSkipped('The PHP engine does not keep resource in child forks');
@@ -57,7 +57,7 @@ trait BlockingStoreTestTrait
                     $this->assertSame(0, pcntl_wexitstatus($status2));
                     $this->assertSame(3, pcntl_wexitstatus($status3));
                 } else {
-                    usleep(2 * $clockDelay);
+                    usleep(1 * $clockDelay);
 
                     try {
                         // This call should failed given the lock should already by acquired by the child #1

--- a/src/Symfony/Component/Lock/phpunit.xml.dist
+++ b/src/Symfony/Component/Lock/phpunit.xml.dist
@@ -8,8 +8,8 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="REDIS_HOST" value="redis.docker" />
-        <env name="MEMCACHED_HOST" value="memcached.docker" />
+        <env name="REDIS_HOST" value="localhost" />
+        <env name="MEMCACHED_HOST" value="localhost" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Adjust the clockDelay to fix tests
This test is here to:

T0.
* Fork A, B, C

T1.
* A acquire Lock then start sleeping for 3*clockDelay
* B start sleeping for 1*clockDelay
* C start sleeping for 1*clockDelay

T2
* B wakeup AND try to acquire lock in wait mode
* C wakeup AND try to acquire lock in non wait mode (lock should be till acquired by A)

T4
* A release Lock
* B acquire lock and release it

At the end, this tests assert than:
* A acquire and delete the lock
* B acquire and delete the lock
* C failed to acquire the lock

The point is, this test is time sensitive, and if the fork is too slow, A, B and C are not synchronized and C is able to acquire Lock.

This PR adjuste clock delay to reduce false failures