### PR TITLE
[DI] Fix named args overridding

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -161,16 +161,11 @@ class ResolveDefinitionTemplatesPass extends AbstractRecursivePass
         foreach ($definition->getArguments() as $k => $v) {
             if (is_numeric($k)) {
                 $def->addArgument($v);
-                continue;
+            } elseif (0 === strpos($k, 'index_')) {
+                $def->replaceArgument((int) substr($k, strlen('index_')), $v);
+            } else {
+                $def->setArgument($k, $v);
             }
-
-            if (0 === strpos($k, 'index_')) {
-                $index = (int) substr($k, strlen('index_'));
-            } elseif (0 !== strpos($k, '$')) {
-                throw new RuntimeException(sprintf('Invalid argument key "%s" found.', $k));
-            }
-
-            $def->replaceArgument($index, $v);
         }
 
         // merge properties

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -216,6 +216,13 @@ class Definition
         return $this;
     }
 
+    public function setArgument($key, $value)
+    {
+        $this->arguments[$key] = $value;
+
+        return $this;
+    }
+
     /**
      * Gets the arguments to pass to the service constructor/factory method.
      *

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -364,6 +364,23 @@ class ResolveDefinitionTemplatesPassTest extends TestCase
         $this->assertSame('ParentClass', $def->getClass());
     }
 
+    public function testProcessSetsArguments()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('parent', 'ParentClass')->setArguments(array(0));
+        $container->setDefinition('child', (new ChildDefinition('parent'))->setArguments(array(
+            1,
+            'index_0' => 2,
+            'foo' => 3,
+        )));
+
+        $this->process($container);
+
+        $def = $container->getDefinition('child');
+        $this->assertSame(array(2, 1, 'foo' => 3), $def->getArguments());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new ResolveDefinitionTemplatesPass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22196
| License       | MIT
| Doc PR        | -

(The exception check in ResolveDefinitionTemplatesPass is not done in ResolveNamedArgumentsPass.)