### PR TITLE
Fix exception "A non-numeric value encountered" in PHP 7.1

### DIFF
--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -140,7 +140,8 @@ abstract class Output implements OutputInterface
     public function write($messages, $newline = false, $options = self::OUTPUT_NORMAL)
     {
         $messages = (array) $messages;
-
+        $options = is_numeric($options) ? (int) $options : 0;
+        
         $types = self::OUTPUT_NORMAL | self::OUTPUT_RAW | self::OUTPUT_PLAIN;
         $type = $types & $options ?: self::OUTPUT_NORMAL;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  |no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Fix exception "A non-numeric value encountered" in PHP 7.1 when variable $options is non numeric, e.g. 'ERROR' from Doctrine\Bundle\DoctrineBundle\Command function execute.
