### PR TITLE
[WebProfiler] Fix race condition in fast Ajax requests

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -117,15 +117,15 @@
         };
 
         var startAjaxRequest = function(index) {
-            var request = requestStack[index];
-            pendingRequests++;
-            var row = document.createElement('tr');
-            request.DOMNode = row;
-
             var tbody = document.querySelector('.sf-toolbar-ajax-request-list');
             if (!tbody) {
                 return;
             }
+
+            var request = requestStack[index];
+            pendingRequests++;
+            var row = document.createElement('tr');
+            request.DOMNode = row;
 
             var methodCell = document.createElement('td');
             methodCell.textContent = request.method;
@@ -171,6 +171,9 @@
 
         var finishAjaxRequest = function(index) {
             var request = requestStack[index];
+            if (!request.DOMNode) {
+                return;
+            }
             pendingRequests--;
             var row = request.DOMNode;
             /* Unpack the children from the row */
@@ -356,6 +359,12 @@
                             el.innerHTML = xhr.responseText;
                             el.setAttribute('data-sfurl', url);
                             removeClass(el, 'loading');
+                            for (var i = 0; i < requestStack.length; i++) {
+                                startAjaxRequest(i);
+                                if (requestStack[i].duration) {
+                                    finishAjaxRequest(i);
+                                }
+                            }
                             (onSuccess || noop)(xhr, el);
                         },
                         function(xhr) { (onError || noop)(xhr, el); },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22297
| License       | MIT

Patch `startAjaxRequest` and `finishAjaxRequest` functions to absolute noop in case the debug toolbar itself is not loaded yet, and spool historic requests after the toolbar is loaded.
