### PR TITLE
[FrameworkBundle] Use findDefinition() instead of getDefinition() on aliases

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolClearerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolClearerPass.php
@@ -56,14 +56,14 @@ final class CachePoolClearerPass implements CompilerPassInterface
             return;
         }
         $factory = array(AbstractAdapter::class, 'createSystemCache');
-        $annotationsPool = $container->getDefinition('cache.annotations');
+        $annotationsPool = $container->findDefinition('cache.annotations');
         if ($factory !== $annotationsPool->getFactory() || 4 !== count($annotationsPool->getArguments())) {
             return;
         }
         if ($container->has('monolog.logger.cache')) {
             $annotationsPool->addArgument(new Reference('monolog.logger.cache'));
         } elseif ($container->has('cache.system')) {
-            $systemPool = $container->getDefinition('cache.system');
+            $systemPool = $container->findDefinition('cache.system');
             if ($factory === $systemPool->getFactory() && 5 <= count($systemArgs = $systemPool->getArguments())) {
                 $annotationsPool->addArgument($systemArgs[4]);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The services for which `has()` is called might be aliases at this point so `getDefinition()` gives an exception, I ran into by executing this pass but not the removing ones (skipping ReplaceAliasByActualDefinitionPass) while working on https://github.com/symfony/symfony/issues/16388. Let's make it safe to use independently.