### PR TITLE
Fixes Monolog Bridge third argument in call to output->write

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -155,8 +155,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      */
     protected function write(array $record)
     {
-        // at this point we've determined for sure that we want to output the record, so use the output's own verbosity
-        $this->output->write((string) $record['formatted'], false, $this->output->getVerbosity());
+        $this->output->write((string) $record['formatted'], false);
     }
 
     /**


### PR DESCRIPTION
The third parameter of `Symfony\Component\Console\Output\OutputInterface::write()` is `$type`; not `$verbosity`. This is intended for distinguishing between normal, raw, and plain output. 

The previous code happens to work in most cases because these constants are similar.

```
interface OutputInterface
{
    const VERBOSITY_QUIET = 0;
    const VERBOSITY_NORMAL = 1;
    const VERBOSITY_VERBOSE = 2;
    const VERBOSITY_VERY_VERBOSE = 3;
    const VERBOSITY_DEBUG = 4;

    const OUTPUT_NORMAL = 0;
    const OUTPUT_RAW = 1;
    const OUTPUT_PLAIN = 2;
```

When VERBOSITY_DEBUG is used, an InvalidArgumentException is thrown with the message `Unknown output type given (4)`.

| Q             | A
| ------------- | ---
| Branch?       | master / 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
