### PR TITLE
[Yaml] Failing test for not in-lined map-objects

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -205,6 +205,25 @@ EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 10), '->dump() takes an inline level argument');
     }
 
+    public function testArrayObjectAsMapNotInLined()
+    {
+        $deep = new \ArrayObject(array('deep1' => 'd', 'deep2' => 'e'));
+        $inner = new \ArrayObject(array('inner1' => 'b', 'inner2' => 'c', 'inner3' => $deep));
+        $outer = new \ArrayObject(array('outer1' => 'a', 'outer1' => $inner));
+
+        $yaml = $this->dumper->dump($outer, 2, 0, Yaml::DUMP_OBJECT_AS_MAP);
+
+        $expected = <<<YAML
+outer1: a
+outer2:
+    inner1: b
+    inner2: c
+    inner3: { deep1: d, deep2: e }
+
+YAML;
+        $this->assertEquals($expected, $yaml);
+    }
+
     public function testObjectSupportEnabled()
     {
         $dump = $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, Yaml::DUMP_OBJECT);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | no
| License       | MIT

This is a failing test case.

`ArrayObject` when dumped with `Yaml::DUMP_OBJECT_AS_MAP` is always inlined.
The `$indent` option looks to be ignored.


When using `array` instead of `ArrayObject` , the result is as expected.

