### PR TITLE
Fix tests expecting a valid date

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -598,7 +598,7 @@ class DateTypeTest extends BaseTypeTest
         ));
 
         $form->submit(array(
-            'day' => '0',
+            'day' => '1',
             'month' => '6',
             'year' => '2010',
         ));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Tests are failing in 2.7 and 2.8 because the day 0 is not considered valid.
