### PR TITLE
[Component][Form][ChoiceType] : Add new option to sort group_by value

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
@@ -152,7 +152,7 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null)
+    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null, $groupByOrder = null)
     {
         // The input is not validated on purpose. This way, the decorated
         // factory may decide which input to accept and which not.
@@ -165,7 +165,8 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface
                 $label,
                 $index,
                 $groupBy,
-                $attr
+                $attr,
+                $groupByOrder
             );
         }
 

--- a/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
@@ -90,8 +90,9 @@ interface ChoiceListFactoryInterface
      *                                              group names
      * @param null|array|callable $attr             The callable generating the
      *                                              HTML attributes
+     * @param null|array|callable $groupByOrder     The group by order
      *
      * @return ChoiceListView The choice list view
      */
-    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null);
+    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null, $groupByOrder = null);
 }

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -45,7 +45,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null)
+    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null, $groupByOrder = null)
     {
         $preferredViews = array();
         $otherViews = array();
@@ -80,6 +80,12 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                     $preferredViews,
                     $otherViews
                 );
+            }
+
+            if ($groupByOrder && is_array($groupByOrder)) {
+                uksort($otherViews, function ($key1, $key2) use ($groupByOrder) {
+                    return array_search($key1, $groupByOrder) > array_search($key2, $groupByOrder);
+                });
             }
         } else {
             // Otherwise use the original structure of the choices

--- a/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
@@ -148,10 +148,11 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
      * @param null|callable|string|PropertyPath       $index            The callable or path generating the view indices
      * @param null|callable|string|PropertyPath       $groupBy          The callable or path generating the group names
      * @param null|array|callable|string|PropertyPath $attr             The callable or path generating the HTML attributes
+     * @param null|array|callable|string|PropertyPath $groupByOrder     The groupBy order
      *
      * @return ChoiceListView The choice list view
      */
-    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null)
+    public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null, $groupByOrder = null)
     {
         $accessor = $this->propertyAccessor;
 
@@ -224,6 +225,6 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             };
         }
 
-        return $this->decoratedFactory->createView($list, $preferredChoices, $label, $index, $groupBy, $attr);
+        return $this->decoratedFactory->createView($list, $preferredChoices, $label, $index, $groupBy, $attr, $groupByOrder);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -332,6 +332,7 @@ class ChoiceType extends AbstractType
             'choice_attr' => null,
             'preferred_choices' => array(),
             'group_by' => null,
+            'group_by_order' => null,
             'empty_data' => $emptyData,
             'placeholder' => $placeholderDefault,
             'error_bubbling' => false,
@@ -356,6 +357,7 @@ class ChoiceType extends AbstractType
         $resolver->setAllowedTypes('choice_attr', array('null', 'array', 'callable', 'string', 'Symfony\Component\PropertyAccess\PropertyPath'));
         $resolver->setAllowedTypes('preferred_choices', array('array', '\Traversable', 'callable', 'string', 'Symfony\Component\PropertyAccess\PropertyPath'));
         $resolver->setAllowedTypes('group_by', array('null', 'callable', 'string', 'Symfony\Component\PropertyAccess\PropertyPath'));
+        $resolver->setAllowedTypes('group_by_order', array('null', 'array', '\Traversable'));
     }
 
     /**
@@ -444,7 +446,8 @@ class ChoiceType extends AbstractType
             $options['choice_label'],
             $options['choice_name'],
             $options['group_by'],
-            $options['choice_attr']
+            $options['choice_attr'],
+            $options['group_by_order']
         );
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1669,6 +1669,37 @@ class ChoiceTypeTest extends BaseTypeTest
         ), $view->vars['preferred_choices']);
     }
 
+    public function testPassHierarchicalChoicesToViewWithGroupOrder()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
+            'choices' => $this->choices,
+            'preferred_choices' => array('b', 'd'),
+            'group_by' => function ($val, $key, $index) {
+                return (strlen($key) > 4) ? 'LongName' : 'ShortName';
+            },
+            'group_by_order' => array('ShortName', 'LongName', 'TestNotMatched'),
+        ))
+            ->createView();
+
+        $this->assertEquals(array(
+            'ShortName' => new ChoiceGroupView('ShortName', array(
+                2 => new ChoiceView('c', 'c', 'Kris'),
+            )),
+            'LongName' => new ChoiceGroupView('LongName', array(
+                0 => new ChoiceView('a', 'a', 'Bernhard'),
+                4 => new ChoiceView('e', 'e', 'Roman'),
+            )),
+        ), $view->vars['choices']);
+        $this->assertEquals(array(
+            'LongName' => new ChoiceGroupView('LongName', array(
+                1 => new ChoiceView('b', 'b', 'Fabien'),
+            )),
+            'ShortName' => new ChoiceGroupView('ShortName', array(
+                3 => new ChoiceView('d', 'd', 'Jon'),
+            )),
+        ), $view->vars['preferred_choices']);
+    }
+
     public function testPassChoiceDataToView()
     {
         $obj1 = (object) array('value' => 'a', 'label' => 'A');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21717 
| License       | MIT
| Doc PR        | symfony/symfony-docs

A Proposal PR to have the possibility to define an order for group_by value without create a difficult twig rendering or override buildView Form
