### PR TITLE
[FrameworkBundle] Restore 3.2-like behavior for FormPass, to help BC with Sonata

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -13,16 +13,76 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 @trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use Symfony\Component\Form\DependencyInjection\FormPass instead.', FormPass::class), E_USER_DEPRECATED);
 
-use Symfony\Component\Form\DependencyInjection\FormPass as BaseFormPass;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
  * Adds all services with the tags "form.type" and "form.type_guesser" as
  * arguments of the "form.extension" service.
  *
- * @deprecated since version 3.3, to be removed in 4.0. Use {@link BaseFormPass} instead.
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated since version 3.3, to be removed in 4.0. Use FormPass in the Form component instead.
  */
-class FormPass extends BaseFormPass
+class FormPass implements CompilerPassInterface
 {
+    use PriorityTaggedServiceTrait;
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('form.extension')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('form.extension');
+
+        // Builds an array with fully-qualified type class names as keys and service IDs as values
+        $types = array();
+
+        foreach ($container->findTaggedServiceIds('form.type') as $serviceId => $tag) {
+            $serviceDefinition = $container->getDefinition($serviceId);
+            if (!$serviceDefinition->isPublic()) {
+                $serviceDefinition->setPublic(true);
+            }
+
+            // Support type access by FQCN
+            $types[$serviceDefinition->getClass()] = $serviceId;
+        }
+
+        $definition->replaceArgument(1, $types);
+
+        $typeExtensions = array();
+
+        foreach ($this->findAndSortTaggedServices('form.type_extension', $container) as $reference) {
+            $serviceId = (string) $reference;
+            $serviceDefinition = $container->getDefinition($serviceId);
+            if (!$serviceDefinition->isPublic()) {
+                $serviceDefinition->setPublic(true);
+            }
+
+            $tag = $serviceDefinition->getTag('form.type_extension');
+            if (isset($tag[0]['extended_type'])) {
+                $extendedType = $tag[0]['extended_type'];
+            } else {
+                throw new InvalidArgumentException(sprintf('Tagged form type extension must have the extended type configured using the extended_type/extended-type attribute, none was configured for the "%s" service.', $serviceId));
+            }
+
+            $typeExtensions[$extendedType][] = $serviceId;
+        }
+
+        $definition->replaceArgument(2, $typeExtensions);
+
+        // Find all services annotated with "form.type_guesser"
+        $guessers = array_keys($container->findTaggedServiceIds('form.type_guesser'));
+        foreach ($guessers as $serviceId) {
+            $serviceDefinition = $container->getDefinition($serviceId);
+            if (!$serviceDefinition->isPublic()) {
+                $serviceDefinition->setPublic(true);
+            }
+        }
+
+        $definition->replaceArgument(3, $guessers);
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -36,6 +36,7 @@
             <argument /><!-- All services with tag "form.type" are stored in a service locator by FormPass -->
             <argument type="collection" /><!-- All services with tag "form.type_extension" are stored here by FormPass -->
             <argument type="iterator" /><!-- All services with tag "form.type_guesser" are stored here by FormPass -->
+            <argument>null</argument><!-- @deprecated argument in 3.3, to be removed in 4.0 -->
         </service>
 
         <!-- ValidatorTypeGuesser -->

--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -50,6 +50,9 @@ class FormPass implements CompilerPassInterface
         }
 
         $definition = $container->getDefinition($this->formExtensionService);
+        if (new IteratorArgument(array()) != $definition->getArgument(2)) {
+            return;
+        }
         $definition->replaceArgument(0, $this->processFormTypes($container, $definition));
         $definition->replaceArgument(1, $this->processFormTypeExtensions($container));
         $definition->replaceArgument(2, $this->processFormTypeGuessers($container));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I tried updating a Sonata project to 3.3, and found it broken.
The issue is that Sonata uses the constructor arguments of the `form.extension` to create its own `form.extension` service - but borrows its first args from the Symfony one.

Here is the form pass doing that:
https://github.com/sonata-project/SonataCoreBundle/blob/3.x/DependencyInjection/Compiler/FormFactoryCompilerPass.php
And the implementation of the form extension:
https://github.com/sonata-project/SonataCoreBundle/blob/3.x/DependencyInjection/SonataCoreExtension.php

Question: is this covered by the BC policy? It shouldn't to me, because that would prevent *any* service reconfiguration.

Thus, I'm proposing the attached patch, which basically reverts the deprecated `FormPass` in FrameworkBundle to its 3.2 state.

I added a check to the new `FormPass` in the Form component so that it doesn't overwrite such compatibility configurations.

See for corresponding fix on https://github.com/sonata-project/SonataCoreBundle/pull/399