### PR TITLE
fixing php error "Cannot use object of type GuzzleHttp\Psr7\Uri as ar…

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -523,6 +523,9 @@ abstract class Client
      */
     protected function getAbsoluteUri($uri)
     {
+        // Implicitly convert to string to enable string operations
+        $uri = strval($uri);
+
         // already absolute?
         if (0 === strpos($uri, 'http://') || 0 === strpos($uri, 'https://')) {
             return $uri;


### PR DESCRIPTION
…ray" in BrowserKit/Client.php (#22654)

| Q             | A
| ------------- | ---
| Branch?       | master <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #22655  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->
