### PR TITLE
[DI] Do not throw autowiring exceptions for a service that will be removed

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireExceptionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireExceptionPass.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Throws autowire exceptions from AutowirePass for definitions that still exist.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class AutowireExceptionPass implements CompilerPassInterface
+{
+    private $autowirePass;
+
+    public function __construct(AutowirePass $autowirePass)
+    {
+        $this->autowirePass = $autowirePass;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($this->autowirePass->getAutowiringExceptions() as $exception) {
+            if ($container->hasDefinition($exception->getServiceId())) {
+                throw $exception;
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -57,7 +57,7 @@ class PassConfig
             new CheckDefinitionValidityPass(),
             new RegisterServiceSubscribersPass(),
             new ResolveNamedArgumentsPass(),
-            new AutowirePass(),
+            $autowirePass = new AutowirePass(false),
             new ResolveServiceSubscribersPass(),
             new ResolveReferencesToAliasesPass(),
             new ResolveInvalidReferencesPass(),
@@ -77,6 +77,7 @@ class PassConfig
                 new AnalyzeServiceReferencesPass(),
                 new RemoveUnusedDefinitionsPass(),
             )),
+            new AutowireExceptionPass($autowirePass),
             new CheckExceptionOnInvalidReferenceBehaviorPass(),
         ));
     }

--- a/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+/**
+ * Thrown when a definition cannot be autowired.
+ */
+class AutowiringFailedException extends RuntimeException
+{
+    private $serviceId;
+
+    public function __construct($serviceId, $message = '', $code = 0, Exception $previous = null)
+    {
+        $this->serviceId = $serviceId;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getServiceId()
+    {
+        return $this->serviceId;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Compiler\AutowireExceptionPass;
+use Symfony\Component\DependencyInjection\Compiler\AutowirePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\AutowiringFailedException;
+
+class AutowireExceptionPassTest extends TestCase
+{
+    public function testThrowsException()
+    {
+        $autowirePass = $this->getMockBuilder(AutowirePass::class)
+            ->getMock();
+
+        $autowireException = new AutowiringFailedException('foo_service_id', 'An autowiring exception message');
+        $autowirePass->expects($this->any())
+            ->method('getAutowiringExceptions')
+            ->will($this->returnValue(array($autowireException)));
+
+        $container = new ContainerBuilder();
+        $container->register('foo_service_id');
+
+        $pass = new AutowireExceptionPass($autowirePass);
+
+        try {
+            $pass->process($container);
+            $this->fail('->process() should throw the exception if the service id exists');
+        } catch (\Exception $e) {
+            $this->assertSame($autowireException, $e);
+        }
+    }
+
+    public function testNoExceptionIfServiceRemoved()
+    {
+        $autowirePass = $this->getMockBuilder(AutowirePass::class)
+            ->getMock();
+
+        $autowireException = new AutowiringFailedException('non_existent_service');
+        $autowirePass->expects($this->any())
+            ->method('getAutowiringExceptions')
+            ->will($this->returnValue(array($autowireException)));
+
+        $container = new ContainerBuilder();
+
+        $pass = new AutowireExceptionPass($autowirePass);
+
+        $pass->process($container);
+        // mark the test as passed
+        $this->assertTrue(true);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -135,6 +135,21 @@ class AutowirePassTest extends TestCase
         $this->assertEquals(DInterface::class, (string) $container->getDefinition('h')->getArgument(1));
     }
 
+    public function testExceptionsAreStored()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('c1', __NAMESPACE__.'\CollisionA');
+        $container->register('c2', __NAMESPACE__.'\CollisionB');
+        $container->register('c3', __NAMESPACE__.'\CollisionB');
+        $aDefinition = $container->register('a', __NAMESPACE__.'\CannotBeAutowired');
+        $aDefinition->setAutowired(true);
+
+        $pass = new AutowirePass(false);
+        $pass->process($container);
+        $this->assertCount(1, $pass->getAutowiringExceptions());
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      * @expectedExceptionMessage Cannot autowire service "a": argument "$collision" of method "Symfony\Component\DependencyInjection\Tests\Compiler\CannotBeAutowired::__construct()" references interface "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" but no such service exists. You should maybe alias this interface to one of these existing services: "c1", "c2", "c3".


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no (arguable)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Hi guys!

tl;dr Do no throw a "Cannot autowire service id foo_bar" if that service (`foo_bar`) is private and is ultimately removed from the container.

I ran into a problem with the new PSR-4 service loader: our existing projects often contains directories with a mixture of services and model classes. In reality, that's not a problem: since the services are private, if any "extra" classes are registered as service, they're removed from the container because they're not referenced. In other words, the system is great: model classes do *not* become services naturally... because nobody tries to inject them as services.

However, if your model classes have constructor args... then things blow up on compilation. This fixes that: it delays autowiring errors until after `RemoveUnusedDefinitionsPass` runs and then does *not* throw those exceptions if the service is gone.

Cheers!