### PR TITLE
[Console] Escape exception messages in renderException

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console;
 
 use Symfony\Component\Console\Descriptor\TextDescriptor;
 use Symfony\Component\Console\Descriptor\XmlDescriptor;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\DebugFormatterHelper;
 use Symfony\Component\Console\Helper\ProcessHelper;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -651,7 +652,7 @@ class Application
             }
             $formatter = $output->getFormatter();
             $lines = array();
-            foreach (preg_split('/\r?\n/', $e->getMessage()) as $line) {
+            foreach (preg_split('/\r?\n/', OutputFormatter::escape($e->getMessage())) as $line) {
                 foreach ($this->splitStringByWidth($line, $width - 4) as $line) {
                     // pre-format lines to get the right string length
                     $lineLength = $this->stringWidth(preg_replace('/\[[^m]*m/', '', $formatter->format($line))) + 4;

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3.txt
@@ -1,13 +1,13 @@
 
-                           
-  [Exception]              
-  Third exception comment  
-                           
+                                              
+  [Exception]                                 
+  Third exception <fg=blue;bg=red>comment</>  
+                                              
 
-                            
-  [Exception]               
-  Second exception comment  
-                            
+                                               
+  [Exception]                                  
+  Second exception <comment>comment</comment>  
+                                               
 
                                        
   [Exception]                          

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception3decorated.txt
@@ -1,17 +1,17 @@
 
-[37;41m                           [39;49m
-[37;41m  [Exception]              [39;49m
-[37;41m  Third exception [39;49m[34;41mcomment[39;49m[37;41m  [39;49m
-[37;41m                           [39;49m
+[37;41m                                              [39;49m
+[37;41m  [Exception]                                 [39;49m
+[37;41m  Third exception <fg=blue;bg=red>comment</>  [39;49m
+[37;41m                                              [39;49m
 
-[37;41m                            [39;49m
-[37;41m  [Exception]               [39;49m
-[37;41m  Second exception [39;49m[33mcomment[39m[37;41m  [39;49m
-[37;41m                            [39;49m
+[37;41m                                               [39;49m
+[37;41m  [Exception]                                  [39;49m
+[37;41m  Second exception <comment>comment</comment>  [39;49m
+[37;41m                                               [39;49m
 
 [37;41m                                       [39;49m
 [37;41m  [Exception]                          [39;49m
-[37;41m  First exception [39;49m[37;41m<p>[39;49m[37;41mthis is html[39;49m[37;41m</p>[39;49m[37;41m  [39;49m
+[37;41m  First exception <p>this is html</p>  [39;49m
 [37;41m                                       [39;49m
 
 [32mfoo3:bar[39m


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22021 
| License       | MIT
| Doc PR        | n/a

Adding style on exception messages should be prevented, it leads to weird results.

> Allowing formatting in them would be a nightmare, given that Symfony itself applies some formatting when rendering the exception. 