### PR TITLE
[WebProfilerBundle] Include badge status in translation tabs

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -8,7 +8,7 @@
             {{ include('@WebProfiler/Icon/translation.svg') }}
             {% set status_color = collector.countMissings ? 'red' : collector.countFallbacks ? 'yellow' %}
             {% set error_count = collector.countMissings + collector.countFallbacks %}
-            <span class="sf-toolbar-value">{{ error_count ?: collector.countdefines }}</span>
+            <span class="sf-toolbar-value">{{ error_count ?: collector.countDefines }}</span>
         {% endset %}
 
         {% set text %}
@@ -28,7 +28,7 @@
 
             <div class="sf-toolbar-info-piece">
                 <b>Defined messages</b>
-                <span class="sf-toolbar-status">{{ collector.countdefines }}</span>
+                <span class="sf-toolbar-status">{{ collector.countDefines }}</span>
             </div>
         {% endset %}
 
@@ -65,7 +65,7 @@
 
     <div class="metrics">
         <div class="metric">
-            <span class="value">{{ collector.countdefines }}</span>
+            <span class="value">{{ collector.countDefines }}</span>
             <span class="label">Defined messages</span>
         </div>
 
@@ -96,7 +96,7 @@
 
     <div class="sf-tabs">
         <div class="tab">
-            <h3 class="tab-title">Defined <span class="badge">{{ messages_defined|length }}</span></h3>
+            <h3 class="tab-title">Defined <span class="badge">{{ collector.countDefines }}</span></h3>
 
             <div class="tab-content">
                 <p class="help">
@@ -114,7 +114,7 @@
         </div>
 
         <div class="tab">
-            <h3 class="tab-title">Fallback <span class="badge">{{ messages_fallback|length }}</span></h3>
+            <h3 class="tab-title">Fallback <span class="badge {{ collector.countFallbacks ? 'status-warning' }}">{{ collector.countFallbacks }}</span></h3>
 
             <div class="tab-content">
                 <p class="help">
@@ -133,7 +133,7 @@
         </div>
 
         <div class="tab">
-            <h3 class="tab-title">Missing <span class="badge">{{ messages_missing|length }}</span></h3>
+            <h3 class="tab-title">Missing <span class="badge {{ collector.countMissings ? 'status-error' }}">{{ collector.countMissings }}</span></h3>
 
             <div class="tab-content">
                 <p class="help">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes-ish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Minor consistency fix for the translation panel. Tab badges should indicate a certain status (at least the logs panel does as of 3.2). But for the missing translations (being the last tab) i think this is a good signal. And we could argue _defined_ fallback messages should really indicate a warning..

Before

![image](https://cloud.githubusercontent.com/assets/1047696/24331093/8d9b1210-122d-11e7-9403-a5a86548b214.png)

After

![image](https://cloud.githubusercontent.com/assets/1047696/24331104/bf2800b8-122d-11e7-92ea-57b2664e869f.png)

Funny sidenote; the log warning is about a missing translation :sweat_smile: 