### PR TITLE
[DI] Populate class of ChildDefinition when its id matches an existing FQCN

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -27,10 +28,13 @@ class ResolveClassPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         foreach ($container->getDefinitions() as $id => $definition) {
-            if ($definition instanceof ChildDefinition || $definition->isSynthetic() || null !== $definition->getClass()) {
+            if ($definition->isSynthetic() || null !== $definition->getClass()) {
                 continue;
             }
             if (preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $id)) {
+                if ($definition instanceof ChildDefinition && !class_exists($id)) {
+                    throw new InvalidArgumentException(sprintf('Service definition "%s" has a parent but no class, and its name looks like a FQCN. Either the class is missing or you want to inherit it from the parent service. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class.', $id));
+                }
                 $this->changes[strtolower($id)] = $id;
                 $definition->setClass($id);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22345
| License       | MIT
| Doc PR        | -

See linked issue for expected DX.
Instead of doing a "continue", let's throw to force the resolution of any ambiguities.
There is a minor potential BC Break, if one uses an ambiguous FQCN as child-definition id in 3.2 or below.
To me, this should be rare, and easy to fix (compile time only).
The DX enhancement this PR provides looks worth it.

> Service definition "App\Foo\Child" has a parent but no class, and its name looks like a FQCN. Either the class is missing or you want to inherit it from the parent service. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class.
