### PR TITLE
[Console] Give errors back to error handler if not handled by console.error listeners

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -138,6 +138,9 @@ class Application
                 $e = null;
                 $exitCode = 0;
             } else {
+                if (!$e instanceof \Exception) {
+                    throw $e;
+                }
                 $exitCode = $e->getCode();
             }
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1118,6 +1118,30 @@ class ApplicationTest extends TestCase
     }
 
     /**
+     * @requires PHP 7
+     */
+    public function testErrorIsRethrownIfNotHandledByConsoleErrorEvent()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setDispatcher(new EventDispatcher());
+
+        $application->register('dym')->setCode(function (InputInterface $input, OutputInterface $output) {
+            new \UnknownClass();
+        });
+
+        $tester = new ApplicationTester($application);
+
+        try {
+            $tester->run(array('command' => 'dym'));
+            $this->fail('->run() should rethrow PHP errors if not handled via ConsoleErrorEvent.');
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf('Error', $e);
+            $this->assertSame($e->getMessage(), 'Class \'UnknownClass\' not found');
+        }
+    }
+
+    /**
      * @expectedException        \LogicException
      * @expectedExceptionMessage error
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22259 
| License       | MIT
| Doc PR        | n/a

Re-throws errors if `ConsoleErrorEvent::markErrorAsHandled()` hasn't been called so that they can reach the global error handler, fixing the BC break.