### PR TITLE
[Validator] Add `canonicalize` option for `Locale` validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Locale.php
+++ b/src/Symfony/Component/Validator/Constraints/Locale.php
@@ -28,4 +28,18 @@ class Locale extends Constraint
     );
 
     public $message = 'This value is not a valid locale.';
+
+    public $canonicalize = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($options = null)
+    {
+        if (isset($options['canonicalize'])) {
+            $this->canonicalize = $options['canonicalize'];
+        }
+
+        parent::__construct($options);
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Locale.php
+++ b/src/Symfony/Component/Validator/Constraints/Locale.php
@@ -28,18 +28,5 @@ class Locale extends Constraint
     );
 
     public $message = 'This value is not a valid locale.';
-
     public $canonicalize = false;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct($options = null)
-    {
-        if (isset($options['canonicalize'])) {
-            $this->canonicalize = $options['canonicalize'];
-        }
-
-        parent::__construct($options);
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -41,6 +41,9 @@ class LocaleValidator extends ConstraintValidator
         }
 
         $value = (string) $value;
+        if ($constraint->canonicalize) {
+            $value = \Locale::canonicalize($value);
+        }
         $locales = Intl::getLocaleBundle()->getLocaleNames();
         $aliases = Intl::getLocaleBundle()->getAliases();
 
@@ -50,5 +53,13 @@ class LocaleValidator extends ConstraintValidator
                 ->setCode(Locale::NO_SUCH_LOCALE_ERROR)
                 ->addViolation();
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'canonicalize';
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -54,12 +54,4 @@ class LocaleValidator extends ConstraintValidator
                 ->addViolation();
         }
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultOption()
-    {
-        return 'canonicalize';
-    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -94,7 +94,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getUncanonicalizedLocales
      */
-    public function testInvalidLocalesWithoutCanonicalization($locale)
+    public function testInvalidLocalesWithoutCanonicalization(string $locale)
     {
         $constraint = new Locale(array(
             'message' => 'myMessage',
@@ -111,7 +111,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getUncanonicalizedLocales
      */
-    public function testValidLocalesWithCanonicalization($locale)
+    public function testValidLocalesWithCanonicalization(string $locale)
     {
         $constraint = new Locale(array(
             'message' => 'myMessage',
@@ -123,7 +123,7 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function getUncanonicalizedLocales()
+    public function getUncanonicalizedLocales(): iterable
     {
         return array(
             array('en-US'),

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -90,4 +90,45 @@ class LocaleValidatorTest extends ConstraintValidatorTestCase
             array('foobar'),
         );
     }
+
+    /**
+     * @dataProvider getUncanonicalizedLocales
+     */
+    public function testInvalidLocalesWithoutCanonicalization($locale)
+    {
+        $constraint = new Locale(array(
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate($locale, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$locale.'"')
+            ->setCode(Locale::NO_SUCH_LOCALE_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getUncanonicalizedLocales
+     */
+    public function testValidLocalesWithCanonicalization($locale)
+    {
+        $constraint = new Locale(array(
+            'message' => 'myMessage',
+            'canonicalize' => true,
+        ));
+
+        $this->validator->validate($locale, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function getUncanonicalizedLocales()
+    {
+        return array(
+            array('en-US'),
+            array('es-AR'),
+            array('fr_FR.utf8'),
+        );
+    }
 }


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |yes   |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |
                      
Allow non canonicalized locales ('fr-FR' by instance) to pass the validation.
Relates to symfony/symfony-docs#7660.