### PR TITLE
[Form] [TwigBridge] Added option to disable usage of default themes when rendering a form

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
+ * added an `only` keyword to `form_theme` tag to disable usage of default themes when rendering a form
  * deprecated `Symfony\Bridge\Twig\Form\TwigRenderer`
  * deprecated `DebugCommand::set/getTwigEnvironment`. Pass an instance of
    `Twig\Environment` as first argument  of the constructor instead

--- a/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
+++ b/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
@@ -124,9 +124,11 @@ class TwigRendererEngine extends AbstractRendererEngine implements TwigRendererE
 
         // Check the default themes once we reach the root view without success
         if (!$view->parent) {
-            for ($i = count($this->defaultThemes) - 1; $i >= 0; --$i) {
-                $this->loadResourcesFromTheme($cacheKey, $this->defaultThemes[$i]);
-                // CONTINUE LOADING (see doc comment)
+            if (!isset($this->useDefaultThemes[$cacheKey]) || $this->useDefaultThemes[$cacheKey]) {
+                for ($i = count($this->defaultThemes) - 1; $i >= 0; --$i) {
+                    $this->loadResourcesFromTheme($cacheKey, $this->defaultThemes[$i]);
+                    // CONTINUE LOADING (see doc comment)
+                }
             }
         }
 

--- a/src/Symfony/Bridge/Twig/Node/FormThemeNode.php
+++ b/src/Symfony/Bridge/Twig/Node/FormThemeNode.php
@@ -22,9 +22,9 @@ use Twig\Node\Node;
  */
 class FormThemeNode extends Node
 {
-    public function __construct(Node $form, Node $resources, $lineno, $tag = null)
+    public function __construct(Node $form, Node $resources, $lineno, $tag = null, $only = false)
     {
-        parent::__construct(array('form' => $form, 'resources' => $resources), array(), $lineno, $tag);
+        parent::__construct(array('form' => $form, 'resources' => $resources), array('only' => (bool) $only), $lineno, $tag);
     }
 
     public function compile(Compiler $compiler)
@@ -44,6 +44,8 @@ class FormThemeNode extends Node
             ->subcompile($this->getNode('form'))
             ->raw(', ')
             ->subcompile($this->getNode('resources'))
+            ->raw(', ')
+            ->raw(false === $this->getAttribute('only') ? 'true' : 'false')
             ->raw(");\n");
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3HorizontalLayoutTest.php
@@ -99,8 +99,8 @@ class FormExtensionBootstrap3HorizontalLayoutTest extends AbstractBootstrap3Hori
         return (string) $this->renderer->renderBlock($view, 'form_end', $vars);
     }
 
-    protected function setTheme(FormView $view, array $themes)
+    protected function setTheme(FormView $view, array $themes, $useDefaultThemes = true)
     {
-        $this->renderer->setTheme($view, $themes);
+        $this->renderer->setTheme($view, $themes, $useDefaultThemes);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap3LayoutTest.php
@@ -119,8 +119,8 @@ class FormExtensionBootstrap3LayoutTest extends AbstractBootstrap3LayoutTest
         return (string) $this->renderer->renderBlock($view, 'form_end', $vars);
     }
 
-    protected function setTheme(FormView $view, array $themes)
+    protected function setTheme(FormView $view, array $themes, $useDefaultThemes = true)
     {
-        $this->renderer->setTheme($view, $themes);
+        $this->renderer->setTheme($view, $themes, $useDefaultThemes);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4HorizontalLayoutTest.php
@@ -100,8 +100,8 @@ class FormExtensionBootstrap4HorizontalLayoutTest extends AbstractBootstrap4Hori
         return (string) $this->renderer->renderBlock($view, 'form_end', $vars);
     }
 
-    protected function setTheme(FormView $view, array $themes)
+    protected function setTheme(FormView $view, array $themes, $useDefaultThemes = true)
     {
-        $this->renderer->setTheme($view, $themes);
+        $this->renderer->setTheme($view, $themes, $useDefaultThemes);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionBootstrap4LayoutTest.php
@@ -122,8 +122,8 @@ class FormExtensionBootstrap4LayoutTest extends AbstractBootstrap4LayoutTest
         return (string) $this->renderer->renderBlock($view, 'form_end', $vars);
     }
 
-    protected function setTheme(FormView $view, array $themes)
+    protected function setTheme(FormView $view, array $themes, $useDefaultThemes = true)
     {
-        $this->renderer->setTheme($view, $themes);
+        $this->renderer->setTheme($view, $themes, $useDefaultThemes);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -193,9 +193,9 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
         return (string) $this->renderer->renderBlock($view, 'form_end', $vars);
     }
 
-    protected function setTheme(FormView $view, array $themes)
+    protected function setTheme(FormView $view, array $themes, $useDefaultThemes = true)
     {
-        $this->renderer->setTheme($view, $themes);
+        $this->renderer->setTheme($view, $themes, $useDefaultThemes);
     }
 
     public static function themeBlockInheritanceProvider()

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -120,8 +120,8 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
         return (string) $this->renderer->renderBlock($view, 'form_end', $vars);
     }
 
-    protected function setTheme(FormView $view, array $themes)
+    protected function setTheme(FormView $view, array $themes, $useDefaultThemes = true)
     {
-        $this->renderer->setTheme($view, $themes);
+        $this->renderer->setTheme($view, $themes, $useDefaultThemes);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -39,6 +39,7 @@ class FormThemeTest extends TestCase
 
         $this->assertEquals($form, $node->getNode('form'));
         $this->assertEquals($resources, $node->getNode('resources'));
+        $this->assertFalse($node->getAttribute('only'));
     }
 
     public function testCompile()
@@ -60,7 +61,17 @@ class FormThemeTest extends TestCase
 
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, array(0 => "tpl1", 1 => "tpl2"));',
+                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, array(0 => "tpl1", 1 => "tpl2"), true);',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+
+        $node = new FormThemeNode($form, $resources, 0, null, true);
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, array(0 => "tpl1", 1 => "tpl2"), false);',
                 $this->getVariableGetter('form')
              ),
             trim($compiler->compile($node)->getSource())
@@ -72,7 +83,17 @@ class FormThemeTest extends TestCase
 
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, "tpl1");',
+                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, "tpl1", true);',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+
+        $node = new FormThemeNode($form, $resources, 0, null, true);
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime("Symfony\\\\Component\\\\Form\\\\FormRenderer")->setTheme(%s, "tpl1", false);',
                 $this->getVariableGetter('form')
              ),
             trim($compiler->compile($node)->getSource())

--- a/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php
@@ -100,6 +100,21 @@ class FormThemeTokenParserTest extends TestCase
                     'form_theme'
                 ),
             ),
+            array(
+                '{% form_theme form with ["tpl1", "tpl2"] only %}',
+                new FormThemeNode(
+                    new NameExpression('form', 1),
+                    new ArrayExpression(array(
+                        new ConstantExpression(0, 1),
+                        new ConstantExpression('tpl1', 1),
+                        new ConstantExpression(1, 1),
+                        new ConstantExpression('tpl2', 1),
+                    ), 1),
+                    1,
+                    'form_theme',
+                    true
+                ),
+            ),
         );
     }
 }

--- a/src/Symfony/Bridge/Twig/TokenParser/FormThemeTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/FormThemeTokenParser.php
@@ -37,10 +37,15 @@ class FormThemeTokenParser extends AbstractTokenParser
         $stream = $this->parser->getStream();
 
         $form = $this->parser->getExpressionParser()->parseExpression();
+        $only = false;
 
         if ($this->parser->getStream()->test(Token::NAME_TYPE, 'with')) {
             $this->parser->getStream()->next();
             $resources = $this->parser->getExpressionParser()->parseExpression();
+
+            if ($this->parser->getStream()->nextIf(Token::NAME_TYPE, 'only')) {
+                $only = true;
+            }
         } else {
             $resources = new ArrayExpression(array(), $stream->getCurrent()->getLine());
             do {
@@ -50,7 +55,7 @@ class FormThemeTokenParser extends AbstractTokenParser
 
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        return new FormThemeNode($form, $resources, $lineno, $this->getTag());
+        return new FormThemeNode($form, $resources, $lineno, $this->getTag(), $only);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -49,12 +49,13 @@ class FormHelper extends Helper
      *
      * The theme format is "<Bundle>:<Controller>".
      *
-     * @param FormView     $view   A FormView instance
-     * @param string|array $themes A theme or an array of theme
+     * @param FormView     $view             A FormView instance
+     * @param string|array $themes           A theme or an array of theme
+     * @param bool         $useDefaultThemes If true, will use default themes defined in the renderer
      */
-    public function setTheme(FormView $view, $themes)
+    public function setTheme(FormView $view, $themes, $useDefaultThemes = true)
     {
-        $this->renderer->setTheme($view, $themes);
+        $this->renderer->setTheme($view, $themes, $useDefaultThemes);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -121,9 +121,9 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
         return (string) $this->engine->get('form')->end($view, $vars);
     }
 
-    protected function setTheme(FormView $view, array $themes)
+    protected function setTheme(FormView $view, array $themes, $useDefaultThemes = true)
     {
-        $this->engine->get('form')->setTheme($view, $themes);
+        $this->engine->get('form')->setTheme($view, $themes, $useDefaultThemes);
     }
 
     public static function themeBlockInheritanceProvider()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
@@ -122,8 +122,8 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
         return (string) $this->engine->get('form')->end($view, $vars);
     }
 
-    protected function setTheme(FormView $view, array $themes)
+    protected function setTheme(FormView $view, array $themes, $useDefaultThemes = true)
     {
-        $this->engine->get('form')->setTheme($view, $themes);
+        $this->engine->get('form')->setTheme($view, $themes, $useDefaultThemes);
     }
 }

--- a/src/Symfony/Component/Form/AbstractRendererEngine.php
+++ b/src/Symfony/Component/Form/AbstractRendererEngine.php
@@ -36,6 +36,11 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
     /**
      * @var array
      */
+    protected $useDefaultThemes = array();
+
+    /**
+     * @var array
+     */
     protected $resources = array();
 
     /**
@@ -57,12 +62,15 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
     /**
      * {@inheritdoc}
      */
-    public function setTheme(FormView $view, $themes)
+    public function setTheme(FormView $view, $themes /*, $useDefaultThemes = true */)
     {
         $cacheKey = $view->vars[self::CACHE_KEY_VAR];
 
         // Do not cast, as casting turns objects into arrays of properties
         $this->themes[$cacheKey] = is_array($themes) ? $themes : array($themes);
+
+        $args = func_get_args();
+        $this->useDefaultThemes[$cacheKey] = isset($args[2]) ? (bool) $args[2] : true;
 
         // Unset instead of resetting to an empty array, in order to allow
         // implementations (like TwigRendererEngine) to check whether $cacheKey

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * added `DebugCommand`
  * deprecated `ChoiceLoaderInterface` implementation in `TimezoneType`
  * added options "input" and "regions" to `TimezoneType`
+ * added an option to ``Symfony\Component\Form\FormRendererEngineInterface::setTheme()`` and
+   ``Symfony\Component\Form\FormRendererInterface::setTheme()`` to disable usage of default themes when rendering a form
 
 3.3.0
 -----

--- a/src/Symfony/Component/Form/Extension/Templating/TemplatingRendererEngine.php
+++ b/src/Symfony/Component/Form/Extension/Templating/TemplatingRendererEngine.php
@@ -72,9 +72,11 @@ class TemplatingRendererEngine extends AbstractRendererEngine
 
         // Check the default themes once we reach the root form without success
         if (!$view->parent) {
-            for ($i = count($this->defaultThemes) - 1; $i >= 0; --$i) {
-                if ($this->loadResourceFromTheme($cacheKey, $blockName, $this->defaultThemes[$i])) {
-                    return true;
+            if (!isset($this->useDefaultThemes[$cacheKey]) || $this->useDefaultThemes[$cacheKey]) {
+                for ($i = count($this->defaultThemes) - 1; $i >= 0; --$i) {
+                    if ($this->loadResourceFromTheme($cacheKey, $blockName, $this->defaultThemes[$i])) {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -70,9 +70,10 @@ class FormRenderer implements FormRendererInterface
     /**
      * {@inheritdoc}
      */
-    public function setTheme(FormView $view, $themes)
+    public function setTheme(FormView $view, $themes /*, $useDefaultThemes = true */)
     {
-        $this->engine->setTheme($view, $themes);
+        $args = func_get_args();
+        $this->engine->setTheme($view, $themes, isset($args[2]) ? (bool) $args[2] : true);
     }
 
     /**

--- a/src/Symfony/Component/Form/FormRendererEngineInterface.php
+++ b/src/Symfony/Component/Form/FormRendererEngineInterface.php
@@ -21,11 +21,13 @@ interface FormRendererEngineInterface
     /**
      * Sets the theme(s) to be used for rendering a view and its children.
      *
-     * @param FormView $view   The view to assign the theme(s) to
-     * @param mixed    $themes The theme(s). The type of these themes
-     *                         is open to the implementation.
+     * @param FormView $view             The view to assign the theme(s) to
+     * @param mixed    $themes           The theme(s). The type of these themes
+     *                                   is open to the implementation.
+     * @param bool     $useDefaultThemes If true, will use default themes specified
+     *                                   in the engine, will be added to the interface in 4.0
      */
-    public function setTheme(FormView $view, $themes);
+    public function setTheme(FormView $view, $themes /*, $useDefaultThemes = true */);
 
     /**
      * Returns the resource for a block name.

--- a/src/Symfony/Component/Form/FormRendererInterface.php
+++ b/src/Symfony/Component/Form/FormRendererInterface.php
@@ -28,11 +28,13 @@ interface FormRendererInterface
     /**
      * Sets the theme(s) to be used for rendering a view and its children.
      *
-     * @param FormView $view   The view to assign the theme(s) to
-     * @param mixed    $themes The theme(s). The type of these themes
-     *                         is open to the implementation.
+     * @param FormView $view             The view to assign the theme(s) to
+     * @param mixed    $themes           The theme(s). The type of these themes
+     *                                   is open to the implementation.
+     * @param bool     $useDefaultThemes If true, will use default themes specified
+     *                                   in the renderer, will be added to the interface in 4.0
      */
-    public function setTheme(FormView $view, $themes);
+    public function setTheme(FormView $view, $themes /*, $useDefaultThemes = true */);
 
     /**
      * Renders a named block of the form theme.

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -125,7 +125,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     abstract protected function renderEnd(FormView $view, array $vars = array());
 
-    abstract protected function setTheme(FormView $view, array $themes);
+    abstract protected function setTheme(FormView $view, array $themes, $useDefaultThemes = true);
 
     public function testLabel()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/8495

This adds a possibility to use `only` keyword in `form_theme` tag to disable usage of globally defined form themes, e.g.

`{% form_theme form with ['common.html.twig', 'form/fields.html.twig'] only %}`

Otherwise, in order to completely control the rendering of the forms (for example in custom admin interfaces), one would need to use a form theme which has all the possible twig blocks defined to prevent globally defined themes to interfere with the rendering.

`only` keyword is already used when including a Twig template to transfer only the variables which are explicitly defined in the `include` tag, so it seemed natural to use it here too.

This, of course, means that the user will need to manually `use` all of the templates that are required to render the form, including `form_div_layout.html.twig`

This issue is described in details over at Symfony Demo repo: https://github.com/symfony/symfony-demo/issues/515

TODO:

- [x] submit changes to the documentation