### PR TITLE
[DI] Restrict autowired registration to "same-vendor" namespaces

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
@@ -71,10 +71,11 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
         }
         $this->container->addObjectResource($class);
         $subscriberMap = array();
+        $declaringClass = (new \ReflectionMethod($class, 'getSubscribedServices'))->class;
 
         foreach ($class::getSubscribedServices() as $key => $type) {
             if (!is_string($type) || !preg_match('/^\??[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+$/', $type)) {
-                throw new InvalidArgumentException(sprintf('%s::getSubscribedServices() must return valid PHP types for service "%s" key "%s", "%s" returned.', $class, $this->currentId, $key, is_string($type) ? $type : gettype($type)));
+                throw new InvalidArgumentException(sprintf('"%s::getSubscribedServices()" must return valid PHP types for service "%s" key "%s", "%s" returned.', $class, $this->currentId, $key, is_string($type) ? $type : gettype($type)));
             }
             if ($optionalBehavior = '?' === $type[0]) {
                 $type = substr($type, 1);
@@ -85,18 +86,18 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
             }
             if (!isset($serviceMap[$key])) {
                 if (!$autowire) {
-                    throw new InvalidArgumentException(sprintf('Service "%s" misses a "container.service_subscriber" tag with "key"/"id" attributes corresponding to entry "%s" as returned by %s::getSubscribedServices().', $this->currentId, $key, $class));
+                    throw new InvalidArgumentException(sprintf('Service "%s" misses a "container.service_subscriber" tag with "key"/"id" attributes corresponding to entry "%s" as returned by "%s::getSubscribedServices()".', $this->currentId, $key, $class));
                 }
                 $serviceMap[$key] = new Reference($type);
             }
 
-            $subscriberMap[$key] = new TypedReference((string) $serviceMap[$key], $type, $optionalBehavior ?: ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);
+            $subscriberMap[$key] = new TypedReference((string) $serviceMap[$key], $type, $declaringClass, $optionalBehavior ?: ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);
             unset($serviceMap[$key]);
         }
 
         if ($serviceMap = array_keys($serviceMap)) {
             $message = sprintf(1 < count($serviceMap) ? 'keys "%s" do' : 'key "%s" does', str_replace('%', '%%', implode('", "', $serviceMap)));
-            throw new InvalidArgumentException(sprintf('Service %s not exist in the map returned by %s::getSubscribedServices() for service "%s".', $message, $class, $this->currentId));
+            throw new InvalidArgumentException(sprintf('Service %s not exist in the map returned by "%s::getSubscribedServices()" for service "%s".', $message, $class, $this->currentId));
         }
 
         $serviceLocator = $this->serviceLocator;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -368,9 +368,9 @@ class AutowirePassTest extends TestCase
         $definition = $container->getDefinition('multiple');
         $this->assertEquals(
             array(
-                new Reference(A::class),
+                new TypedReference(A::class, A::class, MultipleArguments::class),
                 new Reference('foo'),
-                new Reference(Dunglas::class),
+                new TypedReference(Dunglas::class, Dunglas::class, MultipleArguments::class),
             ),
             $definition->getArguments()
         );
@@ -423,10 +423,10 @@ class AutowirePassTest extends TestCase
         $definition = $container->getDefinition('with_optional_scalar');
         $this->assertEquals(
             array(
-                new Reference(A::class),
+                new TypedReference(A::class, A::class, MultipleArgumentsOptionalScalar::class),
                 // use the default value
                 'default_val',
-                new Reference(Lille::class),
+                new TypedReference(Lille::class, Lille::class),
             ),
             $definition->getArguments()
         );
@@ -447,8 +447,8 @@ class AutowirePassTest extends TestCase
         $definition = $container->getDefinition('with_optional_scalar_last');
         $this->assertEquals(
             array(
-                new Reference(A::class),
-                new Reference(Lille::class),
+                new TypedReference(A::class, A::class, MultipleArgumentsOptionalScalarLast::class),
+                new TypedReference(Lille::class, Lille::class, MultipleArgumentsOptionalScalarLast::class),
             ),
             $definition->getArguments()
         );
@@ -486,7 +486,7 @@ class AutowirePassTest extends TestCase
         );
         // test setFoo args
         $this->assertEquals(
-            array(new Reference(Foo::class)),
+            array(new TypedReference(Foo::class, Foo::class, SetterInjection::class)),
             $methodCalls[1][1]
         );
     }
@@ -515,7 +515,7 @@ class AutowirePassTest extends TestCase
             array_column($methodCalls, 0)
         );
         $this->assertEquals(
-            array(new Reference(A::class)),
+            array(new TypedReference(A::class, A::class, SetterInjection::class)),
             $methodCalls[0][1]
         );
     }
@@ -526,7 +526,7 @@ class AutowirePassTest extends TestCase
 
         $container
             ->register('bar', Bar::class)
-            ->setProperty('a', array(new TypedReference(A::class, A::class)))
+            ->setProperty('a', array(new TypedReference(A::class, A::class, Bar::class)))
         ;
 
         $pass = new AutowirePass();
@@ -629,7 +629,7 @@ class AutowirePassTest extends TestCase
         (new ResolveClassPass())->process($container);
         (new AutowirePass())->process($container);
 
-        $this->assertEquals(array(new Reference(A::class), '', new Reference(Lille::class)), $container->getDefinition('foo')->getArguments());
+        $this->assertEquals(array(new TypedReference(A::class, A::class, MultipleArgumentsOptionalScalar::class), '', new TypedReference(Lille::class, Lille::class)), $container->getDefinition('foo')->getArguments());
     }
 
     public function testWithFactory()
@@ -644,7 +644,7 @@ class AutowirePassTest extends TestCase
         (new ResolveClassPass())->process($container);
         (new AutowirePass())->process($container);
 
-        $this->assertEquals(array(new Reference(Foo::class)), $definition->getArguments());
+        $this->assertEquals(array(new TypedReference(Foo::class, Foo::class, A::class)), $definition->getArguments());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterServiceSubscribersPassTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber;
 use Symfony\Component\DependencyInjection\TypedReference;
 
 require_once __DIR__.'/../Fixtures/includes/classes.php';
@@ -32,7 +34,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('foo', 'stdClass')
+        $container->register('foo', CustomDefinition::class)
             ->addTag('container.service_subscriber')
         ;
 
@@ -48,7 +50,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('foo', 'TestServiceSubscriber')
+        $container->register('foo', TestServiceSubscriber::class)
             ->addTag('container.service_subscriber', array('bar' => '123'))
         ;
 
@@ -60,7 +62,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('foo', 'TestServiceSubscriber')
+        $container->register('foo', TestServiceSubscriber::class)
             ->addArgument(new Reference('container'))
             ->addTag('container.service_subscriber')
         ;
@@ -75,10 +77,10 @@ class RegisterServiceSubscribersPassTest extends TestCase
         $this->assertSame(ServiceLocator::class, $locator->getClass());
 
         $expected = array(
-            'TestServiceSubscriber' => new ServiceClosureArgument(new TypedReference('TestServiceSubscriber', 'TestServiceSubscriber')),
-            'stdClass' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
-            'bar' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass')),
-            'baz' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
+            TestServiceSubscriber::class => new ServiceClosureArgument(new TypedReference(TestServiceSubscriber::class, TestServiceSubscriber::class, TestServiceSubscriber::class)),
+            CustomDefinition::class => new ServiceClosureArgument(new TypedReference(CustomDefinition::class, CustomDefinition::class, TestServiceSubscriber::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
+            'bar' => new ServiceClosureArgument(new TypedReference(CustomDefinition::class, CustomDefinition::class, TestServiceSubscriber::class)),
+            'baz' => new ServiceClosureArgument(new TypedReference(CustomDefinition::class, CustomDefinition::class, TestServiceSubscriber::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
         );
 
         $this->assertEquals($expected, $locator->getArgument(0));
@@ -88,7 +90,7 @@ class RegisterServiceSubscribersPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('foo', 'TestServiceSubscriber')
+        $container->register('foo', TestServiceSubscriber::class)
             ->setAutowired(true)
             ->addArgument(new Reference('container'))
             ->addTag('container.service_subscriber', array('key' => 'bar', 'id' => 'bar'))
@@ -105,10 +107,10 @@ class RegisterServiceSubscribersPassTest extends TestCase
         $this->assertSame(ServiceLocator::class, $locator->getClass());
 
         $expected = array(
-            'TestServiceSubscriber' => new ServiceClosureArgument(new TypedReference('TestServiceSubscriber', 'TestServiceSubscriber')),
-            'stdClass' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
-            'bar' => new ServiceClosureArgument(new TypedReference('bar', 'stdClass')),
-            'baz' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
+            TestServiceSubscriber::class => new ServiceClosureArgument(new TypedReference(TestServiceSubscriber::class, TestServiceSubscriber::class, TestServiceSubscriber::class)),
+            CustomDefinition::class => new ServiceClosureArgument(new TypedReference(CustomDefinition::class, CustomDefinition::class, TestServiceSubscriber::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
+            'bar' => new ServiceClosureArgument(new TypedReference('bar', CustomDefinition::class, TestServiceSubscriber::class)),
+            'baz' => new ServiceClosureArgument(new TypedReference(CustomDefinition::class, CustomDefinition::class, TestServiceSubscriber::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
         );
 
         $this->assertEquals($expected, $locator->getArgument(0));
@@ -116,20 +118,20 @@ class RegisterServiceSubscribersPassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Service key "test" does not exist in the map returned by TestServiceSubscriber::getSubscribedServices() for service "foo_service".
+     * @expectedExceptionMessage Service key "test" does not exist in the map returned by "Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber::getSubscribedServices()" for service "foo_service".
      */
     public function testExtraServiceSubscriber()
     {
         $container = new ContainerBuilder();
-        $container->register('foo_service', 'TestServiceSubscriber')
+        $container->register('foo_service', TestServiceSubscriber::class)
             ->setAutowired(true)
             ->addArgument(new Reference('container'))
             ->addTag('container.service_subscriber', array(
                 'key' => 'test',
-                'id' => 'TestServiceSubscriber',
+                'id' => TestServiceSubscriber::class,
             ))
         ;
-        $container->register('TestServiceSubscriber', 'TestServiceSubscriber');
+        $container->register(TestServiceSubscriber::class, TestServiceSubscriber::class);
         $container->compile();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber;
 use Symfony\Component\DependencyInjection\Variable;
 use Symfony\Component\ExpressionLanguage\Expression;
 
@@ -557,15 +558,15 @@ class PhpDumperTest extends TestCase
     public function testServiceSubscriber()
     {
         $container = new ContainerBuilder();
-        $container->register('foo_service', 'TestServiceSubscriber')
+        $container->register('foo_service', TestServiceSubscriber::class)
             ->setAutowired(true)
             ->addArgument(new Reference('container'))
             ->addTag('container.service_subscriber', array(
                 'key' => 'bar',
-                'id' => 'TestServiceSubscriber',
+                'id' => TestServiceSubscriber::class,
             ))
         ;
-        $container->register('TestServiceSubscriber', 'TestServiceSubscriber');
+        $container->register(TestServiceSubscriber::class, TestServiceSubscriber::class);
         $container->compile();
 
         $dumper = new PhpDumper($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
+
+class TestServiceSubscriber implements ServiceSubscriberInterface
+{
+    public function __construct($container)
+    {
+    }
+
+    public static function getSubscribedServices()
+    {
+        return array(
+            __CLASS__,
+            '?'.CustomDefinition::class,
+            'bar' => CustomDefinition::class,
+            'baz' => '?'.CustomDefinition::class,
+        );
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
@@ -108,20 +108,3 @@ class LazyContext
         $this->lazyValues = $lazyValues;
     }
 }
-
-class TestServiceSubscriber implements ServiceSubscriberInterface
-{
-    public function __construct($container)
-    {
-    }
-
-    public static function getSubscribedServices()
-    {
-        return array(
-            __CLASS__,
-            '?stdClass',
-            'bar' => 'stdClass',
-            'baz' => '?stdClass',
-        );
-    }
-}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -28,19 +28,19 @@ class ProjectServiceContainer extends Container
     {
         $this->services = array();
         $this->normalizedIds = array(
-            'autowired.stdclass' => 'autowired.stdClass',
+            'autowired.symfony\\component\\dependencyinjection\\tests\\fixtures\\customdefinition' => 'autowired.Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition',
             'psr\\container\\containerinterface' => 'Psr\\Container\\ContainerInterface',
-            'stdclass' => 'stdClass',
             'symfony\\component\\dependencyinjection\\containerinterface' => 'Symfony\\Component\\DependencyInjection\\ContainerInterface',
-            'testservicesubscriber' => 'TestServiceSubscriber',
+            'symfony\\component\\dependencyinjection\\tests\\fixtures\\customdefinition' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition',
+            'symfony\\component\\dependencyinjection\\tests\\fixtures\\testservicesubscriber' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber',
         );
         $this->methodMap = array(
-            'TestServiceSubscriber' => 'getTestServiceSubscriberService',
-            'autowired.stdClass' => 'getAutowired_StdClassService',
+            'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber' => 'getSymfony_Component_DependencyInjection_Tests_Fixtures_TestServiceSubscriberService',
+            'autowired.Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => 'getAutowired_Symfony_Component_DependencyInjection_Tests_Fixtures_CustomDefinitionService',
             'foo_service' => 'getFooServiceService',
         );
         $this->privates = array(
-            'autowired.stdClass' => true,
+            'autowired.Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => true,
         );
 
         $this->aliases = array();
@@ -73,16 +73,16 @@ class ProjectServiceContainer extends Container
     }
 
     /**
-     * Gets the 'TestServiceSubscriber' service.
+     * Gets the 'Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber' service.
      *
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return \TestServiceSubscriber A TestServiceSubscriber instance
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber A Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber instance
      */
-    protected function getTestServiceSubscriberService()
+    protected function getSymfony_Component_DependencyInjection_Tests_Fixtures_TestServiceSubscriberService()
     {
-        return $this->services['TestServiceSubscriber'] = new \TestServiceSubscriber();
+        return $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber();
     }
 
     /**
@@ -93,23 +93,23 @@ class ProjectServiceContainer extends Container
      *
      * This service is autowired.
      *
-     * @return \TestServiceSubscriber A TestServiceSubscriber instance
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber A Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber instance
      */
     protected function getFooServiceService()
     {
-        return $this->services['foo_service'] = new \TestServiceSubscriber(new \Symfony\Component\DependencyInjection\ServiceLocator(array('TestServiceSubscriber' => function () {
-            $f = function (\TestServiceSubscriber $v) { return $v; }; return $f(${($_ = isset($this->services['TestServiceSubscriber']) ? $this->services['TestServiceSubscriber'] : $this->get('TestServiceSubscriber')) && false ?: '_'});
+        return $this->services['foo_service'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber(new \Symfony\Component\DependencyInjection\ServiceLocator(array('Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => function () {
+            $f = function (\Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition $v) { return $v; }; return $f(${($_ = isset($this->services['autowired.Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition']) ? $this->services['autowired.Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition'] : $this->getAutowired_Symfony_Component_DependencyInjection_Tests_Fixtures_CustomDefinitionService()) && false ?: '_'});
+        }, 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestServiceSubscriber' => function () {
+            $f = function (\Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber $v) { return $v; }; return $f(${($_ = isset($this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber']) ? $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber'] : $this->get('Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber')) && false ?: '_'});
         }, 'bar' => function () {
-            $f = function (\stdClass $v) { return $v; }; return $f(${($_ = isset($this->services['TestServiceSubscriber']) ? $this->services['TestServiceSubscriber'] : $this->get('TestServiceSubscriber')) && false ?: '_'});
+            $f = function (\Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition $v) { return $v; }; return $f(${($_ = isset($this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber']) ? $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber'] : $this->get('Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber')) && false ?: '_'});
         }, 'baz' => function () {
-            $f = function (\stdClass $v = null) { return $v; }; return $f(${($_ = isset($this->services['autowired.stdClass']) ? $this->services['autowired.stdClass'] : $this->getAutowired_StdClassService()) && false ?: '_'});
-        }, 'stdClass' => function () {
-            $f = function (\stdClass $v = null) { return $v; }; return $f(${($_ = isset($this->services['autowired.stdClass']) ? $this->services['autowired.stdClass'] : $this->getAutowired_StdClassService()) && false ?: '_'});
+            $f = function (\Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition $v) { return $v; }; return $f(${($_ = isset($this->services['autowired.Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition']) ? $this->services['autowired.Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition'] : $this->getAutowired_Symfony_Component_DependencyInjection_Tests_Fixtures_CustomDefinitionService()) && false ?: '_'});
         })));
     }
 
     /**
-     * Gets the 'autowired.stdClass' service.
+     * Gets the 'autowired.Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition' service.
      *
      * This service is shared.
      * This method always returns the same instance of the service.
@@ -120,10 +120,10 @@ class ProjectServiceContainer extends Container
      *
      * This service is autowired.
      *
-     * @return \stdClass A stdClass instance
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition A Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition instance
      */
-    protected function getAutowired_StdClassService()
+    protected function getAutowired_Symfony_Component_DependencyInjection_Tests_Fixtures_CustomDefinitionService()
     {
-        return $this->services['autowired.stdClass'] = new \stdClass();
+        return $this->services['autowired.Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/TypedReference.php
+++ b/src/Symfony/Component/DependencyInjection/TypedReference.php
@@ -19,19 +19,19 @@ namespace Symfony\Component\DependencyInjection;
 class TypedReference extends Reference
 {
     private $type;
-    private $canBeAutoregistered;
+    private $requiringClass;
 
     /**
-     * @param string $id                  The service identifier
-     * @param string $type                The PHP type of the identified service
-     * @param int    $invalidBehavior     The behavior when the service does not exist
-     * @param bool   $canBeAutoregistered Whether autowiring can autoregister the referenced service when it's a FQCN or not
+     * @param string $id              The service identifier
+     * @param string $type            The PHP type of the identified service
+     * @param string $requiringClass  The class of the service that requires the referenced type
+     * @param int    $invalidBehavior The behavior when the service does not exist
      */
-    public function __construct($id, $type, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $canBeAutoregistered = true)
+    public function __construct($id, $type, $requiringClass = '', $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
     {
         parent::__construct($id, $invalidBehavior);
         $this->type = $type;
-        $this->canBeAutoregistered = $canBeAutoregistered;
+        $this->requiringClass = $requiringClass;
     }
 
     public function getType()
@@ -39,8 +39,13 @@ class TypedReference extends Reference
         return $this->type;
     }
 
+    public function getRequiringClass()
+    {
+        return $this->requiringClass;
+    }
+
     public function canBeAutoregistered()
     {
-        return $this->canBeAutoregistered;
+        return $this->requiringClass && (false !== $i = strpos($this->type, '\\')) && 0 === strncasecmp($this->type, $this->requiringClass, 1 + $i);
     }
 }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
@@ -43,7 +43,7 @@ class RemoveEmptyControllerArgumentLocatorsPass implements CompilerPassInterface
 
             if (!$argumentLocator->getArgument(0)) {
                 // remove empty argument locators
-                $reason = sprintf('Removing service-argument-resolver for controller "%s": no corresponding definitions were found for the referenced services/types.%s', $controller, !$argumentLocator->isAutowired() ? ' Did you forget to enable autowiring?' : '');
+                $reason = sprintf('Removing service-argument resolver for controller "%s": no corresponding services exist for the referenced types.', $controller);
             } else {
                 // any methods listed for call-at-instantiation cannot be actions
                 $reason = false;

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -145,7 +145,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $this->assertSame(ServiceLocator::class, $locator->getClass());
         $this->assertFalse($locator->isPublic());
 
-        $expected = array('bar' => new ServiceClosureArgument(new TypedReference('stdClass', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, false)));
+        $expected = array('bar' => new ServiceClosureArgument(new TypedReference(ControllerDummy::class, ControllerDummy::class, RegisterTestController::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)));
         $this->assertEquals($expected, $locator->getArgument(0));
     }
 
@@ -165,7 +165,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
         $locator = $container->getDefinition((string) $locator['foo:fooAction']->getValues()[0]);
 
-        $expected = array('bar' => new ServiceClosureArgument(new TypedReference('bar', 'stdClass', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)));
+        $expected = array('bar' => new ServiceClosureArgument(new TypedReference('bar', ControllerDummy::class, RegisterTestController::class)));
         $this->assertEquals($expected, $locator->getArgument(0));
     }
 
@@ -184,22 +184,26 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
         $locator = $container->getDefinition((string) $locator['foo:fooAction']->getValues()[0]);
 
-        $expected = array('bar' => new ServiceClosureArgument(new TypedReference('bar', 'stdClass', ContainerInterface::IGNORE_ON_INVALID_REFERENCE, false)));
+        $expected = array('bar' => new ServiceClosureArgument(new TypedReference('bar', ControllerDummy::class, RegisterTestController::class, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)));
         $this->assertEquals($expected, $locator->getArgument(0));
     }
 }
 
 class RegisterTestController
 {
-    public function __construct(\stdClass $bar)
+    public function __construct(ControllerDummy $bar)
     {
     }
 
-    public function fooAction(\stdClass $bar)
+    public function fooAction(ControllerDummy $bar)
     {
     }
 
-    protected function barAction(\stdClass $bar)
+    protected function barAction(ControllerDummy $bar)
     {
     }
+}
+
+class ControllerDummy
+{
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPassTest.php
@@ -53,7 +53,7 @@ class RemoveEmptyControllerArgumentLocatorsPassTest extends TestCase
         $this->assertSame(array('bar'), array_keys($container->getDefinition((string) $controllers['c1:fooAction']->getValues()[0])->getArgument(0)));
 
         $expectedLog = array(
-            'Symfony\Component\HttpKernel\DependencyInjection\RemoveEmptyControllerArgumentLocatorsPass: Removing service-argument-resolver for controller "c2:fooAction": no corresponding definitions were found for the referenced services/types. Did you forget to enable autowiring?',
+            'Symfony\Component\HttpKernel\DependencyInjection\RemoveEmptyControllerArgumentLocatorsPass: Removing service-argument resolver for controller "c2:fooAction": no corresponding services exist for the referenced types.',
             'Symfony\Component\HttpKernel\DependencyInjection\RemoveEmptyControllerArgumentLocatorsPass: Removing method "setTestCase" of service "c2" from controller candidates: the method is called at instantiation, thus cannot be an action.',
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Following #22295, it came to me that I've already been bitten hard by the auto-registration we decided to keep working: when one type-hints some class in the Symfony namespace (eg `Request`), then autoregistration creates a corresponding service. You see the issue. Hard time debugging that.

By restricting autoregistration to same-vendor (=same-root-namespace), we can keep all benefits of autoregistration, while closing this DX trap.

The patch is bigger than strictly required to implement this, but contains a few related fixes and cleanups.