### PR TITLE
[WebProfilerBundle] Tweaked the Cache profiler panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
@@ -22,14 +22,15 @@
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Cache hits</b>
-            <span>{{ collector.totals.hits }}/{{ collector.totals.reads }}{% if collector.totals.hit_read_ratio is not null %} ({{ collector.totals.hit_read_ratio }}%){% endif %}</span>
+            <span>{{ collector.totals.hits }} / {{ collector.totals.reads }}{% if collector.totals.hit_read_ratio is not null %} ({{ collector.totals.hit_read_ratio }}%){% endif %}</span>
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Cache writes</b>
             <span>{{ collector.totals.writes }}</span>
         </div>
         {% endset %}
-        {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}
     {% endif %}
 {% endblock %}
 
@@ -39,127 +40,116 @@
         {{ include('@WebProfiler/Icon/cache.svg') }}
     </span>
     <strong>Cache</strong>
-    <span class="count">
-        <span>{{ collector.totals.calls }}</span>
-        <span>{{ '%0.2f'|format(collector.totals.time * 1000) }} ms</span>
-    </span>
 </span>
 {% endblock %}
 
 {% block panel %}
     <h2>Cache</h2>
-    <div class="metrics">
-        <div class="metric">
-            <span class="value">{{ collector.totals.calls }}</span>
-            <span class="label">Total calls</span>
-        </div>
-        <div class="metric">
-            <span class="value">{{ '%0.2f'|format(collector.totals.time * 1000) }} <span class="unit">ms</span></span>
-            <span class="label">Total time</span>
-        </div>
-        <div class="metric-divider"></div>
-        <div class="metric">
-            <span class="value">{{ collector.totals.reads }}</span>
-            <span class="label">Total reads</span>
-        </div>
-        <div class="metric">
-            <span class="value">{{ collector.totals.writes }}</span>
-            <span class="label">Total writes</span>
-        </div>
-        <div class="metric">
-            <span class="value">{{ collector.totals.deletes }}</span>
-            <span class="label">Total deletes</span>
-        </div>
-        <div class="metric-divider"></div>
-        <div class="metric">
-            <span class="value">{{ collector.totals.hits }}</span>
-            <span class="label">Total hits</span>
-        </div>
-        <div class="metric">
-            <span class="value">{{ collector.totals.misses }}</span>
-            <span class="label">Total misses</span>
-        </div>
-        <div class="metric">
-            <span class="value">
-                {% if collector.totals.hit_read_ratio is null %}
-                    n/a
-                {% else %}
-                    {{ collector.totals.hit_read_ratio }} <span class="unit">%</span>
-                {% endif %}
-            </span>
-            <span class="label">Hits/reads</span>
-        </div>
-    </div>
 
-    <h2>Pools</h2>
-    <div class="sf-tabs">
-        {% for name, calls in collector.calls %}
-            <div class="tab {{ calls|length == 0 ? 'disabled' }}">
-                <h3 class="tab-title">{{ name }} <span class="badge">{{ collector.statistics[name].calls }}</span></h3>
-
-                <div class="tab-content">
-                    <h3>Statistics</h3>
-                    <div class="metrics">
-                        {% for key, value in collector.statistics[name] %}
-                            <div class="metric">
-                                <span class="value">
-                                    {% if key == 'time' %}
-                                        {{ '%0.2f'|format(1000 * value.value) }} <span class="unit">ms</span>
-                                    {% elseif key == 'hit_read_ratio' %}
-                                        {% if value.value is null %}
-                                            n/a
-                                        {% else %}
-                                            {{ value }} <span class="unit">%</span>
-                                        {% endif %}
-                                    {% else %}
-                                        {{ value }}
-                                    {% endif %}
-                                </span>
-                                <span class="label">{{ key == 'hit_read_ratio' ? 'Hits/reads' : key|capitalize }}</span>
-                            </div>
-                            {% if key == 'time' or key == 'deletes' %}
-                                <div class="metric-divider"></div>
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-
-                    <h4>Calls</h4>
-                    {% if calls|length == 0 %}
-                        <div class="empty">
-                            <p>No calls</p>
-                        </div>
-                    {% else %}
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>#</th>
-                                    <th class="key">Key</th>
-                                    <th>Value</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                            {% for call in calls %}
-                                {% set separatorStyle = not loop.first ? ' style="border-top-width: medium;"' : '' %}
-                                <tr>
-                                    <td class="font-normal text-small text-muted nowrap" rowspan="3"{{ separatorStyle|raw }}>{{ loop.index }}</td>
-                                    <th{{ separatorStyle|raw }}>{{ call.name }}</th>
-                                    <td{{ separatorStyle|raw }}>{{ profiler_dump(call.value.argument, maxDepth=2) }}</td>
-                                </tr>
-                                <tr>
-                                    <th>Result</th>
-                                    <td>{{ profiler_dump(call.value.result, maxDepth=1) }}</td>
-                                </tr>
-                                <tr>
-                                    <th>Time</th>
-                                    <td>{{ '%0.2f'|format((call.end - call.start) * 1000) }} ms</td>
-                                </tr>
-                            {% endfor %}
-                            </tbody>
-                        </table>
-                    {% endif %}
-                </div>
+    {% if collector.totals.calls == 0 %}
+        <div class="empty">
+            <p>No cache calls were made.</p>
+        </div>
+    {% else %}
+        <div class="metrics">
+            <div class="metric">
+                <span class="value">{{ collector.totals.calls }}</span>
+                <span class="label">Total calls</span>
             </div>
-        {% endfor %}
-    </div>
+            <div class="metric">
+                <span class="value">{{ '%0.2f'|format(collector.totals.time * 1000) }} <span class="unit">ms</span></span>
+                <span class="label">Total time</span>
+            </div>
+            <div class="metric-divider"></div>
+            <div class="metric">
+                <span class="value">{{ collector.totals.reads }}</span>
+                <span class="label">Total reads</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.totals.writes }}</span>
+                <span class="label">Total writes</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.totals.deletes }}</span>
+                <span class="label">Total deletes</span>
+            </div>
+            <div class="metric-divider"></div>
+            <div class="metric">
+                <span class="value">{{ collector.totals.hits }}</span>
+                <span class="label">Total hits</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.totals.misses }}</span>
+                <span class="label">Total misses</span>
+            </div>
+            <div class="metric">
+                <span class="value">
+                    {{ collector.totals.hit_read_ratio ?? 0 }} <span class="unit">%</span>
+                </span>
+                <span class="label">Hits/reads</span>
+            </div>
+        </div>
 
+        <h2>Pools</h2>
+        <div class="sf-tabs">
+            {% for name, calls in collector.calls %}
+                <div class="tab {{ calls|length == 0 ? 'disabled' }}">
+                    <h3 class="tab-title">{{ name }} <span class="badge">{{ collector.statistics[name].calls }}</span></h3>
+
+                    <div class="tab-content">
+                        {% if calls|length == 0 %}
+                            <div class="empty">
+                                <p>No calls were made for {{ name }} pool</p>
+                            </div>
+                        {% else %}
+                            <h4>Metrics</h4>
+                            <div class="metrics">
+                                {% for key, value in collector.statistics[name] %}
+                                    <div class="metric">
+                                        <span class="value">
+                                            {% if key == 'time' %}
+                                                {{ '%0.2f'|format(1000 * value.value) }} <span class="unit">ms</span>
+                                            {% elseif key == 'hit_read_ratio' %}
+                                                {{ value.value ?? 0 }} <span class="unit">%</span>
+                                            {% else %}
+                                                {{ value }}
+                                            {% endif %}
+                                        </span>
+                                        <span class="label">{{ key == 'hit_read_ratio' ? 'Hits/reads' : key|capitalize }}</span>
+                                    </div>
+                                    {% if key == 'time' or key == 'deletes' %}
+                                        <div class="metric-divider"></div>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+
+                            <h4>Calls</h4>
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>#</th>
+                                        <th>Time</th>
+                                        <th>Call</th>
+                                        <th>Arguments</th>
+                                        <th>Result</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                {% for call in calls %}
+                                    <tr>
+                                        <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
+                                        <td>{{ '%0.2f'|format((call.end - call.start) * 1000) }} ms</td>
+                                        <td>{{ call.name }}()</td>
+                                        <td>{{ profiler_dump(call.value.argument, maxDepth=1) }}</td>
+                                        <td>{{ profiler_dump(call.value.result, maxDepth=1) }}</td>
+                                    </tr>
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
@@ -99,7 +99,7 @@
                     <div class="tab-content">
                         {% if calls|length == 0 %}
                             <div class="empty">
-                                <p>No calls were made for {{ name }} pool</p>
+                                <p>No calls were made for {{ name }} pool.</p>
                             </div>
                         {% else %}
                             <h4>Metrics</h4>
@@ -130,7 +130,7 @@
                                         <th>#</th>
                                         <th>Time</th>
                                         <th>Call</th>
-                                        <th>Arguments</th>
+                                        <th>Argument</th>
                                         <th>Result</th>
                                     </tr>
                                 </thead>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Main changes:

---

1) When there are no calls in a cache pool, now we display less information:

| Before / After
| ---
| ![before-empty-pool](https://cloud.githubusercontent.com/assets/73419/24652670/fdaa22f6-1932-11e7-8075-1fbcb8f333e2.png)
| ![after-empty-pool](https://cloud.githubusercontent.com/assets/73419/24652672/ffbe3816-1932-11e7-920f-5e0fdd880953.png)

---

2) The "call list" is now displayed in a more compact way:

![after-compact-call-list](https://cloud.githubusercontent.com/assets/73419/24652706/1dfed9fc-1933-11e7-9b56-b453bf87a2ea.png)

Comparison:

| Before | After
| --- | ---
| ![before-call-list](https://cloud.githubusercontent.com/assets/73419/24652721/2935a3d2-1933-11e7-96a5-3bffb93807a1.png) | ![after-call-list](https://cloud.githubusercontent.com/assets/73419/24652723/2aa77466-1933-11e7-9e41-70656b42f086.png)

---

@ro0NL I know that you had a discussion about showing 0% or n/a for the ratio when there are no calls. You settled for `n/a` ... but as you can see, using `0%` allows to simplify templates ... and is still technically correct. I hope you understand it.