### PR TITLE
[Config] allow changing the path separator

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -1,6 +1,12 @@
 UPGRADE FROM 4.0 to 4.1
 =======================
 
+Config
+------
+
+ * Implementing `ParentNodeDefinitionInterface` without the `getChildNodeDefinitions()` method
+   is deprecated and will be unsupported in 5.0.
+
 EventDispatcher
 ---------------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 4.x to 5.0
 =======================
 
+Config
+------
+
+ * Added the `getChildNodeDefinitions()` method to `ParentNodeDefinitionInterface`.
+
 EventDispatcher
 ---------------
 

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * added `setPathSeparator` method to `NodeBuilder` class
+ * added third `$pathSeparator` constructor argument to `BaseNode`
+
 4.0.0
 -----
 

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -23,6 +23,8 @@ use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
  */
 abstract class BaseNode implements NodeInterface
 {
+    const DEFAULT_PATH_SEPARATOR = '.';
+
     protected $name;
     protected $parent;
     protected $normalizationClosures = array();
@@ -32,18 +34,20 @@ abstract class BaseNode implements NodeInterface
     protected $deprecationMessage = null;
     protected $equivalentValues = array();
     protected $attributes = array();
+    protected $pathSeparator;
 
     /**
      * @throws \InvalidArgumentException if the name contains a period
      */
-    public function __construct(?string $name, NodeInterface $parent = null)
+    public function __construct(?string $name, NodeInterface $parent = null, string $pathSeparator = self::DEFAULT_PATH_SEPARATOR)
     {
-        if (false !== strpos($name, '.')) {
-            throw new \InvalidArgumentException('The name must not contain ".".');
+        if (false !== strpos($name, $pathSeparator)) {
+            throw new \InvalidArgumentException('The name must not contain "'.$pathSeparator.'".');
         }
 
         $this->name = $name;
         $this->parent = $parent;
+        $this->pathSeparator = $pathSeparator;
     }
 
     public function setAttribute($key, $value)
@@ -230,13 +234,11 @@ abstract class BaseNode implements NodeInterface
      */
     public function getPath()
     {
-        $path = $this->name;
-
         if (null !== $this->parent) {
-            $path = $this->parent->getPath().'.'.$path;
+            return $this->parent->getPath().$this->pathSeparator.$this->name;
         }
 
-        return $path;
+        return $this->name;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -407,7 +407,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     protected function createNode()
     {
         if (null === $this->prototype) {
-            $node = new ArrayNode($this->name, $this->parent);
+            $node = new ArrayNode($this->name, $this->parent, $this->pathSeparator);
 
             $this->validateConcreteNode($node);
 
@@ -418,7 +418,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
                 $node->addChild($child->getNode());
             }
         } else {
-            $node = new PrototypedArrayNode($this->name, $this->parent);
+            $node = new PrototypedArrayNode($this->name, $this->parent, $this->pathSeparator);
 
             $this->validatePrototypeNode($node);
 
@@ -544,5 +544,13 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
                 );
             }
         }
+    }
+
+    /**
+     * @return NodeDefinition[]
+     */
+    public function getChildNodeDefinitions()
+    {
+        return $this->children;
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
@@ -38,7 +38,7 @@ class BooleanNodeDefinition extends ScalarNodeDefinition
      */
     protected function instantiateNode()
     {
-        return new BooleanNode($this->name, $this->parent);
+        return new BooleanNode($this->name, $this->parent, $this->pathSeparator);
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/EnumNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/EnumNodeDefinition.php
@@ -51,6 +51,6 @@ class EnumNodeDefinition extends ScalarNodeDefinition
             throw new \RuntimeException('You must call ->values() on enum nodes.');
         }
 
-        return new EnumNode($this->name, $this->parent, $this->values);
+        return new EnumNode($this->name, $this->parent, $this->values, $this->pathSeparator);
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/FloatNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/FloatNodeDefinition.php
@@ -27,6 +27,6 @@ class FloatNodeDefinition extends NumericNodeDefinition
      */
     protected function instantiateNode()
     {
-        return new FloatNode($this->name, $this->parent, $this->min, $this->max);
+        return new FloatNode($this->name, $this->parent, $this->min, $this->max, $this->pathSeparator);
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/IntegerNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/IntegerNodeDefinition.php
@@ -27,6 +27,6 @@ class IntegerNodeDefinition extends NumericNodeDefinition
      */
     protected function instantiateNode()
     {
-        return new IntegerNode($this->name, $this->parent, $this->min, $this->max);
+        return new IntegerNode($this->name, $this->parent, $this->min, $this->max, $this->pathSeparator);
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Config\Definition\Builder;
 
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\NodeInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 
@@ -33,6 +34,7 @@ abstract class NodeDefinition implements NodeParentInterface
     protected $nullEquivalent;
     protected $trueEquivalent = true;
     protected $falseEquivalent = false;
+    protected $pathSeparator = BaseNode::DEFAULT_PATH_SEPARATOR;
     protected $parent;
     protected $attributes = array();
 
@@ -346,4 +348,28 @@ abstract class NodeDefinition implements NodeParentInterface
      * @throws InvalidDefinitionException When the definition is invalid
      */
     abstract protected function createNode();
+
+    /**
+     * Set PathSeparator to use.
+     *
+     * @param string $separator
+     *
+     * @return $this
+     */
+    public function setPathSeparator(string $separator)
+    {
+        if ($this instanceof ParentNodeDefinitionInterface) {
+            if (method_exists($this, 'getChildNodeDefinitions')) {
+                foreach ($this->getChildNodeDefinitions() as $child) {
+                    $child->setPathSeparator($separator);
+                }
+            } else {
+                @trigger_error('Passing a ParentNodeDefinitionInterface without getChildNodeDefinitions() is deprecated since version 4.1 and will be removed in 5.0.', E_USER_DEPRECATED);
+            }
+        }
+
+        $this->pathSeparator = $separator;
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/ParentNodeDefinitionInterface.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ParentNodeDefinitionInterface.php
@@ -15,9 +15,14 @@ namespace Symfony\Component\Config\Definition\Builder;
  * An interface that must be implemented by nodes which can have children.
  *
  * @author Victor Berchet <victor@suumit.com>
+ *
+ * @method NodeDefinition[] getChildNodeDefinitions() should be implemented since 4.1
  */
 interface ParentNodeDefinitionInterface
 {
+    /**
+     * @return NodeBuilder
+     */
     public function children();
 
     public function append(NodeDefinition $node);

--- a/src/Symfony/Component/Config/Definition/Builder/ScalarNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ScalarNodeDefinition.php
@@ -27,6 +27,6 @@ class ScalarNodeDefinition extends VariableNodeDefinition
      */
     protected function instantiateNode()
     {
-        return new ScalarNode($this->name, $this->parent);
+        return new ScalarNode($this->name, $this->parent, $this->pathSeparator);
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -50,13 +50,31 @@ class TreeBuilder implements NodeParentInterface
      */
     public function buildTree()
     {
-        if (null === $this->root) {
-            throw new \RuntimeException('The configuration tree has no root node.');
-        }
+        $this->assertTreeHasRootNode();
         if (null !== $this->tree) {
             return $this->tree;
         }
 
         return $this->tree = $this->root->getNode(true);
+    }
+
+    public function setPathSeparator(string $separator)
+    {
+        $this->assertTreeHasRootNode();
+
+        // unset last built as changing path separator changes all nodes
+        $this->tree = null;
+
+        $this->root->setPathSeparator($separator);
+    }
+
+    /**
+     * @throws \RuntimeException if root node is not defined
+     */
+    private function assertTreeHasRootNode()
+    {
+        if (null === $this->root) {
+            throw new \RuntimeException('The configuration tree has no root node.');
+        }
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
@@ -27,7 +27,7 @@ class VariableNodeDefinition extends NodeDefinition
      */
     protected function instantiateNode()
     {
-        return new VariableNode($this->name, $this->parent);
+        return new VariableNode($this->name, $this->parent, $this->pathSeparator);
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -22,14 +22,14 @@ class EnumNode extends ScalarNode
 {
     private $values;
 
-    public function __construct(?string $name, NodeInterface $parent = null, array $values = array())
+    public function __construct(?string $name, NodeInterface $parent = null, array $values = array(), string $pathSeparator = BaseNode::DEFAULT_PATH_SEPARATOR)
     {
         $values = array_unique($values);
         if (empty($values)) {
             throw new \InvalidArgumentException('$values must contain at least one element.');
         }
 
-        parent::__construct($name, $parent);
+        parent::__construct($name, $parent, $pathSeparator);
         $this->values = $values;
     }
 

--- a/src/Symfony/Component/Config/Definition/NumericNode.php
+++ b/src/Symfony/Component/Config/Definition/NumericNode.php
@@ -23,9 +23,9 @@ class NumericNode extends ScalarNode
     protected $min;
     protected $max;
 
-    public function __construct(?string $name, NodeInterface $parent = null, $min = null, $max = null)
+    public function __construct(?string $name, NodeInterface $parent = null, $min = null, $max = null, string $pathSeparator = BaseNode::DEFAULT_PATH_SEPARATOR)
     {
-        parent::__construct($name, $parent);
+        parent::__construct($name, $parent, $pathSeparator);
         $this->min = $min;
         $this->max = $max;
     }

--- a/src/Symfony/Component/Config/Tests/Definition/BaseNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BaseNodeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Definition;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\NodeInterface;
+
+class BaseNodeTest extends TestCase
+{
+    /**
+     * @dataProvider providePath
+     */
+    public function testGetPathForChildNode($expected, array $params)
+    {
+        $constructorArgs = array();
+        $constructorArgs[] = $params[0];
+
+        if (isset($params[1])) {
+            // Handle old PHPUnit version for PHP 5.5
+            $parent = method_exists($this, 'createMock')
+                    ? $this->createMock(NodeInterface::class)
+                    : $this->getMock(NodeInterface::class);
+            $parent->method('getPath')->willReturn($params[1]);
+
+            $constructorArgs[] = $parent;
+
+            if (isset($params[2])) {
+                $constructorArgs[] = $params[2];
+            }
+        }
+
+        $node = $this->getMockForAbstractClass(BaseNode::class, $constructorArgs);
+
+        $this->assertSame($expected, $node->getPath());
+    }
+
+    public function providePath()
+    {
+        return array(
+            'name only' => array('root', array('root')),
+            'name and parent' => array('foo.bar.baz.bim', array('bim', 'foo.bar.baz')),
+            'name and separator' => array('foo', array('foo', null, '/')),
+            'name, parent and separator' => array('foo.bar/baz/bim', array('bim', 'foo.bar/baz', '/')),
+        );
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NodeDefinitionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Definition\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
+
+class NodeDefinitionTest extends TestCase
+{
+    public function testDefaultPathSeparatorIsDot()
+    {
+        $node = $this->getMockForAbstractClass(NodeDefinition::class, array('foo'));
+
+        $this->assertAttributeSame('.', 'pathSeparator', $node);
+    }
+
+    public function testSetPathSeparatorChangesChildren()
+    {
+        $node = new ArrayNodeDefinition('foo');
+        $scalar = new ScalarNodeDefinition('bar');
+        $node->append($scalar);
+
+        $node->setPathSeparator('/');
+
+        $this->assertAttributeSame('/', 'pathSeparator', $node);
+        $this->assertAttributeSame('/', 'pathSeparator', $scalar);
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
@@ -150,4 +150,65 @@ class TreeBuilderTest extends TestCase
 
         $this->assertEquals(array('enabled' => false), $result);
     }
+
+    public function testDefaultPathSeparatorIsDot()
+    {
+        $builder = new TreeBuilder();
+
+        $builder->root('propagation')
+            ->children()
+                ->node('foo', 'variable')->end()
+                ->arrayNode('child')
+                    ->children()
+                        ->node('foo', 'variable')
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
+
+        $node = $builder->buildTree();
+        $children = $node->getChildren();
+
+        $this->assertArrayHasKey('foo', $children);
+        $this->assertInstanceOf('Symfony\Component\Config\Definition\BaseNode', $children['foo']);
+        $this->assertSame('propagation.foo', $children['foo']->getPath());
+
+        $this->assertArrayHasKey('child', $children);
+        $childChildren = $children['child']->getChildren();
+
+        $this->assertArrayHasKey('foo', $childChildren);
+        $this->assertInstanceOf('Symfony\Component\Config\Definition\BaseNode', $childChildren['foo']);
+        $this->assertSame('propagation.child.foo', $childChildren['foo']->getPath());
+    }
+
+    public function testPathSeparatorIsPropagatedToChildren()
+    {
+        $builder = new TreeBuilder();
+
+        $builder->root('propagation')
+            ->children()
+                ->node('foo', 'variable')->end()
+                ->arrayNode('child')
+                    ->children()
+                        ->node('foo', 'variable')
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
+
+        $builder->setPathSeparator('/');
+        $node = $builder->buildTree();
+        $children = $node->getChildren();
+
+        $this->assertArrayHasKey('foo', $children);
+        $this->assertInstanceOf('Symfony\Component\Config\Definition\BaseNode', $children['foo']);
+        $this->assertSame('propagation/foo', $children['foo']->getPath());
+
+        $this->assertArrayHasKey('child', $children);
+        $childChildren = $children['child']->getChildren();
+
+        $this->assertArrayHasKey('foo', $childChildren);
+        $this->assertInstanceOf('Symfony\Component\Config\Definition\BaseNode', $childChildren['foo']);
+        $this->assertSame('propagation/child/foo', $childChildren['foo']->getPath());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22268
| License       | MIT
| Doc PR        | 

In bundles configuration, no dots are allowed in key names, but as a standalone config, there is no such limitation that should be enforced.

By using current `NodeBuilder` it should be possible to change path separator used (for example: `/`)