### PR TITLE
[TwigBundle] 'Content-Type' response header match the requested format when generating error pages

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -59,9 +59,10 @@ class ExceptionController
         $showException = $request->attributes->get('showException', $this->debug); // As opposed to an additional parameter, this maintains BC
 
         $code = $exception->getStatusCode();
+        $format = $request->getRequestFormat();
 
         return new Response($this->twig->render(
-            (string) $this->findTemplate($request, $request->getRequestFormat(), $code, $showException),
+            (string) $this->findTemplate($request, $format, $code, $showException),
             array(
                 'status_code' => $code,
                 'status_text' => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
@@ -69,7 +70,7 @@ class ExceptionController
                 'logger' => $logger,
                 'currentContent' => $currentContent,
             )
-        ));
+        ), $code, ['Content-Type' => $request->getMimeType($format)]);
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -70,7 +70,7 @@ class ExceptionController
                 'logger' => $logger,
                 'currentContent' => $currentContent,
             )
-        ), $code, ['Content-Type' => $request->getMimeType($format)]);
+        ), $code, array('Content-Type' => $request->getMimeType($format)));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no related issue found
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The _Content-Type_ response header needs to match the format of the generated response content.

This is obviously useful when an exception is thrown during an XMLHttpRequest handling using JSON content. Currently, the browser (Firefox Developer Edition) handles well the response content and show it as a JSON object. Maybe by looking the request content type or just by recognizing the response content type while parsing it. But the response type is shown as _html_. This PR fix it.

By using the _Request::getMimeType()_ method, we take care of the additional format added by the developer.
