### PR TITLE
[Serializer] Fix decoding attribute that contains many digits

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -301,11 +301,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         $data = array();
 
         foreach ($node->attributes as $attr) {
-            if (ctype_digit($attr->nodeValue)) {
-                $data['@'.$attr->nodeName] = (int) $attr->nodeValue;
-            } else {
-                $data['@'.$attr->nodeName] = $attr->nodeValue;
-            }
+            $data['@'.$attr->nodeName] = $attr->nodeValue;
         }
 
         return $data;

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -463,6 +463,17 @@ XML;
         $xml = $this->encoder->encode($obj, 'xml');
         $this->assertEquals($expected, $this->encoder->decode($xml, 'xml'));
     }
+    
+    public function testDecodeBigDigitAttributes()
+    {
+        $source = '<?xml version="1.0"?>'.PHP_EOL.
+            '<document index="182077241760011681341821060401202210011000045913000000017100">Name</document>'.PHP_EOL;
+        $expected = array(
+            '#' => 'Name',
+            '@index' => '182077241760011681341821060401202210011000045913000000017100',
+        );
+        $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
+    }    
 
     /**
      * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -463,7 +463,7 @@ XML;
         $xml = $this->encoder->encode($obj, 'xml');
         $this->assertEquals($expected, $this->encoder->decode($xml, 'xml'));
     }
-    
+
     public function testDecodeBigDigitAttributes()
     {
         $source = '<?xml version="1.0"?>'.PHP_EOL.
@@ -473,7 +473,7 @@ XML;
             '@index' => '182077241760011681341821060401202210011000045913000000017100',
         );
         $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
-    }    
+    }
 
     /**
      * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22329 
| License       | MIT