### PR TITLE
[VarDumper] Add filter in VarDumperTestTrait

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -540,6 +540,39 @@ Validator
    changed to `true` as of 4.0. If you need the previous behaviour ensure to
    set the option to `false`.
 
+VarDumper
+---------
+
+ * The `VarDumperTestTrait::assertDumpEquals()` method expects a 3rd `$context = null`
+   argument and moves `$message = ''` argument at 4th position.
+
+   Before:
+
+   ```php
+   VarDumperTestTrait::assertDumpEquals($dump, $data, $message = '');
+   ```
+
+   After:
+
+   ```php
+   VarDumperTestTrait::assertDumpEquals($dump, $data, $filter = 0, $message = '');
+   ```
+
+ * The `VarDumperTestTrait::assertDumpMatchesFormat()` method expects a 3rd `$context = null`
+   argument and moves `$message = ''` argument at 4th position.
+
+   Before:
+
+   ```php
+   VarDumperTestTrait::assertDumpMatchesFormat($dump, $data, $message = '');
+   ```
+
+   After:
+
+   ```php
+   VarDumperTestTrait::assertDumpMatchesFormat($dump, $data, $filter = 0, $message = '');
+   ```
+
 Workflow
 --------
 

--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
@@ -19,17 +19,29 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
  */
 trait VarDumperTestTrait
 {
-    public function assertDumpEquals($dump, $data, $message = '')
+    public function assertDumpEquals($dump, $data, $filter = 0, $message = '')
     {
-        $this->assertSame(rtrim($dump), $this->getDump($data), $message);
+        if (is_string($filter)) {
+            @trigger_error(sprintf('The $message argument of the %s() at 3rd position is deprecated since version 3.4 and will be moved at 4th position in 4.0.', __METHOD__), E_USER_DEPRECATED);
+            $message = $filter;
+            $filter = 0;
+        }
+
+        $this->assertSame(rtrim($dump), $this->getDump($data, null, $filter), $message);
     }
 
-    public function assertDumpMatchesFormat($dump, $data, $message = '')
+    public function assertDumpMatchesFormat($dump, $data, $filter = 0, $message = '')
     {
-        $this->assertStringMatchesFormat(rtrim($dump), $this->getDump($data), $message);
+        if (is_string($filter)) {
+            @trigger_error(sprintf('The $message argument of the %s() at 3rd position is deprecated since version 3.4 and will be moved at 4th position in 4.0.', __METHOD__), E_USER_DEPRECATED);
+            $message = $filter;
+            $filter = 0;
+        }
+
+        $this->assertStringMatchesFormat(rtrim($dump), $this->getDump($data, null, $filter), $message);
     }
 
-    protected function getDump($data, $key = null)
+    protected function getDump($data, $key = null, $filter = 0)
     {
         $flags = getenv('DUMP_LIGHT_ARRAY') ? CliDumper::DUMP_LIGHT_ARRAY : 0;
         $flags |= getenv('DUMP_STRING_LENGTH') ? CliDumper::DUMP_STRING_LENGTH : 0;
@@ -38,7 +50,7 @@ trait VarDumperTestTrait
         $cloner->setMaxItems(-1);
         $dumper = new CliDumper(null, null, $flags);
         $dumper->setColors(false);
-        $data = $cloner->cloneVar($data)->withRefHandles(false);
+        $data = $cloner->cloneVar($data, $filter)->withRefHandles(false);
         if (null !== $key && null === $data = $data->seek($key)) {
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

Many casters uses ``EXCLUDE_*`` flags in their cast method. It would be usefull to use this flags directly with ``VarDumperTestTrait`` to tests many cases.