### PR TITLE
[DI] Throw on "configured-keys <> getSubscribedServices()" mismatch

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
@@ -92,7 +92,8 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
         }
 
         if ($serviceMap = array_keys($serviceMap)) {
-            $this->container->log($this, sprintf('Service keys "%s" do not exist in the map returned by %s::getSubscribedServices() for service "%s".', implode('", "', $serviceMap), $class, $this->currentId));
+            $message = sprintf(1 < count($serviceMap) ? 'keys "%s" do' : 'key "%s" does', str_replace('%', '%%', implode('", "', $serviceMap)));
+            throw new InvalidArgumentException(sprintf('Service %s not exist in the map returned by %s::getSubscribedServices() for service "%s".', $message, $class, $this->currentId));
         }
 
         $serviceLocator = $this->serviceLocator;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -115,4 +115,23 @@ class RegisterServiceSubscribersPassTest extends TestCase
 
         $this->assertEquals($expected, $locator->getArgument(0));
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Service key "test" does not exist in the map returned by TestServiceSubscriber::getSubscribedServices() for service "foo_service".
+     */
+    public function testExtraServiceSubscriber()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo_service', 'TestServiceSubscriber')
+            ->setAutowired(true)
+            ->addArgument(new Reference('container'))
+            ->addTag('container.service_subscriber', array(
+                'key' => 'test',
+                'id' => 'TestServiceSubscriber',
+            ))
+        ;
+        $container->register('TestServiceSubscriber', 'TestServiceSubscriber');
+        $container->compile();
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -561,7 +561,7 @@ class PhpDumperTest extends TestCase
             ->setAutowired(true)
             ->addArgument(new Reference('container'))
             ->addTag('container.service_subscriber', array(
-                'key' => 'test',
+                'key' => 'bar',
                 'id' => 'TestServiceSubscriber',
             ))
         ;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -102,7 +102,7 @@ class ProjectServiceContainer extends Container
         }, 'stdClass' => function () {
             $f = function (\stdClass $v = null) { return $v; }; return $f(${($_ = isset($this->services['autowired.stdClass']) ? $this->services['autowired.stdClass'] : $this->getAutowired_StdClassService()) && false ?: '_'});
         }, 'bar' => function () {
-            $f = function (\stdClass $v) { return $v; }; return $f(${($_ = isset($this->services['autowired.stdClass']) ? $this->services['autowired.stdClass'] : $this->getAutowired_StdClassService()) && false ?: '_'});
+            $f = function (\stdClass $v) { return $v; }; return $f(${($_ = isset($this->services['TestServiceSubscriber']) ? $this->services['TestServiceSubscriber'] : $this->get('TestServiceSubscriber')) && false ?: '_'});
         }, 'baz' => function () {
             $f = function (\stdClass $v = null) { return $v; }; return $f(${($_ = isset($this->services['autowired.stdClass']) ? $this->services['autowired.stdClass'] : $this->getAutowired_StdClassService()) && false ?: '_'});
         })));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As reported on Slack, this creates DX issues, and provides no practical benefit. Let's throw instead of logging.