### PR TITLE
[Console] Allow setting input values from console.command event

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Helper\DebugFormatterHelper;
 use Symfony\Component\Console\Helper\ProcessHelper;
 use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputDecorator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StreamableInputInterface;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -876,13 +877,13 @@ class Application
             // ignore invalid options/arguments for now, to allow the event listeners to customize the InputDefinition
         }
 
-        $event = new ConsoleCommandEvent($command, $input, $output);
+        $event = new ConsoleCommandEvent($command, $eventInput = new InputDecorator($input), $output);
         $this->dispatcher->dispatch(ConsoleEvents::COMMAND, $event);
 
         if ($event->commandShouldRun()) {
             try {
                 $e = null;
-                $exitCode = $command->run($input, $output);
+                $exitCode = $command->run($eventInput, $output);
             } catch (\Exception $x) {
                 $e = $x;
             } catch (\Throwable $x) {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Command;
 
 use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Input\InputDecorator;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -222,6 +223,10 @@ class Command
             if (!$this->ignoreValidationErrors) {
                 throw $e;
             }
+        }
+
+        if ($input instanceof InputDecorator) {
+            $input = $input->getInner();
         }
 
         $this->initialize($input, $output);

--- a/src/Symfony/Component/Console/Input/InputDecorator.php
+++ b/src/Symfony/Component/Console/Input/InputDecorator.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Input;
+
+/**
+ * Allows to preset/override input options and arguments before/after input binding.
+ * This is mainly useful for preserving input changes made from console events.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ *
+ * @internal
+ */
+class InputDecorator implements InputInterface
+{
+    private $inner;
+    private $arguments = array();
+    private $options = array();
+
+    public function __construct(InputInterface $inner)
+    {
+        $this->inner = $inner;
+    }
+
+    public function getInner()
+    {
+        return $this->inner;
+    }
+
+    public function setArgument($key, $value)
+    {
+        $this->arguments[$key] = $value;
+
+        return $this->inner->setArgument($key, $value);
+    }
+
+    public function setOption($key, $value)
+    {
+        $this->options[$key] = $value;
+
+        return $this->inner->setOption($key, $value);
+    }
+
+    public function getFirstArgument()
+    {
+        return $this->inner->getFirstArgument();
+    }
+
+    public function hasParameterOption($values, $onlyParams = false)
+    {
+        return $this->inner->hasParameterOption($values);
+    }
+
+    public function getParameterOption($values, $default = false, $onlyParams = false)
+    {
+        return $this->inner->getParameterOption($values, $default);
+    }
+
+    public function bind(InputDefinition $definition)
+    {
+        $ret = $this->inner->bind($definition);
+
+        foreach ($this->arguments as $k => $v) {
+            $this->inner->setArgument($k, $v);
+        }
+
+        foreach ($this->options as $k => $v) {
+            $this->inner->setOption($k, $v);
+        }
+
+        return $ret;
+    }
+
+    public function validate()
+    {
+        return $this->inner->validate();
+    }
+
+    public function getArguments()
+    {
+        return $this->inner->getArguments();
+    }
+
+    public function getArgument($name)
+    {
+        return $this->inner->getArgument($name);
+    }
+
+    public function hasArgument($name)
+    {
+        return $this->inner->hasArgument($name);
+    }
+
+    public function getOptions()
+    {
+        return $this->inner->getOptions();
+    }
+
+    public function getOption($name)
+    {
+        return $this->inner->getOption($name);
+    }
+
+    public function hasOption($name)
+    {
+        return $this->inner->hasOption($name);
+    }
+
+    public function isInteractive()
+    {
+        return $this->inner->isInteractive();
+    }
+
+    public function setInteractive($interactive)
+    {
+        return $this->inner->setInteractive($interactive);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #19441
| License       | MIT
| Doc PR        | todo

Allows setting input arguments/options values from the `console.command` event by adding an `InputDecorator` passed to the event and `Command::run()` sort as values set from the event are preserved. This one should not have any side effect (keep existing binding/validation).

Could be considered as a bugfix since the event class says
>  Allows to do things before the command is executed, like skipping the command or changing the input.