### PR TITLE
Allow user to set input class attributes

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -4,7 +4,7 @@
 
 {% block form_widget_simple -%}
     {% if type is not defined or type not in ['file', 'hidden'] %}
-        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
+        {%- set attr = attr|merge({class: (attr.class|default('form-control'))|trim}) -%}
     {% endif %}
     {{- parent() -}}
 {%- endblock form_widget_simple %}


### PR DESCRIPTION
When a user sets a form input attribute class, we shouldn't force-add the
form-control class.

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | maybe?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |


We are using a theme built on bootstrap 3. However we have cases where the input 
class should be simply =col-xs-X for width control. When we set this on the form 
we still get form-control and so the input is wide and ignores the other class. 

It took awhile to find this where everything gets the form-control regardless of 
having a class already set. It seems to me that if you are setting the class you 
should set *all* classes required for what you are doing. This is a proof of concept 
change at the moment as I didn't touch the textarea/buttons or any other widget 
that uses the same syntax. Making this change locally keeps all other input fields 
properly styled and allows us to override the class attribute as I would expect. 
Our only other choice is to override the bootstrap_3_layout.html.twig if this 
type of change is unwanted. If it is wanted, then I can make the rest of the changes.
