### PR TITLE
Fixes twig bundle project root dir discovery

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -80,16 +80,16 @@ class ExtensionPass implements CompilerPassInterface
             $container->getDefinition('twig.extension.debug')->addTag('twig.extension');
         }
 
-        $composerRootDir = $this->getComposerRootDir($container->getParameter('kernel.root_dir'));
+        $projectDir = $container->getParameter('kernel.project_dir');
         $twigLoader = $container->getDefinition('twig.loader.native_filesystem');
         if ($container->has('templating')) {
             $loader = $container->getDefinition('twig.loader.filesystem');
             $loader->setMethodCalls(array_merge($twigLoader->getMethodCalls(), $loader->getMethodCalls()));
-            $loader->replaceArgument(2, $composerRootDir);
+            $loader->replaceArgument(2, $projectDir);
 
             $twigLoader->clearTag('twig.loader');
         } else {
-            $twigLoader->replaceArgument(1, $composerRootDir);
+            $twigLoader->replaceArgument(1, $projectDir);
             $container->setAlias('twig.loader.filesystem', new Alias('twig.loader.native_filesystem', false));
         }
 
@@ -108,19 +108,5 @@ class ExtensionPass implements CompilerPassInterface
         if ($container->hasDefinition('twig.extension.expression')) {
             $container->getDefinition('twig.extension.expression')->addTag('twig.extension');
         }
-    }
-
-    private function getComposerRootDir($rootDir)
-    {
-        $dir = $rootDir;
-        while (!file_exists($dir.'/composer.json')) {
-            if ($dir === dirname($dir)) {
-                return $rootDir;
-            }
-
-            $dir = dirname($dir);
-        }
-
-        return $dir;
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -80,16 +80,13 @@ class ExtensionPass implements CompilerPassInterface
             $container->getDefinition('twig.extension.debug')->addTag('twig.extension');
         }
 
-        $projectDir = $container->getParameter('kernel.project_dir');
         $twigLoader = $container->getDefinition('twig.loader.native_filesystem');
         if ($container->has('templating')) {
             $loader = $container->getDefinition('twig.loader.filesystem');
             $loader->setMethodCalls(array_merge($twigLoader->getMethodCalls(), $loader->getMethodCalls()));
-            $loader->replaceArgument(2, $projectDir);
 
             $twigLoader->clearTag('twig.loader');
         } else {
-            $twigLoader->replaceArgument(1, $projectDir);
             $container->setAlias('twig.loader.filesystem', new Alias('twig.loader.native_filesystem', false));
         }
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/templating.xml
@@ -7,7 +7,7 @@
         <service id="twig.loader.filesystem" class="Symfony\Bundle\TwigBundle\Loader\FilesystemLoader" public="false">
             <argument type="service" id="templating.locator" />
             <argument type="service" id="templating.name_parser" />
-            <argument /> <!-- project's root dir -->
+            <argument>%kernel.project_dir%</argument>
             <tag name="twig.loader"/>
         </service>
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -48,7 +48,7 @@
 
         <service id="twig.loader.native_filesystem" class="Twig_Loader_Filesystem" public="false">
             <argument type="collection" /> <!-- paths -->
-            <argument /> <!-- project's root dir -->
+            <argument>%kernel.project_dir%</argument>
             <tag name="twig.loader"/>
         </service>
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -256,6 +256,7 @@ class TwigExtensionTest extends TestCase
         $container = new ContainerBuilder(new ParameterBag(array(
             'kernel.cache_dir' => __DIR__,
             'kernel.root_dir' => __DIR__.'/Fixtures',
+            'kernel.project_dir' => __DIR__,
             'kernel.charset' => 'UTF-8',
             'kernel.debug' => false,
             'kernel.bundles' => array(

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/config": "~3.2",
         "symfony/twig-bridge": "^3.2.1",
         "symfony/http-foundation": "~2.8|~3.0",
-        "symfony/http-kernel": "~2.8.16|~3.1.9|^3.2.2",
+        "symfony/http-kernel": "^3.2.2",
         "twig/twig": "^1.32|^2.2"
     },
     "require-dev": {

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/config": "~3.2",
         "symfony/twig-bridge": "^3.2.1",
         "symfony/http-foundation": "~2.8|~3.0",
-        "symfony/http-kernel": "^3.2.2",
+        "symfony/http-kernel": "^3.3",
         "twig/twig": "^1.32|^2.2"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22149
| License       | MIT
| Doc PR        | none

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

TwigBundle ExtensionPass uses a directory lookup algorithm to find the composer.json file. When working under open_basedir restrictions, if the project root folder is not allowed PHP runtime to read, the composer.json will never be found, throwing PHP notices along the way and ending up using the filesystem root instead.

Since that 3.3 introduced the kernel getProjectRoot() method and kernel.project_dir variable, the TwigBundle can now leverage it, in order to get more consistent, and allow site builders to override the getProjectRoot() kernel method, hence bypass the open_basedir restrictions in reliable and safe way.
