### PR TITLE
[DIC][3.3] ServiceLocator generated with invalid callable

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/ClosureProxyArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ClosureProxyArgument.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Argument;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -41,6 +42,9 @@ class ClosureProxyArgument implements ArgumentInterface
      */
     public function setValues(array $values)
     {
+        if (!$values[0] instanceof Reference) {
+            throw new InvalidArgumentException(sprintf('A ClosureProxyArgument must hold a Reference, "%s" given.', is_object($values[0]) ? get_class($values[0]) : gettype($values[0])));
+        }
         list($this->reference, $this->method) = $values;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -58,7 +58,6 @@ class PhpDumper extends Dumper
 
     private $inlinedDefinitions;
     private $definitionVariables;
-    private $referenceVariables;
     private $variableCount;
     private $reservedVariables = array('instance', 'class');
     private $expressionLanguage;
@@ -197,55 +196,6 @@ class PhpDumper extends Dumper
         }
 
         return $this->proxyDumper;
-    }
-
-    /**
-     * Generates Service local temp variables.
-     *
-     * @param string     $cId
-     * @param Definition $definition
-     * @param array      $inlinedDefinitions
-     *
-     * @return string
-     */
-    private function addServiceLocalTempVariables($cId, Definition $definition, array $inlinedDefinitions)
-    {
-        static $template = "        \$%s = %s;\n";
-
-        array_unshift($inlinedDefinitions, $definition);
-
-        $calls = $behavior = array();
-        foreach ($inlinedDefinitions as $iDefinition) {
-            $this->getServiceCallsFromArguments($iDefinition->getArguments(), $calls, $behavior);
-            $this->getServiceCallsFromArguments($iDefinition->getMethodCalls(), $calls, $behavior);
-            $this->getServiceCallsFromArguments($iDefinition->getProperties(), $calls, $behavior);
-            $this->getServiceCallsFromArguments(array($iDefinition->getConfigurator()), $calls, $behavior);
-            $this->getServiceCallsFromArguments(array($iDefinition->getFactory()), $calls, $behavior);
-        }
-
-        $code = '';
-        foreach ($calls as $id => $callCount) {
-            if ('service_container' === $id || $id === $cId) {
-                continue;
-            }
-
-            if ($callCount > 1) {
-                $name = $this->getNextVariableName();
-                $this->referenceVariables[$id] = new Variable($name);
-
-                if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE === $behavior[$id]) {
-                    $code .= sprintf($template, $name, $this->getServiceCall($id));
-                } else {
-                    $code .= sprintf($template, $name, $this->getServiceCall($id, new Reference($id, ContainerInterface::NULL_ON_INVALID_REFERENCE)));
-                }
-            }
-        }
-
-        if ('' !== $code) {
-            $code .= "\n";
-        }
-
-        return $code;
     }
 
     /**
@@ -508,8 +458,6 @@ class PhpDumper extends Dumper
      */
     private function addServiceInlinedDefinitionsSetup($id, array $inlinedDefinitions, $isSimpleInstance)
     {
-        $this->referenceVariables[$id] = new Variable('instance');
-
         $code = '';
         $processed = new \SplObjectStorage();
         foreach ($inlinedDefinitions as $iDefinition) {
@@ -592,7 +540,6 @@ class PhpDumper extends Dumper
             return '';
         }
         $this->definitionVariables = new \SplObjectStorage();
-        $this->referenceVariables = array();
         $this->variableCount = 0;
 
         $return = array();
@@ -687,7 +634,6 @@ EOF;
 
         $code .=
             $this->addServiceInclude($id, $definition, $inlinedDefinitions).
-            $this->addServiceLocalTempVariables($id, $definition, $inlinedDefinitions).
             $this->addServiceInlinedDefinitions($id, $inlinedDefinitions).
             $this->addServiceInstance($id, $definition, $isSimpleInstance).
             $this->addServiceInlinedDefinitionsSetup($id, $inlinedDefinitions, $isSimpleInstance).
@@ -698,7 +644,6 @@ EOF;
         ;
 
         $this->definitionVariables = null;
-        $this->referenceVariables = null;
 
         return $code;
     }
@@ -1415,17 +1360,12 @@ EOF;
             $code = $this->dumpValue($value, $interpolate);
 
             if ($value instanceof TypedReference) {
-                $return = sprintf('$f = function (\\%s $v%s) { return $v; }; return $f(%s);', $value->getType(), ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $value->getInvalidBehavior() ? ' = null' : '', $code);
+                $code = sprintf('$f = function (\\%s $v%s) { return $v; }; return $f(%s);', $value->getType(), ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $value->getInvalidBehavior() ? ' = null' : '', $code);
             } else {
-                $return = sprintf('return %s;', $code);
+                $code = sprintf('return %s;', $code);
             }
 
-            // dealing with a reference that needs to be imported into the callable scope
-            if (preg_match('/^\$[a-z]+$/', $code)) {
-                return sprintf("function () use (%s) {\n            %s\n        }", $code, $return);
-            }
-
-            return sprintf("function () {\n            %s\n        }", $return);
+            return sprintf("function () {\n            %s\n        }", $code);
         } elseif ($value instanceof IteratorArgument) {
             $countCode = array();
             $countCode[] = 'function () {';
@@ -1528,10 +1468,6 @@ EOF;
         } elseif ($value instanceof Variable) {
             return '$'.$value;
         } elseif ($value instanceof Reference) {
-            if (null !== $this->referenceVariables && isset($this->referenceVariables[$id = (string) $value])) {
-                return $this->dumpValue($this->referenceVariables[$id], $interpolate);
-            }
-
             return $this->getServiceCall((string) $value, $value);
         } elseif ($value instanceof Expression) {
             return $this->getExpressionLanguage()->compile((string) $value, array('this' => 'container'));

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
-use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -568,8 +567,6 @@ class PhpDumperTest extends TestCase
             ->addArgument(new Reference('translator.loader_3_locator'))
             ->addMethodCall('addResource', array('db', new Reference('translator.loader_3'), 'nl'))
             ->addMethodCall('addResource', array('db', new Reference('translator.loader_3'), 'en'));
-
-
 
         $nil->setValues(array(null));
         $container->register('bar_service', 'stdClass')->setArguments(array(new Reference('baz_service')));

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\MethodCallClass;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -533,6 +534,20 @@ class PhpDumperTest extends TestCase
                 'nil' => $nil = new ServiceClosureArgument(new Reference('nil')),
             ))
         ;
+
+        $container->register('method_call_class', MethodCallClass::class);
+
+        // 1 callable method
+        $container->register('service_locator_with_inline_reference_1', ServiceLocator::class)
+            ->addArgument(array('method_call_class' => new ServiceClosureArgument(new Reference('method_call_class'))))
+            ->addMethodCall('callableMethod', array('a', new Reference('method_call_class')));
+
+        // 2 callable methods
+        $container->register('service_locator_with_inline_reference_2', ServiceLocator::class)
+            ->addArgument(array('method_call_class' => new ServiceClosureArgument(new Reference('method_call_class'))))
+            ->addMethodCall('callableMethod', array('a', new Reference('method_call_class')))
+            ->addMethodCall('callableMethod', array('b', new Reference('method_call_class')));
+
         $nil->setValues(array(null));
         $container->register('bar_service', 'stdClass')->setArguments(array(new Reference('baz_service')));
         $container->register('baz_service', 'stdClass')->setPublic(false);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/MethodCallClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/MethodCallClass.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+/**
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+class MethodCallClass
+{
+    public function callableMethod()
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StubbedTranslator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StubbedTranslator.php
@@ -11,12 +11,19 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
+use Psr\Container\ContainerInterface;
+
 /**
  * @author Iltar van der Berg <kjarli@gmail.com>
  */
-class MethodCallClass
+class StubbedTranslator
 {
-    public function callableMethod()
+    public function __construct(ContainerInterface $container)
+    {
+
+    }
+
+    public function addResource($format, $resource, $locale, $domain = null)
     {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -83,11 +83,9 @@ class ProjectServiceContainer extends Container
      */
     protected function getBarService()
     {
-        $a = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
+        $this->services['bar'] = $instance = new \Bar\FooClass('foo', ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}, $this->getParameter('foo_bar'));
 
-        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
-
-        $a->configure($instance);
+        ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}->configure($instance);
 
         return $instance;
     }
@@ -250,12 +248,10 @@ class ProjectServiceContainer extends Container
      */
     protected function getFooService()
     {
-        $a = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
-
-        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo').'', 'foobar' => $this->getParameter('foo')), true, $this);
+        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}, array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo').'', 'foobar' => $this->getParameter('foo')), true, $this);
 
         $instance->foo = 'bar';
-        $instance->moo = $a;
+        $instance->moo = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
         $instance->qux = array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo').'', 'foobar' => $this->getParameter('foo'));
         $instance->setBar(${($_ = isset($this->services['bar']) ? $this->services['bar'] : $this->get('bar')) && false ?: '_'});
         $instance->initialize();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -93,11 +93,9 @@ class ProjectServiceContainer extends Container
      */
     protected function getBarService()
     {
-        $a = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
+        $this->services['bar'] = $instance = new \Bar\FooClass('foo', ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}, $this->getParameter('foo_bar'));
 
-        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
-
-        $a->configure($instance);
+        ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}->configure($instance);
 
         return $instance;
     }
@@ -250,12 +248,10 @@ class ProjectServiceContainer extends Container
      */
     protected function getFooService()
     {
-        $a = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
-
-        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array('bar' => 'foo is bar', 'foobar' => 'bar'), true, $this);
+        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}, array('bar' => 'foo is bar', 'foobar' => 'bar'), true, $this);
 
         $instance->foo = 'bar';
-        $instance->moo = $a;
+        $instance->moo = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
         $instance->qux = array('bar' => 'foo is bar', 'foobar' => 'bar');
         $instance->setBar(${($_ = isset($this->services['bar']) ? $this->services['bar'] : $this->get('bar')) && false ?: '_'});
         $instance->initialize();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -31,6 +31,9 @@ class ProjectServiceContainer extends Container
             'bar_service' => 'getBarServiceService',
             'baz_service' => 'getBazServiceService',
             'foo_service' => 'getFooServiceService',
+            'method_call_class' => 'getMethodCallClassService',
+            'service_locator_with_inline_reference_1' => 'getServiceLocatorWithInlineReference1Service',
+            'service_locator_with_inline_reference_2' => 'getServiceLocatorWithInlineReference2Service',
         );
         $this->privates = array(
             'baz_service' => true,
@@ -95,6 +98,60 @@ class ProjectServiceContainer extends Container
         }, 'nil' => function () {
             return NULL;
         }));
+    }
+
+    /**
+     * Gets the 'method_call_class' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\MethodCallClass A Symfony\Component\DependencyInjection\Tests\Fixtures\MethodCallClass instance
+     */
+    protected function getMethodCallClassService()
+    {
+        return $this->services['method_call_class'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\MethodCallClass();
+    }
+
+    /**
+     * Gets the 'service_locator_with_inline_reference_1' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\ServiceLocator A Symfony\Component\DependencyInjection\ServiceLocator instance
+     */
+    protected function getServiceLocatorWithInlineReference1Service()
+    {
+        $this->services['service_locator_with_inline_reference_1'] = $instance = new \Symfony\Component\DependencyInjection\ServiceLocator(array('method_call_class' => function () {
+            return ${($_ = isset($this->services['method_call_class']) ? $this->services['method_call_class'] : $this->get('method_call_class')) && false ?: '_'};
+        }));
+
+        $instance->callableMethod('a', ${($_ = isset($this->services['method_call_class']) ? $this->services['method_call_class'] : $this->get('method_call_class')) && false ?: '_'});
+
+        return $instance;
+    }
+
+    /**
+     * Gets the 'service_locator_with_inline_reference_2' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\ServiceLocator A Symfony\Component\DependencyInjection\ServiceLocator instance
+     */
+    protected function getServiceLocatorWithInlineReference2Service()
+    {
+        $a = ${($_ = isset($this->services['method_call_class']) ? $this->services['method_call_class'] : $this->get('method_call_class')) && false ?: '_'};
+
+        $this->services['service_locator_with_inline_reference_2'] = $instance = new \Symfony\Component\DependencyInjection\ServiceLocator(array('method_call_class' => function () use ($a) {
+            return $a;
+        }));
+
+        $instance->callableMethod('a', $a);
+        $instance->callableMethod('b', $a);
+
+        return $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -186,14 +186,12 @@ class ProjectServiceContainer extends Container
      */
     protected function getTranslator3Service()
     {
-        $a = ${($_ = isset($this->services['translator.loader_3']) ? $this->services['translator.loader_3'] : $this->get('translator.loader_3')) && false ?: '_'};
-
-        $this->services['translator_3'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(array('translator.loader_3' => function () use ($a) {
-            return $a;
+        $this->services['translator_3'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(array('translator.loader_3' => function () {
+            return ${($_ = isset($this->services['translator.loader_3']) ? $this->services['translator.loader_3'] : $this->get('translator.loader_3')) && false ?: '_'};
         })));
 
-        $instance->addResource('db', $a, 'nl');
-        $instance->addResource('db', $a, 'en');
+        $instance->addResource('db', ${($_ = isset($this->services['translator.loader_3']) ? $this->services['translator.loader_3'] : $this->get('translator.loader_3')) && false ?: '_'}, 'nl');
+        $instance->addResource('db', ${($_ = isset($this->services['translator.loader_3']) ? $this->services['translator.loader_3'] : $this->get('translator.loader_3')) && false ?: '_'}, 'en');
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -31,9 +31,12 @@ class ProjectServiceContainer extends Container
             'bar_service' => 'getBarServiceService',
             'baz_service' => 'getBazServiceService',
             'foo_service' => 'getFooServiceService',
-            'method_call_class' => 'getMethodCallClassService',
-            'service_locator_with_inline_reference_1' => 'getServiceLocatorWithInlineReference1Service',
-            'service_locator_with_inline_reference_2' => 'getServiceLocatorWithInlineReference2Service',
+            'translator.loader_1' => 'getTranslator_Loader1Service',
+            'translator.loader_2' => 'getTranslator_Loader2Service',
+            'translator.loader_3' => 'getTranslator_Loader3Service',
+            'translator_1' => 'getTranslator1Service',
+            'translator_2' => 'getTranslator2Service',
+            'translator_3' => 'getTranslator3Service',
         );
         $this->privates = array(
             'baz_service' => true,
@@ -101,55 +104,96 @@ class ProjectServiceContainer extends Container
     }
 
     /**
-     * Gets the 'method_call_class' service.
+     * Gets the 'translator.loader_1' service.
      *
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\MethodCallClass A Symfony\Component\DependencyInjection\Tests\Fixtures\MethodCallClass instance
+     * @return \stdClass A stdClass instance
      */
-    protected function getMethodCallClassService()
+    protected function getTranslator_Loader1Service()
     {
-        return $this->services['method_call_class'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\MethodCallClass();
+        return $this->services['translator.loader_1'] = new \stdClass();
     }
 
     /**
-     * Gets the 'service_locator_with_inline_reference_1' service.
+     * Gets the 'translator.loader_2' service.
      *
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return \Symfony\Component\DependencyInjection\ServiceLocator A Symfony\Component\DependencyInjection\ServiceLocator instance
+     * @return \stdClass A stdClass instance
      */
-    protected function getServiceLocatorWithInlineReference1Service()
+    protected function getTranslator_Loader2Service()
     {
-        $this->services['service_locator_with_inline_reference_1'] = $instance = new \Symfony\Component\DependencyInjection\ServiceLocator(array('method_call_class' => function () {
-            return ${($_ = isset($this->services['method_call_class']) ? $this->services['method_call_class'] : $this->get('method_call_class')) && false ?: '_'};
-        }));
+        return $this->services['translator.loader_2'] = new \stdClass();
+    }
 
-        $instance->callableMethod('a', ${($_ = isset($this->services['method_call_class']) ? $this->services['method_call_class'] : $this->get('method_call_class')) && false ?: '_'});
+    /**
+     * Gets the 'translator.loader_3' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getTranslator_Loader3Service()
+    {
+        return $this->services['translator.loader_3'] = new \stdClass();
+    }
+
+    /**
+     * Gets the 'translator_1' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator A Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator instance
+     */
+    protected function getTranslator1Service()
+    {
+        return $this->services['translator_1'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(array('translator.loader_1' => function () {
+            return ${($_ = isset($this->services['translator.loader_1']) ? $this->services['translator.loader_1'] : $this->get('translator.loader_1')) && false ?: '_'};
+        })));
+    }
+
+    /**
+     * Gets the 'translator_2' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator A Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator instance
+     */
+    protected function getTranslator2Service()
+    {
+        $this->services['translator_2'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(array('translator.loader_2' => function () {
+            return ${($_ = isset($this->services['translator.loader_2']) ? $this->services['translator.loader_2'] : $this->get('translator.loader_2')) && false ?: '_'};
+        })));
+
+        $instance->addResource('db', ${($_ = isset($this->services['translator.loader_2']) ? $this->services['translator.loader_2'] : $this->get('translator.loader_2')) && false ?: '_'}, 'nl');
 
         return $instance;
     }
 
     /**
-     * Gets the 'service_locator_with_inline_reference_2' service.
+     * Gets the 'translator_3' service.
      *
      * This service is shared.
      * This method always returns the same instance of the service.
      *
-     * @return \Symfony\Component\DependencyInjection\ServiceLocator A Symfony\Component\DependencyInjection\ServiceLocator instance
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator A Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator instance
      */
-    protected function getServiceLocatorWithInlineReference2Service()
+    protected function getTranslator3Service()
     {
-        $a = ${($_ = isset($this->services['method_call_class']) ? $this->services['method_call_class'] : $this->get('method_call_class')) && false ?: '_'};
+        $a = ${($_ = isset($this->services['translator.loader_3']) ? $this->services['translator.loader_3'] : $this->get('translator.loader_3')) && false ?: '_'};
 
-        $this->services['service_locator_with_inline_reference_2'] = $instance = new \Symfony\Component\DependencyInjection\ServiceLocator(array('method_call_class' => function () use ($a) {
+        $this->services['translator_3'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(array('translator.loader_3' => function () use ($a) {
             return $a;
-        }));
+        })));
 
-        $instance->callableMethod('a', $a);
-        $instance->callableMethod('b', $a);
+        $instance->addResource('db', $a, 'nl');
+        $instance->addResource('db', $a, 'en');
 
         return $instance;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Currently, when having a service definition which has more than 1 usage of that service, it will put the argument in `$a` for example. By doing so, it will also use `$a` in the callable of the `ServiceLocator`, which result in an undefined variable `$a`.

I managed to trigger this with the translator service, where I have my own loader, that I add for NL and EN, causing 2 method calls to turn the direct getter into a variable. I've added 2 test cases, 1 with only 1 method call and 1 with 2 method calls.

I'm not sure if this is the correct solution, but this managed to make my application work again with 3.3.

ping @nicolas-grekas 