### PR TITLE
[HttpKernel] minor: add ability to construct with headers on http exceptions

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
@@ -25,9 +25,10 @@ class AccessDeniedHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(403, $message, $previous, array(), $code);
+        parent::__construct(403, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
@@ -24,9 +24,10 @@ class BadRequestHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(400, $message, $previous, array(), $code);
+        parent::__construct(400, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
@@ -24,9 +24,10 @@ class ConflictHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(409, $message, $previous, array(), $code);
+        parent::__construct(409, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
@@ -24,9 +24,10 @@ class GoneHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(410, $message, $previous, array(), $code);
+        parent::__construct(410, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
@@ -24,9 +24,10 @@ class LengthRequiredHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(411, $message, $previous, array(), $code);
+        parent::__construct(411, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
@@ -25,10 +25,11 @@ class MethodNotAllowedHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct(array $allow, $message = null, \Exception $previous = null, $code = 0)
+    public function __construct(array $allow, $message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        $headers = array('Allow' => strtoupper(implode(', ', $allow)));
+        $headers['Allow'] = strtoupper(implode(', ', $allow));
 
         parent::__construct(405, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
@@ -24,9 +24,10 @@ class NotAcceptableHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(406, $message, $previous, array(), $code);
+        parent::__construct(406, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
@@ -24,9 +24,10 @@ class NotFoundHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(404, $message, $previous, array(), $code);
+        parent::__construct(404, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
@@ -24,9 +24,10 @@ class PreconditionFailedHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(412, $message, $previous, array(), $code);
+        parent::__construct(412, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
@@ -26,9 +26,10 @@ class PreconditionRequiredHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(428, $message, $previous, array(), $code);
+        parent::__construct(428, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
@@ -25,12 +25,12 @@ class ServiceUnavailableHttpException extends HttpException
      * @param string     $message    The internal exception message
      * @param \Exception $previous   The previous exception
      * @param int        $code       The internal exception code
+     * @param array      $headers
      */
-    public function __construct($retryAfter = null, $message = null, \Exception $previous = null, $code = 0)
+    public function __construct($retryAfter = null, $message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        $headers = array();
         if ($retryAfter) {
-            $headers = array('Retry-After' => $retryAfter);
+            $headers['Retry-After'] = $retryAfter;
         }
 
         parent::__construct(503, $message, $previous, $headers, $code);

--- a/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
@@ -27,12 +27,12 @@ class TooManyRequestsHttpException extends HttpException
      * @param string     $message    The internal exception message
      * @param \Exception $previous   The previous exception
      * @param int        $code       The internal exception code
+     * @param array      $headers
      */
-    public function __construct($retryAfter = null, $message = null, \Exception $previous = null, $code = 0)
+    public function __construct($retryAfter = null, $message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        $headers = array();
         if ($retryAfter) {
-            $headers = array('Retry-After' => $retryAfter);
+            $headers['Retry-After'] = $retryAfter;
         }
 
         parent::__construct(429, $message, $previous, $headers, $code);

--- a/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
@@ -25,10 +25,11 @@ class UnauthorizedHttpException extends HttpException
      * @param string     $message   The internal exception message
      * @param \Exception $previous  The previous exception
      * @param int        $code      The internal exception code
+     * @param array      $headers
      */
-    public function __construct($challenge, $message = null, \Exception $previous = null, $code = 0)
+    public function __construct($challenge, $message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        $headers = array('WWW-Authenticate' => $challenge);
+        $headers['WWW-Authenticate'] = $challenge;
 
         parent::__construct(401, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
@@ -24,9 +24,10 @@ class UnprocessableEntityHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(422, $message, $previous, array(), $code);
+        parent::__construct(422, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
@@ -24,9 +24,10 @@ class UnsupportedMediaTypeHttpException extends HttpException
      * @param string     $message  The internal exception message
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
+     * @param array      $headers
      */
-    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    public function __construct($message = null, \Exception $previous = null, $code = 0, array $headers = array())
     {
-        parent::__construct(415, $message, $previous, array(), $code);
+        parent::__construct(415, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
@@ -12,6 +12,19 @@ class MethodNotAllowedHttpExceptionTest extends HttpExceptionTest
         $this->assertSame(array('Allow' => 'GET, PUT'), $exception->getHeaders());
     }
 
+    public function testWithHeaderConstruct()
+    {
+        $headers = array(
+            'Cache-Control' => 'public, s-maxage=1200',
+        );
+
+        $exception = new MethodNotAllowedHttpException(array('get'), null, null, null, $headers);
+
+        $headers['Allow'] = 'GET';
+
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+
     /**
      * @dataProvider headerDataProvider
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
@@ -12,6 +12,19 @@ class ServiceUnavailableHttpExceptionTest extends HttpExceptionTest
         $this->assertSame(array('Retry-After' => 10), $exception->getHeaders());
     }
 
+    public function testWithHeaderConstruct()
+    {
+        $headers = array(
+            'Cache-Control' => 'public, s-maxage=1337',
+        );
+
+        $exception = new ServiceUnavailableHttpException(1337, null, null, null, $headers);
+
+        $headers['Retry-After'] = 1337;
+
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+
     /**
      * @dataProvider headerDataProvider
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
@@ -12,6 +12,19 @@ class TooManyRequestsHttpExceptionTest extends HttpExceptionTest
         $this->assertSame(array('Retry-After' => 10), $exception->getHeaders());
     }
 
+    public function testWithHeaderConstruct()
+    {
+        $headers = array(
+            'Cache-Control' => 'public, s-maxage=69',
+        );
+
+        $exception = new TooManyRequestsHttpException(69, null, null, null, $headers);
+
+        $headers['Retry-After'] = 69;
+
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+
     /**
      * @dataProvider headerDataProvider
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
@@ -12,6 +12,19 @@ class UnauthorizedHttpExceptionTest extends HttpExceptionTest
         $this->assertSame(array('WWW-Authenticate' => 'Challenge'), $exception->getHeaders());
     }
 
+    public function testWithHeaderConstruct()
+    {
+        $headers = array(
+            'Cache-Control' => 'public, s-maxage=1200',
+        );
+
+        $exception = new UnauthorizedHttpException('Challenge', null, null, null, $headers);
+
+        $headers['WWW-Authenticate'] = 'Challenge';
+
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+
     /**
      * @dataProvider headerDataProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This adds the ability to set the headers for the exception within the constructor.

With alot of the following exceptions its sometimes very useful to be able to set the headers. For example with a reverse proxy cache (Varnish) if you want to match the `Retry-After` with a Varnish cache header to protect the backend. 

I see that `setHeaders()` did get added https://github.com/symfony/symfony/commit/6a1080f899f0661a2724d81f6629d4ca7009f16b but that means the exception needs to be assigned to a variable and set and then thrown, it also doesn't merge with the existing header set in some of the constructors. 

~~I've chosen to `array_merge()` where key/values~~ were being set within the constructor as I think this is the most useful and 'correct' whereas `setHeaders` is explicit that its setting not amending or adding to. 

