### PR TITLE
[Security] json login listener: ensure a json response is sent on bad request

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
@@ -61,4 +61,15 @@ class JsonLoginTest extends WebTestCase
         $this->assertSame(500, $response->getStatusCode());
         $this->assertSame(array('message' => 'Something went wrong'), json_decode($response->getContent(), true));
     }
+
+    public function testDefaultJsonLoginBadRequest()
+    {
+        $client = $this->createClient(array('test_case' => 'JsonLogin', 'root_config' => 'config.yml'));
+        $client->request('POST', '/chk', array(), array(), array('CONTENT_TYPE' => 'application/json'), 'Not a json content');
+        $response = $client->getResponse();
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertArraySubset(array('error' => array('code' => 400, 'message' => 'Bad Request')), json_decode($response->getContent(), true));
+    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/bundles.php
@@ -12,5 +12,6 @@
 return array(
     new Symfony\Bundle\SecurityBundle\SecurityBundle(),
     new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new Symfony\Bundle\TwigBundle\TwigBundle(),
     new Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\JsonLoginBundle\JsonLoginBundle(),
 );

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -122,6 +122,10 @@ class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
             $response = $this->onSuccess($request, $authenticatedToken);
         } catch (AuthenticationException $e) {
             $response = $this->onFailure($request, $e);
+        } catch (BadRequestHttpException $e) {
+            $request->setRequestFormat('json');
+
+            throw $e;
         }
 
         if (null === $response) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (3.3)
| Bug fix?      | yesish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

I would have simply recommended to set the proper format when declaring the route:

```yml
# routing.yml
api_login:
    path: /login
    defaults: { _format: json }
```

but, since https://github.com/symfony/symfony/pull/22477 has been merged, and considering https://github.com/symfony/symfony/pull/22477#issuecomment-295897629:

> my point above regarding checking the content type is so that one could use form_login and json_login in parallel on the same routes and within the same firewall

we may consider setting the request format to json when throwing the `BadRequestHttpException`, so used conjointly with the TwigBundle, the exception is rendered using the `exception.json.twig` template.

ping @lsmith77 

(An alternative would be to check the Accept header to set the request format to json if it's the preferred one instead of doing it each time we throw the exception. But Symfony never used such content negotiation AFAIK, and I think it's safe enough to assume someone sending json is expecting json as ouput for exceptions.)