### PR TITLE
Filesystem: annotate the one network test with a "network" group.

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -156,6 +156,9 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
     }
 
+    /**
+     * @group network
+     */
     public function testCopyForOriginUrlsAndExistingLocalFileDefaultsToCopy()
     {
         $sourceFilePath = 'http://symfony.com/images/common/logo/logo_symfony_header.png';


### PR DESCRIPTION
This is one tiny commit that lets us avoid hitting the network while running the test suite. We've packaged symfony-filesystem in Gentoo, and our users can run the test suite when they install it. However, network access is forbidden during the test phase (it causes spurious failures, privacy issues, etc.). By marking the one network test with `@group network`, we are able to skip it with `--exclude-group network`.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 