### PR TITLE
[DX] [DI] Throw more helpful error when shortcutting global classes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -48,6 +48,15 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
                 if ($definition->getFactory()) {
                     throw new RuntimeException(sprintf('Please add the class to service "%s" even if it is constructed by a factory since we might need to add method calls based on compile-time checks.', $id));
                 }
+                if (class_exists($id) || interface_exists($id, false)) {
+                    throw new RuntimeException(sprintf(
+                         'The definition for "%s" has no class attribute, and appears to reference a '
+                        .'class or interface in the global namespace. Leaving out the "class" attribute '
+                        .'is only allowed for namespaced classes. Please specify the class attribute '
+                        .'explicitly to get rid of this error.',
+                        $id
+                    ));
+                }
 
                 throw new RuntimeException(sprintf(
                     'The definition for "%s" has no class. If you intend to inject '

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1106,7 +1106,7 @@ class ContainerBuilderTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The definition for "DateTime" has no class.
+     * @expectedExceptionMessage The definition for "DateTime" has no class attribute, and appears to reference a class or interface in the global namespace.
      */
     public function testNoClassFromGlobalNamespaceClassId()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    |no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #22146 
| License       | MIT

As discussed in #22146 the error message received when trying to use a class in the global
namespace as a service without defined class is confusing. Helpful information was added
pointing out this current limitation.
