### PR TITLE
Prevent double registrations related to tag priorities

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SerializerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SerializerPass.php
@@ -47,11 +47,9 @@ class SerializerPass implements CompilerPassInterface
         }
 
         $sortedServices = array();
-        foreach ($services as $serviceId => $tags) {
-            foreach ($tags as $tag) {
-                $priority = isset($tag['priority']) ? $tag['priority'] : 0;
-                $sortedServices[$priority][] = new Reference($serviceId);
-            }
+        foreach ($services as $serviceId => $attributes) {
+            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
+            $sortedServices[$priority][] = new Reference($serviceId);
         }
 
         krsort($sortedServices);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SerializerPassTest.php
@@ -72,9 +72,9 @@ class SerializerPassTest extends TestCase
     public function testServicesAreOrderedAccordingToPriority()
     {
         $services = array(
-            'n3' => array('tag' => array()),
-            'n1' => array('tag' => array('priority' => 200)),
-            'n2' => array('tag' => array('priority' => 100)),
+            'n3' => array(array()),
+            'n1' => array(array('priority' => 200)),
+            'n2' => array(array('priority' => 100)),
         );
 
         $expected = array(

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -29,27 +29,23 @@ class TwigLoaderPass implements CompilerPassInterface
             return;
         }
 
-        // register additional template loaders
-        $loaderIds = $container->findTaggedServiceIds('twig.loader');
+        $prioritizedLoaders = array();
+        $found = 0;
 
-        if (count($loaderIds) === 0) {
+        foreach ($container->findTaggedServiceIds('twig.loader') as $id => $attributes) {
+            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
+            $prioritizedLoaders[$priority][] = $id;
+            ++$found;
+        }
+
+        if (!$found) {
             throw new LogicException('No twig loaders found. You need to tag at least one loader with "twig.loader"');
         }
 
-        if (count($loaderIds) === 1) {
-            $container->setAlias('twig.loader', key($loaderIds));
+        if (1 === $found) {
+            $container->setAlias('twig.loader', $id);
         } else {
             $chainLoader = $container->getDefinition('twig.loader.chain');
-
-            $prioritizedLoaders = array();
-
-            foreach ($loaderIds as $id => $tags) {
-                foreach ($tags as $tag) {
-                    $priority = isset($tag['priority']) ? $tag['priority'] : 0;
-                    $prioritizedLoaders[$priority][] = $id;
-                }
-            }
-
             krsort($prioritizedLoaders);
 
             foreach ($prioritizedLoaders as $loaders) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The current logic is inconsistent, and allows the same id to be used several times. This makes the first explicit priority to always win.