### PR TITLE
[Workflow] Move twig extension registration to twig bundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.xml
@@ -22,10 +22,5 @@
         <service id="workflow.marking_store.single_state" class="Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore" abstract="true" />
 
         <service id="workflow.registry" class="Symfony\Component\Workflow\Registry" />
-
-        <service id="workflow.twig_extension" class="Symfony\Bridge\Twig\Extension\WorkflowExtension">
-            <argument type="service" id="workflow.registry" />
-            <tag name="twig.extension" />
-        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\Workflow\Workflow;
 use Symfony\Component\Yaml\Parser as YamlParser;
 
 /**
@@ -114,6 +115,13 @@ class ExtensionPass implements CompilerPassInterface
         $container->addResource(new ClassExistenceResource(ExpressionLanguage::class));
         if (class_exists(ExpressionLanguage::class)) {
             $container->getDefinition('twig.extension.expression')->addTag('twig.extension');
+        }
+
+        $container->addResource(new ClassExistenceResource(Workflow::class));
+        if (!class_exists(Workflow::class) || !$container->has('workflow.registry')) {
+            $container->removeDefinition('workflow.twig_extension');
+        } else {
+            $container->getDefinition('workflow.twig_extension')->addTag('twig.extension');
         }
     }
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -106,6 +106,10 @@
 
         <service id="twig.extension.debug" class="Twig_Extension_Debug" public="false" />
 
+        <service id="workflow.twig_extension" class="Symfony\Bridge\Twig\Extension\WorkflowExtension">
+            <argument type="service" id="workflow.registry" />
+        </service>
+
         <service id="twig.translation.extractor" class="Symfony\Bridge\Twig\Translation\TwigExtractor">
             <argument type="service" id="twig" />
             <tag name="translation.extractor" alias="twig" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | not really
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

It's probably very late, but I think the twig extension registration is supposed to be done from the `TwigBundle` rather than the `FrameworkBundle`. Fortunately, it doesn't cause any issue currently when using the framework bundle and the workflow component without twig, because it only creates a `workflow.twig_extension` service you'll probably never call, and the `twig.extension` tag is never processed. But still, creates a useless service that cannot be called (and is not removed because it's public).

So this PR aims for consistency over other twig extensions registration, and removing this service when not using twig.
It isn't a BC break to me, as you usually already use the `TwigBundle` for other extensions.