### PR TITLE
[Lock] Expose an expiringDate and isExpired method in Lock

### DIFF
--- a/src/Symfony/Component/Lock/Key.php
+++ b/src/Symfony/Component/Lock/Key.php
@@ -19,6 +19,7 @@ namespace Symfony\Component\Lock;
 final class Key
 {
     private $resource;
+    private $expiringDate;
     private $state = array();
 
     /**
@@ -69,5 +70,28 @@ final class Key
     public function getState($stateKey)
     {
         return $this->state[$stateKey];
+    }
+
+    public function resetExpiringDate()
+    {
+        $this->expiringDate = null;
+    }
+
+    /**
+     * @param \DateTimeImmutable $expiringDate
+     */
+    public function reduceExpiringDate(\DateTimeImmutable $expiringDate)
+    {
+        if (null === $this->expiringDate || $this->expiringDate > $expiringDate) {
+            $this->expiringDate = $expiringDate;
+        }
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function getExpiringDate()
+    {
+        return $this->expiringDate;
     }
 }

--- a/src/Symfony/Component/Lock/Key.php
+++ b/src/Symfony/Component/Lock/Key.php
@@ -72,19 +72,21 @@ final class Key
         return $this->state[$stateKey];
     }
 
+    /**
+     * @param float $ttl The expiration delay of locks in seconds.
+     */
+    public function reduceLifetime($ttl)
+    {
+        $newExpiringDate = \DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $ttl));
+
+        if (null === $this->expiringDate || $newExpiringDate < $this->expiringDate) {
+            $this->expiringDate = $newExpiringDate;
+        }
+    }
+
     public function resetExpiringDate()
     {
         $this->expiringDate = null;
-    }
-
-    /**
-     * @param \DateTimeImmutable $expiringDate
-     */
-    public function reduceExpiringDate(\DateTimeImmutable $expiringDate)
-    {
-        if (null === $this->expiringDate || $this->expiringDate > $expiringDate) {
-            $this->expiringDate = $expiringDate;
-        }
     }
 
     /**

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -89,6 +89,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
         }
 
         try {
+            $this->key->resetExpiringDate();
             $this->store->putOffExpiration($this->key, $this->ttl);
             $this->logger->info('Expiration defined for "{resource}" lock for "{ttl}" seconds.', array('resource' => $this->key, 'ttl' => $this->ttl));
         } catch (LockConflictedException $e) {
@@ -119,5 +120,22 @@ final class Lock implements LockInterface, LoggerAwareInterface
             $this->logger->warning('Failed to release the "{resource}" lock.', array('resource' => $this->key));
             throw new LockReleasingException(sprintf('Failed to release the "%s" lock.', $this->key));
         }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isExpired()
+    {
+        if (null === $expireDate = $this->key->getExpiringDate()) {
+            return false;
+        }
+
+        return $expireDate <= new \DateTime();
+    }
+
+    public function getExpiringDate()
+    {
+        return $this->key->getExpiringDate();
     }
 }

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -58,7 +58,7 @@ class MemcachedStore implements StoreInterface
     {
         $token = $this->getToken($key);
 
-        $key->reduceExpiringDate(\DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $this->initialTtl)));
+        $key->reduceLifetime($this->initialTtl);
         if ($this->memcached->add((string) $key, $token, (int) ceil($this->initialTtl))) {
             return;
         }
@@ -88,7 +88,7 @@ class MemcachedStore implements StoreInterface
 
         list($value, $cas) = $this->getValueAndCas($key);
 
-        $key->reduceExpiringDate(\DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $ttl)));
+        $key->reduceLifetime($ttl);
         // Could happens when we ask a putOff after a timeout but in luck nobody steal the lock
         if (\Memcached::RES_NOTFOUND === $this->memcached->getResultCode()) {
             if ($this->memcached->add((string) $key, $token, $ttl)) {

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -58,6 +58,7 @@ class MemcachedStore implements StoreInterface
     {
         $token = $this->getToken($key);
 
+        $key->reduceExpiringDate(\DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $this->initialTtl)));
         if ($this->memcached->add((string) $key, $token, (int) ceil($this->initialTtl))) {
             return;
         }
@@ -87,6 +88,7 @@ class MemcachedStore implements StoreInterface
 
         list($value, $cas) = $this->getValueAndCas($key);
 
+        $key->reduceExpiringDate(\DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $ttl)));
         // Could happens when we ask a putOff after a timeout but in luck nobody steal the lock
         if (\Memcached::RES_NOTFOUND === $this->memcached->getResultCode()) {
             if ($this->memcached->add((string) $key, $token, $ttl)) {

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -57,8 +57,8 @@ class RedisStore implements StoreInterface
             end
         ';
 
-        $expire = (int) ceil($this->initialTtl * 1000);
-        if (!$this->evaluate($script, (string) $key, array($this->getToken($key), $expire))) {
+        $key->reduceExpiringDate(\DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $this->initialTtl)));
+        if (!$this->evaluate($script, (string) $key, array($this->getToken($key), (int) ceil($this->initialTtl * 1000)))) {
             throw new LockConflictedException();
         }
     }
@@ -81,8 +81,8 @@ class RedisStore implements StoreInterface
             end
         ';
 
-        $expire = (int) ceil($ttl * 1000);
-        if (!$this->evaluate($script, (string) $key, array($this->getToken($key), $expire))) {
+        $key->reduceExpiringDate(\DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $ttl)));
+        if (!$this->evaluate($script, (string) $key, array($this->getToken($key), (int) ceil($ttl * 1000)))) {
             throw new LockConflictedException();
         }
     }

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -57,7 +57,7 @@ class RedisStore implements StoreInterface
             end
         ';
 
-        $key->reduceExpiringDate(\DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $this->initialTtl)));
+        $key->reduceLifetime($this->initialTtl);
         if (!$this->evaluate($script, (string) $key, array($this->getToken($key), (int) ceil($this->initialTtl * 1000)))) {
             throw new LockConflictedException();
         }
@@ -81,7 +81,7 @@ class RedisStore implements StoreInterface
             end
         ';
 
-        $key->reduceExpiringDate(\DateTimeImmutable::createFromFormat('U.u', (string) (microtime(true) + $ttl)));
+        $key->reduceLifetime($ttl);
         if (!$this->evaluate($script, (string) $key, array($this->getToken($key), (int) ceil($ttl * 1000)))) {
             throw new LockConflictedException();
         }

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -157,17 +157,17 @@ class LockTest extends TestCase
     /**
      * @dataProvider provideExpiredDates
      */
-    public function testExpiration($dates, $expected)
+    public function testExpiration($ttls, $expected)
     {
         $key = new Key(uniqid(__METHOD__, true));
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
         $lock = new Lock($key, $store, 10);
 
-        foreach ($dates as $date) {
-            if (null === $date) {
+        foreach ($ttls as $ttl) {
+            if (null === $ttl) {
                 $key->resetExpiringDate();
             } else {
-                $key->reduceExpiringDate(new \DateTimeImmutable($date));
+                $key->reduceLifetime($ttl);
             }
         }
         $this->assertSame($expected, $lock->isExpired());
@@ -175,12 +175,12 @@ class LockTest extends TestCase
 
     public function provideExpiredDates()
     {
-        yield array(array('yesterday'), true);
-        yield array(array('tomorrow', 'yesterday'), true);
-        yield array(array('yesterday', 'tomorrow'), true);
+        yield array(array(-1.0), true);
+        yield array(array(1, -1.0), true);
+        yield array(array(-1.0, 1), true);
 
         yield array(array(), false);
-        yield array(array('tomorrow'), false);
-        yield array(array('yesterday', null), false);
+        yield array(array(1), false);
+        yield array(array(-1.0, null), false);
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/AbstractStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/AbstractStoreTest.php
@@ -49,14 +49,17 @@ abstract class AbstractStoreTest extends TestCase
         $store->save($key1);
         $this->assertTrue($store->exists($key1));
         $this->assertFalse($store->exists($key2));
-        $store->save($key2);
 
+        $store->save($key2);
         $this->assertTrue($store->exists($key1));
         $this->assertTrue($store->exists($key2));
 
         $store->delete($key1);
         $this->assertFalse($store->exists($key1));
+        $this->assertTrue($store->exists($key2));
+
         $store->delete($key2);
+        $this->assertFalse($store->exists($key1));
         $this->assertFalse($store->exists($key2));
     }
 
@@ -74,7 +77,7 @@ abstract class AbstractStoreTest extends TestCase
 
         try {
             $store->save($key2);
-            throw new \Exception('The store shouldn\'t save the second key');
+            $this->fail('The store shouldn\'t save the second key');
         } catch (LockConflictedException $e) {
         }
 

--- a/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ExpiringStoreTestTrait.php
@@ -75,4 +75,16 @@ trait ExpiringStoreTestTrait
         usleep(2.1 * $clockDelay);
         $this->assertFalse($store->exists($key));
     }
+
+    public function testSetExpiration()
+    {
+        $key = new Key(uniqid(__METHOD__, true));
+
+        /** @var StoreInterface $store */
+        $store = $this->getStore();
+
+        $store->save($key);
+        $store->putOffExpiration($key, 1);
+        $this->assertNotNull($key->getExpiringDate());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22452 
| License       | MIT
| Doc PR        | NA

This PR store the expiration date of the lock in the key and exposes public method to let the user know the state of the Lock expiration.