### PR TITLE
[FrameworkBundle] Add autowiring alias for Stopwatch

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -22,6 +22,7 @@
         </service>
 
         <service id="debug.stopwatch" class="Symfony\Component\Stopwatch\Stopwatch" />
+        <service id="Symfony\Component\Stopwatch\Stopwatch" alias="debug.stopwatch" public="false" />
 
         <service id="debug.file_link_formatter" class="Symfony\Component\HttpKernel\Debug\FileLinkFormatter" public="false">
             <argument>%debug.file_link_format%</argument>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Following in the footsteps of #22098 to add aliases for various services, this adds an alias for `Symfony\Component\Stopwatch\Stopwatch`.
