### PR TITLE
[Yaml] release memory after parsing

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -86,6 +86,12 @@ class Parser
             mb_internal_encoding($mbEncoding);
         }
 
+        $this->lines = array();
+        $this->currentLine = '';
+        $this->refs = array();
+        $this->skippedLineNumbers = array();
+        $this->locallySkippedLineNumbers = array();
+
         if (null !== $e) {
             throw $e;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22351#discussion_r110647360
| License       | MIT
| Doc PR        | 

Follow up of #22351 to release memory after parsing as suggested by @stof.