### PR TITLE
Release v3.2.8

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -7,6 +7,35 @@ in 3.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.2.0...v3.2.1
 
+* 3.2.8 (2017-05-01)
+
+ * bug #22550 Allow Upper Case property names in ObjectNormalizer (insekticid)
+ * bug #22528 [Asset] Starting slash should indicate no basePath wanted (weaverryan)
+ * bug #22568 [EventDispatcher] fix getting priorities of listeners during dispatch (dmaicher)
+ * bug #22541 [EventDispatcher] fix: unwrap listeners for correct info (dmaicher)
+ * bug #22526 [Asset] Preventing the base path or absolute URL from being prefixed incorrectly (weaverryan)
+ * bug #22523 [WebProfilerBundle] Fixed the flickering when loading complex profiler panels (javiereguiluz)
+ * bug #21958 [Console] Fix bar width with multilines ProgressBar's format (maidmaid)
+ * bug #22435 [Console] Fix dispatching throwables from ConsoleEvents::COMMAND (nicolas-grekas)
+ * bug #22478 [Serializer] XmlEncoder: fix negative int and large numbers handling (dunglas)
+ * bug #22424 [Debug] Set exit status to 255 on error (nicolas-grekas)
+ * bug #22426 [PropertyInfo] Prevent returning int values in some cases (dunglas)
+ * bug #22401  Prevent double registrations related to tag priorities (nicolas-grekas)
+ * bug #22399  Prevent double registrations related to tag priorities (nicolas-grekas)
+ * bug #22396 Prevent double registrations related to tag priorities (nicolas-grekas)
+ * bug #22374 [Cache] Remove exception false-positive from FilesystemAdapterTrait (nicolas-grekas)
+ * bug #22377 [Console] Allow terminal dimensions to be set to 0 (unbounded) (duncan3dc)
+ * bug #22352 [HttpFoundation] Add `use_strict_mode` in validOptions for session (sstok)
+ * bug #22351 [Yaml] don't keep internal state between parser runs (xabbuh)
+ * bug #22304 Moved $this->setDate() before the deprecation handling. (mpdonadio)
+ * bug #22307 [Debug] Fix php notice (enumag)
+ * bug #22311 [DI] Fix second auto-registration (nicolas-grekas)
+ * bug #22109 [Validator] check for empty host when calling checkdnsrr() (apetitpa)
+ * bug #22280 [DI] Fix the xml schema (GuilhemN)
+ * bug #22282 [DI] Prevent AutowirePass from triggering irrelevant deprecations (chalasr)
+ * bug #22255 [Translation] avoid creating cache files for fallback locales. (aitboudad)
+ * bug #22292 Fixes #22264 - add support for Chrome headless (redthor)
+
 * 3.2.7 (2017-04-05)
 
  * bug #22285 [HttpKernel] Fix forward compat with Request::setTrustedProxies() (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '3.2.8-DEV';
+    const VERSION = '3.2.8';
     const VERSION_ID = 30208;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 2;
     const RELEASE_VERSION = 8;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '07/2017';
     const END_OF_LIFE = '01/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.2.7...v3.2.8)

 * bug #22550 Allow Upper Case property names in ObjectNormalizer (@insekticid)
 * bug #22528 [Asset] Starting slash should indicate no basePath wanted (@weaverryan)
 * bug #22568 [EventDispatcher] fix getting priorities of listeners during dispatch (@dmaicher)
 * bug #22541 [EventDispatcher] fix: unwrap listeners for correct info (@dmaicher)
 * bug #22526 [Asset] Preventing the base path or absolute URL from being prefixed incorrectly (@weaverryan)
 * bug #22523 [WebProfilerBundle] Fixed the flickering when loading complex profiler panels (@javiereguiluz)
 * bug #21958 [Console] Fix bar width with multilines ProgressBar's format (@maidmaid)
 * bug #22435 [Console] Fix dispatching throwables from ConsoleEvents::COMMAND (@nicolas-grekas)
 * bug #22478 [Serializer] XmlEncoder: fix negative int and large numbers handling (@dunglas)
 * bug #22424 [Debug] Set exit status to 255 on error (@nicolas-grekas)
 * bug #22426 [PropertyInfo] Prevent returning int values in some cases (@dunglas)
 * bug #22401  Prevent double registrations related to tag priorities (@nicolas-grekas)
 * bug #22399  Prevent double registrations related to tag priorities (@nicolas-grekas)
 * bug #22396 Prevent double registrations related to tag priorities (@nicolas-grekas)
 * bug #22374 [Cache] Remove exception false-positive from FilesystemAdapterTrait (@nicolas-grekas)
 * bug #22377 [Console] Allow terminal dimensions to be set to 0 (unbounded) (@duncan3dc)
 * bug #22352 [HttpFoundation] Add `use_strict_mode` in validOptions for session (@sstok)
 * bug #22351 [Yaml] don't keep internal state between parser runs (@xabbuh)
 * bug #22304 Moved $this->setDate() before the deprecation handling. (@mpdonadio)
 * bug #22307 [Debug] Fix php notice (@enumag)
 * bug #22311 [DI] Fix second auto-registration (@nicolas-grekas)
 * bug #22109 [Validator] check for empty host when calling checkdnsrr() (@apetitpa)
 * bug #22280 [DI] Fix the xml schema (@GuilhemN)
 * bug #22282 [DI] Prevent AutowirePass from triggering irrelevant deprecations (@chalasr)
 * bug #22255 [Translation] avoid creating cache files for fallback locales. (@aitboudad)
 * bug #22292 Fixes #22264 - add support for Chrome headless (@redthor)
