### PR TITLE
[Form] Fixed PercentToLocalizedStringTransformer to accept both comma and dot as decimal separator, if possible

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -25,6 +25,7 @@ CHANGELOG
    * "choice_value"
    * "choice_attr"
    * "group_by"
+ * added PercentToLocalizedStringTransformer to accept both comma and dot as decimal separator, if possible
 
 2.6.2
 -----

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -25,7 +25,6 @@ CHANGELOG
    * "choice_value"
    * "choice_attr"
    * "group_by"
- * added PercentToLocalizedStringTransformer to accept both comma and dot as decimal separator, if possible
 
 2.6.2
 -----

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -119,6 +119,18 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
         }
 
         $formatter = $this->getNumberFormatter();
+        $groupSep = $formatter->getSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
+        $decSep = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+        $grouping = $formatter->getAttribute(\NumberFormatter::GROUPING_USED);
+
+        if ('.' !== $decSep && (!$grouping || '.' !== $groupSep)) {
+            $value = str_replace('.', $decSep, $value);
+        }
+
+        if (',' !== $decSep && (!$grouping || ',' !== $groupSep)) {
+            $value = str_replace(',', $decSep, $value);
+        }
+
         // replace normal spaces so that the formatter can read them
         $value = $formatter->parse(str_replace(' ', "\xc2\xa0", $value));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -119,4 +119,115 @@ class PercentToLocalizedStringTransformerTest extends TestCase
 
         $transformer->reverseTransform(1);
     }
+
+    public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsNotDot()
+    {
+        \Locale::setDefault('fr');
+        $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
+
+        // completely valid format
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1 234,5'));
+        // accept dots
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1 234.5'));
+        // omit group separator
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot()
+    {
+        // Since we test against "de_DE", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_DE');
+
+        $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
+
+        $transformer->reverseTransform('1.234.5');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
+    {
+        // Since we test against "de_DE", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_DE');
+
+        $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
+
+        $transformer->reverseTransform('1234.5');
+    }
+
+    public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsDotButNoGroupingUsed()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('fr');
+        $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
+
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
+    }
+
+    public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsNotComma()
+    {
+        // Since we test against other locales, we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('bg');
+        $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
+
+        // completely valid format
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1 234.5'));
+        // accept commas
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1 234,5'));
+        // omit group separator
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma()
+    {
+        $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
+
+        $transformer->reverseTransform('1,234,5');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
+    {
+        $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
+
+        $transformer->reverseTransform('1234,5');
+    }
+
+    public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsCommaButNoGroupingUsed()
+    {
+        $formatter = new \NumberFormatter(\Locale::getDefault(), \NumberFormatter::DECIMAL);
+        $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, 1);
+        $formatter->setAttribute(\NumberFormatter::GROUPING_USED, false);
+
+        $transformer = $this->getMockBuilder('Symfony\Component\Form\Extension\Core\DataTransformer\PercentToLocalizedStringTransformer')
+            ->setMethods(array('getNumberFormatter'))
+            ->setConstructorArgs(array(1, 'integer'))
+            ->getMock();
+        $transformer->expects($this->any())
+            ->method('getNumberFormatter')
+            ->willReturn($formatter);
+
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(1234.5, $transformer->reverseTransform('1234.5'));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -122,6 +122,8 @@ class PercentToLocalizedStringTransformerTest extends TestCase
 
     public function testDecimalSeparatorMayBeDotIfGroupingSeparatorIsNotDot()
     {
+        IntlTestHelper::requireFullIntl($this, '4.8.1.1');
+
         \Locale::setDefault('fr');
         $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
 
@@ -139,10 +141,10 @@ class PercentToLocalizedStringTransformerTest extends TestCase
      */
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot()
     {
-        // Since we test against "de_DE", we need the full implementation
-        IntlTestHelper::requireFullIntl($this, false);
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
-        \Locale::setDefault('de_DE');
+        \Locale::setDefault('de_AT');
 
         $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
 
@@ -155,7 +157,7 @@ class PercentToLocalizedStringTransformerTest extends TestCase
     public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
     {
         // Since we test against "de_DE", we need the full implementation
-        IntlTestHelper::requireFullIntl($this, false);
+        IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
         \Locale::setDefault('de_DE');
 
@@ -179,7 +181,7 @@ class PercentToLocalizedStringTransformerTest extends TestCase
     public function testDecimalSeparatorMayBeCommaIfGroupingSeparatorIsNotComma()
     {
         // Since we test against other locales, we need the full implementation
-        IntlTestHelper::requireFullIntl($this, false);
+        IntlTestHelper::requireFullIntl($this, '4.8.1.1');
 
         \Locale::setDefault('bg');
         $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
@@ -198,6 +200,8 @@ class PercentToLocalizedStringTransformerTest extends TestCase
      */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma()
     {
+        IntlTestHelper::requireFullIntl($this, '4.8.1.1');
+
         $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
 
         $transformer->reverseTransform('1,234,5');
@@ -208,6 +212,8 @@ class PercentToLocalizedStringTransformerTest extends TestCase
      */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
     {
+        IntlTestHelper::requireFullIntl($this, '4.8.1.1');
+
         $transformer = new PercentToLocalizedStringTransformer(1, 'integer');
 
         $transformer->reverseTransform('1234,5');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see comment below -->
| Bug fix?      | yes-ish
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

Implements the same behaviour that `NumberToLocalizedStringTransformer` in order to accept both comma and dot implemented in #5941


