### PR TITLE
Allow Upper Case property names in ObjectNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -208,10 +208,22 @@ class ObjectNormalizer extends AbstractNormalizer
 
             if (0 === strpos($name, 'get') || 0 === strpos($name, 'has')) {
                 // getters and hassers
-                $attributes[lcfirst(substr($name, 3))] = true;
+                $propertyName = substr($name, 3);
+
+                if (!$reflClass->hasProperty($propertyName)) {
+                    $propertyName = lcfirst($propertyName);
+                }
+
+                $attributes[$propertyName] = true;
             } elseif (strpos($name, 'is') === 0) {
                 // issers
-                $attributes[lcfirst(substr($name, 2))] = true;
+                $propertyName = substr($name, 2);
+
+                if (!$reflClass->hasProperty($propertyName)) {
+                    $propertyName = lcfirst($propertyName);
+                }
+
+                $attributes[$propertyName] = true;
             }
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -488,6 +488,11 @@ class ObjectNormalizerTest extends TestCase
         $this->assertEquals(array('foo' => 'K'), $this->normalizer->normalize(new ObjectWithStaticPropertiesAndMethods()));
     }
 
+    public function testNormalizeUpperCaseAttributes()
+    {
+        $this->assertEquals(array('Foo' => 'Foo', 'Bar' => 'BarBar'), $this->normalizer->normalize(new ObjectWithUpperCaseAttributeNames()));
+    }
+
     public function testNormalizeNotSerializableContext()
     {
         $objectDummy = new ObjectDummy();
@@ -660,5 +665,16 @@ class ObjectWithStaticPropertiesAndMethods
     public static function getBaz()
     {
         return 'L';
+    }
+}
+
+class ObjectWithUpperCaseAttributeNames
+{
+    private $Foo = 'Foo';
+    public $Bar = 'BarBar';
+
+    public function getFoo()
+    {
+        return $this->Foo;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22547
| License       | MIT

Same problem that has been fixed here https://github.com/symfony/symfony/pull/22265
and here https://github.com/api-platform/core/pull/1037

ObjectNormalizer returns $id instead of $Id. It is bad naming convention, but is possible

```php
class Entity {
    protected $Id;

    public function getId()
    {
        return $this->Id;
    }
}
```



