### PR TITLE
Release v2.7.27

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,22 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.27 (2017-05-01)
+
+ * bug #22528 [Asset] Starting slash should indicate no basePath wanted (weaverryan)
+ * bug #22526 [Asset] Preventing the base path or absolute URL from being prefixed incorrectly (weaverryan)
+ * bug #22435 [Console] Fix dispatching throwables from ConsoleEvents::COMMAND (nicolas-grekas)
+ * bug #22478 [Serializer] XmlEncoder: fix negative int and large numbers handling (dunglas)
+ * bug #22424 [Debug] Set exit status to 255 on error (nicolas-grekas)
+ * bug #22396 Prevent double registrations related to tag priorities (nicolas-grekas)
+ * bug #22352 [HttpFoundation] Add `use_strict_mode` in validOptions for session (sstok)
+ * bug #22351 [Yaml] don't keep internal state between parser runs (xabbuh)
+ * bug #22307 [Debug] Fix php notice (enumag)
+ * bug #22109 [Validator] check for empty host when calling checkdnsrr() (apetitpa)
+ * bug #22280 [DI] Fix the xml schema (GuilhemN)
+ * bug #22255 [Translation] avoid creating cache files for fallback locales. (aitboudad)
+ * bug #22292 Fixes #22264 - add support for Chrome headless (redthor)
+
 * 2.7.26 (2017-04-04)
 
  * bug #22229 [ExpressionLanguage] Provide the expression in syntax errors (k0pernikus, stof)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,9 +26,9 @@ Symfony is the result of the work of many people who made the code better
  - Grégoire Pineau (lyrixx)
  - Joseph Bielawski (stloyd)
  - Karma Dordrak (drak)
+ - Robin Chalas (chalas_r)
  - Lukas Kahwe Smith (lsmith)
  - Martin Hasoň (hason)
- - Robin Chalas (chalas_r)
  - Maxime Steinhausser (ogizanagi)
  - Jeremy Mikola (jmikola)
  - Jean-François Simon (jfsimon)
@@ -37,10 +37,10 @@ Symfony is the result of the work of many people who made the code better
  - Eriksen Costa (eriksencosta)
  - Jules Pietri (heah)
  - Sarah Khalil (saro0h)
+ - Roland Franssen (ro0)
  - Jonathan Wage (jwage)
  - Guilhem Niot (energetick)
  - Diego Saint Esteben (dosten)
- - Roland Franssen (ro0)
  - Alexandre Salomé (alexandresalome)
  - William Durand (couac)
  - ornicar
@@ -73,10 +73,10 @@ Symfony is the result of the work of many people who made the code better
  - Titouan Galopin (tgalopin)
  - Douglas Greenshields (shieldo)
  - Konstantin Myakshin (koc)
+ - Jáchym Toušek (enumag)
  - Lee McDermott
  - Brandon Turner
  - Luis Cordova (cordoval)
- - Jáchym Toušek (enumag)
  - Graham Campbell (graham)
  - Daniel Holmes (dholmes)
  - Toni Uebernickel (havvg)
@@ -84,12 +84,12 @@ Symfony is the result of the work of many people who made the code better
  - Jordan Alliot (jalliot)
  - Jérémy DERUSSÉ (jderusse)
  - John Wards (johnwards)
+ - Dariusz Ruminski
  - Fran Moreno (franmomu)
  - Antoine Hérault (herzult)
- - Paráda József (paradajozsef)
- - Dariusz Ruminski
- - Arnaud Le Blanc (arnaud-lb)
  - Jérôme Tamarelle (gromnan)
+ - Paráda József (paradajozsef)
+ - Arnaud Le Blanc (arnaud-lb)
  - Maxime STEINHAUSSER
  - Michal Piotrowski (eventhorizon)
  - Tim Nagel (merk)
@@ -120,6 +120,7 @@ Symfony is the result of the work of many people who made the code better
  - Théo FIDRY (theofidry)
  - Robert Schönthal (digitalkaoz)
  - Florian Lonqueu-Brochard (florianlb)
+ - Sebastiaan Stok (sstok)
  - Stefano Sala (stefano.sala)
  - Yonel Ceruto González (yonelceruto)
  - Evgeniy (ewgraf)
@@ -128,7 +129,6 @@ Symfony is the result of the work of many people who made the code better
  - Sebastian Hörl (blogsh)
  - Daniel Gomes (danielcsgomes)
  - Hidenori Goto (hidenorigoto)
- - Sebastiaan Stok (sstok)
  - Guilherme Blanco (guilhermeblanco)
  - Pablo Godel (pgodel)
  - Jérémie Augustin (jaugustin)
@@ -146,6 +146,7 @@ Symfony is the result of the work of many people who made the code better
  - Vincent AUBERT (vincent)
  - Rouven Weßling (realityking)
  - Teoh Han Hui (teohhanhui)
+ - Jérôme Vasseur (jvasseur)
  - Clemens Tolboom
  - Helmer Aaviksoo
  - Grégoire Paris (greg0ire)
@@ -178,8 +179,11 @@ Symfony is the result of the work of many people who made the code better
  - Daniel Espendiller
  - sun (sun)
  - Larry Garfield (crell)
+ - Julien Falque (julienfalque)
  - Martin Schuhfuß (usefulthink)
+ - apetitpa
  - Matthieu Bontemps (mbontemps)
+ - apetitpa
  - Pierre Minnieur (pminnieur)
  - fivestar
  - Dominique Bongiraud
@@ -201,7 +205,6 @@ Symfony is the result of the work of many people who made the code better
  - SpacePossum
  - Eugene Wissner
  - Julien Brochet (mewt)
- - Julien Falque (julienfalque)
  - Tristan Darricau (nicofuma)
  - Sergey Linnik (linniksa)
  - Michaël Perrin (michael.perrin)
@@ -220,7 +223,6 @@ Symfony is the result of the work of many people who made the code better
  - Elnur Abdurrakhimov (elnur)
  - Manuel Reinhard (sprain)
  - Danny Berger (dpb587)
- - Jérôme Vasseur
  - Ruben Gonzalez (rubenrua)
  - Adam Prager (padam87)
  - Roman Marintšenko (inori)
@@ -230,6 +232,7 @@ Symfony is the result of the work of many people who made the code better
  - Arjen Brouwer (arjenjb)
  - Katsuhiro OGAWA
  - Patrick McDougle (patrick-mcdougle)
+ - Dany Maillard (maidmaid)
  - Alif Rachmawadi
  - Kristen Gilden (kgilden)
  - Pierre-Yves LEBECQ (pylebecq)
@@ -267,7 +270,9 @@ Symfony is the result of the work of many people who made the code better
  - Michael Holm (hollo)
  - Marc Weistroff (futurecat)
  - Christian Schmidt
+ - Marek Štípek (maryo)
  - Hidde Wieringa (hiddewie)
+ - Jordan Samouh (jordansamouh)
  - Chris Smith (cs278)
  - Florian Klein (docteurklein)
  - Oleg Voronkovich
@@ -281,6 +286,7 @@ Symfony is the result of the work of many people who made the code better
  - Andrey Esaulov (andremaha)
  - Grégoire Passault (gregwar)
  - Ismael Ambrosi (iambrosi)
+ - gadelat (gadelat)
  - Baptiste Lafontaine
  - Aurelijus Valeiša (aurelijus)
  - Victor Bocharsky (bocharsky_bw)
@@ -324,7 +330,8 @@ Symfony is the result of the work of many people who made the code better
  - Yaroslav Kiliba
  - Terje Bråten
  - Robbert Klarenbeek (robbertkl)
- - Marek Štípek (maryo)
+ - Thomas Calvet (fancyweb)
+ - Niels Keurentjes (curry684)
  - Alessandro Chitolina
  - JhonnyL
  - hossein zolfi (ocean)
@@ -342,14 +349,15 @@ Symfony is the result of the work of many people who made the code better
  - Vyacheslav Salakhutdinov (megazoll)
  - Jerzy Zawadzki (jzawadzki)
  - Hassan Amouhzi
- - gadelat (gadelat)
  - Tamas Szijarto
  - Pavel Volokitin (pvolok)
  - François Pluchino (francoispluchino)
+ - Arthur de Moulins (4rthem)
  - Nicolas Dewez (nicolas_dewez)
  - Endre Fejes
  - Tobias Naumann (tna)
  - Daniel Beyer
+ - Nikolay Labinskiy (e-moe)
  - Shein Alexey
  - Romain Gautier (mykiwi)
  - Joe Lencioni
@@ -399,10 +407,10 @@ Symfony is the result of the work of many people who made the code better
  - Andreas Braun
  - Chris Sedlmayr (catchamonkey)
  - Seb Koelen
- - Dany Maillard (maidmaid)
  - Christoph Mewes (xrstf)
  - Vitaliy Tverdokhlib (vitaliytv)
  - Ariel Ferrandini (aferrandini)
+ - Samuel ROZE (sroze)
  - Dirk Pahl (dirkaholic)
  - cedric lombardot (cedriclombardot)
  - Jonas Flodén (flojon)
@@ -416,7 +424,6 @@ Symfony is the result of the work of many people who made the code better
  - Gintautas Miselis
  - Rob Bast
  - David Badura (davidbadura)
- - Jordan Samouh (jordansamouh)
  - Zander Baldwin
  - Adam Harvey
  - Alex Bakhturin
@@ -425,7 +432,6 @@ Symfony is the result of the work of many people who made the code better
  - Fabrice Bernhard (fabriceb)
  - Jérôme Macias (jeromemacias)
  - Andrey Astakhov (aast)
- - Thomas Calvet
  - Fabian Lange (codingfabian)
  - Frank Neff (fneff)
  - Roman Lapin (memphys)
@@ -461,13 +467,12 @@ Symfony is the result of the work of many people who made the code better
  - Jakub Škvára (jskvara)
  - Andrew Udvare (audvare)
  - alexpods
- - Nikolay Labinskiy (e-moe)
  - Arjen van der Meijden
  - Michele Locati
  - Dariusz Ruminski
+ - Alex Rock Ancelet (pierstoval)
  - Erik Trapman (eriktrapman)
  - De Cock Xavier (xdecock)
- - Arthur de Moulins (4rthem)
  - Almog Baku (almogbaku)
  - Scott Arciszewski
  - Norbert Orzechowicz (norzechowicz)
@@ -581,7 +586,6 @@ Symfony is the result of the work of many people who made the code better
  - Ulumuddin Yunus (joenoez)
  - Luc Vieillescazes (iamluc)
  - Johann Saunier (prophet777)
- - Samuel ROZE (sroze)
  - Michael Devery (mickadoo)
  - Antoine Corcy
  - Artur Eshenbrener
@@ -695,6 +699,7 @@ Symfony is the result of the work of many people who made the code better
  - Pierre Vanliefland (pvanliefland)
  - Sofiane HADDAG (sofhad)
  - frost-nzcr4
+ - Sanpi
  - Abhoryo
  - Fabian Vogler (fabian)
  - Korvin Szanto
@@ -751,6 +756,7 @@ Symfony is the result of the work of many people who made the code better
  - Martijn Evers
  - Jacques Moati
  - Balazs Csaba (balazscsaba2006)
+ - Douglas Reith (douglas_reith)
  - Harry Walter (haswalt)
  - Johnson Page (jwpage)
  - Michael Roterman (wtfzdotnet)
@@ -764,7 +770,6 @@ Symfony is the result of the work of many people who made the code better
  - Gábor Tóth
  - Daniel Cestari
  - David Lima
- - Jérôme Vasseur
  - Brunet Laurent (lbrunet)
  - Mikhail Yurasov (mym)
  - LOUARDI Abdeltif (ouardisoft)
@@ -819,6 +824,7 @@ Symfony is the result of the work of many people who made the code better
  - Danilo Silva
  - Zachary Tong (polyfractal)
  - Hryhorii Hrebiniuk
+ - Thomas Perez (scullwm)
  - Dennis Fridrich (dfridrich)
  - hamza
  - dantleech
@@ -933,6 +939,7 @@ Symfony is the result of the work of many people who made the code better
  - Klaus Purer
  - Gilles Doge (gido)
  - abulford
+ - Philipp Kretzschmar
  - antograssiot
  - Brooks Boyd
  - Roger Webb
@@ -1039,6 +1046,7 @@ Symfony is the result of the work of many people who made the code better
  - Kim Laï Trinh
  - Jason Desrosiers
  - m.chwedziak
+ - insekticid
  - Philip Frank
  - Lance McNearney
  - Giorgio Premi
@@ -1061,6 +1069,7 @@ Symfony is the result of the work of many people who made the code better
  - Tadcka
  - Beth Binkovitz
  - Gonzalo Míguez
+ - Pierre Rineau
  - Romain Geissler
  - Adrien Moiruad
  - Tomaz Ahlin
@@ -1084,6 +1093,7 @@ Symfony is the result of the work of many people who made the code better
  - Martin Eckhardt
  - Pieter Jordaan
  - Damien Tournoud
+ - Craig Duncan (duncan3dc)
  - Jon Gotlin (jongotlin)
  - Michael Dowling (mtdowling)
  - Karlos Presumido (oneko)
@@ -1184,12 +1194,12 @@ Symfony is the result of the work of many people who made the code better
  - Michal Gebauer
  - Gleb Sidora
  - David Stone
- - Niels Keurentjes (curry684)
  - Jovan Perovic (jperovic)
  - Pablo Maria Martelletti (pmartelletti)
  - Yassine Guedidi (yguedidi)
  - Waqas Ahmed
  - Luis Muñoz
+ - Matthew Donadio
  - Andreas
  - Thomas Chmielowiec
  - Andrey Ryaguzov
@@ -1246,7 +1256,6 @@ Symfony is the result of the work of many people who made the code better
  - Jordi Llonch (jordillonch)
  - Cédric Dugat (ph3nol)
  - Philip Dahlstrøm (phidah)
- - Alex Rock Ancelet (pierstoval)
  - Milos Colakovic (project2481)
  - Rénald Casagraude (rcasagraude)
  - Robin Duval (robin-duval)
@@ -1389,6 +1398,7 @@ Symfony is the result of the work of many people who made the code better
  - Joeri Verdeyen (jverdeyen)
  - Kevin Herrera (kherge)
  - Luis Ramón López López (lrlopez)
+ - Bart Reunes (metalarend)
  - Muriel (metalmumu)
  - Michael Pohlers (mick_the_big)
  - mlpo (mlpo)
@@ -1530,6 +1540,7 @@ Symfony is the result of the work of many people who made the code better
  - Oncle Tom
  - Christian Stocker
  - Dawid Nowak
+ - Lesnykh Ilia
  - Karolis Daužickas
  - Sergio Santoro
  - tirnanog06
@@ -1594,6 +1605,7 @@ Symfony is the result of the work of many people who made the code better
  - Florent Viel (luxifer)
  - Matthieu Moquet (mattketmo)
  - Moritz Borgmann (mborgmann)
+ - Michal Čihař (mcihar)
  - Matt Drollette (mdrollette)
  - Adam Monsen (meonkeys)
  - Ala Eddine Khefifi (nayzo)
@@ -1646,6 +1658,7 @@ Symfony is the result of the work of many people who made the code better
  - smokeybear87
  - Gustavo Adrian
  - Kevin Weber
+ - Ben Scott
  - Dionysis Arvanitis
  - Sergey Fedotov
  - Michael

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.27-DEV';
+    const VERSION = '2.7.27';
     const VERSION_ID = 20727;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 27;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.7.26...v2.7.27)

 * bug #22528 [Asset] Starting slash should indicate no basePath wanted (@weaverryan)
 * bug #22526 [Asset] Preventing the base path or absolute URL from being prefixed incorrectly (@weaverryan)
 * bug #22435 [Console] Fix dispatching throwables from ConsoleEvents::COMMAND (@nicolas-grekas)
 * bug #22478 [Serializer] XmlEncoder: fix negative int and large numbers handling (@dunglas)
 * bug #22424 [Debug] Set exit status to 255 on error (@nicolas-grekas)
 * bug #22396 Prevent double registrations related to tag priorities (@nicolas-grekas)
 * bug #22352 [HttpFoundation] Add `use_strict_mode` in validOptions for session (@sstok)
 * bug #22351 [Yaml] don't keep internal state between parser runs (@xabbuh)
 * bug #22307 [Debug] Fix php notice (@enumag)
 * bug #22109 [Validator] check for empty host when calling checkdnsrr() (@apetitpa)
 * bug #22280 [DI] Fix the xml schema (@GuilhemN)
 * bug #22255 [Translation] avoid creating cache files for fallback locales. (@aitboudad)
 * bug #22292 Fixes #22264 - add support for Chrome headless (@redthor)
