### PR TITLE
[VarDumper] Add iconv dependency

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -167,6 +167,9 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
      */
     protected function utf8Encode($s)
     {
+        if (!function_exists('iconv')) {
+            throw new \RuntimeException('Unable to convert a non-UTF-8 string to UTF-8: required function iconv() does not exist. You should install ext-iconv or symfony/polyfill-iconv.');
+        }
         if (false !== $c = @iconv($this->charset, 'UTF-8', $s)) {
             return $c;
         }

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -20,12 +20,14 @@
         "symfony/polyfill-mbstring": "~1.0"
     },
     "require-dev": {
+        "ext-iconv": "*",
         "twig/twig": "~1.20|~2.0"
     },
     "conflict": {
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
     },
     "suggest": {
+        "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
         "ext-symfony_debug": ""
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Alternative to #20927.

I still think adding `@requires extension iconv` to the related tests would be nice though: on some PHP setups the iconv extension is not available by default, those tests will fail and result in red errors when running the test suite, even when working on something unrelated. The test would still run on CI so it's fine IMO.

Should I add `ext-iconv` and/or `symfony/polyfill` to `require-dev`?

/cc @nicolas-grekas 