### PR TITLE
[Workflow] Added 'workflow_marked_places' twig function

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added a `workflow_has_marked_place` function
+ * added a `workflow_marked_places` function
 
 3.2.0
 -----

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -33,6 +33,7 @@ class WorkflowExtension extends \Twig_Extension
             new \Twig_SimpleFunction('workflow_can', array($this, 'canTransition')),
             new \Twig_SimpleFunction('workflow_transitions', array($this, 'getEnabledTransitions')),
             new \Twig_SimpleFunction('workflow_has_marked_place', array($this, 'hasMarkedPlace')),
+            new \Twig_SimpleFunction('workflow_marked_places', array($this, 'getMarkedPlaces')),
         );
     }
 
@@ -63,9 +64,38 @@ class WorkflowExtension extends \Twig_Extension
         return $this->workflowRegistry->get($subject, $name)->getEnabledTransitions($subject);
     }
 
-    public function hasMarkedPlace($object, $place, $name = null)
+    /**
+     * Returns true if the place is marked.
+     *
+     * @param object $subject   A subject
+     * @param string $placeName A place name
+     * @param string $name      A workflow name
+     *
+     * @return bool true if the transition is enabled
+     */
+    public function hasMarkedPlace($subject, $placeName, $name = null)
     {
-        return $this->workflowRegistry->get($object, $name)->getMarking($object)->has($place);
+        return $this->workflowRegistry->get($subject, $name)->getMarking($subject)->has($placeName);
+    }
+
+    /**
+     * Returns marked places.
+     *
+     * @param object $subject        A subject
+     * @param string $placesNameOnly If true, returns only places name. If false returns the raw representation
+     * @param string $name           A workflow name
+     *
+     * @return string[]|int[]
+     */
+    public function getMarkedPlaces($subject, $placesNameOnly = true, $name = null)
+    {
+        $places = $this->workflowRegistry->get($subject, $name)->getMarking($subject)->getPlaces();
+
+        if ($placesNameOnly) {
+            return array_keys($places);
+        }
+
+        return $places;
     }
 
     public function getName()

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
@@ -75,4 +75,14 @@ class WorkflowExtensionTest extends TestCase
         $this->assertTrue($this->extension->hasMarkedPlace($subject, 'waiting_for_payment'));
         $this->assertFalse($this->extension->hasMarkedPlace($subject, 'processed'));
     }
+
+    public function testGetMarkedPlaces()
+    {
+        $subject = new \stdClass();
+        $subject->marking = array();
+        $subject->marking = array('ordered' => 1, 'waiting_for_payment' => 1);
+
+        $this->assertSame(array('ordered', 'waiting_for_payment'), $this->extension->getMarkedPlaces($subject));
+        $this->assertSame($subject->marking, $this->extension->getMarkedPlaces($subject, false));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

---

When someone uses a custom MarkingStore, the value in the
$subject::marking can be really different from the value inside
Marking::getPlaces(). This occurs, for example, when the value stored in
the subject is a bit mask.

So it's always safer to get the places names from the marking, and so
with this new function.

---

usage: 
```twig
{{ workflow_marked_places(post)|join(',') }}
```