### PR TITLE
[FrameworkBundle] Add type hint for ContainerInterface on ControllerTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Controller;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,6 +34,8 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
  * @author Fabien Potencier <fabien@symfony.com>
  *
  * @internal
+ *
+ * @property ContainerInterface $container
  */
 trait ControllerTrait
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When inspecting code using the `ControllerTrait`, IDE autocompletion and automatic type resolving of services does not work as the IDE (e.g. PHPStorm with the Symfony plugin) does not know what `$this->container` refers to:

![image](https://cloud.githubusercontent.com/assets/27403/25742248/eee5f280-318e-11e7-83df-c417bc7edb84.png)

This adds a type hint for the container property, making the IDE aware what `container` is.

![image](https://cloud.githubusercontent.com/assets/27403/25742238/dceda64a-318e-11e7-9f63-c92a82e75744.png)


