### PR TITLE
[Console] Fix render exception test

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -593,6 +593,7 @@ class ApplicationTest extends TestCase
         $application->expects($this->any())
             ->method('getTerminalWidth')
             ->will($this->returnValue(22));
+        putenv('COLUMNS=22');
         $application->register('foo')->setCode(function () {
             throw new \Exception('dont break here <info>!</info>');
         });
@@ -600,6 +601,7 @@ class ApplicationTest extends TestCase
 
         $tester->run(array('command' => 'foo'), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception_escapeslines.txt', $tester->getDisplay(true), '->renderException() escapes lines containing formatting');
+        putenv('COLUMNS=120');
     }
 
     public function testRun()

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -588,11 +588,8 @@ class ApplicationTest extends TestCase
 
     public function testRenderExceptionEscapesLines()
     {
-        $application = $this->getMockBuilder('Symfony\Component\Console\Application')->setMethods(array('getTerminalWidth'))->getMock();
+        $application = new Application();
         $application->setAutoExit(false);
-        $application->expects($this->any())
-            ->method('getTerminalWidth')
-            ->will($this->returnValue(22));
         putenv('COLUMNS=22');
         $application->register('foo')->setCode(function () {
             throw new \Exception('dont break here <info>!</info>');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2 and up
| Bug fix?      | yes (regression from #22188 in master)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22217#issuecomment-291437500
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

As pointed out by @chalasr tests are mysteriously broken.. not sure what i missed but this is apparently needed now..

cc @fabpot 