### PR TITLE
[Yaml] report deprecations when linting YAML files

### DIFF
--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -102,10 +102,20 @@ EOF
 
     private function validate($content, $file = null)
     {
+        $prevErrorHandler = set_error_handler(function ($level, $message, $file, $line) use (&$prevErrorHandler) {
+            if (E_USER_DEPRECATED === $level) {
+                throw new ParseException($message);
+            }
+
+            return $prevErrorHandler ? $prevErrorHandler($level, $message, $file, $line) : false;
+        });
+
         try {
             $this->getParser()->parse($content);
         } catch (ParseException $e) {
             return array('file' => $file, 'valid' => false, 'message' => $e->getMessage());
+        } finally {
+            restore_error_handler();
         }
 
         return array('file' => $file, 'valid' => true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In a project I frequently discovered usages of deprecated YAML formats. I first wanted to set up a build step that would lint all YAML files found in that project to be able to report it inside the CI. While doing so I noticed that the lint command was ignoring all deprecations after all. I suggest that catch all deprecations triggered by the YAML components and turn them into reported errors here. If we think that this could be seen as misbehaviour as the Symfony YAML parser is still able to handle these files properly, we could think about adding an additional option to the command that would turn on the deprecation handling.