### PR TITLE
[FrameworkBundle] KernelTestCase: allow to provide the kernel class with a var

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -106,6 +106,14 @@ abstract class KernelTestCase extends TestCase
      */
     protected static function getKernelClass()
     {
+        if (isset($_SERVER['KERNEL_CLASS'])) {
+            if (!class_exists($class = $_SERVER['KERNEL_CLASS'])) {
+                throw new \RuntimeException(sprintf('Class "%s" doesn\'t exist or cannot be autoloaded. Check that the KERNEL_CLASS value in phpunit.xml matches the fully-qualified class name of your Kernel or override the %s::createKernel() method.', $class, static::class));
+            }
+
+            return $class;
+        }
+
         if (isset($_SERVER['KERNEL_DIR'])) {
             $dir = $_SERVER['KERNEL_DIR'];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | yes, but must-have for the new project structure when using flex
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22661
| License       | MIT
| Doc PR        | todo in https://symfony.com/doc/current/testing.html#your-first-functional-test

So, when using flex, the new `phpunit.xml.dist` will be:

```diff
<?xml version="1.0" encoding="UTF-8"?>

<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
         backupGlobals="false"
         colors="true"
         bootstrap="vendor/autoload.php"
>
    <php>
        <ini name="error_reporting" value="-1" />
-        <server name="KERNEL_DIR" value="etc/" />
+        <server name="KERNEL_CLASS" value="App\Kernel" />
    </php>

    <testsuites>
        <testsuite name="Project Test Suite">
            <directory>tests/</directory>
        </testsuite>
    </testsuites>
</phpunit>
```

As it may cause issues when refactoring, I added a `class_exists` check with an appropriate exception to indicate the class is either not found or not autoloadable.