### PR TITLE
[FrameworkBundle] Clear global cache pool using cache:clear

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -99,11 +99,11 @@
             </call>
         </service>
 
-        <service id="cache.default_clearer" class="Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer">
+        <service id="cache.global_clearer" parent="cache.default_clearer">
             <tag name="kernel.cache_clearer" />
         </service>
 
-        <service id="cache.global_clearer" parent="cache.default_clearer" />
+        <service id="cache.default_clearer" class="Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer" />
         <service id="cache.app_clearer" alias="cache.default_clearer" />
         <service id="Psr\Cache\CacheItemPoolInterface" alias="cache.app" public="false" />
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes/no
| Fixed tickets | #22047
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Im not sure this was intended in any way, but it creates a nasty side effect causing a pool to be cleared based on the filesystem location / clearer used.

```yml
services:
    my_cache:
        class: Symfony\Component\Cache\Adapter\FilesystemAdapter
        arguments: [my_namespace, 0, '%kernel.root_dir%/my_cache']
        tags:
            - { name: cache.pool, clearer: my_clearer }

    my_clearer:
        parent: cache.default_clearer
```

```
$ bin/console cache:clear
```

Before

Pool `my_cache` is **not** cleared

After

Pool `my_cache` is cleared

To clarify if i used `$kernel.cache_dir%` it would have been cleared before as well (by accident more or less).