### PR TITLE
[Routing] Add backslashes in front of global functions in the generated matcher

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -104,8 +104,8 @@ EOF;
     public function match(\$pathinfo)
     {
         \$allow = array();
-        \$pathinfo = rawurldecode(\$pathinfo);
-        \$trimmedPathinfo = rtrim(\$pathinfo, '/');
+        \$pathinfo = \\rawurldecode(\$pathinfo);
+        \$trimmedPathinfo = \\rtrim(\$pathinfo, '/');
         \$context = \$this->context;
         \$request = \$this->request;
         \$requestMethod = \$canonicalMethod = \$context->getMethod();
@@ -118,7 +118,7 @@ EOF;
 
 $code
 
-        throw 0 < count(\$allow) ? new MethodNotAllowedException(array_unique(\$allow)) : new ResourceNotFoundException();
+        throw 0 < \\count(\$allow) ? new MethodNotAllowedException(\\array_unique(\$allow)) : new ResourceNotFoundException();
     }
 EOF;
     }
@@ -144,7 +144,7 @@ EOF;
                     $fetchedHost = true;
                 }
 
-                $code .= sprintf("        if (preg_match(%s, \$host, \$hostMatches)) {\n", var_export($regex, true));
+                $code .= sprintf("        if (\\preg_match(%s, \$host, \$hostMatches)) {\n", var_export($regex, true));
             }
 
             $tree = $this->buildStaticPrefixCollection($collection);
@@ -192,7 +192,7 @@ EOF;
         $prefix = $collection->getPrefix();
 
         if (!empty($prefix) && '/' !== $prefix) {
-            $code .= sprintf("    %s (0 === strpos(\$pathinfo, %s)) {\n", $ifOrElseIf, var_export($prefix, true));
+            $code .= sprintf("    %s (0 === \\strpos(\$pathinfo, %s)) {\n", $ifOrElseIf, var_export($prefix, true));
         }
 
         $ifOrElseIf = 'if';
@@ -250,14 +250,14 @@ EOF;
             }
         } else {
             if ($compiledRoute->getStaticPrefix() && $compiledRoute->getStaticPrefix() !== $parentPrefix) {
-                $conditions[] = sprintf('0 === strpos($pathinfo, %s)', var_export($compiledRoute->getStaticPrefix(), true));
+                $conditions[] = sprintf('0 === \\strpos($pathinfo, %s)', var_export($compiledRoute->getStaticPrefix(), true));
             }
 
             if ($supportsTrailingSlash && $pos = strpos($regex, '/$')) {
                 $regex = substr($regex, 0, $pos).'/?$'.substr($regex, $pos + 2);
                 $hasTrailingSlash = true;
             }
-            $conditions[] = sprintf('preg_match(%s, $pathinfo, $matches)', var_export($regex, true));
+            $conditions[] = sprintf('\\preg_match(%s, $pathinfo, $matches)', var_export($regex, true));
 
             $matches = true;
         }
@@ -322,8 +322,8 @@ EOF;
                 } else {
                     $methods = implode("', '", $methods);
                     $code .= <<<EOF
-            if (!in_array(\$$methodVariable, array('$methods'))) {
-                \$allow = array_merge(\$allow, array('$methods'));
+            if (!\\in_array(\$$methodVariable, array('$methods'))) {
+                \$allow = \\array_merge(\$allow, array('$methods'));
                 goto $gotoname;
             }
 
@@ -335,7 +335,7 @@ EOF;
 
         if ($hasTrailingSlash) {
             $code .= <<<EOF
-            if (substr(\$pathinfo, -1) !== '/') {
+            if (\\substr(\$pathinfo, -1) !== '/') {
                 return \$this->redirect(\$pathinfo.'/', '$name');
             }
 
@@ -351,7 +351,7 @@ EOF;
             $code .= <<<EOF
             \$requiredSchemes = $schemes;
             if (!isset(\$requiredSchemes[\$scheme])) {
-                return \$this->redirect(\$pathinfo, '$name', key(\$requiredSchemes));
+                return \$this->redirect(\$pathinfo, '$name', \\key(\$requiredSchemes));
             }
 
 
@@ -370,7 +370,7 @@ EOF;
             $vars[] = "array('_route' => '$name')";
 
             $code .= sprintf(
-                "            return \$this->mergeDefaults(array_replace(%s), %s);\n",
+                "            return \$this->mergeDefaults(\\array_replace(%s), %s);\n",
                 implode(', ', $vars),
                 str_replace("\n", '', var_export($route->getDefaults(), true))
             );

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -23,8 +23,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     public function match($pathinfo)
     {
         $allow = array();
-        $pathinfo = rawurldecode($pathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
+        $pathinfo = \rawurldecode($pathinfo);
+        $trimmedPathinfo = \rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -35,10 +35,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
 
-        if (0 === strpos($pathinfo, '/foo')) {
+        if (0 === \strpos($pathinfo, '/foo')) {
             // foo
-            if (preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
+            if (\preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
             }
 
             // foofoo
@@ -48,33 +48,33 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         }
 
-        elseif (0 === strpos($pathinfo, '/bar')) {
+        elseif (0 === \strpos($pathinfo, '/bar')) {
             // bar
-            if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+            if (\preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
                 if ('GET' !== $canonicalMethod) {
                     $allow[] = 'GET';
                     goto not_bar;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array ());
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'bar')), array ());
             }
             not_bar:
 
             // barhead
-            if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+            if (0 === \strpos($pathinfo, '/barhead') && \preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
                 if ('GET' !== $canonicalMethod) {
                     $allow[] = 'GET';
                     goto not_barhead;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array ());
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'barhead')), array ());
             }
             not_barhead:
 
         }
 
-        elseif (0 === strpos($pathinfo, '/test')) {
-            if (0 === strpos($pathinfo, '/test/baz')) {
+        elseif (0 === \strpos($pathinfo, '/test')) {
+            if (0 === \strpos($pathinfo, '/test/baz')) {
                 // baz
                 if ('/test/baz' === $pathinfo) {
                     return array('_route' => 'baz');
@@ -93,37 +93,37 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             }
 
             // baz4
-            if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
+            if (\preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'baz4')), array ());
             }
 
             // baz5
-            if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+            if (\preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
                 if ('POST' !== $canonicalMethod) {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array ());
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'baz5')), array ());
             }
             not_baz5:
 
             // baz.baz6
-            if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+            if (\preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
                 if ('PUT' !== $canonicalMethod) {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array ());
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'baz.baz6')), array ());
             }
             not_bazbaz6:
 
         }
 
         // quoter
-        if (preg_match('#^/(?P<quoter>[\']+)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array ());
+        if (\preg_match('#^/(?P<quoter>[\']+)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'quoter')), array ());
         }
 
         // space
@@ -131,44 +131,44 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return array('_route' => 'space');
         }
 
-        if (0 === strpos($pathinfo, '/a')) {
-            if (0 === strpos($pathinfo, '/a/b\'b')) {
+        if (0 === \strpos($pathinfo, '/a')) {
+            if (0 === \strpos($pathinfo, '/a/b\'b')) {
                 // foo1
-                if (preg_match('#^/a/b\'b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array ());
+                if (\preg_match('#^/a/b\'b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo1')), array ());
                 }
 
                 // bar1
-                if (preg_match('#^/a/b\'b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array ());
+                if (\preg_match('#^/a/b\'b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($matches, array('_route' => 'bar1')), array ());
                 }
 
             }
 
             // overridden
-            if (preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array ());
+            if (\preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'overridden')), array ());
             }
 
-            if (0 === strpos($pathinfo, '/a/b\'b')) {
+            if (0 === \strpos($pathinfo, '/a/b\'b')) {
                 // foo2
-                if (preg_match('#^/a/b\'b/(?P<foo1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array ());
+                if (\preg_match('#^/a/b\'b/(?P<foo1>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo2')), array ());
                 }
 
                 // bar2
-                if (preg_match('#^/a/b\'b/(?P<bar1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array ());
+                if (\preg_match('#^/a/b\'b/(?P<bar1>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($matches, array('_route' => 'bar2')), array ());
                 }
 
             }
 
         }
 
-        elseif (0 === strpos($pathinfo, '/multi')) {
+        elseif (0 === \strpos($pathinfo, '/multi')) {
             // helloWorld
-            if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?P<who>[^/]++))?$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
+            if (0 === \strpos($pathinfo, '/multi/hello') && \preg_match('#^/multi/hello(?:/(?P<who>[^/]++))?$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
             }
 
             // hey
@@ -184,31 +184,31 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // foo3
-        if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array ());
+        if (\preg_match('#^/(?P<_locale>[^/]++)/b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo3')), array ());
         }
 
         // bar3
-        if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array ());
+        if (\preg_match('#^/(?P<_locale>[^/]++)/b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'bar3')), array ());
         }
 
-        if (0 === strpos($pathinfo, '/aba')) {
+        if (0 === \strpos($pathinfo, '/aba')) {
             // ababa
             if ('/ababa' === $pathinfo) {
                 return array('_route' => 'ababa');
             }
 
             // foo4
-            if (preg_match('#^/aba/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array ());
+            if (\preg_match('#^/aba/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo4')), array ());
             }
 
         }
 
         $host = $context->getHost();
 
-        if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route1
             if ('/route1' === $pathinfo) {
                 return array('_route' => 'route1');
@@ -221,7 +221,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         }
 
-        if (preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
             // route3
             if ('/c2/route3' === $pathinfo) {
                 return array('_route' => 'route3');
@@ -229,7 +229,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         }
 
-        if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route4
             if ('/route4' === $pathinfo) {
                 return array('_route' => 'route4');
@@ -237,7 +237,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         }
 
-        if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route5
             if ('/route5' === $pathinfo) {
                 return array('_route' => 'route5');
@@ -250,43 +250,43 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return array('_route' => 'route6');
         }
 
-        if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#si', $host, $hostMatches)) {
-            if (0 === strpos($pathinfo, '/route1')) {
+        if (\preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#si', $host, $hostMatches)) {
+            if (0 === \strpos($pathinfo, '/route1')) {
                 // route11
                 if ('/route11' === $pathinfo) {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+                    return $this->mergeDefaults(\array_replace($hostMatches, array('_route' => 'route11')), array ());
                 }
 
                 // route12
                 if ('/route12' === $pathinfo) {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+                    return $this->mergeDefaults(\array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
                 }
 
                 // route13
-                if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+                if (0 === \strpos($pathinfo, '/route13') && \preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
                 }
 
                 // route14
-                if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
+                if (0 === \strpos($pathinfo, '/route14') && \preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
                 }
 
             }
 
         }
 
-        if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route15
-            if (0 === strpos($pathinfo, '/route15') && preg_match('#^/route15/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array ());
+            if (0 === \strpos($pathinfo, '/route15') && \preg_match('#^/route15/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'route15')), array ());
             }
 
         }
 
         // route16
-        if (0 === strpos($pathinfo, '/route16') && preg_match('#^/route16/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
+        if (0 === \strpos($pathinfo, '/route16') && \preg_match('#^/route16/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
         }
 
         // route17
@@ -299,19 +299,19 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return array('_route' => 'a');
         }
 
-        if (0 === strpos($pathinfo, '/a/b')) {
+        if (0 === \strpos($pathinfo, '/a/b')) {
             // b
-            if (preg_match('#^/a/b/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array ());
+            if (\preg_match('#^/a/b/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'b')), array ());
             }
 
             // c
-            if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array ());
+            if (0 === \strpos($pathinfo, '/a/b/c') && \preg_match('#^/a/b/c/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'c')), array ());
             }
 
         }
 
-        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+        throw 0 < \count($allow) ? new MethodNotAllowedException(\array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -23,8 +23,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
     public function match($pathinfo)
     {
         $allow = array();
-        $pathinfo = rawurldecode($pathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
+        $pathinfo = \rawurldecode($pathinfo);
+        $trimmedPathinfo = \rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -35,10 +35,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
 
-        if (0 === strpos($pathinfo, '/foo')) {
+        if (0 === \strpos($pathinfo, '/foo')) {
             // foo
-            if (preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
+            if (\preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
             }
 
             // foofoo
@@ -48,33 +48,33 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         }
 
-        elseif (0 === strpos($pathinfo, '/bar')) {
+        elseif (0 === \strpos($pathinfo, '/bar')) {
             // bar
-            if (preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+            if (\preg_match('#^/bar/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
                 if ('GET' !== $canonicalMethod) {
                     $allow[] = 'GET';
                     goto not_bar;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array ());
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'bar')), array ());
             }
             not_bar:
 
             // barhead
-            if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+            if (0 === \strpos($pathinfo, '/barhead') && \preg_match('#^/barhead/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
                 if ('GET' !== $canonicalMethod) {
                     $allow[] = 'GET';
                     goto not_barhead;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array ());
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'barhead')), array ());
             }
             not_barhead:
 
         }
 
-        elseif (0 === strpos($pathinfo, '/test')) {
-            if (0 === strpos($pathinfo, '/test/baz')) {
+        elseif (0 === \strpos($pathinfo, '/test')) {
+            if (0 === \strpos($pathinfo, '/test/baz')) {
                 // baz
                 if ('/test/baz' === $pathinfo) {
                     return array('_route' => 'baz');
@@ -87,7 +87,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
                 // baz3
                 if ('/test/baz3' === $trimmedPathinfo) {
-                    if (substr($pathinfo, -1) !== '/') {
+                    if (\substr($pathinfo, -1) !== '/') {
                         return $this->redirect($pathinfo.'/', 'baz3');
                     }
 
@@ -97,41 +97,41 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             }
 
             // baz4
-            if (preg_match('#^/test/(?P<foo>[^/]++)/?$#s', $pathinfo, $matches)) {
-                if (substr($pathinfo, -1) !== '/') {
+            if (\preg_match('#^/test/(?P<foo>[^/]++)/?$#s', $pathinfo, $matches)) {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'baz4');
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'baz4')), array ());
             }
 
             // baz5
-            if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+            if (\preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
                 if ('POST' !== $canonicalMethod) {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array ());
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'baz5')), array ());
             }
             not_baz5:
 
             // baz.baz6
-            if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+            if (\preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
                 if ('PUT' !== $canonicalMethod) {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array ());
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'baz.baz6')), array ());
             }
             not_bazbaz6:
 
         }
 
         // quoter
-        if (preg_match('#^/(?P<quoter>[\']+)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array ());
+        if (\preg_match('#^/(?P<quoter>[\']+)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'quoter')), array ());
         }
 
         // space
@@ -139,49 +139,49 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             return array('_route' => 'space');
         }
 
-        if (0 === strpos($pathinfo, '/a')) {
-            if (0 === strpos($pathinfo, '/a/b\'b')) {
+        if (0 === \strpos($pathinfo, '/a')) {
+            if (0 === \strpos($pathinfo, '/a/b\'b')) {
                 // foo1
-                if (preg_match('#^/a/b\'b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array ());
+                if (\preg_match('#^/a/b\'b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo1')), array ());
                 }
 
                 // bar1
-                if (preg_match('#^/a/b\'b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array ());
+                if (\preg_match('#^/a/b\'b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($matches, array('_route' => 'bar1')), array ());
                 }
 
             }
 
             // overridden
-            if (preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array ());
+            if (\preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'overridden')), array ());
             }
 
-            if (0 === strpos($pathinfo, '/a/b\'b')) {
+            if (0 === \strpos($pathinfo, '/a/b\'b')) {
                 // foo2
-                if (preg_match('#^/a/b\'b/(?P<foo1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array ());
+                if (\preg_match('#^/a/b\'b/(?P<foo1>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo2')), array ());
                 }
 
                 // bar2
-                if (preg_match('#^/a/b\'b/(?P<bar1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array ());
+                if (\preg_match('#^/a/b\'b/(?P<bar1>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($matches, array('_route' => 'bar2')), array ());
                 }
 
             }
 
         }
 
-        elseif (0 === strpos($pathinfo, '/multi')) {
+        elseif (0 === \strpos($pathinfo, '/multi')) {
             // helloWorld
-            if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?P<who>[^/]++))?$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
+            if (0 === \strpos($pathinfo, '/multi/hello') && \preg_match('#^/multi/hello(?:/(?P<who>[^/]++))?$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
             }
 
             // hey
             if ('/multi/hey' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'hey');
                 }
 
@@ -196,31 +196,31 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // foo3
-        if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array ());
+        if (\preg_match('#^/(?P<_locale>[^/]++)/b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo3')), array ());
         }
 
         // bar3
-        if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array ());
+        if (\preg_match('#^/(?P<_locale>[^/]++)/b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'bar3')), array ());
         }
 
-        if (0 === strpos($pathinfo, '/aba')) {
+        if (0 === \strpos($pathinfo, '/aba')) {
             // ababa
             if ('/ababa' === $pathinfo) {
                 return array('_route' => 'ababa');
             }
 
             // foo4
-            if (preg_match('#^/aba/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array ());
+            if (\preg_match('#^/aba/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'foo4')), array ());
             }
 
         }
 
         $host = $context->getHost();
 
-        if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route1
             if ('/route1' === $pathinfo) {
                 return array('_route' => 'route1');
@@ -233,7 +233,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         }
 
-        if (preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
             // route3
             if ('/c2/route3' === $pathinfo) {
                 return array('_route' => 'route3');
@@ -241,7 +241,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         }
 
-        if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
             // route4
             if ('/route4' === $pathinfo) {
                 return array('_route' => 'route4');
@@ -249,7 +249,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         }
 
-        if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route5
             if ('/route5' === $pathinfo) {
                 return array('_route' => 'route5');
@@ -262,43 +262,43 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             return array('_route' => 'route6');
         }
 
-        if (preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#si', $host, $hostMatches)) {
-            if (0 === strpos($pathinfo, '/route1')) {
+        if (\preg_match('#^(?P<var1>[^\\.]++)\\.example\\.com$#si', $host, $hostMatches)) {
+            if (0 === \strpos($pathinfo, '/route1')) {
                 // route11
                 if ('/route11' === $pathinfo) {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+                    return $this->mergeDefaults(\array_replace($hostMatches, array('_route' => 'route11')), array ());
                 }
 
                 // route12
                 if ('/route12' === $pathinfo) {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+                    return $this->mergeDefaults(\array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
                 }
 
                 // route13
-                if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+                if (0 === \strpos($pathinfo, '/route13') && \preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
                 }
 
                 // route14
-                if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
+                if (0 === \strpos($pathinfo, '/route14') && \preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                    return $this->mergeDefaults(\array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
                 }
 
             }
 
         }
 
-        if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
+        if (\preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route15
-            if (0 === strpos($pathinfo, '/route15') && preg_match('#^/route15/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array ());
+            if (0 === \strpos($pathinfo, '/route15') && \preg_match('#^/route15/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'route15')), array ());
             }
 
         }
 
         // route16
-        if (0 === strpos($pathinfo, '/route16') && preg_match('#^/route16/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
+        if (0 === \strpos($pathinfo, '/route16') && \preg_match('#^/route16/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
         }
 
         // route17
@@ -311,15 +311,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             return array('_route' => 'a');
         }
 
-        if (0 === strpos($pathinfo, '/a/b')) {
+        if (0 === \strpos($pathinfo, '/a/b')) {
             // b
-            if (preg_match('#^/a/b/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array ());
+            if (\preg_match('#^/a/b/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'b')), array ());
             }
 
             // c
-            if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array ());
+            if (0 === \strpos($pathinfo, '/a/b/c') && \preg_match('#^/a/b/c/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'c')), array ());
             }
 
         }
@@ -328,7 +328,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if ('/secure' === $pathinfo) {
             $requiredSchemes = array (  'https' => 0,);
             if (!isset($requiredSchemes[$scheme])) {
-                return $this->redirect($pathinfo, 'secure', key($requiredSchemes));
+                return $this->redirect($pathinfo, 'secure', \key($requiredSchemes));
             }
 
             return array('_route' => 'secure');
@@ -338,12 +338,12 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if ('/nonsecure' === $pathinfo) {
             $requiredSchemes = array (  'http' => 0,);
             if (!isset($requiredSchemes[$scheme])) {
-                return $this->redirect($pathinfo, 'nonsecure', key($requiredSchemes));
+                return $this->redirect($pathinfo, 'nonsecure', \key($requiredSchemes));
             }
 
             return array('_route' => 'nonsecure');
         }
 
-        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+        throw 0 < \count($allow) ? new MethodNotAllowedException(\array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -23,8 +23,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     public function match($pathinfo)
     {
         $allow = array();
-        $pathinfo = rawurldecode($pathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
+        $pathinfo = \rawurldecode($pathinfo);
+        $trimmedPathinfo = \rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -35,15 +35,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
 
-        if (0 === strpos($pathinfo, '/rootprefix')) {
+        if (0 === \strpos($pathinfo, '/rootprefix')) {
             // static
             if ('/rootprefix/test' === $pathinfo) {
                 return array('_route' => 'static');
             }
 
             // dynamic
-            if (preg_match('#^/rootprefix/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'dynamic')), array ());
+            if (\preg_match('#^/rootprefix/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
+                return $this->mergeDefaults(\array_replace($matches, array('_route' => 'dynamic')), array ());
             }
 
         }
@@ -53,6 +53,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return array('_route' => 'with-condition');
         }
 
-        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+        throw 0 < \count($allow) ? new MethodNotAllowedException(\array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -23,8 +23,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     public function match($pathinfo)
     {
         $allow = array();
-        $pathinfo = rawurldecode($pathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
+        $pathinfo = \rawurldecode($pathinfo);
+        $trimmedPathinfo = \rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -59,8 +59,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         // post_and_head
         if ('/post_and_get' === $pathinfo) {
-            if (!in_array($requestMethod, array('POST', 'HEAD'))) {
-                $allow = array_merge($allow, array('POST', 'HEAD'));
+            if (!\in_array($requestMethod, array('POST', 'HEAD'))) {
+                $allow = \array_merge($allow, array('POST', 'HEAD'));
                 goto not_post_and_head;
             }
 
@@ -68,11 +68,11 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
         not_post_and_head:
 
-        if (0 === strpos($pathinfo, '/put_and_post')) {
+        if (0 === \strpos($pathinfo, '/put_and_post')) {
             // put_and_post
             if ('/put_and_post' === $pathinfo) {
-                if (!in_array($requestMethod, array('PUT', 'POST'))) {
-                    $allow = array_merge($allow, array('PUT', 'POST'));
+                if (!\in_array($requestMethod, array('PUT', 'POST'))) {
+                    $allow = \array_merge($allow, array('PUT', 'POST'));
                     goto not_put_and_post;
                 }
 
@@ -82,8 +82,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // put_and_get_and_head
             if ('/put_and_post' === $pathinfo) {
-                if (!in_array($canonicalMethod, array('PUT', 'GET'))) {
-                    $allow = array_merge($allow, array('PUT', 'GET'));
+                if (!\in_array($canonicalMethod, array('PUT', 'GET'))) {
+                    $allow = \array_merge($allow, array('PUT', 'GET'));
                     goto not_put_and_get_and_head;
                 }
 
@@ -93,6 +93,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         }
 
-        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+        throw 0 < \count($allow) ? new MethodNotAllowedException(\array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher5.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher5.php
@@ -23,8 +23,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
     public function match($pathinfo)
     {
         $allow = array();
-        $pathinfo = rawurldecode($pathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
+        $pathinfo = \rawurldecode($pathinfo);
+        $trimmedPathinfo = \rtrim($pathinfo, '/');
         $context = $this->context;
         $request = $this->request;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -35,7 +35,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
 
-        if (0 === strpos($pathinfo, '/a')) {
+        if (0 === \strpos($pathinfo, '/a')) {
             // a_first
             if ('/a/11' === $pathinfo) {
                 return array('_route' => 'a_first');
@@ -54,14 +54,14 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // a_wildcard
-        if (preg_match('#^/(?P<param>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'a_wildcard')), array ());
+        if (\preg_match('#^/(?P<param>[^/]++)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'a_wildcard')), array ());
         }
 
-        if (0 === strpos($pathinfo, '/a')) {
+        if (0 === \strpos($pathinfo, '/a')) {
             // a_fourth
             if ('/a/44' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'a_fourth');
                 }
 
@@ -70,7 +70,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // a_fifth
             if ('/a/55' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'a_fifth');
                 }
 
@@ -79,7 +79,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // a_sixth
             if ('/a/66' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'a_sixth');
                 }
 
@@ -89,14 +89,14 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // nested_wildcard
-        if (0 === strpos($pathinfo, '/nested') && preg_match('#^/nested/(?P<param>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'nested_wildcard')), array ());
+        if (0 === \strpos($pathinfo, '/nested') && \preg_match('#^/nested/(?P<param>[^/]++)$#s', $pathinfo, $matches)) {
+            return $this->mergeDefaults(\array_replace($matches, array('_route' => 'nested_wildcard')), array ());
         }
 
-        if (0 === strpos($pathinfo, '/nested/group')) {
+        if (0 === \strpos($pathinfo, '/nested/group')) {
             // nested_a
             if ('/nested/group/a' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'nested_a');
                 }
 
@@ -105,7 +105,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // nested_b
             if ('/nested/group/b' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'nested_b');
                 }
 
@@ -114,7 +114,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // nested_c
             if ('/nested/group/c' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'nested_c');
                 }
 
@@ -123,10 +123,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         }
 
-        elseif (0 === strpos($pathinfo, '/slashed/group')) {
+        elseif (0 === \strpos($pathinfo, '/slashed/group')) {
             // slashed_a
             if ('/slashed/group' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'slashed_a');
                 }
 
@@ -135,7 +135,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // slashed_b
             if ('/slashed/group/b' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'slashed_b');
                 }
 
@@ -144,7 +144,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // slashed_c
             if ('/slashed/group/c' === $trimmedPathinfo) {
-                if (substr($pathinfo, -1) !== '/') {
+                if (\substr($pathinfo, -1) !== '/') {
                     return $this->redirect($pathinfo.'/', 'slashed_c');
                 }
 
@@ -153,6 +153,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         }
 
-        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+        throw 0 < \count($allow) ? new MethodNotAllowedException(\array_unique($allow)) : new ResourceNotFoundException();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Just wondering @frankdejonge: can you spot any performance benefits doing this on PHP7 with your benchs (since you did some recently?)