### PR TITLE
Allow Upper Case property names

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -76,7 +76,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             if (!$propertyName || isset($properties[$propertyName])) {
                 continue;
             }
-            if (!preg_match('/^[A-Z]{2,}/', $propertyName)) {
+            if (!$reflectionClass->hasProperty($propertyName) && !preg_match('/^[A-Z]{2,}/', $propertyName)) {
                 $propertyName = lcfirst($propertyName);
             }
             $properties[$propertyName] = true;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
@@ -38,6 +38,7 @@ class ReflectionExtractorTest extends TestCase
                 'parent',
                 'collection',
                 'B',
+                'Guid',
                 'g',
                 'foo',
                 'foo2',
@@ -47,6 +48,7 @@ class ReflectionExtractorTest extends TestCase
                 'files',
                 'a',
                 'DOB',
+                'Id',
                 'c',
                 'd',
                 'e',
@@ -129,6 +131,10 @@ class ReflectionExtractorTest extends TestCase
         $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'd', array()));
         $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'e', array()));
         $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'f', array()));
+        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'Id', array()));
+        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'id', array()));
+        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'Guid', array()));
+        $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'guid', array()));
     }
 
     public function testIsWritable()
@@ -142,5 +148,8 @@ class ReflectionExtractorTest extends TestCase
         $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'd', array()));
         $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'e', array()));
         $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'f', array()));
+        $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'Id', array()));
+        $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'Guid', array()));
+        $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'guid', array()));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -52,6 +52,16 @@ class Dummy extends ParentDummy
     public $B;
 
     /**
+     * @var int
+     */
+    protected $Id;
+
+    /**
+     * @var string
+     */
+    public $Guid;
+
+    /**
      * Nullable array.
      *
      * @var array|null
@@ -97,6 +107,13 @@ class Dummy extends ParentDummy
      * @return \DateTime
      */
     public function getDOB()
+    {
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
     {
     }
 }


### PR DESCRIPTION
ReflectionExtractor::getProperties() returns $id instead of $Id. It is bad naming convention, but is possible

```
class Entity {
    protected $Id;

    public function getId()
    {
        return $this->Id;
    }
}
```

| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | no
| License       | MIT

https://github.com/api-platform/core/issues/1026