### PR TITLE
[Bridge] [Twig] Get and flush only flash sessions you need in getFlashes method

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -174,6 +174,13 @@ class AppVariable
             return $session->getFlashBag()->get($types);
         }
 
-        return array_intersect_key($session->getFlashBag()->all(), array_flip($types));
+        $result = array();
+        foreach ($types as $type) {
+            if ($value = $session->getFlashBag()->get($type)) {
+                $result[$type] = $value;
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -212,6 +212,11 @@ class AppVariableTest extends TestCase
             array('notice' => $flashMessages['notice'], 'error' => $flashMessages['error']),
             $this->appVariable->getFlashes(array('notice', 'error'))
         );
+
+        $this->assertEquals(
+            array('warning' => $flashMessages['warning']),
+            $this->appVariable->getFlashes(array('warning'))
+        );
     }
 
     protected function setRequestStack($request)


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no ?!
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #22355 
| License       | MIT
| Doc PR        | symfony/symfony-docs

PR to get only flash sessions you need without flush everything