### PR TITLE
[Profiler] DataCollector: Remove unused static property

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -39,8 +39,6 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
      */
     private static $cloner;
 
-    private static $stubsCache = array();
-
     public function serialize()
     {
         return serialize($this->data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Unless I missed something, any usage of this property were removed in https://github.com/symfony/symfony/pull/21638.