### PR TITLE
[Lock] Check TTL expiration in lock acquisition

### DIFF
--- a/src/Symfony/Component/Lock/Exception/LockExpiredException.php
+++ b/src/Symfony/Component/Lock/Exception/LockExpiredException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Exception;
+
+/**
+ * LockExpiredException is thrown when a lock may conflict due to a TTL expiration.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class LockExpiredException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Lock/Key.php
+++ b/src/Symfony/Component/Lock/Key.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Lock;
 final class Key
 {
     private $resource;
-    private $expiringDate;
+    private $expiringTime;
     private $state = array();
 
     /**
@@ -77,16 +77,16 @@ final class Key
      */
     public function reduceLifetime($ttl)
     {
-        $newExpiringDate = \DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $ttl));
+        $newTime = microtime(true) + $ttl;
 
-        if (null === $this->expiringDate || $newExpiringDate < $this->expiringDate) {
-            $this->expiringDate = $newExpiringDate;
+        if (null === $this->expiringTime || $this->expiringTime > $newTime) {
+            $this->expiringTime = $newTime;
         }
     }
 
     public function resetExpiringDate()
     {
-        $this->expiringDate = null;
+        $this->expiringTime = null;
     }
 
     /**
@@ -94,6 +94,14 @@ final class Key
      */
     public function getExpiringDate()
     {
-        return $this->expiringDate;
+        return \DateTimeImmutable::createFromFormat('U.u', (string) $this->expiringTime);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isExpired()
+    {
+        return null !== $this->expiringTime && $this->expiringTime <= microtime(true);
     }
 }

--- a/src/Symfony/Component/Lock/Key.php
+++ b/src/Symfony/Component/Lock/Key.php
@@ -72,6 +72,11 @@ final class Key
         return $this->state[$stateKey];
     }
 
+    public function resetLifetime()
+    {
+        $this->expiringTime = null;
+    }
+
     /**
      * @param float $ttl The expiration delay of locks in seconds.
      */
@@ -84,17 +89,14 @@ final class Key
         }
     }
 
-    public function resetExpiringDate()
-    {
-        $this->expiringTime = null;
-    }
-
     /**
-     * @return \DateTimeImmutable
+     * Returns the remaining lifetime.
+     *
+     * @return float|null Remaining lifetime in seconds. Null when the key won't expire.
      */
-    public function getExpiringDate()
+    public function getRemainingLifetime()
     {
-        return \DateTimeImmutable::createFromFormat('U.u', (string) $this->expiringTime);
+        return null === $this->expiringTime ? null : $this->expiringTime - microtime(true);
     }
 
     /**

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\LockExpiredException;
 use Symfony\Component\Lock\Exception\LockReleasingException;
 
 /**
@@ -64,6 +65,10 @@ final class Lock implements LockInterface, LoggerAwareInterface
                 $this->refresh();
             }
 
+            if ($this->key->isExpired()) {
+                throw new LockExpiredException(sprintf('Failed to store the "%s" lock.', $this->key));
+            }
+
             return true;
         } catch (LockConflictedException $e) {
             $this->logger->warning('Failed to acquire the "{resource}" lock. Someone else already acquired the lock.', array('resource' => $this->key));
@@ -91,6 +96,11 @@ final class Lock implements LockInterface, LoggerAwareInterface
         try {
             $this->key->resetExpiringDate();
             $this->store->putOffExpiration($this->key, $this->ttl);
+
+            if ($this->key->isExpired()) {
+                throw new LockExpiredException(sprintf('Failed to put off the expiration of the "%s" lock within the specified time.', $this->key));
+            }
+
             $this->logger->info('Expiration defined for "{resource}" lock for "{ttl}" seconds.', array('resource' => $this->key, 'ttl' => $this->ttl));
         } catch (LockConflictedException $e) {
             $this->logger->warning('Failed to define an expiration for the "{resource}" lock, someone else acquired the lock.', array('resource' => $this->key));
@@ -127,11 +137,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
      */
     public function isExpired()
     {
-        if (null === $expireDate = $this->key->getExpiringDate()) {
-            return false;
-        }
-
-        return $expireDate <= new \DateTime();
+        return $this->key->isExpired();
     }
 
     public function getExpiringDate()

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -94,7 +94,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
         }
 
         try {
-            $this->key->resetExpiringDate();
+            $this->key->resetLifetime();
             $this->store->putOffExpiration($this->key, $this->ttl);
 
             if ($this->key->isExpired()) {
@@ -140,8 +140,13 @@ final class Lock implements LockInterface, LoggerAwareInterface
         return $this->key->isExpired();
     }
 
-    public function getExpiringDate()
+    /**
+     * Returns the remaining lifetime.
+     *
+     * @return float|null Remaining lifetime in seconds. Null when the lock won't expire.
+     */
+    public function getRemainingLifetime()
     {
-        return $this->key->getExpiringDate();
+        return $this->key->getRemainingLifetime();
     }
 }

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Lock\Store;
 
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\LockExpiredException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
 
@@ -57,14 +58,15 @@ class MemcachedStore implements StoreInterface
     public function save(Key $key)
     {
         $token = $this->getToken($key);
-
         $key->reduceLifetime($this->initialTtl);
-        if ($this->memcached->add((string) $key, $token, (int) ceil($this->initialTtl))) {
-            return;
+        if (!$this->memcached->add((string) $key, $token, (int) ceil($this->initialTtl))) {
+            // the lock is already acquired. It could be us. Let's try to put off.
+            $this->putOffExpiration($key, $this->initialTtl);
         }
 
-        // the lock is already acquire. It could be us. Let's try to put off.
-        $this->putOffExpiration($key, $this->initialTtl);
+        if ($key->isExpired()) {
+            throw new LockExpiredException(sprintf('Failed to store the "%s" lock.', $key));
+        }
     }
 
     public function waitAndSave(Key $key)
@@ -106,6 +108,10 @@ class MemcachedStore implements StoreInterface
 
         if (!$this->memcached->cas($cas, (string) $key, $token, $ttl)) {
             throw new LockConflictedException();
+        }
+
+        if ($key->isExpired()) {
+            throw new LockExpiredException(sprintf('Failed to put off the expiration of the "%s" lock within the specified time.', $key));
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -165,7 +165,7 @@ class LockTest extends TestCase
 
         foreach ($ttls as $ttl) {
             if (null === $ttl) {
-                $key->resetExpiringDate();
+                $key->resetLifetime();
             } else {
                 $key->reduceLifetime($ttl);
             }

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -175,12 +175,12 @@ class LockTest extends TestCase
 
     public function provideExpiredDates()
     {
-        yield array(array(-1.0), true);
-        yield array(array(1, -1.0), true);
-        yield array(array(-1.0, 1), true);
+        yield array(array(-0.1), true);
+        yield array(array(0.1, -0.1), true);
+        yield array(array(-0.1, 0.1), true);
 
         yield array(array(), false);
-        yield array(array(1), false);
-        yield array(array(-1.0, null), false);
+        yield array(array(0.1), false);
+        yield array(array(-0.1, null), false);
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -175,12 +175,12 @@ class CombinedStoreTest extends AbstractStoreTest
         $this->store1
             ->expects($this->once())
             ->method('putOffExpiration')
-            ->with($key, $ttl)
+            ->with($key, $this->lessThanOrEqual($ttl))
             ->willThrowException(new LockConflictedException());
         $this->store2
             ->expects($this->once())
             ->method('putOffExpiration')
-            ->with($key, $ttl)
+            ->with($key, $this->lessThanOrEqual($ttl))
             ->willThrowException(new LockConflictedException());
 
         $this->strategy
@@ -203,12 +203,12 @@ class CombinedStoreTest extends AbstractStoreTest
         $this->store1
             ->expects($this->once())
             ->method('putOffExpiration')
-            ->with($key, $ttl)
+            ->with($key, $this->lessThanOrEqual($ttl))
             ->willThrowException(new LockConflictedException());
         $this->store2
             ->expects($this->once())
             ->method('putOffExpiration')
-            ->with($key, $ttl)
+            ->with($key, $this->lessThanOrEqual($ttl))
             ->willThrowException(new LockConflictedException());
 
         $this->store1
@@ -242,7 +242,7 @@ class CombinedStoreTest extends AbstractStoreTest
         $this->store1
             ->expects($this->once())
             ->method('putOffExpiration')
-            ->with($key, $ttl)
+            ->with($key, $this->lessThanOrEqual($ttl))
             ->willThrowException(new LockConflictedException());
         $this->store2
             ->expects($this->never())

--- a/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
@@ -53,6 +53,22 @@ trait ExpiringStoreTestTrait
     }
 
     /**
+     * Tests the store thrown exception when TTL expires.
+     *
+     * @expectedException \Symfony\Component\Lock\Exception\LockExpiredException
+     */
+    public function testAbortAfterExpiration()
+    {
+        $key = new Key(uniqid(__METHOD__, true));
+
+        /** @var StoreInterface $store */
+        $store = $this->getStore();
+
+        $store->save($key);
+        $store->putOffExpiration($key, 1 / 1000000);
+    }
+
+    /**
      * Tests the refresh can push the limits to the expiration.
      *
      * This test is time sensible: the $clockDelay could be adjust.
@@ -69,10 +85,10 @@ trait ExpiringStoreTestTrait
         $store = $this->getStore();
 
         $store->save($key);
-        $store->putOffExpiration($key, 1.0 * $clockDelay / 1000000);
+        $store->putOffExpiration($key, $clockDelay / 1000000);
         $this->assertTrue($store->exists($key));
 
-        usleep(2.1 * $clockDelay);
+        usleep(2 * $clockDelay);
         $this->assertFalse($store->exists($key));
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
@@ -101,6 +101,7 @@ trait ExpiringStoreTestTrait
 
         $store->save($key);
         $store->putOffExpiration($key, 1);
-        $this->assertNotNull($key->getExpiringDate());
+        $this->assertGreaterThanOrEqual(0, $key->getRemainingLifetime());
+        $this->assertLessThanOrEqual(1, $key->getRemainingLifetime());
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -49,4 +49,9 @@ class MemcachedStoreTest extends AbstractStoreTest
 
         return new MemcachedStore($memcached);
     }
+
+    public function testAbortAfterExpiration()
+    {
+        $this->markTestSkipped('Memcached expects a TTL greater than 1 sec. Simulating a slow network is too hard');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22452 
| License       | MIT
| Doc PR        | NA

This PR improve lock acquisition by throwing exception when the TTL is expired during the lock process.