### PR TITLE
[DotEnv] Don't override existing $_SERVER vars

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -67,7 +67,7 @@ final class Dotenv
     public function populate($values)
     {
         foreach ($values as $name => $value) {
-            if (isset($_ENV[$name]) || false !== getenv($name)) {
+            if (isset($_ENV[$name]) || isset($_SERVER[$name]) || false !== getenv($name)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -157,21 +157,21 @@ class DotenvTest extends TestCase
 
     public function testServerSuperglobalIsNotOverriden()
     {
-        $baseValue = $_SERVER['argc'];
+        $originalValue = $_SERVER['argc'];
 
         $dotenv = new DotEnv();
-        $dotenv->populate(array('argc' => 'whatever'));
+        $dotenv->populate(array('argc' => 'newValue'));
 
-        $this->assertSame($baseValue, $_SERVER['argc']);
+        $this->assertSame($originalValue, $_SERVER['argc']);
     }
 
     public function testEnvVarIsNotOverriden()
     {
-        putenv('TEST_ENV_VAR=test_var');
+        putenv('TEST_ENV_VAR=original_value');
 
         $dotenv = new DotEnv();
-        $dotenv->populate(array('TEST_ENV_VAR' => 'whatever'));
+        $dotenv->populate(array('TEST_ENV_VAR' => 'new_value'));
 
-        $this->assertSame('test_var', getenv('TEST_ENV_VAR'));
+        $this->assertSame('original_value', getenv('TEST_ENV_VAR'));
     }
 }

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -160,7 +160,7 @@ class DotenvTest extends TestCase
         $originalValue = $_SERVER['argc'];
 
         $dotenv = new DotEnv();
-        $dotenv->populate(array('argc' => 'newValue'));
+        $dotenv->populate(array('argc' => 'new_value'));
 
         $this->assertSame($originalValue, $_SERVER['argc']);
     }

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -154,4 +154,24 @@ class DotenvTest extends TestCase
         $dotenv = new Dotenv();
         $dotenv->load(__DIR__);
     }
+
+    public function testServerSuperglobalIsNotOverriden()
+    {
+        $baseValue = $_SERVER['argc'];
+
+        $dotenv = new DotEnv();
+        $dotenv->populate(array('argc' => 'whatever'));
+
+        $this->assertSame($baseValue, $_SERVER['argc']);
+    }
+
+    public function testEnvVarIsNotOverriden()
+    {
+        putenv('TEST_ENV_VAR=test_var');
+
+        $dotenv = new DotEnv();
+        $dotenv->populate(array('TEST_ENV_VAR' => 'whatever'));
+
+        $this->assertSame('test_var', getenv('TEST_ENV_VAR'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22493
| License       | MIT
| Doc PR        | ~

As of #22493 I decided to make a PR in order to add a specific test just for this behavior and make sure we never touch `$_SERVER` predefined variables.