### PR TITLE
[WebProfilerBundle] Imply forward request by a new X-Previous-Debug-Token header

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -16,6 +16,7 @@ FrameworkBundle
 ---------------
 
  * A `RouterInterface` that does not implement the `WarmableInterface` is deprecated and will not be supported in Symfony 5.0.
+ * The `RequestDataCollector` class has been deprecated and will be removed in Symfony 5.0. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
 
 HttpFoundation
 --------------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -15,6 +15,7 @@ FrameworkBundle
 ---------------
 
  * Using a `RouterInterface` that does not implement the `WarmableInterface` is not supported anymore.
+ * The `RequestDataCollector` class has been removed. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,7 +9,8 @@ CHANGELOG
  * Allowed the `Router` to work with any PSR-11 container
  * Added option in workflow dump command to label graph with a custom label
  * Using a `RouterInterface` that does not implement the `WarmableInterface` is deprecated and will not be supported in Symfony 5.0.
- 
+ * The `RequestDataCollector` class has been deprecated and will be removed in Symfony 5.0. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
+
 4.0.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -83,7 +83,6 @@ trait ControllerTrait
     protected function forward(string $controller, array $path = array(), array $query = array()): Response
     {
         $request = $this->container->get('request_stack')->getCurrentRequest();
-        $path['_forwarded'] = $request->attributes;
         $path['_controller'] = $controller;
         $subRequest = $request->duplicate($query, null, $path);
 

--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/RequestDataCollector.php
@@ -11,67 +11,17 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DataCollector;
 
-use Symfony\Component\HttpFoundation\ParameterBag;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector as BaseRequestCollector;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector as BaseRequestDataCollector;
+
+@trigger_error(sprintf('The "%s" class is deprecated since version 4.1 and will be removed in Symfony 5.0. Use %s instead.', RequestDataCollector::class, BaseRequestDataCollector::class), E_USER_DEPRECATED);
 
 /**
  * RequestDataCollector.
  *
  * @author Jules Pietri <jusles@heahprod.com>
+ *
+ * @deprecated since version 4.1, to be removed in Symfony 5.0
  */
-class RequestDataCollector extends BaseRequestCollector implements EventSubscriberInterface
+class RequestDataCollector extends BaseRequestDataCollector
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
-    {
-        parent::collect($request, $response, $exception);
-
-        if ($parentRequestAttributes = $request->attributes->get('_forwarded')) {
-            if ($parentRequestAttributes instanceof ParameterBag) {
-                $parentRequestAttributes->set('_forward_token', $response->headers->get('x-debug-token'));
-            }
-        }
-        if ($request->attributes->has('_forward_controller')) {
-            $this->data['forward'] = array(
-                'token' => $request->attributes->get('_forward_token'),
-                'controller' => $this->parseController($request->attributes->get('_forward_controller')),
-            );
-        }
-    }
-
-    /**
-     * Gets the parsed forward controller.
-     *
-     * @return array|bool An array with keys 'token' the forward profile token, and
-     *                    'controller' the parsed forward controller, false otherwise
-     */
-    public function getForward()
-    {
-        return isset($this->data['forward']) ? $this->data['forward'] : false;
-    }
-
-    public function onKernelController(FilterControllerEvent $event)
-    {
-        $this->controllers[$event->getRequest()] = $event->getController();
-
-        if ($parentRequestAttributes = $event->getRequest()->attributes->get('_forwarded')) {
-            if ($parentRequestAttributes instanceof ParameterBag) {
-                $parentRequestAttributes->set('_forward_controller', $event->getController());
-            }
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'request';
-    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -12,7 +12,7 @@
             <call method="setKernel"><argument type="service" id="kernel" on-invalid="ignore" /></call>
         </service>
 
-        <service id="data_collector.request" class="Symfony\Bundle\FrameworkBundle\DataCollector\RequestDataCollector">
+        <service id="data_collector.request" class="Symfony\Component\HttpKernel\DataCollector\RequestDataCollector">
             <tag name="kernel.event_subscriber" />
             <tag name="data_collector" template="@WebProfiler/Collector/request.html.twig" id="request" priority="335" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SubRequestServiceResolutionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SubRequestServiceResolutionController.php
@@ -24,7 +24,6 @@ class SubRequestServiceResolutionController implements ContainerAwareInterface
     public function indexAction()
     {
         $request = $this->container->get('request_stack')->getCurrentRequest();
-        $path['_forwarded'] = $request->attributes;
         $path['_controller'] = 'TestBundle:SubRequestServiceResolution:fragment';
         $subRequest = $request->duplicate(array(), null, $path);
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -12,9 +12,10 @@
         {% endset %}
     {% endif %}
 
-    {% if collector.forward|default(false) %}
+    {% if collector.forwardtoken|default(null) %}
+        {% set forward_profile = profile.childByToken(collector.forwardtoken) %}
         {% set forward_handler %}
-            {{ helper.set_handler(collector.forward.controller) }}
+            {{ helper.set_handler(forward_profile ? forward_profile.collector('request').controller : 'n/a') }}
         {% endset %}
     {% endif %}
 
@@ -24,7 +25,7 @@
         <span class="sf-toolbar-status sf-toolbar-status-{{ request_status_code_color }}">{{ collector.statuscode }}</span>
         {% if collector.route %}
             {% if collector.redirect %}{{ include('@WebProfiler/Icon/redirect.svg') }}{% endif %}
-            {% if collector.forward|default(false) %}{{ include('@WebProfiler/Icon/forward.svg') }}{% endif %}
+            {% if collector.forwardtoken|default(null) %}{{ include('@WebProfiler/Icon/forward.svg') }}{% endif %}
             <span class="sf-toolbar-label">{{ 'GET' != collector.method ? collector.method }} @</span>
             <span class="sf-toolbar-value sf-toolbar-info-piece-additional">{{ collector.route }}</span>
         {% endif %}
@@ -81,7 +82,7 @@
                     <b>Forwarded to</b>
                     <span>
                         {{ forward_handler }}
-                        (<a href="{{ path('_profiler', { token: collector.forward.token }) }}">{{ collector.forward.token }}</a>)
+                        (<a href="{{ path('_profiler', { token: collector.forwardtoken }) }}">{{ collector.forwardtoken }}</a>)
                     </span>
                 </div>
             </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -12,7 +12,7 @@
         {% endset %}
     {% endif %}
 
-    {% if collector.forwardtoken|default(null) %}
+    {% if collector.forwardtoken %}
         {% set forward_profile = profile.childByToken(collector.forwardtoken) %}
         {% set forward_handler %}
             {{ helper.set_handler(forward_profile ? forward_profile.collector('request').controller : 'n/a') }}
@@ -25,7 +25,7 @@
         <span class="sf-toolbar-status sf-toolbar-status-{{ request_status_code_color }}">{{ collector.statuscode }}</span>
         {% if collector.route %}
             {% if collector.redirect %}{{ include('@WebProfiler/Icon/redirect.svg') }}{% endif %}
-            {% if collector.forwardtoken|default(null) %}{{ include('@WebProfiler/Icon/forward.svg') }}{% endif %}
+            {% if collector.forwardtoken %}{{ include('@WebProfiler/Icon/forward.svg') }}{% endif %}
             <span class="sf-toolbar-label">{{ 'GET' != collector.method ? collector.method }} @</span>
             <span class="sf-toolbar-value sf-toolbar-info-piece-additional">{{ collector.route }}</span>
         {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -44,7 +44,7 @@
                             </dl>
                         {%- endif %}
 
-                        {% if request_collector and request_collector.forwardtoken|default(null) -%}
+                        {% if request_collector and request_collector.forwardtoken -%}
                             {% set forward_profile = profile.childByToken(request_collector.forwardtoken) %}
                             {% set controller = forward_profile ? forward_profile.collector('request').controller : 'n/a' %}
                             <dl class="metadata">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -44,18 +44,22 @@
                             </dl>
                         {%- endif %}
 
-                        {% if request_collector and request_collector.forward|default(false) and request_collector.forward.controller.class is defined -%}
-                            {%- set forward = request_collector.forward -%}
-                            {%- set controller = forward.controller -%}
+                        {% if request_collector and request_collector.forwardtoken|default(null) -%}
+                            {% set forward_profile = profile.childByToken(request_collector.forwardtoken) %}
+                            {% set controller = forward_profile ? forward_profile.collector('request').controller : 'n/a' %}
                             <dl class="metadata">
                                 <dt>Forwarded to</dt>
                                 <dd>
-                                    {% set link = controller.file|file_link(controller.line) -%}
+                                    {% set link = controller.file is defined ? controller.file|file_link(controller.line) : null -%}
                                     {%- if link %}<a href="{{ link }}" title="{{ controller.file }}">{% endif -%}
-                                        {{- controller.class|abbr_class|striptags -}}
-                                        {{- controller.method ? ' :: ' ~ controller.method }}
+                                        {% if controller.class is defined %}
+                                            {{- controller.class|abbr_class|striptags -}}
+                                            {{- controller.method ? ' :: ' ~ controller.method -}}
+                                        {% else %}
+                                            {{- controller -}}
+                                        {% endif %}
                                     {%- if link %}</a>{% endif %}
-                                    (<a href="{{ path('_profiler', { token: forward.token }) }}">{{ forward.token }}</a>)
+                                    (<a href="{{ path('_profiler', { token: request_collector.forwardtoken }) }}">{{ request_collector.forwardtoken }}</a>)
                                 </dd>
                             </dl>
                         {%- endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/http-kernel": "~3.4|~4.0",
+        "symfony/http-kernel": "~4.1",
         "symfony/routing": "~3.4|~4.0",
         "symfony/twig-bridge": "~3.4|~4.0",
         "symfony/var-dumper": "~3.4|~4.0",

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -158,6 +158,10 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         $this->data['identifier'] = $this->data['route'] ?: (is_array($this->data['controller']) ? $this->data['controller']['class'].'::'.$this->data['controller']['method'].'()' : $this->data['controller']);
+
+        if ($response->headers->has('x-previous-debug-token')) {
+            $this->data['forward_token'] = $response->headers->get('x-previous-debug-token');
+        }
     }
 
     public function lateCollect()
@@ -320,6 +324,11 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
     public function getRedirect()
     {
         return isset($this->data['redirect']) ? $this->data['redirect'] : false;
+    }
+
+    public function getForwardToken()
+    {
+        return isset($this->data['forward_token']) ? $this->data['forward_token'] : null;
     }
 
     public function onKernelController(FilterControllerEvent $event)

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -216,6 +216,17 @@ class Profile
         $child->setParent($this);
     }
 
+    public function getChildByToken(string $token): ?self
+    {
+        foreach ($this->children as $child) {
+            if ($token === $child->getToken()) {
+                return $child;
+            }
+        }
+
+        return null;
+    }
+
     /**
      * Gets a Collector by name.
      *

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -156,6 +156,10 @@ class Profiler
             $profile->setIp('Unknown');
         }
 
+        if ($prevToken = $response->headers->get('X-Debug-Token')) {
+            $response->headers->set('X-Previous-Debug-Token', $prevToken);
+        }
+
         $response->headers->set('X-Debug-Token', $profile->getToken());
 
         foreach ($this->collectors as $collector) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

TLDR; imply a "forwarded" request in the profiler if one _returns_ a response with a x-debug-token set. Otherwise dont.
____

Currently a forward request is implied by the WDT/profiler based on the latest sub-request made, however the main request can return it's own response, or one from a non-latest sub-request. The current behavior is a bit misleading imo.

```php
public function indexAction(Request $request)
{
    $bar1 = $this->forward(__CLASS__.'::barAction');
    $bar2 = $this->forward(__CLASS__.'::bar2Action');
    return $bar1;
}
```

It shows the request was forwarded to `bar2Action`. This changes that, so that `barAction` is shown instead. No forward is implied if a new response was returned by `indexAction`.

![image](https://cloud.githubusercontent.com/assets/1047696/25064022/e24d999e-21f1-11e7-8f94-afa3fad7462f.png)

~~Note we dont really need the collector in the framework bundle anymore with this approach.~~ deprecated it.