### PR TITLE
[Asset] Preventing the base path or absolute URL from being prefixed incorrectly

### DIFF
--- a/src/Symfony/Component/Asset/PathPackage.php
+++ b/src/Symfony/Component/Asset/PathPackage.php
@@ -56,7 +56,13 @@ class PathPackage extends Package
             return $path;
         }
 
-        return $this->getBasePath().ltrim($this->getVersionStrategy()->applyVersion($path), '/');
+        $versionedPath = $this->getVersionStrategy()->applyVersion($path);
+
+        if ($this->isAbsoluteUrl($versionedPath)) {
+            return $versionedPath;
+        }
+
+        return $this->getBasePath().ltrim($versionedPath, '/');
     }
 
     /**

--- a/src/Symfony/Component/Asset/Tests/PathPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PathPackageTest.php
@@ -75,6 +75,17 @@ class PathPackageTest extends TestCase
         );
     }
 
+    public function testVersionStrategyGivesAbsoluteURL()
+    {
+        $versionStrategy = $this->getMockBuilder('Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface')->getMock();
+        $versionStrategy->expects($this->any())
+            ->method('applyVersion')
+            ->willReturn('https://cdn.com/bar/main.css');
+        $package = new PathPackage('/subdirectory', $versionStrategy, $this->getContext('/bar'));
+
+        $this->assertEquals('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
+    }
+
     private function getContext($basePath)
     {
         $context = $this->getMockBuilder('Symfony\Component\Asset\Context\ContextInterface')->getMock();

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -77,6 +77,17 @@ class UrlPackageTest extends TestCase
         );
     }
 
+    public function testVersionStrategyGivesAbsoluteURL()
+    {
+        $versionStrategy = $this->getMockBuilder('Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface')->getMock();
+        $versionStrategy->expects($this->any())
+            ->method('applyVersion')
+            ->willReturn('https://cdn.com/bar/main.css');
+        $package = new UrlPackage('https://example.com', $versionStrategy);
+
+        $this->assertEquals('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
+    }
+
     /**
      * @expectedException \Symfony\Component\Asset\Exception\LogicException
      */

--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -81,6 +81,10 @@ class UrlPackage extends Package
 
         $url = $this->getVersionStrategy()->applyVersion($path);
 
+        if ($this->isAbsoluteUrl($url)) {
+            return $url;
+        }
+
         if ($url && '/' != $url[0]) {
             $url = '/'.$url;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Fixes an edge case (which I need) where the version strategy returns an absolute URL. Currently, if this happens, the baseUrl or basePath is prefixed - giving `https://baseurl.com/https://pathreturnedfromversioning.com` or `/basePath/https://pathreturnedfromversioning.com`.

I don't see any reason to prevent an absolute URL from being returned by the version strategy. And it's not a BC break, because the previous paths that were returned were nonsense.

Cheers!