### PR TITLE
[WebLink][TwigBundle] Fix registration of the twig extension

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -55,6 +55,7 @@ class TwigExtension extends Extension
             $definition = $container->register('twig.extension.weblink', WebLinkExtension::class);
             $definition->setPublic(false);
             $definition->addArgument(new Reference('request_stack'));
+            $definition->addTag('twig.extension');
         }
 
         foreach ($configs as $key => $config) {

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/config": "~3.2",
-        "symfony/twig-bridge": "^3.2.1",
+        "symfony/twig-bridge": "^3.3",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/http-kernel": "^3.3",
         "twig/twig": "^1.32|^2.2"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | See http://symfony.com/blog/new-in-symfony-3-3-weblink-component comments
| License       | MIT
| Doc PR        | N/A

BTW it is the only extension not using a classic service definition and adding the tag using the `Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\ExtensionPass` class.

(Fabbot failure fixed in https://github.com/symfony/symfony/pull/22640)