### PR TITLE
Update composer.json

### DIFF
--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -18,11 +18,11 @@
     "require": {
         "php": ">=5.3.9",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/debug": "^2.7.2|~3.0.0"
+        "symfony/debug": "^2.7.2"
     },
     "require-dev": {
-        "symfony/event-dispatcher": "~2.1|~3.0.0",
-        "symfony/process": "~2.1|~3.0.0",
+        "symfony/event-dispatcher": "~2.1",
+        "symfony/process": "~2.1",
         "psr/log": "~1.0"
     },
     "suggest": {


### PR DESCRIPTION
Before update, composer 1.4.1 was installing now unsupported version 3.0 of symfony/debug instead of 2.8.
This could also be seen as a feature to correct inside of composer, but it looks it could be fairly long to improve composer.

| Q             | A
| ------------- | ---
| Branch?       | master / 2.7, 2.8 or 3.2 <!-- see comment below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | yes/no
| Deprecations? | yes/no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
