### PR TITLE
[Security] Fix TraceableAccessDecisionManager / DebugAccessDecisionManager BC layer

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/DebugAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/DebugAccessDecisionManager.php
@@ -11,12 +11,26 @@
 
 namespace Symfony\Component\Security\Core\Authorization;
 
-/*
- * @internal
- *
- * @deprecated The DebugAccessDecisionManager class has been renamed and is deprecated since version 3.3 and will be removed in 4.0. Use the TraceableAccessDecisionManager class instead.
- *
- * This is a placeholder for the old class, that got renamed; this is not a BC break since the class is internal, this
- * placeholder is here just to help backward compatibility with older SecurityBundle versions.
- */
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
 class_exists(TraceableAccessDecisionManager::class);
+
+if (false) {
+    /**
+     * This is a placeholder for the old class, that got renamed; this is not a BC break since the class is internal, this
+     * placeholder is here just to help backward compatibility with older SecurityBundle versions.
+     *
+     * @deprecated The DebugAccessDecisionManager class has been renamed and is deprecated since version 3.3 and will be removed in 4.0. Use the TraceableAccessDecisionManager class instead.
+     *
+     * @internal
+     */
+    class DebugAccessDecisionManager implements AccessDecisionManagerInterface
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function decide(TokenInterface $token, array $attributes, $object = null)
+        {
+        }
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
  * Decorates the original AccessDecisionManager class to log information


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22657#issuecomment-299728726
| License       | MIT
| Doc PR        | N/A

Same as #22657 for the renaming of `DebugAccessDecisionManager` into `TraceableAccessDecisionManager`. Indeed, I think we also require to redeclare the old `DebugAccessDecisionManager` for composer `classmap-authoritative` autoloading strategy & classmap dumper.

AppVeyor failures unrelated.

Edit: Re-thinking about it, it's probably not very common to dump the classmap and use the `classmap-authoritative` strategy when using those classes... That's to say: in debug mode/dev env. So it may be the reason why the class wasn't redeclared on contrary of `DefinitionDecorator`.