### PR TITLE
[Yaml] Add support for ::class constants

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
    ```php
    Yaml::dump([], 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
    ```
+ * Added support for ::class constants
 
 3.2.0
 -----

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -627,6 +627,10 @@ class Inline
                                 return constant($const);
                             }
 
+                            if (class_exists($constWithoutClassSuffix = str_replace('::class', '', $const))) {
+                                return $constWithoutClassSuffix;
+                            }
+
                             throw new ParseException(sprintf('The constant "%s" is not defined.', $const));
                         }
                         if (self::$exceptionOnInvalidType) {

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -50,6 +50,8 @@ class InlineTest extends TestCase
     {
         return array(
             array('!php/const:Symfony\Component\Yaml\Yaml::PARSE_CONSTANT', Yaml::PARSE_CONSTANT),
+            array('!php/const:Symfony\Component\Yaml\Yaml::class', Yaml::class),
+            array('!php/const:Symfony\Component\Yaml\Yaml', Yaml::class),
             array('!php/const:PHP_INT_MAX', PHP_INT_MAX),
             array('[!php/const:PHP_INT_MAX]', array(PHP_INT_MAX)),
             array('{ foo: !php/const:PHP_INT_MAX }', array('foo' => PHP_INT_MAX)),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Current parser doesn't recognize FCQN constants via !php/const prefix, which means users have to define it as a regular string and they loose the checking if class/constant exists. This patch brings Yaml constant support a bit closer to native PHP constant resolving.