### PR TITLE
added a more specialized exception for a better error message

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -64,7 +64,7 @@ class DelegatingLoader extends BaseDelegatingLoader
             // - this handles the case and prevents the second fatal error
             //   by triggering an exception beforehand.
 
-            throw new FileLoaderLoadException($resource);
+            throw new FileLoaderLoadException($resource, null, null, null, $type);
         }
         $this->loading = true;
 

--- a/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
@@ -23,8 +23,9 @@ class FileLoaderLoadException extends \Exception
      * @param string     $sourceResource The original resource importing the new resource
      * @param int        $code           The error code
      * @param \Exception $previous       A previous exception
+     * @param string     $type           The type of resource
      */
-    public function __construct($resource, $sourceResource = null, $code = null, $previous = null)
+    public function __construct($resource, $sourceResource = null, $code = null, $previous = null, $type = null)
     {
         $message = '';
         if ($previous) {
@@ -60,6 +61,13 @@ class FileLoaderLoadException extends \Exception
             $bundle = substr($parts[0], 1);
             $message .= sprintf(' Make sure the "%s" bundle is correctly registered and loaded in the application kernel class.', $bundle);
             $message .= sprintf(' If the bundle is registered, make sure the bundle path "%s" is not empty.', $resource);
+        } elseif (null !== $type) {
+            // maybe there is no loader for this specific type
+            if ('annotation' === $type) {
+                $message .= ' Make sure annotations are enabled.';
+            } else {
+                $message .= sprintf(' Make sure there is a loader supporting the "%s" type.', $type);
+            }
         }
 
         parent::__construct($message, $code, $previous);

--- a/src/Symfony/Component/Config/Loader/DelegatingLoader.php
+++ b/src/Symfony/Component/Config/Loader/DelegatingLoader.php
@@ -39,7 +39,7 @@ class DelegatingLoader extends Loader
     public function load($resource, $type = null)
     {
         if (false === $loader = $this->resolver->resolve($resource, $type)) {
-            throw new FileLoaderLoadException($resource);
+            throw new FileLoaderLoadException($resource, null, null, null, $type);
         }
 
         return $loader->load($resource, $type);

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -210,7 +210,7 @@ abstract class FileLoader extends Loader
                     throw $e;
                 }
 
-                throw new FileLoaderLoadException($resource, $sourceResource, null, $e);
+                throw new FileLoaderLoadException($resource, $sourceResource, null, $e, $type);
             }
         }
     }

--- a/src/Symfony/Component/Config/Loader/Loader.php
+++ b/src/Symfony/Component/Config/Loader/Loader.php
@@ -70,7 +70,7 @@ abstract class Loader implements LoaderInterface
         $loader = null === $this->resolver ? false : $this->resolver->resolve($resource, $type);
 
         if (false === $loader) {
-            throw new FileLoaderLoadException($resource);
+            throw new FileLoaderLoadException($resource, null, null, null, $type);
         }
 
         return $loader;

--- a/src/Symfony/Component/Config/Tests/Exception/FileLoaderLoadExceptionTest.php
+++ b/src/Symfony/Component/Config/Tests/Exception/FileLoaderLoadExceptionTest.php
@@ -22,6 +22,18 @@ class FileLoaderLoadExceptionTest extends TestCase
         $this->assertEquals('Cannot load resource "resource".', $exception->getMessage());
     }
 
+    public function testMessageCannotLoadResourceWithType()
+    {
+        $exception = new FileLoaderLoadException('resource', null, null, null, 'foobar');
+        $this->assertEquals('Cannot load resource "resource". Make sure there is a loader supporting the "foobar" type.', $exception->getMessage());
+    }
+
+    public function testMessageCannotLoadResourceWithAnnotationType()
+    {
+        $exception = new FileLoaderLoadException('resource', null, null, null, 'annotation');
+        $this->assertEquals('Cannot load resource "resource". Make sure annotations are enabled.', $exception->getMessage());
+    }
+
     public function testMessageCannotImportResourceFromSource()
     {
         $exception = new FileLoaderLoadException('resource', 'sourceResource');

--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -369,11 +369,11 @@ class RouteCollectionBuilder
         }
 
         if (null === $resolver = $this->loader->getResolver()) {
-            throw new FileLoaderLoadException($resource);
+            throw new FileLoaderLoadException($resource, null, null, null, $type);
         }
 
         if (false === $loader = $resolver->resolve($resource, $type)) {
-            throw new FileLoaderLoadException($resource);
+            throw new FileLoaderLoadException($resource, null, null, null, $type);
         }
 
         $collections = $loader->load($resource, $type);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When trying to load a resource, it is very interesting to understand why a resource cannot be loaded. Especially when you get `Cannot load resource "../src/Controller/".`... when the real error is that annotation support is disabled. This PR adds more information in that case.
