### PR TITLE
[Console] Make SymfonyQuestionHelper::ask optional by default

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 3.3 to 3.4
 =======================
 
+Console
+-------
+
+  * Default validation in `SymfonyQuestionHelper::ask` has been deprecated and will be removed in 4.0. Apply validation using `Question::setValidator` instead.
+
 DependencyInjection
 -------------------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -61,6 +61,8 @@ Console
  * The `console.exception` event and the related `ConsoleExceptionEvent` class have
    been removed in favor of the `console.error` event and the `ConsoleErrorEvent` class.
 
+ * Default validation in `SymfonyQuestionHelper::ask` has been removed in favor of `Question::setValidator`.
+
 Debug
 -----
 

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -93,7 +93,7 @@ EOF
                 'You can either install it or use the "server:run" command instead.',
             ));
 
-            if ($io->ask('Do you want to execute <info>server:run</info> immediately? [yN] ', false)) {
+            if ($io->confirm('Do you want to execute <info>server:run</info> immediately?', false)) {
                 return $this->getApplication()->find('server:run')->run($input, $output);
             }
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
 * deprecated console.exception event in favor of console.error
 * added ability to handle `CommandNotFoundException` through the 
  `console.error` event
+* deprecated default validation in `SymfonyQuestionHelper::ask`
 
 3.2.0
 ------

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -29,6 +29,8 @@ class SymfonyQuestionHelper extends QuestionHelper
 {
     /**
      * {@inheritdoc}
+     *
+     * BC to be removed in 4.0
      */
     public function ask(InputInterface $input, OutputInterface $output, Question $question)
     {
@@ -39,6 +41,8 @@ class SymfonyQuestionHelper extends QuestionHelper
             } else {
                 // make required
                 if (!is_array($value) && !is_bool($value) && 0 === strlen($value)) {
+                    @trigger_error('The default question validator is deprecated since Symfony 3.4 and will not be used anymore in version 4.0. Set a custom question validator instead.', E_USER_DEPRECATED);
+
                     throw new LogicException('A value is required.');
                 }
             }

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -120,6 +120,18 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTest
         $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream('')), $this->createOutputInterface(), new Question('What\'s your name?'));
     }
 
+    /**
+     * @group legacy
+     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
+     * @expectedExceptionMessage Aborted
+     * @expectedDeprecation The default question validator is deprecated since Symfony 3.4 and will not be used anymore in version 4.0. Set a custom question validator instead.
+     */
+    public function testLegacyAsk()
+    {
+        $dialog = new SymfonyQuestionHelper();
+        $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream(' ')), $this->createOutputInterface(), new Question('Question'));
+    }
+
     protected function getInputStream($input)
     {
         $stream = fopen('php://memory', 'r+', false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes (nothing in core depends on it)
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

i noticed when writing commands i always keep doing

```php
$io = new SymfonyStyle($input, $output);
$answer = $io->ask('...', null, function ($value) { return $value; });

// instead of just
$answer = $io->ask('...');
```

only to bypass a built-in validation, of which im not sure why it's there. Note the base question helper doesnt make this assumption...