### PR TITLE
Fix Framework UPGRADE notice about trusted proxies

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -165,7 +165,7 @@ FrameworkBundle
 
  * The `cache:clear` command should always be called with the `--no-warmup` option.
    Warmup should be done via the `cache:warmup` command.
-   
+
  * The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies"
    parameter have been removed. Use the Request::setTrustedProxies() method in your front controller instead.
 

--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -166,7 +166,7 @@ FrameworkBundle
  * The `cache:clear` command should always be called with the `--no-warmup` option.
    Warmup should be done via the `cache:warmup` command.
 
- * The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies"
+ * [BC BREAK] The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies"
    parameter have been removed. Use the Request::setTrustedProxies() method in your front controller instead.
 
  * Not defining the `type` option of the `framework.workflows.*` configuration entries is deprecated.

--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -165,8 +165,9 @@ FrameworkBundle
 
  * The `cache:clear` command should always be called with the `--no-warmup` option.
    Warmup should be done via the `cache:warmup` command.
-
- * The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies" parameter have been deprecated and will be removed in 4.0. Use the Request::setTrustedProxies() method in your front controller instead.
+   
+ * The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies"
+   parameter have been removed. Use the Request::setTrustedProxies() method in your front controller instead.
 
  * Not defining the `type` option of the `framework.workflows.*` configuration entries is deprecated.
    The default value will be `state_machine` in Symfony 4.0.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22506
| License       | MIT
| Doc PR        | 

The `framework.trusted_proxies` configuration is not really removed (it gives an error) but that's only to help with the upgrade process. So I think mentioning it's removed is enough.