### PR TITLE
[FrameworkBundle] clarify constraint for the Asset component

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "fig/link-util": "^1.0",
-        "symfony/asset": "~2.8|~3.0",
+        "symfony/asset": "~3.3",
         "symfony/browser-kit": "~2.8|~3.0",
         "symfony/console": "~3.3",
         "symfony/css-selector": "~2.8|~3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The conflict rule already forbids installing releases before 3.3 of the
Asset component. This will bring the constraint in the `require-dev`
section inline with the conflict rule.
