### PR TITLE
Add getFlashBag method to Session interface.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -238,9 +238,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     }
 
     /**
-     * Gets the flashbag interface.
-     *
-     * @return FlashBagInterface
+     * {@inheritdoc}
      */
     public function getFlashBag()
     {

--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Session;
 
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
 
 /**
@@ -179,4 +180,11 @@ interface SessionInterface
      * @return MetadataBag
      */
     public function getMetadataBag();
+
+    /**
+     * Gets the flashbag interface.
+     *
+     * @return FlashBagInterface
+     */
+    public function getFlashBag();
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | probably yes
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | –
| License       | MIT
| Doc PR        | –

---

Now, the PHPDoc of [Request::getSession](https://github.com/Aliance/symfony/blob/c0ed0cbdff3db45297692713afdbbb97ac14ad1e/src/Symfony/Component/HttpFoundation/Request.php#L750) method said that it returns the SessionInterface. But the
Session, getting from the Request in [WebProfilerBundle](https://github.com/symfony/web-profiler-bundle/blob/2.8/EventListener/WebDebugToolbarListener.php#L85) uses `getFlashBag` method, which IDE marks as suspicious (because SessionInterface does knows nothing about it).
So I decided to add that method to symfony Session interface, but mb I should do it at WebProfilerBundle?

Is this change BC or not? I do not sure, someone could implement the session interface, so this will be a BC for them.

<img width="802" alt="2017-04-12 15 40 02" src="https://cloud.githubusercontent.com/assets/7838144/24957961/5791e0c4-1f96-11e7-9903-47672549bb85.png">
