### PR TITLE
[FrameworkBundle] Show welcome page when no routes have been configured

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/WelcomeController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/WelcomeController.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Welcome controller.
+ *
+ * Show welcome page when no routes have been configured.
+ *
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ *
+ * @internal
+ */
+class WelcomeController extends Controller
+{
+    public function __invoke()
+    {
+        $version = Kernel::VERSION;
+        $docVersion = substr(Kernel::VERSION, 0, 3);
+        $projectDir = $this->getParameter('kernel.project_dir');
+
+        return new Response(
+            <<<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="robots" content="NONE,NOARCHIVE">
+    <title>Welcome to Symfony</title>
+    <style>
+        body { background: #F5F5F5; font: 18px/1.5 sans-serif; }
+        h1, h2 { line-height: 1.2; margin: 0 0 .5em; }
+        h1 { font-size: 36px; }
+        h2 { font-size: 21px; margin-bottom: 1em; }
+        p { margin: 0 0 1em 0; }
+        a { color: #0000F0; }
+        a:hover { text-decoration: none; }
+        code { background: #F5F5F5; max-width: 100px; padding: 2px 6px; word-wrap: break-word; }
+        #wrapper { background: #FFF; margin: 1em auto; max-width: 800px; width: 95%; border-radius: 5px; }
+        #container { padding: 2em; }
+        #welcome, #status { margin-bottom: 2em; }
+        #welcome h1 span { display: block; font-size: 75%; }
+        #icon-status, #icon-book { float: left; height: 64px; margin-right: 1em; margin-top: -4px; width: 64px; }
+        #icon-book { display: none; }
+        #explanation { margin-top: 40px; padding: 15px; font-size: 16px; background-color: #f0f8ff; border-radius: 5px; }
+        #explanation p { margin-bottom: 0; }
+
+        @media (min-width: 768px) {
+            #wrapper { width: 80%; margin: 2em auto; }
+            #icon-book { display: inline-block; }
+            #status a, #next a { display: block; }
+
+            @-webkit-keyframes fade-in { 0% { opacity: 0; } 100% { opacity: 1; } }
+            @keyframes fade-in { 0% { opacity: 0; } 100% { opacity: 1; } }
+            .sf-toolbar { opacity: 0; -webkit-animation: fade-in 1s .2s forwards; animation: fade-in 1s .2s forwards;}
+        }
+    </style>
+</head>
+
+<body>
+<div id="wrapper">
+    <div id="container">
+        <div id="welcome">
+            <h1><span>Welcome to</span> Symfony $version</h1>
+        </div>
+
+        <div id="status">
+            <p>
+                <svg id="icon-status" width="1792" height="1792" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1671 566q0 40-28 68l-724 724-136 136q-28 28-68 28t-68-28l-136-136-362-362q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 295 656-657q28-28 68-28t68 28l136 136q28 28 28 68z" fill="#759E1A"/></svg>
+
+                Your application is now ready. You can start working on it at:
+                <code>$projectDir</code>
+            </p>
+        </div>
+
+        <div id="next">
+            <h2>What's next?</h2>
+            <p>
+                <svg id="icon-book" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="-12.5 9 64 64" enable-background="new -12.5 9 64 64" xml:space="preserve">
+                        <path fill="#AAA" d="M6.8,40.8c2.4,0.8,4.5-0.7,4.9-2.5c0.2-1.2-0.3-2.1-1.3-3.2l-0.8-0.8c-0.4-0.5-0.6-1.3-0.2-1.9
+                            c0.4-0.5,0.9-0.8,1.8-0.5c1.3,0.4,1.9,1.3,2.9,2.2c-0.4,1.4-0.7,2.9-0.9,4.2l-0.2,1c-0.7,4-1.3,6.2-2.7,7.5
+                            c-0.3,0.3-0.7,0.5-1.3,0.6c-0.3,0-0.4-0.3-0.4-0.3c0-0.3,0.2-0.3,0.3-0.4c0.2-0.1,0.5-0.3,0.4-0.8c0-0.7-0.6-1.3-1.3-1.3
+                            c-0.6,0-1.4,0.6-1.4,1.7s1,1.9,2.4,1.8c0.8,0,2.5-0.3,4.2-2.5c2-2.5,2.5-5.4,2.9-7.4l0.5-2.8c0.3,0,0.5,0.1,0.8,0.1
+                            c2.4,0.1,3.7-1.3,3.7-2.3c0-0.6-0.3-1.2-0.9-1.2c-0.4,0-0.8,0.3-1,0.8c-0.1,0.6,0.8,1.1,0.1,1.5c-0.5,0.3-1.4,0.6-2.7,0.4l0.3-1.3
+                            c0.5-2.6,1-5.7,3.2-5.8c0.2,0,0.8,0,0.8,0.4c0,0.2,0,0.2-0.2,0.5c-0.2,0.3-0.3,0.4-0.2,0.7c0,0.7,0.5,1.1,1.2,1.1
+                            c0.9,0,1.2-1,1.2-1.4c0-1.2-1.2-1.8-2.6-1.8c-1.5,0.1-2.8,0.9-3.7,2.1c-1.1,1.3-1.8,2.9-2.3,4.5c-0.9-0.8-1.6-1.8-3.1-2.3
+                            c-1.1-0.7-2.3-0.5-3.4,0.3c-0.5,0.4-0.8,1-1,1.6c-0.4,1.5,0.4,2.9,0.8,3.4l0.9,1c0.2,0.2,0.6,0.8,0.4,1.5c-0.3,0.8-1.2,1.3-2.1,1
+                            c-0.4-0.2-1-0.5-0.9-0.9c0.1-0.2,0.2-0.3,0.3-0.5s0.1-0.3,0.1-0.3c0.2-0.6-0.1-1.4-0.7-1.6c-0.6-0.2-1.2,0-1.3,0.8
+                            C4.3,38.4,4.7,40,6.8,40.8z M46.1,20.9c0-4.2-3.2-7.5-7.1-7.5h-3.8C34.8,10.8,32.7,9,30.2,9L-2.3,9.1c-2.8,0.1-4.9,2.4-4.9,5.4
+                            L-7,58.6c0,4.8,8.1,13.9,11.6,14.1l34.7-0.1c3.9,0,7-3.4,7-7.6L46.1,20.9z M-0.3,36.4c0-8.6,6.5-15.6,14.5-15.6
+                            c8,0,14.5,7,14.5,15.6S22.1,52,14.2,52C6.1,52-0.3,45-0.3,36.4z M42.1,65.1c0,1.8-1.5,3.1-3.1,3.1H4.6c-0.7,0-3-1.8-4.5-4.4h30.4
+                            c2.8,0,5-2.4,5-5.4V17.9h3.7c1.6,0,2.9,1.4,2.9,3.1V65.1L42.1,65.1z"/>
+                    </svg>
+
+                Read the documentation to learn
+                <a href="http://symfony.com/doc/$docVersion/page_creation.html" target="_blank">
+                    How to create your first page in Symfony
+                </a>
+            </p>
+        </div>
+
+        <div id="explanation">
+            <p>
+                You're seeing this message because you have debug mode enabled and you haven't configured any URLs. Get to work!
+            </p>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>
+EOF
+        );
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -100,6 +100,10 @@ EOF;
     {
         $code = rtrim($this->compileRoutes($this->getRoutes(), $supportsRedirections), "\n");
 
+        if ('' === $code && class_exists('Symfony\Bundle\FrameworkBundle\Controller\WelcomeController')) {
+            $code = "        return array (  '_controller' => 'Symfony\\Bundle\\FrameworkBundle\\Controller\\WelcomeController',  '_route' => 'welcome',);";
+        }
+
         return <<<EOF
     public function match(\$pathinfo)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/flex/issues/20
| License       | MIT

## Improving the first time experience (debug enabled)

```
$ composer create-project symfony/skeleton:3.3.x-dev flex_demo
```
![what's next](https://cloud.githubusercontent.com/assets/73419/24615688/41b7aed6-188f-11e7-81c9-8d8a7037269a.png)

```
$ make serve
Listening on http://127.0.0.1:8000
Document root is /home/yceruto/demos/flex_demo/web
Press Ctrl-C to quit.
```

![welcome2](https://cloud.githubusercontent.com/assets/2028198/25718739/39a19f64-30d5-11e7-8106-1b5824883ddd.png)

Once the first route is added, this message is no longer displayed.

---

Original idea from @sstok (https://github.com/symfony/flex/issues/20#issuecomment-298525323)
ping @javiereguiluz 