### PR TITLE
Add new Flag component

### DIFF
--- a/flag.php
+++ b/flag.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file shows some use examples of Flag component, and will be removed if proposal is accepted.
+ */
+
+namespace Demo;
+
+require 'vendor/autoload.php';
+
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Flag\Flag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\VarDumper\Caster\Caster;
+use Symfony\Component\Yaml\Yaml;
+
+$logger = new ConsoleLogger(new ConsoleOutput(ConsoleOutput::VERBOSITY_DEBUG));
+
+echo "\nOverview\n";
+$flag = Flag::create(Yaml::class);
+$flag->setLogger($logger);
+$flag
+    ->add(Yaml::DUMP_OBJECT)
+    ->add(Yaml::PARSE_DATETIME)
+    ->remove(Yaml::DUMP_OBJECT)
+;
+dump(
+    $flag->has(Yaml::DUMP_OBJECT),
+    $flag->has(Yaml::PARSE_DATETIME),
+    $flag->get()
+);
+$flag->set(100);
+foreach ($flag as $k => $v) {
+    echo "$k => $v ";
+}
+
+echo "\n\nExample\n";
+class Color
+{
+    const RED = 1;
+    const GREEN = 2;
+    const YELLOW = 3;
+    public $flag;
+
+    public function __construct($logger)
+    {
+        $this->flag = Flag::create(self::class);
+        $this->flag->setLogger($logger);
+    }
+}
+(new Color($logger))->flag
+    ->add(Color::RED)
+    ->add(Color::GREEN)
+    ->remove(Color::GREEN)
+;
+
+echo "\nPrefix\n";
+$flag = Flag::create(Caster::class, 'EXCLUDE_');
+$flag->setLogger($logger);
+$flag
+    ->add(Caster::EXCLUDE_EMPTY)
+    ->add(Caster::EXCLUDE_PRIVATE)
+    ->add(Caster::EXCLUDE_NOT_IMPORTANT)
+    ->remove(Caster::EXCLUDE_NOT_IMPORTANT)
+;
+
+echo "\nHierarchical\n";
+$flag = Flag::create(Output::class, 'VERBOSITY_', true);
+$flag->setLogger($logger);
+$flag
+    ->add(Output::VERBOSITY_VERBOSE)
+    ->add(Output::VERBOSITY_DEBUG)
+    ->remove(Output::VERBOSITY_DEBUG)
+;
+
+echo "\nGlobal space\n";
+$flag = Flag::create(null, 'E_');
+$flag->setLogger($logger);
+$flag
+    ->add(E_ALL)
+    ->set(0)
+    ->add(E_USER_ERROR)
+    ->add(E_USER_DEPRECATED)
+    ->remove(E_USER_DEPRECATED)
+;
+
+echo "\nBinarizedFlag\n";
+$flag = Flag::create(Request::class, 'METHOD_');
+$flag->setLogger($logger);
+$flag
+    ->add(Request::METHOD_GET)
+    ->add(Request::METHOD_POST)
+    ->add(Request::METHOD_PUT)
+    ->remove(Request::METHOD_PUT)
+;
+
+echo "\nStandalone\n";
+$flag = new Flag();
+$flag->setLogger($logger);
+$flag
+    ->add(8)
+    ->add(32)
+    ->remove(32)
+;
+echo "\n";
+$flag = Flag::create();
+$flag->setLogger($logger);
+$flag
+    ->add('a')
+    ->add('b')
+    ->remove('b')
+;

--- a/src/Symfony/Component/Flag/AbstractFlag.php
+++ b/src/Symfony/Component/Flag/AbstractFlag.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag;
+
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Flag\Exception\InvalidArgumentException;
+
+/**
+ * Base class implementing the FlagInterface.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+abstract class AbstractFlag implements FlagInterface
+{
+    protected $from;
+    protected $prefix;
+    protected $bitfield;
+    protected $flags = array();
+
+    use LoggerAwareTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($from = false, $prefix = '', $bitfield = 0)
+    {
+        $this->from = $from;
+        $this->prefix = $prefix;
+        $this->set($bitfield);
+
+        if (false !== $this->from) {
+            $this->flags = self::search($this->from, $this->prefix);
+        }
+    }
+
+    /**
+     * Creates dynamically instance of Flag.
+     *
+     * @param string|null|bool $from         Class from where the searching flags is made; define to null to
+     *                                       search flags in global space; define to false for standalone use
+     * @param string           $prefix       Prefix flags from the search flags is made
+     * @param bool             $hierarchical Defines hierarchical flags
+     * @param int              $bitfield     Sets bitfield value
+     *
+     * @return AbstractFlag
+     *
+     * @throws InvalidArgumentException When standalone use is defined as hierarchical
+     * @throws InvalidArgumentException When no-integer flags is defined as hierarchical
+     */
+    public static function create($from = false, $prefix = '', $hierarchical = false, $bitfield = 0)
+    {
+        $onlyInt = true;
+        $forceToBinarize = false;
+
+        if (false === $from) {
+            if ($hierarchical) {
+                throw new InvalidArgumentException('Potential no-integer flags must not be hierarchical.');
+            }
+            $forceToBinarize = true;
+        } else {
+            foreach (self::search($from, $prefix) as $value => $flag) {
+                if (!is_int($value)) {
+                    $onlyInt = false;
+                    break;
+                }
+            }
+            if ($hierarchical && !$onlyInt) {
+                throw new InvalidArgumentException('No-integer flags must not be hierarchical.');
+            }
+        }
+
+        switch (true) {
+            case !$forceToBinarize && $onlyInt && !$hierarchical:
+                $class = Flag::class;
+                break;
+            case !$forceToBinarize && $onlyInt && $hierarchical:
+                $class = HierarchicalFlag::class;
+                break;
+            default:
+                $class = BinarizedFlag::class;
+        }
+
+        return new $class($from, $prefix, $bitfield);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        // ID can be "Prefix*", "ShortClass", "ShortClass::Prefix*" or empty in standalone case
+        $id = '';
+        if (null === $this->from) {
+            $id = $this->prefix.'*';
+        } elseif (class_exists($this->from)) {
+            $id = (new \ReflectionClass($this->from))->getShortName();
+            if ('' !== $this->prefix) {
+                $id .= '::'.$this->prefix.'*';
+            }
+        }
+
+        // removes prefix of each flag (example with E_ prefix, E_ALL becomes ALL)
+        $flags = $this->prefix
+            ? array_map(function ($flag) { return substr($flag, strlen($this->prefix)); }, iterator_to_array($this))
+            : iterator_to_array($this);
+        ;
+
+        return trim(sprintf(
+            '%s [bin: %b] [dec: %s] [%s: %s]',
+            $id,
+            $this->bitfield,
+            $this->bitfield,
+            $this->prefix ? $this->prefix.'*' : 'flags',
+            implode(' | ', $flags)
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        return $this->bitfield;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($bitfield)
+    {
+        if ($this->bitfield !== $bitfield) {
+            $this->bitfield = $bitfield;
+            if (null !== $this->logger) {
+                $this->logger->debug('bitfield changed {flag}', array('flag' => (string) $this));
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator($flagged = true)
+    {
+        return new \ArrayIterator($flagged
+            ? array_filter($this->flags, function ($v) { return $this->has($v); }, ARRAY_FILTER_USE_KEY)
+            : $this->flags
+        );
+    }
+
+    /**
+     * Searchs flags from class or global space.
+     *
+     * @param null|string $from   Class from where the flags searching flags is made; define to null to search flags
+     *                            in global space
+     * @param string      $prefix Prefix flags that filter search result
+     *
+     * @return array Array of flags.
+     */
+    public static function search($from, $prefix = '')
+    {
+        if (null === $from && '' === $prefix) {
+            throw new InvalidArgumentException('A prefix must be setted if searching is in global space.');
+        }
+
+        // TODO search in namespaced constants (get_defined_constants(true)['user'])
+        $constants = null === $from
+            ? get_defined_constants()
+            : (new \ReflectionClass($from))->getConstants()
+        ;
+
+        if ('' !== $prefix) {
+            foreach ($constants as $constant => $value) {
+                if (0 !== strpos($constant, $prefix)) {
+                    unset($constants[$constant]);
+                }
+            }
+        }
+
+        return array_flip($constants);
+    }
+}

--- a/src/Symfony/Component/Flag/BinarizedFlag.php
+++ b/src/Symfony/Component/Flag/BinarizedFlag.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag;
+
+/**
+ * Concrete Flag class that handles no-integer values.
+ *
+ * Some flags have no-integer values like this:
+ *
+ * <code>
+ * const METHOD_HEAD = 'HEAD';
+ * const METHOD_GET = 'GET';
+ * const METHOD_POST = 'POST';
+ * const METHOD_PUT = 'PUT';
+ * </code>
+ *
+ * This Flag class binarizes no-integer values internaly.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class BinarizedFlag extends Flag
+{
+    private $map = array();
+    private $binarized = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($from = false, $prefix = '', $bitfield = 0)
+    {
+        parent::__construct($from, $prefix, $bitfield);
+
+        if (false !== $this->from) {
+            array_walk($this->flags, function ($flag, $value) { $this->binarize($value, $flag); });
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($flag)
+    {
+        if (false === $this->from && !isset($this->flags[$flag])) {
+            $this->flags[$flag] = $flag;
+        }
+
+        $this->set($this->bitfield | $this->binarize($flag));
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($flag)
+    {
+        return parent::remove($this->binarize($flag));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($flags)
+    {
+        return parent::has($this->binarize($flags));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator($flagged = true)
+    {
+        return new \ArrayIterator($flagged
+            ? array_filter($this->binarized, function ($v) { return parent::has($v); }, ARRAY_FILTER_USE_KEY)
+            : $this->binarized
+        );
+    }
+
+    /**
+     * Converts no-integer value flag in saved binary field.
+     *
+     * <code>
+     * | Flag         | Value  | Index | Binary |
+     * ------------------------------------------
+     * | METHOD_HEAD  | 'HEAD' | 0     | 0b0001 |
+     * | METHOD_GET   | 'GET'  | 1     | 0b0010 |
+     * | METHOD_POST  | 'POST' | 2     | 0b0100 |
+     * | METHOD_PUT   | 'PUT'  | 3     | 0b1000 |
+     * </code>
+     *
+     * @param string $value No-integer value
+     *
+     * @return int Binarized value
+     */
+    private function binarize($value, $flag = null)
+    {
+        if (!isset($this->map[$value])) {
+            $this->map[$value] = 1 << count($this->map);
+            $this->binarized[$this->map[$value]] = null === $flag ? $value : $flag;
+        }
+
+        return $this->map[$value];
+    }
+}

--- a/src/Symfony/Component/Flag/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Flag/Exception/ExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag\Exception;
+
+/**
+ * Base ExceptionInterface for the Flag component.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+interface ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Flag/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Flag/Exception/InvalidArgumentException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag\Exception;
+
+/**
+ * Base InvalidArgumentException for the Flag component.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Flag/Flag.php
+++ b/src/Symfony/Component/Flag/Flag.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag;
+
+use Symfony\Component\Flag\Exception\InvalidArgumentException;
+
+/**
+ * Concrete Flag class that handles bitfields.
+ *
+ * @see https://en.wikipedia.org/wiki/Bit_field
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class Flag extends AbstractFlag
+{
+    /**
+     * Sets bitfield value.
+     *
+     * @param int $bitfield Bitfield value
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException When bitfield exceeds integer max limit
+     * @throws InvalidArgumentException When bitfield is not an integer
+     */
+    public function set($bitfield)
+    {
+        if (PHP_INT_MAX < $bitfield) {
+            throw new InvalidArgumentException('Bitfield must not exceed integer max limit.');
+        }
+
+        if (!is_int($bitfield)) {
+            throw new InvalidArgumentException('Bitfield must be an integer.');
+        }
+
+        parent::set($bitfield);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($flag)
+    {
+        if (false === $this->from && !isset($this->flags[$flag])) {
+            $this->flags[$flag] = $flag;
+        }
+
+        $this->set($this->bitfield | $flag);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($flag)
+    {
+        $this->set($this->bitfield & ~$flag);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($flags)
+    {
+        return ($this->bitfield & $flags) === $flags;
+    }
+}

--- a/src/Symfony/Component/Flag/FlagInterface.php
+++ b/src/Symfony/Component/Flag/FlagInterface.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag;
+
+/**
+ * FlagInterface represents a flag.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+interface FlagInterface extends \IteratorAggregate
+{
+    /**
+     * Constructor.
+     *
+     * @param bool   $from     Class from where the searching flags is made
+     * @param string $prefix   Prefix flags
+     * @param int    $bitfield Bitfield value
+     */
+    public function __construct($from = false, $prefix = '', $bitfield = 0);
+
+    /**
+     * Returns a string representation of flag.
+     *
+     * @return string
+     */
+    public function __toString();
+
+    /**
+     * Sets bitfield value.
+     *
+     * @param int $bitfield Bitfield value
+     *
+     * @return $this
+     */
+    public function set($bitfield);
+
+    /**
+     * Gets bitfield value.
+     *
+     * @return int
+     */
+    public function get();
+
+    /**
+     * Adds a flag.
+     *
+     * @param int $flag Bitfield to add
+     *
+     * @return $this
+     */
+    public function add($flag);
+
+    /**
+     * Removes a flag.
+     *
+     * @param int $flag Bitfield to remove
+     *
+     * @return $this
+     */
+    public function remove($flag);
+
+    /**
+     * Checks if flag exists.
+     *
+     * @param int $flag Bitfield to check
+     *
+     * @return bool
+     */
+    public function has($flag);
+
+    /**
+     * Gets flags iterator.
+     *
+     * @param bool $flagged Filter to iterate only on flagged flags; define to false to iterate on all flags
+     *
+     * @return \ArrayIterator
+     */
+    public function getIterator($flagged = true);
+}

--- a/src/Symfony/Component/Flag/HierarchicalFlag.php
+++ b/src/Symfony/Component/Flag/HierarchicalFlag.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag;
+
+/**
+ * Concrete Flag class that handles hierarchical bitfields.
+ *
+ * Some flags have hierarchical bitfields handle. For example, with the next flags:
+ *
+ * <code>
+ * const VERBOSITY_VERBOSE = 64;
+ * const VERBOSITY_VERY_VERBOSE = 128;
+ * const VERBOSITY_DEBUG = 256;
+ * </code>
+ *
+ * if <code>VERBOSITY_DEBUG</code> is flagged, <code>VERBOSITY_VERY_VERBOSE</code> and <code>VERBOSITY_VERBOSE</code>
+ * will be implicitly flagged.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class HierarchicalFlag extends Flag
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function has($flags)
+    {
+        return $flags <= $this->bitfield;
+    }
+}

--- a/src/Symfony/Component/Flag/Tests/AbstractFlagTest.php
+++ b/src/Symfony/Component/Flag/Tests/AbstractFlagTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Flag\AbstractFlag;
+use Symfony\Component\Flag\BinarizedFlag;
+use Symfony\Component\Flag\Flag;
+use Symfony\Component\Flag\HierarchicalFlag;
+use Symfony\Component\Flag\Tests\Fixtures\Bar;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class AbstractFlagTest extends TestCase
+{
+    public function testSearchInGlobalSpace()
+    {
+        $flags = AbstractFlag::search(null, 'E_');
+
+        $expects = array(
+            array(E_ERROR, 'E_ERROR'),
+            array(E_WARNING, 'E_WARNING'),
+            array(E_NOTICE, 'E_NOTICE'),
+            array(E_CORE_ERROR, 'E_CORE_ERROR'),
+            array(E_CORE_WARNING, 'E_CORE_WARNING'),
+            array(E_COMPILE_WARNING, 'E_COMPILE_ERROR'),
+            array(E_USER_ERROR, 'E_USER_ERROR'),
+            array(E_USER_WARNING, 'E_USER_WARNING'),
+            array(E_STRICT, 'E_USER_NOTICE'),
+            array(E_RECOVERABLE_ERROR, 'E_RECOVERABLE_ERROR'),
+            array(E_DEPRECATED, 'E_DEPRECATED'),
+            array(E_USER_DEPRECATED, 'E_USER_DEPRECATED'),
+            array(E_ALL, 'E_ALL'),
+        );
+
+        foreach ($expects as $expect) {
+            $this->assertArrayHasKey($expect[0], $flags);
+            $this->assertContains($expect[1], $flags);
+        }
+
+        $this->assertArrayNotHasKey(PHP_VERSION, $flags);
+        $this->assertNotContains('PHP_VERSION', $flags);
+    }
+
+    public function testSearchInClass()
+    {
+        $flags = AbstractFlag::search(Bar::class);
+
+        foreach (Bar::getFlags() as $expect) {
+            $this->assertArrayHasKey($expect[0], $flags);
+            $this->assertContains($expect[1], $flags);
+        }
+    }
+
+    public function testSearchInClassWithPrefix()
+    {
+        $flags = AbstractFlag::search(Bar::class, 'FLAG_');
+
+        foreach (Bar::getPrefixedFlags() as $expected) {
+            $this->assertArrayHasKey($expected[0], $flags);
+            $this->assertContains($expected[1], $flags);
+        }
+
+        foreach (Bar::getNotPrefixedFlags() as $expected) {
+            $this->assertArrayNotHasKey($expected[0], $flags);
+            $this->assertNotContains($expected[1], $flags);
+        }
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Flag\Exception\InvalidArgumentException
+     * @expectedExceptionMessage A prefix must be setted if searching is in global space.
+     */
+    public function testSearchInGlobalSpaceWithoutPrefix()
+    {
+        AbstractFlag::search(null);
+    }
+
+    /**
+     * @dataProvider provideCreate
+     */
+    public function testCreate($from, $prefix, $hierarchical, $expected)
+    {
+        $flag = AbstractFlag::create($from, $prefix, $hierarchical, 0);
+
+        $this->assertInstanceOf($expected, $flag);
+    }
+
+    public function provideCreate()
+    {
+        return array(
+            array(false, '', false, BinarizedFlag::class),
+
+            array(null, 'E_', false, Flag::class),
+            array(null, 'E_', true, HierarchicalFlag::class),
+
+            array(Bar::class, '', false, BinarizedFlag::class),
+            array(Bar::class, 'FLAG_', false, Flag::class),
+            array(Bar::class, 'FLAG_', true, HierarchicalFlag::class),
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Flag\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Potential no-integer flags must not be hierarchical.
+     */
+    public function testCreateHierarchicalStandalone()
+    {
+        AbstractFlag::create(false, '', true);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Flag\Exception\InvalidArgumentException
+     * @expectedExceptionMessage No-integer flags must not be hierarchical.
+     */
+    public function testCreateHierarchicalNoIntFlags()
+    {
+        AbstractFlag::create(Bar::class, '', true);
+    }
+
+    public function testSetAndGet()
+    {
+        $flag = $this->getMockBuilder(AbstractFlag::class)
+            ->enableOriginalConstructor()
+            ->setMethodsExcept(array('set', 'get'))
+            ->getMock()
+        ;
+
+        $flag->set(1);
+        $this->assertEquals(1, $flag->get());
+    }
+}

--- a/src/Symfony/Component/Flag/Tests/BinarizedFlagTest.php
+++ b/src/Symfony/Component/Flag/Tests/BinarizedFlagTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Flag\BinarizedFlag;
+use Symfony\Component\Flag\Tests\Fixtures\Bar;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class BinarizedFlagTest extends TestCase
+{
+    public function testAdd()
+    {
+        $flag = new BinarizedFlag(Bar::class);
+
+        $flag->add(Bar::A);
+        $this->assertEquals(1 /* Bar::A */, $flag->get());
+
+        $flag->add(Bar::B);
+        $this->assertEquals(1 /* Bar::A */ | 2 /* Bar::B */, $flag->get());
+
+        $this->assertNotEquals(4 /* Bar::C */, $flag->get());
+    }
+
+    public function testAddStandalone()
+    {
+        $flag = new BinarizedFlag();
+
+        $flag->add('a');
+        $this->assertEquals(1 /* a */, $flag->get());
+
+        $flag->add('b');
+        $this->assertEquals(1 /* a */ | 2 /* b */, $flag->get());
+
+        $this->assertNotEquals(4 /* c */, $flag->get());
+    }
+
+    public function testRemove()
+    {
+        $flag = (new BinarizedFlag(Bar::class))
+            ->add(Bar::A)
+            ->add(Bar::B)
+        ;
+
+        $flag->remove(Bar::B);
+        $this->assertEquals(1 /* Bar::A */, $flag->get());
+
+        $this->assertNotEquals(4 /* Bar::C */, $flag->get());
+    }
+
+    public function testHas()
+    {
+        $flag = (new BinarizedFlag(Bar::class))
+            ->add(Bar::A)
+            ->add(Bar::B)
+        ;
+
+        $this->assertTrue($flag->has(Bar::A));
+        $this->assertTrue($flag->has(Bar::B));
+        $this->assertFalse($flag->has(Bar::C));
+    }
+
+    public function testGetIterator()
+    {
+        $flag = (new BinarizedFlag(Bar::class))
+            ->add(Bar::A)
+            ->add(Bar::B)
+        ;
+
+        $flags = $flag->getIterator(false);
+        foreach (Bar::getBinarizedFlags() as $expected) {
+            $this->assertArrayHasKey($expected[0], $flags);
+            $this->assertContains($expected[1], $flags);
+        }
+
+        $flags = $flag->getIterator();
+        $this->assertArrayHasKey(1 /* Bar::A */, $flags);
+        $this->assertArrayHasKey(2 /* Bar::B */, $flags);
+        $this->assertArrayNotHasKey(4 /* Bar::C */, $flags);
+    }
+}

--- a/src/Symfony/Component/Flag/Tests/Fixtures/Bar.php
+++ b/src/Symfony/Component/Flag/Tests/Fixtures/Bar.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag\Tests\Fixtures;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class Bar extends Foo
+{
+    const A = 'a';
+    const B = 'b';
+    const C = 'c';
+
+    public static function getNotPrefixedFlags()
+    {
+        return array(
+            array(self::A, 'A'),
+            array(self::B, 'B'),
+            array(self::C, 'C'),
+        );
+    }
+
+    public static function getFlags()
+    {
+        return array_merge(self::getNotPrefixedFlags(), self::getPrefixedFlags());
+    }
+
+    public static function getBinarizedFlags()
+    {
+        return array(
+            array(1, 'A'),
+            array(2, 'B'),
+            array(4, 'C'),
+            array(8, 'FLAG_A'),
+            array(16, 'FLAG_B'),
+            array(32, 'FLAG_C'),
+        );
+    }
+}

--- a/src/Symfony/Component/Flag/Tests/Fixtures/Foo.php
+++ b/src/Symfony/Component/Flag/Tests/Fixtures/Foo.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag\Tests\Fixtures;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class Foo
+{
+    const FLAG_A = 1;
+    const FLAG_B = 2;
+    const FLAG_C = 4;
+
+    public static function getPrefixedFlags()
+    {
+        return array(
+            array(Bar::FLAG_A, 'FLAG_A'),
+            array(Bar::FLAG_B, 'FLAG_B'),
+            array(Bar::FLAG_C, 'FLAG_C'),
+        );
+    }
+}

--- a/src/Symfony/Component/Flag/Tests/FlagTest.php
+++ b/src/Symfony/Component/Flag/Tests/FlagTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Flag\Flag;
+use Symfony\Component\Flag\Tests\Fixtures\Bar;
+use Symfony\Component\Flag\Tests\Fixtures\Foo;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class FlagTest extends TestCase
+{
+    /**
+     * @dataProvider provideBitfields
+     */
+    public function testSetAndGet($bitfield)
+    {
+        $flag = (new Flag())->set($bitfield);
+
+        $this->assertEquals($bitfield, $flag->get());
+    }
+
+    public function provideBitfields()
+    {
+        return array(
+            array(0),
+            array(1),
+            array(2),
+            array(4),
+            array(1023),
+            array(1024),
+            array(E_ALL),
+            array(PHP_INT_MAX),
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Flag\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Bitfield must be an integer.
+     */
+    public function testSetNotIntBitfield()
+    {
+        (new Flag())->set('a');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Flag\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Bitfield must not exceed integer max limit.
+     */
+    public function testSetToBigBitfield()
+    {
+        (new Flag())->set(PHP_INT_MAX * 2);
+    }
+
+    public function testGetIterator()
+    {
+        $flag = new Flag(Foo::class, 'FLAG_', Bar::FLAG_A);
+
+        $flags = $flag->getIterator(false);
+        foreach (Foo::getPrefixedFlags() as $expected) {
+            $this->assertArrayHasKey($expected[0], $flags);
+        }
+
+        $flags = $flag->getIterator();
+        $this->assertArrayHasKey(Foo::FLAG_A, $flags);
+        $this->assertArrayNotHasKey(Foo::FLAG_B, $flags);
+        $this->assertArrayNotHasKey(Foo::FLAG_C, $flags);
+    }
+
+    /**
+     * @dataProvider provideToString
+     */
+    public function testToString($from, $prefix, $bitfield, $expected)
+    {
+        $flag = new Flag($from, $prefix, $bitfield);
+
+        $this->assertEquals($expected, (string) $flag);
+    }
+
+    public function provideToString()
+    {
+        return array(
+            array(null, 'E_', E_ERROR, 'E_* [bin: 1] [dec: 1] [E_*: ERROR]'),
+            array(Foo::class, '', 0, 'Foo [bin: 0] [dec: 0] [flags: ]'),
+            array(Foo::class, '', Foo::FLAG_A, 'Foo [bin: 1] [dec: 1] [flags: FLAG_A]'),
+            array(Foo::class, '', Foo::FLAG_A | Foo::FLAG_B, 'Foo [bin: 11] [dec: 3] [flags: FLAG_A | FLAG_B]'),
+            array(Foo::class, 'FLAG_', 0, 'Foo::FLAG_* [bin: 0] [dec: 0] [FLAG_*: ]'),
+            array(Foo::class, 'FLAG_', Foo::FLAG_A, 'Foo::FLAG_* [bin: 1] [dec: 1] [FLAG_*: A]'),
+            array(Foo::class, 'FLAG_', Foo::FLAG_A | Foo::FLAG_B, 'Foo::FLAG_* [bin: 11] [dec: 3] [FLAG_*: A | B]'),
+        );
+    }
+
+    public function testAdd()
+    {
+        $flag = new Flag(Foo::class, 'FLAG_');
+
+        $flag->add(Foo::FLAG_A);
+        $this->assertEquals(Foo::FLAG_A, $flag->get());
+
+        $flag->add(Foo::FLAG_B);
+        $this->assertEquals(Foo::FLAG_A | Foo::FLAG_B, $flag->get());
+
+        $this->assertNotEquals(Foo::FLAG_C, $flag->get());
+    }
+
+    public function testAddStandalone()
+    {
+        $flag = new Flag();
+
+        $flag->add(1);
+        $this->assertEquals(1, $flag->get());
+
+        $flag->add(2);
+        $this->assertEquals(1 | 2, $flag->get());
+
+        $this->assertNotEquals(4, $flag->get());
+    }
+
+    public function testRemove()
+    {
+        $flag = new Flag(Foo::class, 'FLAG_', Foo::FLAG_A | Foo::FLAG_B);
+
+        $this->assertEquals(Foo::FLAG_A | Foo::FLAG_B, $flag->get());
+        $flag->remove(Foo::FLAG_B);
+        $this->assertEquals(Foo::FLAG_A, $flag->get());
+    }
+
+    public function testHas()
+    {
+        $flag = new Flag(Foo::class, 'FLAG_', Foo::FLAG_A | Foo::FLAG_B);
+
+        $this->assertTrue($flag->has(Foo::FLAG_A));
+        $this->assertTrue($flag->has(Foo::FLAG_B));
+        $this->assertFalse($flag->has(Foo::FLAG_C));
+    }
+}

--- a/src/Symfony/Component/Flag/Tests/HierarchicalFlagTest.php
+++ b/src/Symfony/Component/Flag/Tests/HierarchicalFlagTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Flag\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Flag\HierarchicalFlag;
+use Symfony\Component\Flag\Tests\Fixtures\Foo;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+class HierarchicalFlagTest extends TestCase
+{
+    public function testHas()
+    {
+        $flag = new HierarchicalFlag(Foo::class, 'FLAG_', Foo::FLAG_B);
+
+        $this->assertTrue($flag->has(Foo::FLAG_A));
+        $this->assertTrue($flag->has(Foo::FLAG_B));
+        $this->assertFalse($flag->has(Foo::FLAG_C));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

<p align="center">:golf:<p>

Symfony likes to flag values (for example in [Yaml](https://github.com/symfony/symfony/blob/ac5cfee6f12f5c93fe8d8b67941fd478dfaa397a/src/Symfony/Component/Yaml/Yaml.php#L23-L34), in [VarDumper](https://github.com/symfony/symfony/blob/ac5cfee6f12f5c93fe8d8b67941fd478dfaa397a/src/Symfony/Component/VarDumper/Caster/Caster.php#L25-L34), in [Console](https://github.com/symfony/symfony/blob/ac5cfee6f12f5c93fe8d8b67941fd478dfaa397a/src/Symfony/Component/Console/Output/OutputInterface.php#L23-L27) and elsewhere). But theses flags are not  intuitive to understand, using concepts like [bitwise operators](http://php.net/manual/en/language.operators.bitwise.php), [bitmask](https://en.wikipedia.org/wiki/Mask_(computing)) or [bit field](https://en.wikipedia.org/wiki/Bit_field). Moreover, theses flags are not easy to debug; find flags that hide behind integer bitfield is very annoying. I propose a new **Flag** component that abstracts theses binary concepts and improves DX to debug them.

## Overview

For example, here is how to play with ``Yaml`` flags:

```php
use Symfony\Component\Flag\Flag;
use Symfony\Component\Yaml\Yaml;

$flag = Flag::create(Yaml::class)
    ->add(Yaml::DUMP_OBJECT)      // logs '[debug] bitfield changed Yaml [bin: 1] [dec: 1] [flags: DUMP_OBJECT]'
    ->add(Yaml::PARSE_DATETIME)   // logs '[debug] bitfield changed Yaml [bin: 100001] [dec: 33] [flags: DUMP_OBJECT | PARSE_DATETIME]'
    ->remove(Yaml::DUMP_OBJECT)   // logs '[debug] bitfield changed Yaml [bin: 100000] [dec: 32] [flags: PARSE_DATETIME]'
;

$flag->has(Yaml::DUMP_OBJECT);    // returns false
$flag->has(Yaml::PARSE_DATETIME); // returns true
$flag->get();                     // returns 288
$flag->set(100);                  // logs '[debug] bitfield changed Yaml [bin: 1100100] [dec: 100] [flags: PARSE_OBJECT | PARSE_DATETIME | DUMP_OBJECT_AS_MAP]'

foreach ($flag as $k => $v) {
    echo "$k => $v ";            // writes '4 => PARSE_OBJECT 32 => PARSE_DATETIME 64 => DUMP_OBJECT_AS_MAP '
}
```

## Prefixed Flags

As in ``Caster::EXCLUDE_*`` case, it's possible to handle prefixed flags.

```php
use Symfony\Component\Flag\Flag;
use Symfony\Component\VarDumper\Caster\Caster;

$flag = Flag::create(Caster::class, 'EXCLUDE_')
    ->add(Caster::EXCLUDE_EMPTY)         // logs '[debug] bitfield changed Caster::EXCLUDE_* [bin: 10000000] [dec: 128] [EXCLUDE_*: EMPTY]'
    ->add(Caster::EXCLUDE_PRIVATE)       // logs '[debug] bitfield changed Caster::EXCLUDE_* [bin: 10100000] [dec: 160] [EXCLUDE_*: PRIVATE | EMPTY]'
    ->add(Caster::EXCLUDE_NOT_IMPORTANT) // logs '[debug] bitfield changed Caster::EXCLUDE_* [bin: 110100000] [dec: 416] [EXCLUDE_*: PRIVATE | EMPTY | NOT_IMPORTANT]'
;
```
## Hierarchical Flags

As in ``Output::VERBOSITY_*`` case, flags are hierachical, like this:

```
VERBOSITY_VERY_VERBOSE
└── VERBOSITY_VERBOSE
    └── VERBOSITY_NORMAL
```

This means that if ``VERBOSITY_VERY_VERBOSE`` is flagged, ``VERBOSITY_VERBOSE`` and ``VERBOSITY_NORMAL`` will be also implicitly flagged.

```php
use Symfony\Component\Console\Output\Output;
use Symfony\Component\Flag\Flag;

$flag = Flag::create(Output::class, 'VERBOSITY_', $hierachical = true)
    ->add(Output::VERBOSITY_VERBOSE) // logs '[debug] bitfield changed Output::VERBOSITY_* [bin: 1000000] [dec: 64] [VERBOSITY_*: QUIET | NORMAL | VERBOSE]'
    ->add(Output::VERBOSITY_DEBUG)   // logs '[debug] bitfield changed Output::VERBOSITY_* [bin: 101000000] [dec: 320] [VERBOSITY_*: QUIET | NORMAL | VERBOSE | VERY_VERBOSE | DEBUG]'
;
```

## Global Flags

It's possible to handle flags in global space, like with ``E_*`` errors flags.

```php
use Symfony\Component\Flag\Flag;

$flag = Flag::create(null, 'E_')
    ->add(E_ALL)             // logs '[debug] bitfield changed E_* [bin: 111111111111111] [dec: 32767] [E_*: ERROR | RECOVERABLE_ERROR | WARNING | PARSE | NOTICE | STRICT | DEPRECATED | CORE_ERROR | CORE_WARNING | COMPILE_ERROR | COMPILE_WARNING | USER_ERROR | USER_WARNING | USER_NOTICE | USER_DEPRECATED | ALL]'
    ->set(0)                 // logs '[debug] bitfield changed E_* [bin: 0] [dec: 0] [E_*: ]'
    ->add(E_USER_ERROR)      // logs '[debug] bitfield changed E_* [bin: 100000000] [dec: 256] [E_*: USER_ERROR]'
    ->add(E_USER_DEPRECATED) // logs '[debug] bitfield changed E_* [bin: 100000100000000] [dec: 16640] [E_*: USER_ERROR | USER_DEPRECATED]'
;
```

## No-int Flags

As in ``Request::METHOD_*`` case, values flags are not integer but string. For example, ``METHOD_GET`` has ``GET`` string as value. This string values are internally binarized.

```php
use Symfony\Component\Flag\Flag;
use Symfony\Component\HttpFoundation\Request;

$flag = Flag::create(Request::class, 'METHOD_')
    ->add(Request::METHOD_GET)  // logs '[debug] bitfield changed Request::METHOD_* [bin: 10] [dec: 2] [METHOD_*: GET]'
    ->add(Request::METHOD_POST) // logs '[debug] bitfield changed Request::METHOD_* [bin: 110] [dec: 6] [METHOD_*: GET | POST]'
    ->add(Request::METHOD_PUT)  // logs '[debug] bitfield changed Request::METHOD_* [bin: 1110] [dec: 14] [METHOD_*: GET | POST | PUT]'
;
```

## Standalone Flags

It's also possible to handle no-constants flags.

```php
use Symfony\Component\Flag\Flag;

$flag = Flag::create()
    ->add('a') // logs '[debug] bitfield changed [bin: 1] [dec: 1] [flags: a]'
    ->add('b') // logs '[debug] bitfield changed [bin: 11] [dec: 3] [flags: a | b]'
;

$flag = (new Flag())
    ->add(8)  // logs '[debug] bitfield changed [bin: 1000] [dec: 8] [flags: 8]'
    ->add(32) // logs '[debug] bitfield changed [bin: 101000] [dec: 40] [flags: 8 | 32]'
;
```

---
**notes**

- You can see some examples of changes would be made in the core in [this link](https://github.com/maidmaid/symfony/compare/flag...maidmaid:flag-implementation).
- You can play with all previous examples by running ``php flag.php``.

**todo**
- [x] do a poc
- [ ] do the rest if this proposal is accepted