### PR TITLE
[FrameworkBundle] AbstractConfigCommand: do not try registering bundles twice

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -95,7 +95,7 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         // Re-build bundle manually to initialize DI extensions that can be extended by other bundles in their build() method
         // as this method is not called when the container is loaded from the cache.
         $container = $this->getContainerBuilder();
-        $bundles = $this->getContainer()->get('kernel')->registerBundles();
+        $bundles = $this->getContainer()->get('kernel')->getBundles();
         foreach ($bundles as $bundle) {
             if ($extension = $bundle->getContainerExtension()) {
                 $container->registerExtension($extension);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/recipes/issues/46
| License       | MIT
| Doc PR        | N/A

As spotted in https://github.com/symfony/recipes/issues/46, there is no reason to call `registerBundles` on the kernel instance, as it's already booted. So we just have to use `getBundles` instead and `registerBundles` can be implemented in a non-rewindable way, as done with flex.