### PR TITLE
[Config] Added Prototype::preserveKeys

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -35,6 +35,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     protected $addDefaultChildren = false;
     protected $nodeBuilder;
     protected $normalizeKeys = true;
+    protected $preserveKeys = false;
 
     /**
      * {@inheritdoc}
@@ -246,6 +247,13 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
         return $this;
     }
 
+    public function preserveKeys()
+    {
+        $this->preserveKeys = true;
+
+        return $this;
+    }
+
     /**
      * Sets whether the node can be unset.
      *
@@ -426,6 +434,10 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
 
             if (null !== $this->key) {
                 $node->setKeyAttribute($this->key, $this->removeKeyItem);
+            }
+
+            if (true === $this->preserveKeys) {
+                $node->setPreserveKeys();
             }
 
             if (true === $this->atLeastOne) {

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -29,6 +29,8 @@ class PrototypedArrayNode extends ArrayNode
     protected $minNumberOfElements = 0;
     protected $defaultValue = array();
     protected $defaultChildren;
+    protected $preserveKeys = false;
+
     /**
      * @var NodeInterface[] An array of the prototypes of the simplified value children
      */
@@ -83,6 +85,11 @@ class PrototypedArrayNode extends ArrayNode
     public function getKeyAttribute()
     {
         return $this->keyAttribute;
+    }
+
+    public function setPreserveKeys()
+    {
+        $this->preserveKeys = true;
     }
 
     /**
@@ -314,7 +321,7 @@ class PrototypedArrayNode extends ArrayNode
 
         foreach ($rightSide as $k => $v) {
             // prototype, and key is irrelevant, so simply append the element
-            if (null === $this->keyAttribute) {
+            if (null === $this->keyAttribute && false === $this->preserveKeys) {
                 $leftSide[] = $v;
                 continue;
             }

--- a/src/Symfony/Component/Config/Tests/Definition/MergeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/MergeTest.php
@@ -168,6 +168,49 @@ class MergeTest extends TestCase
         ), $tree->merge($a, $b));
     }
 
+    public function testPreserveKeys()
+    {
+        $tb = new TreeBuilder();
+
+        $tree = $tb
+            ->root('config', 'array')
+                ->children()
+                    ->arrayNode('append_elements')
+                        ->preserveKeys()
+                        ->prototype('scalar')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->buildTree()
+        ;
+
+        $a = array(
+            'append_elements' => array(
+                'key1' => 'a',
+                'key2' => 'b',
+            ),
+        );
+
+        $b = array(
+            'append_elements' => array(
+                'key3' => 'c',
+                'key4' => 'd',
+            ),
+        );
+
+        $expected = array(
+            'append_elements' => array(
+                'key1' => 'a',
+                'key2' => 'b',
+                'key3' => 'c',
+                'key4' => 'd',
+            ),
+        );
+
+        $this->assertEquals($expected, $tree->merge($a, $b));
+    }
+
     public function testPrototypeWithoutAKeyAttribute()
     {
         $tb = new TreeBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

---

**Use case**:

I want to use this configuration format:

```
bundle:
    fetchers: # hardcoded key
        amqp: # hardcoded key
            fetcher_queue_a: # prototype, put what you want here (issue here)
                queue_name: queue_a # hardcoded key
```

And I have N files where I repeat this pattern.

**Issue**

When symfony merge all files, all keys in file N>1 are lost. I don't want to loose my keys.

I'm aware of ->useAttributeAsKey, But I do not want to use the queue_name as key, because it could be different.

---

Before adding tests & co, I wanted to validate the idea with you.

Another solution would be to add a new scalar node "name" in *my* config and use it. But may be this feature could be interesting for others too.