### PR TITLE
[Console][HttpKernel] Avoid reflection-based registration for command public services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
@@ -53,7 +53,7 @@ class AddConsoleCommandPassTest extends TestCase
         }
 
         $this->assertTrue($container->hasParameter('console.command.ids'));
-        $this->assertSame(array($id), $container->getParameter('console.command.ids'));
+        $this->assertSame(array($alias => $id), $container->getParameter('console.command.ids'));
     }
 
     public function visibilityProvider()

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -39,16 +39,16 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 throw new InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must be a subclass of "%s".', $id, Command::class));
             }
 
+            $commandId = 'console.command.'.strtolower(str_replace('\\', '_', $class));
+            if ($container->hasAlias($commandId) || isset($serviceIds[$commandId])) {
+                $commandId = $commandId.'_'.$id;
+            }
             if (!$definition->isPublic()) {
-                $serviceId = 'console.command.'.strtolower(str_replace('\\', '_', $class));
-                if ($container->hasAlias($serviceId)) {
-                    $serviceId = $serviceId.'_'.$id;
-                }
-                $container->setAlias($serviceId, $id);
-                $id = $serviceId;
+                $container->setAlias($commandId, $id);
+                $id = $commandId;
             }
 
-            $serviceIds[] = $id;
+            $serviceIds[$commandId] = $id;
         }
 
         $container->setParameter('console.command.ids', $serviceIds);

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -50,7 +50,7 @@ class AddConsoleCommandPassTest extends TestCase
         }
 
         $this->assertTrue($container->hasParameter('console.command.ids'));
-        $this->assertSame(array($id), $container->getParameter('console.command.ids'));
+        $this->assertSame(array($alias => $id), $container->getParameter('console.command.ids'));
     }
 
     public function visibilityProvider()

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -183,8 +183,9 @@ abstract class Bundle implements BundleInterface
             }
             $class = $ns.'\\'.$file->getBasename('.php');
             if ($this->container) {
+                $commandIds = $this->container->hasParameter('console.command.ids') ? $this->container->getParameter('console.command.ids') : array();
                 $alias = 'console.command.'.strtolower(str_replace('\\', '_', $class));
-                if ($this->container->has($alias)) {
+                if (isset($commandIds[$alias]) || $this->container->has($alias)) {
                     continue;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22410#issuecomment-298158585
| License       | MIT
| Doc PR        | n/a

By mapping commands ids by their alias in `console.command.ids` (even if the alias is not registered in the container for public services), then skipping reflection if the predictable alias exists as a key of `console.command.ids`.

Please note that the whole command service registration process is far from ideal.
I'm working on changing this for 3.4 in a transparent way regarding end users, leveraging PSR-11 to make the console component DI friendly, allowing to register commands as true private services (no more public aliases) and providing laziness for those.