### PR TITLE
[Cache] Keep only hit/miss (not values) in TraceableAdapter/Cache

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/cache.html.twig
@@ -130,18 +130,16 @@
                                         <th>#</th>
                                         <th>Time</th>
                                         <th>Call</th>
-                                        <th>Argument</th>
-                                        <th>Result</th>
+                                        <th>Hit</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                 {% for call in calls %}
                                     <tr>
                                         <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
-                                        <td>{{ '%0.2f'|format((call.end - call.start) * 1000) }} ms</td>
-                                        <td>{{ call.name }}()</td>
-                                        <td>{{ profiler_dump(call.value.argument, maxDepth=1) }}</td>
-                                        <td>{{ profiler_dump(call.value.result, maxDepth=1) }}</td>
+                                        <td class="nowrap">{{ '%0.2f'|format((call.end - call.start) * 1000) }} ms</td>
+                                        <td class="nowrap">{{ call.name }}()</td>
+                                        <td>{{ profiler_dump(call.value.result, maxDepth=2) }}</td>
                                     </tr>
                                 {% endfor %}
                                 </tbody>

--- a/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
@@ -24,7 +24,7 @@ class TraceableAdapterTest extends AdapterTestCase
         return new TraceableAdapter(new FilesystemAdapter('', $defaultLifetime));
     }
 
-    public function testGetItemMiss()
+    public function testGetItemMissTrace()
     {
         $pool = $this->createCachePool();
         $pool->getItem('k');
@@ -33,15 +33,14 @@ class TraceableAdapterTest extends AdapterTestCase
 
         $call = $calls[0];
         $this->assertSame('getItem', $call->name);
-        $this->assertSame('k', $call->argument);
+        $this->assertSame(array('k' => false), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(1, $call->misses);
-        $this->assertNull($call->result);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testGetItemHit()
+    public function testGetItemHitTrace()
     {
         $pool = $this->createCachePool();
         $item = $pool->getItem('k')->set('foo');
@@ -55,7 +54,7 @@ class TraceableAdapterTest extends AdapterTestCase
         $this->assertSame(0, $call->misses);
     }
 
-    public function testGetItemsMiss()
+    public function testGetItemsMissTrace()
     {
         $pool = $this->createCachePool();
         $arg = array('k0', 'k1');
@@ -67,13 +66,13 @@ class TraceableAdapterTest extends AdapterTestCase
 
         $call = $calls[0];
         $this->assertSame('getItems', $call->name);
-        $this->assertSame($arg, $call->argument);
+        $this->assertSame(array('k0' => false, 'k1' => false), $call->result);
         $this->assertSame(2, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testHasItemMiss()
+    public function testHasItemMissTrace()
     {
         $pool = $this->createCachePool();
         $pool->hasItem('k');
@@ -82,13 +81,12 @@ class TraceableAdapterTest extends AdapterTestCase
 
         $call = $calls[0];
         $this->assertSame('hasItem', $call->name);
-        $this->assertSame('k', $call->argument);
-        $this->assertFalse($call->result);
+        $this->assertSame(array('k' => false), $call->result);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testHasItemHit()
+    public function testHasItemHitTrace()
     {
         $pool = $this->createCachePool();
         $item = $pool->getItem('k')->set('foo');
@@ -99,13 +97,12 @@ class TraceableAdapterTest extends AdapterTestCase
 
         $call = $calls[2];
         $this->assertSame('hasItem', $call->name);
-        $this->assertSame('k', $call->argument);
-        $this->assertTrue($call->result);
+        $this->assertSame(array('k' => true), $call->result);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testDeleteItem()
+    public function testDeleteItemTrace()
     {
         $pool = $this->createCachePool();
         $pool->deleteItem('k');
@@ -114,14 +111,14 @@ class TraceableAdapterTest extends AdapterTestCase
 
         $call = $calls[0];
         $this->assertSame('deleteItem', $call->name);
-        $this->assertSame('k', $call->argument);
+        $this->assertSame(array('k' => true), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testDeleteItems()
+    public function testDeleteItemsTrace()
     {
         $pool = $this->createCachePool();
         $arg = array('k0', 'k1');
@@ -131,14 +128,14 @@ class TraceableAdapterTest extends AdapterTestCase
 
         $call = $calls[0];
         $this->assertSame('deleteItems', $call->name);
-        $this->assertSame($arg, $call->argument);
+        $this->assertSame(array('keys' => $arg, 'result' => true), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testSave()
+    public function testSaveTrace()
     {
         $pool = $this->createCachePool();
         $item = $pool->getItem('k')->set('foo');
@@ -148,14 +145,14 @@ class TraceableAdapterTest extends AdapterTestCase
 
         $call = $calls[1];
         $this->assertSame('save', $call->name);
-        $this->assertSame($item, $call->argument);
+        $this->assertSame(array('k' => true), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testSaveDeferred()
+    public function testSaveDeferredTrace()
     {
         $pool = $this->createCachePool();
         $item = $pool->getItem('k')->set('foo');
@@ -165,14 +162,14 @@ class TraceableAdapterTest extends AdapterTestCase
 
         $call = $calls[1];
         $this->assertSame('saveDeferred', $call->name);
-        $this->assertSame($item, $call->argument);
+        $this->assertSame(array('k' => true), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testCommit()
+    public function testCommitTrace()
     {
         $pool = $this->createCachePool();
         $pool->commit();
@@ -181,7 +178,7 @@ class TraceableAdapterTest extends AdapterTestCase
 
         $call = $calls[0];
         $this->assertSame('commit', $call->name);
-        $this->assertNull(null, $call->argument);
+        $this->assertTrue($call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);

--- a/src/Symfony/Component/Cache/Tests/Simple/TraceableCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/TraceableCacheTest.php
@@ -24,7 +24,7 @@ class TraceableCacheTest extends CacheTestCase
         return new TraceableCache(new FilesystemCache('', $defaultLifetime));
     }
 
-    public function testGetMiss()
+    public function testGetMissTrace()
     {
         $pool = $this->createSimpleCache();
         $pool->get('k');
@@ -33,15 +33,14 @@ class TraceableCacheTest extends CacheTestCase
 
         $call = $calls[0];
         $this->assertSame('get', $call->name);
-        $this->assertSame(array('key' => 'k', 'default' => null), $call->arguments);
+        $this->assertSame(array('k' => false), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(1, $call->misses);
-        $this->assertNull($call->result);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testGetHit()
+    public function testGetHitTrace()
     {
         $pool = $this->createSimpleCache();
         $pool->set('k', 'foo');
@@ -54,25 +53,25 @@ class TraceableCacheTest extends CacheTestCase
         $this->assertSame(0, $call->misses);
     }
 
-    public function testGetMultipleMiss()
+    public function testGetMultipleMissTrace()
     {
         $pool = $this->createSimpleCache();
-        $arg = array('k0', 'k1');
-        $values = $pool->getMultiple($arg);
+        $pool->set('k1', 123);
+        $values = $pool->getMultiple(array('k0', 'k1'));
         foreach ($values as $value) {
         }
         $calls = $pool->getCalls();
-        $this->assertCount(1, $calls);
+        $this->assertCount(2, $calls);
 
-        $call = $calls[0];
+        $call = $calls[1];
         $this->assertSame('getMultiple', $call->name);
-        $this->assertSame(array('keys' => $arg, 'default' => null), $call->arguments);
-        $this->assertSame(2, $call->misses);
+        $this->assertSame(array('k1' => true, 'k0' => false), $call->result);
+        $this->assertSame(1, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testHasMiss()
+    public function testHasMissTrace()
     {
         $pool = $this->createSimpleCache();
         $pool->has('k');
@@ -81,13 +80,12 @@ class TraceableCacheTest extends CacheTestCase
 
         $call = $calls[0];
         $this->assertSame('has', $call->name);
-        $this->assertSame(array('key' => 'k'), $call->arguments);
-        $this->assertFalse($call->result);
+        $this->assertSame(array('k' => false), $call->result);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testHasHit()
+    public function testHasHitTrace()
     {
         $pool = $this->createSimpleCache();
         $pool->set('k', 'foo');
@@ -97,13 +95,12 @@ class TraceableCacheTest extends CacheTestCase
 
         $call = $calls[1];
         $this->assertSame('has', $call->name);
-        $this->assertSame(array('key' => 'k'), $call->arguments);
-        $this->assertTrue($call->result);
+        $this->assertSame(array('k' => true), $call->result);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testDelete()
+    public function testDeleteTrace()
     {
         $pool = $this->createSimpleCache();
         $pool->delete('k');
@@ -112,14 +109,14 @@ class TraceableCacheTest extends CacheTestCase
 
         $call = $calls[0];
         $this->assertSame('delete', $call->name);
-        $this->assertSame(array('key' => 'k'), $call->arguments);
+        $this->assertSame(array('k' => true), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testDeleteMultiple()
+    public function testDeleteMultipleTrace()
     {
         $pool = $this->createSimpleCache();
         $arg = array('k0', 'k1');
@@ -129,14 +126,14 @@ class TraceableCacheTest extends CacheTestCase
 
         $call = $calls[0];
         $this->assertSame('deleteMultiple', $call->name);
-        $this->assertSame(array('keys' => $arg), $call->arguments);
+        $this->assertSame(array('keys' => $arg, 'result' => true), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testSet()
+    public function testTraceSetTrace()
     {
         $pool = $this->createSimpleCache();
         $pool->set('k', 'foo');
@@ -145,14 +142,14 @@ class TraceableCacheTest extends CacheTestCase
 
         $call = $calls[0];
         $this->assertSame('set', $call->name);
-        $this->assertSame(array('key' => 'k', 'value' => 'foo', 'ttl' => null), $call->arguments);
+        $this->assertSame(array('k' => true), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);
         $this->assertNotEmpty($call->end);
     }
 
-    public function testSetMultiple()
+    public function testSetMultipleTrace()
     {
         $pool = $this->createSimpleCache();
         $pool->setMultiple(array('k' => 'foo'));
@@ -161,7 +158,7 @@ class TraceableCacheTest extends CacheTestCase
 
         $call = $calls[0];
         $this->assertSame('setMultiple', $call->name);
-        $this->assertSame(array('values' => array('k' => 'foo'), 'ttl' => null), $call->arguments);
+        $this->assertSame(array('keys' => array('k'), 'result' => true), $call->result);
         $this->assertSame(0, $call->hits);
         $this->assertSame(0, $call->misses);
         $this->assertNotEmpty($call->start);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Right now, TraceableAdapter and TraceableCache both keep all fetched values.
This exhaustive reporting is too much data gathering to me.
Here is a PR that keeps only true/false for each hit/miss + all corresponding keys.
That can still be a lot of data (one item per fetched key) - but a bit better.
Should we go further in stats-only gathering? Or should we *not* do this and keep collecting *all* the values?
The PR also fixes "Traversable" handling.

ping @Nyholm 

The profiler panel still works (although breaking lines in the middle of words is strange, but this is the profiler's CSS, nothing special to this specific case).

![capture du 2017-04-19 11-40-13](https://cloud.githubusercontent.com/assets/243674/25173586/f9615dd6-24f4-11e7-8d6f-36fb2437c3b6.png)
