### PR TITLE
If an instanceof does not exist, throw an exception

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -154,4 +154,32 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         // no automatic_tag, it was not enabled on the Definition
         $this->assertFalse($def->isAutowired());
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage "App\FakeInterface" is set as an "instanceof" conditional, but it does not exist.
+     */
+    public function testBadInterfaceThrowsException()
+    {
+        $container = new ContainerBuilder();
+        $def = $container->register('normal_service', self::class);
+        $def->setInstanceofConditionals(array(
+            'App\\FakeInterface' => (new ChildDefinition(''))
+                ->addTag('foo_tag'),
+        ));
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+    }
+
+    public function testBadInterfaceForAutomaticInstanceofIsOkException()
+    {
+        $container = new ContainerBuilder();
+        $container->register('normal_service', self::class)
+            ->setAutoconfigured(true);
+        $container->registerForAutoconfiguration('App\\FakeInterface')
+            ->setAutowired(true);
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+        $this->assertTrue($container->hasDefinition('normal_service'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes-ish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n/a

Before, it was possible to add an `instanceof` with a non-existent class/interface. Now it throws an exception, but ONLY for conditionals set directly on a Definition: we still allow for global "automatic" instanceof definitions to be set on the `ContainerBuilder`. I'm not sure if that's correct... it makes life easier for bundler maintainers. If we also strictly validated the existence of "automatic" instanceof's, then (for example) in `FrameworkExtension`, we would need to do an `if interface_exists()` around most of the `registerForAutoconfiguration()` calls.
