### PR TITLE
[VarDumper] Add date caster

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Casts DateTimeInterface related classes to array representation.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class DateCaster
+{
+    public static function castDateTime(\DateTimeInterface $d, array $a, Stub $stub, $isNested, $filter)
+    {
+        $prefix = Caster::PREFIX_VIRTUAL;
+        $location = $d->getTimezone()->getLocation();
+        $fromNow = (new \DateTime())->diff($d);
+
+        $title = $d->format('l, F j, Y')
+            ."\n".$fromNow->format('%R').(ltrim($fromNow->format('%yy %mm %dd %H:%I:%Ss'), ' 0ymd:s') ?: '0s').' from now'
+            .($location ? ($d->format('I') ? "\nDST On" : "\nDST Off") : '')
+        ;
+
+        $a = array();
+        $a[$prefix.'date'] = new ConstStub($d->format('Y-m-d H:i:s.u '.($location ? 'e (P)' : 'P')), $title);
+
+        $stub->class .= $d->format(' @U');
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -109,6 +109,8 @@ abstract class AbstractCloner implements ClonerInterface
         'Redis' => array('Symfony\Component\VarDumper\Caster\RedisCaster', 'castRedis'),
         'RedisArray' => array('Symfony\Component\VarDumper\Caster\RedisCaster', 'castRedisArray'),
 
+        'DateTimeInterface' => array('Symfony\Component\VarDumper\Caster\DateCaster', 'castDateTime'),
+
         ':curl' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castCurl'),
         ':dba' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'),
         ':dba persistent' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'),

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Caster\DateCaster;
+use Symfony\Component\VarDumper\Cloner\Stub;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class DateCasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    /**
+     * @dataProvider provideDateTimes
+     */
+    public function testDumpDateTime($time, $timezone, $expected)
+    {
+        if ((defined('HHVM_VERSION_ID') || PHP_VERSION_ID <= 50509) && preg_match('/[-+]\d{2}:\d{2}/', $timezone)) {
+            $this->markTestSkipped('DateTimeZone GMT offsets are supported since 5.5.10. See https://github.com/facebook/hhvm/issues/5875 for HHVM.');
+        }
+
+        $date = new \DateTime($time, new \DateTimeZone($timezone));
+
+        $xDump = <<<EODUMP
+DateTime @1493503200 {
+  date: $expected
+}
+EODUMP;
+
+        $this->assertDumpMatchesFormat($xDump, $date);
+    }
+
+    public function testCastDateTime()
+    {
+        $stub = new Stub();
+        $date = new \DateTime('2017-08-30 00:00:00.000000', new \DateTimeZone('Europe/Zurich'));
+        $cast = DateCaster::castDateTime($date, array('foo' => 'bar'), $stub, false, 0);
+
+        $xDump = <<<'EODUMP'
+array:1 [
+  "\x00~\x00date" => 2017-08-30 00:00:00.000000 Europe/Zurich (+02:00)
+]
+EODUMP;
+
+        $this->assertDumpMatchesFormat($xDump, $cast);
+
+        $xDump = <<<'EODUMP'
+Symfony\Component\VarDumper\Caster\ConstStub {
+  +type: "ref"
+  +class: "2017-08-30 00:00:00.000000 Europe/Zurich (+02:00)"
+  +value: """
+    Wednesday, August 30, 2017\n
+    +%a from now\n
+    DST On
+    """
+  +cut: 0
+  +handle: 0
+  +refCount: 0
+  +position: 0
+  +attr: []
+}
+EODUMP;
+
+        $this->assertDumpMatchesFormat($xDump, $cast["\0~\0date"]);
+    }
+
+    public function provideDateTimes()
+    {
+        return array(
+            array('2017-04-30 00:00:00.000000', 'Europe/Zurich', '2017-04-30 00:00:00.000000 Europe/Zurich (+02:00)'),
+            array('2017-04-30 00:00:00.000000', '+02:00', '2017-04-30 00:00:00.000000 +02:00'),
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

I propose to add a ``DateCaster`` that casts date (with timestamp, date, time, timezone (offset + id), literal date, delta from now and DST) and interval.

Todo:
- [x] cast date
- [x] cast interval
- [x] add tests