### PR TITLE
Fold Travis CI output by component

### DIFF
--- a/.github/travis_fold.sh
+++ b/.github/travis_fold.sh
@@ -9,7 +9,7 @@
 tfold () {
     FOLD=$(echo $1 | tr / .)
     echo "travis_fold:start:$FOLD"
-    echo -e "\\e[32m$FOLD\\e[0m"
+    echo -e "\\e[34m$1\\e[0m"
     sh -c "$2" && echo "travis_fold:end:$FOLD"
 }
 

--- a/.github/travis_fold.sh
+++ b/.github/travis_fold.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 #######################################
 # Fold Travis CI output

--- a/.github/travis_fold.sh
+++ b/.github/travis_fold.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+#######################################
+# Fold Travis CI output
+# Arguments:
+#   $1 fold name
+#   $2 command to execute
+#######################################
+fold () {
+    FOLD=$(echo $1 | tr / .)
+    echo "travis_fold:start:$FOLD"
+    echo -e "\\e[32m$FOLD\\e[0m"
+    sh -c "$2" && echo "travis_fold:end:$FOLD"
+}
+
+export -f fold

--- a/.github/travis_fold.sh
+++ b/.github/travis_fold.sh
@@ -6,11 +6,11 @@
 #   $1 fold name
 #   $2 command to execute
 #######################################
-fold () {
+tfold () {
     FOLD=$(echo $1 | tr / .)
     echo "travis_fold:start:$FOLD"
     echo -e "\\e[32m$FOLD\\e[0m"
     sh -c "$2" && echo "travis_fold:end:$FOLD"
 }
 
-export -f fold
+export -f tfold

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,9 +86,9 @@ install:
 
 script:
     - if [[ $skip ]]; then echo -e "\\n\\e[1;34mIntermediate PHP version $PHP is skipped for pull requests.\\e[0m"; fi
-    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu 'tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data {}"'; fi
+    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu -k 'tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data {}"'; fi
     - if [[ ! $deps && ! $PHP = hhvm* ]]; then tfold PHPUnit.tty "$PHPUNIT --group tty"; fi
     - if [[ ! $deps && $PHP = hhvm* ]]; then $PHPUNIT --exclude-group benchmark,intl-data; fi
     - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'tfold PHPUnit.sigchild "ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/"'; fi
-    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'cd {}; tfold {}.composer "composer update --no-progress --no-suggest --ansi 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY"'; fi
-    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'cd {}; tfold {}.composer "composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data"'; fi
+    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -k -j10% 'cd {}; tfold {}.composer "composer update --no-progress --no-suggest --ansi 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY"'; fi
+    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -k -j10% 'cd {}; tfold {}.composer "composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data"'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,9 +86,9 @@ install:
 
 script:
     - if [[ $skip ]]; then echo -e "\\n\\e[1;34mIntermediate PHP version $PHP is skipped for pull requests.\\e[0m"; fi
-    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu 'fold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data {}"'; fi
-    - if [[ ! $deps && ! $PHP = hhvm* ]]; then fold PHPUnit.tty "$PHPUNIT --group tty"; fi
+    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu 'tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data {}"'; fi
+    - if [[ ! $deps && ! $PHP = hhvm* ]]; then tfold PHPUnit.tty "$PHPUNIT --group tty"; fi
     - if [[ ! $deps && $PHP = hhvm* ]]; then $PHPUNIT --exclude-group benchmark,intl-data; fi
-    - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'fold PHPUnit.sigchild "ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/"'; fi
-    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'fold {}.composer "cd {}; composer update --no-progress --no-suggest --ansi 2>&1"; fold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY"'; fi
-    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'fold {}.composer "cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1"; fold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data"'; fi
+    - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'tfold PHPUnit.sigchild "ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/"'; fi
+    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'tfold {}.composer "cd {}; composer update --no-progress --no-suggest --ansi 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY"'; fi
+    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'tfold {}.composer "cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data"'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,4 +93,4 @@ script:
     - if [[ ! $deps && $PHP = hhvm* ]]; then $PHPUNIT --exclude-group benchmark,intl-data; fi
     - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'echo "\\nPHP --enable-sigchild enhanced={}" && ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/'; fi
     - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% $FOLD_START'cd {}; composer update --no-progress --no-suggest --ansi 2>&1; $PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY;'$FOLD_END"$REPORT"; fi
-    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% $FOLD_START'cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable; $PHPUNIT --exclude-group tty,benchmark,intl-data'$FOLD_END"$REPORT"; fi
+    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% $FOLD_START'cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1; $PHPUNIT --exclude-group tty,benchmark,intl-data'$FOLD_END"$REPORT"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ install:
     - if [[ ! $skip ]]; then composer update --no-suggest; fi
     - if [[ ! $skip ]]; then ./phpunit install; fi
     - if [[ ! $skip && ! $PHP = hhvm* ]]; then php -i; else hhvm --php -r 'print_r($_SERVER);print_r(ini_get_all());'; fi
-    - .github/travis_fold.sh
+    - . .github/travis_fold.sh
 
 script:
     - if [[ $skip ]]; then echo -e "\\n\\e[1;34mIntermediate PHP version $PHP is skipped for pull requests.\\e[0m"; fi
@@ -90,5 +90,5 @@ script:
     - if [[ ! $deps && ! $PHP = hhvm* ]]; then tfold PHPUnit.tty "$PHPUNIT --group tty"; fi
     - if [[ ! $deps && $PHP = hhvm* ]]; then $PHPUNIT --exclude-group benchmark,intl-data; fi
     - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'tfold PHPUnit.sigchild "ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/"'; fi
-    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'tfold {}.composer "cd {}; composer update --no-progress --no-suggest --ansi 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY"'; fi
-    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'tfold {}.composer "cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data"'; fi
+    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'cd {}; tfold {}.composer "composer update --no-progress --no-suggest --ansi 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY"'; fi
+    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'cd {}; tfold {}.composer "composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1"; tfold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data"'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,5 +90,5 @@ script:
     - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo -e "\\nRunning tests requiring tty"; $PHPUNIT --group tty; fi
     - if [[ ! $deps && $PHP = hhvm* ]]; then $PHPUNIT --exclude-group benchmark,intl-data; fi
     - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'echo "\\nPHP --enable-sigchild enhanced={}" && ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/'; fi
-    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'cd {}; composer update --no-progress --no-suggest --ansi; $PHPUNIT --exclude-group tty,benchmark,intl-data'$LEGACY"$REPORT"; fi
+    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'FOLD=$(echo "{}"|tr / .); echo -e "travis_fold:start:$FOLD\\n"; cd {}; composer update --no-progress --no-suggest --ansi 2>&1; $PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY; echo -e "travis_fold:end:$FOLD\\n"'"$REPORT"; fi
     - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable; $PHPUNIT --exclude-group tty,benchmark,intl-data'"$REPORT"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,13 +84,12 @@ install:
     - if [[ ! $skip && ! $PHP = hhvm* ]]; then php -i; else hhvm --php -r 'print_r($_SERVER);print_r(ini_get_all());'; fi
 
 script:
-    - REPORT=' && echo -e "\\e[32mOK\\e[0m {}\\n" || (echo -e "\\e[41mKO\\e[0m {}\\n" && $(exit 1))'
-    - FOLD_START='FOLD=$(echo "{}"|tr / .); echo -e "travis_fold:start:$FOLD\\n"; '
-    - FOLD_END=' echo -e "travis_fold:end:$FOLD\\n"'
+    - FOLD_START='echo "travis_fold:start:$FOLD"; echo -e "\\e[32m$FOLD\\e[0m"'
+    - FOLD_END='echo "travis_fold:end:$FOLD"'
     - if [[ $skip ]]; then echo -e "\\n\\e[1;34mIntermediate PHP version $PHP is skipped for pull requests.\\e[0m"; fi
-    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu $FOLD_START'$PHPUNIT --exclude-group tty,benchmark,intl-data {}'$FOLD_END"$REPORT"; fi
-    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo -e "\\nRunning tests requiring tty"; $PHPUNIT --group tty; fi
-    - if [[ ! $deps && $PHP = hhvm* ]]; then $PHPUNIT --exclude-group benchmark,intl-data; fi
-    - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'echo "\\nPHP --enable-sigchild enhanced={}" && ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/'; fi
-    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% $FOLD_START'cd {}; composer update --no-progress --no-suggest --ansi 2>&1; $PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY;'$FOLD_END"$REPORT"; fi
-    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% $FOLD_START'cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1; $PHPUNIT --exclude-group tty,benchmark,intl-data'$FOLD_END"$REPORT"; fi
+    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu 'FOLD=$(echo "{}.PHPUnit"|tr / .); '$FOLD_START'; $PHPUNIT --exclude-group tty,benchmark,intl-data {} && '$FOLD_END; fi
+    - if [[ ! $deps && ! $PHP = hhvm* ]]; then FOLD="PHPUnit.tty"; eval $FOLD_START; $PHPUNIT --group tty && eval $FOLD_END; fi
+    - if [[ ! $deps && $PHP = hhvm* ]]; then FOLD="PHPUnit.hhvm"; $PHPUNIT --exclude-group benchmark,intl-data && eval $FOLD_END; fi
+    - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'FOLD="PHPUnit.sigchild"; '$FOLD_START'; ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/ && '$FOLD_END; fi
+    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'FOLD=$(echo "{}.composer"|tr / .); '$FOLD_START'; cd {}; composer update --no-progress --no-suggest --ansi 2>&1 && '$FOLD_END'; FOLD=$(echo "{}.PHPUnit"|tr / .); '$FOLD_START'; $PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY && '$FOLD_END; fi
+    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'FOLD=$(echo "{}.composer"|tr / .); '$FOLD_START'; cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1 && '$FOLD_END'; FOLD=$(echo "{}.PHPUnit"|tr / .); '$FOLD_START'; $PHPUNIT --exclude-group tty,benchmark,intl-data && '$FOLD_END; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,14 +82,13 @@ install:
     - if [[ ! $skip ]]; then composer update --no-suggest; fi
     - if [[ ! $skip ]]; then ./phpunit install; fi
     - if [[ ! $skip && ! $PHP = hhvm* ]]; then php -i; else hhvm --php -r 'print_r($_SERVER);print_r(ini_get_all());'; fi
+    - .github/travis_fold.sh
 
 script:
-    - FOLD_START='echo "travis_fold:start:$FOLD"; echo -e "\\e[32m$FOLD\\e[0m"'
-    - FOLD_END='echo "travis_fold:end:$FOLD"'
     - if [[ $skip ]]; then echo -e "\\n\\e[1;34mIntermediate PHP version $PHP is skipped for pull requests.\\e[0m"; fi
-    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu 'FOLD=$(echo "{}.PHPUnit"|tr / .); '$FOLD_START'; $PHPUNIT --exclude-group tty,benchmark,intl-data {} && '$FOLD_END; fi
-    - if [[ ! $deps && ! $PHP = hhvm* ]]; then FOLD="PHPUnit.tty"; eval $FOLD_START; $PHPUNIT --group tty && eval $FOLD_END; fi
-    - if [[ ! $deps && $PHP = hhvm* ]]; then FOLD="PHPUnit.hhvm"; $PHPUNIT --exclude-group benchmark,intl-data && eval $FOLD_END; fi
-    - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'FOLD="PHPUnit.sigchild"; '$FOLD_START'; ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/ && '$FOLD_END; fi
-    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'FOLD=$(echo "{}.composer"|tr / .); '$FOLD_START'; cd {}; composer update --no-progress --no-suggest --ansi 2>&1 && '$FOLD_END'; FOLD=$(echo "{}.PHPUnit"|tr / .); '$FOLD_START'; $PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY && '$FOLD_END; fi
-    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'FOLD=$(echo "{}.composer"|tr / .); '$FOLD_START'; cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1 && '$FOLD_END'; FOLD=$(echo "{}.PHPUnit"|tr / .); '$FOLD_START'; $PHPUNIT --exclude-group tty,benchmark,intl-data && '$FOLD_END; fi
+    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu 'fold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data {}"'; fi
+    - if [[ ! $deps && ! $PHP = hhvm* ]]; then fold PHPUnit.tty "$PHPUNIT --group tty"; fi
+    - if [[ ! $deps && $PHP = hhvm* ]]; then $PHPUNIT --exclude-group benchmark,intl-data; fi
+    - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'fold PHPUnit.sigchild "ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/"'; fi
+    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'fold {}.composer "cd {}; composer update --no-progress --no-suggest --ansi 2>&1"; fold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY"'; fi
+    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'fold {}.composer "cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable 2>&1"; fold {}.PHPUnit "$PHPUNIT --exclude-group tty,benchmark,intl-data"'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,9 +88,9 @@ script:
     - FOLD_START='FOLD=$(echo "{}"|tr / .); echo -e "travis_fold:start:$FOLD\\n"; '
     - FOLD_END=' echo -e "travis_fold:end:$FOLD\\n"'
     - if [[ $skip ]]; then echo -e "\\n\\e[1;34mIntermediate PHP version $PHP is skipped for pull requests.\\e[0m"; fi
-    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu '$PHPUNIT --exclude-group tty,benchmark,intl-data {}'"$REPORT"; fi
+    - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu $FOLD_START'$PHPUNIT --exclude-group tty,benchmark,intl-data {}'$FOLD_END"$REPORT"; fi
     - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo -e "\\nRunning tests requiring tty"; $PHPUNIT --group tty; fi
     - if [[ ! $deps && $PHP = hhvm* ]]; then $PHPUNIT --exclude-group benchmark,intl-data; fi
     - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'echo "\\nPHP --enable-sigchild enhanced={}" && ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/'; fi
     - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% $FOLD_START'cd {}; composer update --no-progress --no-suggest --ansi 2>&1; $PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY;'$FOLD_END"$REPORT"; fi
-    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable; $PHPUNIT --exclude-group tty,benchmark,intl-data'"$REPORT"; fi
+    - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% $FOLD_START'cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable; $PHPUNIT --exclude-group tty,benchmark,intl-data'$FOLD_END"$REPORT"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,11 +84,13 @@ install:
     - if [[ ! $skip && ! $PHP = hhvm* ]]; then php -i; else hhvm --php -r 'print_r($_SERVER);print_r(ini_get_all());'; fi
 
 script:
-    - REPORT=' && echo -e "\\e[32mOK\\e[0m {}\\n\\n" || (echo -e "\\e[41mKO\\e[0m {}\\n\\n" && $(exit 1))'
+    - REPORT=' && echo -e "\\e[32mOK\\e[0m {}\\n" || (echo -e "\\e[41mKO\\e[0m {}\\n" && $(exit 1))'
+    - FOLD_START='FOLD=$(echo "{}"|tr / .); echo -e "travis_fold:start:$FOLD\\n"; '
+    - FOLD_END=' echo -e "travis_fold:end:$FOLD\\n"'
     - if [[ $skip ]]; then echo -e "\\n\\e[1;34mIntermediate PHP version $PHP is skipped for pull requests.\\e[0m"; fi
     - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo "$COMPONENTS" | parallel --gnu '$PHPUNIT --exclude-group tty,benchmark,intl-data {}'"$REPORT"; fi
     - if [[ ! $deps && ! $PHP = hhvm* ]]; then echo -e "\\nRunning tests requiring tty"; $PHPUNIT --group tty; fi
     - if [[ ! $deps && $PHP = hhvm* ]]; then $PHPUNIT --exclude-group benchmark,intl-data; fi
     - if [[ ! $deps && $PHP = ${MIN_PHP%.*} ]]; then echo -e "1\\n0" | xargs -I{} sh -c 'echo "\\nPHP --enable-sigchild enhanced={}" && ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8/phpunit --colors=always src/Symfony/Component/Process/'; fi
-    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'FOLD=$(echo "{}"|tr / .); echo -e "travis_fold:start:$FOLD\\n"; cd {}; composer update --no-progress --no-suggest --ansi 2>&1; $PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY; echo -e "travis_fold:end:$FOLD\\n"'"$REPORT"; fi
+    - if [[ $deps = high ]]; then echo "$COMPONENTS" | parallel --gnu -j10% $FOLD_START'cd {}; composer update --no-progress --no-suggest --ansi 2>&1; $PHPUNIT --exclude-group tty,benchmark,intl-data$LEGACY;'$FOLD_END"$REPORT"; fi
     - if [[ $deps = low ]]; then echo "$COMPONENTS" | parallel --gnu -j10% 'cd {}; composer update --no-progress --no-suggest --ansi --prefer-lowest --prefer-stable; $PHPUNIT --exclude-group tty,benchmark,intl-data'"$REPORT"; fi

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -24,6 +24,7 @@ class DoctrineDataCollectorTest extends TestCase
         $c = $this->createCollector(array());
         $c->collect(new Request(), new Response());
         $this->assertEquals(array('default' => 'doctrine.dbal.default_connection'), $c->getConnections());
+        $this->assertTrue(false);
     }
 
     public function testCollectManagers()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Travis CI has [a feature that allows fold in tests output](https://github.com/travis-ci/travis-ci/issues/2285#issuecomment-42724719). For better tests readability, I propose to fold all components output that have successful result.
