### PR TITLE
[FrameworkBundle] Don't create unused alias if the command is public

### DIFF
--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -39,12 +39,16 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 throw new InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must be a subclass of "%s".', $id, Command::class));
             }
 
-            $serviceId = 'console.command.'.strtolower(str_replace('\\', '_', $class));
-            if ($container->hasAlias($serviceId)) {
-                $serviceId = $serviceId.'_'.$id;
+            if (!$definition->isPublic()) {
+                $serviceId = 'console.command.'.strtolower(str_replace('\\', '_', $class));
+                if ($container->hasAlias($serviceId)) {
+                    $serviceId = $serviceId.'_'.$id;
+                }
+                $container->setAlias($serviceId, $id);
+                $id = $serviceId;
             }
-            $container->setAlias($serviceId, $id);
-            $serviceIds[] = $definition->isPublic() ? $id : $serviceId;
+
+            $serviceIds[] = $id;
         }
 
         $container->setParameter('console.command.ids', $serviceIds);

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -26,7 +26,6 @@ class AddConsoleCommandPassTest extends TestCase
     public function testProcess($public)
     {
         $container = new ContainerBuilder();
-        $container->setResourceTracking(false);
         $container->addCompilerPass(new AddConsoleCommandPass());
         $container->setParameter('my-command.class', 'Symfony\Component\Console\Tests\DependencyInjection\MyCommand');
 
@@ -37,7 +36,19 @@ class AddConsoleCommandPassTest extends TestCase
 
         $container->compile();
 
-        $id = $public ? 'my-command' : 'console.command.symfony_component_console_tests_dependencyinjection_mycommand';
+        $alias = 'console.command.symfony_component_console_tests_dependencyinjection_mycommand';
+
+        if ($public) {
+            $this->assertFalse($container->hasAlias($alias));
+            $id = 'my-command';
+        } else {
+            $id = $alias;
+            // The alias is replaced by a Definition by the ReplaceAliasByActualDefinitionPass
+            // in case the original service is private
+            $this->assertFalse($container->hasDefinition('my-command'));
+            $this->assertTrue($container->hasDefinition($alias));
+        }
+
         $this->assertTrue($container->hasParameter('console.command.ids'));
         $this->assertSame(array($id), $container->getParameter('console.command.ids'));
     }
@@ -83,6 +94,28 @@ class AddConsoleCommandPassTest extends TestCase
         $container->setDefinition('my-command', $definition);
 
         $container->compile();
+    }
+
+    public function testProcessPrivateServicesWithSameCommand()
+    {
+        $container = new ContainerBuilder();
+        $className = 'Symfony\Component\Console\Tests\DependencyInjection\MyCommand';
+
+        $definition1 = new Definition($className);
+        $definition1->addTag('console.command')->setPublic(false);
+
+        $definition2 = new Definition($className);
+        $definition2->addTag('console.command')->setPublic(false);
+
+        $container->setDefinition('my-command1', $definition1);
+        $container->setDefinition('my-command2', $definition2);
+
+        (new AddConsoleCommandPass())->process($container);
+
+        $alias1 = 'console.command.symfony_component_console_tests_dependencyinjection_mycommand';
+        $alias2 = $alias1.'_my-command2';
+        $this->assertTrue($container->hasAlias($alias1));
+        $this->assertTrue($container->hasAlias($alias2));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | maste
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Currently, a public alias is created for any `console.command` tagged service, but this alias is unused if the service is public (as it would be useless).