### PR TITLE
fail when detecting risky tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bridge/Doctrine/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Doctrine/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bridge/Monolog/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Monolog/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bridge/PhpUnit/phpunit.xml.dist
+++ b/src/Symfony/Bridge/PhpUnit/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bridge/ProxyManager/phpunit.xml.dist
+++ b/src/Symfony/Bridge/ProxyManager/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "symfony/asset": "~2.7",
         "symfony/finder": "~2.3",
-        "symfony/form": "~2.7.25|^2.8.18",
+        "symfony/form": "~2.7.26|^2.8.19",
         "symfony/http-kernel": "~2.3",
         "symfony/intl": "~2.3",
         "symfony/routing": "~2.2",

--- a/src/Symfony/Bridge/Twig/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Twig/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bundle/DebugBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/DebugBundle/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -40,7 +40,7 @@
         "symfony/dom-crawler": "^2.0.5",
         "symfony/intl": "~2.3",
         "symfony/security": "~2.6",
-        "symfony/form": "~2.7.25|^2.8.18",
+        "symfony/form": "~2.7.26|^2.8.19",
         "symfony/class-loader": "~2.1",
         "symfony/expression-language": "~2.6",
         "symfony/process": "^2.0.5",

--- a/src/Symfony/Bundle/FrameworkBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/FrameworkBundle/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bundle/SecurityBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/SecurityBundle/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bundle/TwigBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/TwigBundle/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Bundle/WebProfilerBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/WebProfilerBundle/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Asset/phpunit.xml.dist
+++ b/src/Symfony/Component/Asset/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/BrowserKit/phpunit.xml.dist
+++ b/src/Symfony/Component/BrowserKit/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/ClassLoader/phpunit.xml.dist
+++ b/src/Symfony/Component/ClassLoader/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Config/phpunit.xml.dist
+++ b/src/Symfony/Component/Config/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Console/Tests/Helper/LegacyTableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/LegacyTableHelperTest.php
@@ -34,7 +34,7 @@ class LegacyTableHelperTest extends TestCase
     }
 
     /**
-     * @dataProvider testRenderProvider
+     * @dataProvider renderProvider
      */
     public function testRender($headers, $rows, $layout, $expected)
     {
@@ -50,7 +50,7 @@ class LegacyTableHelperTest extends TestCase
     }
 
     /**
-     * @dataProvider testRenderProvider
+     * @dataProvider renderProvider
      */
     public function testRenderAddRows($headers, $rows, $layout, $expected)
     {
@@ -66,7 +66,7 @@ class LegacyTableHelperTest extends TestCase
     }
 
     /**
-     * @dataProvider testRenderProvider
+     * @dataProvider renderProvider
      */
     public function testRenderAddRowsOneByOne($headers, $rows, $layout, $expected)
     {
@@ -83,7 +83,7 @@ class LegacyTableHelperTest extends TestCase
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
-    public function testRenderProvider()
+    public function renderProvider()
     {
         $books = array(
             array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),

--- a/src/Symfony/Component/Console/phpunit.xml.dist
+++ b/src/Symfony/Component/Console/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/CssSelector/phpunit.xml.dist
+++ b/src/Symfony/Component/CssSelector/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Debug/phpunit.xml.dist
+++ b/src/Symfony/Component/Debug/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/DependencyInjection/phpunit.xml.dist
+++ b/src/Symfony/Component/DependencyInjection/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/DomCrawler/phpunit.xml.dist
+++ b/src/Symfony/Component/DomCrawler/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/EventDispatcher/phpunit.xml.dist
+++ b/src/Symfony/Component/EventDispatcher/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/ExpressionLanguage/phpunit.xml.dist
+++ b/src/Symfony/Component/ExpressionLanguage/phpunit.xml.dist
@@ -10,6 +10,8 @@
          stopOnFailure="false"
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Filesystem/phpunit.xml.dist
+++ b/src/Symfony/Component/Filesystem/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Finder/phpunit.xml.dist
+++ b/src/Symfony/Component/Finder/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Form/phpunit.xml.dist
+++ b/src/Symfony/Component/Form/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/HttpKernel/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpKernel/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
@@ -153,6 +153,8 @@ class LocaleTest extends AbstractLocaleTest
     public function testSetDefaultAcceptsEn()
     {
         $this->call('setDefault', 'en');
+
+        $this->assertSame('en', $this->call('getDefault'));
     }
 
     protected function call($methodName)

--- a/src/Symfony/Component/Intl/phpunit.xml.dist
+++ b/src/Symfony/Component/Intl/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Locale/phpunit.xml.dist
+++ b/src/Symfony/Component/Locale/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/OptionsResolver/phpunit.xml.dist
+++ b/src/Symfony/Component/OptionsResolver/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Process/phpunit.xml.dist
+++ b/src/Symfony/Component/Process/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/PropertyAccess/phpunit.xml.dist
+++ b/src/Symfony/Component/PropertyAccess/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Routing/phpunit.xml.dist
+++ b/src/Symfony/Component/Routing/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Security/Acl/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Acl/phpunit.xml.dist
@@ -10,6 +10,8 @@
          stopOnFailure="false"
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Security/Core/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Core/phpunit.xml.dist
@@ -10,6 +10,8 @@
          stopOnFailure="false"
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Security/Csrf/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Csrf/phpunit.xml.dist
@@ -10,6 +10,8 @@
          stopOnFailure="false"
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Security/Http/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Http/phpunit.xml.dist
@@ -10,6 +10,8 @@
          stopOnFailure="false"
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Security/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Serializer/phpunit.xml.dist
+++ b/src/Symfony/Component/Serializer/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Stopwatch/phpunit.xml.dist
+++ b/src/Symfony/Component/Stopwatch/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Templating/phpunit.xml.dist
+++ b/src/Symfony/Component/Templating/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Translation/phpunit.xml.dist
+++ b/src/Symfony/Component/Translation/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Validator/phpunit.xml.dist
+++ b/src/Symfony/Component/Validator/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/VarDumper/phpunit.xml.dist
+++ b/src/Symfony/Component/VarDumper/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/src/Symfony/Component/Yaml/phpunit.xml.dist
+++ b/src/Symfony/Component/Yaml/phpunit.xml.dist
@@ -5,6 +5,8 @@
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The `--fail-on-risky` option is available since sebastianbergmann/phpunit@7e06a82806be004cbfd30a02d92162e9ed4abc7c which was first released with PHPUnit 5.2.