### PR TITLE
[Security] Trigger a deprecation when a voter is missing the VoterInterface

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -1,0 +1,8 @@
+UPGRADE FROM 3.3 to 3.4
+=======================
+
+Security
+--------
+
+ * Using voters in the `AccessDecisionManager` without `VoterInterface` is now
+   deprecated and this functionality will be removed in 4.0.

--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -4,5 +4,5 @@ UPGRADE FROM 3.3 to 3.4
 Security
 --------
 
- * Using voters in the `AccessDecisionManager` without `VoterInterface` is now
-   deprecated and this functionality will be removed in 4.0.
+ * Using voters that do not implement the `VoterInterface`is now deprecated in
+   the `AccessDecisionManager` and this functionality will be removed in 4.0.

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * Tagging voters with the `security.voter` tag without implementing the
+   `VoterInterface` on the class is now deprecated and will be removed in 4.0.
+
 3.3.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
  * Adds all configured security voters to the access decision manager.
@@ -38,6 +39,20 @@ class AddSecurityVotersPass implements CompilerPassInterface
         $voters = $this->findAndSortTaggedServices('security.voter', $container);
         if (!$voters) {
             throw new LogicException('No security voters found. You need to tag at least one with "security.voter"');
+        }
+
+        foreach ($voters as $voter) {
+            $class = $container->getDefinition($voter->__toString())->getClass();
+
+            if (!is_a($class, VoterInterface::class, true)) {
+                @trigger_error(sprintf('Using a security.voter tag on a class without implementing the %1$s is deprecated as of 3.4 and will be removed in 4.0. Implement the %1$s instead.', VoterInterface::class), E_USER_DEPRECATED);
+                $container->log($this, sprintf('Detected usage of security.voter for class "%s" without implementing the %s.', $class, VoterInterface::class));
+            }
+
+            if (!method_exists($class, 'vote')) {
+                // in case the vote method is completely missing, to prevent exceptions when voting
+                throw new LogicException(sprintf('%s should implement the %s class when used as voter.', $class, VoterInterface::class));
+            }
         }
 
         $adm = $container->getDefinition('security.access.decision_manager');

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
@@ -42,16 +42,15 @@ class AddSecurityVotersPass implements CompilerPassInterface
         }
 
         foreach ($voters as $voter) {
-            $class = $container->getDefinition($voter->__toString())->getClass();
+            $class = $container->getDefinition((string) $voter)->getClass();
 
             if (!is_a($class, VoterInterface::class, true)) {
                 @trigger_error(sprintf('Using a security.voter tag on a class without implementing the %1$s is deprecated as of 3.4 and will be removed in 4.0. Implement the %1$s instead.', VoterInterface::class), E_USER_DEPRECATED);
-                $container->log($this, sprintf('Detected usage of security.voter for class "%s" without implementing the %s.', $class, VoterInterface::class));
             }
 
             if (!method_exists($class, 'vote')) {
                 // in case the vote method is completely missing, to prevent exceptions when voting
-                throw new LogicException(sprintf('%s should implement the %s class when used as voter.', $class, VoterInterface::class));
+                throw new LogicException(sprintf('%s should implement the %s interface when used as voter.', $class, VoterInterface::class));
             }
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
@@ -92,8 +92,6 @@ class AddSecurityVotersPassTest extends TestCase
         $refs = $argument->getValues();
         $this->assertEquals(new Reference('without_interface'), $refs[0]);
         $this->assertCount(1, $refs);
-
-        $this->assertSame($container->getCompiler()->getLog()[0], 'Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass: Detected usage of security.voter for class "Symfony\Component\Security\Core\Tests\Authorization\Stub\VoterWithoutInterface" without implementing the Symfony\Component\Security\Core\Authorization\Voter\VoterInterface.');
     }
 
     /**
@@ -102,7 +100,7 @@ class AddSecurityVotersPassTest extends TestCase
     public function testVoterMissingInterfaceAndMethod()
     {
         $exception = LogicException::class;
-        $message = 'stdClass should implement the Symfony\Component\Security\Core\Authorization\Voter\VoterInterface class when used as voter.';
+        $message = 'stdClass should implement the Symfony\Component\Security\Core\Authorization\Voter\VoterInterface interface when used as voter.';
 
         if (method_exists($this, 'expectException')) {
             $this->expectException($exception);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
@@ -101,8 +101,15 @@ class AddSecurityVotersPassTest extends TestCase
      */
     public function testVoterMissingInterfaceAndMethod()
     {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('stdClass should implement the Symfony\Component\Security\Core\Authorization\Voter\VoterInterface class when used as voter.');
+        $exception = LogicException::class;
+        $message = 'stdClass should implement the Symfony\Component\Security\Core\Authorization\Voter\VoterInterface class when used as voter.';
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($exception);
+            $this->expectExceptionMessage($message);
+        } else {
+            $this->setExpectedException($exception, $message);
+        }
 
         $container = new ContainerBuilder();
         $container

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,8 +4,8 @@ CHANGELOG
 3.4.0
 -----
 
- * Using voters in the `AccessDecisionManager` without `VoterInterface` is now
-   deprecated and this functionality will be removed in 4.0.
+ * Using voters that do not implement the `VoterInterface`is now deprecated in
+   the `AccessDecisionManager` and this functionality will be removed in 4.0.
 
 3.3.0
 -----

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * Using voters in the `AccessDecisionManager` without `VoterInterface` is now
+   deprecated and this functionality will be removed in 4.0.
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\LogicException;
 
 /**
  * AccessDecisionManager is the base class for all access decision managers
@@ -209,6 +210,6 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
             return $voter->vote($token, $subject, $attributes);
         }
 
-        throw new \BadMethodCallException(sprintf('%s should implement the %s interface when used as voter.', get_class($voter), VoterInterface::class));
+        throw new LogicException(sprintf('%s should implement the %s interface when used as voter.', get_class($voter), VoterInterface::class));
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -209,6 +209,6 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
             return $voter->vote($token, $subject, $attributes);
         }
 
-        throw new \BadMethodCallException(sprintf('%s should implement the %s class when used as voter.', get_class($voter), VoterInterface::class));
+        throw new \BadMethodCallException(sprintf('%s should implement the %s interface when used as voter.', get_class($voter), VoterInterface::class));
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -196,6 +196,8 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      * TokenInterface vote proxy method.
      *
      * Acts as a BC layer when the VoterInterface is not implemented on the voter.
+     *
+     * @deprecated as of 3.4 and will be removed in 4.0. Call the voter directly as the instance will always be a VoterInterface
      */
     private function vote($voter, TokenInterface $token, $subject, $attributes)
     {

--- a/src/Symfony/Component/Security/Core/Exception/LogicException.php
+++ b/src/Symfony/Component/Security/Core/Exception/LogicException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Exception;
+
+/**
+ * Base LogicException for the Security component.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Core\Tests\Authorization\Stub\VoterWithoutInterface;
 
 class AccessDecisionManagerTest extends TestCase
@@ -143,7 +144,7 @@ class AccessDecisionManagerTest extends TestCase
 
     public function testVotingWrongTypeNoVoteMethod()
     {
-        $exception = \BadMethodCallException::class;
+        $exception = LogicException::class;
         $message = sprintf('stdClass should implement the %s interface when used as voter.', VoterInterface::class);
 
         if (method_exists($this, 'expectException')) {

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Tests\Authorization\Stub\VoterWithoutInterface;
 
 class AccessDecisionManagerTest extends TestCase
 {
@@ -137,5 +139,28 @@ class AccessDecisionManagerTest extends TestCase
               ->will($this->returnValue($vote));
 
         return $voter;
+    }
+
+    public function testVotingWrongTypeNoVoteMethod()
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage(sprintf('stdClass should implement the %s class when used as voter.', VoterInterface::class));
+
+        $adm = new AccessDecisionManager(array(new \stdClass()));
+        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
+
+        $adm->decide($token, array('TEST'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Calling vote() on an voter without Symfony\Component\Security\Core\Authorization\Voter\VoterInterface is deprecated as of 3.4 and will be removed in 4.0. Implement the Symfony\Component\Security\Core\Authorization\Voter\VoterInterface on your voter.
+     */
+    public function testVotingWrongTypeWithVote()
+    {
+        $adm = new AccessDecisionManager(array(new VoterWithoutInterface()));
+        $token = $this->getMockBuilder(TokenInterface::class)->getMock();
+
+        $adm->decide($token, array('TEST'));
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -143,8 +143,15 @@ class AccessDecisionManagerTest extends TestCase
 
     public function testVotingWrongTypeNoVoteMethod()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(sprintf('stdClass should implement the %s class when used as voter.', VoterInterface::class));
+        $exception = \BadMethodCallException::class;
+        $message = sprintf('stdClass should implement the %s class when used as voter.', VoterInterface::class);
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($exception);
+            $this->expectExceptionMessage($message);
+        } else {
+            $this->setExpectedException($exception, $message);
+        }
 
         $adm = new AccessDecisionManager(array(new \stdClass()));
         $token = $this->getMockBuilder(TokenInterface::class)->getMock();

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -144,7 +144,7 @@ class AccessDecisionManagerTest extends TestCase
     public function testVotingWrongTypeNoVoteMethod()
     {
         $exception = \BadMethodCallException::class;
-        $message = sprintf('stdClass should implement the %s class when used as voter.', VoterInterface::class);
+        $message = sprintf('stdClass should implement the %s interface when used as voter.', VoterInterface::class);
 
         if (method_exists($this, 'expectException')) {
             $this->expectException($exception);

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Stub/VoterWithoutInterface.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Stub/VoterWithoutInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authorization\Stub;
+
+/**
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+class VoterWithoutInterface
+{
+    public function vote()
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Right now it's possible to add voters to the access decision manager that do not have a `VoterInterface`.
 - No Interface, no `vote()` method, and it will give a PHP error.
 - No Interface, but `vote()` method, it will still work.
 - If I don't implement the interface _and_ have no `vote()` method, I will get weird exception that's not meaningful: `Attempted to call an undefined method named "vote" of class "App\Voter\MyVoter".`

This PR will deprecate the ability to use voters without the interface, it will also throw a proper exception when missing the interface _and_ the `vote()` method. Why when using and not when setting? Due to the fact that the voters can be set lazily via the `IteratorArgument`. The SecurityBundle will trigger a deprecation if the interface is not implemented and an exception if there's not even a `vote()` method present (to prevent exceptions at run-time).

This should have full backwards compatibility with 3.3, but give more meaningful errors. The only behavioral difference, might be that the container will throw an exception instead of maybe succeeding in voting when 1 voter would be broken at the end of the list (based on strategy). This case however, will be detected during development and deployment, rather than run-time.