### PR TITLE
Improved the stack traces that don't contain a function

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/trace.txt.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/trace.txt.twig
@@ -1,9 +1,6 @@
 {% if trace.function %}
-    {{- trace.class ~ trace.type ~ trace.function }}({{ trace.args|format_args }})
-{%- else -%}
-    n/a
+at {{ trace.class ~ trace.type ~ trace.function }}({{ trace.args|format_args }})
 {%- endif -%}
 {% if trace.file|default('') is not empty and trace.line|default('') is not empty %}
-
-     ({{ trace.file|format_file(trace.line)|striptags|replace({ (' at line ' ~ trace.line): '' }) }}:{{ trace.line }})
-{%- endif -%}
+  {{- trace.function ? '\n     (' : 'at '}}{{ trace.file|format_file(trace.line)|striptags|replace({ (' at line ' ~ trace.line): '' }) }}:{{ trace.line }}{{ trace.function ? ')' }}
+{%- endif %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.txt.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.txt.twig
@@ -6,7 +6,7 @@
 {% endif %}
 
 {% for trace in exception.trace %}
-  at {{ include('@Twig/Exception/trace.txt.twig', { trace: trace }, with_context = false) }}
+  {{ include('@Twig/Exception/trace.txt.twig', { trace: trace }, with_context = false) }}
 {% endfor %}
 </pre>
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When a trace doesn't have a method/function associated, we display `n/a` and the file path below it. This usually happens in the first line of the stack traces. I don't think this looks OK, so I'm proposing to change it as follows:

### Before

![before-exception](https://cloud.githubusercontent.com/assets/73419/25782450/ae521cc6-334b-11e7-9e22-b31342667f6c.png)

### After

![after-exception](https://cloud.githubusercontent.com/assets/73419/25782451/b1b9957e-334b-11e7-812f-8c24ab8872df.png)
