### PR TITLE
[Process]  Fixed escaping arguments on Windows when inheritEnvironmentVariables is set to false

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1465,6 +1465,19 @@ class ProcessTest extends TestCase
         $this->assertSame($arg, $p->getOutput());
     }
 
+    /**
+     * @dataProvider provideEscapeArgument
+     * @group legacy
+     */
+    public function testEscapeArgumentWhenInheritEnvDisabled($arg)
+    {
+        $p = new Process(array(self::$phpBin, '-r', 'echo $argv[1];', $arg), null, array('BAR' => 'BAZ'));
+        $p->inheritEnvironmentVariables(false);
+        $p->run();
+
+        $this->assertSame($arg, $p->getOutput());
+    }
+
     public function provideEscapeArgument()
     {
         yield array('a"b%c%');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I've added a FAILING testcase on Windows. It incorrectly substitutes an argument containing a quotation mark probably assuming it's an env var needed to backup when inheritEnvironmentVariables is set to false.