### PR TITLE
[PropertyInfo] Prevent returning int values in some cases

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -64,7 +64,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         $properties = array();
         foreach ($reflectionClass->getProperties(\ReflectionProperty::IS_PUBLIC) as $reflectionProperty) {
-            $properties[$reflectionProperty->name] = true;
+            $properties[$reflectionProperty->name] = $reflectionProperty->name;
         }
 
         foreach ($reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $reflectionMethod) {
@@ -79,10 +79,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             if (!$reflectionClass->hasProperty($propertyName) && !preg_match('/^[A-Z]{2,}/', $propertyName)) {
                 $propertyName = lcfirst($propertyName);
             }
-            $properties[$propertyName] = true;
+            $properties[$propertyName] = $propertyName;
         }
 
-        return array_keys($properties);
+        return array_values($properties);
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
@@ -32,7 +32,7 @@ class ReflectionExtractorTest extends TestCase
 
     public function testGetProperties()
     {
-        $this->assertEquals(
+        $this->assertSame(
             array(
                 'bal',
                 'parent',
@@ -49,6 +49,7 @@ class ReflectionExtractorTest extends TestCase
                 'a',
                 'DOB',
                 'Id',
+                '123',
                 'c',
                 'd',
                 'e',

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -116,4 +116,8 @@ class Dummy extends ParentDummy
     public function getId()
     {
     }
+
+    public function get123()
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | api-platform/api-platform#282, api-platform/core#1055
| License       | MIT
| Doc PR        | n/a

PHP automatically converts array keys to an int if and only if it looks like an int... When a getter looks like `get123`, the ReflectionExtractor returns an array containing an int instead of a string. This PR fixes this.