### PR TITLE
[Console] CommandTester: disable color support detection

### DIFF
--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -70,9 +70,7 @@ class CommandTester
         }
 
         $this->output = new StreamOutput(fopen('php://memory', 'w', false));
-        if (isset($options['decorated'])) {
-            $this->output->setDecorated($options['decorated']);
-        }
+        $this->output->setDecorated(isset($options['decorated']) ? $options['decorated'] : false);
         if (isset($options['verbosity'])) {
             $this->output->setVerbosity($options['verbosity']);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

By default, the command tester relies on [color support guessing](https://github.com/julienfalque/symfony/blob/3fe419cf66a8a9f033db54186896b142c5cbcada/src/Symfony/Component/Console/Output/StreamOutput.php#L91) to enable output decoration.

This is an issue for tests in that guessing is done against the stream instance on Linux and against the actual environment running the test on Windows, so color support can be detected on Windows even when the used stream is a memory stream like here, resulting in non-deterministic tests.

This PR disables output decoration by default. This will only change behavior on Windows with color support, as guessing on Linux always detects color as not supported for memory streams anyway. Tests should enable decoration explicitly when they want to test it.

A better fix would be to actually detect that we are using a memory stream on Windows as well, but I'm not sure it's possible.