### PR TITLE
[Form] Avoid forcing to define the choices_as_values option when using choice_loader

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -357,7 +357,7 @@ class ChoiceType extends AbstractType
         };
 
         $choicesAsValuesNormalizer = function (Options $options, $choicesAsValues) use ($that) {
-            if (true !== $choicesAsValues) {
+            if (true !== $choicesAsValues && null === $options['choice_loader']) {
                 @trigger_error(sprintf('The value "false" for the "choices_as_values" option of the "%s" form type (%s) is deprecated since version 2.8 and will not be supported anymore in 3.0. Set this option to "true" and flip the contents of the "choices" option instead.', $that->getName(), __CLASS__), E_USER_DEPRECATED);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When using the choice loader, choices are ignored entirely. Forcing the dev to add the choices_as_values just to avoid the deprecation warning (and then to remove the option again at some point in 3.x due to deprecation) is a bad developer experience.