### PR TITLE
[ExpressionLanguage] Avoid ExpressionLanguage dependency on ctype

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -45,7 +45,7 @@ class Lexer
             if (preg_match('/[0-9]+(?:\.[0-9]+)?/A', $expression, $match, null, $cursor)) {
                 // numbers
                 $number = (float) $match[0];  // floats
-                if (ctype_digit($match[0]) && $number <= PHP_INT_MAX) {
+                if (preg_match('/^[0-9]+$/', $match[0]) && $number <= PHP_INT_MAX) {
                     $number = (int) $match[0]; // integers lower than the maximum
                 }
                 $tokens[] = new Token(Token::NUMBER_TYPE, $number, $cursor + 1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

There is undocumented dependency on ctype extension in ExpressionLanguage. I've chosen to remove it rather than document as we're using ExpressionLanguage in phpMyAdmin and this is only dependency which needs ctype.

I'm submitting this against 3.2 to get this fix to released version sooner, but it can be without problems applied to master as well.
