### PR TITLE
[HttpFoundation][bugfix] $bags should always be initialized

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -60,7 +60,7 @@ class MockArraySessionStorage implements SessionStorageInterface
     /**
      * @var array
      */
-    protected $bags;
+    protected $bags = array();
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
@@ -112,6 +112,15 @@ class MockArraySessionStorageTest extends TestCase
         $this->assertTrue($this->storage->isStarted());
     }
 
+    public function testClearWithNoBagsStartsSession()
+    {
+        $storage = new MockArraySessionStorage();
+
+        $storage->clear();
+
+        $this->assertTrue($storage->isStarted());
+    }
+
     /**
      * @expectedException \RuntimeException
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
@@ -97,6 +97,21 @@ class MockArraySessionStorageTest extends TestCase
         $this->assertNotEquals('', $this->storage->getId());
     }
 
+    public function testClearClearsBags()
+    {
+        $this->storage->clear();
+
+        $this->assertSame(array(), $this->storage->getBag('attributes')->all());
+        $this->assertSame(array(), $this->storage->getBag('flashes')->peekAll());
+    }
+
+    public function testClearStartsSession()
+    {
+        $this->storage->clear();
+
+        $this->assertTrue($this->storage->isStarted());
+    }
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21990
| License       | MIT
