### PR TITLE
[DX][FrameworkBundle] Show private aliases in debug:container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -109,7 +109,9 @@ class JsonDescriptor extends Descriptor
             $service = $this->resolveServiceDefinition($builder, $serviceId);
 
             if ($service instanceof Alias) {
-                $data['aliases'][$serviceId] = $this->getContainerAliasData($service);
+                if ($showPrivate || $service->isPublic()) {
+                    $data['aliases'][$serviceId] = $this->getContainerAliasData($service);
+                }
             } elseif ($service instanceof Definition) {
                 if (($showPrivate || $service->isPublic())) {
                     $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, $omitTags, $showArguments);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -128,7 +128,6 @@ class MarkdownDescriptor extends Descriptor
         $this->write($title."\n".str_repeat('=', strlen($title)));
 
         $serviceIds = isset($options['tag']) && $options['tag'] ? array_keys($builder->findTaggedServiceIds($options['tag'])) : $builder->getServiceIds();
-        $showPrivate = isset($options['show_private']) && $options['show_private'];
         $showArguments = isset($options['show_arguments']) && $options['show_arguments'];
         $services = array('definitions' => array(), 'aliases' => array(), 'services' => array());
 
@@ -136,7 +135,9 @@ class MarkdownDescriptor extends Descriptor
             $service = $this->resolveServiceDefinition($builder, $serviceId);
 
             if ($service instanceof Alias) {
-                $services['aliases'][$serviceId] = $service;
+                if ($showPrivate || $service->isPublic()) {
+                    $services['aliases'][$serviceId] = $service;
+                }
             } elseif ($service instanceof Definition) {
                 if (($showPrivate || $service->isPublic())) {
                     $services['definitions'][$serviceId] = $service;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -207,6 +207,11 @@ class TextDescriptor extends Descriptor
                         }
                     }
                 }
+            } elseif ($definition instanceof Alias) {
+                if (!$showPrivate && !$definition->isPublic()) {
+                    unset($serviceIds[$key]);
+                    continue;
+                }
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -320,7 +320,7 @@ class XmlDescriptor extends Descriptor
         foreach ($this->sortServiceIds($serviceIds) as $serviceId) {
             $service = $this->resolveServiceDefinition($builder, $serviceId);
 
-            if ($service instanceof Definition && !($showPrivate || $service->isPublic())) {
+            if (($service instanceof Definition || $service instanceof Alias) && !($showPrivate || $service->isPublic())) {
                 continue;
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
@@ -11,11 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\XmlDumper;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Dumps the ContainerBuilder to a cache file so that it can be used by
@@ -28,14 +27,9 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $dumper = new XmlDumper($container);
-        $filename = $container->getParameter('debug.container.dump');
-        $filesystem = new Filesystem();
-        $filesystem->dumpFile($filename, $dumper->dump(), null);
-        try {
-            $filesystem->chmod($filename, 0666, umask());
-        } catch (IOException $e) {
-            // discard chmod failure (some filesystem may not support it)
+        $cache = new ConfigCache($container->getParameter('debug.container.dump'), true);
+        if (!$cache->isFresh()) {
+            $cache->write((new XmlDumper($container))->dump(), $container->getResources());
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -113,7 +113,7 @@ class FrameworkBundle extends Bundle
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);
-            $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_AFTER_REMOVING);
+            $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_BEFORE_REMOVING, -255);
             $this->addCompilerPassIfExists($container, ConfigCachePass::class);
             $container->addCompilerPass(new CacheCollectorPass());
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
@@ -79,10 +79,6 @@
         "alias_1": {
             "service": "service_1",
             "public": true
-        },
-        "alias_2": {
-            "service": "service_2",
-            "public": false
         }
     },
     "services": {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.md
@@ -27,11 +27,6 @@ Aliases
 - Service: `service_1`
 - Public: yes
 
-### alias_2
-
-- Service: `service_2`
-- Public: no
-
 
 Services
 --------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.txt
@@ -6,7 +6,6 @@
  [32m Service ID        [39m [32m Class name                                             [39m 
  ------------------- -------------------------------------------------------- 
   alias_1             alias for "service_1"                                   
-  alias_2             alias for "service_2"                                   
   definition_1        Full\Qualified\Class1                                   
   service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
  ------------------- -------------------------------------------------------- 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container>
   <alias id="alias_1" service="service_1" public="true"/>
-  <alias id="alias_2" service="service_2" public="false"/>
   <definition id="definition_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" autoconfigured="false" file="">
     <factory class="Full\Qualified\FactoryClass" method="get"/>
     <argument type="service" id="definition2"/>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
@@ -19,10 +19,6 @@
         "alias_1": {
             "service": "service_1",
             "public": true
-        },
-        "alias_2": {
-            "service": "service_2",
-            "public": false
         }
     },
     "services": {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
@@ -26,11 +26,6 @@ Aliases
 - Service: `service_1`
 - Public: yes
 
-### alias_2
-
-- Service: `service_2`
-- Public: no
-
 
 Services
 --------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.txt
@@ -6,7 +6,6 @@
  [32m Service ID        [39m [32m Class name                                             [39m 
  ------------------- -------------------------------------------------------- 
   alias_1             alias for "service_1"                                   
-  alias_2             alias for "service_2"                                   
   definition_1        Full\Qualified\Class1                                   
   service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
  ------------------- -------------------------------------------------------- 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container>
   <alias id="alias_1" service="service_1" public="true"/>
-  <alias id="alias_2" service="service_2" public="false"/>
   <definition id="definition_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" autoconfigured="false" file="">
     <factory class="Full\Qualified\FactoryClass" method="get"/>
   </definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+/**
+ * @group functional
+ */
+class ContainerDebugCommandTest extends WebTestCase
+{
+    public function testDumpContainerIfNotExists()
+    {
+        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        @unlink(static::$kernel->getContainer()->getParameter('debug.container.dump'));
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'debug:container'));
+
+        $this->assertFileExists(static::$kernel->getContainer()->getParameter('debug.container.dump'));
+    }
+
+    public function testNoDebug()
+    {
+        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml', 'debug' => false));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'debug:container'));
+
+        $this->assertContains('public', $tester->getDisplay());
+    }
+
+    public function testPrivateAlias()
+    {
+        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'debug:container', '--show-private' => true));
+        $this->assertContains('public', $tester->getDisplay());
+        $this->assertContains('private_alias', $tester->getDisplay());
+
+        $tester->run(array('command' => 'debug:container'));
+        $this->assertContains('public', $tester->getDisplay());
+        $this->assertNotContains('private_alias', $tester->getDisplay());
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return array(
+    new FrameworkBundle(),
+    new TestBundle(),
+);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: ../config/default.yml }
+
+services:
+    public:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\DeclaredClass
+    private_alias:
+        alias: public
+        public: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/16388 https://github.com/Haehnchen/idea-php-symfony2-plugin/issues/618
| License       | MIT
| Doc PR        | n/a

By building and compiling the container without `TYPE_REMOVING` passes, private aliases are available (shown when `--show-private` is passed). The ContainerBuilderDebugDumpPass now makes use of the ConfigCache component, removing the need for clearing the cache to get the debug:container output up to date (in sync with latest config).
 
Config
-------

```yaml
services:
    AppBundle\Foo:
        public: false

    foo_consumer1:
        class: AppBundle\Foo
        arguments: [ '@AppBundle\Foo' ]

    foo_consumer2:
        class: AppBundle\Foo
        arguments: [ '@AppBundle\Foo' ]

    foo_alias:
        alias: AppBundle\Foo

    foo_private_alias:
        public: false
        alias: AppBundle\Foo
```

Before
-------

![before](http://image.prntscr.com/image/2a69485a4a764316a90260b4e3dfc2a2.png)

After
------

![after](http://image.prntscr.com/image/ea42daa0e5c94841a28dd256450dc8ef.png)