### PR TITLE
[Debug] Fix php notice

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -186,7 +186,7 @@ class DebugClassLoader
 
         $exists = class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false));
 
-        if ('\\' === $class[0]) {
+        if ($class !== '' && '\\' === $class[0]) {
             $class = substr($class, 1);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Of course autoloading of an empty string should not actually happen (fixed that in https://github.com/twigphp/Twig/pull/2438) but if it does happen it should not throw a php notice.

```
Notice: Uninitialized string offset 0
```
