### PR TITLE
[FrameworkBundle] Cache pool clear command requires at least 1 pool

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
@@ -33,7 +33,7 @@ final class CachePoolClearCommand extends ContainerAwareCommand
         $this
             ->setName('cache:pool:clear')
             ->setDefinition(array(
-                new InputArgument('pools', InputArgument::IS_ARRAY, 'A list of cache pools or cache pool clearers'),
+                new InputArgument('pools', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'A list of cache pools or cache pool clearers'),
             ))
             ->setDescription('Clears cache pools')
             ->setHelp(<<<'EOF'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #22047
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

The commands help description already states this should be required.

```
The cache:pool:clear command clears the given cache pools or cache pool clearers.
  
    bin/console cache:pool:clear <cache pool or clearer 1> [...<cache pool or clearer N>]
```

So this could also be qualified a bugfix.