### PR TITLE
[Process] Fix incorrectly calling PHP process when path contains space

### DIFF
--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -36,10 +36,10 @@ class PhpProcess extends Process
     public function __construct($script, $cwd = null, array $env = null, $timeout = 60, array $options = null)
     {
         $executableFinder = new PhpExecutableFinder();
-        if (false === $php = $executableFinder->find()) {
+        if (false === $php = $executableFinder->find(false)) {
             $php = null;
         } else {
-            $php = explode(' ', $php);
+            $php = array_merge(array($php), $executableFinder->findArguments());
         }
         if ('phpdbg' === PHP_SAPI) {
             $file = tempnam(sys_get_temp_dir(), 'dbg');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22556 
| License       | MIT

I have PHP installed at "D:\Program Files\PHP" which contains a space. `PhpExecutableFinder` found it but then `PhpProcess` splitted the path by space. This PR fixes it. I wanted to write a test but I don't know ho to do it properly since it is dependent on the location where PHP is installed and I can't even mock `PhpExecutableFinder` because it is hardcoded dependency and an implementation detail.
