### PR TITLE
[DX] Making the RegisterControllerArgumentLocatorsPass throw exception on bad types

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPassTest.php
@@ -120,7 +120,7 @@ class RemoveEmptyControllerArgumentLocatorsPassTest extends TestCase
 
 class RemoveTestController1
 {
-    public function fooAction(\stdClass $bar, NotFound $baz)
+    public function fooAction(\stdClass $bar, ClassNotInContainer $baz)
     {
     }
 }
@@ -131,7 +131,7 @@ class RemoveTestController2
     {
     }
 
-    public function fooAction(NotFound $bar)
+    public function fooAction(ClassNotInContainer $bar)
     {
     }
 }
@@ -141,4 +141,8 @@ class InvokableRegisterTestController
     public function __invoke(\stdClass $bar)
     {
     }
+}
+
+class ClassNotInContainer
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n/a

Suppose you type-hint a controller arg with a non-existent class:

```php
public function fooAction(FakeClass $foo)
```

Current error:

> Class AppBundle\Controller\FakeClass does not exist

(from `ParamConverterListener`, and only when you hit that route)

New error:

> Cannot determine controller argument for "AppBundle\Controller\BlogController::indexAction()  
  ": the $foo argument is type-hinted with the non-existent class or interface: "AppBundle\Con  
  troller\FakeClass". Did you forget to add a use statement?

(at build time)

The extra `Did you forget to add a use statement?` only shows up if it appears you likely forgot a `use` statement.

I think this will be a really common error (especially forgetting the `use` statement)... so let's make it a *really* nice error! An alternative would be to enhance the args resolver to throw a clearer exception when no arg can be wired and the type-hint is bad (we would also need to make the `ParamConverterListener` stop throwing the current error... so that the args resolver would have the opportunity to do that. Disadvantage would be that this error would only happen when you hit the route, not at build time.

Cheers!