### PR TITLE
[FrameworkBundle] KernelTestCase: deprecate not using KERNEL_CLASS

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -8,6 +8,19 @@ Finder
    deprecated and will be removed in 4.0 as it used to fix a bug which existed 
    before version 5.5.23/5.6.7
 
+FrameworkBundle
+---------------
+
+ * Using the `KERNEL_DIR` environment variable or the automatic guessing based
+   on the `phpunit.xml` / `phpunit.xml.dist` file location is deprecated since 3.4. 
+   Set the `KERNEL_CLASS` environment variable to the fully-qualified class name
+   of your Kernel instead. Not setting the `KERNEL_CLASS` environment variable 
+   will throw an exception on 4.0 unless you override the `KernelTestCase::createKernel()` 
+   or `KernelTestCase::getKernelClass()` method.
+   
+ * The `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()` 
+   methods are deprecated since 3.4 and will be removed in 4.0.
+
 Validator
 ---------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -333,6 +333,15 @@ FrameworkBundle
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ValidateWorkflowsPass` class
    has been removed. Use the `Symfony\Component\Workflow\DependencyInjection\ValidateWorkflowsPass`
    class instead.
+   
+ * Using the `KERNEL_DIR` environment variable and the automatic guessing based
+   on the `phpunit.xml` file location have been removed from the `KernelTestCase::getKernelClass()` 
+   method implementation. Set the `KERNEL_CLASS` environment variable to the
+   fully-qualified class name of your Kernel or override the `KernelTestCase::createKernel()` 
+   or `KernelTestCase::getKernelClass()` method instead.
+   
+ * The methods `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()`
+   have been removed.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+* Deprecated using the `KERNEL_DIR` environment variable with `KernelTestCase::getKernelClass()`.
+* Deprecated the `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()` methods.
+
 3.3.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -39,9 +39,13 @@ abstract class KernelTestCase extends TestCase
      * @return string The directory where phpunit.xml(.dist) is stored
      *
      * @throws \RuntimeException
+     *
+     * @deprecated since 3.4 and will be removed in 4.0.
      */
     protected static function getPhpUnitXmlDir()
     {
+        @trigger_error(sprintf('The %s() method is deprecated since 3.4 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+
         if (!isset($_SERVER['argv']) || false === strpos($_SERVER['argv'][0], 'phpunit')) {
             throw new \RuntimeException('You must override the KernelTestCase::createKernel() method.');
         }
@@ -72,9 +76,13 @@ abstract class KernelTestCase extends TestCase
      * the last configuration argument.
      *
      * @return string The value of the PHPUnit CLI configuration option
+     *
+     * @deprecated since 3.4 and will be removed in 4.0.
      */
     private static function getPhpUnitCliConfigArgument()
     {
+        @trigger_error(sprintf('The %s() method is deprecated since 3.4 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+
         $dir = null;
         $reversedArgs = array_reverse($_SERVER['argv']);
         foreach ($reversedArgs as $argIndex => $testArg) {
@@ -112,6 +120,8 @@ abstract class KernelTestCase extends TestCase
             }
 
             return $class;
+        } else {
+            @trigger_error(sprintf('Using the KERNEL_DIR environment variable or the automatic guessing based on the phpunit.xml / phpunit.xml.dist file location is deprecated since 3.4. Set the KERNEL_CLASS environment variable to the fully-qualified class name of your Kernel instead. Not setting the KERNEL_CLASS environment variable will throw an exception on 4.0 unless you override the %1$::createKernel() or %1$::getKernelClass() method.', static::class), E_USER_DEPRECATED);
         }
 
         if (isset($_SERVER['KERNEL_DIR'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22668#issuecomment-299875161
| License       | MIT
| Doc PR        | N/A