### PR TITLE
[Serializer] Add missing normalizer options constants

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -30,6 +30,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
     const CIRCULAR_REFERENCE_LIMIT = 'circular_reference_limit';
     const OBJECT_TO_POPULATE = 'object_to_populate';
     const GROUPS = 'groups';
+    const ATTRIBUTES = 'attributes';
 
     /**
      * @var int
@@ -240,13 +241,13 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
             return false;
         }
 
-        if (isset($context['attributes'][$attribute])) {
+        if (isset($context[self::ATTRIBUTES][$attribute])) {
             // Nested attributes
             return true;
         }
 
-        if (isset($context['attributes']) && is_array($context['attributes'])) {
-            return in_array($attribute, $context['attributes'], true);
+        if (isset($context[self::ATTRIBUTES]) && is_array($context[self::ATTRIBUTES])) {
+            return in_array($attribute, $context[self::ATTRIBUTES], true);
         }
 
         return true;
@@ -396,8 +397,8 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      */
     protected function createChildContext(array $parentContext, $attribute)
     {
-        if (isset($parentContext['attributes'][$attribute])) {
-            $parentContext['attributes'] = $parentContext['attributes'][$attribute];
+        if (isset($parentContext[self::ATTRIBUTES][$attribute])) {
+            $parentContext[self::ATTRIBUTES] = $parentContext[self::ATTRIBUTES][$attribute];
         }
 
         return $parentContext;

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -32,6 +32,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 {
     const ENABLE_MAX_DEPTH = 'enable_max_depth';
     const DEPTH_KEY_PATTERN = 'depth_%s::%s';
+    const ALLOW_EXTRA_ATTRIBUTES = 'allow_extra_attributes';
 
     private $propertyTypeExtractor;
     private $attributesCache = array();
@@ -189,7 +190,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             }
 
             if (($allowedAttributes !== false && !in_array($attribute, $allowedAttributes)) || !$this->isAllowedAttribute($class, $attribute, $format, $context)) {
-                if (isset($context['allow_extra_attributes']) && !$context['allow_extra_attributes']) {
+                if (isset($context[self::ALLOW_EXTRA_ATTRIBUTES]) && !$context[self::ALLOW_EXTRA_ATTRIBUTES]) {
                     $extraAttributes[] = $attribute;
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (3.3)
| Bug fix?      | not really
| New feature?  | yesish, but for 3.3 as those options were added on this branch and not released yet
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22537#discussion_r113719848
| License       | MIT
| Doc PR        | N/A

As seen in https://github.com/symfony/symfony/pull/22537#discussion_r113719848.

@dunglas : I'm not sure about the exposing the `key_type` option as a constant in `ArrayDenormalizer`/`AbstractObjectNormalizer`, as it looks more or less like a detail of the AbstractObjectNormalizer implementation, but anyway it should be in 3.2 if we add it, so I haven't included it here.
However, I wonder if this option shouldn't directly accept a string too, rather than just a `Symfony\Component\PropertyInfo\Type` instance if we want to consider this option "public"?