### PR TITLE
Skip tags on abstract definitions when relevant

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheClearerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheClearerPass.php
@@ -33,6 +33,9 @@ class AddCacheClearerPass implements CompilerPassInterface
 
         $clearers = array();
         foreach ($container->findTaggedServiceIds('kernel.cache_clearer') as $id => $attributes) {
+            if ($container->getDefinition($id)->isAbstract()) {
+                continue;
+            }
             $clearers[] = new Reference($id);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
@@ -31,6 +31,9 @@ class AddExpressionLanguageProvidersPass implements CompilerPassInterface
         if ($container->has('router')) {
             $definition = $container->findDefinition('router');
             foreach ($container->findTaggedServiceIds('routing.expression_language_provider') as $id => $attributes) {
+                if ($container->getDefinition($id)->isAbstract()) {
+                    continue;
+                }
                 $definition->addMethodCall('addExpressionLanguageProvider', array(new Reference($id)));
             }
         }
@@ -39,6 +42,9 @@ class AddExpressionLanguageProvidersPass implements CompilerPassInterface
         if ($container->has('security.access.expression_voter')) {
             $definition = $container->findDefinition('security.access.expression_voter');
             foreach ($container->findTaggedServiceIds('security.expression_language_provider') as $id => $attributes) {
+                if ($container->getDefinition($id)->isAbstract()) {
+                    continue;
+                }
                 $definition->addMethodCall('addExpressionLanguageProvider', array(new Reference($id)));
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolClearerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolClearerPass.php
@@ -31,6 +31,9 @@ final class CachePoolClearerPass implements CompilerPassInterface
         $pools = array();
 
         foreach ($container->findTaggedServiceIds('cache.pool') as $id => $attributes) {
+            if ($container->getDefinition($id)->isAbstract()) {
+                continue;
+            }
             $pools[$id] = new Reference($id);
             foreach (array_reverse($attributes) as $attr) {
                 if (isset($attr['clearer'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ProfilerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ProfilerPass.php
@@ -34,6 +34,9 @@ class ProfilerPass implements CompilerPassInterface
         $collectors = new \SplPriorityQueue();
         $order = PHP_INT_MAX;
         foreach ($container->findTaggedServiceIds('data_collector') as $id => $attributes) {
+            if ($container->getDefinition($id)->isAbstract()) {
+                continue;
+            }
             $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
             $template = null;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TemplatingPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TemplatingPass.php
@@ -33,6 +33,9 @@ class TemplatingPass implements CompilerPassInterface
         if ($container->hasDefinition('templating.engine.php')) {
             $helpers = array();
             foreach ($container->findTaggedServiceIds('templating.helper') as $id => $attributes) {
+                if ($container->getDefinition($id)->isAbstract()) {
+                    continue;
+                }
                 if (isset($attributes[0]['alias'])) {
                     $helpers[$attributes[0]['alias']] = $id;
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslationDumperPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslationDumperPass.php
@@ -29,6 +29,9 @@ class TranslationDumperPass implements CompilerPassInterface
         $definition = $container->getDefinition('translation.writer');
 
         foreach ($container->findTaggedServiceIds('translation.dumper') as $id => $attributes) {
+            if ($container->getDefinition($id)->isAbstract()) {
+                continue;
+            }
             $definition->addMethodCall('addDumper', array($attributes[0]['alias'], new Reference($id)));
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslationExtractorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslationExtractorPass.php
@@ -30,6 +30,9 @@ class TranslationExtractorPass implements CompilerPassInterface
         $definition = $container->getDefinition('translation.extractor');
 
         foreach ($container->findTaggedServiceIds('translation.extractor') as $id => $attributes) {
+            if ($container->getDefinition($id)->isAbstract()) {
+                continue;
+            }
             if (!isset($attributes[0]['alias'])) {
                 throw new RuntimeException(sprintf('The alias for the tag "translation.extractor" of service "%s" must be set.', $id));
             }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslatorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TranslatorPass.php
@@ -27,6 +27,9 @@ class TranslatorPass implements CompilerPassInterface
         $loaders = array();
         $loaderRefs = array();
         foreach ($container->findTaggedServiceIds('translation.loader') as $id => $attributes) {
+            if ($container->getDefinition($id)->isAbstract()) {
+                continue;
+            }
             $loaderRefs[$id] = new Reference($id);
             $loaders[$id][] = $attributes[0]['alias'];
             if (isset($attributes[0]['legacy-alias'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
@@ -33,7 +33,6 @@ class AddCacheWarmerPassTest extends TestCase
             ->will($this->returnValue($services));
         $container->expects($this->atLeastOnce())
             ->method('getDefinition')
-            ->with('cache_warmer')
             ->will($this->returnValue($definition));
         $container->expects($this->atLeastOnce())
             ->method('hasDefinition')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ConfigCachePassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ConfigCachePassTest.php
@@ -37,7 +37,6 @@ class ConfigCachePassTest extends TestCase
             ->will($this->returnValue($services));
         $container->expects($this->atLeastOnce())
             ->method('getDefinition')
-            ->with('config_cache_factory')
             ->will($this->returnValue($definition));
 
         $definition->expects($this->once())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PropertyInfoPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PropertyInfoPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\PropertyInfoPass;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -34,12 +35,16 @@ class PropertyInfoPassTest extends TestCase
             new Reference('n3'),
         );
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds'))->getMock();
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds', 'getDefinition'))->getMock();
 
         $container
             ->expects($this->any())
             ->method('findTaggedServiceIds')
             ->will($this->returnValue($services));
+        $container
+            ->expects($this->any())
+            ->method('getDefinition')
+            ->will($this->returnValue(new Definition()));
 
         $propertyInfoPass = new PropertyInfoPass();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\SerializerPass;
 
@@ -61,7 +62,7 @@ class SerializerPassTest extends TestCase
                     array()
               ));
 
-        $container->expects($this->once())
+        $container->expects($this->atLeastOnce())
             ->method('getDefinition')
             ->will($this->returnValue($definition));
 
@@ -85,11 +86,14 @@ class SerializerPassTest extends TestCase
            new Reference('n3'),
        );
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds'))->getMock();
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds', 'getDefinition'))->getMock();
 
         $container->expects($this->any())
             ->method('findTaggedServiceIds')
             ->will($this->returnValue($services));
+        $container->expects($this->any())
+            ->method('getDefinition')
+            ->will($this->returnValue(new Definition()));
 
         $serializerPass = new SerializerPass();
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
@@ -37,6 +37,9 @@ class TwigEnvironmentPass implements CompilerPassInterface
         $calls = $definition->getMethodCalls();
         $definition->setMethodCalls(array());
         foreach ($container->findTaggedServiceIds('twig.extension') as $id => $attributes) {
+            if ($container->getDefinition($id)->isAbstract()) {
+                continue;
+            }
             $definition->addMethodCall('addExtension', array(new Reference($id)));
         }
         $definition->setMethodCalls(array_merge($definition->getMethodCalls(), $calls));

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -54,6 +54,9 @@ class TwigLoaderPassTest extends TestCase
             ->with('twig.loader')
             ->will($this->returnValue($serviceIds));
         $this->builder->expects($this->once())
+            ->method('getDefinition')
+            ->will($this->returnValue(new Definition()));
+        $this->builder->expects($this->once())
             ->method('setAlias')
             ->with('twig.loader', 'test_loader_1');
 
@@ -79,10 +82,11 @@ class TwigLoaderPassTest extends TestCase
             ->method('findTaggedServiceIds')
             ->with('twig.loader')
             ->will($this->returnValue($serviceIds));
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(3))
             ->method('getDefinition')
-            ->with('twig.loader.chain')
-            ->will($this->returnValue($this->chainLoader));
+            ->withConsecutive(array('test_loader_1'), array('test_loader_2'), array('twig.loader.chain'))
+            ->willReturnOnConsecutiveCalls(new Definition(), new Definition(), $this->chainLoader);
+
         $this->builder->expects($this->once())
             ->method('setAlias')
             ->with('twig.loader', 'twig.loader.chain');
@@ -115,10 +119,10 @@ class TwigLoaderPassTest extends TestCase
             ->method('findTaggedServiceIds')
             ->with('twig.loader')
             ->will($this->returnValue($serviceIds));
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(3))
             ->method('getDefinition')
-            ->with('twig.loader.chain')
-            ->will($this->returnValue($this->chainLoader));
+            ->withConsecutive(array('test_loader_1'), array('test_loader_2'), array('twig.loader.chain'))
+            ->willReturnOnConsecutiveCalls(new Definition(), new Definition(), $this->chainLoader);
         $this->builder->expects($this->once())
             ->method('setAlias')
             ->with('twig.loader', 'twig.loader.chain');

--- a/src/Symfony/Component/Config/Tests/DependencyInjection/ConfigCachePassTest.php
+++ b/src/Symfony/Component/Config/Tests/DependencyInjection/ConfigCachePassTest.php
@@ -34,7 +34,6 @@ class ConfigCachePassTest extends TestCase
             ->will($this->returnValue($services));
         $container->expects($this->atLeastOnce())
             ->method('getDefinition')
-            ->with('config_cache_factory')
             ->will($this->returnValue($definition));
 
         $definition->expects($this->once())

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -41,6 +41,9 @@ trait PriorityTaggedServiceTrait
         $services = array();
 
         foreach ($container->findTaggedServiceIds($tagName) as $serviceId => $tags) {
+            if ($container->getDefinition($serviceId)->isAbstract()) {
+                continue;
+            }
             foreach ($tags as $attributes) {
                 $priority = isset($attributes['priority']) ? $attributes['priority'] : 0;
                 $services[$priority][] = new Reference($serviceId);

--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -63,6 +63,9 @@ class FormPass implements CompilerPassInterface
         // Builds an array with fully-qualified type class names as keys and service IDs as values
         foreach ($container->findTaggedServiceIds($this->formTypeTag) as $serviceId => $tag) {
             $serviceDefinition = $container->getDefinition($serviceId);
+            if ($serviceDefinition->isAbstract()) {
+                continue;
+            }
 
             // Add form type service to the service locator
             $servicesMap[$serviceDefinition->getClass()] = new Reference($serviceId);

--- a/src/Symfony/Component/PropertyInfo/Tests/DependencyInjection/PropertyInfoPassTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/DependencyInjection/PropertyInfoPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoPass;
 
@@ -31,12 +32,16 @@ class PropertyInfoPassTest extends TestCase
             new Reference('n3'),
         );
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds'))->getMock();
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds', 'getDefinition'))->getMock();
 
         $container
             ->expects($this->any())
             ->method('findTaggedServiceIds')
             ->will($this->returnValue($services));
+        $container
+            ->expects($this->any())
+            ->method('getDefinition')
+            ->will($this->returnValue(new Definition()));
 
         $propertyInfoPass = new PropertyInfoPass();
 

--- a/src/Symfony/Component/Routing/DependencyInjection/RoutingResolverPass.php
+++ b/src/Symfony/Component/Routing/DependencyInjection/RoutingResolverPass.php
@@ -40,6 +40,9 @@ class RoutingResolverPass implements CompilerPassInterface
         $definition = $container->getDefinition($this->resolverServiceId);
 
         foreach ($container->findTaggedServiceIds($this->loaderTag) as $id => $attributes) {
+            if ($container->getDefinition($id)->isAbstract()) {
+                continue;
+            }
             $definition->addMethodCall('addLoader', array(new Reference($id)));
         }
     }

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/SerializerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
 
@@ -59,7 +60,7 @@ class SerializerPassTest extends TestCase
                     array()
               ));
 
-        $container->expects($this->once())
+        $container->expects($this->atLeastOnce())
             ->method('getDefinition')
             ->will($this->returnValue($definition));
 
@@ -83,11 +84,14 @@ class SerializerPassTest extends TestCase
            new Reference('n3'),
        );
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds'))->getMock();
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds', 'getDefinition'))->getMock();
 
         $container->expects($this->any())
             ->method('findTaggedServiceIds')
             ->will($this->returnValue($services));
+        $container->expects($this->any())
+            ->method('getDefinition')
+            ->will($this->returnValue(new Definition()));
 
         $serializerPass = new SerializerPass();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Not a bug fix on a lower branch because this does not work right now: refs to abstract services are caught by CheckDefinitionValidityPass.
But with "instanceof" & other new 3.3 features, we're going to use abstract services more extensively, thus we need this now.