### PR TITLE
[HttpKernel et al.] Move DataCollector::cloneVar() to lateCollect()

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
@@ -30,7 +31,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class SecurityDataCollector extends DataCollector
+class SecurityDataCollector extends DataCollector implements LateDataCollectorInterface
 {
     private $tokenStorage;
     private $roleHierarchy;
@@ -157,7 +158,10 @@ class SecurityDataCollector extends DataCollector
                 );
             }
         }
+    }
 
+    public function lateCollect()
+    {
         $this->data = $this->cloneVar($this->data);
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -63,6 +63,7 @@ class SecurityDataCollectorTest extends TestCase
 
         $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy());
         $collector->collect($this->getRequest(), $this->getResponse());
+        $collector->lateCollect();
 
         $this->assertTrue($collector->isEnabled());
         $this->assertTrue($collector->isAuthenticated());
@@ -90,6 +91,7 @@ class SecurityDataCollectorTest extends TestCase
 
         $collector = new SecurityDataCollector(null, null, null, null, $firewallMap);
         $collector->collect($request, $this->getResponse());
+        $collector->lateCollect();
         $collected = $collector->getFirewall();
 
         $this->assertSame($firewallConfig->getName(), $collected['name']);

--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -16,12 +16,13 @@ use Symfony\Component\Cache\Adapter\TraceableAdapterEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 
 /**
  * @author Aaron Scherer <aequasi@gmail.com>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class CacheDataCollector extends DataCollector
+class CacheDataCollector extends DataCollector implements LateDataCollectorInterface
 {
     /**
      * @var TraceableAdapter[]
@@ -50,7 +51,10 @@ class CacheDataCollector extends DataCollector
 
         $this->data['instances']['statistics'] = $this->calculateStatistics();
         $this->data['total']['statistics'] = $this->calculateTotalStatistics();
+    }
 
+    public function lateCollect()
+    {
         $this->data = $this->cloneVar($this->data);
     }
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -22,7 +22,7 @@ use Symfony\Component\VarDumper\Caster\LinkStub;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ConfigDataCollector extends DataCollector
+class ConfigDataCollector extends DataCollector implements LateDataCollectorInterface
 {
     /**
      * @var KernelInterface
@@ -97,6 +97,10 @@ class ConfigDataCollector extends DataCollector
             $this->data['php_version'] = $matches[1];
             $this->data['php_version_extra'] = $matches[2];
         }
+    }
+
+    public function lateCollect()
+    {
         $this->data = $this->cloneVar($this->data);
     }
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -24,7 +24,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class RequestDataCollector extends DataCollector implements EventSubscriberInterface
+class RequestDataCollector extends DataCollector implements EventSubscriberInterface, LateDataCollectorInterface
 {
     /** @var \SplObjectStorage */
     protected $controllers;
@@ -147,7 +147,10 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                 ));
             }
         }
+    }
 
+    public function lateCollect()
+    {
         $this->data = $this->cloneVar($this->data);
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -34,6 +34,7 @@ class RequestDataCollectorTest extends TestCase
         $c = new RequestDataCollector();
 
         $c->collect($request = $this->createRequest(), $this->createResponse());
+        $c->lateCollect();
 
         $attributes = $c->getRequestAttributes();
 
@@ -65,6 +66,7 @@ class RequestDataCollectorTest extends TestCase
 
         $c = new RequestDataCollector();
         $c->collect($request, $this->createResponse());
+        $c->lateCollect();
 
         $this->assertEquals(array(), $c->getRouteParams());
     }
@@ -93,6 +95,7 @@ class RequestDataCollectorTest extends TestCase
         $response = $this->createResponse();
         $this->injectController($c, $callable, $request);
         $c->collect($request, $response);
+        $c->lateCollect();
 
         $this->assertSame($expected, $c->getController()->getValue(true), sprintf('Testing: %s', $name));
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -33,10 +33,11 @@ class ProfilerTest extends TestCase
         $profiler = new Profiler($this->storage);
         $profiler->add($collector);
         $profile = $profiler->collect($request, $response);
+        $profiler->saveProfile($profile);
 
         $this->assertSame(204, $profile->getStatusCode());
         $this->assertSame('GET', $profile->getMethod());
-        $this->assertSame('bar', $profiler->get('request')->getRequestQuery()->all()['foo']->getValue());
+        $this->assertSame('bar', $profile->getCollector('request')->getRequestQuery()->all()['foo']->getValue());
     }
 
     public function testFindWorksWithDates()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22166
| License       | MIT
| Doc PR        | -

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
