### PR TITLE
[DI/Yaml] Remove `@experimental` flag from "instanceof" and "prototype"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,8 +8,8 @@ CHANGELOG
  * added "container.service_locator" tag for defining service-locator services
  * added anonymous services support in YAML configuration files using the `!service` tag.
  * added "TypedReference" and "ServiceClosureArgument" for creating service-locator services
- * [EXPERIMENTAL] added "instanceof" section for local interface-defined configs
- * [EXPERIMENTAL] added prototype services for PSR4-based discovery and registration
+ * added "instanceof" section for local interface-defined configs
+ * added prototype services for PSR4-based discovery and registration
  * added `ContainerBuilder::getReflectionClass()` for retrieving and tracking reflection class info
  * deprecated `ContainerBuilder::getClassResource()`, use `ContainerBuilder::getReflectionClass()` or `ContainerBuilder::addObjectResource()` instead
  * added `ContainerBuilder::fileExists()` for checking and tracking file or directory existence

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -335,8 +335,6 @@ class Definition
      * Sets the definition templates to conditionally apply on the current definition, keyed by parent interface/class.
      *
      * @param $instanceof ChildDefinition[]
-     *
-     * @experimental in version 3.3
      */
     public function setInstanceofConditionals(array $instanceof)
     {
@@ -349,8 +347,6 @@ class Definition
      * Gets the definition templates to conditionally apply on the current definition, keyed by parent interface/class.
      *
      * @return ChildDefinition[]
-     *
-     * @experimental in version 3.3
      */
     public function getInstanceofConditionals()
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -46,8 +46,6 @@ abstract class FileLoader extends BaseFileLoader
      * @param Definition $prototype A definition to use as template
      * @param string     $namespace The namespace prefix of classes in the scanned directory
      * @param string     $resource  The directory to look for classes, glob-patterns allowed
-     *
-     * @experimental in version 3.3
      */
     public function registerClasses(Definition $prototype, $namespace, $resource)
     {
@@ -68,7 +66,10 @@ abstract class FileLoader extends BaseFileLoader
     }
 
     /**
-     * @experimental in version 3.3
+     * Registers a definition in the container with its instanceof-conditionals.
+     *
+     * @param string     $id
+     * @param Definition $definition
      */
     protected function setDefinition($id, Definition $definition)
     {

--- a/src/Symfony/Component/Yaml/Tag/TaggedValue.php
+++ b/src/Symfony/Component/Yaml/Tag/TaggedValue.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Yaml\Tag;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Guilhem N. <egetick@gmail.com>
- *
- * @experimental in version 3.3
  */
 final class TaggedValue
 {

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -29,13 +29,9 @@ class Yaml
     const DUMP_OBJECT_AS_MAP = 64;
     const DUMP_MULTI_LINE_LITERAL_BLOCK = 128;
     const PARSE_CONSTANT = 256;
+    const PARSE_CUSTOM_TAGS = 512;
     const DUMP_EMPTY_ARRAY_AS_SEQUENCE = 1024;
     const PARSE_KEYS_AS_STRINGS = 2048;
-
-    /**
-     * @experimental in version 3.3
-     */
-    const PARSE_CUSTOM_TAGS = 512;
 
     /**
      * Parses YAML into a PHP value.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

We don't need this flag on these features: the implementation is stable, and regular deprecations should be the way to go in the event where we decide to remove this later on.

That would leave only one single `@experimental` feature in 3.3: `CacheItem::getPreviousTags()`, which looks legitimate to me (since this method is aiming at interop).