### PR TITLE
[DependencyInjection] Make named arguments optional for prototypes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
@@ -4,4 +4,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
 
 class Foo
 {
+    public function __construct($bar = null)
+    {
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/prototype_named_args.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/prototype_named_args.yml
@@ -1,0 +1,5 @@
+services:
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\:
+        resource: ../Prototype
+        arguments:
+            $bar: foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/prototype_unused_named_args.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/prototype_unused_named_args.yml
@@ -1,0 +1,6 @@
+services:
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\:
+        resource: ../Prototype
+        arguments:
+            $invalid: foo
+            $invalid2: quz


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21711
| License       | MIT
| Doc PR        |

This PR makes named arguments optional in prototypes: an argument can be declared but no used in every classes' constructor, note that this behavior is not applied to normal method calls.
To prevent typos, it must be used in at least one class, otherwise it throws an error.