### PR TITLE
[Lock] Automaticaly release lock when user forget it

### DIFF
--- a/src/Symfony/Component/Lock/Factory.php
+++ b/src/Symfony/Component/Lock/Factory.php
@@ -36,14 +36,15 @@ class Factory implements LoggerAwareInterface
     /**
      * Creates a lock for the given resource.
      *
-     * @param string $resource The resource to lock
-     * @param float  $ttl      Maximum expected lock duration in seconds
+     * @param string $resource    The resource to lock
+     * @param float  $ttl         Maximum expected lock duration in seconds
+     * @param bool   $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
      *
      * @return Lock
      */
-    public function createLock($resource, $ttl = 300.0)
+    public function createLock($resource, $ttl = 300.0, $autoRelease = true)
     {
-        $lock = new Lock(new Key($resource), $this->store, $ttl);
+        $lock = new Lock(new Key($resource), $this->store, $ttl, $autoRelease);
         $lock->setLogger($this->logger);
 
         return $lock;

--- a/src/Symfony/Component/Lock/Factory.php
+++ b/src/Symfony/Component/Lock/Factory.php
@@ -37,7 +37,7 @@ class Factory implements LoggerAwareInterface
      * Creates a lock for the given resource.
      *
      * @param string $resource The resource to lock
-     * @param float  $ttl      maximum expected lock duration
+     * @param float  $ttl      Maximum expected lock duration in seconds
      *
      * @return Lock
      */

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -34,9 +34,9 @@ final class Lock implements LockInterface, LoggerAwareInterface
     private $ttl;
 
     /**
-     * @param Key            $key
-     * @param StoreInterface $store
-     * @param float|null     $ttl
+     * @param Key            $key   Resource to lock
+     * @param StoreInterface $store Store used to handle lock persistence
+     * @param float|null     $ttl   Maximum expected lock duration in seconds
      */
     public function __construct(Key $key, StoreInterface $store, $ttl = null)
     {
@@ -45,6 +45,20 @@ final class Lock implements LockInterface, LoggerAwareInterface
         $this->ttl = $ttl;
 
         $this->logger = new NullLogger();
+    }
+
+    /**
+     * Automatically release the underlying lock when the object is destructed.
+     */
+    public function __destruct()
+    {
+        try {
+            if ($this->isAcquired()) {
+                $this->release();
+            }
+        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
+        }
     }
 
     /**

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -116,7 +116,7 @@ class SemaphoreStore implements StoreInterface
      */
     public function putOffExpiration(Key $key, $ttl)
     {
-        // do nothing, the flock locks forever.
+        // do nothing, the semaphore locks forever.
     }
 
     /**

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -103,7 +103,7 @@ class LockTest extends TestCase
         $lock = new Lock($key, $store, 10);
 
         $store
-            ->expects($this->once())
+            ->expects($this->atLeast(1))
             ->method('exists')
             ->with($key)
             ->willReturn(true);
@@ -123,12 +123,29 @@ class LockTest extends TestCase
             ->with($key);
 
         $store
-            ->expects($this->once())
+            ->expects($this->atLeast(1))
             ->method('exists')
             ->with($key)
             ->willReturn(false);
 
         $lock->release();
+    }
+
+    public function testReleaseOnDestruction()
+    {
+        $key = new Key(uniqid(__METHOD__, true));
+        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $lock = new Lock($key, $store, 10);
+
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(array(true, false))
+        ;
+        $store
+            ->expects($this->once())
+            ->method('delete')
+        ;
+        unset($lock);
     }
 
     /**
@@ -141,12 +158,12 @@ class LockTest extends TestCase
         $lock = new Lock($key, $store, 10);
 
         $store
-            ->expects($this->once())
+            ->expects($this->atLeast(1))
             ->method('delete')
             ->with($key);
 
         $store
-            ->expects($this->once())
+            ->expects($this->atLeast(1))
             ->method('exists')
             ->with($key)
             ->willReturn(true);

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -103,7 +103,7 @@ class LockTest extends TestCase
         $lock = new Lock($key, $store, 10);
 
         $store
-            ->expects($this->atLeast(1))
+            ->expects($this->any())
             ->method('exists')
             ->with($key)
             ->willReturn(true);
@@ -123,7 +123,7 @@ class LockTest extends TestCase
             ->with($key);
 
         $store
-            ->expects($this->atLeast(1))
+            ->expects($this->once())
             ->method('exists')
             ->with($key)
             ->willReturn(false);
@@ -145,6 +145,8 @@ class LockTest extends TestCase
             ->expects($this->once())
             ->method('delete')
         ;
+
+        $lock->acquire(false);
         unset($lock);
     }
 
@@ -158,12 +160,12 @@ class LockTest extends TestCase
         $lock = new Lock($key, $store, 10);
 
         $store
-            ->expects($this->atLeast(1))
+            ->expects($this->once())
             ->method('delete')
             ->with($key);
 
         $store
-            ->expects($this->atLeast(1))
+            ->expects($this->once())
             ->method('exists')
             ->with($key)
             ->willReturn(true);

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -106,7 +106,7 @@ class LockTest extends TestCase
             ->expects($this->any())
             ->method('exists')
             ->with($key)
-            ->willReturn(true);
+            ->will($this->onConsecutiveCalls(true, false));
 
         $this->assertTrue($lock->isAcquired());
     }
@@ -143,6 +143,25 @@ class LockTest extends TestCase
         ;
         $store
             ->expects($this->once())
+            ->method('delete')
+        ;
+
+        $lock->acquire(false);
+        unset($lock);
+    }
+
+    public function testNoAutoReleaseWhenNotConfigured()
+    {
+        $key = new Key(uniqid(__METHOD__, true));
+        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $lock = new Lock($key, $store, 10, false);
+
+        $store
+            ->method('exists')
+            ->willReturnOnConsecutiveCalls(array(true, false))
+        ;
+        $store
+            ->expects($this->never())
             ->method('delete')
         ;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The objective of this PR is to automatically release the Lock when the user forget to call the `release` method (like the `fclose` function does in, php core).
The implementation is comparable to #22115 but the purpose is not the same.

I create a new PR to not mix things.