### PR TITLE
[DI] add ServiceLocatorTagPass::register() to share service locators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslatorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslatorPass.php
@@ -11,11 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 
 class TranslatorPass implements CompilerPassInterface
 {
@@ -46,7 +45,7 @@ class TranslatorPass implements CompilerPassInterface
 
         $container
             ->findDefinition('translator.default')
-            ->replaceArgument(0, (new Definition(ServiceLocator::class, array($loaderRefs)))->addTag('container.service_locator'))
+            ->replaceArgument(0, ServiceLocatorTagPass::register($container, $loaderRefs))
             ->replaceArgument(3, $loaders)
         ;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
@@ -41,11 +41,12 @@ class AddConstraintValidatorsPassTest extends TestCase
         $addConstraintValidatorsPass = new AddConstraintValidatorsPass();
         $addConstraintValidatorsPass->process($container);
 
-        $this->assertEquals((new Definition(ServiceLocator::class, array(array(
+        $expected = (new Definition(ServiceLocator::class, array(array(
             Validator1::class => new ServiceClosureArgument(new Reference('my_constraint_validator_service1')),
             'my_constraint_validator_alias1' => new ServiceClosureArgument(new Reference('my_constraint_validator_service1')),
             Validator2::class => new ServiceClosureArgument(new Reference('my_constraint_validator_service2')),
-        ))))->addTag('container.service_locator'), $validatorFactory->getArgument(0));
+        ))))->addTag('container.service_locator')->setPublic(false);
+        $this->assertEquals($expected, $container->getDefinition((string) $validatorFactory->getArgument(0)));
     }
 
     public function testThatCompilerPassIsIgnoredIfThereIsNoConstraintValidatorFactoryDefinition()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
@@ -53,7 +53,7 @@ class FormPassTest extends TestCase
             (new Definition(ServiceLocator::class, array(array(
                 __CLASS__.'_Type1' => new ServiceClosureArgument(new Reference('my.type1')),
                 __CLASS__.'_Type2' => new ServiceClosureArgument(new Reference('my.type2')),
-            ))))->addTag('container.service_locator'),
+            ))))->addTag('container.service_locator')->setPublic(false),
             $extDefinition->getArgument(0)
         );
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TranslatorPassTest.php
@@ -12,45 +12,39 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslatorPass;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslatorPass;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class TranslatorPassTest extends TestCase
 {
     public function testValidCollector()
     {
-        $definition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock();
-        $definition->expects($this->at(0))
-            ->method('addMethodCall')
-            ->with('addLoader', array('xliff', new Reference('xliff')));
-        $definition->expects($this->at(1))
-            ->method('addMethodCall')
-            ->with('addLoader', array('xlf', new Reference('xliff')));
+        $loader = (new Definition())
+            ->addTag('translation.loader', array('alias' => 'xliff', 'legacy-alias' => 'xlf'));
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('hasDefinition', 'getDefinition', 'findTaggedServiceIds', 'findDefinition'))->getMock();
-        $container->expects($this->any())
-            ->method('hasDefinition')
-            ->will($this->returnValue(true));
-        $container->expects($this->once())
-            ->method('getDefinition')
-            ->will($this->returnValue($definition));
-        $container->expects($this->once())
-            ->method('findTaggedServiceIds')
-            ->will($this->returnValue(array('xliff' => array(array('alias' => 'xliff', 'legacy-alias' => 'xlf')))));
-        $container->expects($this->once())
-            ->method('findDefinition')
-            ->will($this->returnValue($translator = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock()));
-        $translator->expects($this->at(0))
-            ->method('replaceArgument')
-            ->with(0, $this->equalTo((new Definition(ServiceLocator::class, array(array('xliff' => new Reference('xliff')))))->addTag('container.service_locator')))
-            ->willReturn($translator);
-        $translator->expects($this->at(1))
-            ->method('replaceArgument')
-            ->with(3, array('xliff' => array('xliff', 'xlf')))
-            ->willReturn($translator);
+        $translator = (new Definition())
+            ->setArguments(array(null, null, null, null));
+
+        $container = new ContainerBuilder();
+        $container->setDefinition('translator.default', $translator);
+        $container->setDefinition('translation.loader', $loader);
+
         $pass = new TranslatorPass();
         $pass->process($container);
+
+        $expected = (new Definition())
+            ->addTag('translation.loader', array('alias' => 'xliff', 'legacy-alias' => 'xlf'))
+            ->addMethodCall('addLoader', array('xliff', new Reference('translation.loader')))
+            ->addMethodCall('addLoader', array('xlf', new Reference('translation.loader')))
+        ;
+        $this->assertEquals($expected, $loader);
+
+        $this->assertSame(array('translation.loader' => array('xliff', 'xlf')), $translator->getArgument(3));
+
+        $expected = array('translation.loader' => new ServiceClosureArgument(new Reference('translation.loader')));
+        $this->assertEquals($expected, $container->getDefinition((string) $translator->getArgument(0))->getArgument(0));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -17,14 +17,13 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
-use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
 
@@ -262,10 +261,10 @@ class SecurityExtension extends Extension
                 ->replaceArgument(2, new Reference($configId))
             ;
 
-            $contextRefs[$contextId] = new ServiceClosureArgument(new Reference($contextId));
+            $contextRefs[$contextId] = new Reference($contextId);
             $map[$contextId] = $matcher;
         }
-        $mapDef->replaceArgument(0, (new Definition(ServiceLocator::class, array($contextRefs)))->addTag('container.service_locator'));
+        $mapDef->replaceArgument(0, ServiceLocatorTagPass::register($container, $contextRefs));
         $mapDef->replaceArgument(1, new IteratorArgument($map));
 
         // add authentication providers to authentication manager

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/RuntimeLoaderPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/RuntimeLoaderPass.php
@@ -11,12 +11,10 @@
 
 namespace Symfony\Bundle\TwigBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * Registers Twig runtime services.
@@ -38,9 +36,9 @@ class RuntimeLoaderPass implements CompilerPassInterface
                 continue;
             }
 
-            $mapping[$def->getClass()] = new ServiceClosureArgument(new Reference($id));
+            $mapping[$def->getClass()] = new Reference($id);
         }
 
-        $definition->replaceArgument(0, (new Definition(ServiceLocator::class, array($mapping)))->addTag('container.service_locator'));
+        $definition->replaceArgument(0, ServiceLocatorTagPass::register($container, $mapping));
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -244,7 +244,7 @@ class TwigExtensionTest extends TestCase
         $container->compile();
 
         $loader = $container->getDefinition('twig.runtime_loader');
-        $args = $loader->getArgument(0)->getArgument(0);
+        $args = $container->getDefinition((string) $loader->getArgument(0))->getArgument(0);
         $this->assertArrayHasKey('Symfony\Bridge\Twig\Form\TwigRenderer', $args);
         $this->assertArrayHasKey('FooClass', $args);
         $this->assertEquals('twig.form.renderer', $args['Symfony\Bridge\Twig\Form\TwigRenderer']->getValues()[0]);

--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceClosureArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceClosureArgument.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Argument;
 
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Represents a service wrapped in a memoizing closure.
@@ -28,11 +28,17 @@ class ServiceClosureArgument implements ArgumentInterface
         $this->values = array($reference);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getValues()
     {
         return $this->values;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setValues(array $values)
     {
         if (array(0) !== array_keys($values) || !($values[0] instanceof Reference || null === $values[0])) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -99,11 +99,11 @@ class ProjectServiceContainer extends Container
     {
         return $this->services['foo_service'] = new \TestServiceSubscriber(new \Symfony\Component\DependencyInjection\ServiceLocator(array('TestServiceSubscriber' => function () {
             $f = function (\TestServiceSubscriber $v) { return $v; }; return $f(${($_ = isset($this->services['TestServiceSubscriber']) ? $this->services['TestServiceSubscriber'] : $this->get('TestServiceSubscriber')) && false ?: '_'});
-        }, 'stdClass' => function () {
-            $f = function (\stdClass $v = null) { return $v; }; return $f(${($_ = isset($this->services['autowired.stdClass']) ? $this->services['autowired.stdClass'] : $this->getAutowired_StdClassService()) && false ?: '_'});
         }, 'bar' => function () {
             $f = function (\stdClass $v) { return $v; }; return $f(${($_ = isset($this->services['TestServiceSubscriber']) ? $this->services['TestServiceSubscriber'] : $this->get('TestServiceSubscriber')) && false ?: '_'});
         }, 'baz' => function () {
+            $f = function (\stdClass $v = null) { return $v; }; return $f(${($_ = isset($this->services['autowired.stdClass']) ? $this->services['autowired.stdClass'] : $this->getAutowired_StdClassService()) && false ?: '_'});
+        }, 'stdClass' => function () {
             $f = function (\stdClass $v = null) { return $v; }; return $f(${($_ = isset($this->services['autowired.stdClass']) ? $this->services['autowired.stdClass'] : $this->getAutowired_StdClassService()) && false ?: '_'});
         })));
     }

--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -12,14 +12,13 @@
 namespace Symfony\Component\Form\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
-use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * Adds all services with the tags "form.type", "form.type_extension" and
@@ -60,17 +59,16 @@ class FormPass implements CompilerPassInterface
     {
         // Get service locator argument
         $servicesMap = array();
-        $locator = $definition->getArgument(0);
 
         // Builds an array with fully-qualified type class names as keys and service IDs as values
         foreach ($container->findTaggedServiceIds($this->formTypeTag) as $serviceId => $tag) {
             $serviceDefinition = $container->getDefinition($serviceId);
 
             // Add form type service to the service locator
-            $servicesMap[$serviceDefinition->getClass()] = new ServiceClosureArgument(new Reference($serviceId));
+            $servicesMap[$serviceDefinition->getClass()] = new Reference($serviceId);
         }
 
-        return (new Definition(ServiceLocator::class, array($servicesMap)))->addTag('container.service_locator');
+        return ServiceLocatorTagPass::register($container, $servicesMap);
     }
 
     private function processFormTypeExtensions(ContainerBuilder $container)

--- a/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
+++ b/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
@@ -51,7 +51,7 @@ class FormPassTest extends TestCase
             (new Definition(ServiceLocator::class, array(array(
                 __CLASS__.'_Type1' => new ServiceClosureArgument(new Reference('my.type1')),
                 __CLASS__.'_Type2' => new ServiceClosureArgument(new Reference('my.type2')),
-            ))))->addTag('container.service_locator'),
+            ))))->addTag('container.service_locator')->setPublic(false),
             $extDefinition->getArgument(0)
         );
     }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/FragmentRendererPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/FragmentRendererPass.php
@@ -11,13 +11,11 @@
 
 namespace Symfony\Component\HttpKernel\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
 /**
@@ -64,10 +62,10 @@ class FragmentRendererPass implements CompilerPassInterface
             }
 
             foreach ($tags as $tag) {
-                $renderers[$tag['alias']] = new ServiceClosureArgument(new Reference($id));
+                $renderers[$tag['alias']] = new Reference($id);
             }
         }
 
-        $definition->replaceArgument(0, (new Definition(ServiceLocator::class, array($renderers)))->addTag('container.service_locator'));
+        $definition->replaceArgument(0, ServiceLocatorTagPass::register($container, $renderers));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
@@ -12,10 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
@@ -65,7 +62,7 @@ class FragmentRendererPassTest extends TestCase
         $renderer
             ->expects($this->once())
             ->method('replaceArgument')
-            ->with(0, $this->equalTo((new Definition(ServiceLocator::class, array(array('foo' => new ServiceClosureArgument(new Reference('my_content_renderer'))))))->addTag('container.service_locator')));
+            ->with(0, $this->equalTo(new Reference('service_locator.5ae0a401097c64ca63ed976c71bc9642')));
 
         $definition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock();
         $definition->expects($this->atLeastOnce())

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\DependencyInjection\TypedReference;
@@ -128,7 +127,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
     public function testAllActions()
     {
         $container = new ContainerBuilder();
-        $container->register('argument_resolver.service')->addArgument(array());
+        $resolver = $container->register('argument_resolver.service')->addArgument(array());
 
         $container->register('foo', RegisterTestController::class)
             ->setAutowired(true)
@@ -138,12 +137,12 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass = new RegisterControllerArgumentLocatorsPass();
         $pass->process($container);
 
-        $expected = new Definition(ServiceLocator::class);
-        $expected->addArgument(array('foo:fooAction' => new ServiceClosureArgument(new Reference('arguments.foo:fooAction'))));
-        $expected->addTag('container.service_locator');
-        $this->assertEquals($expected, $container->getDefinition('argument_resolver.service')->getArgument(0));
+        $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
 
-        $locator = $container->getDefinition('arguments.foo:fooAction');
+        $this->assertEquals(array('foo:fooAction' => new ServiceClosureArgument(new Reference('service_locator.d964744f7278cba85dee823607f8c07f'))), $locator);
+
+        $locator = $container->getDefinition((string) $locator['foo:fooAction']->getValues()[0]);
+
         $this->assertSame(ServiceLocator::class, $locator->getClass());
         $this->assertFalse($locator->isPublic());
         $this->assertTrue($locator->isAutowired());
@@ -155,7 +154,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
     public function testExplicitArgument()
     {
         $container = new ContainerBuilder();
-        $container->register('argument_resolver.service')->addArgument(array());
+        $resolver = $container->register('argument_resolver.service')->addArgument(array());
 
         $container->register('foo', RegisterTestController::class)
             ->addTag('controller.service_arguments', array('action' => 'fooAction', 'argument' => 'bar', 'id' => 'bar'))
@@ -165,7 +164,8 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass = new RegisterControllerArgumentLocatorsPass();
         $pass->process($container);
 
-        $locator = $container->getDefinition('arguments.foo:fooAction');
+        $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
+        $locator = $container->getDefinition((string) $locator['foo:fooAction']->getValues()[0]);
         $this->assertFalse($locator->isAutowired());
 
         $expected = array('bar' => new ServiceClosureArgument(new TypedReference('bar', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)));
@@ -175,7 +175,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
     public function testOptionalArgument()
     {
         $container = new ContainerBuilder();
-        $container->register('argument_resolver.service')->addArgument(array());
+        $resolver = $container->register('argument_resolver.service')->addArgument(array());
 
         $container->register('foo', RegisterTestController::class)
             ->addTag('controller.service_arguments', array('action' => 'fooAction', 'argument' => 'bar', 'id' => '?bar'))
@@ -184,29 +184,11 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $pass = new RegisterControllerArgumentLocatorsPass();
         $pass->process($container);
 
-        $locator = $container->getDefinition('arguments.foo:fooAction');
+        $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
+        $locator = $container->getDefinition((string) $locator['foo:fooAction']->getValues()[0]);
 
         $expected = array('bar' => new ServiceClosureArgument(new TypedReference('bar', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, false)));
         $this->assertEquals($expected, $locator->getArgument(0));
-    }
-
-    public function testSameIdClass()
-    {
-        $container = new ContainerBuilder();
-        $resolver = $container->register('argument_resolver.service')->addArgument(array());
-
-        $container->register(RegisterTestController::class, RegisterTestController::class)
-            ->addTag('controller.service_arguments')
-        ;
-
-        $pass = new RegisterControllerArgumentLocatorsPass();
-        $pass->process($container);
-
-        $expected = array(
-            RegisterTestController::class.':fooAction' => new ServiceClosureArgument(new Reference('arguments.'.RegisterTestController::class.':fooAction')),
-            RegisterTestController::class.'::fooAction' => new ServiceClosureArgument(new Reference('arguments.'.RegisterTestController::class.':fooAction')),
-        );
-        $this->assertEquals($expected, $resolver->getArgument(0)->getArgument(0));
     }
 }
 

--- a/src/Symfony/Component/Validator/DependencyInjection/AddConstraintValidatorsPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddConstraintValidatorsPass.php
@@ -11,12 +11,10 @@
 
 namespace Symfony\Component\Validator\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
@@ -48,15 +46,15 @@ class AddConstraintValidatorsPass implements CompilerPassInterface
             }
 
             if (isset($attributes[0]['alias'])) {
-                $validators[$attributes[0]['alias']] = new ServiceClosureArgument(new Reference($id));
+                $validators[$attributes[0]['alias']] = new Reference($id);
             }
 
-            $validators[$definition->getClass()] = new ServiceClosureArgument(new Reference($id));
+            $validators[$definition->getClass()] = new Reference($id);
         }
 
         $container
             ->getDefinition('validator.validator_factory')
-            ->replaceArgument(0, (new Definition(ServiceLocator::class, array($validators)))->addTag('container.service_locator'))
+            ->replaceArgument(0, ServiceLocatorTagPass::register($container, $validators))
         ;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/DependencyInjection/AddConstraintValidatorsPassTest.php
+++ b/src/Symfony/Component/Validator/Tests/DependencyInjection/AddConstraintValidatorsPassTest.php
@@ -38,11 +38,12 @@ class AddConstraintValidatorsPassTest extends TestCase
         $addConstraintValidatorsPass = new AddConstraintValidatorsPass();
         $addConstraintValidatorsPass->process($container);
 
-        $this->assertEquals((new Definition(ServiceLocator::class, array(array(
+        $expected = (new Definition(ServiceLocator::class, array(array(
             Validator1::class => new ServiceClosureArgument(new Reference('my_constraint_validator_service1')),
             'my_constraint_validator_alias1' => new ServiceClosureArgument(new Reference('my_constraint_validator_service1')),
             Validator2::class => new ServiceClosureArgument(new Reference('my_constraint_validator_service2')),
-        ))))->addTag('container.service_locator'), $validatorFactory->getArgument(0));
+        ))))->addTag('container.service_locator')->setPublic(false);
+        $this->assertEquals($expected, $container->getDefinition((string) $validatorFactory->getArgument(0)));
     }
 
     public function testThatCompilerPassIsIgnoredIfThereIsNoConstraintValidatorFactoryDefinition()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Right now, one service locator is created per controller / service subscriber. But since service locators are stateless, this is just wasting resources when several controllers have the exact same set of services managed by their locators (as would be the case when registering the new `AbstractController` as a service subscribers).

This PR fixes this issue, and a few related others found along the way.