### PR TITLE
[DI] Allow imports in string format for YAML

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -177,7 +177,10 @@ class YamlFileLoader extends FileLoader
         $defaultDirectory = dirname($file);
         foreach ($content['imports'] as $import) {
             if (!is_array($import)) {
-                throw new InvalidArgumentException(sprintf('The values in the "imports" key should be arrays in %s. Check your YAML syntax.', $file));
+                $import = array('resource' => $import);
+            }
+            if (!isset($import['resource'])) {
+                throw new InvalidArgumentException(sprintf('An import should provide a resource in %s. Check your YAML syntax.', $file));
             }
 
             $this->setCurrentDir($defaultDirectory);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_import.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_import.yml
@@ -1,2 +1,2 @@
 imports:
-    - foo.yml
+    - { resource: ~ }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services4.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services4.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: services2.yml }
+    - services2.yml
     - { resource: services3.yml }
     - { resource: "../php/simple.php" }
     - { resource: "../ini/parameters.ini", class: Symfony\Component\DependencyInjection\Loader\IniFileLoader }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

I see no real reasons why this shouldnt be allowed..

Before

```yml
imports:
    - { resource: config.yml }
```

After

```yml
imports:
    - config.yml
```