### PR TITLE
[HttpKernel] Add glob support for bundle resource locator

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -249,11 +249,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 $files[] = $file;
             }
 
-            if (file_exists($file = $bundle->getPath().'/'.$path)) {
+            if ($paths = glob($bundle->getPath().'/'.$path, defined('GLOB_BRACE') ? GLOB_BRACE : 0)) {
                 if ($first && !$isResource) {
-                    return $file;
+                    return $paths[0];
                 }
-                $files[] = $file;
+
+                $files = array_merge($files, $paths);
                 $resourceBundle = $bundle->getName();
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -469,6 +469,24 @@ EOF;
         );
     }
 
+    public function testLocateResourceWithGlob()
+    {
+        $kernel = $this->getKernel(array('getBundle'));
+        $kernel
+            ->expects($this->once())
+            ->method('getBundle')
+            ->will($this->returnValue(array($this->getBundle(__DIR__.'/Fixtures/Bundle1Bundle'))))
+        ;
+
+        $this->assertEquals(
+            array(
+                __DIR__.'/Fixtures/Bundle1Bundle/bar.txt',
+                __DIR__.'/Fixtures/Bundle1Bundle/foo.txt',
+            ),
+            $kernel->locateResource('@Bundle1Bundle/*.txt', __DIR__.'/Fixtures', null, false)
+        );
+    }
+
     public function testLocateResourceReturnsTheDirOneForResources()
     {
         $kernel = $this->getKernel(array('getBundle'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This is a continuation of #21270 and #21635 to add glob support when locating bundle resources.
So the following becomes possible:

```
@SomeBundle/{Action,Controller}
@SomeBunde/Resources/config/*.yml
``` 