### PR TITLE
Make the exception pages work when the WebProfilerBundle is not installed

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
@@ -1,5 +1,5 @@
-{# This file is duplicated in TwigBundle/Resources/views/base_js.html.twig. If you
-   make any change in this file, do the same change in the other file. #}
+{# This file is duplicated in WebProfilerBundle/Resources/views/Profiler/base_js.html.twig.
+   If you make any change in this file, do the same change in the other file. #}
 <script{% if csp_script_nonce is defined and csp_script_nonce %} nonce={{ csp_script_nonce }}{% endif %}>/*<![CDATA[*/
     {# Caution: the contents of this file are processed by Twig before loading
                 them as JavaScript source code. Always use '/*' comments instead

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
@@ -31,5 +31,6 @@
         </header>
 
         {% block body %}{% endblock %}
+        {{ include('@Twig/base_js.html.twig') }}
     </body>
 </html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22631
| License       | MIT
| Doc PR        | -

