### PR TITLE
[FrameworkBundle] Fix "Locale class not found" in AboutCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -70,7 +70,7 @@ class AboutCommand extends ContainerAwareCommand
             new TableSeparator(),
             array('Version', PHP_VERSION),
             array('Architecture', (PHP_INT_SIZE * 8).' bits'),
-            array('Intl locale', \Locale::getDefault() ?: 'n/a'),
+            array('Intl locale', class_exists('Locale', false) && \Locale::getDefault() ? \Locale::getDefault() : 'n/a'),
             array('Timezone', date_default_timezone_get().' (<comment>'.(new \DateTime())->format(\DateTime::W3C).'</>)'),
             array('OPcache', extension_loaded('Zend OPcache') && ini_get('opcache.enable') ? 'true' : 'false'),
             array('APCu', extension_loaded('apcu') && ini_get('apc.enabled') ? 'true' : 'false'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -


Found testing http://fabien.potencier.org/symfony4-demo.html with docker `php:7.1`
