### PR TITLE
[FrameworkBundle] Do not extend @final SessionListener internally

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/SessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/SessionListener.php
@@ -11,17 +11,33 @@
 
 namespace Symfony\Bundle\FrameworkBundle\EventListener;
 
-use Symfony\Component\HttpKernel\EventListener\SessionListener as BaseSessionListener;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 
-@trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use %s instead.', SessionListener::class, BaseSessionListener::class), E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use Symfony\Component\HttpKernel\EventListener\SessionListener instead.', SessionListener::class), E_USER_DEPRECATED);
 
 /**
  * Sets the session in the request.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @deprecated since version 3.3, to be removed in 4.0. Use {@link BaseSessionListener} instead
+ * @deprecated since version 3.3, to be removed in 4.0. Use Symfony\Component\HttpKernel\EventListener\SessionListener instead
  */
-class SessionListener extends BaseSessionListener
+class SessionListener extends AbstractSessionListener
 {
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    protected function getSession()
+    {
+        if (!$this->container->has('session')) {
+            return;
+        }
+
+        return $this->container->get('session');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Revert the deprecated SessionListener class body instead of extending the new one which is `@final`, avoiding the following deprecations from the debug class loader:

> User Deprecated: The Symfony\Bundle\FrameworkBundle\EventListener\SessionListener class is deprecated since version 3.3 and will be removed in 4.0. Use Symfony\Component\HttpKernel\EventListener\SessionListener instead.

> User Deprecated: The Symfony\Component\HttpKernel\EventListener\SessionListener class is considered final since version 3.3. It may change without further notice as of its next major version. You should not extend it from Symfony\Bundle\FrameworkBundle\EventListener\SessionListener.

spotted in #22533 