### PR TITLE
Add \Traversable typehint to phpdoc

### DIFF
--- a/src/Symfony/Component/Form/DataMapperInterface.php
+++ b/src/Symfony/Component/Form/DataMapperInterface.php
@@ -19,8 +19,8 @@ interface DataMapperInterface
     /**
      * Maps properties of some data to a list of forms.
      *
-     * @param mixed                     $data  Structured data
-     * @param FormInterface[]|\Iterator $forms A list of {@link FormInterface} instances
+     * @param mixed                        $data  Structured data
+     * @param FormInterface[]|\Traversable $forms A list of {@link FormInterface} instances
      *
      * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported.
      */
@@ -29,8 +29,8 @@ interface DataMapperInterface
     /**
      * Maps the data of a list of forms into the properties of some data.
      *
-     * @param FormInterface[]|\Iterator $forms A list of {@link FormInterface} instances
-     * @param mixed                     $data  Structured data
+     * @param FormInterface[]|\Traversable $forms A list of {@link FormInterface} instances
+     * @param mixed                        $data  Structured data
      *
      * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported.
      */

--- a/src/Symfony/Component/Form/DataMapperInterface.php
+++ b/src/Symfony/Component/Form/DataMapperInterface.php
@@ -19,8 +19,8 @@ interface DataMapperInterface
     /**
      * Maps properties of some data to a list of forms.
      *
-     * @param mixed           $data  Structured data
-     * @param FormInterface[] $forms A list of {@link FormInterface} instances
+     * @param mixed                     $data  Structured data
+     * @param FormInterface[]|\Iterator $forms A list of {@link FormInterface} instances
      *
      * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported.
      */
@@ -29,8 +29,8 @@ interface DataMapperInterface
     /**
      * Maps the data of a list of forms into the properties of some data.
      *
-     * @param FormInterface[] $forms A list of {@link FormInterface} instances
-     * @param mixed           $data  Structured data
+     * @param FormInterface[]|\Iterator $forms A list of {@link FormInterface} instances
+     * @param mixed                     $data  Structured data
      *
      * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Most of the times you use a DataMapperInterface, the first thing you do on the `$forms` parameter is `iterator_to_array`. However, as that variable is only hinted as `FormInterface[]`, and most IDE's and static analysers don't rely on code, but on the phpdoc...