### PR TITLE
[HttpKernel] Dont implement ServiceSubscriberInterface on *SessionListener

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -53,8 +53,14 @@
 
         <service id="session_listener" class="Symfony\Component\HttpKernel\EventListener\SessionListener">
             <tag name="kernel.event_subscriber" />
-            <tag name="container.service_subscriber" id="session" />
-            <argument type="service" id="container" />
+            <argument type="service">
+                <service class="Symfony\Component\DependencyInjection\ServiceLocator">
+                    <tag name="container.service_locator" />
+                    <argument type="collection">
+                        <argument key="session" type="service" id="session" on-invalid="ignore" />
+                    </argument>
+                </service>
+            </argument>
         </service>
 
         <service id="session.save_listener" class="Symfony\Component\HttpKernel\EventListener\SaveSessionListener">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -22,8 +22,14 @@
 
         <service id="test.session.listener" class="Symfony\Component\HttpKernel\EventListener\TestSessionListener">
             <tag name="kernel.event_subscriber" />
-            <tag name="container.service_subscriber" id="session" />
-            <argument type="service" id="container" />
+            <argument type="service">
+                <service class="Symfony\Component\DependencyInjection\ServiceLocator">
+                    <tag name="container.service_locator" />
+                    <argument type="collection">
+                        <argument key="session" type="service" id="session" on-invalid="ignore" />
+                    </argument>
+                </service>
+            </argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Container\ContainerInterface;
-use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * Sets the session in the request.
@@ -22,7 +20,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  *
  * @final since version 3.3
  */
-class SessionListener extends AbstractSessionListener implements ServiceSubscriberInterface
+class SessionListener extends AbstractSessionListener
 {
     private $container;
 
@@ -38,15 +36,5 @@ class SessionListener extends AbstractSessionListener implements ServiceSubscrib
         }
 
         return $this->container->get('session');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function getSubscribedServices()
-    {
-        return array(
-            'session' => '?'.SessionInterface::class,
-        );
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Container\ContainerInterface;
-use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * Sets the session in the request.
@@ -22,7 +20,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  *
  * @final since version 3.3
  */
-class TestSessionListener extends AbstractTestSessionListener implements ServiceSubscriberInterface
+class TestSessionListener extends AbstractTestSessionListener
 {
     private $container;
 
@@ -38,15 +36,5 @@ class TestSessionListener extends AbstractTestSessionListener implements Service
         }
 
         return $this->container->get('session');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function getSubscribedServices()
-    {
-        return array(
-            'session' => '?'.SessionInterface::class,
-        );
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\SessionListener;
+use Symfony\Component\HttpKernel\EventListener\TestSessionListener;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -77,6 +80,15 @@ class TestSessionListenerTest extends TestCase
         $this->sessionMustNotBeSaved();
 
         $this->filterResponse(new Request());
+    }
+
+    public function testDoesNotImplementServiceSubscriberInterface()
+    {
+        $this->assertTrue(interface_exists(ServiceSubscriberInterface::class));
+        $this->assertTrue(class_exists(SessionListener::class));
+        $this->assertTrue(class_exists(TestSessionListener::class));
+        $this->assertFalse(is_subclass_of(SessionListener::class, ServiceSubscriberInterface::class), 'Implementing ServiceSubscriberInterface would create a dep on the DI component, which eg Silex cannot afford');
+        $this->assertFalse(is_subclass_of(TestSessionListener::class, ServiceSubscriberInterface::class, 'Implementing ServiceSubscriberInterface would create a dep on the DI component, which eg Silex cannot afford'));
     }
 
     private function filterResponse(Request $request, $type = HttpKernelInterface::MASTER_REQUEST)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22171, silexphp/Silex#1496
| License       | MIT
| Doc PR        | -

Implementing `ServiceSubscriberInterface` creates a dep on the DI component, which Silex can't afford. Let's revert that part.

@GromNaN can you please confirm this fixes your issue?