### PR TITLE
Throwing an exception if the class is not found

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -103,8 +103,9 @@ abstract class FileLoader extends BaseFileLoader
             if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+$/', $class)) {
                 continue;
             }
+            // check to make sure the expected class exists
             if (!$r = $this->container->getReflectionClass($class, true)) {
-                continue;
+                throw new InvalidArgumentException(sprintf('Expected to find class "%s" in file "%s" while importing services from resource "%s", but it was not found! Check the namespace prefix used with the resource.', $class, $path, $resource));
             }
             if (!$r->isInterface() && !$r->isTrait()) {
                 $classes[] = $class;

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -104,7 +104,7 @@ abstract class FileLoader extends BaseFileLoader
                 continue;
             }
             // check to make sure the expected class exists
-            if (!$r = $this->container->getReflectionClass($class, true)) {
+            if (!$r = $this->container->getReflectionClass($class)) {
                 throw new InvalidArgumentException(sprintf('Expected to find class "%s" in file "%s" while importing services from resource "%s", but it was not found! Check the namespace prefix used with the resource.', $class, $path, $resource));
             }
             if (!$r->isInterface() && !$r->isTrait()) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/MissingParent.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/MissingParent.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
-
-class MissingParent extends NotExistingParent
-{
-}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -86,6 +86,19 @@ class FileLoaderTest extends TestCase
 
         $this->assertTrue($container->has(Bar::class));
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp /Expected to find class "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\Prototype\\Bar" in file ".+" while importing services from resource "Prototype\/Sub\/\*", but it was not found\! Check the namespace prefix used with the resource/
+     */
+    public function testRegisterClassesWithBadPrefix()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        // the Sub is missing from namespace prefix
+        $loader->registerClasses(new Definition(), 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\\', 'Prototype/Sub/*');
+    }
 }
 
 class TestFileLoader extends FileLoader


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

We now throw an exception if the user makes a mistake with their PSR-4 prefix and namespace. For example:

```yml
AppBundle\Controller\:
    resource: '../../src/AppBundle/{Controller}'
    public: true
```

I should not have the `\Controller` at the end of the key. Previously, it would silently not import any services from the directory. Now it throws:

> Expected to find class "AppBundle\Controller\Controller\Admin\BlogController" in file "/path/to/project/src/AppBundle/Controller/Admin/BlogController.php" while importing services from resource "../../src/AppBundle/{Controller}", but it was not found! Check the namespace prefix used with the resource. 

The only "downside" is that this prevents someone from importing files from a resource that has a file with no class in it (`functions.php`). @nicolas-grekas and I decided today that we can throw an exception now to be safe, and see if anyone has that valid use-case.

Cheers!