### PR TITLE
[HttpKernel] Resolve invokable controllers short notations using ServiceValueResolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
@@ -60,6 +60,9 @@ class RemoveEmptyControllerArgumentLocatorsPass implements CompilerPassInterface
                     if ($controllerDef->getClass() === $id) {
                         $controllers[$id.'::'.$action] = $argumentRef;
                     }
+                    if ('__invoke' === $action) {
+                        $controllers[$id] = $argumentRef;
+                    }
                     continue;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22202 
| License       | MIT
| Doc PR        | n/a

Register the service id as an alias of `id:__invoke` so that using the invokable short notation (id only) triggers the ServiceArgumentResolver.