### PR TITLE
[2.8] Prevent double registrations related to tag priorities

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PropertyInfoPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PropertyInfoPass.php
@@ -57,11 +57,9 @@ class PropertyInfoPass implements CompilerPassInterface
         $services = $container->findTaggedServiceIds($tagName);
 
         $sortedServices = array();
-        foreach ($services as $serviceId => $tags) {
-            foreach ($tags as $attributes) {
-                $priority = isset($attributes['priority']) ? $attributes['priority'] : 0;
-                $sortedServices[$priority][] = new Reference($serviceId);
-            }
+        foreach ($services as $serviceId => $attributes) {
+            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
+            $sortedServices[$priority][] = new Reference($serviceId);
         }
 
         if (empty($sortedServices)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PropertyInfoPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PropertyInfoPassTest.php
@@ -20,9 +20,9 @@ class PropertyInfoPassTest extends TestCase
     public function testServicesAreOrderedAccordingToPriority()
     {
         $services = array(
-            'n3' => array('tag' => array()),
-            'n1' => array('tag' => array('priority' => 200)),
-            'n2' => array('tag' => array('priority' => 100)),
+            'n3' => array(array()),
+            'n1' => array(array('priority' => 200)),
+            'n2' => array(array('priority' => 100)),
         );
 
         $expected = array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

#22396 on 2.8