### PR TITLE
[Yaml] add changelog for the DUMP_OBJECT_AS_MAP flag

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -20,6 +20,9 @@ CHANGELOG
 3.1.0
 -----
 
+ * Added support to dump `stdClass` and `ArrayAccess` objects as YAML mappings
+   through the `Yaml::DUMP_OBJECT_AS_MAP` flag.
+
  * Strings that are not UTF-8 encoded will be dumped as base64 encoded binary
    data.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17728
| License       | MIT
| Doc PR        | 

Adds missing changelog entry for the `DUMP_OBJECT_AS_MAP` flag introduced in #17728.