### PR TITLE
[WebProfilerBundle] Display environment variables

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -254,6 +254,25 @@
         <a href="{{ path('_profiler_phpinfo') }}">View full PHP configuration</a>
     </p>
 
+    <h2>Environment Configuration <small>({{ collector.environment|length }})</small></h2>
+
+    <table>
+        <thead>
+            <tr>
+                <th class="key">Name</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for name in collector.environment|keys|sort %}
+            <tr>
+                <th scope="row" class="font-normal">{{ name }}</th>
+                <td class="font-normal">{{ collector.environment[name] }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
     {% if collector.bundles %}
         <h2>Enabled Bundles <small>({{ collector.bundles|length }})</small></h2>
         <table>

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -78,6 +78,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
             'zend_opcache_enabled' => extension_loaded('Zend OPcache') && ini_get('opcache.enable'),
             'bundles' => array(),
             'sapi_name' => PHP_SAPI,
+            'environment' => $_ENV,
         );
 
         if (isset($this->kernel)) {
@@ -302,6 +303,16 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
     public function getName()
     {
         return 'config';
+    }
+
+    /**
+     * Gets the environment variables.
+     *
+     * @return string The environment variables
+     */
+    public function getEnvironment()
+    {
+        return $this->data['environment'];
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -41,6 +41,7 @@ class ConfigDataCollectorTest extends TestCase
         $this->assertSame(extension_loaded('xdebug'), $c->hasXDebug());
         $this->assertSame(extension_loaded('Zend OPcache') && ini_get('opcache.enable'), $c->hasZendOpcache());
         $this->assertSame(extension_loaded('apcu') && ini_get('apc.enabled'), $c->hasApcu());
+        $this->assertSame($_ENV, $c->getEnvironment());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

With the new dotenv component it’s usefull to have environment variables in the profiler page.

![screen shot 2017-04-12 at 21 02 37-fullpage](https://cloud.githubusercontent.com/assets/113045/24974898/135f5c3c-1fc4-11e7-80b5-f404ae65cd54.png)
