### PR TITLE
[SecurityBundle] Allow for custom logout request matcher

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -235,6 +235,7 @@ class MainConfiguration implements ConfigurationInterface
                     ->scalarNode('csrf_parameter')->defaultValue('_csrf_token')->end()
                     ->scalarNode('csrf_token_generator')->cannotBeEmpty()->end()
                     ->scalarNode('csrf_token_id')->defaultValue('logout')->end()
+                    ->scalarNode('request_matcher')->end()
                     ->scalarNode('path')->defaultValue('/logout')->end()
                     ->scalarNode('target')->defaultValue('/')->end()
                     ->scalarNode('success_handler')->end()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -370,9 +370,10 @@ class SecurityExtension extends Extension
             $listener->replaceArgument(2, new Reference($logoutSuccessHandlerId));
 
             // add CSRF provider
-            if (isset($firewall['logout']['csrf_token_generator'])) {
-                $listener->addArgument(new Reference($firewall['logout']['csrf_token_generator']));
-            }
+            $listener->replaceArgument(4, isset($firewall['logout']['csrf_token_generator']) ? new Reference($firewall['logout']['csrf_token_generator']) : null);
+
+            // add request matcher
+            $listener->replaceArgument(5, isset($firewall['logout']['request_matcher']) ? new Reference($firewall['logout']['request_matcher']) : null);
 
             // add session logout handler
             if (true === $firewall['logout']['invalidate_session'] && false === $firewall['stateless']) {

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -50,6 +50,8 @@
             <argument type="service" id="security.http_utils" />
             <argument type="service" id="security.logout.success_handler" />
             <argument /> <!-- Options -->
+            <argument /> <!-- CSRF token manager -->
+            <argument /> <!-- Request matcher -->
         </service>
 
         <service id="security.logout.handler.session" class="Symfony\Component\Security\Http\Logout\SessionLogoutHandler" public="false" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #22473
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

So you can do something like

```yml
logout:
  path: ~
  request_matcher: my_logout_matcher
```

and bypass path-matching, or combine it with a custom check afterwards.

Should go after #22574 and #22584