### PR TITLE
Support handling Throwable in HttpKernel (ref #22128)

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -33,7 +33,14 @@ class FlattenException
     private $file;
     private $line;
 
-    public static function create(\Exception $exception, $statusCode = null, array $headers = array())
+    /**
+     * @param \Exception|\Throwable $exception  Exception or Error instance
+     * @param int                   $statusCode HTTP status code
+     * @param array                 $headers    HTTP headers
+     *
+     * @return FlattenException
+     */
+    public static function create($exception, $statusCode = null, array $headers = array())
     {
         $e = new static();
         $e->setMessage($exception->getMessage());

--- a/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
@@ -30,9 +30,9 @@ use Symfony\Component\HttpFoundation\Request;
 class GetResponseForExceptionEvent extends GetResponseEvent
 {
     /**
-     * The exception object.
+     * The exception or error object.
      *
-     * @var \Exception
+     * @var \Exception|\Throwable
      */
     private $exception;
 
@@ -41,7 +41,14 @@ class GetResponseForExceptionEvent extends GetResponseEvent
      */
     private $allowCustomResponseCode = false;
 
-    public function __construct(HttpKernelInterface $kernel, Request $request, $requestType, \Exception $e)
+    /**
+     * GetResponseForExceptionEvent constructor.
+     * @param HttpKernelInterface   $kernel
+     * @param Request               $request
+     * @param int                   $requestType
+     * @param \Exception|\Throwable $e
+     */
+    public function __construct(HttpKernelInterface $kernel, Request $request, $requestType, $e)
     {
         parent::__construct($kernel, $request, $requestType);
 
@@ -51,7 +58,7 @@ class GetResponseForExceptionEvent extends GetResponseEvent
     /**
      * Returns the thrown exception.
      *
-     * @return \Exception The thrown exception
+     * @return \Exception|\Throwable The thrown exception or error
      */
     public function getException()
     {
@@ -63,9 +70,9 @@ class GetResponseForExceptionEvent extends GetResponseEvent
      *
      * This exception will be thrown if no response is set in the event.
      *
-     * @param \Exception $exception The thrown exception
+     * @param \Exception|\Throwable $exception The thrown exception
      */
-    public function setException(\Exception $exception)
+    public function setException($exception)
     {
         $this->exception = $exception;
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -79,10 +79,10 @@ class ExceptionListener implements EventSubscriberInterface
     /**
      * Logs an exception.
      *
-     * @param \Exception $exception The \Exception instance
-     * @param string     $message   The error message to log
+     * @param \Exception|\Throwable $exception The \Exception or \Error instance
+     * @param string                $message   The error message to log
      */
-    protected function logException(\Exception $exception, $message)
+    protected function logException($exception, $message)
     {
         if (null !== $this->logger) {
             if (!$exception instanceof HttpExceptionInterface || $exception->getStatusCode() >= 500) {
@@ -96,12 +96,12 @@ class ExceptionListener implements EventSubscriberInterface
     /**
      * Clones the request for the exception.
      *
-     * @param \Exception $exception The thrown exception
-     * @param Request    $request   The original request
+     * @param \Exception|\Throwable $exception The thrown exception
+     * @param Request               $request   The original request
      *
      * @return Request $request The cloned request
      */
-    protected function duplicateRequest(\Exception $exception, Request $request)
+    protected function duplicateRequest($exception, Request $request)
     {
         $attributes = array(
             '_controller' => $this->controller,

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -84,30 +84,32 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         try {
             return $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
         } catch (\Exception $e) {
-            // we dispatch the exception event to trigger the logging
-            // the response that comes back is simply ignored
-            if (isset($options['ignore_errors']) && $options['ignore_errors'] && $this->dispatcher) {
-                $event = new GetResponseForExceptionEvent($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $e);
-
-                $this->dispatcher->dispatch(KernelEvents::EXCEPTION, $event);
-            }
-
-            // let's clean up the output buffers that were created by the sub-request
-            Response::closeOutputBuffers($level, false);
-
-            if (isset($options['alt'])) {
-                $alt = $options['alt'];
-                unset($options['alt']);
-
-                return $this->render($alt, $request, $options);
-            }
-
-            if (!isset($options['ignore_errors']) || !$options['ignore_errors']) {
-                throw $e;
-            }
-
-            return new Response();
+        } catch (\Throwable $e) {
         }
+
+        // we dispatch the exception event to trigger the logging
+        // the response that comes back is simply ignored
+        if (isset($options['ignore_errors']) && $options['ignore_errors'] && $this->dispatcher) {
+            $event = new GetResponseForExceptionEvent($this->kernel, $request, HttpKernelInterface::SUB_REQUEST, $e);
+
+            $this->dispatcher->dispatch(KernelEvents::EXCEPTION, $event);
+        }
+
+        // let's clean up the output buffers that were created by the sub-request
+        Response::closeOutputBuffers($level, false);
+
+        if (isset($options['alt'])) {
+            $alt = $options['alt'];
+            unset($options['alt']);
+
+            return $this->render($alt, $request, $options);
+        }
+
+        if (!isset($options['ignore_errors']) || !$options['ignore_errors']) {
+            throw $e;
+        }
+
+        return new Response();
     }
 
     protected function createSubRequest($uri, Request $request)

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -67,17 +67,21 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         try {
             return $this->handleRaw($request, $type);
         } catch (\Exception $e) {
-            if ($e instanceof RequestExceptionInterface) {
-                $e = new BadRequestHttpException($e->getMessage(), $e);
-            }
-            if (false === $catch) {
-                $this->finishRequest($request, $type);
 
-                throw $e;
-            }
+        } catch (\Throwable $e) {
 
-            return $this->handleException($e, $request, $type);
         }
+
+        if ($e instanceof RequestExceptionInterface) {
+            $e = new BadRequestHttpException($e->getMessage(), $e);
+        }
+        if (false === $catch) {
+            $this->finishRequest($request, $type);
+
+            throw $e;
+        }
+
+        return $this->handleException($e, $request, $type);
     }
 
     /**
@@ -216,15 +220,15 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     /**
      * Handles an exception by trying to convert it to a Response.
      *
-     * @param \Exception $e       An \Exception instance
-     * @param Request    $request A Request instance
-     * @param int        $type    The type of the request
+     * @param \Exception|\Throwable $e       An \Exception instance
+     * @param Request               $request A Request instance
+     * @param int                   $type    The type of the request
      *
      * @return Response A Response instance
      *
      * @throws \Exception
      */
-    private function handleException(\Exception $e, $request, $type)
+    private function handleException($e, $request, $type)
     {
         $event = new GetResponseForExceptionEvent($this, $request, $type, $e);
         $this->dispatcher->dispatch(KernelEvents::EXCEPTION, $event);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -53,15 +53,33 @@ class HttpKernelTest extends TestCase
     public function testHandleWhenControllerThrowsAnExceptionAndCatchIsTrueWithAHandlingListener()
     {
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(KernelEvents::EXCEPTION, function ($event) {
+        $dispatcher->addListener(KernelEvents::EXCEPTION, function (GetResponseForExceptionEvent $event) {
             $event->setResponse(new Response($event->getException()->getMessage()));
         });
 
-        $kernel = $this->getHttpKernel($dispatcher, function () { throw new \RuntimeException('foo'); });
+        $kernel = $this->getHttpKernel($dispatcher, function () { throw new \RuntimeException('exception'); });
         $response = $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
 
         $this->assertEquals('500', $response->getStatusCode());
-        $this->assertEquals('foo', $response->getContent());
+        $this->assertEquals('exception', $response->getContent());
+    }
+
+    public function testHandleWhenControllerThrowsAnErrorAndCatchIsTrueWithAHandlingListener()
+    {
+        if (!class_exists('Error', false)) {
+            $this->markTestSkipped('PHP 7 Error required');
+        }
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::EXCEPTION, function (GetResponseForExceptionEvent $event) {
+            $event->setResponse(new Response($event->getException()->getMessage()));
+        });
+
+        $kernel = $this->getHttpKernel($dispatcher, function () { throw new \Error('error'); });
+        $response = $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
+
+        $this->assertEquals('500', $response->getStatusCode());
+        $this->assertEquals('error', $response->getContent());
     }
 
     public function testHandleWhenControllerThrowsAnExceptionAndCatchIsTrueWithANonHandlingListener()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22128
| License       | MIT
| Doc PR        | -

Support for PHP 7’s Throwable in HttpKernel.