### PR TITLE
[Console] Fix table cell styling

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -110,6 +110,11 @@ abstract class Helper implements HelperInterface
 
     public static function strlenWithoutDecoration(OutputFormatterInterface $formatter, $string)
     {
+        return self::strlen(self::removeDecoration($formatter, $string));
+    }
+
+    public static function removeDecoration(OutputFormatterInterface $formatter, $string)
+    {
         $isDecorated = $formatter->isDecorated();
         $formatter->setDecorated(false);
         // remove <...> formatting
@@ -118,6 +123,6 @@ abstract class Helper implements HelperInterface
         $string = preg_replace("/\033\[[^m]*m/", '', $string);
         $formatter->setDecorated($isDecorated);
 
-        return self::strlen($string);
+        return $string;
     }
 }

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -341,7 +341,7 @@ class Table
                 if (!strstr($cell, "\n")) {
                     continue;
                 }
-                $lines = explode("\n", $cell);
+                $lines = explode("\n", str_replace("\n", "<fg=default;bg=default>\n</>", $cell));
                 foreach ($lines as $lineKey => $line) {
                     if ($cell instanceof TableCell) {
                         $line = new TableCell($line, array('colspan' => $cell->getColspan()));
@@ -382,7 +382,7 @@ class Table
                 $nbLines = $cell->getRowspan() - 1;
                 $lines = array($cell);
                 if (strstr($cell, "\n")) {
-                    $lines = explode("\n", $cell);
+                    $lines = explode("\n", str_replace("\n", "<fg=default;bg=default>\n</>", $cell));
                     $nbLines = count($lines) > $nbLines ? substr_count($cell, "\n") : $nbLines;
 
                     $rows[$line][$column] = new TableCell($lines[0], array('colspan' => $cell->getColspan()));
@@ -514,6 +514,8 @@ class Table
             return $this->columnWidths[$column];
         }
 
+        $lengths = array();
+
         foreach (array_merge($this->headers, $this->rows) as $row) {
             if ($row instanceof TableSeparator) {
                 continue;
@@ -521,9 +523,10 @@ class Table
 
             foreach ($row as $i => $cell) {
                 if ($cell instanceof TableCell) {
-                    $textLength = Helper::strlenWithoutDecoration($this->output->getFormatter(), $cell);
+                    $textContent = Helper::removeDecoration($this->output->getFormatter(), $cell);
+                    $textLength = Helper::strlen($textContent);
                     if ($textLength > 0) {
-                        $contentColumns = str_split($cell, ceil($textLength / $cell->getColspan()));
+                        $contentColumns = str_split($textContent, ceil($textLength / $cell->getColspan()));
                         foreach ($contentColumns as $position => $content) {
                             $row[$i + $position] = $content;
                         }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -515,6 +515,35 @@ TABLE
             ,
                 true,
             ),
+            'Row with formatted cells containing a newline' => array(
+                array(),
+                array(
+                    array(
+                        new TableCell('<error>Dont break'."\n".'here</error>', array('colspan' => 2)),
+                    ),
+                    new TableSeparator(),
+                    array(
+                        'foo',
+                         new TableCell('<error>Dont break'."\n".'here</error>', array('rowspan' => 2)),
+                    ),
+                    array(
+                        'bar',
+                    ),
+                ),
+                'default',
+                <<<'TABLE'
++-------+------------+
+[39;49m| [39;49m[37;41mDont break[39;49m[39;49m         |[39;49m
+[39;49m| [39;49m[37;41mhere[39;49m               |
++-------+------------+
+[39;49m| foo   | [39;49m[37;41mDont break[39;49m[39;49m |[39;49m
+[39;49m| bar   | [39;49m[37;41mhere[39;49m       |
++-------+------------+
+
+TABLE
+            ,
+                true,
+            ),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | tiny one
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Fixes an issue with newlines and table cells. Remembered this little trick from @chalasr as we had it before with style blocks i believe..

```php
$table = new Table($output);
$table->setRows(array(
    array(new TableCell('<error>Dont break'."\n".'here</error>', array('colspan' => 2))),
    new TableSeparator(),
    array('foo', new TableCell('<error>Dont break'."\n".'here</error>', array('rowspan' => 2))),
    array('bar'),
));
$table->render();
```

Before

![image](https://cloud.githubusercontent.com/assets/1047696/24467857/74dacc9e-14b6-11e7-8f62-3831508ac949.png)

After

![image](https://cloud.githubusercontent.com/assets/1047696/24467923/bb578f0e-14b6-11e7-85ed-039cd73b81a0.png)
