### PR TITLE
[FrameworkBundle][Workflow] Deprecate the default type of a workflow

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -138,14 +138,14 @@ Form
  * Using the "choices" option in ``CountryType``, ``CurrencyType``, ``LanguageType``,
    ``LocaleType``, and ``TimezoneType`` without overriding the ``choice_loader``
    option has been deprecated and will be ignored in 4.0.
-   
+
    Before:
    ```php
    $builder->add('custom_locales', LocaleType::class, array(
        'choices' => $availableLocales,
    ));
    ```
-   
+
    After:
    ```php
    $builder->add('custom_locales', LocaleType::class, array(
@@ -167,6 +167,9 @@ FrameworkBundle
    Warmup should be done via the `cache:warmup` command.
 
  * The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies" parameter have been deprecated and will be removed in 4.0. Use the Request::setTrustedProxies() method in your front controller instead.
+
+ * Not defining the `type` option of the `framework.workflows.*` configuration entries is deprecated.
+   The default value will be `state_machine` in Symfony 4.0.
 
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CompilerDebugDumpPass` has been deprecated.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -198,14 +198,14 @@ Form
  * Using the "choices" option in ``CountryType``, ``CurrencyType``, ``LanguageType``,
    ``LocaleType``, and ``TimezoneType`` without overriding the ``choice_loader``
    option is now ignored.
-   
+
    Before:
    ```php
    $builder->add('custom_locales', LocaleType::class, array(
        'choices' => $availableLocales,
    ));
    ```
-   
+
    After:
    ```php
    $builder->add('custom_locales', LocaleType::class, array(
@@ -227,6 +227,8 @@ FrameworkBundle
    be done via the `cache:warmup` command.
 
  * The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies" parameter have been removed. Use the `Request::setTrustedProxies()` method in your front controller instead.
+
+ * The default value of the `framework.workflows.[name].type` configuration options is now `state_machine`.
 
  * Support for absolute template paths has been removed.
 
@@ -411,7 +413,7 @@ Security
 
  * The `RoleInterface` has been removed. Extend the `Symfony\Component\Security\Core\Role\Role`
    class instead.
-   
+
  * The `LogoutUrlGenerator::registerListener()` method expects a 6th `$context = null` argument.
 
  * The `AccessDecisionManager::setVoters()` method has been removed. Pass the

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.3.0
 -----
 
+ * Not defining the `type` option of the `framework.workflows.*` configuration entries is deprecated.
+   The default value will be `state_machine` in Symfony 4.0.
  * Deprecated the `CompilerDebugDumpPass` class
  * [BC BREAK] Removed the "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies" parameter
  * Added a new new version strategy option called json_manifest_path
@@ -33,13 +35,13 @@ CHANGELOG
  * Deprecated `ControllerArgumentValueResolverPass`. Use
    `Symfony\Component\HttpKernel\DependencyInjection\ControllerArgumentValueResolverPass` instead
  * Deprecated `RoutingResolverPass`, use `Symfony\Component\Routing\DependencyInjection\RoutingResolverPass` instead
- * [BC BREAK] The `server:run`, `server:start`, `server:stop` and 
-   `server:status` console commands have been moved to a dedicated bundle. 
-   Require `symfony/web-server-bundle` in your composer.json and register 
+ * [BC BREAK] The `server:run`, `server:start`, `server:stop` and
+   `server:status` console commands have been moved to a dedicated bundle.
+   Require `symfony/web-server-bundle` in your composer.json and register
    `Symfony\Bundle\WebServerBundle\WebServerBundle` in your AppKernel to use them.
  * Added `$defaultLocale` as 3rd argument of `Translator::__construct()`
    making `Translator` works with any PSR-11 container
- * Added `framework.serializer.mapping` config option allowing to define custom 
+ * Added `framework.serializer.mapping` config option allowing to define custom
    serialization mapping files and directories
  * Deprecated `AddValidatorInitializersPass`, use
    `Symfony\Component\Validator\DependencyInjection\AddValidatorInitializersPass` instead

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -230,7 +230,6 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->enumNode('type')
                                 ->values(array('workflow', 'state_machine'))
-                                ->defaultValue('workflow')
                             ->end()
                             ->arrayNode('marking_store')
                                 ->fixXmlConfig('argument')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -440,6 +440,10 @@ class FrameworkExtension extends Extension
         $registryDefinition = $container->getDefinition('workflow.registry');
 
         foreach ($workflows as $name => $workflow) {
+            if (!array_key_exists('type', $workflow)) {
+                $workflow['type'] = 'workflow';
+                @trigger_error(sprintf('The "type" option of the "framework.workflows.%s" configuration entry must be defined since Symfony 3.3. The default value will be "state_machine" in Symfony 4.0.', $name), E_USER_DEPRECATED);
+            }
             $type = $workflow['type'];
 
             $transitions = array();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
@@ -89,6 +89,7 @@ $container->loadFromExtension('framework', array(
             ),
         ),
         'service_marking_store_workflow' => array(
+            'type' => 'workflow',
             'marking_store' => array(
                 'service' => 'workflow_service',
             ),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_without_type.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows_without_type.php
@@ -1,0 +1,26 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+
+$container->loadFromExtension('framework', array(
+    'workflows' => array(
+        'missing_type' => array(
+            'marking_store' => array(
+                'service' => 'workflow_service',
+            ),
+            'supports' => array(
+                \stdClass::class,
+            ),
+            'places' => array(
+                'first',
+                'last',
+            ),
+            'transitions' => array(
+                'go' => array(
+                    'from' => 'first',
+                    'to' => 'last',
+                ),
+            ),
+        ),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
@@ -80,7 +80,7 @@
             </framework:transition>
         </framework:workflow>
 
-        <framework:workflow name="service_marking_store_workflow">
+        <framework:workflow name="service_marking_store_workflow" type="workflow">
             <framework:marking-store service="workflow_service"/>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
             <framework:place>first</framework:place>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_without_type.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows_without_type.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+            <framework:workflow name="missing_type">
+            <framework:marking-store service="workflow_service"/>
+            <framework:support>stdClass</framework:support>
+            <framework:place>first</framework:place>
+            <framework:place>last</framework:place>
+            <framework:transition name="go">
+                <framework:from>first</framework:from>
+                <framework:to>last</framework:to>
+            </framework:transition>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
@@ -64,6 +64,7 @@ framework:
                     from: closed
                     to: review
         service_marking_store_workflow:
+            type: workflow
             marking_store:
                 service: workflow_service
             supports:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_without_type.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows_without_type.yml
@@ -1,0 +1,7 @@
+framework:
+    workflows:
+        missing_type:
+            supports: stdClass
+            places: [ first, second ]
+            transitions:
+                go: {from: first, to: last }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -208,6 +208,15 @@ abstract class FrameworkExtensionTest extends TestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation The "type" option of the "framework.workflows.missing_type" configuration entry must be defined since Symfony 3.3. The default value will be "state_machine" in Symfony 4.0.
+     */
+    public function testDeprecatedWorkflowMissingType()
+    {
+        $container = $this->createContainerFromFile('workflows_without_type');
+    }
+
+    /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage "type" and "service" cannot be used together.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

---

Before this patch, the default type is "workflow". Most of the time a
"state_machine" is better because it's simpler and it involves less
knowledge to be able to use it.

So this patch deprecate a missing type in Symfony 3.3. And In Symfony
4.0 the default value will become "state_machine".
