### PR TITLE
[DI] Add support for factory in service defaults

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -90,6 +90,7 @@ class YamlFileLoader extends FileLoader
         'calls' => 'calls',
         'tags' => 'tags',
         'autowire' => 'autowire',
+        'factory' => 'factory',
     );
 
     private static $defaultsKeywords = array(
@@ -98,6 +99,7 @@ class YamlFileLoader extends FileLoader
         'autowire' => 'autowire',
         'autoconfigure' => 'autoconfigure',
         'bind' => 'bind',
+        'factory' => 'factory',
     );
 
     private $yamlParser;
@@ -401,6 +403,9 @@ class YamlFileLoader extends FileLoader
             }
             if (isset($defaults['autoconfigure'])) {
                 $definition->setAutoconfigured($defaults['autoconfigure']);
+            }
+            if (isset($defaults['factory'])) {
+                $definition->setFactory($this->parseCallable($defaults['factory'], 'factory', $id, $file));
             }
 
             $definition->setChanges(array());

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/factory_in_defaults.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/factory_in_defaults.yml
@@ -1,0 +1,6 @@
+services:
+    _defaults:
+        factory:        [ "@default_factory", foo ]
+
+    Foo:
+        arguments:      [ "bar" ]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/factory_in_instanceof.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/factory_in_instanceof.yml
@@ -1,0 +1,7 @@
+services:
+    _instanceof:
+        Symfony\Component\DependencyInjection\Tests\Loader\FooInterface:
+            factory:    [ "@default_factory", foo ]
+
+    Symfony\Component\DependencyInjection\Tests\Loader\Foo:
+        arguments:      [ "bar" ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22189
| License       | MIT

Add support for `factory` keyword in service defaults and `_instanceof` sections.