### PR TITLE
[EventDispatcher] fix merge of #22541 from 2.8

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\EventDispatcher\Tests\Debug;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
-use Symfony\Component\EventDispatcher\Debug\WrappedListener;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -105,20 +104,10 @@ class TraceableEventDispatcherTest extends TestCase
         $this->assertCount(0, $dispatcher->getListeners('foo'));
     }
 
-    /**
-     * @dataProvider isWrappedDataProvider
-     *
-     * @param bool $isWrapped
-     */
-    public function testGetCalledListeners($isWrapped)
+    public function testGetCalledListeners()
     {
-        $dispatcher = new EventDispatcher();
-        $stopWatch = new Stopwatch();
-        $tdispatcher = new TraceableEventDispatcher($dispatcher, $stopWatch);
-
-        $listener = function () {};
-
-        $tdispatcher->addListener('foo', $listener, 5);
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', function () {}, 5);
 
         $listeners = $tdispatcher->getNotCalledListeners();
         $this->assertArrayHasKey('data', $listeners['foo.closure']);
@@ -132,14 +121,6 @@ class TraceableEventDispatcherTest extends TestCase
         unset($listeners['foo.closure']['data']);
         $this->assertEquals(array('foo.closure' => array('event' => 'foo', 'pretty' => 'closure', 'priority' => 5)), $listeners);
         $this->assertEquals(array(), $tdispatcher->getNotCalledListeners());
-    }
-
-    public function isWrappedDataProvider()
-    {
-        return array(
-            array(false),
-            array(true),
-        );
     }
 
     public function testGetCalledListenersNested()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This cleans up a test case that was merged from 2.8 into 3.2 here: https://github.com/symfony/symfony/commit/824dc8ba5f25399ba7c5bac24df2e9ba9cdda336

@fabpot due to different implementations I created 2 PR's:

2.8: https://github.com/symfony/symfony/pull/22541
3.2: https://github.com/symfony/symfony/pull/22568

So the 2.8 merge into 3.2 of my change-set introduced some unused variable `$isWrapped` here: https://github.com/symfony/symfony/commit/824dc8ba5f25399ba7c5bac24df2e9ba9cdda336#diff-af3c4fbca8bb77957c00087543ae5a4dR113

This PR just cleans it up and also removes the data provider :wink: 