### PR TITLE
Shift responsibility for keeping Date header to ResponseHeaderBag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -201,11 +201,6 @@ class Response
         $this->setContent($content);
         $this->setStatusCode($status);
         $this->setProtocolVersion('1.0');
-
-        /* RFC2616 - 14.18 says all Responses need to have a Date */
-        if (!$this->headers->has('Date')) {
-            $this->setDate(\DateTime::createFromFormat('U', time()));
-        }
     }
 
     /**
@@ -332,11 +327,6 @@ class Response
         // headers have already been sent by the developer
         if (headers_sent()) {
             return $this;
-        }
-
-        /* RFC2616 - 14.18 says all Responses need to have a Date */
-        if (!$this->headers->has('Date')) {
-            $this->setDate(\DateTime::createFromFormat('U', time()));
         }
 
         // headers
@@ -648,15 +638,6 @@ class Response
      */
     public function getDate()
     {
-        /*
-            RFC2616 - 14.18 says all Responses need to have a Date.
-            Make sure we provide one even if it the header
-            has been removed in the meantime.
-         */
-        if (!$this->headers->has('Date')) {
-            $this->setDate(\DateTime::createFromFormat('U', time()));
-        }
-
         return $this->headers->getDate('Date');
     }
 

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -51,6 +51,11 @@ class ResponseHeaderBag extends HeaderBag
         if (!isset($this->headers['cache-control'])) {
             $this->set('Cache-Control', '');
         }
+
+        /* RFC2616 - 14.18 says all Responses need to have a Date */
+        if (!isset($this->headers['date'])) {
+            $this->initDate();
+        }
     }
 
     /**
@@ -89,6 +94,10 @@ class ResponseHeaderBag extends HeaderBag
 
         if (!isset($this->headers['cache-control'])) {
             $this->set('Cache-Control', '');
+        }
+
+        if (!isset($this->headers['date'])) {
+            $this->initDate();
         }
     }
 
@@ -155,6 +164,10 @@ class ResponseHeaderBag extends HeaderBag
 
         if ('cache-control' === $uniqueKey) {
             $this->computedCacheControl = array();
+        }
+
+        if ('date' === $uniqueKey) {
+            $this->initDate();
         }
     }
 
@@ -337,5 +350,12 @@ class ResponseHeaderBag extends HeaderBag
         }
 
         return $header;
+    }
+
+    private function initDate()
+    {
+        $now = \DateTime::createFromFormat('U', time());
+        $now->setTimezone(new \DateTimeZone('UTC'));
+        $this->set('Date', $now->format('D, d M Y H:i:s').' GMT');
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -332,6 +332,43 @@ class ResponseHeaderBagTest extends TestCase
         );
     }
 
+    public function testDateHeaderAddedOnCreation()
+    {
+        $now = time();
+
+        $bag = new ResponseHeaderBag();
+        $this->assertTrue($bag->has('Date'));
+
+        $this->assertEquals($now, $bag->getDate('Date')->getTimestamp());
+    }
+
+    public function testDateHeaderCanBeSetOnCreation()
+    {
+        $someDate = 'Thu, 23 Mar 2017 09:15:12 GMT';
+        $bag = new ResponseHeaderBag(array('Date' => $someDate));
+
+        $this->assertEquals($someDate, $bag->get('Date'));
+    }
+
+    public function testDateHeaderWillBeRecreatedWhenRemoved()
+    {
+        $someDate = 'Thu, 23 Mar 2017 09:15:12 GMT';
+        $bag = new ResponseHeaderBag(array('Date' => $someDate));
+        $bag->remove('Date');
+
+        // a (new) Date header is still present
+        $this->assertTrue($bag->has('Date'));
+        $this->assertNotEquals($someDate, $bag->get('Date'));
+    }
+
+    public function testDateHeaderWillBeRecreatedWhenHeadersAreReplaced()
+    {
+        $bag = new ResponseHeaderBag();
+        $bag->replace(array());
+
+        $this->assertTrue($bag->has('Date'));
+    }
+
     private function assertSetCookieHeader($expected, ResponseHeaderBag $actual)
     {
         $this->assertRegExp('#^Set-Cookie:\s+'.preg_quote($expected, '#').'$#m', str_replace("\r\n", "\n", (string) $actual));

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -20,48 +20,24 @@ use Symfony\Component\HttpFoundation\Cookie;
  */
 class ResponseHeaderBagTest extends TestCase
 {
-    /**
-     * @dataProvider provideAllPreserveCase
-     */
-    public function testAllPreserveCase($headers, $expected)
+    public function testAllPreserveCase()
     {
-        $bag = new ResponseHeaderBag($headers);
-
-        $this->assertEquals($expected, $bag->allPreserveCase(), '->allPreserveCase() gets all input keys in original case');
-    }
-
-    public function provideAllPreserveCase()
-    {
-        return array(
-            array(
-                array('fOo' => 'BAR'),
-                array('fOo' => array('BAR'), 'Cache-Control' => array('no-cache, private')),
-            ),
-            array(
-                array('ETag' => 'xyzzy'),
-                array('ETag' => array('xyzzy'), 'Cache-Control' => array('private, must-revalidate')),
-            ),
-            array(
-                array('Content-MD5' => 'Q2hlY2sgSW50ZWdyaXR5IQ=='),
-                array('Content-MD5' => array('Q2hlY2sgSW50ZWdyaXR5IQ=='), 'Cache-Control' => array('no-cache, private')),
-            ),
-            array(
-                array('P3P' => 'CP="CAO PSA OUR"'),
-                array('P3P' => array('CP="CAO PSA OUR"'), 'Cache-Control' => array('no-cache, private')),
-            ),
-            array(
-                array('WWW-Authenticate' => 'Basic realm="WallyWorld"'),
-                array('WWW-Authenticate' => array('Basic realm="WallyWorld"'), 'Cache-Control' => array('no-cache, private')),
-            ),
-            array(
-                array('X-UA-Compatible' => 'IE=edge,chrome=1'),
-                array('X-UA-Compatible' => array('IE=edge,chrome=1'), 'Cache-Control' => array('no-cache, private')),
-            ),
-            array(
-                array('X-XSS-Protection' => '1; mode=block'),
-                array('X-XSS-Protection' => array('1; mode=block'), 'Cache-Control' => array('no-cache, private')),
-            ),
+        $headers = array(
+            'fOo' => 'BAR',
+            'ETag' => 'xyzzy',
+            'Content-MD5' => 'Q2hlY2sgSW50ZWdyaXR5IQ==',
+            'P3P' => 'CP="CAO PSA OUR"',
+            'WWW-Authenticate' => 'Basic realm="WallyWorld"',
+            'X-UA-Compatible' => 'IE=edge,chrome=1',
+            'X-XSS-Protection' => '1; mode=block',
         );
+
+        $bag = new ResponseHeaderBag($headers);
+        $allPreservedCase = $bag->allPreserveCase();
+
+        foreach (array_keys($headers) as $headerName) {
+            $this->assertArrayHasKey($headerName, $allPreservedCase, '->allPreserveCase() gets all input keys in original case');
+        }
     }
 
     public function testCacheControlHeader()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This is an improvement over #22036. It shifts responsibility for preserving a `Date` header to the `ResponseHeaderBag`.

We already have similar logic there for the `Cache-Control` header.