### PR TITLE
[ExpressionLanguage] Don't stripslashes to allow "normal" regexes

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -71,7 +71,7 @@ class Lexer
                 ++$cursor;
             } elseif (preg_match('/"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\'/As', $expression, $match, 0, $cursor)) {
                 // strings
-                $tokens[] = new Token(Token::STRING_TYPE, stripcslashes(substr($match[0], 1, -1)), $cursor + 1);
+                $tokens[] = new Token(Token::STRING_TYPE, substr($match[0], 1, -1), $cursor + 1);
                 $cursor += strlen($match[0]);
             } elseif (preg_match('/not in(?=[\s(])|\!\=\=|not(?=[\s(])|and(?=[\s(])|\=\=\=|\>\=|or(?=[\s(])|\<\=|\*\*|\.\.|in(?=[\s(])|&&|\|\||matches|\=\=|\!\=|\*|~|%|\/|\>|\||\!|\^|&|\+|\<|\-/A', $expression, $match, 0, $cursor)) {
                 // operators

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -155,6 +155,16 @@ class ParserTest extends TestCase
                 'bar',
                 array('foo' => 'bar'),
             ),
+
+            array(
+                new Node\BinaryNode('matches', new Node\ConstantNode('[x] Bug'), new Node\ConstantNode('/\[\s*x\s*\] Bug/')),
+                '"[x] Bug" matches "/\[\s*x\s*\] Bug/"',
+            ),
+
+            array(
+                new Node\BinaryNode('matches', new Node\ConstantNode('a\b'), new Node\ConstantNode('/^a\\b$/')),
+                '"a\b" matches "/^a\\b$/"',
+            ),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes (sort of, because the docs states a user should escape backslashes)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | TODO if this is accepted

I want to expose the expression to the users of my app and have them write expressions. But the regex part of the expression is no so user friendly as the user has to escape a `\` so it results in `\\\\\\\\` in the expression.

> A backslash (`\`) must be escaped by 4 backslashes (`\\\\`) in a string and 8 backslashes (`\\\\\\\\`) in a regex:
> 
> ```
> echo $language->evaluate('"\\\\"'); // prints \
> $language->evaluate('"a\\\\b" matches "/^a\\\\\\\\b$/"'); // returns true
> ```
> Control characters (e.g. \n) in expressions are replaced with whitespace. To avoid this, escape the sequence with a single backslash (e.g. \\n).

see: https://symfony.com/doc/current/components/expression_language/syntax.html#supported-literals

Someone on the symfony slack channel explained it to me as it had something todo with yaml and php needed escaped slashes. But I've now tried my patch in my app by reading "normal" regexes from yaml and having them parsed and evaluated by the expression language component and everything seems to work as expected.

So I would like to have some feedback on this patch, maybe I don't know the whole story behind the use of the `stripcslashes` function.
<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
