### PR TITLE
[Bridge\Doctrine] Fix change breaking doctrine-bundle test suite

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -109,15 +109,12 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                     throw new RuntimeException(sprintf('The Doctrine connection "%s" referenced in service "%s" does not exist. Available connections names: %s', $con, $id, implode(', ', array_keys($this->connections))));
                 }
 
-                if ($lazy = isset($tag['lazy']) && $tag['lazy']) {
+                if ($lazy = !empty($tag['lazy'])) {
                     $taggedListenerDef->setPublic(true);
                 }
 
                 // we add one call per event per service so we have the correct order
-                $this->getEventManagerDef($container, $con)->addMethodCall('addEventListener', array(
-                    $tag['event'],
-                    $lazy ? $id : new Reference($id),
-                ));
+                $this->getEventManagerDef($container, $con)->addMethodCall('addEventListener', array(array($tag['event']), $lazy ? $id : new Reference($id)));
             }
         }
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -90,11 +90,11 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
 
         $this->assertEquals(
             array(
-                array('addEventListener', array('foo_bar', new Reference('c'))),
-                array('addEventListener', array('foo_bar', new Reference('a'))),
-                array('addEventListener', array('bar', new Reference('a'))),
-                array('addEventListener', array('foo', new Reference('b'))),
-                array('addEventListener', array('foo', new Reference('a'))),
+                array('addEventListener', array(array('foo_bar'), new Reference('c'))),
+                array('addEventListener', array(array('foo_bar'), new Reference('a'))),
+                array('addEventListener', array(array('bar'), new Reference('a'))),
+                array('addEventListener', array(array('foo'), new Reference('b'))),
+                array('addEventListener', array(array('foo'), new Reference('a'))),
             ),
             $methodCalls
         );
@@ -138,16 +138,16 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
 
         $this->assertEquals(
             array(
-                array('addEventListener', array('onFlush', new Reference('a'))),
-                array('addEventListener', array('onFlush', new Reference('b'))),
+                array('addEventListener', array(array('onFlush'), new Reference('a'))),
+                array('addEventListener', array(array('onFlush'), new Reference('b'))),
             ),
             $container->getDefinition('doctrine.dbal.default_connection.event_manager')->getMethodCalls()
         );
 
         $this->assertEquals(
             array(
-                array('addEventListener', array('onFlush', new Reference('a'))),
-                array('addEventListener', array('onFlush', new Reference('c'))),
+                array('addEventListener', array(array('onFlush'), new Reference('a'))),
+                array('addEventListener', array(array('onFlush'), new Reference('c'))),
             ),
             $container->getDefinition('doctrine.dbal.second_connection.event_manager')->getMethodCalls()
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Doctrine Bundle's test suite [is currently broken](https://travis-ci.org/doctrine/DoctrineBundle/jobs/215222182) with `2.8@dev` because the tests expect `addEventListener` to be called with an array as first arg, but #22001 optimized them away as string. Since internally strings are turned back into arrays, let's tweak that change and make Doctrine Bundle green again.