### PR TITLE
[WebProfilerBundle] Fix rendering empty cache calls

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
@@ -99,12 +99,12 @@
                 </div>
             {% endfor %}
         </div>
-        <h4>Calls for '{{ name }}'</h4>
 
-        {% if not collector.totals.calls %}
-            <p>
-                <em>No calls.</em>
-            </p>
+        <h4>Calls for '{{ name }}'</h4>
+        {% if calls|length == 0 %}
+            <div class="empty">
+                <p>No calls</p>
+            </div>
         {% else %}
             <table>
                 <thead>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Before

![image](https://cloud.githubusercontent.com/assets/1047696/24264020/54c0ae80-0fff-11e7-81ed-173ec841bd51.png)

After

![image](https://cloud.githubusercontent.com/assets/1047696/24264072/7c700dae-0fff-11e7-841e-4ffda165d851.png)

The bug is real, given the current intention.

Regarding makeup; i think for now this is the most consistent. However the page is extremely long by default, so yes, this extra empty block margin makes it even longer (but still it looks better IMO).

Somewhat related to https://github.com/symfony/symfony/pull/21065#issuecomment-269613182