### PR TITLE
[Process] Ecaping of CLI arguments containing slashes on Windows

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1717,7 +1717,7 @@ class Process implements \IteratorAggregate
         if (false !== strpos($argument, "\0")) {
             $argument = str_replace("\0", '?', $argument);
         }
-        if (!preg_match('/[()%!^"<>&|\s]/', $argument)) {
+        if (!preg_match('/[\/()%!^"<>&|\s]/', $argument)) {
             return $argument;
         }
         $argument = preg_replace('/(\\\\+)$/', '$1$1', $argument);

--- a/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
@@ -91,14 +91,14 @@ class ProcessBuilderTest extends TestCase
 
         $proc = $pb->setArguments(array('-v'))->getProcess();
         if ('\\' === DIRECTORY_SEPARATOR) {
-            $this->assertEquals('/usr/bin/php -v', $proc->getCommandLine());
+            $this->assertEquals('"/usr/bin/php" -v', $proc->getCommandLine());
         } else {
             $this->assertEquals("'/usr/bin/php' '-v'", $proc->getCommandLine());
         }
 
         $proc = $pb->setArguments(array('-i'))->getProcess();
         if ('\\' === DIRECTORY_SEPARATOR) {
-            $this->assertEquals('/usr/bin/php -i', $proc->getCommandLine());
+            $this->assertEquals('"/usr/bin/php" -i', $proc->getCommandLine());
         } else {
             $this->assertEquals("'/usr/bin/php' '-i'", $proc->getCommandLine());
         }
@@ -111,14 +111,14 @@ class ProcessBuilderTest extends TestCase
 
         $proc = $pb->setArguments(array('-v'))->getProcess();
         if ('\\' === DIRECTORY_SEPARATOR) {
-            $this->assertEquals('/usr/bin/php composer.phar -v', $proc->getCommandLine());
+            $this->assertEquals('"/usr/bin/php" composer.phar -v', $proc->getCommandLine());
         } else {
             $this->assertEquals("'/usr/bin/php' 'composer.phar' '-v'", $proc->getCommandLine());
         }
 
         $proc = $pb->setArguments(array('-i'))->getProcess();
         if ('\\' === DIRECTORY_SEPARATOR) {
-            $this->assertEquals('/usr/bin/php composer.phar -i', $proc->getCommandLine());
+            $this->assertEquals('"/usr/bin/php" composer.phar -i', $proc->getCommandLine());
         } else {
             $this->assertEquals("'/usr/bin/php' 'composer.phar' '-i'", $proc->getCommandLine());
         }
@@ -164,7 +164,7 @@ class ProcessBuilderTest extends TestCase
             ->getProcess();
 
         if ('\\' === DIRECTORY_SEPARATOR) {
-            $this->assertEquals('/usr/bin/php', $process->getCommandLine());
+            $this->assertEquals('"/usr/bin/php"', $process->getCommandLine());
         } else {
             $this->assertEquals("'/usr/bin/php'", $process->getCommandLine());
         }
@@ -176,7 +176,7 @@ class ProcessBuilderTest extends TestCase
             ->getProcess();
 
         if ('\\' === DIRECTORY_SEPARATOR) {
-            $this->assertEquals('/usr/bin/php', $process->getCommandLine());
+            $this->assertEquals('"/usr/bin/php"', $process->getCommandLine());
         } else {
             $this->assertEquals("'/usr/bin/php'", $process->getCommandLine());
         }

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1446,6 +1446,14 @@ class ProcessTest extends TestCase
         $this->assertSame($expected, $env);
     }
 
+    public function testGetCommandLine()
+    {
+        $p = new Process(array('/usr/bin/php'));
+
+        $expected = '\\' === DIRECTORY_SEPARATOR ? '"/usr/bin/php"' : '/usr/bin/php';
+        $this->assertSame($expected, $p->getCommandLine());
+    }
+
     /**
      * @dataProvider provideEscapeArgument
      */

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -715,8 +715,8 @@ class ProcessTest extends TestCase
         // Ensure that both processed finished and the output is numeric
         $this->assertFalse($process1->isRunning());
         $this->assertFalse($process2->isRunning());
-        $this->assertTrue(is_numeric($process1->getOutput()));
-        $this->assertTrue(is_numeric($process2->getOutput()));
+        $this->assertInternalType('numeric', $process1->getOutput());
+        $this->assertInternalType('numeric', $process2->getOutput());
 
         // Ensure that restart returned a new process by check that the output is different
         $this->assertNotEquals($process1->getOutput(), $process2->getOutput());
@@ -1450,7 +1450,7 @@ class ProcessTest extends TestCase
     {
         $p = new Process(array('/usr/bin/php'));
 
-        $expected = '\\' === DIRECTORY_SEPARATOR ? '"/usr/bin/php"' : '/usr/bin/php';
+        $expected = '\\' === DIRECTORY_SEPARATOR ? '"/usr/bin/php"' : "'/usr/bin/php'";
         $this->assertSame($expected, $p->getCommandLine());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22549 
| License       | MIT

Actually only the first argument - the command needs to be escaped but that would need another condition. I think it should be OK.
