### PR TITLE
Bump monolog to 1.19 and use the agent regex const from parent

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
@@ -41,7 +41,7 @@ class ChromePhpHandler extends BaseChromePhpHandler
             return;
         }
 
-        if (!preg_match('{\b(?:Chrome/\d+(?:\.\d+)*|Firefox/(?:4[3-9]|[5-9]\d|\d{3,})(?:\.\d)*)\b}', $event->getRequest()->headers->get('User-Agent'))) {
+        if (!preg_match(static::USER_AGENT_REGEX, $event->getRequest()->headers->get('User-Agent'))) {
             $this->sendHeaders = false;
             $this->headers = array();
 

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "monolog/monolog": "~1.11",
+        "monolog/monolog": "~1.19",
         "symfony/http-kernel": "~2.8|~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
See #22264

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | refer to #22264 
| License       | MIT
| Doc PR        | 

Bump monolog and use const from parent. See https://github.com/symfony/symfony/issues/22264#issuecomment-291524038

I went for `static` instead of `self` in case anyone wanted to easily override just the agent string.