### PR TITLE
[Serializer] Added a ConstraintViolationListNormalizer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -73,6 +73,7 @@ use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
+use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -1225,6 +1226,10 @@ class FrameworkExtension extends Extension
 
         if (!class_exists(DateIntervalNormalizer::class)) {
             $container->removeDefinition('serializer.normalizer.dateinterval');
+        }
+
+        if (!class_exists(ConstraintViolationListNormalizer::class)) {
+            $container->removeDefinition('serializer.normalizer.constraint_violation_list');
         }
 
         if (!class_exists(ClassDiscriminatorFromClassMetadata::class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -31,6 +31,11 @@
         <service id="Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface" alias="serializer.mapping.class_discriminator_resolver" />
 
         <!-- Normalizer -->
+        <service id="serializer.normalizer.constraint_violation_list" class="Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer">
+            <!-- Run before serializer.normalizer.object -->
+            <tag name="serializer.normalizer" priority="-915" />
+        </service>
+
         <service id="serializer.normalizer.dateinterval" class="Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer">
             <!-- Run before serializer.normalizer.object -->
             <tag name="serializer.normalizer" priority="-915" />

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
   maximum depth is reached
 * added optional `int[] $ignoredNodeTypes` argument to `XmlEncoder::__construct`. XML decoding now
   ignores comment node types by default.
+* added `ConstraintViolationListNormalizer`
 
 4.0.0
 -----
@@ -33,7 +34,7 @@ CHANGELOG
  * added support for serializing `DateInterval` objects
  * added getter for extra attributes in `ExtraAttributesException`
  * improved `CsvEncoder` to handle variable nested structures
- * CSV headers can be passed to the `CsvEncoder` via the `csv_headers` serialization context variable 
+ * CSV headers can be passed to the `CsvEncoder` via the `csv_headers` serialization context variable
  * added `$context` when checking for encoding, decoding and normalizing in `Serializer`
 
 3.3.0

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * A normalizer that normalizes a ConstraintViolationListInterface instance.
+ *
+ * This Normalizer implements RFC7807 {@link https://tools.ietf.org/html/rfc7807}.
+ *
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ConstraintViolationListNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $violations = array();
+        $messages = array();
+        foreach ($object as $violation) {
+            $violations[] = array(
+                'propertyPath' => $violation->getPropertyPath(),
+                'message' => $violation->getMessage(),
+                'code' => $violation->getCode(),
+            );
+            $propertyPath = $violation->getPropertyPath();
+            $prefix = $propertyPath ? sprintf('%s: ', $propertyPath) : '';
+            $messages[] = $prefix.$violation->getMessage();
+        }
+
+        return array(
+            'title' => isset($context['title']) ? $context['title'] : 'An error occurred',
+            'detail' => $messages ? implode("\n", $messages) : '',
+            'violations' => $violations,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof ConstraintViolationListInterface;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ConstraintViolationListNormalizerTest extends TestCase
+{
+    private $normalizer;
+
+    protected function setUp()
+    {
+        $this->normalizer = new ConstraintViolationListNormalizer();
+    }
+
+    public function testSupportsNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new ConstraintViolationList()));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testNormalize()
+    {
+        $list = new ConstraintViolationList(array(
+            new ConstraintViolation('a', 'b', array(), 'c', 'd', 'e', null, 'f'),
+            new ConstraintViolation('1', '2', array(), '3', '4', '5', null, '6'),
+        ));
+
+        $expected = array(
+            'title' => 'An error occurred',
+            'detail' => 'd: a
+4: 1',
+            'violations' => array(
+                    array(
+                        'propertyPath' => 'd',
+                        'message' => 'a',
+                        'code' => 'f',
+                    ),
+                    array(
+                        'propertyPath' => '4',
+                        'message' => '1',
+                        'code' => '6',
+                    ),
+                ),
+        );
+
+        $this->assertEquals($expected, $this->normalizer->normalize($list));
+    }
+}

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -25,6 +25,7 @@
         "symfony/http-foundation": "~3.4|~4.0",
         "symfony/cache": "~3.4|~4.0",
         "symfony/property-info": "~3.4|~4.0",
+        "symfony/validator": "~3.4|~4.0",
         "doctrine/annotations": "~1.0",
         "symfony/dependency-injection": "~3.4|~4.0",
         "doctrine/cache": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11309
| License       | MIT
| Doc PR        | -

---

It seems logical to me that Symfony is able to serialise natively some very common Symfony data structure. (and requested by @nicolas-grekas & @javiereguiluz )

Usage example (from symfony/symfony-demo):

```php
    /**
     * @Route("", name="api_blog_new")
     * @Method("POST")
     * @Security("is_granted('ROLE_ADMIN')")
     */
    public function newAction(Request $request)
    {
        $data = $request->getContent();

        $post = $this->get('serializer')->deserialize($data, Post::class, 'json', ['groups' => ['post_write']]);

        $post->setAuthor($this->getUser());

        $violations = $this->get('validator')->validate($post);

        $post->setSlug($this->get('slugger')->slugify($post->getTitle()));

        if (count($violations) > 0) {
            $repr = $this->get('serializer')->serialize($violations, 'json');

            return JsonResponse::fromJsonString($repr, 400);
        }

        $this->getDoctrine()->getManager()->persist($post);
        $this->getDoctrine()->getManager()->flush();

        $repr = $this->get('serializer')->serialize($post, 'json', ['groups' => ['post_read']]);

        return JsonResponse::fromJsonString($repr);
    }
```