### PR TITLE
[DI] Fix Cannot declare class ...\DefinitionDecorator, because the name is already in use

### DIFF
--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -15,15 +15,15 @@ namespace Symfony\Component\DependencyInjection;
 
 class_exists(ChildDefinition::class);
 
-return;
-
-/**
- * This definition decorates another definition.
- *
- * @author Johannes M. Schmitt <schmittjoh@gmail.com>
- *
- * @deprecated The DefinitionDecorator class is deprecated since version 3.3 and will be removed in 4.0. Use the Symfony\Component\DependencyInjection\ChildDefinition class instead.
- */
-class DefinitionDecorator extends Definition
-{
+if (false) {
+    /**
+     * This definition decorates another definition.
+     *
+     * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+     *
+     * @deprecated The DefinitionDecorator class is deprecated since version 3.3 and will be removed in 4.0. Use the Symfony\Component\DependencyInjection\ChildDefinition class instead.
+     */
+    class DefinitionDecorator extends Definition
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21369
| License       | MIT
| Doc PR        | N/A

The `return` trick doesn't seem to work, and php is still trying to declare the `DefinitionDecorator` class, which causes the "Cannot declare class ...\DefinitionDecorator, because the name is already in use" error because of the `class_alias` previously declared in `ChildDefinition.php`.

This never happens as soon as the `ChildDefinition` class is used first, as the alias will take hand, but their are some situations, like in some unit test cases it can happen apparently, because `DefinitionDecorator` is used first.