### PR TITLE
Add Kernel::getProjectDir()

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.3.0
 -----
 
+ * Added `kernel.project_dir` and `Kernel::getProjectDir()`
+ * Deprecated `kernel.root_dir` and `Kernel::getRootDir()`
  * Deprecated `Kernel::getEnvParameters()`
  * Deprecated the special `SYMFONY__` environment variables
  * added the possibility to change the query string parameter used by `UriSigner`

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,6 +59,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
+    private $projectDir;
+
     const VERSION = '3.3.0-DEV';
     const VERSION_ID = 30300;
     const MAJOR_VERSION = 3;
@@ -80,6 +82,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $this->environment = $environment;
         $this->debug = (bool) $debug;
         $this->rootDir = $this->getRootDir();
+        $this->projectDir = $this->getProjectDir();
         $this->name = $this->getName();
 
         if ($this->debug) {
@@ -304,6 +307,28 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         }
 
         return $this->rootDir;
+    }
+
+    /**
+     * Gets the application root dir (path of the project's composer file).
+     *
+     * @return string The project root dir
+     */
+    public function getProjectDir()
+    {
+        if (null === $this->projectDir) {
+            $r = new \ReflectionObject($this);
+            $dir = $rootDir = dirname($r->getFileName());
+            while (!file_exists($dir.'/composer.json')) {
+                if ($dir === dirname($dir)) {
+                    return $this->projectDir = $rootDir;
+                }
+                $dir = dirname($dir);
+            }
+            $this->projectDir = $dir;
+        }
+
+        return $this->projectDir;
     }
 
     /**
@@ -553,6 +578,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         return array_merge(
             array(
                 'kernel.root_dir' => realpath($this->rootDir) ?: $this->rootDir,
+                'kernel.project_dir' => realpath($this->projectDir) ?: $this->projectDir,
                 'kernel.environment' => $this->environment,
                 'kernel.debug' => $this->debug,
                 'kernel.name' => $this->name,

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -121,9 +121,9 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     public function isDebug();
 
     /**
-     * Gets the application root dir.
+     * Gets the application root dir (path of the project's Kernel class).
      *
-     * @return string The application root dir
+     * @return string The Kernel root dir
      */
     public function getRootDir();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes/no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | symfony/symfony-docs#7768

`Kernel::getRootDir()` is misleading. It returns the path where `AppKernel.php` is stored, which is `app/` in Symfony 2/3, but `src/` in Symfony 4. But most of the time, we are using `getRootDir()` to get the project root dir, so `%kernel.root_dir%/../` is a common idiom.

Changing the value of `getRootDir()` would be a hard BC break, so I propose to create a new method, `getProjectDir()` to "replace" `getRootDir()` gradually.
