### PR TITLE
[BrowserKit] Emulate back/forward browser navigation

### DIFF
--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -7,6 +7,9 @@ CHANGELOG
  * [BC BREAK] The request method is dropped from POST to GET when the response
    status code is 301.
 
+ * [BC BREAK] Client will skip redirects during history navigation
+   (back and forward calls) according to W3C Browsers recommendation
+
 3.2.0
 -----
 

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -42,6 +42,7 @@ abstract class Client
 
     private $maxRedirects = -1;
     private $redirectCount = 0;
+    private $redirects = array();
     private $isMainRequest = true;
 
     /**
@@ -328,6 +329,8 @@ abstract class Client
         }
 
         if ($this->followRedirects && $this->redirect) {
+            $this->redirects[serialize($this->history->current())] = true;
+
             return $this->crawler = $this->followRedirect();
         }
 
@@ -430,7 +433,11 @@ abstract class Client
      */
     public function back()
     {
-        return $this->requestFromRequest($this->history->back(), false);
+        do {
+            $request = $this->history->back();
+        } while (array_key_exists(serialize($request), $this->redirects));
+
+        return $this->requestFromRequest($request, false);
     }
 
     /**
@@ -440,7 +447,11 @@ abstract class Client
      */
     public function forward()
     {
-        return $this->requestFromRequest($this->history->forward(), false);
+        do {
+            $request = $this->history->forward();
+        } while (array_key_exists(serialize($request), $this->redirects));
+
+        return $this->requestFromRequest($request, false);
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -573,6 +573,25 @@ class ClientTest extends TestCase
         $this->assertEquals($content, $client->getRequest()->getContent(), '->forward() keeps content');
     }
 
+    public function testBackAndFrowardWithRedirects()
+    {
+        $client = new TestClient();
+
+        $client->request('GET', 'http://www.example.com/foo');
+        $client->setNextResponse(new Response('', 301, array('Location' => 'http://www.example.com/redirected')));
+        $client->request('GET', 'http://www.example.com/bar');
+
+        $this->assertEquals('http://www.example.com/redirected', $client->getRequest()->getUri(), 'client followed redirect');
+
+        $client->back();
+
+        $this->assertEquals('http://www.example.com/foo', $client->getRequest()->getUri(), '->back() goes back in the history skipping redirects');
+
+        $client->forward();
+
+        $this->assertEquals('http://www.example.com/redirected', $client->getRequest()->getUri(), '->forward() goes forward in the history skipping redirects');
+    }
+
     public function testReload()
     {
         $client = new TestClient();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22336
| License       | MIT
| Doc PR        | CHANGELOG.md updated


Hi all, please review this code for emulating back/forward browser navigation (skip redirects). If code is ok I will add tests and docs