### PR TITLE
[Validator]: Fix append propertyPath in collection

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Util/PropertyPathTest.php
@@ -32,6 +32,7 @@ class PropertyPathTest extends TestCase
             array('foo', 'bar', 'foo.bar', 'It append the subPath to the basePath'),
             array('foo', '[bar]', 'foo[bar]', 'It does not include the dot separator if subPath uses the array notation'),
             array('0', 'bar', '0.bar', 'Leading zeros are kept.'),
+            array('children[foo].data', 'bar', 'children[foo].bar', 'It does not include data suffix if basePath start by contain children and finish by data (collection form validation context).'),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Util/PropertyPath.php
+++ b/src/Symfony/Component/Validator/Util/PropertyPath.php
@@ -41,6 +41,10 @@ class PropertyPath
                 return $basePath.$subPath;
             }
 
+            if (preg_match('/^(children\[.*\])(\.data)$/', $basePath, $match)) {
+                $basePath = $match[1];
+            }
+
             return '' !== (string) $basePath ? $basePath.'.'.$subPath : $subPath;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22298
| License       | MIT

I raised a bug in validator component.
I try to build violation for a children in my collection and affect a custom path to target my specific child.

However, in this context the propertyPath inherit of basePath sufixed with '.data'. And this breaks the message of validation.

Exemple:

BasePath of violation path is :  ``` children[customers].data ```

AtPath: ```children[1].children[followupMailingList].data```

Final Violation path is: ``` children[customers].data.children[1].children[followupMailingList].data ```

The right final violation path sould be (without the .data of basePath):  ``` children[customers].children[1].children[followupMailingList].data ```

https://github.com/symfony/symfony/issues/22298