### PR TITLE
[Console] Support formatted text cutting

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * deprecated passing a command as a string to `ProcessHelper::run()`,
    pass it the command as an array of its arguments instead
  * made the `ProcessHelper` class final
+ * added `WrappableOutputFormatterInterface::formatAndWrap()` (implemented in `OutputFormatter`)
 
 4.1.0
 -----

--- a/src/Symfony/Component/Console/Formatter/WrappableOutputFormatterInterface.php
+++ b/src/Symfony/Component/Console/Formatter/WrappableOutputFormatterInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Formatter;
+
+/**
+ * Formatter interface for console output that supports word wrapping.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+interface WrappableOutputFormatterInterface extends OutputFormatterInterface
+{
+    /**
+     * Formats a message according to the given styles, wrapping at `$width` (0 means no wrapping).
+     */
+    public function formatAndWrap(string $message, int $width);
+}

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -322,6 +322,17 @@ more text
 EOF
         ));
     }
+
+    public function testFormatAndWrap()
+    {
+        $formatter = new OutputFormatter(true);
+
+        $this->assertSame("pre\n\033[37;41mfoo\nbar\nbaz\033[39;49m\npos\nt", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 3));
+
+        $formatter = new OutputFormatter();
+
+        $this->assertSame("pre\nfoo\nbar\nbaz\npos\nt", $formatter->formatAndWrap('pre <error>foo bar baz</error> post', 3));
+    }
 }
 
 class TableCell


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

allows cutting a formatted text to a certain width. Actually needed if we want to support max. column widths in tables (see #22156)

```php
$text = 'pre <error>foo bar baz</error> post';
dump('BEFORE');
$output->writeln(wordwrap($output->getFormatter()->format($text), 3, "\n", true), OutputInterface::OUTPUT_RAW);
dump('AFTER');
$output->writeln($output->getFormatter()->format($text, 3), OutputInterface::OUTPUT_RAW);
```
![image](https://cloud.githubusercontent.com/assets/1047696/24519346/19c9b0ca-1585-11e7-8437-0bcfb6fab63e.png)