### PR TITLE
Release v2.7.26

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,37 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.26 (2017-04-04)
+
+ * bug #22229 [ExpressionLanguage] Provide the expression in syntax errors (k0pernikus, stof)
+ * bug #22240 [DI] Fix fatal error at ContainerBuilder::compile() if config is not installed (chalasr)
+ * bug #22140 [Form] Improve the exceptions when trying to get the data in a PRE_SET_DATA listener and the data has not already been set (fancyweb)
+ * bug #22217 [Console] Fix table cell styling (ro0NL)
+ * bug #22194 [Console] CommandTester: disable color support detection (julienfalque)
+ * bug #22188 [Console] Revised exception rendering (ro0NL)
+ * bug #22154 [WebProfilerBundle] Normalize whitespace in exceptions passed in headers (curry684)
+ * bug #22142 [Console] Escape exception messages in renderException (chalasr)
+ * bug #22172 Fix port usage in server:status command (alcaeus)
+ * bug #22164 [Bridge\Doctrine] Fix change breaking doctrine-bundle test suite (nicolas-grekas)
+ * bug #22133 [Filesystem] normalize paths before making them relative (xabbuh)
+ * bug #22138 [HttpFoundation][bugfix] $bags should always be initialized (MacDada)
+ * bug #21810 #21809 [SecurityBundle] bugfix: if security provider's name contains upper cases then container didn't compile (Antanas Arvasevicius)
+ * bug #19778 [Security] Fixed roles serialization on token from user object (eko)
+ * bug #22022 [Validator] fix URL validator to detect non supported chars according to RFC 3986 (e-moe)
+ * bug #21968 Fixed pathinfo calculation for requests starting with a question mark. (syzygymsu)
+ * bug #21846 [HttpFoundation] Fix Request::getHost() when having several hosts in X_FORWARDED_HOST (nicolas-grekas)
+ * bug #21208 [Validator] Add object handling of invalid constraints in Composite (SenseException)
+ * bug #22044 [Serializer] [XML] Ignore Process Instruction (jordscream)
+ * bug #22079 [HttpKernel] Fixed bug with purging of HTTPS URLs (ausi)
+ * bug #21523 #20411 fix Yaml parsing for very long quoted strings (RichardBradley)
+ * bug #22001 [Doctrine Bridge] fix priority for doctrine event listeners (dmaicher)
+ * bug #21981 [Console] Use proper line endings in BufferedOutput (julienfalque)
+ * bug #21957 [Form] Choice type int values (BC Fix) (mcfedr)
+ * bug #21923 [travis] Test with hhvm 3.18 (nicolas-grekas)
+ * bug #21823 dumpFile(), preserve existing file permissions (chs2)
+ * bug #21865 [Security] context listener: hardening user provider handling (xabbuh)
+ * bug #21883 [HttpKernel] fix Kernel name when stored in a directory starting with a number (fabpot)
+
 * 2.7.25 (2017-03-06)
 
  * bug #21671 [Serializer] Xml encoder throws exception for valid data (gr1ev0us)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,25 +23,26 @@ Symfony is the result of the work of many people who made the code better
  - Pascal Borreli (pborreli)
  - Wouter De Jong (wouterj)
  - Romain Neutron (romain)
+ - Grégoire Pineau (lyrixx)
  - Joseph Bielawski (stloyd)
  - Karma Dordrak (drak)
  - Lukas Kahwe Smith (lsmith)
- - Grégoire Pineau (lyrixx)
  - Martin Hasoň (hason)
- - Jeremy Mikola (jmikola)
+ - Robin Chalas (chalas_r)
  - Maxime Steinhausser (ogizanagi)
+ - Jeremy Mikola (jmikola)
  - Jean-François Simon (jfsimon)
  - Benjamin Eberlei (beberlei)
  - Igor Wiedler (igorw)
- - Robin Chalas (chalas_r)
  - Eriksen Costa (eriksencosta)
  - Jules Pietri (heah)
  - Sarah Khalil (saro0h)
  - Jonathan Wage (jwage)
+ - Guilhem Niot (energetick)
  - Diego Saint Esteben (dosten)
+ - Roland Franssen (ro0)
  - Alexandre Salomé (alexandresalome)
  - William Durand (couac)
- - Guilhem Niot (energetick)
  - ornicar
  - Francis Besset (francisbesset)
  - stealth35 ‏ (stealth35)
@@ -50,20 +51,20 @@ Symfony is the result of the work of many people who made the code better
  - Peter Rehm (rpet)
  - Saša Stamenković (umpirsky)
  - Henrik Bjørnskov (henrikbjorn)
- - Roland Franssen (ro0)
  - Miha Vrhovnik
  - Iltar van der Berg (kjarli)
  - Diego Saint Esteben (dii3g0)
  - Konstantin Kudryashov (everzet)
  - Bilal Amarni (bamarni)
  - Florin Patan (florinpatan)
+ - Matthias Pigulla (mpdude)
  - Kevin Bond (kbond)
  - Andrej Hudec (pulzarraider)
  - Gábor Egyed (1ed)
  - Michel Weimerskirch (mweimerskirch)
  - Eric Clemmons (ericclemmons)
  - Charles Sarrazin (csarrazi)
- - Matthias Pigulla (mpdude)
+ - Pierre du Plessis (pierredup)
  - Christian Raue
  - Arnout Boks (aboks)
  - Deni
@@ -71,39 +72,38 @@ Symfony is the result of the work of many people who made the code better
  - Dariusz Górecki (canni)
  - Titouan Galopin (tgalopin)
  - Douglas Greenshields (shieldo)
- - Pierre du Plessis (pierredup)
  - Konstantin Myakshin (koc)
  - Lee McDermott
  - Brandon Turner
  - Luis Cordova (cordoval)
+ - Jáchym Toušek (enumag)
  - Graham Campbell (graham)
  - Daniel Holmes (dholmes)
  - Toni Uebernickel (havvg)
  - Bart van den Burg (burgov)
  - Jordan Alliot (jalliot)
+ - Jérémy DERUSSÉ (jderusse)
  - John Wards (johnwards)
  - Fran Moreno (franmomu)
- - Jáchym Toušek (enumag)
  - Antoine Hérault (herzult)
  - Paráda József (paradajozsef)
  - Dariusz Ruminski
  - Arnaud Le Blanc (arnaud-lb)
  - Jérôme Tamarelle (gromnan)
+ - Maxime STEINHAUSSER
  - Michal Piotrowski (eventhorizon)
  - Tim Nagel (merk)
- - Maxime STEINHAUSSER
  - Issei Murasawa (issei_m)
  - Brice BERNARD (brikou)
  - Alexander M. Turek (derrabus)
+ - Baptiste Clavié (talus)
  - marc.weistroff
  - lenar
  - Włodzimierz Gajda (gajdaw)
- - Baptiste Clavié (talus)
  - Vladimir Reznichenko (kalessil)
  - Alexander Schwenn (xelaris)
  - Florian Voutzinos (florianv)
  - Colin Frei
- - Jérémy DERUSSÉ (jderusse)
  - Adrien Brault (adrienbrault)
  - Joshua Thijssen
  - Peter Kokot (maastermedia)
@@ -148,6 +148,7 @@ Symfony is the result of the work of many people who made the code better
  - Teoh Han Hui (teohhanhui)
  - Clemens Tolboom
  - Helmer Aaviksoo
+ - Grégoire Paris (greg0ire)
  - Hiromi Hishida (77web)
  - Richard van Laak (rvanlaak)
  - Matthieu Ouellette-Vachon (maoueh)
@@ -160,7 +161,7 @@ Symfony is the result of the work of many people who made the code better
  - Warnar Boekkooi (boekkooi)
  - Dmitrii Chekaliuk (lazyhammer)
  - Clément JOBEILI (dator)
- - Grégoire Paris (greg0ire)
+ - Dawid Nowak
  - Possum
  - Dorian Villet (gnutix)
  - Richard Miller (mr_r_miller)
@@ -168,6 +169,7 @@ Symfony is the result of the work of many people who made the code better
  - Dennis Benkert (denderello)
  - Benjamin Dulau (dbenjamin)
  - Mathieu Lemoine (lemoinem)
+ - Chris Wilkinson (thewilkybarkid)
  - Andreas Hucks (meandmymonkey)
  - Noel Guilbert (noel)
  - Lars Strojny (lstrojny)
@@ -191,16 +193,15 @@ Symfony is the result of the work of many people who made the code better
  - John Kary (johnkary)
  - Justin Hileman (bobthecow)
  - Blanchon Vincent (blanchonvincent)
- - Chris Wilkinson (thewilkybarkid)
  - Christian Schmidt
  - Michele Orselli (orso)
  - Tom Van Looy (tvlooy)
  - Sven Paulus (subsven)
  - Rui Marinho (ruimarinho)
  - SpacePossum
- - Dawid Nowak
  - Eugene Wissner
  - Julien Brochet (mewt)
+ - Julien Falque (julienfalque)
  - Tristan Darricau (nicofuma)
  - Sergey Linnik (linniksa)
  - Michaël Perrin (michael.perrin)
@@ -211,6 +212,7 @@ Symfony is the result of the work of many people who made the code better
  - julien pauli (jpauli)
  - Lorenz Schori
  - Sébastien Lavoie (lavoiesl)
+ - David Maicher (dmaicher)
  - Francois Zaninotto
  - Alexander Kotynia (olden)
  - Daniel Tschinder
@@ -236,7 +238,6 @@ Symfony is the result of the work of many people who made the code better
  - Uwe Jäger (uwej711)
  - Eugene Leonovich (rybakit)
  - Filippo Tessarotto
- - Julien Falque (julienfalque)
  - Joseph Rouff (rouffj)
  - Félix Labrecque (woodspire)
  - GordonsLondon
@@ -258,7 +259,6 @@ Symfony is the result of the work of many people who made the code better
  - Beau Simensen (simensen)
  - Michael Hirschler (mvhirsch)
  - Robert Kiss (kepten)
- - David Maicher (dmaicher)
  - Roumen Damianoff (roumen)
  - Antonio J. García Lagar (ajgarlag)
  - Kim Hemsø Rasmussen (kimhemsoe)
@@ -396,6 +396,7 @@ Symfony is the result of the work of many people who made the code better
  - EdgarPE
  - Florian Pfitzer (marmelatze)
  - Asier Illarramendi (doup)
+ - Andreas Braun
  - Chris Sedlmayr (catchamonkey)
  - Seb Koelen
  - Dany Maillard (maidmaid)
@@ -415,6 +416,7 @@ Symfony is the result of the work of many people who made the code better
  - Gintautas Miselis
  - Rob Bast
  - David Badura (davidbadura)
+ - Jordan Samouh (jordansamouh)
  - Zander Baldwin
  - Adam Harvey
  - Alex Bakhturin
@@ -459,11 +461,13 @@ Symfony is the result of the work of many people who made the code better
  - Jakub Škvára (jskvara)
  - Andrew Udvare (audvare)
  - alexpods
+ - Nikolay Labinskiy (e-moe)
  - Arjen van der Meijden
  - Michele Locati
  - Dariusz Ruminski
  - Erik Trapman (eriktrapman)
  - De Cock Xavier (xdecock)
+ - Arthur de Moulins (4rthem)
  - Almog Baku (almogbaku)
  - Scott Arciszewski
  - Norbert Orzechowicz (norzechowicz)
@@ -510,8 +514,10 @@ Symfony is the result of the work of many people who made the code better
  - Disquedur
  - Michiel Boeckaert (milio)
  - Geoffrey Tran (geoff)
+ - Romain Pierre (romain-pierre)
  - Jan Behrens
  - Mantas Var (mvar)
+ - Frank de Jonge (frenkynet)
  - Sebastian Krebs
  - Jean-Christophe Cuvelier [Artack]
  - Christopher Davis (chrisguitarguy)
@@ -539,8 +545,8 @@ Symfony is the result of the work of many people who made the code better
  - Maxime Douailin
  - Jean Pasdeloup (pasdeloup)
  - Benjamin Cremer (bcremer)
+ - Thierry Thuon (lepiaf)
  - Javier López (loalf)
- - Andreas Braun
  - Reinier Kip
  - Geoffrey Brier (geoffrey-brier)
  - Dustin Dobervich (dustin10)
@@ -553,6 +559,7 @@ Symfony is the result of the work of many people who made the code better
  - Kamil Kokot (pamil)
  - Aurimas Niekis (gcds)
  - Max Grigorian (maxakawizard)
+ - mcfedr (mcfedr)
  - Rostyslav Kinash
  - Maciej Malarz (malarzm)
  - Daisuke Ohata
@@ -570,6 +577,7 @@ Symfony is the result of the work of many people who made the code better
  - Denis Brumann (dbrumann)
  - Quentin de Longraye (quentinus95)
  - Chris Heng (gigablah)
+ - Richard Bradley
  - Ulumuddin Yunus (joenoez)
  - Luc Vieillescazes (iamluc)
  - Johann Saunier (prophet777)
@@ -629,6 +637,7 @@ Symfony is the result of the work of many people who made the code better
  - Besnik Br
  - Dariusz Ruminski
  - Joshua Nye
+ - Claudio Zizza
  - Dave Marshall (davedevelopment)
  - avorobiev
  - Venu
@@ -647,6 +656,7 @@ Symfony is the result of the work of many people who made the code better
  - John Bohn (jbohn)
  - Marc Morera (mmoreram)
  - Andrew Hilobok (hilobok)
+ - Noah Heck (myesain)
  - Christian Soronellas (theunic)
  - Yosmany Garcia (yosmanyga)
  - Wouter de Wild
@@ -654,17 +664,18 @@ Symfony is the result of the work of many people who made the code better
  - Degory Valentine
  - Benoit Lévêque (benoit_leveque)
  - Jeroen Fiege (fieg)
- - Arthur de Moulins (4rthem)
  - Krzysiek Łabuś
  - Xavier Lacot (xavier)
  - possum
  - Denis Zunke (donalberto)
+ - Ahmed TAILOULOUTE (ahmedtai)
  - Olivier Maisonneuve (olineuve)
  - Masterklavi
  - Francis Turmel (fturmel)
  - Nikita Nefedov (nikita2206)
  - cgonzalez
  - Ben
+ - Vincent Composieux (eko)
  - Jayson Xu (superjavason)
  - Jaik Dean (jaikdean)
  - fago
@@ -675,6 +686,7 @@ Symfony is the result of the work of many people who made the code better
  - James Michael DuPont
  - Tom Klingenberg
  - Christopher Hall (mythmakr)
+ - Patrick Dawkins (pjcdawkins)
  - Paul Kamer (pkamer)
  - Rafał Wrzeszcz (rafalwrzeszcz)
  - Reen Lokum
@@ -720,6 +732,7 @@ Symfony is the result of the work of many people who made the code better
  - corphi
  - grizlik
  - Derek ROTH
+ - Dmytro Boiko (eagle)
  - Shin Ohno (ganchiku)
  - Geert De Deckere (geertdd)
  - Jan Kramer (jankramer)
@@ -782,7 +795,6 @@ Symfony is the result of the work of many people who made the code better
  - Phan Thanh Ha (haphan)
  - Chris Jones (leek)
  - Colin O&#039;Dell (colinodell)
- - Frank de Jonge (frenkynet)
  - xaav
  - Mahmoud Mostafa (mahmoud)
  - Alessandro Lai
@@ -808,7 +820,6 @@ Symfony is the result of the work of many people who made the code better
  - Zachary Tong (polyfractal)
  - Hryhorii Hrebiniuk
  - Dennis Fridrich (dfridrich)
- - mcfedr (mcfedr)
  - hamza
  - dantleech
  - Bastien DURAND (deamon)
@@ -841,6 +852,7 @@ Symfony is the result of the work of many people who made the code better
  - Troy McCabe
  - Ville Mattila
  - ilyes kooli
+ - gr1ev0us
  - Boris Vujicic (boris.vujicic)
  - Max Beutel
  - Antanas Arvasevicius
@@ -864,10 +876,12 @@ Symfony is the result of the work of many people who made the code better
  - Martynas Narbutas
  - Bailey Parker
  - Eddie Jaoude
+ - Antanas Arvasevicius
  - Haritz Iturbe (hizai)
  - Nerijus Arlauskas (nercury)
  - SPolischook
  - Diego Sapriza
+ - Anton A. Sumin
  - Joan Cruz
  - inspiran
  - Cristobal Dabed
@@ -964,6 +978,7 @@ Symfony is the result of the work of many people who made the code better
  - Aharon Perkel
  - matze
  - Abdul.Mohsen B. A. A
+ - Martin Auswöger
  - BenoÃ®t Burnichon
  - pthompson
  - Malaney J. Hill
@@ -1009,7 +1024,9 @@ Symfony is the result of the work of many people who made the code better
  - Klaas Cuvelier (kcuvelier)
  - markusu49
  - Steve Frécinaux
+ - Jules Lamur
  - ShiraNai7
+ - Markus Fasselt (digilist)
  - Vašek Purchart (vasek-purchart)
  - Janusz Jabłoński (yanoosh)
  - Sandro Hopf
@@ -1034,17 +1051,16 @@ Symfony is the result of the work of many people who made the code better
  - Luis Galeas
  - Martin Pärtel
  - George Mponos (gmponos)
- - Noah Heck (myesain)
  - Patrick Daley (padrig)
  - Xavier Briand (xavierbriand)
  - Max Summe
  - WedgeSama
  - Felds Liscia
- - Ahmed TAILOULOUTE (ahmedtai)
  - Maxime Veber (nek-)
  - Sullivan SENECHAL
  - Tadcka
  - Beth Binkovitz
+ - Gonzalo Míguez
  - Romain Geissler
  - Adrien Moiruad
  - Tomaz Ahlin
@@ -1104,7 +1120,6 @@ Symfony is the result of the work of many people who made the code better
  - Konrad Mohrfeldt
  - Lance Chen
  - Andrew (drew)
- - Nikolay Labinskiy (e-moe)
  - kor3k kor3k (kor3k)
  - Stelian Mocanita (stelian)
  - Flavian (2much)
@@ -1143,11 +1158,9 @@ Symfony is the result of the work of many people who made the code better
  - victoria
  - Francisco Facioni (fran6co)
  - Iwan van Staveren (istaveren)
- - Thierry Thuon (lepiaf)
  - Povilas S. (povilas)
  - pborreli
  - Eric Caron
- - Richard Bradley
  - 2manypeople
  - Wing
  - Thomas Bibb
@@ -1171,6 +1184,7 @@ Symfony is the result of the work of many people who made the code better
  - Michal Gebauer
  - Gleb Sidora
  - David Stone
+ - Niels Keurentjes (curry684)
  - Jovan Perovic (jperovic)
  - Pablo Maria Martelletti (pmartelletti)
  - Yassine Guedidi (yguedidi)
@@ -1228,6 +1242,7 @@ Symfony is the result of the work of many people who made the code better
  - Brian Graham (incognito)
  - Kevin Vergauwen (innocenzo)
  - Alessio Baglio (ioalessio)
+ - Johannes Müller (johmue)
  - Jordi Llonch (jordillonch)
  - Cédric Dugat (ph3nol)
  - Philip Dahlstrøm (phidah)
@@ -1289,6 +1304,7 @@ Symfony is the result of the work of many people who made the code better
  - Jérémy M (th3mouk)
  - Vincent LEFORT (vlefort)
  - Sadicov Vladimir (xtech)
+ - Kevin EMO (zarcox)
  - Alexander Zogheb
  - Rémi Blaise
  - Joel Marcey
@@ -1301,7 +1317,6 @@ Symfony is the result of the work of many people who made the code better
  - adenkejawen
  - Ari Pringle (apringle)
  - Dan Ordille (dordille)
- - Dmytro Boiko (eagle)
  - Jan Eichhorn (exeu)
  - Grégory Pelletier (ip512)
  - John Nickell (jrnickell)
@@ -1350,7 +1365,6 @@ Symfony is the result of the work of many people who made the code better
  - ddebree
  - Tomas Liubinas
  - Alex
- - Patrick Dawkins
  - Klaas Naaijkens
  - Daniel González Cerviño
  - Rafał
@@ -1363,7 +1377,6 @@ Symfony is the result of the work of many people who made the code better
  - David Joos (djoos)
  - Denis Klementjev (dklementjev)
  - Tomáš Polívka (draczris)
- - Vincent Composieux (eko)
  - Franz Liedke (franzliedke)
  - Christophe BECKER (goabonga)
  - gondo (gondo)
@@ -1399,6 +1412,7 @@ Symfony is the result of the work of many people who made the code better
  - Curtis
  - Gabriel Moreira
  - Alexey Popkov
+ - ChS
  - Joseph Deray
  - Damian Sromek
  - Ben
@@ -1437,6 +1451,7 @@ Symfony is the result of the work of many people who made the code better
  - znerol
  - Christian Eikermann
  - Antonio Angelino
+ - Matt Fields
  - Shawn Iwinski
  - Niklas Keller
  - Vladimir Sazhin
@@ -1562,6 +1577,7 @@ Symfony is the result of the work of many people who made the code better
  - ibasaw (ibasaw)
  - Vladislav Krupenkin (ideea)
  - Imangazaliev Muhammad (imangazaliev)
+ - j0k (j0k)
  - joris de wit (jdewit)
  - Jérémy CROMBEZ (jeremy)
  - Jose Manuel Gonzalez (jgonzalez)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.26-DEV';
+    const VERSION = '2.7.26';
     const VERSION_ID = 20726;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 26;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.7.25...v2.7.26)

 * bug #22229 [ExpressionLanguage] Provide the expression in syntax errors (@k0pernikus, @stof)
 * bug #22240 [DI] Fix fatal error at ContainerBuilder::compile() if config is not installed (@chalasr)
 * bug #22140 [Form] Improve the exceptions when trying to get the data in a PRE_SET_DATA listener and the data has not already been set (@fancyweb)
 * bug #22217 [Console] Fix table cell styling (@ro0NL)
 * bug #22194 [Console] CommandTester: disable color support detection (@julienfalque)
 * bug #22188 [Console] Revised exception rendering (@ro0NL)
 * bug #22154 [WebProfilerBundle] Normalize whitespace in exceptions passed in headers (@curry684)
 * bug #22142 [Console] Escape exception messages in renderException (@chalasr)
 * bug #22172 Fix port usage in server:status command (@alcaeus)
 * bug #22164 [Bridge\Doctrine] Fix change breaking doctrine-bundle test suite (@nicolas-grekas)
 * bug #22133 [Filesystem] normalize paths before making them relative (@xabbuh)
 * bug #22138 [HttpFoundation][bugfix] $bags should always be initialized (@MacDada)
 * bug #21810 #21809 [SecurityBundle] bugfix: if security provider's name contains upper cases then container didn't compile (@Antanas Arvasevicius)
 * bug #19778 [Security] Fixed roles serialization on token from user object (@eko)
 * bug #22022 [Validator] fix URL validator to detect non supported chars according to RFC 3986 (@e-moe)
 * bug #21968 Fixed pathinfo calculation for requests starting with a question mark. (@syzygymsu)
 * bug #21846 [HttpFoundation] Fix Request::getHost() when having several hosts in X_FORWARDED_HOST (@nicolas-grekas)
 * bug #21208 [Validator] Add object handling of invalid constraints in Composite (@SenseException)
 * bug #22044 [Serializer] [XML] Ignore Process Instruction (@jordscream)
 * bug #22079 [HttpKernel] Fixed bug with purging of HTTPS URLs (@ausi)
 * bug #21523 #20411 fix Yaml parsing for very long quoted strings (@RichardBradley)
 * bug #22001 [Doctrine Bridge] fix priority for doctrine event listeners (@dmaicher)
 * bug #21981 [Console] Use proper line endings in BufferedOutput (@julienfalque)
 * bug #21957 [Form] Choice type int values (BC Fix) (@mcfedr)
 * bug #21923 [travis] Test with hhvm 3.18 (@nicolas-grekas)
 * bug #21823 dumpFile(), preserve existing file permissions (@chs2)
 * bug #21865 [Security] context listener: hardening user provider handling (@xabbuh)
 * bug #21883 [HttpKernel] fix Kernel name when stored in a directory starting with a number (@fabpot)
