### PR TITLE
[Validator] Add min/max amount of pixels to Image constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,12 +1,16 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * added min/max amount of pixels check to `Image` constraint via `minPixels` and `maxPixels`
+
 3.3.0
 -----
 
  * added `AddValidatorInitializersPass`
  * added `AddConstraintValidatorsPass`
- * added min/max amount of pixels check to `Image` constraint via `minPixels` and `maxPixels`
 
 3.2.0
 -----

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added `AddValidatorInitializersPass`
  * added `AddConstraintValidatorsPass`
+ * added min/max amount of pixels check to `Image` constraint via `minPixels` and `maxPixels`
 
 3.2.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -25,8 +25,8 @@ class Image extends File
     const TOO_NARROW_ERROR = '9afbd561-4f90-4a27-be62-1780fc43604a';
     const TOO_HIGH_ERROR = '7efae81c-4877-47ba-aa65-d01ccb0d4645';
     const TOO_LOW_ERROR = 'aef0cb6a-c07f-4894-bc08-1781420d7b4c';
-    const TOO_FEW_ERROR = '1b06b97d-ae48-474e-978f-038a74854c43';
-    const TOO_MANY_ERROR = 'ee0804e8-44db-4eac-9775-be91aaf72ce1';
+    const TOO_FEW_PX_ERROR = '1b06b97d-ae48-474e-978f-038a74854c43';
+    const TOO_MANY_PX_ERROR = 'ee0804e8-44db-4eac-9775-be91aaf72ce1';
     const RATIO_TOO_BIG_ERROR = '70cafca6-168f-41c9-8c8c-4e47a52be643';
     const RATIO_TOO_SMALL_ERROR = '59b8c6ef-bcf2-4ceb-afff-4642ed92f12e';
     const SQUARE_NOT_ALLOWED_ERROR = '5d41425b-facb-47f7-a55a-de9fbe45cb46';
@@ -47,8 +47,8 @@ class Image extends File
         self::TOO_NARROW_ERROR => 'TOO_NARROW_ERROR',
         self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',
         self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
-        self::TOO_FEW_ERROR => 'TOO_FEW_ERROR',
-        self::TOO_MANY_ERROR => 'TOO_MANY_ERROR',
+        self::TOO_FEW_PX_ERROR => 'TOO_FEW_PX_ERROR',
+        self::TOO_MANY_PX_ERROR => 'TOO_MANY_PX_ERROR',
         self::RATIO_TOO_BIG_ERROR => 'RATIO_TOO_BIG_ERROR',
         self::RATIO_TOO_SMALL_ERROR => 'RATIO_TOO_SMALL_ERROR',
         self::SQUARE_NOT_ALLOWED_ERROR => 'SQUARE_NOT_ALLOWED_ERROR',
@@ -78,8 +78,8 @@ class Image extends File
     public $minWidthMessage = 'The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.';
     public $maxHeightMessage = 'The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.';
     public $minHeightMessage = 'The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.';
-    public $minPixelsMessage = 'The image has to few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.';
-    public $maxPixelsMessage = 'The image has to many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.';
+    public $minPixelsMessage = 'The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.';
+    public $maxPixelsMessage = 'The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.';
     public $maxRatioMessage = 'The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.';
     public $minRatioMessage = 'The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.';
     public $allowSquareMessage = 'The image is square ({{ width }}x{{ height }}px). Square images are not allowed.';

--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -25,6 +25,8 @@ class Image extends File
     const TOO_NARROW_ERROR = '9afbd561-4f90-4a27-be62-1780fc43604a';
     const TOO_HIGH_ERROR = '7efae81c-4877-47ba-aa65-d01ccb0d4645';
     const TOO_LOW_ERROR = 'aef0cb6a-c07f-4894-bc08-1781420d7b4c';
+    const TOO_FEW_ERROR = '1b06b97d-ae48-474e-978f-038a74854c43';
+    const TOO_MANY_ERROR = 'ee0804e8-44db-4eac-9775-be91aaf72ce1';
     const RATIO_TOO_BIG_ERROR = '70cafca6-168f-41c9-8c8c-4e47a52be643';
     const RATIO_TOO_SMALL_ERROR = '59b8c6ef-bcf2-4ceb-afff-4642ed92f12e';
     const SQUARE_NOT_ALLOWED_ERROR = '5d41425b-facb-47f7-a55a-de9fbe45cb46';
@@ -45,6 +47,8 @@ class Image extends File
         self::TOO_NARROW_ERROR => 'TOO_NARROW_ERROR',
         self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',
         self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
+        self::TOO_FEW_ERROR => 'TOO_FEW_ERROR',
+        self::TOO_MANY_ERROR => 'TOO_MANY_ERROR',
         self::RATIO_TOO_BIG_ERROR => 'RATIO_TOO_BIG_ERROR',
         self::RATIO_TOO_SMALL_ERROR => 'RATIO_TOO_SMALL_ERROR',
         self::SQUARE_NOT_ALLOWED_ERROR => 'SQUARE_NOT_ALLOWED_ERROR',
@@ -60,6 +64,8 @@ class Image extends File
     public $minHeight;
     public $maxRatio;
     public $minRatio;
+    public $minPixels;
+    public $maxPixels;
     public $allowSquare = true;
     public $allowLandscape = true;
     public $allowPortrait = true;
@@ -72,6 +78,8 @@ class Image extends File
     public $minWidthMessage = 'The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.';
     public $maxHeightMessage = 'The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.';
     public $minHeightMessage = 'The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.';
+    public $minPixelsMessage = 'The image has to few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.';
+    public $maxPixelsMessage = 'The image has to many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.';
     public $maxRatioMessage = 'The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.';
     public $minRatioMessage = 'The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.';
     public $allowSquareMessage = 'The image is square ({{ width }}x{{ height }}px). Square images are not allowed.';

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -155,6 +155,8 @@ class ImageValidator extends FileValidator
                 $this->context->buildViolation($constraint->maxPixelsMessage)
                     ->setParameter('{{ pixels }}', $pixels)
                     ->setParameter('{{ max_pixels }}', $constraint->maxPixels)
+                    ->setParameter('{{ height }}', $height)
+                    ->setParameter('{{ width }}', $width)
                     ->setCode(Image::TOO_MANY_PX_ERROR)
                     ->addViolation();
             }

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -46,6 +46,7 @@ class ImageValidator extends FileValidator
 
         if (null === $constraint->minWidth && null === $constraint->maxWidth
             && null === $constraint->minHeight && null === $constraint->maxHeight
+            && null === $constraint->minPixels && null === $constraint->maxPixels
             && null === $constraint->minRatio && null === $constraint->maxRatio
             && $constraint->allowSquare && $constraint->allowLandscape && $constraint->allowPortrait
             && !$constraint->detectCorrupted) {
@@ -123,6 +124,36 @@ class ImageValidator extends FileValidator
                     ->setParameter('{{ height }}', $height)
                     ->setParameter('{{ max_height }}', $constraint->maxHeight)
                     ->setCode(Image::TOO_HIGH_ERROR)
+                    ->addViolation();
+            }
+        }
+
+        $pixels = $width * $height;
+
+        if (null !== $constraint->minPixels) {
+            if (!ctype_digit((string) $constraint->minPixels)) {
+                throw new ConstraintDefinitionException(sprintf('"%s" is not a valid minimum amount of pixels', $constraint->minPixels));
+            }
+
+            if ($pixels < $constraint->minPixels) {
+                $this->context->buildViolation($constraint->minPixelsMessage)
+                    ->setParameter('{{ pixels }}', $pixels)
+                    ->setParameter('{{ min_pixels }}', $constraint->minPixels)
+                    ->setCode(Image::TOO_FEW_ERROR)
+                    ->addViolation();
+            }
+        }
+
+        if (null !== $constraint->maxPixels) {
+            if (!ctype_digit((string) $constraint->maxPixels)) {
+                throw new ConstraintDefinitionException(sprintf('"%s" is not a valid maximum amount of pixels', $constraint->maxPixels));
+            }
+
+            if ($pixels > $constraint->maxPixels) {
+                $this->context->buildViolation($constraint->maxPixelsMessage)
+                    ->setParameter('{{ pixels }}', $pixels)
+                    ->setParameter('{{ max_pixels }}', $constraint->maxPixels)
+                    ->setCode(Image::TOO_MANY_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -139,7 +139,9 @@ class ImageValidator extends FileValidator
                 $this->context->buildViolation($constraint->minPixelsMessage)
                     ->setParameter('{{ pixels }}', $pixels)
                     ->setParameter('{{ min_pixels }}', $constraint->minPixels)
-                    ->setCode(Image::TOO_FEW_ERROR)
+                    ->setParameter('{{ height }}', $height)
+                    ->setParameter('{{ width }}', $width)
+                    ->setCode(Image::TOO_FEW_PX_ERROR)
                     ->addViolation();
             }
         }
@@ -153,7 +155,7 @@ class ImageValidator extends FileValidator
                 $this->context->buildViolation($constraint->maxPixelsMessage)
                     ->setParameter('{{ pixels }}', $pixels)
                     ->setParameter('{{ max_pixels }}', $constraint->maxPixels)
-                    ->setCode(Image::TOO_MANY_ERROR)
+                    ->setCode(Image::TOO_MANY_PX_ERROR)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -164,6 +164,38 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testPixelsTooFew()
+    {
+        $constraint = new Image(array(
+            'minPixels' => 5,
+            'minPixelsMessage' => 'myMessage',
+        ));
+
+        $this->validator->validate($this->image, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ pixels }}', '4')
+            ->setParameter('{{ min_pixels }}', '5')
+            ->setCode(Image::TOO_FEW_ERROR)
+            ->assertRaised();
+    }
+
+    public function testPixelsTooMany()
+    {
+        $constraint = new Image(array(
+            'maxPixels' => 3,
+            'maxPixelsMessage' => 'myMessage',
+        ));
+
+        $this->validator->validate($this->image, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ pixels }}', '4')
+            ->setParameter('{{ max_pixels }}', '3')
+            ->setCode(Image::TOO_MANY_ERROR)
+            ->assertRaised();
+    }
+
     /**
      * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
      */
@@ -207,6 +239,30 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Image(array(
             'maxHeight' => '1abc',
+        ));
+
+        $this->validator->validate($this->image, $constraint);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
+    public function testInvalidMinPixels()
+    {
+        $constraint = new Image(array(
+            'minPixels' => '1abc',
+        ));
+
+        $this->validator->validate($this->image, $constraint);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
+    public function testInvalidMaxPixels()
+    {
+        $constraint = new Image(array(
+            'maxPixels' => '1abc',
         ));
 
         $this->validator->validate($this->image, $constraint);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -176,7 +176,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
             ->setParameter('{{ min_pixels }}', '5')
-            ->setCode(Image::TOO_FEW_ERROR)
+            ->setCode(Image::TOO_FEW_PX_ERROR)
             ->assertRaised();
     }
 
@@ -192,7 +192,7 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
             ->setParameter('{{ max_pixels }}', '3')
-            ->setCode(Image::TOO_MANY_ERROR)
+            ->setCode(Image::TOO_MANY_PX_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -176,6 +176,8 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
             ->setParameter('{{ min_pixels }}', '5')
+            ->setParameter('{{ height }}', '2')
+            ->setParameter('{{ width }}', '2')
             ->setCode(Image::TOO_FEW_PX_ERROR)
             ->assertRaised();
     }
@@ -192,6 +194,8 @@ class ImageValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->setParameter('{{ pixels }}', '4')
             ->setParameter('{{ max_pixels }}', '3')
+            ->setParameter('{{ height }}', '2')
+            ->setParameter('{{ width }}', '2')
             ->setCode(Image::TOO_MANY_PX_ERROR)
             ->assertRaised();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/7756

Useful for asserting image sizes/areas in pixels.