### PR TITLE
[Config] Added the import method to the LoaderInterface.

### DIFF
--- a/src/Symfony/Component/Config/Loader/Loader.php
+++ b/src/Symfony/Component/Config/Loader/Loader.php
@@ -39,12 +39,7 @@ abstract class Loader implements LoaderInterface
     }
 
     /**
-     * Imports a resource.
-     *
-     * @param mixed       $resource A resource
-     * @param string|null $type     The resource type or null if unknown
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
     public function import($resource, $type = null)
     {

--- a/src/Symfony/Component/Config/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Config/Loader/LoaderInterface.php
@@ -51,4 +51,14 @@ interface LoaderInterface
      * @param LoaderResolverInterface $resolver A LoaderResolverInterface instance
      */
     public function setResolver(LoaderResolverInterface $resolver);
+
+    /**
+     * Imports a resource.
+     *
+     * @param mixed       $resource A resource
+     * @param string|null $type     The resource type or null if unknown
+     *
+     * @return mixed
+     */
+    public function import($resource, $type = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | yes
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The config loader is used in symfony/skeleton:3.3's new `App\Kernel`, it calls the import function, which is not defined in the LoaderInterface but it _is_ part of the abstract Loader class. Since an interface is public API it's technically a BC break, however the base class does already provide it.
