### PR TITLE
[DI] Fix inlining conflict by restricting IteratorArgument to Reference[]

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/IteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/IteratorArgument.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection\Argument;
 
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
+
 /**
  * Represents a collection of values to lazily iterate over.
  *
@@ -20,9 +23,12 @@ class IteratorArgument implements ArgumentInterface
 {
     private $values;
 
+    /**
+     * @param Reference[] $values
+     */
     public function __construct(array $values)
     {
-        $this->values = $values;
+        $this->setValues($values);
     }
 
     /**
@@ -34,10 +40,16 @@ class IteratorArgument implements ArgumentInterface
     }
 
     /**
-     * @param array $values The values to lazily iterate over
+     * @param Reference[] $values The service references to lazily iterate over
      */
     public function setValues(array $values)
     {
+        foreach ($values as $k => $v) {
+            if (null !== $v && !$v instanceof Reference) {
+                throw new InvalidArgumentException(sprintf('An IteratorArgument must hold only Reference instances, "%s" given.', is_object($v) ? get_class($v) : gettype($v)));
+            }
+        }
+
         $this->values = $values;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -38,8 +38,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
     protected function processValue($value, $isRoot = false)
     {
         if ($value instanceof ArgumentInterface) {
-            $this->processValue($value->getValues());
-
+            // Reference found in ArgumentInterface::getValues() are not inlineable
             return $value;
         }
         if ($value instanceof Reference && $this->container->hasDefinition($id = (string) $value)) {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1125,8 +1125,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 return $this->resolveServices($reference);
             };
         } elseif ($value instanceof IteratorArgument) {
-            $parameterBag = $this->getParameterBag();
-            $value = new RewindableGenerator(function () use ($value, $parameterBag) {
+            $value = new RewindableGenerator(function () use ($value) {
                 foreach ($value->getValues() as $k => $v) {
                     foreach (self::getServiceConditionals($v) as $s) {
                         if (!$this->has($s)) {
@@ -1134,7 +1133,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                         }
                     }
 
-                    yield $k => $this->resolveServices($parameterBag->unescapeValue($parameterBag->resolveValue($v)));
+                    yield $k => $this->resolveServices($v);
                 }
             }, function () use ($value) {
                 $count = 0;
@@ -1409,7 +1408,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * Shares a given service in the container.
      *
      * @param Definition  $definition
-     * @param mixed       $service
+     * @param object      $service
      * @param string|null $id
      */
     private function shareService(Definition $definition, $service, $id)

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -480,7 +480,12 @@ class XmlFileLoader extends FileLoader
                     $arguments[$key] = $this->getArgumentsAsPhp($arg, $name, false);
                     break;
                 case 'iterator':
-                    $arguments[$key] = new IteratorArgument($this->getArgumentsAsPhp($arg, $name, false));
+                    $arg = $this->getArgumentsAsPhp($arg, $name, false);
+                    try {
+                        $arguments[$key] = new IteratorArgument($arg);
+                    } catch (InvalidArgumentException $e) {
+                        throw new InvalidArgumentException(sprintf('Tag "<%s>" with type="iterator" only accepts collections of type="service" references.', $name));
+                    }
                     break;
                 case 'string':
                     $arguments[$key] = $arg->nodeValue;

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -654,14 +654,18 @@ class YamlFileLoader extends FileLoader
             $argument = $value->getValue();
             if ('iterator' === $value->getTag()) {
                 if (!is_array($argument)) {
-                    throw new InvalidArgumentException('"!iterator" tag only accepts sequences.');
+                    throw new InvalidArgumentException(sprintf('"!iterator" tag only accepts sequences in "%s".', $file));
                 }
-
-                return new IteratorArgument($this->resolveServices($argument, $file, $isParameter));
+                $argument = $this->resolveServices($argument, $file, $isParameter);
+                try {
+                    return new IteratorArgument($argument);
+                } catch (InvalidArgumentException $e) {
+                    throw new InvalidArgumentException(sprintf('"!iterator" tag only accepts arrays of "@service" references in "%s".', $file));
+                }
             }
             if ('closure_proxy' === $value->getTag()) {
                 if (!is_array($argument) || array(0, 1) !== array_keys($argument) || !is_string($argument[0]) || !is_string($argument[1]) || 0 !== strpos($argument[0], '@') || 0 === strpos($argument[0], '@@')) {
-                    throw new InvalidArgumentException('"!closure_proxy" tagged values must be arrays of [@service, method].');
+                    throw new InvalidArgumentException(sprintf('"!closure_proxy" tagged values must be arrays of [@service, method] in "%s".', $file));
                 }
 
                 if (0 === strpos($argument[0], '@?')) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -434,7 +434,7 @@ class PhpDumperTest extends TestCase
         $container->register('lazy_referenced', 'stdClass');
         $container
             ->register('lazy_context', 'LazyContext')
-            ->setArguments(array(new IteratorArgument(array('foo', new Reference('lazy_referenced'), 'k1' => array('foo' => 'bar'), true, 'k2' => new Reference('service_container')))))
+            ->setArguments(array(new IteratorArgument(array('k1' => new Reference('lazy_referenced'), 'k2' => new Reference('service_container')))))
         ;
         $container->compile();
 
@@ -450,24 +450,12 @@ class PhpDumperTest extends TestCase
         foreach ($lazyContext->lazyValues as $k => $v) {
             switch (++$i) {
                 case 0:
-                    $this->assertEquals(0, $k);
-                    $this->assertEquals('foo', $v);
+                    $this->assertEquals('k1', $k);
+                    $this->assertInstanceOf('stdCLass', $v);
                     break;
                 case 1:
-                    $this->assertEquals(1, $k);
-                    $this->assertInstanceOf('stdClass', $v);
-                    break;
-                case 2:
-                    $this->assertEquals('k1', $k);
-                    $this->assertEquals(array('foo' => 'bar'), $v);
-                    break;
-                case 3:
-                    $this->assertEquals(2, $k);
-                    $this->assertTrue($v);
-                    break;
-                case 4:
                     $this->assertEquals('k2', $k);
-                    $this->assertInstanceOf('\Symfony_DI_PhpDumper_Test_Lazy_Argument_Provide_Generator', $v);
+                    $this->assertInstanceOf('Symfony_DI_PhpDumper_Test_Lazy_Argument_Provide_Generator', $v);
                     break;
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -134,7 +134,7 @@ $container
 ;
 $container
     ->register('lazy_context', 'LazyContext')
-    ->setArguments(array(new IteratorArgument(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%'), true, new Reference('service_container')))))
+    ->setArguments(array(new IteratorArgument(array('k1' => new Reference('foo.baz'), 'k2' => new Reference('service_container')))))
 ;
 $container
     ->register('lazy_context_ignore_invalid_ref', 'LazyContext')

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -321,12 +321,9 @@ class ProjectServiceContainer extends Container
     protected function getLazyContextService()
     {
         return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function () {
-            yield 0 => 'foo';
-            yield 1 => ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
-            yield 2 => array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo').'', 'foobar' => $this->getParameter('foo'));
-            yield 3 => true;
-            yield 4 => $this;
-        }, 5));
+            yield 'k1' => ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
+            yield 'k2' => $this;
+        }, 2));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -328,12 +328,9 @@ class ProjectServiceContainer extends Container
     protected function getLazyContextService()
     {
         return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function () {
-            yield 0 => 'foo';
-            yield 1 => ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
-            yield 2 => array('bar' => 'foo is bar', 'foobar' => 'bar');
-            yield 3 => true;
-            yield 4 => $this;
-        }, 5));
+            yield 'k1' => ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
+            yield 'k2' => $this;
+        }, 2));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -118,14 +118,8 @@
     </service>
     <service id="lazy_context" class="LazyContext">
       <argument type="iterator">
-        <argument>foo</argument>
-        <argument type="service" id="foo.baz"/>
-        <argument type="collection">
-          <argument key="%foo%">foo is %foo%</argument>
-          <argument key="foobar">%foo%</argument>
-        </argument>
-        <argument>true</argument>
-        <argument type="service" id="service_container"/>
+        <argument key="k1" type="service" id="foo.baz"/>
+        <argument key="k2" type="service" id="service_container"/>
       </argument>
     </service>
     <service id="lazy_context_ignore_invalid_ref" class="LazyContext">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -112,7 +112,7 @@ services:
         factory: ['@factory_simple', getInstance]
     lazy_context:
         class: LazyContext
-        arguments: [!iterator [foo, '@foo.baz', { '%foo%': 'foo is %foo%', foobar: '%foo%' }, true, '@service_container']]
+        arguments: [!iterator {'k1': '@foo.baz', 'k2': '@service_container'}]
     lazy_context_ignore_invalid_ref:
         class: LazyContext
         arguments: [!iterator ['@foo.baz', '@?invalid']]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -273,7 +273,7 @@ class XmlFileLoaderTest extends TestCase
 
         $lazyDefinition = $container->getDefinition('lazy_context');
 
-        $this->assertEquals(array(new IteratorArgument(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%'), true, new Reference('service_container')))), $lazyDefinition->getArguments(), '->load() parses lazy arguments');
+        $this->assertEquals(array(new IteratorArgument(array('k1' => new Reference('foo.baz'), 'k2' => new Reference('service_container')))), $lazyDefinition->getArguments(), '->load() parses lazy arguments');
     }
 
     public function testParsesTags()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -346,7 +346,7 @@ class YamlFileLoaderTest extends TestCase
 
         $lazyDefinition = $container->getDefinition('lazy_context');
 
-        $this->assertEquals(array(new IteratorArgument(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%'), true, new Reference('service_container')))), $lazyDefinition->getArguments(), '->load() parses lazy arguments');
+        $this->assertEquals(array(new IteratorArgument(array('k1' => new Reference('foo.baz'), 'k2' => new Reference('service_container')))), $lazyDefinition->getArguments(), '->load() parses lazy arguments');
     }
 
     public function testAutowire()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

`Reference` found in `ArgumentInterface::getValue()` are currently not inlined.
While trying to do so (hint: I failed), I noticed that the current code is broken for `IteratorArgument` which can contain anonymous `Definition` for now, which are then not inlined correctly.

This PR restricts `IteratorArgument` to arrays of `Reference`, and improves a few related things found while doing it.

(fabbot failure is false positive)