### PR TITLE
[Serializer] XmlEncoder: fix negative int and large numbers handling

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -301,11 +301,19 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         $data = array();
 
         foreach ($node->attributes as $attr) {
-            if (ctype_digit($attr->nodeValue)) {
-                $data['@'.$attr->nodeName] = (int) $attr->nodeValue;
-            } else {
+            if (!is_numeric($attr->nodeValue)) {
                 $data['@'.$attr->nodeName] = $attr->nodeValue;
+
+                continue;
             }
+
+            if (false !== $val = filter_var($attr->nodeValue, FILTER_VALIDATE_INT)) {
+                $data['@'.$attr->nodeName] = $val;
+
+                continue;
+            }
+
+            $data['@'.$attr->nodeName] = (float) $attr->nodeValue;
         }
 
         return $data;

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -222,6 +222,46 @@ XML;
         $this->assertEquals('foo', $this->encoder->decode($source, 'xml'));
     }
 
+    public function testDecodeBigDigitAttributes()
+    {
+        $source = <<<XML
+<?xml version="1.0"?>
+<document index="182077241760011681341821060401202210011000045913000000017100">Name</document>
+XML;
+
+        $this->assertSame(array('@index' => 182077241760011681341821060401202210011000045913000000017100, '#' => 'Name'), $this->encoder->decode($source, 'xml'));
+    }
+
+    public function testDecodeNegativeIntAttribute()
+    {
+        $source = <<<XML
+<?xml version="1.0"?>
+<document index="-1234">Name</document>
+XML;
+
+        $this->assertSame(array('@index' => -1234, '#' => 'Name'), $this->encoder->decode($source, 'xml'));
+    }
+
+    public function testDecodeFloatAttribute()
+    {
+        $source = <<<XML
+<?xml version="1.0"?>
+<document index="-12.11">Name</document>
+XML;
+
+        $this->assertSame(array('@index' => -12.11, '#' => 'Name'), $this->encoder->decode($source, 'xml'));
+    }
+
+    public function testDecodeNegativeFloatAttribute()
+    {
+        $source = <<<XML
+<?xml version="1.0"?>
+<document index="-12.11">Name</document>
+XML;
+
+        $this->assertSame(array('@index' => -12.11, '#' => 'Name'), $this->encoder->decode($source, 'xml'));
+    }
+
     public function testEncode()
     {
         $source = $this->getXmlSource();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #22329, #22333 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a

Alternative to #22333.

* Negative integers are now handled
* Float are now handled
* Large numbers are converted to float (as the `JsonEncoder` and native PHP functions like `ceil` do)

@vlastv, I've adapted your test. Can you check if it fixes your problem?
