### PR TITLE
CS: Remove invisible chars

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -120,7 +120,7 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
 
         $formatter = $this->getNumberFormatter();
         // replace normal spaces so that the formatter can read them
-        $value = $formatter->parse(str_replace(' ', pack('CC', 0xc2, 0xa0), $value));
+        $value = $formatter->parse(str_replace(' ', "\xc2\xa0", $value));
 
         if (intl_is_failure($formatter->getErrorCode())) {
             throw new TransformationFailedException($formatter->getErrorMessage());

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -120,7 +120,7 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
 
         $formatter = $this->getNumberFormatter();
         // replace normal spaces so that the formatter can read them
-        $value = $formatter->parse(str_replace(' ', ' ', $value));
+        $value = $formatter->parse(str_replace(' ', pack('CC', 0xc2, 0xa0), $value));
 
         if (intl_is_failure($formatter->getErrorCode())) {
             throw new TransformationFailedException($formatter->getErrorMessage());

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -59,7 +59,7 @@ class ValidatorExtension extends AbstractExtension
 
     public function loadTypeGuesser()
     {
-        // 2.5 API
+        // 2.5 API
         if ($this->validator instanceof ValidatorInterface) {
             return new ValidatorTypeGuesser($this->validator);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I found out that we have 2 non-visible in regular IDE chars in codebase.
One is just inside a comment, it could be safely removed.
But second is inside a real code, I have replaced it with `pack`, so one won't accidentally replace non-breaking space with regular space.