### PR TITLE
[SecurityBundle] Allow for custom request matchers in access control

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -164,6 +164,7 @@ class MainConfiguration implements ConfigurationInterface
                         ->fixXmlConfig('ip')
                         ->fixXmlConfig('method')
                         ->children()
+                            ->scalarNode('request_matcher')->defaultNull()->end()
                             ->scalarNode('requires_channel')->defaultNull()->end()
                             ->scalarNode('path')
                                 ->defaultNull()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -211,13 +211,11 @@ class SecurityExtension extends Extension
         }
 
         foreach ($config['access_control'] as $access) {
-            $matcher = $this->createRequestMatcher(
-                $container,
-                $access['path'],
-                $access['host'],
-                $access['methods'],
-                $access['ips']
-            );
+            if (null !== $access['request_matcher']) {
+                $matcher = new Reference($access['request_matcher']);
+            } else {
+                $matcher = $this->createRequestMatcher($container, $access['path'], $access['host'], $access['methods'], $access['ips']);
+            }
 
             $attributes = $access['roles'];
             if ($access['allow_if']) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Re-opening #20272 in the same spirit of #22572, and i have no better solution to enable route matching :)

Not sure about the config yet, it differs from the logout listener where both configs (path + request_matcher) must match.

So for access control to get the same behavior (where all configs must match) it needs a chain request matcher or get creative with `AccessMap::add`. 

Otherwise i think the logout listener should follow this behavior.