### PR TITLE
[PropertyInfo] Support nullable array or collection

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -242,7 +242,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
      * @param string $ucFirstProperty
      * @param int    $type
      *
-     * @return DocBlock|null
+     * @return array|null
      */
     private function getDocBlockFromMethod($class, $ucFirstProperty, $type)
     {
@@ -337,10 +337,10 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
                 $collectionValueType = null;
             } else {
                 $collectionKeyType = new Type(Type::BUILTIN_TYPE_INT);
-                $collectionValueType = new Type($phpType, false, $class);
+                $collectionValueType = new Type($phpType, $nullable, $class);
             }
 
-            return new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, $collectionKeyType, $collectionValueType);
+            return new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true, $collectionKeyType, $collectionValueType);
         }
 
         return new Type($phpType, $nullable, $class);

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
@@ -68,6 +68,7 @@ class PhpDocExtractorTest extends TestCase
             array('d', array(new Type(Type::BUILTIN_TYPE_BOOL)), null, null),
             array('e', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_RESOURCE))), null, null),
             array('f', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))), null, null),
+            array('g', array(new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)), 'Nullable array.', null),
             array('donotexist', null, null, null),
             array('staticGetter', null, null, null),
             array('staticSetter', null, null, null),

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
@@ -38,6 +38,7 @@ class ReflectionExtractorTest extends TestCase
                 'parent',
                 'collection',
                 'B',
+                'g',
                 'foo',
                 'foo2',
                 'foo3',

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -51,6 +51,13 @@ class Dummy extends ParentDummy
      */
     public $B;
 
+    /**
+     * Nullable array.
+     *
+     * @var array|null
+     */
+    public $g;
+
     public static function getStatic()
     {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22248
| License       | MIT
| Doc PR        | 

`@var array|null` was always considered as not nullable in the `PhpDocExtractor`.
