### PR TITLE
[DI] [DX] Suggest what to do when container fails to autowire an inteface

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -508,9 +508,14 @@ class AutowirePass extends AbstractRecursivePass
         if (!$classOrInterface = class_exists($type, false) ? 'class' : (interface_exists($type, false) ? 'interface' : null)) {
             return sprintf('Cannot autowire service "%s": %s has type "%s" but this class does not exist.', $this->currentId, $label, $type);
         }
-        $message = sprintf('no services were found matching the "%s" %s and it cannot be auto-registered for %s.', $type, $classOrInterface, $label);
 
-        return sprintf('Cannot autowire service "%s": %s', $this->currentId, $message);
+        $message = sprintf('Cannot autowire service "%s": no services were found matching the "%s" %s and it cannot be auto-registered for %s.', $this->currentId, $type, $classOrInterface, $label);
+
+        if ($classOrInterface === 'interface') {
+            $message .= sprintf(' Make sure that a service implementing "%s" interface is registered in the container before registering service "%s".', $type, $this->currentId);
+        }
+
+        return $message;
     }
 
     private function createTypeAlternatives($type)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Lets consider this example files:
```php
class Service1 {
    public function __construct(MyInterface $my) {}
}
```
```php
class Service2 implements MyInterface {}
```

If you have the service `Service2` defined before `Service1` in your `services.yml` file then everything is OK.
But if you have `Service1` first and `Service2` second you will get the following exception:
```
[Symfony\Component\DependencyInjection\Exception\RuntimeException]
Cannot autowire argument $my of method AppBundle\Model\Service1::__construct() for service "my_service1": No services were found matching the "AppBundle\Model\MyInterface" interface and it cannot be auto-registered.
```

Another example: The same happens if you do not have `Service2` in your `services.yml` and you want to autowire this:
```php
class Service3 {
    // Note that the interface is to be autowired before the service implementing the interface
    public function __construct(MyInterface $my1, Service2 $my2)
}
```

After this PR the exception message changes to:
```
[Symfony\Component\DependencyInjection\Exception\RuntimeException]
Cannot autowire argument $my1 of method AppBundle\Model\Service3::__construct() for service "my_service3": No services were found matching the "AppBundle\Model\MyInterface" interface and it cannot be auto-registered. Make sure that a service implementing "AppBundle\Model\MyInterface" interface is registered in the container before registering service "my_service3".
```
Notice the last sentence. It suggests the developer what is the common case for this mistake and what can be the solution.

**UPDATE**: The first described example actually does not cause any problem. See https://github.com/sustmi/symfony-standard/tree/autowiring-order-dependent for another example that presents the problem.