### PR TITLE
[Console] Allow terminal dimensions to be set to 0 (unbounded)

### DIFF
--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -23,8 +23,9 @@ class Terminal
      */
     public function getWidth()
     {
-        if ($width = trim(getenv('COLUMNS'))) {
-            return (int) $width;
+        $width = getenv('COLUMNS');
+        if (false !== $width) {
+            return (int) trim($width);
         }
 
         if (null === self::$width) {
@@ -41,8 +42,9 @@ class Terminal
      */
     public function getHeight()
     {
-        if ($height = trim(getenv('LINES'))) {
-            return (int) $height;
+        $height = getenv('LINES');
+        if (false !== $height) {
+            return (int) trim($height);
         }
 
         if (null === self::$height) {

--- a/src/Symfony/Component/Console/Tests/TerminalTest.php
+++ b/src/Symfony/Component/Console/Tests/TerminalTest.php
@@ -30,4 +30,15 @@ class TerminalTest extends TestCase
         $this->assertSame(120, $terminal->getWidth());
         $this->assertSame(60, $terminal->getHeight());
     }
+
+    public function test_zero_values()
+    {
+        putenv('COLUMNS=0');
+        putenv('LINES=0');
+
+        $terminal = new Terminal();
+
+        $this->assertSame(0, $terminal->getWidth());
+        $this->assertSame(0, $terminal->getHeight());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21513
| License       | MIT

A previous PR (#20328) changed the behavior of terminals with undefined widths from unbounded to 80 characters. And due to the way the existing code worked it become impossible to set a terminal to be unbounded again. This PR provides a way to restore the previous behavior:
```php
putenv('COLUMNS=0');
```

