### PR TITLE
[Console] Review console.ERROR related behavior

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -6,7 +6,7 @@
 
     <services>
 
-        <service id="console.exception_listener" class="Symfony\Component\Console\EventListener\ExceptionListener" public="false">
+        <service id="console.error_listener" class="Symfony\Component\Console\EventListener\ErrorListener" public="false">
             <argument type="service" id="logger" on-invalid="null" />
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="console" />

--- a/src/Symfony/Component/Console/ConsoleEvents.php
+++ b/src/Symfony/Component/Console/ConsoleEvents.php
@@ -55,8 +55,7 @@ final class ConsoleEvents
     const EXCEPTION = 'console.exception';
 
     /**
-     * The ERROR event occurs when an uncaught exception appears or
-     * a throwable error.
+     * The ERROR event occurs when an uncaught exception or error appears.
      *
      * This event allows you to deal with the exception/error or
      * to modify the thrown exception.

--- a/src/Symfony/Component/Console/Event/ConsoleExceptionEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleExceptionEvent.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Event;
 
+@trigger_error(sprintf('The "%s" class is deprecated since version 3.3 and will be removed in 4.0. Use the ConsoleErrorEvent instead.', ConsoleExceptionEvent::class), E_USER_DEPRECATED);
+
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,22 +22,18 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @deprecated ConsoleExceptionEvent is deprecated since version 3.3 and will be removed in 4.0. Use ConsoleErrorEvent instead.
+ * @deprecated since version 3.3, to be removed in 4.0. Use ConsoleErrorEvent instead.
  */
 class ConsoleExceptionEvent extends ConsoleEvent
 {
     private $exception;
     private $exitCode;
 
-    public function __construct(Command $command = null, InputInterface $input, OutputInterface $output, \Exception $exception, $exitCode, $deprecation = true)
+    public function __construct(Command $command, InputInterface $input, OutputInterface $output, \Exception $exception, $exitCode)
     {
-        if ($deprecation) {
-            @trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use the ConsoleErrorEvent instead.', __CLASS__), E_USER_DEPRECATED);
-        }
-
         parent::__construct($command, $input, $output);
 
-        $this->exception = $exception;
+        $this->setException($exception);
         $this->exitCode = (int) $exitCode;
     }
 

--- a/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
@@ -29,7 +29,7 @@ class ConsoleTerminateEvent extends ConsoleEvent
      */
     private $exitCode;
 
-    public function __construct(Command $command = null, InputInterface $input, OutputInterface $output, $exitCode)
+    public function __construct(Command $command, InputInterface $input, OutputInterface $output, $exitCode)
     {
         parent::__construct($command, $input, $output);
 

--- a/src/Symfony/Component/Console/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/Console/EventListener/ErrorListener.php
@@ -12,9 +12,9 @@
 namespace Symfony\Component\Console\EventListener;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @author James Halsall <james.t.halsall@googlemail.com>
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-class ExceptionListener implements EventSubscriberInterface
+class ErrorListener implements EventSubscriberInterface
 {
     private $logger;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR is a follow up of #18140 that I wanted to do since a few weeks.
It enhances this work with fixes and behavior changes.
It embeds #22435 and resolves issues like the one described in #20808.

- makes ConsoleErrorEvent *not* extend the deprecated ConsoleExceptionEvent
- replace ConsoleErrorEvent::markErrorAsHandled by ConsoleErrorEvent::setExitCode
- triggers the deprecation in a more appropriate moment
- renames ExceptionListener to ErrorListener
- tweaks the behavior in relation to  #22435

