### PR TITLE
[Asset] Starting slash should indicate no basePath wanted

### DIFF
--- a/src/Symfony/Component/Asset/PathPackage.php
+++ b/src/Symfony/Component/Asset/PathPackage.php
@@ -58,7 +58,8 @@ class PathPackage extends Package
 
         $versionedPath = $this->getVersionStrategy()->applyVersion($path);
 
-        if ($this->isAbsoluteUrl($versionedPath) || 0 === strpos($versionedPath, '/')) {
+        // if absolute or begins with /, we're done
+        if ($this->isAbsoluteUrl($versionedPath) || ($versionedPath && '/' === $versionedPath[0])) {
             return $versionedPath;
         }
 

--- a/src/Symfony/Component/Asset/PathPackage.php
+++ b/src/Symfony/Component/Asset/PathPackage.php
@@ -58,7 +58,7 @@ class PathPackage extends Package
 
         $versionedPath = $this->getVersionStrategy()->applyVersion($path);
 
-        if ($this->isAbsoluteUrl($versionedPath)) {
+        if ($this->isAbsoluteUrl($versionedPath) || '/' === substr($versionedPath, 0, 1)) {
             return $versionedPath;
         }
 

--- a/src/Symfony/Component/Asset/PathPackage.php
+++ b/src/Symfony/Component/Asset/PathPackage.php
@@ -58,7 +58,7 @@ class PathPackage extends Package
 
         $versionedPath = $this->getVersionStrategy()->applyVersion($path);
 
-        if ($this->isAbsoluteUrl($versionedPath) || '/' === substr($versionedPath, 0, 1)) {
+        if ($this->isAbsoluteUrl($versionedPath) || 0 === strpos($versionedPath, '/')) {
             return $versionedPath;
         }
 

--- a/src/Symfony/Component/Asset/Tests/PathPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PathPackageTest.php
@@ -35,16 +35,16 @@ class PathPackageTest extends TestCase
 
             array('', '', '/foo', '/foo?v1'),
 
-            array('/foo', '', '/foo', '/foo/foo?v1'),
-            array('/foo', '', 'foo', '/foo/foo?v1'),
-            array('foo', '', 'foo', '/foo/foo?v1'),
-            array('foo/', '', 'foo', '/foo/foo?v1'),
-            array('/foo/', '', 'foo', '/foo/foo?v1'),
+            array('/foo', '', '/bar', '/foo/bar?v1'),
+            array('/foo', '', 'bar', '/foo/bar?v1'),
+            array('foo', '', 'bar', '/foo/bar?v1'),
+            array('foo/', '', 'bar', '/foo/bar?v1'),
+            array('/foo/', '', 'bar', '/foo/bar?v1'),
 
-            array('/foo', 'version-%2$s/%1$s', '/foo', '/foo/version-v1/foo'),
-            array('/foo', 'version-%2$s/%1$s', 'foo', '/foo/version-v1/foo'),
-            array('/foo', 'version-%2$s/%1$s', 'foo/', '/foo/version-v1/foo/'),
-            array('/foo', 'version-%2$s/%1$s', '/foo/', '/foo/version-v1/foo/'),
+            array('/foo', 'version-%2$s/%1$s', '/bar', '/foo/version-v1/bar'),
+            array('/foo', 'version-%2$s/%1$s', 'bar', '/foo/version-v1/bar'),
+            array('/foo', 'version-%2$s/%1$s', 'bar/', '/foo/version-v1/bar/'),
+            array('/foo', 'version-%2$s/%1$s', '/bar/', '/foo/version-v1/bar/'),
         );
     }
 
@@ -61,17 +61,17 @@ class PathPackageTest extends TestCase
     public function getContextConfigs()
     {
         return array(
-            array('', '/foo', '', '/foo', '/foo/foo?v1'),
-            array('', '/foo', '', 'foo', '/foo/foo?v1'),
-            array('', 'foo', '', 'foo', '/foo/foo?v1'),
-            array('', 'foo/', '', 'foo', '/foo/foo?v1'),
-            array('', '/foo/', '', 'foo', '/foo/foo?v1'),
+            array('', '/foo', '', '/baz', '/foo/baz?v1'),
+            array('', '/foo', '', 'baz', '/foo/baz?v1'),
+            array('', 'foo', '', 'baz', '/foo/baz?v1'),
+            array('', 'foo/', '', 'baz', '/foo/baz?v1'),
+            array('', '/foo/', '', 'baz', '/foo/baz?v1'),
 
-            array('/bar', '/foo', '', '/foo', '/bar/foo/foo?v1'),
-            array('/bar', '/foo', '', 'foo', '/bar/foo/foo?v1'),
-            array('/bar', 'foo', '', 'foo', '/bar/foo/foo?v1'),
-            array('/bar', 'foo/', '', 'foo', '/bar/foo/foo?v1'),
-            array('/bar', '/foo/', '', 'foo', '/bar/foo/foo?v1'),
+            array('/bar', '/foo', '', '/baz', '/bar/foo/baz?v1'),
+            array('/bar', '/foo', '', 'baz', '/bar/foo/baz?v1'),
+            array('/bar', 'foo', '', 'baz', '/bar/foo/baz?v1'),
+            array('/bar', 'foo/', '', 'baz', '/bar/foo/baz?v1'),
+            array('/bar', '/foo/', '', 'baz', '/bar/foo/baz?v1'),
         );
     }
 

--- a/src/Symfony/Component/Asset/Tests/PathPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PathPackageTest.php
@@ -35,16 +35,16 @@ class PathPackageTest extends TestCase
 
             array('', '', '/foo', '/foo?v1'),
 
-            array('/foo', '', '/bar', '/foo/bar?v1'),
+            array('/foo', '', '/bar', '/bar?v1'),
             array('/foo', '', 'bar', '/foo/bar?v1'),
             array('foo', '', 'bar', '/foo/bar?v1'),
             array('foo/', '', 'bar', '/foo/bar?v1'),
             array('/foo/', '', 'bar', '/foo/bar?v1'),
 
-            array('/foo', 'version-%2$s/%1$s', '/bar', '/foo/version-v1/bar'),
+            array('/foo', 'version-%2$s/%1$s', '/bar', '/version-v1/bar'),
             array('/foo', 'version-%2$s/%1$s', 'bar', '/foo/version-v1/bar'),
             array('/foo', 'version-%2$s/%1$s', 'bar/', '/foo/version-v1/bar/'),
-            array('/foo', 'version-%2$s/%1$s', '/bar/', '/foo/version-v1/bar/'),
+            array('/foo', 'version-%2$s/%1$s', '/bar/', '/version-v1/bar/'),
         );
     }
 
@@ -61,13 +61,13 @@ class PathPackageTest extends TestCase
     public function getContextConfigs()
     {
         return array(
-            array('', '/foo', '', '/baz', '/foo/baz?v1'),
+            array('', '/foo', '', '/baz', '/baz?v1'),
             array('', '/foo', '', 'baz', '/foo/baz?v1'),
             array('', 'foo', '', 'baz', '/foo/baz?v1'),
             array('', 'foo/', '', 'baz', '/foo/baz?v1'),
             array('', '/foo/', '', 'baz', '/foo/baz?v1'),
 
-            array('/bar', '/foo', '', '/baz', '/bar/foo/baz?v1'),
+            array('/bar', '/foo', '', '/baz', '/baz?v1'),
             array('/bar', '/foo', '', 'baz', '/bar/foo/baz?v1'),
             array('/bar', 'foo', '', 'baz', '/bar/foo/baz?v1'),
             array('/bar', 'foo/', '', 'baz', '/bar/foo/baz?v1'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes-ish... and no-ish
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

**Important** View the second commit for an accurate diff. The first commit just renames some strings in a test for clarity.

When we moved `PathPackage` from `Templating` to `Asset`, we actually changed its behavior. Assume that we're deployed under a `/subdir` subdirectory:

**Before** `{{ asset('/main.css') }}` would *not* have the base path prefixed -> `/main.css`

**After** `{{ asset('/main.css') }}` *does* have the base path prefixed -> `/subdir/main.css`

https://github.com/symfony/symfony/blob/3adff11d729ccdfc4eb4b189417ec04491c6eaad/src/Symfony/Component/Templating/Asset/PathPackage.php#L61-L63

This PR simply reverses that, to the *previous* behavior. This *is* a BC break... and also arguably a bug fix :). Interestingly, when we changed the behavior the first time (i.e. broke BC), I don't think that anyone noticed. It should only affect users deployed under a subdirectory.

Why do I care? I'm using the new `JsonManifestVersionStrategy` with a library that is outputting paths that *already* include my subdirectory:

```json
{
    "build/main.css": "/subdir/build/main.abc123.css"
}
```

So, I do not want Symfony to detect the `/subdir` and apply it a second time.
