### PR TITLE
[DI] Fix indexed arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -46,7 +46,7 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
             $resolvedArguments = array();
 
             foreach ($arguments as $key => $argument) {
-                if (is_int($key)) {
+                if (is_int($key) || 0 === strpos($key, 'index_')) {
                     $resolvedArguments[] = $argument;
                     continue;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

small breakage with 3.2 :)

```yml
Foo:
  class: Foo
  arguments: { index_0: first, index_1: 2nd, index_2: third }
```

is now producing

```
Invalid key "index_0" found in arguments of method "__construct" for service "Foo": only integer or $named arguments are allowed.
```