### PR TITLE
[DI][DX] Fix missing autoconfigure in container debug

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -307,6 +307,7 @@ class TextDescriptor extends Descriptor
         $tableRows[] = array('Shared', $definition->isShared() ? 'yes' : 'no');
         $tableRows[] = array('Abstract', $definition->isAbstract() ? 'yes' : 'no');
         $tableRows[] = array('Autowired', $definition->isAutowired() ? 'yes' : 'no');
+        $tableRows[] = array('Autoconfigured', $definition->isAutoconfigured() ? 'yes' : 'no');
 
         if ($autowiringTypes = $definition->getAutowiringTypes(false)) {
             $tableRows[] = array('Autowiring Types', implode(', ', $autowiringTypes));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
@@ -15,6 +15,7 @@
   Shared           yes                          
   Abstract         yes                          
   Autowired        no                           
+  Autoconfigured   no                           
   Factory Class    Full\Qualified\FactoryClass  
   Factory Method   get                          
  ---------------- -----------------------------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
@@ -18,6 +18,7 @@
   Shared            yes                              
   Abstract          no                               
   Autowired         no                               
+  Autoconfigured    no                               
   Required File     /path/to/file                    
   Factory Service   factory.service                  
   Factory Method    get                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.txt
@@ -10,6 +10,7 @@
   Shared           yes                          
   Abstract         yes                          
   Autowired        no                           
+  Autoconfigured   no                           
   Factory Class    Full\Qualified\FactoryClass  
   Factory Method   get                          
  ---------------- ----------------------------- 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
@@ -13,6 +13,7 @@
   Shared            yes                              
   Abstract          no                               
   Autowired         no                               
+  Autoconfigured    no                               
   Required File     /path/to/file                    
   Factory Service   factory.service                  
   Factory Method    get                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
@@ -10,6 +10,7 @@
   Shared           yes                                        
   Abstract         yes                                        
   Autowired        no                                         
+  Autoconfigured   no                                         
   Factory Class    Full\Qualified\FactoryClass                
   Factory Method   get                                        
 [39;49m  Arguments        Service(definition2)[39;49m[39;49m                       [39;49m

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
@@ -13,6 +13,7 @@
   Shared            yes                              
   Abstract          no                               
   Autowired         no                               
+  Autoconfigured    no                               
   Required File     /path/to/file                    
   Factory Service   factory.service                  
   Factory Method    get                              


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Added missing autoconfigure flag for `debug:container` with service id.