### PR TITLE
Fixing problem where _defaults set to null was seen as a service

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -205,7 +205,7 @@ class YamlFileLoader extends FileLoader
             throw new InvalidArgumentException(sprintf('The "services" key should contain an array in %s. Check your YAML syntax.', $file));
         }
 
-        if (isset($content['services']['_instanceof'])) {
+        if (array_key_exists('_instanceof', $content['services'])) {
             $instanceof = $content['services']['_instanceof'];
             unset($content['services']['_instanceof']);
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -242,7 +242,7 @@ class YamlFileLoader extends FileLoader
      */
     private function parseDefaults(array &$content, $file)
     {
-        if (!isset($content['services']['_defaults'])) {
+        if (!array_key_exists('_defaults', $content['services'])) {
             return array();
         }
         $defaults = $content['services']['_defaults'];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_empty_defaults.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_empty_defaults.yml
@@ -1,0 +1,2 @@
+services:
+    _defaults:

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_empty_instanceof.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_empty_instanceof.yml
@@ -1,0 +1,2 @@
+services:
+    _instanceof:

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -588,6 +588,17 @@ class YamlFileLoaderTest extends TestCase
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('bad_empty_defaults.yml');
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Service "_instanceof" key must be an array, "NULL" given in "bad_empty_instanceof.yml".
+     */
+    public function testEmptyInstanceofThrowsClearException()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('bad_empty_instanceof.yml');
+    }
 }
 
 interface FooInterface

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -577,6 +577,17 @@ class YamlFileLoaderTest extends TestCase
         $this->assertTrue($container->getDefinition('use_defaults_settings')->isAutoconfigured());
         $this->assertFalse($container->getDefinition('override_defaults_settings_to_false')->isAutoconfigured());
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Service "_defaults" key must be an array, "NULL" given in "bad_empty_defaults.yml".
+     */
+    public function testEmptyDefaultsThrowsClearException()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('bad_empty_defaults.yml');
+    }
 }
 
 interface FooInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

```yml
services:
    _defaults:
```

If you leave `_defaults` empty (i.e. null), you got a bad error before. Now it's better :)

Before:
>The definition for "_defaults" has no class. If you intend to inject this service dynamicall  
  y at runtime, please mark it as synthetic=true. If this is an abstract definition solely use  
  d by child definitions, please add abstract=true, otherwise specify a class to get rid of th  
  is error.

After:
> Service "_defaults" key must be an array, "NULL" given in "/path/to/services.yml"
