### PR TITLE
[Yaml] respect inline level when dumping objects as maps

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -82,14 +82,16 @@ class Dumper
         $output = '';
         $prefix = $indent ? str_repeat(' ', $indent) : '';
 
-        if (Yaml::DUMP_OBJECT_AS_MAP & $flags && ($input instanceof \ArrayObject || $input instanceof \stdClass)) {
-            $input = $this->castObjectToArray($input);
-        }
+        $isObjectMap = self::isNotEmptyMap($input, $flags);
 
-        if ($inline <= 0 || !is_array($input) || empty($input)) {
+        if ($inline <= 0 || (!is_array($input) && !$isObjectMap) || empty($input)) {
             $output .= $prefix.Inline::dump($input, $flags);
         } else {
-            $isAHash = Inline::isHash($input);
+            $isAHash = $isObjectMap || Inline::isHash($input, $flags);
+
+            if ($isObjectMap) {
+                $input = (array) $input;
+            }
 
             foreach ($input as $key => $value) {
                 if ($inline >= 1 && Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK & $flags && is_string($value) && false !== strpos($value, "\n")) {
@@ -102,7 +104,7 @@ class Dumper
                     continue;
                 }
 
-                $willBeInlined = $inline - 1 <= 0 || !is_array($value) || empty($value);
+                $willBeInlined = $inline - 1 <= 0 || (!is_array($value) && !self::isNotEmptyMap($value, $flags)) || empty($value);
 
                 $output .= sprintf('%s%s%s%s',
                     $prefix,
@@ -116,16 +118,20 @@ class Dumper
         return $output;
     }
 
-    private function castObjectToArray($object)
+    private static function isNotEmptyMap($input, $flags)
     {
-        $array = (array) $object;
-
-        foreach ($array as $key => $value) {
-            if ($value instanceof \ArrayObject || $value instanceof \stdClass) {
-                $array[$key] = $this->castObjectToArray($value);
-            }
+        if ($flags & ~Yaml::DUMP_OBJECT_AS_MAP) {
+            return false;
         }
 
-        return $array;
+        if ($input instanceof \ArrayObject && 0 < count($input)) {
+            return true;
+        }
+
+        if ($input instanceof \stdClass && 0 < count((array) $input)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -82,6 +82,10 @@ class Dumper
         $output = '';
         $prefix = $indent ? str_repeat(' ', $indent) : '';
 
+        if (Yaml::DUMP_OBJECT_AS_MAP & $flags && ($input instanceof \ArrayObject || $input instanceof \stdClass)) {
+            $input = $this->castObjectToArray($input);
+        }
+
         if ($inline <= 0 || !is_array($input) || empty($input)) {
             $output .= $prefix.Inline::dump($input, $flags);
         } else {
@@ -110,5 +114,18 @@ class Dumper
         }
 
         return $output;
+    }
+
+    private function castObjectToArray($object)
+    {
+        $array = (array) $object;
+
+        foreach ($array as $key => $value) {
+            if ($value instanceof \ArrayObject || $value instanceof \stdClass) {
+                $array[$key] = $this->castObjectToArray($value);
+            }
+        }
+
+        return $array;
     }
 }

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -163,10 +163,6 @@ class Inline
                     return '!php/object:'.serialize($value);
                 }
 
-                if (Yaml::DUMP_OBJECT_AS_MAP & $flags && ($value instanceof \stdClass || $value instanceof \ArrayObject)) {
-                    return self::dumpArray((array) $value, $flags);
-                }
-
                 if (Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE & $flags) {
                     throw new DumpException('Object support when dumping a YAML file has been disabled.');
                 }

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -163,6 +163,10 @@ class Inline
                     return '!php/object:'.serialize($value);
                 }
 
+                if (Yaml::DUMP_OBJECT_AS_MAP & $flags && ($value instanceof \stdClass || $value instanceof \ArrayObject)) {
+                    return self::dumpMap((array) $value, $flags);
+                }
+
                 if (Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE & $flags) {
                     throw new DumpException('Object support when dumping a YAML file has been disabled.');
                 }
@@ -257,6 +261,19 @@ class Inline
             return sprintf('[%s]', implode(', ', $output));
         }
 
+        return self::dumpMap($value, $flags);
+    }
+
+    /**
+     * Dumps a PHP array to a YAML string as map.
+     *
+     * @param array $value The PHP array to dump
+     * @param int   $flags A bit field of Yaml::DUMP_* constants to customize the dumped YAML string
+     *
+     * @return string The YAML string representing the PHP array  as map
+     */
+    private static function dumpMap($value, $flags)
+    {
         // hash
         $output = array();
         foreach ($value as $key => $val) {

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -206,25 +206,6 @@ EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 10), '->dump() takes an inline level argument');
     }
 
-    public function testArrayObjectAsMapNotInLined()
-    {
-        $deep = new \ArrayObject(array('deep1' => 'd', 'deep2' => 'e'));
-        $inner = new \ArrayObject(array('inner1' => 'b', 'inner2' => 'c', 'inner3' => $deep));
-        $outer = new \ArrayObject(array('outer1' => 'a', 'outer1' => $inner));
-
-        $yaml = $this->dumper->dump($outer, 2, 0, Yaml::DUMP_OBJECT_AS_MAP);
-
-        $expected = <<<YAML
-outer1: a
-outer2:
-    inner1: b
-    inner2: c
-    inner3: { deep1: d, deep2: e }
-
-YAML;
-        $this->assertEquals($expected, $yaml);
-    }
-
     public function testObjectSupportEnabled()
     {
         $dump = $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, Yaml::DUMP_OBJECT);
@@ -350,6 +331,63 @@ YAML;
         $tests['arbitrary-object'] = array($a, null);
 
         return $tests;
+    }
+
+    public function testDumpEmptyArrayObjectInstanceAsMap()
+    {
+        $this->assertSame('{  }', $this->dumper->dump(new \ArrayObject(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
+    }
+
+    public function testDumpingArrayObjectInstancesRespectsInlineLevel()
+    {
+        $deep = new \ArrayObject(array('deep1' => 'd', 'deep2' => 'e'));
+        $inner = new \ArrayObject(array('inner1' => 'b', 'inner2' => 'c', 'inner3' => $deep));
+        $outer = new \ArrayObject(array('outer1' => 'a', 'outer2' => $inner));
+
+        $yaml = $this->dumper->dump($outer, 2, 0, Yaml::DUMP_OBJECT_AS_MAP);
+
+        $expected = <<<YAML
+outer1: a
+outer2:
+    inner1: b
+    inner2: c
+    inner3: { deep1: d, deep2: e }
+
+YAML;
+        $this->assertSame($expected, $yaml);
+    }
+
+    public function testDumpEmptyStdClassInstanceAsMap()
+    {
+        $this->assertSame('{  }', $this->dumper->dump(new \stdClass(), 2, 0, Yaml::DUMP_OBJECT_AS_MAP));
+    }
+
+    public function testDumpingStdClassInstancesRespectsInlineLevel()
+    {
+        $deep = new \stdClass();
+        $deep->deep1 = 'd';
+        $deep->deep2 = 'e';
+
+        $inner = new \stdClass();
+        $inner->inner1 = 'b';
+        $inner->inner2 = 'c';
+        $inner->inner3 = $deep;
+
+        $outer = new \stdClass();
+        $outer->outer1 = 'a';
+        $outer->outer2 = $inner;
+
+        $yaml = $this->dumper->dump($outer, 2, 0, Yaml::DUMP_OBJECT_AS_MAP);
+
+        $expected = <<<YAML
+outer1: a
+outer2:
+    inner1: b
+    inner2: c
+    inner3: { deep1: d, deep2: e }
+
+YAML;
+        $this->assertSame($expected, $yaml);
     }
 
     public function testDumpMultiLineStringAsScalarBlock()

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Yaml\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Dumper;
+use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Yaml;
 
 class DumperTest extends TestCase
@@ -388,6 +388,38 @@ outer2:
 
 YAML;
         $this->assertSame($expected, $yaml);
+    }
+
+    public function testDumpingArrayObjectInstancesWithNumericKeysRespectsInlineLevel()
+    {
+        $deep = new \ArrayObject(array('d', 'e'));
+        $inner = new \ArrayObject(array('b', 'c', $deep));
+        $outer = new \ArrayObject(array('a', $inner));
+
+        $yaml = $this->dumper->dump($outer, 2, 0, Yaml::DUMP_OBJECT_AS_MAP);
+
+        $expected = <<<YAML
+0: a
+1:
+    0: b
+    1: c
+    2: { 0: d, 1: e }
+
+YAML;
+        $this->assertEquals($expected, $yaml);
+    }
+
+    public function testDumpingArrayObjectInstancesWithNumericKeysInlined()
+    {
+        $deep = new \ArrayObject(array('d', 'e'));
+        $inner = new \ArrayObject(array('b', 'c', $deep));
+        $outer = new \ArrayObject(array('a', $inner));
+
+        $yaml = $this->dumper->dump($outer, 0, 0, Yaml::DUMP_OBJECT_AS_MAP);
+        $expected = <<<YAML
+{ 0: a, 1: { 0: b, 1: c, 2: { 0: d, 1: e } } }
+YAML;
+        $this->assertEquals($expected, $yaml);
     }
 
     public function testDumpMultiLineStringAsScalarBlock()

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -206,6 +206,25 @@ EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 10), '->dump() takes an inline level argument');
     }
 
+    public function testArrayObjectAsMapNotInLined()
+    {
+        $deep = new \ArrayObject(array('deep1' => 'd', 'deep2' => 'e'));
+        $inner = new \ArrayObject(array('inner1' => 'b', 'inner2' => 'c', 'inner3' => $deep));
+        $outer = new \ArrayObject(array('outer1' => 'a', 'outer1' => $inner));
+
+        $yaml = $this->dumper->dump($outer, 2, 0, Yaml::DUMP_OBJECT_AS_MAP);
+
+        $expected = <<<YAML
+outer1: a
+outer2:
+    inner1: b
+    inner2: c
+    inner3: { deep1: d, deep2: e }
+
+YAML;
+        $this->assertEquals($expected, $yaml);
+    }
+
     public function testObjectSupportEnabled()
     {
         $dump = $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, Yaml::DUMP_OBJECT);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22409
| License       | MIT
| Doc PR        | 

Alternative version of #22409 that addresses the issues expressed in https://github.com/symfony/symfony/pull/22409#issuecomment-293836002
