### PR TITLE
Relax some mocks

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheWarmerPass;
 
@@ -19,37 +20,22 @@ class AddCacheWarmerPassTest extends TestCase
 {
     public function testThatCacheWarmersAreProcessedInPriorityOrder()
     {
-        $services = array(
-            'my_cache_warmer_service1' => array(0 => array('priority' => 100)),
-            'my_cache_warmer_service2' => array(0 => array('priority' => 200)),
-            'my_cache_warmer_service3' => array(0 => array()),
-        );
+        $container = new ContainerBuilder();
 
-        $definition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock();
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds', 'getDefinition', 'hasDefinition'))->getMock();
-
-        $container->expects($this->atLeastOnce())
-            ->method('findTaggedServiceIds')
-            ->will($this->returnValue($services));
-        $container->expects($this->atLeastOnce())
-            ->method('getDefinition')
-            ->with('cache_warmer')
-            ->will($this->returnValue($definition));
-        $container->expects($this->atLeastOnce())
-            ->method('hasDefinition')
-            ->with('cache_warmer')
-            ->will($this->returnValue(true));
-
-        $definition->expects($this->once())
-            ->method('replaceArgument')
-            ->with(0, array(
-                new Reference('my_cache_warmer_service2'),
-                new Reference('my_cache_warmer_service1'),
-                new Reference('my_cache_warmer_service3'),
-            ));
+        $definition = $container->register('cache_warmer')->addArgument(null);
+        $container->register('my_cache_warmer_service1')->addTag('kernel.cache_warmer', array('priority' => 100));
+        $container->register('my_cache_warmer_service2')->addTag('kernel.cache_warmer', array('priority' => 200));
+        $container->register('my_cache_warmer_service3')->addTag('kernel.cache_warmer');
 
         $addCacheWarmerPass = new AddCacheWarmerPass();
         $addCacheWarmerPass->process($container);
+
+        $expected = array(
+            new Reference('my_cache_warmer_service2'),
+            new Reference('my_cache_warmer_service1'),
+            new Reference('my_cache_warmer_service3'),
+        );
+        $this->assertEquals($expected, $definition->getArgument(0));
     }
 
     public function testThatCompilerPassIsIgnoredIfThereIsNoCacheWarmerDefinition()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ConfigCachePassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ConfigCachePassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConfigCachePass;
 
@@ -19,33 +20,22 @@ class ConfigCachePassTest extends TestCase
 {
     public function testThatCheckersAreProcessedInPriorityOrder()
     {
-        $services = array(
-            'checker_2' => array(0 => array('priority' => 100)),
-            'checker_1' => array(0 => array('priority' => 200)),
-            'checker_3' => array(0 => array()),
-        );
+        $container = new ContainerBuilder();
 
-        $definition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')->getMock();
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds', 'getDefinition', 'hasDefinition'))->getMock();
-
-        $container->expects($this->atLeastOnce())
-            ->method('findTaggedServiceIds')
-            ->will($this->returnValue($services));
-        $container->expects($this->atLeastOnce())
-            ->method('getDefinition')
-            ->with('config_cache_factory')
-            ->will($this->returnValue($definition));
-
-        $definition->expects($this->once())
-            ->method('replaceArgument')
-            ->with(0, array(
-                    new Reference('checker_1'),
-                    new Reference('checker_2'),
-                    new Reference('checker_3'),
-                ));
+        $definition = $container->register('config_cache_factory')->addArgument(null);
+        $container->register('checker_2')->addTag('config_cache.resource_checker', array('priority' => 100));
+        $container->register('checker_1')->addTag('config_cache.resource_checker', array('priority' => 200));
+        $container->register('checker_3')->addTag('config_cache.resource_checker');
 
         $pass = new ConfigCachePass();
         $pass->process($container);
+
+        $expected = array(
+            new Reference('checker_1'),
+            new Reference('checker_2'),
+            new Reference('checker_3'),
+        );
+        $this->assertEquals($expected, $definition->getArgument(0));
     }
 
     public function testThatCheckersCanBeMissing()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PropertyInfoPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PropertyInfoPassTest.php
@@ -13,42 +13,42 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\PropertyInfoPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 class PropertyInfoPassTest extends TestCase
 {
-    public function testServicesAreOrderedAccordingToPriority()
+    /**
+     * @dataProvider provideTags
+     */
+    public function testServicesAreOrderedAccordingToPriority($index, $tag)
     {
-        $services = array(
-            'n3' => array(array()),
-            'n1' => array(array('priority' => 200)),
-            'n2' => array(array('priority' => 100)),
-        );
+        $container = new ContainerBuilder();
+
+        $definition = $container->register('property_info')->setArguments(array(null, null, null, null));
+        $container->register('n2')->addTag($tag, array('priority' => 100));
+        $container->register('n1')->addTag($tag, array('priority' => 200));
+        $container->register('n3')->addTag($tag);
+
+        $propertyInfoPass = new PropertyInfoPass();
+        $propertyInfoPass->process($container);
 
         $expected = array(
             new Reference('n1'),
             new Reference('n2'),
             new Reference('n3'),
         );
+        $this->assertEquals($expected, $definition->getArgument($index));
+    }
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds'))->getMock();
-
-        $container
-            ->expects($this->any())
-            ->method('findTaggedServiceIds')
-            ->will($this->returnValue($services));
-
-        $propertyInfoPass = new PropertyInfoPass();
-
-        $method = new \ReflectionMethod(
-            'Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\PropertyInfoPass',
-            'findAndSortTaggedServices'
+    public function provideTags()
+    {
+        return array(
+            array(0, 'property_info.list_extractor'),
+            array(1, 'property_info.type_extractor'),
+            array(2, 'property_info.description_extractor'),
+            array(3, 'property_info.access_extractor'),
         );
-        $method->setAccessible(true);
-
-        $actual = $method->invoke($propertyInfoPass, 'tag', $container);
-
-        $this->assertEquals($expected, $actual);
     }
 
     public function testReturningEmptyArrayWhenNoService()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\SerializerPass;
 
@@ -59,7 +60,7 @@ class SerializerPassTest extends TestCase
                     array()
               ));
 
-        $container->expects($this->once())
+        $container->expects($this->any())
             ->method('getDefinition')
             ->will($this->returnValue($definition));
 
@@ -71,34 +72,22 @@ class SerializerPassTest extends TestCase
 
     public function testServicesAreOrderedAccordingToPriority()
     {
-        $services = array(
-            'n3' => array(array()),
-            'n1' => array(array('priority' => 200)),
-            'n2' => array(array('priority' => 100)),
-        );
+        $container = new ContainerBuilder();
 
-        $expected = array(
-           new Reference('n1'),
-           new Reference('n2'),
-           new Reference('n3'),
-       );
-
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('findTaggedServiceIds'))->getMock();
-
-        $container->expects($this->any())
-            ->method('findTaggedServiceIds')
-            ->will($this->returnValue($services));
+        $definition = $container->register('serializer')->setArguments(array(null, null));
+        $container->register('n2')->addTag('serializer.normalizer', array('priority' => 100))->addTag('serializer.encoder', array('priority' => 100));
+        $container->register('n1')->addTag('serializer.normalizer', array('priority' => 200))->addTag('serializer.encoder', array('priority' => 200));
+        $container->register('n3')->addTag('serializer.normalizer')->addTag('serializer.encoder');
 
         $serializerPass = new SerializerPass();
+        $serializerPass->process($container);
 
-        $method = new \ReflectionMethod(
-          'Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\SerializerPass',
-          'findAndSortTaggedServices'
+        $expected = array(
+            new Reference('n1'),
+            new Reference('n2'),
+            new Reference('n3'),
         );
-        $method->setAccessible(true);
-
-        $actual = $method->invoke($serializerPass, 'tag', $container);
-
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals($expected, $definition->getArgument(0));
+        $this->assertEquals($expected, $definition->getArgument(1));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

We should not use mocks when it's not required - they too often run assertions on internal behavior.
These changes will unlock #22388