### PR TITLE
[Dotenv] Throwing an error when loading nothing

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -39,12 +39,13 @@ final class Dotenv
     /**
      * Loads one or several .env files.
      *
-     * @param ...string A list of files to load
+     * @param string    $path  A file to load
+     * @param ...string $paths A list of additionnal files to load
      *
      * @throws FormatException when a file has a syntax error
      * @throws PathException   when a file does not exist or is not readable
      */
-    public function load(/*...$paths*/)
+    public function load($path/*, ...$paths*/)
     {
         // func_get_args() to be replaced by a variadic argument for Symfony 4.0
         foreach (func_get_args() as $path) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This is a quick fix to prevent anoying when you follow a tutorial using another dotenv component. For example, this code uses [vlucas/phpdotenv](https://packagist.org/packages/vlucas/phpdotenv):

```php
$dotenv = new Dotenv\Dotenv(__DIR__.'/../');
$dotenv->load();
```

Silently failed with symfony/dotenv.