### PR TITLE
[BC BREAK][HttpFoundation] Request::setTrustedProxies() takes a new required $trustedHeaderSet argument

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -207,9 +207,8 @@ FrameworkBundle
 HttpFoundation
 --------------
 
- * The `Request::setTrustedProxies()` method takes a new `$trustedHeaderSet` argument - not setting it is deprecated.
-   Set it to `Request::HEADER_FORWARDED` if your reverse-proxy uses the RFC7239 `Forwarded` header,
-   or to `Request::HEADER_X_FORWARDED_ALL` if it is using `X-Forwarded-*` headers instead.
+ * [BC BREAK] The `Request::setTrustedProxies()` method takes a new `$trustedHeaderSet` argument.
+   See http://symfony.com/doc/current/components/http_foundation/trusting_proxies.html for more info.
 
  * The `Request::setTrustedHeaderName()` and `Request::getTrustedHeaderName()` methods are deprecated,
    use the RFC7239 `Forwarded` header, or the `X-Forwarded-*` headers instead.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -300,8 +300,7 @@ HttpFoundation
 --------------
 
  * The `Request::setTrustedProxies()` method takes a new `$trustedHeaderSet` argument.
-   Set it to `Request::HEADER_FORWARDED` if your reverse-proxy uses the RFC7239 `Forwarded` header,
-   or to `Request::HEADER_X_FORWARDED_ALL` if it is using `X-Forwarded-*` headers instead.
+   See http://symfony.com/doc/current/components/http_foundation/trusting_proxies.html for more info.
 
  * The `Request::setTrustedHeaderName()` and `Request::getTrustedHeaderName()` methods have been removed.
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.3.0
 -----
 
+ * [BC BREAK] Removed the "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies" parameter
  * Added a new new version strategy option called json_manifest_path
    that allows you to use the `JsonManifestVersionStrategy`.
  * Added `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`. It provides
@@ -11,7 +12,6 @@ CHANGELOG
    injection container, in order to encourage explicit dependency declarations.
  * Added support for the `controller.service_arguments` tag, for injecting services into controllers' actions
  * Deprecated `cache:clear` with warmup (always call it with `--no-warmup`)
- * Deprecated the "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies" parameter
  * Changed default configuration for
    assets/forms/validation/translation/serialization/csrf from `canBeEnabled()` to
    `canBeDisabled()` when Flex is used

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -59,48 +59,16 @@ class Configuration implements ConfigurationInterface
                     return $v;
                 })
             ->end()
-            ->beforeNormalization()
-                ->ifTrue(function ($v) { return isset($v['trusted_proxies']); })
-                ->then(function ($v) {
-                    @trigger_error('The "framework.trusted_proxies" configuration key is deprecated since version 3.3 and will be removed in 4.0. Use the Request::setTrustedProxies() method in your front controller instead.', E_USER_DEPRECATED);
-
-                    return $v;
-                })
-            ->end()
             ->children()
                 ->scalarNode('secret')->end()
                 ->scalarNode('http_method_override')
                     ->info("Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. Note: When using the HttpCache, you need to call the method in your front controller instead")
                     ->defaultTrue()
                 ->end()
-                ->arrayNode('trusted_proxies')
+                ->arrayNode('trusted_proxies') // @deprecated in version 3.3, to be removed in 4.0
                     ->beforeNormalization()
-                        ->ifTrue(function ($v) { return !is_array($v) && null !== $v; })
-                        ->then(function ($v) { return is_bool($v) ? array() : preg_split('/\s*,\s*/', $v); })
-                    ->end()
-                    ->prototype('scalar')
-                        ->validate()
-                            ->ifTrue(function ($v) {
-                                if (empty($v)) {
-                                    return false;
-                                }
-
-                                if (false !== strpos($v, '/')) {
-                                    if ('0.0.0.0/0' === $v) {
-                                        return false;
-                                    }
-
-                                    list($v, $mask) = explode('/', $v, 2);
-
-                                    if (strcmp($mask, (int) $mask) || $mask < 1 || $mask > (false !== strpos($v, ':') ? 128 : 32)) {
-                                        return true;
-                                    }
-                                }
-
-                                return !filter_var($v, FILTER_VALIDATE_IP);
-                            })
-                            ->thenInvalid('Invalid proxy IP "%s"')
-                        ->end()
+                        ->always()
+                        ->thenInvalid('The "framework.trusted_proxies" configuration key has been removed in Symfony 3.3. Use the Request::setTrustedProxies() method in your front controller instead.')
                     ->end()
                 ->end()
                 ->scalarNode('ide')->defaultNull()->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -124,7 +124,6 @@ class FrameworkExtension extends Extension
 
         $container->setParameter('kernel.http_method_override', $config['http_method_override']);
         $container->setParameter('kernel.trusted_hosts', $config['trusted_hosts']);
-        $container->setParameter('kernel.trusted_proxies', $config['trusted_proxies']);
         $container->setParameter('kernel.default_locale', $config['default_locale']);
 
         if (!$container->hasParameter('debug.file_link_format')) {

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -61,10 +61,12 @@ class FrameworkBundle extends Bundle
     {
         ErrorHandler::register(null, false)->throwAt($this->container->getParameter('debug.error_handler.throw_at'), true);
 
-        if ($trustedProxies = $this->container->getParameter('kernel.trusted_proxies')) {
+        if ($this->container->hasParameter('kernel.trusted_proxies')) {
             @trigger_error('The "kernel.trusted_proxies" parameter is deprecated since version 3.3 and will be removed in 4.0. Use the Request::setTrustedProxies() method in your front controller instead.', E_USER_DEPRECATED);
 
-            Request::setTrustedProxies($trustedProxies, Request::getTrustedHeaderSet());
+            if ($trustedProxies = $this->container->getParameter('kernel.trusted_proxies')) {
+                Request::setTrustedProxies($trustedProxies, Request::getTrustedHeaderSet());
+            }
         }
 
         if ($this->container->getParameter('kernel.http_method_override')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -43,70 +43,6 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(array('FrameworkBundle:Form'), $config['templating']['form']['resources']);
     }
 
-    /**
-     * @group legacy
-     * @dataProvider getTestValidTrustedProxiesData
-     */
-    public function testValidTrustedProxies($trustedProxies, $processedProxies)
-    {
-        $processor = new Processor();
-        $configuration = new Configuration(true);
-        $config = $processor->processConfiguration($configuration, array(array(
-            'secret' => 's3cr3t',
-            'trusted_proxies' => $trustedProxies,
-        )));
-
-        $this->assertEquals($processedProxies, $config['trusted_proxies']);
-    }
-
-    public function getTestValidTrustedProxiesData()
-    {
-        return array(
-            array(array('127.0.0.1'), array('127.0.0.1')),
-            array(array('::1'), array('::1')),
-            array(array('127.0.0.1', '::1'), array('127.0.0.1', '::1')),
-            array(null, array()),
-            array(false, array()),
-            array(array(), array()),
-            array(array('10.0.0.0/8'), array('10.0.0.0/8')),
-            array(array('::ffff:0:0/96'), array('::ffff:0:0/96')),
-            array(array('0.0.0.0/0'), array('0.0.0.0/0')),
-        );
-    }
-
-    /**
-     * @group legacy
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
-    public function testInvalidTypeTrustedProxies()
-    {
-        $processor = new Processor();
-        $configuration = new Configuration(true);
-        $processor->processConfiguration($configuration, array(
-            array(
-                'secret' => 's3cr3t',
-                'trusted_proxies' => 'Not an IP address',
-            ),
-        ));
-    }
-
-    /**
-     * @group legacy
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
-    public function testInvalidValueTrustedProxies()
-    {
-        $processor = new Processor();
-        $configuration = new Configuration(true);
-
-        $processor->processConfiguration($configuration, array(
-            array(
-                'secret' => 's3cr3t',
-                'trusted_proxies' => array('Not an IP address'),
-            ),
-        ));
-    }
-
     public function testAssetsCanBeEnabled()
     {
         $processor = new Processor();
@@ -188,7 +124,6 @@ class ConfigurationTest extends TestCase
     {
         return array(
             'http_method_override' => true,
-            'trusted_proxies' => array(),
             'ide' => null,
             'default_locale' => 'en',
             'csrf_protection' => array(

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 3.3.0
 -----
 
- * added `$trustedHeaderSet` argument to `Request::setTrustedProxies()` - deprecate not setting it,
+ * [BC BREAK] the `Request::setTrustedProxies()` method takes a new `$trustedHeaderSet` argument,
+   see http://symfony.com/doc/current/components/http_foundation/trusting_proxies.html for more info,
  * deprecated the `Request::setTrustedHeaderName()` and `Request::getTrustedHeaderName()` methods,
  * added `File\Stream`, to be passed to `BinaryFileResponse` when the size of the served file is unknown,
    disabling `Range` and `Content-Length` handling, switching to chunked encoding instead

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -589,9 +589,8 @@ class Request
         self::$trustedProxies = $proxies;
 
         if (2 > func_num_args()) {
-            @trigger_error(sprintf('The %s() method expects a bit field of Request::HEADER_* as second argument. Not defining it is deprecated since version 3.3 and will be required in 4.0.', __METHOD__), E_USER_DEPRECATED);
-
-            return;
+            // @deprecated code path in 3.3, to be replaced by mandatory argument in 4.0.
+            throw new \InvalidArgumentException(sprintf('The %s() method expects a bit field of Request::HEADER_* as second argument. Defining it is required since version 3.3. See http://symfony.com/doc/current/components/http_foundation/trusting_proxies.html for more info.', __METHOD__));
         }
         $trustedHeaderSet = func_get_arg(1);
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2127,22 +2127,6 @@ class RequestTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The Symfony\Component\HttpFoundation\Request::setTrustedProxies() method expects a bit field of Request::HEADER_* as second argument. Not defining it is deprecated since version 3.3 and will be required in 4.0.
-     * @expectedDeprecation The "Symfony\Component\HttpFoundation\Request::getTrustedHeaderName()" method is deprecated since version 3.3 and will be removed in 4.0. Use the Request::getTrustedHeaderSet() method instead.
-     */
-    public function testSetTrustedProxiesNoSecondArg()
-    {
-        Request::setTrustedProxies(array('8.8.8.8'));
-
-        $this->assertSame('FORWARDED', Request::getTrustedHeaderName(Request::HEADER_FORWARDED));
-        $this->assertSame('X_FORWARDED_FOR', Request::getTrustedHeaderName(Request::HEADER_CLIENT_IP));
-        $this->assertSame('X_FORWARDED_HOST', Request::getTrustedHeaderName(Request::HEADER_CLIENT_HOST));
-        $this->assertSame('X_FORWARDED_PORT', Request::getTrustedHeaderName(Request::HEADER_CLIENT_PORT));
-        $this->assertSame('X_FORWARDED_PROTO', Request::getTrustedHeaderName(Request::HEADER_CLIENT_PROTO));
-    }
-
-    /**
-     * @group legacy
      */
     public function testGetTrustedHeaderName()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #20178
| License       | MIT
| Doc PR        | -

As discussed in linked issue, and already deprecated by #21830

See http://symfony.com/blog/fixing-the-trusted-proxies-configuration-for-symfony-3-3