### PR TITLE
[Form] rename getTypedExtensions() to getTypeExtensions()

### DIFF
--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -29,7 +29,7 @@ abstract class FormIntegrationTestCase extends TestCase
     {
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())
-            ->addTypeExtensions($this->getTypedExtensions())
+            ->addTypeExtensions($this->getTypeExtensions())
             ->addTypes($this->getTypes())
             ->addTypeGuessers($this->getTypeGuessers())
             ->getFormFactory();
@@ -40,7 +40,7 @@ abstract class FormIntegrationTestCase extends TestCase
         return array();
     }
 
-    protected function getTypedExtensions()
+    protected function getTypeExtensions()
     {
         return array();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21780#discussion_r111664409
| License       | MIT
| Doc PR        | 