### PR TITLE
[Filesystem] Fixed makePathRelative

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -378,7 +378,7 @@ class Filesystem
             foreach ($pathSegments as $segment) {
                 if ('..' === $segment) {
                     array_pop($result);
-                } else {
+                } elseif ('.' !== $segment) {
                     $result[] = $segment;
                 }
             }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -373,7 +373,7 @@ class Filesystem
         $endPathArr = explode('/', trim($endPath, '/'));
 
         $normalizePathArray = function ($pathSegments, $path) {
-            $absolute = static::isAbsolutePath($path);
+            $absolute = Filesystem::isAbsolutePath($path);
             $result = array();
 
             foreach ($pathSegments as $segment) {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -358,10 +358,11 @@ class Filesystem
             $startPath = str_replace('\\', '/', $startPath);
         }
 
-        $stripDriveLetter = function($path) {
+        $stripDriveLetter = function ($path) {
             if (strlen($path) > 2 && substr($path, 1, 2) === ':/' && ctype_alpha($path[0])) {
                 return substr($path, 2);
             }
+
             return $path;
         };
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -400,13 +400,8 @@ class Filesystem
             $depth = count($startPathArr) - $index;
         }
 
-        // When we need to traverse from the start, and we are starting from a root path, don't add '../'
-        if ('/' === $startPath[0] && 0 === $index && 0 === $depth) {
-            $traverser = '';
-        } else {
-            // Repeated "../" for each level need to reach the common path
-            $traverser = str_repeat('../', $depth);
-        }
+        // Repeated "../" for each level need to reach the common path
+        $traverser = str_repeat('../', $depth);
 
         $endPathRemainder = implode('/', array_slice($endPathArr, $index));
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -373,8 +373,7 @@ class Filesystem
         $startPathArr = explode('/', trim($startPath, '/'));
         $endPathArr = explode('/', trim($endPath, '/'));
 
-        $normalizePathArray = function ($pathSegments, $path) {
-            $absolute = Filesystem::isAbsolutePath($path);
+        $normalizePathArray = function ($pathSegments, $absolute) {
             $result = array();
 
             foreach ($pathSegments as $segment) {
@@ -388,8 +387,8 @@ class Filesystem
             return $result;
         };
 
-        $startPathArr = $normalizePathArray($startPathArr, $startPath);
-        $endPathArr = $normalizePathArray($endPathArr, $endPath);
+        $startPathArr = $normalizePathArray($startPathArr, static::isAbsolutePath($startPath));
+        $endPathArr = $normalizePathArray($endPathArr, static::isAbsolutePath($endPath));
 
         // Find for which directory the common path stops
         $index = 0;

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -372,11 +372,12 @@ class Filesystem
         $startPathArr = explode('/', trim($startPath, '/'));
         $endPathArr = explode('/', trim($endPath, '/'));
 
-        $normalizePathArray = function ($pathSegments) {
+        $normalizePathArray = function ($pathSegments, $path) {
+            $absolute = static::isAbsolutePath($path);
             $result = array();
 
             foreach ($pathSegments as $segment) {
-                if ('..' === $segment) {
+                if ('..' === $segment && ($absolute || count($result))) {
                     array_pop($result);
                 } elseif ('.' !== $segment) {
                     $result[] = $segment;
@@ -386,8 +387,8 @@ class Filesystem
             return $result;
         };
 
-        $startPathArr = $normalizePathArray($startPathArr);
-        $endPathArr = $normalizePathArray($endPathArr);
+        $startPathArr = $normalizePathArray($startPathArr, $startPath);
+        $endPathArr = $normalizePathArray($endPathArr, $endPath);
 
         // Find for which directory the common path stops
         $index = 0;

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -358,17 +358,19 @@ class Filesystem
             $startPath = str_replace('\\', '/', $startPath);
         }
 
+        $stripDriveLetter = function($path) {
+            if (strlen($path) > 2 && substr($path, 1, 2) === ':/' && ctype_alpha($path[0])) {
+                return substr($path, 2);
+            }
+            return $path;
+        };
+
+        $endPath = $stripDriveLetter($endPath);
+        $startPath = $stripDriveLetter($startPath);
+
         // Split the paths into arrays
         $startPathArr = explode('/', trim($startPath, '/'));
         $endPathArr = explode('/', trim($endPath, '/'));
-
-        if ('/' !== $startPath[0]) {
-            array_shift($startPathArr);
-        }
-
-        if ('/' !== $endPath[0]) {
-            array_shift($endPathArr);
-        }
 
         $normalizePathArray = function ($pathSegments) {
             $result = array();

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -345,8 +345,8 @@ class Filesystem
     /**
      * Given an existing path, convert it to a path relative to a given starting path.
      *
-     * @param string $endPath   Absolute path of target
-     * @param string $startPath Absolute path where traversal begins
+     * @param string $endPath   Path of target
+     * @param string $startPath Path where traversal begins
      *
      * @return string Path of target relative to starting path
      */

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -397,7 +397,7 @@ class Filesystem
         }
 
         // Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
-        if (count($startPathArr) === 1 && $startPathArr[0] === '') {
+        if (1 === count($startPathArr) && '' === $startPathArr[0]) {
             $depth = 0;
         } else {
             $depth = count($startPathArr) - $index;
@@ -498,7 +498,7 @@ class Filesystem
     {
         return strspn($file, '/\\', 0, 1)
             || (strlen($file) > 3 && ctype_alpha($file[0])
-                && substr($file, 1, 1) === ':'
+                && ':' === substr($file, 1, 1)
                 && strspn($file, '/\\', 2, 1)
             )
             || null !== parse_url($file, PHP_URL_SCHEME)

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -359,7 +359,7 @@ class Filesystem
         }
 
         $stripDriveLetter = function ($path) {
-            if (strlen($path) > 2 && substr($path, 1, 2) === ':/' && ctype_alpha($path[0])) {
+            if (strlen($path) > 2 && ':' === $path[1] && '/' === $path[2] && ctype_alpha($path[0])) {
                 return substr($path, 2);
             }
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -345,8 +345,8 @@ class Filesystem
     /**
      * Given an existing path, convert it to a path relative to a given starting path.
      *
-     * @param string $endPath   Path of target
-     * @param string $startPath Path where traversal begins
+     * @param string $endPath   Absolute path of target
+     * @param string $startPath Absolute path where traversal begins
      *
      * @return string Path of target relative to starting path
      */

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -884,6 +884,12 @@ class FilesystemTest extends FilesystemTestCase
             array('aa/bb', 'aa/./cc', '../bb/'),
             array('aa/./bb', 'aa/cc', '../bb/'),
             array('aa/./bb', 'aa/./cc', '../bb/'),
+            array('../../', '../../', './'),
+            array('../aa/bb/', 'aa/bb/', '../../../aa/bb/'),
+            array('../../../', '../../', '../'),
+            array('', '', './'),
+            array('', 'aa/', '../'),
+            array('aa/', '', 'aa/'),
         );
 
         if ('\\' === DIRECTORY_SEPARATOR) {

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -847,6 +847,7 @@ class FilesystemTest extends FilesystemTestCase
             array('/var/lib/symfony/src/Symfony', '/var/lib/symfony/src/Symfony/Component/', '../'),
             array('var/lib/symfony/', 'var/lib/symfony/src/Symfony/Component', '../../../'),
             array('/usr/lib/symfony/', '/var/lib/symfony/src/Symfony/Component', '../../../../../../usr/lib/symfony/'),
+            array('usr/lib/symfony/', 'var/lib/symfony/src/Symfony/Component', '../../../../../../usr/lib/symfony/'),
             array('/var/lib/symfony/src/Symfony/', '/var/lib/symfony/', 'src/Symfony/'),
             array('/aa/bb', '/aa/bb', './'),
             array('/aa/bb', '/aa/bb/', './'),
@@ -878,6 +879,8 @@ class FilesystemTest extends FilesystemTestCase
             array('C:/aa/bb/../../cc', 'C:/aa/../dd/..', 'cc/'),
             array('C:/../aa/bb/cc', 'C:/aa/dd/..', 'bb/cc/'),
             array('C:/../../aa/../bb/cc', 'C:/aa/dd/..', '../bb/cc/'),
+            array('aa/bb', 'aa/cc', '../bb/'),
+            array('aa/cc', 'bb/cc', '../../aa/cc/'),
         );
 
         if ('\\' === DIRECTORY_SEPARATOR) {

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -881,6 +881,9 @@ class FilesystemTest extends FilesystemTestCase
             array('C:/../../aa/../bb/cc', 'C:/aa/dd/..', '../bb/cc/'),
             array('aa/bb', 'aa/cc', '../bb/'),
             array('aa/cc', 'bb/cc', '../../aa/cc/'),
+            array('aa/bb', 'aa/./cc', '../bb/'),
+            array('aa/./bb', 'aa/cc', '../bb/'),
+            array('aa/./bb', 'aa/./cc', '../bb/'),
         );
 
         if ('\\' === DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Updating to Symfony 3.2.7 @agoat noticed a bug with `Filesystem::makePathRelative()` in contao/core-bundle#751:

- In Symfony 3.2.6 `makePathRelative('aa/cc', 'bb/cc')` returned correctly `../../aa/cc`
- In Symfony 3.2.7 the same method call returns `./`

I think this issue was introduced with #22133.

While working on the fix I noticed some other issues too:

- An unnecessary if construct that did nothing, fc745f45949fdb8d5aa590618ec73537721f99b4
- Missing normalization of `./` path segments, 15982d4b083723555cfa149368eaaae9609d0e22
- `../` got ignored at the beginning of relative paths, 9586e880d69f613b10e23dd53cea877e622b221a
- The documentation of the method only allowed absolute paths, but there are already unit tests ([FilesystemTest.php:1097](https://github.com/symfony/symfony/blob/ab93feae3f9a16c4f18c5736435d18fa36338d2c/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php#L1097)) that test the behavior of relative paths, cec473eeb099c074b5883e7187f74663402f9d87

This pull request fixes all these issues and adds tests for them.