### PR TITLE
[DX] [TwigBundle] Improve default expand states of exception template

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
@@ -33,7 +33,7 @@
             {% set _exceptions_with_user_code = [] %}
             {% for i, e in exception_as_array %}
                 {% for trace in e.trace %}
-                    {% if (trace.file is not empty) and ()'/vendor/' not in trace.file) and not loop.last %}
+                    {% if (trace.file is not empty) and ('/vendor/' not in trace.file) and not loop.last %}
                         {% set _exceptions_with_user_code = _exceptions_with_user_code|merge([i]) %}
                     {% endif %}
                 {% endfor %}
@@ -48,7 +48,7 @@
 
             <div class="tab-content">
                 {% for i, e in exception_as_array %}
-                    {{ include('@Twig/Exception/traces.html.twig', { exception: e, index: loop.index, expand: (i in _exceptions_with_user_code or _exceptions_with_user_code is empty) }, with_context = false) }}
+                    {{ include('@Twig/Exception/traces.html.twig', { exception: e, index: loop.index, expand: i in _exceptions_with_user_code or (_exceptions_with_user_code is empty and loop.first) }, with_context = false) }}
                 {% endfor %}
             </div>
         </div>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
@@ -33,7 +33,7 @@
             {% set _exceptions_with_user_code = [] %}
             {% for i, e in exception_as_array %}
                 {% for trace in e.trace %}
-                    {% if (trace.file is not empty) and ('/vendor/' not in trace.file) and not loop.last %}
+                    {% if (trace.file is not empty) and ('/vendor/' not in trace.file) and ('/var/cache/' not in trace.file) and not loop.last %}
                         {% set _exceptions_with_user_code = _exceptions_with_user_code|merge([i]) %}
                     {% endif %}
                 {% endfor %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
@@ -30,6 +30,14 @@
     <div class="sf-tabs">
         <div class="tab">
             {% set exception_as_array = exception.toarray %}
+            {% set _exceptions_with_user_code = [] %}
+            {% for i, e in exception_as_array %}
+                {% for trace in e.trace %}
+                    {% if (trace.file is not empty) and ()'/vendor/' not in trace.file) and not loop.last %}
+                        {% set _exceptions_with_user_code = _exceptions_with_user_code|merge([i]) %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
             <h3 class="tab-title">
                 {% if exception_as_array|length > 1 %}
                     Exceptions <span class="badge">{{ exception_as_array|length }}</span>
@@ -39,8 +47,8 @@
             </h3>
 
             <div class="tab-content">
-                {% for e in exception_as_array %}
-                    {{ include('@Twig/Exception/traces.html.twig', { exception: e, index: loop.index }, with_context = false) }}
+                {% for i, e in exception_as_array %}
+                    {{ include('@Twig/Exception/traces.html.twig', { exception: e, index: loop.index, expand: (i in _exceptions_with_user_code or _exceptions_with_user_code is empty) }, with_context = false) }}
                 {% endfor %}
             </div>
         </div>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.html.twig
@@ -2,7 +2,7 @@
     <table class="trace-details">
         <thead class="trace-head">
             <tr>
-                <th class="sf-toggle" data-toggle-selector="#trace-html-{{ index }}" data-toggle-initial="{{ 1 == index ? 'display' }}">
+                <th class="sf-toggle" data-toggle-selector="#trace-html-{{ index }}" data-toggle-initial="{{ expand ? 'display' }}">
                     <h3 class="trace-class">
                         <span class="trace-namespace">
                             {{ exception.class|split('\\')|slice(0, -1)|join('\\') }}
@@ -24,7 +24,7 @@
         <tbody id="trace-html-{{ index }}" class="sf-toggle-content">
         {% set _is_first_user_code = true %}
         {% for i, trace in exception.trace %}
-            {% set _display_code_snippet = _is_first_user_code and ('/vendor/' not in trace.file) %}
+            {% set _display_code_snippet = _is_first_user_code and ('/vendor/' not in trace.file) and (trace.file is not empty) %}
             {% if _display_code_snippet %}{% set _is_first_user_code = false %}{% endif %}
             <tr>
                 <td class="trace-line {{ trace.file|default(false) ? 'sf-toggle' }}" data-toggle-selector="#trace-html-{{ index }}-{{ i }}" data-toggle-initial="{{ _display_code_snippet ? 'display' }}">

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.html.twig
@@ -24,7 +24,7 @@
         <tbody id="trace-html-{{ index }}" class="sf-toggle-content">
         {% set _is_first_user_code = true %}
         {% for i, trace in exception.trace %}
-            {% set _display_code_snippet = _is_first_user_code and ('/vendor/' not in trace.file) and (trace.file is not empty) %}
+            {% set _display_code_snippet = _is_first_user_code and ('/vendor/' not in trace.file) and ('/var/cache/' not in trace.file) and (trace.file is not empty) %}
             {% if _display_code_snippet %}{% set _is_first_user_code = false %}{% endif %}
             <tr>
                 <td class="trace-line {{ trace.file|default(false) ? 'sf-toggle' }}" data-toggle-selector="#trace-html-{{ index }}-{{ i }}" data-toggle-initial="{{ _display_code_snippet ? 'display' }}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #22334 
| License       | MIT

As discussed in #22334 this PR changes the default exception template to more intelligently decide which call stack to initially expand:
- All exceptions are scanned for user code, ignoring the front controller and callbacks
- Only exceptions containing user code are expanded
- If no user code is found the first exception is expanded