### PR TITLE
Allow inherited classes set trusted proxies via attribute

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -586,7 +586,7 @@ class Request
      */
     public static function setTrustedProxies(array $proxies/*, int $trustedHeaderSet*/)
     {
-        self::$trustedProxies = $proxies;
+        static::$trustedProxies = $proxies;
 
         if (2 > func_num_args()) {
             // @deprecated code path in 3.3, to be replaced by mandatory argument in 4.0.
@@ -607,7 +607,7 @@ class Request
      */
     public static function getTrustedProxies()
     {
-        return self::$trustedProxies;
+        return static::$trustedProxies;
     }
 
     /**
@@ -2021,7 +2021,7 @@ class Request
      */
     public function isFromTrustedProxy()
     {
-        return self::$trustedProxies && IpUtils::checkIp($this->server->get('REMOTE_ADDR'), self::$trustedProxies);
+        return static::$trustedProxies && IpUtils::checkIp($this->server->get('REMOTE_ADDR'), static::$trustedProxies);
     }
 
     private function getTrustedValues($type, $ip = null)
@@ -2081,7 +2081,7 @@ class Request
                 continue;
             }
 
-            if (IpUtils::checkIp($clientIp, self::$trustedProxies)) {
+            if (IpUtils::checkIp($clientIp, static::$trustedProxies)) {
                 unset($clientIps[$key]);
 
                 // Fallback to this when the client IP falls into the range of trusted proxies

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1975,6 +1975,17 @@ class RequestTest extends TestCase
         Request::setTrustedHosts(array());
     }
 
+    public function testInheritedTrustedProxies()
+    {
+        $request = InheritedRequest::create('/');
+        $request->server->set('REMOTE_ADDR', '3.3.3.3');
+        $request->headers->set('X_FORWARDED_FOR', '1.1.1.1, 2.2.2.2');
+        $request->headers->set('X_FORWARDED_HOST', 'foo.example.com:1234, real.example.com:8080');
+        $request->headers->set('X_FORWARDED_PROTO', 'https');
+        $request->headers->set('X_FORWARDED_PORT', 443);
+        $this->assertFalse($request->isSecure());
+    }
+
     public function testFactory()
     {
         Request::setFactory(function (array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null) {
@@ -2204,4 +2215,9 @@ class NewRequest extends Request
     {
         return 'foo';
     }
+}
+
+class InheritedRequest extends Request
+{
+    protected static $trustedProxies = array('3.3.3.4', '2.2.2.2');
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

When inherited class want to set `$trustedProxies` via attribute, it does not get used, because resolution for attribute is done via `self::` instead of `static::`