### PR TITLE
[Validator] Add `TimezoneValidator`

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -24,7 +24,7 @@ class Timezone extends Constraint
 {
     const NO_SUCH_TIMEZONE_ERROR = '45de6628-3479-46d6-a210-00ad584f530a';
 
-    public $zone = \DateTimeZone::ALL;
+    public $zone;
 
     public $countryCode;
 

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -23,6 +23,8 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 class Timezone extends Constraint
 {
     const NO_SUCH_TIMEZONE_ERROR = '45de6628-3479-46d6-a210-00ad584f530a';
+    const NO_SUCH_TIMEZONE_IN_ZONE_ERROR = 'b57767b1-36c0-40ac-a3d7-629420c775b8';
+    const NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR = 'c4a22222-dc92-4fc0-abb0-d95b268c7d0b';
 
     public $zone;
 

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * @Annotation
@@ -23,7 +24,9 @@ class Timezone extends Constraint
 {
     const NO_SUCH_TIMEZONE_ERROR = '45de6628-3479-46d6-a210-00ad584f530a';
 
-    public $value = \DateTimeZone::ALL;
+    public $timezone = \DateTimeZone::ALL;
+
+    public $countryCode;
 
     public $message = 'This value is not a valid timezone at {{ timezone_group }}.';
 
@@ -36,8 +39,16 @@ class Timezone extends Constraint
      */
     public function __construct($options = null)
     {
-        if (isset($options['value'])) {
-            $this->value = $options['value'];
+        if (isset($options['timezone'])) {
+            $this->timezone = $options['timezone'];
+        }
+
+        if (isset($options['countryCode'])) {
+            if (\DateTimeZone::PER_COUNTRY !== $this->timezone) {
+                throw new ConstraintDefinitionException('The option "countryCode" can only be used when "timezone" option has `\DateTimeZone::PER_COUNTRY` as value');
+            }
+
+            $this->countryCode = $options['countryCode'];
         }
 
         parent::__construct($options);

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -25,10 +25,9 @@ class Timezone extends Constraint
     const NO_SUCH_TIMEZONE_ERROR = '45de6628-3479-46d6-a210-00ad584f530a';
     const NO_SUCH_TIMEZONE_IN_ZONE_ERROR = 'b57767b1-36c0-40ac-a3d7-629420c775b8';
     const NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR = 'c4a22222-dc92-4fc0-abb0-d95b268c7d0b';
-
-    public $zone;
+    public $zone = \DateTimeZone::ALL;
     public $countryCode;
-    public $message = 'This value is not a valid timezone{{ zone_message }}{{ country_code_message }}.';
+    public $message = 'This value is not a valid timezone.';
 
     protected static $errorNames = array(
         self::NO_SUCH_TIMEZONE_ERROR => 'NO_SUCH_TIMEZONE_ERROR',
@@ -41,16 +40,10 @@ class Timezone extends Constraint
      */
     public function __construct(array $options = null)
     {
-        $this->zone = $options['zone'] ?? null;
-
-        if (isset($options['countryCode'])) {
-            if (\DateTimeZone::PER_COUNTRY !== $this->zone) {
-                throw new ConstraintDefinitionException('The option "countryCode" can only be used when "zone" option has `\DateTimeZone::PER_COUNTRY` as value');
-            }
-
-            $this->countryCode = $options['countryCode'];
-        }
-
         parent::__construct($options);
+
+        if ($this->countryCode && \DateTimeZone::PER_COUNTRY !== $this->zone) {
+            throw new ConstraintDefinitionException('The option "countryCode" can only be used when "zone" option has `\DateTimeZone::PER_COUNTRY` as value');
+        }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -27,23 +27,21 @@ class Timezone extends Constraint
     const NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR = 'c4a22222-dc92-4fc0-abb0-d95b268c7d0b';
 
     public $zone;
-
     public $countryCode;
-
-    public $message = 'This value is not a valid timezone{{ extra_info }}.';
+    public $message = 'This value is not a valid timezone{{ zone_message }}{{ country_code_message }}.';
 
     protected static $errorNames = array(
         self::NO_SUCH_TIMEZONE_ERROR => 'NO_SUCH_TIMEZONE_ERROR',
+        self::NO_SUCH_TIMEZONE_IN_ZONE_ERROR => 'NO_SUCH_TIMEZONE_IN_ZONE_ERROR',
+        self::NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR => 'NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR',
     );
 
     /**
      * {@inheritdoc}
      */
-    public function __construct($options = null)
+    public function __construct(array $options = null)
     {
-        if (isset($options['zone'])) {
-            $this->zone = $options['zone'];
-        }
+        $this->zone = $options['zone'] ?? null;
 
         if (isset($options['countryCode'])) {
             if (\DateTimeZone::PER_COUNTRY !== $this->zone) {

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -28,7 +28,7 @@ class Timezone extends Constraint
 
     public $countryCode;
 
-    public $message = 'This value is not a valid timezone at {{ timezone_group }}.';
+    public $message = 'This value is not a valid timezone{{ extra_info }}.';
 
     protected static $errorNames = array(
         self::NO_SUCH_TIMEZONE_ERROR => 'NO_SUCH_TIMEZONE_ERROR',

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class Timezone extends Constraint
+{
+    const NO_SUCH_TIMEZONE_ERROR = '45de6628-3479-46d6-a210-00ad584f530a';
+
+    public $value = \DateTimeZone::ALL;
+
+    public $message = 'This value is not a valid timezone at {{ timezone_group }}.';
+
+    protected static $errorNames = array(
+        self::NO_SUCH_TIMEZONE_ERROR => 'NO_SUCH_TIMEZONE_ERROR',
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($options = null)
+    {
+        if (isset($options['value'])) {
+            $this->value = $options['value'];
+        }
+
+        parent::__construct($options);
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -24,7 +24,7 @@ class Timezone extends Constraint
 {
     const NO_SUCH_TIMEZONE_ERROR = '45de6628-3479-46d6-a210-00ad584f530a';
 
-    public $timezone = \DateTimeZone::ALL;
+    public $zone = \DateTimeZone::ALL;
 
     public $countryCode;
 
@@ -39,13 +39,13 @@ class Timezone extends Constraint
      */
     public function __construct($options = null)
     {
-        if (isset($options['timezone'])) {
-            $this->timezone = $options['timezone'];
+        if (isset($options['zone'])) {
+            $this->zone = $options['zone'];
         }
 
         if (isset($options['countryCode'])) {
-            if (\DateTimeZone::PER_COUNTRY !== $this->timezone) {
-                throw new ConstraintDefinitionException('The option "countryCode" can only be used when "timezone" option has `\DateTimeZone::PER_COUNTRY` as value');
+            if (\DateTimeZone::PER_COUNTRY !== $this->zone) {
+                throw new ConstraintDefinitionException('The option "countryCode" can only be used when "zone" option has `\DateTimeZone::PER_COUNTRY` as value');
             }
 
             $this->countryCode = $options['countryCode'];

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -69,20 +69,16 @@ class TimezoneValidator extends ConstraintValidator
      */
     private function formatExtraInfo($zone, $countryCode = null)
     {
-        if (!$zone) {
-            return '';
-        }
-        $r = new \ReflectionClass('\DateTimeZone');
-        $consts = $r->getConstants();
-
-        if (!$value = array_search($zone, $consts, true)) {
-            $value = $zone;
-        }
-
-        $value = ' for "'.$value.'" zone';
-
         if ($countryCode) {
-            $value = ' for ISO 3166-1 country code '.$countryCode;
+            $value = ' for ISO 3166-1 country code "'.$countryCode.'"';
+        } else {
+            $r = new \ReflectionClass('\DateTimeZone');
+            $consts = $r->getConstants();
+            if ($value = array_search($zone, $consts, true)) {
+                $value = ' for "'.$value.'" zone';
+            } else {
+                $value = ' for zone with identifier '.$zone;
+            }
         }
 
         return $this->formatValue($value);

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -67,7 +67,7 @@ class TimezoneValidator extends ConstraintValidator
      *
      * @return string
      */
-    protected function formatExtraInfo($zone, $countryCode = null)
+    private function formatExtraInfo($zone, $countryCode = null)
     {
         if (!$zone) {
             return '';

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -40,11 +40,11 @@ class TimezoneValidator extends ConstraintValidator
         }
 
         $value = (string) $value;
-        $timezoneIds = \DateTimeZone::listIdentifiers($constraint->timezone, $constraint->countryCode);
+        $timezoneIds = \DateTimeZone::listIdentifiers($constraint->zone, $constraint->countryCode);
 
         if ($timezoneIds && !in_array($value, $timezoneIds, true)) {
             $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ extra_info }}', $this->formatExtraInfo($constraint->timezone, $constraint->countryCode))
+                ->setParameter('{{ extra_info }}', $this->formatExtraInfo($constraint->zone, $constraint->countryCode))
                 ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
                 ->addViolation();
         }
@@ -55,28 +55,28 @@ class TimezoneValidator extends ConstraintValidator
      */
     public function getDefaultOption()
     {
-        return 'timezone';
+        return 'zone';
     }
 
     /**
      * Format the extra info which is appended to validation message based on
      * constraint options
      *
-     * @param int $timezone
+     * @param int $zone
      * @param string|null $countryCode
      *
      * @return string
      */
-    protected function formatExtraInfo($timezone, $countryCode = null)
+    protected function formatExtraInfo($zone, $countryCode = null)
     {
-        if (!$timezone) {
+        if (!$zone) {
             return '';
         }
         $r = new \ReflectionClass('\DateTimeZone');
         $consts = $r->getConstants();
 
-        if (!$value = array_search($timezone, $consts, true)) {
-            $value = $timezone;
+        if (!$value = array_search($zone, $consts, true)) {
+            $value = $zone;
         }
 
         $value = ' for "'.$value.'" zone';

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -40,7 +40,7 @@ class TimezoneValidator extends ConstraintValidator
         }
 
         $value = (string) $value;
-        $timezoneIds = \DateTimeZone::listIdentifiers($constraint->value);
+        $timezoneIds = \DateTimeZone::listIdentifiers($constraint->timezone, $constraint->countryCode);
 
         if ($timezoneIds && !in_array($value, $timezoneIds, true)) {
             $this->context->buildViolation($constraint->message)
@@ -55,6 +55,6 @@ class TimezoneValidator extends ConstraintValidator
      */
     public function getDefaultOption()
     {
-        return 'value';
+        return 'timezone';
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -40,7 +40,8 @@ class TimezoneValidator extends ConstraintValidator
         }
 
         $value = (string) $value;
-        $timezoneIds = \DateTimeZone::listIdentifiers($constraint->zone, $constraint->countryCode);
+        $zone = null !== $constraint->zone ? $constraint->zone : \DateTimeZone::ALL;
+        $timezoneIds = \DateTimeZone::listIdentifiers($zone, $constraint->countryCode);
 
         if ($timezoneIds && !in_array($value, $timezoneIds, true)) {
             $this->context->buildViolation($constraint->message)
@@ -62,13 +63,16 @@ class TimezoneValidator extends ConstraintValidator
      * Format the extra info which is appended to validation message based on
      * constraint options.
      *
-     * @param int         $zone
+     * @param int|null    $zone
      * @param string|null $countryCode
      *
      * @return string
      */
     private function formatExtraInfo($zone, $countryCode = null)
     {
+        if (null === $zone) {
+            return '';
+        }
         if ($countryCode) {
             $value = ' for ISO 3166-1 country code "'.$countryCode.'"';
         } else {

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -60,9 +60,9 @@ class TimezoneValidator extends ConstraintValidator
 
     /**
      * Format the extra info which is appended to validation message based on
-     * constraint options
+     * constraint options.
      *
-     * @param int $zone
+     * @param int         $zone
      * @param string|null $countryCode
      *
      * @return string

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -93,6 +93,6 @@ class TimezoneValidator extends ConstraintValidator
             }
         }
 
-        return $this->formatValue($value);
+        return $value;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -44,9 +44,17 @@ class TimezoneValidator extends ConstraintValidator
         $timezoneIds = \DateTimeZone::listIdentifiers($zone, $constraint->countryCode);
 
         if ($timezoneIds && !in_array($value, $timezoneIds, true)) {
+            if ($constraint->countryCode) {
+                $code = Timezone::NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR;
+            } elseif (null !== $constraint->zone) {
+                $code = Timezone::NO_SUCH_TIMEZONE_IN_ZONE_ERROR;
+            } else {
+                $code = Timezone::NO_SUCH_TIMEZONE_ERROR;
+            }
+
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ extra_info }}', $this->formatExtraInfo($constraint->zone, $constraint->countryCode))
-                ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
+                ->setCode($code)
                 ->addViolation();
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Validates whether a value is a valid timezone identifier.
+ *
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class TimezoneValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof Timezone) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Timezone');
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        $value = (string) $value;
+        $timezoneIds = \DateTimeZone::listIdentifiers($constraint->value);
+
+        if ($timezoneIds && !in_array($value, $timezoneIds, true)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ timezone_group }}', $this->formatValue($value))
+                ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
+                ->addViolation();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'value';
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimezoneValidator.php
@@ -44,7 +44,7 @@ class TimezoneValidator extends ConstraintValidator
 
         if ($timezoneIds && !in_array($value, $timezoneIds, true)) {
             $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ timezone_group }}', $this->formatValue($value))
+                ->setParameter('{{ extra_info }}', $this->formatExtraInfo($constraint->timezone, $constraint->countryCode))
                 ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
                 ->addViolation();
         }
@@ -56,5 +56,35 @@ class TimezoneValidator extends ConstraintValidator
     public function getDefaultOption()
     {
         return 'timezone';
+    }
+
+    /**
+     * Format the extra info which is appended to validation message based on
+     * constraint options
+     *
+     * @param int $timezone
+     * @param string|null $countryCode
+     *
+     * @return string
+     */
+    protected function formatExtraInfo($timezone, $countryCode = null)
+    {
+        if (!$timezone) {
+            return '';
+        }
+        $r = new \ReflectionClass('\DateTimeZone');
+        $consts = $r->getConstants();
+
+        if (!$value = array_search($timezone, $consts, true)) {
+            $value = $timezone;
+        }
+
+        $value = ' for "'.$value.'" zone';
+
+        if ($countryCode) {
+            $value = ' for ISO 3166-1 country code '.$countryCode;
+        }
+
+        return $this->formatValue($value);
     }
 }

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -326,6 +326,10 @@
                 <source>This value should be a multiple of {{ compared_value }}.</source>
                 <target>This value should be a multiple of {{ compared_value }}.</target>
             </trans-unit>
+            <trans-unit id="85">
+                <source>This value is not a valid timezone.</source>
+                <target>This value is not a valid timezone.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -326,6 +326,10 @@
                 <source>This value should be a multiple of {{ compared_value }}.</source>
                 <target>Este valor debería ser un múltiplo de {{ compared_value }}.</target>
             </trans-unit>
+            <trans-unit id="85">
+                <source>This value is not a valid timezone.</source>
+                <target>Este valor no es una zona horaria válida.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Timezone;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class TimezoneTest extends TestCase
+{
+    public function testValidTimezoneConstraints()
+    {
+        $constraint = new Timezone();
+
+        $constraint = new Timezone(array(
+            'message' => 'myMessage',
+            'timezone' => \DateTimeZone::PER_COUNTRY,
+            'countryCode' => 'AR',
+        ));
+
+        $constraint = new Timezone(array(
+            'message' => 'myMessage',
+            'timezone' => \DateTimeZone::ALL,
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
+    public function testExceptionForGroupedTimezonesByCountryWithWrongTimezone()
+    {
+        $constraint = new Timezone(array(
+            'message' => 'myMessage',
+            'timezone' => \DateTimeZone::ALL,
+            'countryCode' => 'AR',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
+    public function testExceptionForGroupedTimezonesByCountryWithoutTimezone()
+    {
+        $constraint = new Timezone(array(
+            'message' => 'myMessage',
+            'countryCode' => 'AR',
+        ));
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
@@ -33,6 +33,9 @@ class TimezoneTest extends TestCase
             'message' => 'myMessage',
             'zone' => \DateTimeZone::ALL,
         ));
+
+        // Make an assertion in order to avoid this test to be marked as risky
+        $this->assertInstanceOf(Timezone::class, $constraint);
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneTest.php
@@ -25,13 +25,13 @@ class TimezoneTest extends TestCase
 
         $constraint = new Timezone(array(
             'message' => 'myMessage',
-            'timezone' => \DateTimeZone::PER_COUNTRY,
+            'zone' => \DateTimeZone::PER_COUNTRY,
             'countryCode' => 'AR',
         ));
 
         $constraint = new Timezone(array(
             'message' => 'myMessage',
-            'timezone' => \DateTimeZone::ALL,
+            'zone' => \DateTimeZone::ALL,
         ));
     }
 
@@ -42,7 +42,7 @@ class TimezoneTest extends TestCase
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
-            'timezone' => \DateTimeZone::ALL,
+            'zone' => \DateTimeZone::ALL,
             'countryCode' => 'AR',
         ));
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -154,7 +154,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             array('America/Barbados', \DateTimeZone::ANTARCTICA, ' for "ANTARCTICA" zone'),
             array('Europe/Kiev', \DateTimeZone::ARCTIC, ' for "ARCTIC" zone'),
             array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN, ' for "INDIAN" zone'),
-            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN | \DateTimeZone::ANTARCTICA, ' for "260" zone'),
+            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN | \DateTimeZone::ANTARCTICA, ' for zone with identifier 260'),
         );
     }
 
@@ -214,8 +214,8 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidGroupedTimezonesByCountry()
     {
         return array(
-            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'FR', ' for ISO 3166-1 country code FR'),
-            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT', ' for ISO 3166-1 country code PT'),
+            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'FR', ' for ISO 3166-1 country code "FR"'),
+            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT', ' for ISO 3166-1 country code "PT"'),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -76,7 +76,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function testValidGroupedTimezones($timezone, $what)
     {
         $constraint = new Timezone(array(
-            'timezone' => $what,
+            'zone' => $what,
         ));
 
         $this->validator->validate($timezone, $constraint);
@@ -135,7 +135,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidGroupedTimezones($timezone, $what, $extraInfo)
     {
         $constraint = new Timezone(array(
-            'timezone' => $what,
+            'zone' => $what,
             'message' => 'myMessage',
         ));
 
@@ -164,7 +164,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function testValidGroupedTimezonesByCountry($timezone, $what, $country)
     {
         $constraint = new Timezone(array(
-            'timezone' => $what,
+            'zone' => $what,
             'countryCode' => $country,
         ));
 
@@ -199,7 +199,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
-            'timezone' => $what,
+            'zone' => $what,
             'countryCode' => $country,
         ));
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -106,7 +106,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getInvalidTimezones
      */
-    public function testInvalidTimezones($timezone, $extraInfo)
+    public function testInvalidTimezonesWithoutZone($timezone, $extraInfo)
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
@@ -115,7 +115,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ extra_info }}', '"'.$extraInfo.'"')
+            ->setParameter('{{ extra_info }}', $extraInfo)
             ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
             ->assertRaised();
     }
@@ -123,9 +123,9 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidTimezones()
     {
         return array(
-            array('Buenos_Aires/Argentina/America', ' for "ALL" zone'),
-            array('Mayotte/Indian', ' for "ALL" zone'),
-            array('foobar', ' for "ALL" zone'),
+            array('Buenos_Aires/Argentina/America', ''),
+            array('Mayotte/Indian', ''),
+            array('foobar', ''),
         );
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -76,7 +76,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function testValidGroupedTimezones($timezone, $what)
     {
         $constraint = new Timezone(array(
-            'value' => $what,
+            'timezone' => $what,
         ));
 
         $this->validator->validate($timezone, $constraint);
@@ -135,7 +135,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function testInvalidGroupedTimezones($timezone, $what)
     {
         $constraint = new Timezone(array(
-            'value' => $what,
+            'timezone' => $what,
             'message' => 'myMessage',
         ));
 
@@ -154,6 +154,67 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             array('America/Barbados', \DateTimeZone::ANTARCTICA),
             array('Europe/Kiev', \DateTimeZone::ARCTIC),
             array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN),
+        );
+    }
+
+    /**
+     * @dataProvider getValidGroupedTimezonesByCountry
+     */
+    public function testValidGroupedTimezonesByCountry($timezone, $what, $country)
+    {
+        $constraint = new Timezone(array(
+            'timezone' => $what,
+            'countryCode' => $country,
+        ));
+
+        $this->validator->validate($timezone, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidGroupedTimezonesByCountry()
+    {
+        return array(
+            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'AR'),
+            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'BB'),
+            array('Africa/Cairo', \DateTimeZone::PER_COUNTRY, 'EG'),
+            array('Atlantic/Cape_Verde', \DateTimeZone::PER_COUNTRY, 'CV'),
+            array('Europe/Bratislava', \DateTimeZone::PER_COUNTRY, 'SK'),
+            array('Indian/Christmas', \DateTimeZone::PER_COUNTRY, 'CX'),
+            array('Pacific/Kiritimati', \DateTimeZone::PER_COUNTRY, 'KI'),
+            array('Pacific/Kiritimati', \DateTimeZone::PER_COUNTRY, 'KI'),
+            array('Pacific/Kiritimati', \DateTimeZone::PER_COUNTRY, 'KI'),
+            array('Arctic/Longyearbyen', \DateTimeZone::PER_COUNTRY, 'SJ'),
+            array('Asia/Beirut', \DateTimeZone::PER_COUNTRY, 'LB'),
+            array('Atlantic/Bermuda', \DateTimeZone::PER_COUNTRY, 'BM'),
+            array('Atlantic/Azores', \DateTimeZone::PER_COUNTRY, 'PT'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidGroupedTimezonesByCountry
+     */
+    public function testInvalidGroupedTimezonesByCountry($timezone, $what, $country)
+    {
+        $constraint = new Timezone(array(
+            'message' => 'myMessage',
+            'timezone' => $what,
+            'countryCode' => $country,
+        ));
+
+        $this->validator->validate($timezone, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ timezone_group }}', '"'.$timezone.'"')
+            ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidGroupedTimezonesByCountry()
+    {
+        return array(
+            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'FR'),
+            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT'),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -106,7 +106,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getInvalidTimezones
      */
-    public function testInvalidTimezonesWithoutZone(string $timezone, string $zoneMessage, string $countryCodeMessage)
+    public function testInvalidTimezonesWithoutZone(string $timezone)
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
@@ -115,8 +115,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ zone_message }}', $zoneMessage)
-            ->setParameter('{{ country_code_message }}', $countryCodeMessage)
+            ->setParameter('{{ value }}', '"'.$timezone.'"')
             ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
             ->assertRaised();
     }
@@ -124,16 +123,16 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidTimezones(): iterable
     {
         return array(
-            array('Buenos_Aires/Argentina/America', '', ''),
-            array('Mayotte/Indian', '', ''),
-            array('foobar', '', ''),
+            array('Buenos_Aires/Argentina/America'),
+            array('Mayotte/Indian'),
+            array('foobar'),
         );
     }
 
     /**
      * @dataProvider getInvalidGroupedTimezones
      */
-    public function testInvalidGroupedTimezones(string $timezone, int $what, string $zoneMessage, string $countryCodeMessage)
+    public function testInvalidGroupedTimezones(string $timezone, int $what)
     {
         $constraint = new Timezone(array(
             'zone' => $what,
@@ -143,8 +142,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ zone_message }}', $zoneMessage)
-            ->setParameter('{{ country_code_message }}', $countryCodeMessage)
+            ->setParameter('{{ value }}', '"'.$timezone.'"')
             ->setCode(Timezone::NO_SUCH_TIMEZONE_IN_ZONE_ERROR)
             ->assertRaised();
     }
@@ -152,11 +150,11 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidGroupedTimezones(): iterable
     {
         return array(
-            array('Antarctica/McMurdo', \DateTimeZone::AMERICA, ' at "AMERICA" zone', ''),
-            array('America/Barbados', \DateTimeZone::ANTARCTICA, ' at "ANTARCTICA" zone', ''),
-            array('Europe/Kiev', \DateTimeZone::ARCTIC, ' at "ARCTIC" zone', ''),
-            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN, ' at "INDIAN" zone', ''),
-            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN | \DateTimeZone::ANTARCTICA, ' at zone with identifier 260', ''),
+            array('Antarctica/McMurdo', \DateTimeZone::AMERICA),
+            array('America/Barbados', \DateTimeZone::ANTARCTICA),
+            array('Europe/Kiev', \DateTimeZone::ARCTIC),
+            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN),
+            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN | \DateTimeZone::ANTARCTICA),
         );
     }
 
@@ -197,7 +195,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getInvalidGroupedTimezonesByCountry
      */
-    public function testInvalidGroupedTimezonesByCountry(string $timezone, int $what, string $country, string $zoneMessage, string $countryCodeMessage)
+    public function testInvalidGroupedTimezonesByCountry(string $timezone, int $what, string $country)
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
@@ -208,8 +206,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ zone_message }}', $zoneMessage)
-            ->setParameter('{{ country_code_message }}', $countryCodeMessage)
+            ->setParameter('{{ value }}', '"'.$timezone.'"')
             ->setCode(Timezone::NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR)
             ->assertRaised();
     }
@@ -217,8 +214,8 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidGroupedTimezonesByCountry(): iterable
     {
         return array(
-            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'FR', '', ' for ISO 3166-1 country code "FR"'),
-            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT', '', ' for ISO 3166-1 country code "PT"'),
+            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'FR'),
+            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT'),
         );
     }
 
@@ -248,8 +245,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ zone_message }}', '')
-            ->setParameter('{{ country_code_message }}', '')
+            ->setParameter('{{ value }}', '"'.$timezone.'"')
             ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
             ->assertRaised();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Timezone;
+use Symfony\Component\Validator\Constraints\TimezoneValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class TimezoneValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new TimezoneValidator();
+    }
+
+    public function testNullIsValid()
+    {
+        $this->validator->validate(null, new Timezone());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->validator->validate('', new Timezone());
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
+    public function testExpectsStringCompatibleType()
+    {
+        $this->validator->validate(new \stdClass(), new Timezone());
+    }
+
+    /**
+     * @dataProvider getValidTimezones
+     */
+    public function testValidTimezones($timezone)
+    {
+        $this->validator->validate($timezone, new Timezone());
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidTimezones()
+    {
+        return array(
+            array('America/Argentina/Buenos_Aires'),
+            array('America/Barbados'),
+            array('Antarctica/Syowa'),
+            array('Africa/Douala'),
+            array('Atlantic/Canary'),
+            array('Asia/Gaza'),
+            array('Europe/Copenhagen'),
+        );
+    }
+
+    /**
+     * @dataProvider getValidGroupedTimezones
+     */
+    public function testValidGroupedTimezones($timezone, $what)
+    {
+        $constraint = new Timezone(array(
+            'value' => $what,
+        ));
+
+        $this->validator->validate($timezone, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidGroupedTimezones()
+    {
+        return array(
+            array('America/Argentina/Cordoba', \DateTimeZone::AMERICA),
+            array('America/Barbados', \DateTimeZone::AMERICA),
+            array('Africa/Cairo', \DateTimeZone::AFRICA),
+            array('Atlantic/Cape_Verde', \DateTimeZone::ATLANTIC),
+            array('Europe/Bratislava', \DateTimeZone::EUROPE),
+            array('Indian/Christmas', \DateTimeZone::INDIAN),
+            array('Pacific/Kiritimati', \DateTimeZone::ALL),
+            array('Pacific/Kiritimati', \DateTimeZone::ALL_WITH_BC),
+            array('Pacific/Kiritimati', \DateTimeZone::PACIFIC),
+            array('Arctic/Longyearbyen', \DateTimeZone::ARCTIC),
+            array('Asia/Beirut', \DateTimeZone::ASIA),
+            array('Atlantic/Bermuda', \DateTimeZone::ASIA | \DateTimeZone::ATLANTIC),
+            array('Atlantic/Azores', \DateTimeZone::ATLANTIC | \DateTimeZone::ASIA),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidTimezones
+     */
+    public function testInvalidTimezones($timezone)
+    {
+        $constraint = new Timezone(array(
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate($timezone, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ timezone_group }}', '"'.$timezone.'"')
+            ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidTimezones()
+    {
+        return array(
+            array('Buenos_Aires/Argentina/America'),
+            array('Mayotte/Indian'),
+            array('foobar'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidGroupedTimezones
+     */
+    public function testInvalidGroupedTimezones($timezone, $what)
+    {
+        $constraint = new Timezone(array(
+            'value' => $what,
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate($timezone, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ timezone_group }}', '"'.$timezone.'"')
+            ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidGroupedTimezones()
+    {
+        return array(
+            array('Antarctica/McMurdo', \DateTimeZone::AMERICA),
+            array('America/Barbados', \DateTimeZone::ANTARCTICA),
+            array('Europe/Kiev', \DateTimeZone::ARCTIC),
+            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN),
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -106,7 +106,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getInvalidTimezones
      */
-    public function testInvalidTimezones($timezone)
+    public function testInvalidTimezones($timezone, $extraInfo)
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
@@ -115,7 +115,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ timezone_group }}', '"'.$timezone.'"')
+            ->setParameter('{{ extra_info }}', '"'.$extraInfo.'"')
             ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
             ->assertRaised();
     }
@@ -123,16 +123,16 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidTimezones()
     {
         return array(
-            array('Buenos_Aires/Argentina/America'),
-            array('Mayotte/Indian'),
-            array('foobar'),
+            array('Buenos_Aires/Argentina/America', ' for "ALL" zone'),
+            array('Mayotte/Indian', ' for "ALL" zone'),
+            array('foobar', ' for "ALL" zone'),
         );
     }
 
     /**
      * @dataProvider getInvalidGroupedTimezones
      */
-    public function testInvalidGroupedTimezones($timezone, $what)
+    public function testInvalidGroupedTimezones($timezone, $what, $extraInfo)
     {
         $constraint = new Timezone(array(
             'timezone' => $what,
@@ -142,7 +142,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ timezone_group }}', '"'.$timezone.'"')
+            ->setParameter('{{ extra_info }}', '"'.$extraInfo.'"')
             ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
             ->assertRaised();
     }
@@ -150,10 +150,11 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidGroupedTimezones()
     {
         return array(
-            array('Antarctica/McMurdo', \DateTimeZone::AMERICA),
-            array('America/Barbados', \DateTimeZone::ANTARCTICA),
-            array('Europe/Kiev', \DateTimeZone::ARCTIC),
-            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN),
+            array('Antarctica/McMurdo', \DateTimeZone::AMERICA, ' for "AMERICA" zone'),
+            array('America/Barbados', \DateTimeZone::ANTARCTICA, ' for "ANTARCTICA" zone'),
+            array('Europe/Kiev', \DateTimeZone::ARCTIC, ' for "ARCTIC" zone'),
+            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN, ' for "INDIAN" zone'),
+            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN | \DateTimeZone::ANTARCTICA, ' for "260" zone'),
         );
     }
 
@@ -194,7 +195,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getInvalidGroupedTimezonesByCountry
      */
-    public function testInvalidGroupedTimezonesByCountry($timezone, $what, $country)
+    public function testInvalidGroupedTimezonesByCountry($timezone, $what, $country, $extraInfo)
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
@@ -205,7 +206,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ timezone_group }}', '"'.$timezone.'"')
+            ->setParameter('{{ extra_info }}', '"'.$extraInfo.'"')
             ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
             ->assertRaised();
     }
@@ -213,8 +214,8 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidGroupedTimezonesByCountry()
     {
         return array(
-            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'FR'),
-            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT'),
+            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'FR', ' for ISO 3166-1 country code FR'),
+            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT', ' for ISO 3166-1 country code PT'),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -142,7 +142,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ extra_info }}', '"'.$extraInfo.'"')
+            ->setParameter('{{ extra_info }}', $extraInfo)
             ->setCode(Timezone::NO_SUCH_TIMEZONE_IN_ZONE_ERROR)
             ->assertRaised();
     }
@@ -206,7 +206,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ extra_info }}', '"'.$extraInfo.'"')
+            ->setParameter('{{ extra_info }}', $extraInfo)
             ->setCode(Timezone::NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR)
             ->assertRaised();
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -218,4 +218,44 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
             array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT', ' for ISO 3166-1 country code "PT"'),
         );
     }
+
+    /**
+     * @dataProvider getDeprecatedTimezones
+     */
+    public function testDeprecatedTimezonesAreVaildWithBC($timezone)
+    {
+        $constraint = new Timezone(array(
+            'zone' => \DateTimeZone::ALL_WITH_BC,
+        ));
+
+        $this->validator->validate($timezone, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getDeprecatedTimezones
+     */
+    public function testDeprecatedTimezonesAreInvaildWithoutBC($timezone)
+    {
+        $constraint = new Timezone(array(
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate($timezone, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ extra_info }}', '')
+            ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
+            ->assertRaised();
+    }
+
+    public function getDeprecatedTimezones()
+    {
+        return array(
+            array('America/Buenos_Aires'),
+            array('Etc/GMT'),
+            array('US/Pacific'),
+        );
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -143,7 +143,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ extra_info }}', '"'.$extraInfo.'"')
-            ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
+            ->setCode(Timezone::NO_SUCH_TIMEZONE_IN_ZONE_ERROR)
             ->assertRaised();
     }
 
@@ -207,7 +207,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ extra_info }}', '"'.$extraInfo.'"')
-            ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
+            ->setCode(Timezone::NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimezoneValidatorTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class TimezoneValidatorTest extends ConstraintValidatorTestCase
 {
-    protected function createValidator()
+    protected function createValidator(): TimezoneValidator
     {
         return new TimezoneValidator();
     }
@@ -50,14 +50,14 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getValidTimezones
      */
-    public function testValidTimezones($timezone)
+    public function testValidTimezones(string $timezone)
     {
         $this->validator->validate($timezone, new Timezone());
 
         $this->assertNoViolation();
     }
 
-    public function getValidTimezones()
+    public function getValidTimezones(): iterable
     {
         return array(
             array('America/Argentina/Buenos_Aires'),
@@ -73,7 +73,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getValidGroupedTimezones
      */
-    public function testValidGroupedTimezones($timezone, $what)
+    public function testValidGroupedTimezones(string $timezone, int $what)
     {
         $constraint = new Timezone(array(
             'zone' => $what,
@@ -84,7 +84,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function getValidGroupedTimezones()
+    public function getValidGroupedTimezones(): iterable
     {
         return array(
             array('America/Argentina/Cordoba', \DateTimeZone::AMERICA),
@@ -106,7 +106,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getInvalidTimezones
      */
-    public function testInvalidTimezonesWithoutZone($timezone, $extraInfo)
+    public function testInvalidTimezonesWithoutZone(string $timezone, string $zoneMessage, string $countryCodeMessage)
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
@@ -115,24 +115,25 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ extra_info }}', $extraInfo)
+            ->setParameter('{{ zone_message }}', $zoneMessage)
+            ->setParameter('{{ country_code_message }}', $countryCodeMessage)
             ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
             ->assertRaised();
     }
 
-    public function getInvalidTimezones()
+    public function getInvalidTimezones(): iterable
     {
         return array(
-            array('Buenos_Aires/Argentina/America', ''),
-            array('Mayotte/Indian', ''),
-            array('foobar', ''),
+            array('Buenos_Aires/Argentina/America', '', ''),
+            array('Mayotte/Indian', '', ''),
+            array('foobar', '', ''),
         );
     }
 
     /**
      * @dataProvider getInvalidGroupedTimezones
      */
-    public function testInvalidGroupedTimezones($timezone, $what, $extraInfo)
+    public function testInvalidGroupedTimezones(string $timezone, int $what, string $zoneMessage, string $countryCodeMessage)
     {
         $constraint = new Timezone(array(
             'zone' => $what,
@@ -142,26 +143,27 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ extra_info }}', $extraInfo)
+            ->setParameter('{{ zone_message }}', $zoneMessage)
+            ->setParameter('{{ country_code_message }}', $countryCodeMessage)
             ->setCode(Timezone::NO_SUCH_TIMEZONE_IN_ZONE_ERROR)
             ->assertRaised();
     }
 
-    public function getInvalidGroupedTimezones()
+    public function getInvalidGroupedTimezones(): iterable
     {
         return array(
-            array('Antarctica/McMurdo', \DateTimeZone::AMERICA, ' for "AMERICA" zone'),
-            array('America/Barbados', \DateTimeZone::ANTARCTICA, ' for "ANTARCTICA" zone'),
-            array('Europe/Kiev', \DateTimeZone::ARCTIC, ' for "ARCTIC" zone'),
-            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN, ' for "INDIAN" zone'),
-            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN | \DateTimeZone::ANTARCTICA, ' for zone with identifier 260'),
+            array('Antarctica/McMurdo', \DateTimeZone::AMERICA, ' at "AMERICA" zone', ''),
+            array('America/Barbados', \DateTimeZone::ANTARCTICA, ' at "ANTARCTICA" zone', ''),
+            array('Europe/Kiev', \DateTimeZone::ARCTIC, ' at "ARCTIC" zone', ''),
+            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN, ' at "INDIAN" zone', ''),
+            array('Asia/Ho_Chi_Minh', \DateTimeZone::INDIAN | \DateTimeZone::ANTARCTICA, ' at zone with identifier 260', ''),
         );
     }
 
     /**
      * @dataProvider getValidGroupedTimezonesByCountry
      */
-    public function testValidGroupedTimezonesByCountry($timezone, $what, $country)
+    public function testValidGroupedTimezonesByCountry(string $timezone, int $what, string $country)
     {
         $constraint = new Timezone(array(
             'zone' => $what,
@@ -173,7 +175,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function getValidGroupedTimezonesByCountry()
+    public function getValidGroupedTimezonesByCountry(): iterable
     {
         return array(
             array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'AR'),
@@ -195,7 +197,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getInvalidGroupedTimezonesByCountry
      */
-    public function testInvalidGroupedTimezonesByCountry($timezone, $what, $country, $extraInfo)
+    public function testInvalidGroupedTimezonesByCountry(string $timezone, int $what, string $country, string $zoneMessage, string $countryCodeMessage)
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
@@ -206,23 +208,24 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ extra_info }}', $extraInfo)
+            ->setParameter('{{ zone_message }}', $zoneMessage)
+            ->setParameter('{{ country_code_message }}', $countryCodeMessage)
             ->setCode(Timezone::NO_SUCH_TIMEZONE_IN_COUNTRY_ERROR)
             ->assertRaised();
     }
 
-    public function getInvalidGroupedTimezonesByCountry()
+    public function getInvalidGroupedTimezonesByCountry(): iterable
     {
         return array(
-            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'FR', ' for ISO 3166-1 country code "FR"'),
-            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT', ' for ISO 3166-1 country code "PT"'),
+            array('America/Argentina/Cordoba', \DateTimeZone::PER_COUNTRY, 'FR', '', ' for ISO 3166-1 country code "FR"'),
+            array('America/Barbados', \DateTimeZone::PER_COUNTRY, 'PT', '', ' for ISO 3166-1 country code "PT"'),
         );
     }
 
     /**
      * @dataProvider getDeprecatedTimezones
      */
-    public function testDeprecatedTimezonesAreVaildWithBC($timezone)
+    public function testDeprecatedTimezonesAreVaildWithBC(string $timezone)
     {
         $constraint = new Timezone(array(
             'zone' => \DateTimeZone::ALL_WITH_BC,
@@ -236,7 +239,7 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getDeprecatedTimezones
      */
-    public function testDeprecatedTimezonesAreInvaildWithoutBC($timezone)
+    public function testDeprecatedTimezonesAreInvaildWithoutBC(string $timezone)
     {
         $constraint = new Timezone(array(
             'message' => 'myMessage',
@@ -245,12 +248,13 @@ class TimezoneValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($timezone, $constraint);
 
         $this->buildViolation('myMessage')
-            ->setParameter('{{ extra_info }}', '')
+            ->setParameter('{{ zone_message }}', '')
+            ->setParameter('{{ country_code_message }}', '')
             ->setCode(Timezone::NO_SUCH_TIMEZONE_ERROR)
             ->assertRaised();
     }
 
-    public function getDeprecatedTimezones()
+    public function getDeprecatedTimezones(): iterable
     {
         return array(
             array('America/Buenos_Aires'),


### PR DESCRIPTION
|Q            |A        |
|---          |---      |
|Branch       |master   |
|Bug fix?     |no       |
|New feature? |yes      |
|BC breaks?   |no       |
|Deprecations?|no       |
|Tests pass?  |yes      |
|Fixed tickets|n/a      |
|License      |MIT      |
|Doc PR       |n/a (yet)|

Add `TimezoneValidator` in order to validate timezones against `\DateTimeZone::listIdentifiers()`.

TODO:
- [x] Add support for constraints with `\DateTimeZone::PER_COUNTRY` argument
- [x] Improve the validation message