### PR TITLE
Moved $this->setDate() before the deprecation handling.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -228,7 +228,7 @@ class Response
 
         /* RFC2616 - 14.18 says all Responses need to have a Date */
         if (!$this->headers->has('Date')) {
-           $this->setDate(new \DateTime(null, new \DateTimeZone('UTC')));
+            $this->setDate(new \DateTime(null, new \DateTimeZone('UTC')));
         }
 
         // Deprecations

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -226,6 +226,11 @@ class Response
         $this->setStatusCode($status);
         $this->setProtocolVersion('1.0');
 
+        /* RFC2616 - 14.18 says all Responses need to have a Date */
+        if (!$this->headers->has('Date')) {
+           $this->setDate(new \DateTime(null, new \DateTimeZone('UTC')));
+        }
+
         // Deprecations
         $class = get_class($this);
         if ($this instanceof \PHPUnit_Framework_MockObject_MockObject || $this instanceof \Prophecy\Doubler\DoubleInterface) {
@@ -241,11 +246,6 @@ class Response
             if (__CLASS__ !== $r->getDeclaringClass()->getName()) {
                 @trigger_error(sprintf('Extending %s::%s() in %s is deprecated since version 3.2 and won\'t be supported anymore in 4.0 as it will be final.', __CLASS__, $method, $class), E_USER_DEPRECATED);
             }
-        }
-
-        /* RFC2616 - 14.18 says all Responses need to have a Date */
-        if (!$this->headers->has('Date')) {
-            $this->setDate(new \DateTime(null, new \DateTimeZone('UTC')));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no?
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

https://github.com/symfony/symfony/pull/22036 merged the patch into the wrong place; the `$this->setDate()` happens after the deprecation handling, so it does not always get called.

See also https://www.drupal.org/node/2712647?page=1#comment-12025349