### PR TITLE
Enhancing integration test to show that "override" tags show up first

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -135,7 +135,7 @@ class IntegrationTest extends TestCase
         // all tags are kept
         $this->assertEquals(
             array(
-                'foo_tag' => array(array('priority' => 100), array()),
+                'foo_tag' => array(array('tag_option' => 'from_service'), array('tag_option' => 'from_instanceof')),
                 'bar_tag' => array(array()),
             ),
             $simpleService->getTags()
@@ -169,10 +169,10 @@ class IntegrationTest extends TestCase
         // tags inherit like normal
         $this->assertEquals(
             array(
-                'foo_tag' => array(array('priority' => 100), array()),
+                'foo_tag' => array(array('tag_option' => 'from_child_def'), array('tag_option' => 'from_parent_def'), array('tag_option' => 'from_instanceof')),
                 'bar_tag' => array(array()),
             ),
-            $simpleService->getTags()
+            $childDef2->getTags()
         );
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_defaults_instanceof_parent.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_defaults_instanceof_parent.yml
@@ -8,7 +8,7 @@ services:
             autowire: false
             shared: false
             tags:
-                - { name: foo_tag }
+                - { name: foo_tag, tag_option: from_instanceof }
             calls:
                 - [setSunshine, [bright]]
 
@@ -20,8 +20,8 @@ services:
     service_simple:
         class: Symfony\Component\DependencyInjection\Tests\Compiler\IntegrationTestStub
         tags:
-            - { name: foo_tag, priority: 100 }
-            # calls from instanceof are kept, but this comes later
+            - { name: foo_tag, tag_option: from_service }
+        # calls from instanceof are kept, but this comes later
         calls:
             - [enableSummer, [true]]
             - [setSunshine, [warm]]
@@ -43,7 +43,12 @@ services:
     parent_service_with_class:
         abstract: true
         class: Symfony\Component\DependencyInjection\Tests\Compiler\IntegrationTestStub
+        tags:
+            - { name: foo_tag, tag_option: from_parent_def }
 
     child_service_with_parent_instanceof:
         parent: parent_service_with_class
         shared: true
+        inherit_tags: true
+        tags:
+            - { name: foo_tag, tag_option: from_child_def }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | not needed

Relates a bit to #22396, in that I'm clarifying and emphasizing the following types of situations:

```yml
services:
    _instanceof:
        Symfony\Component\Security\Core\Authorization\Voter\VoterInterface:
            tags:
                # you probably shouldn't set priority here, but let's pretend we did
                - { name: security.voter, priority: 100 }

    AppBundle\Security\CoolPersonVoter:
        tags:
            - { name: security.voter, priority: 50 }
```

In the final `Definition`, the tags will appear in this order:
* security.voter, priority 50
* security.voter, priority 100

It works the same for parent-child definitions.

tl;dr; If a service has the same tag multiple times, the one that should be used should appear *earlier* in the Definition. The code already works that way - this test emphasizes it.