### PR TITLE
[DI] Resolve iterator argument as plain array if required

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -20,6 +20,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 abstract class AbstractRecursivePass implements CompilerPassInterface
 {
+    /**
+     * @var ContainerBuilder
+     */
     protected $container;
     protected $currentId;
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -57,6 +57,7 @@ class PassConfig
             new CheckDefinitionValidityPass(),
             new RegisterServiceSubscribersPass(),
             new ResolveNamedArgumentsPass(),
+            new ResolveArrayIterablesPass(),
             new AutowirePass(),
             new ResolveReferencesToAliasesPass(),
             new ResolveInvalidReferencesPass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveArrayIterablesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveArrayIterablesPass.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\LazyProxy\ProxyHelper;
+
+/**
+ * Resolves iterator arguments needed to be an array by definition.
+ *
+ * @author Roland Franssen <franssen.rolandd@gmail.com>
+ */
+class ResolveArrayIterablesPass extends AbstractRecursivePass
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function processValue($value, $isRoot = false)
+    {
+        if (!$value instanceof Definition || !$reflectionClass = $this->container->getReflectionClass($value->getClass())) {
+            return parent::processValue($value, $isRoot);
+        }
+
+        $calls = $value->getMethodCalls();
+        $calls[] = array('__construct', $value->getArguments());
+
+        foreach ($calls as $i => $call) {
+            list($method, $arguments) = $call;
+
+            if (!$reflectionClass->hasMethod($method)) {
+                continue;
+            }
+
+            $reflectionMethod = $reflectionClass->getMethod($method);
+            $reflectionParams = $reflectionMethod->getParameters();
+
+            foreach ($arguments as $key => $argument) {
+                if (!$argument instanceof IteratorArgument || !isset($reflectionParams[$key])) {
+                    continue;
+                }
+
+                if ('array' === ProxyHelper::getTypeHint($reflectionMethod, $reflectionParams[$key])) {
+                    $calls[$i][1][$key] = $argument->getValues();
+                }
+            }
+        }
+
+        $value->setArguments(array_pop($calls)[1]);
+        $value->setMethodCalls($calls);
+
+        return $value;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Given

```php
class Foo {
    private $bars;
    public function __construct(array $bars) {
        $this->bars = $bars;
    }
}
```

```yml
services:
    a: { class: stdClass }
    b: { class: stdClass }
    Foo: [!iterator ['@a', '@b']]
```

```php
dump($this->get(Foo::class));
```

Before

```
Catchable Fatal Error: Argument 1 passed to AppBundle\Foo::__construct() must be of the type array, object given
```

After

```
Foo {#223 ▼
  -bars: array:2 [▼
    0 => {#224}
    1 => {#222}
  ]
}
```