### PR TITLE
[DI] Fixed index args bug with ResolveNamedArgumentsPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -40,7 +40,7 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
 
             foreach ($arguments as $key => $argument) {
                 if (is_int($key)) {
-                    $resolvedArguments[] = $argument;
+                    $resolvedArguments[$key] = $argument;
                     continue;
                 }
                 if ('' === $key || '$' !== $key[0]) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -27,13 +27,17 @@ class ResolveNamedArgumentsPassTest extends TestCase
         $container = new ContainerBuilder();
 
         $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
-        $definition->setArguments(array(0 => new Reference('foo'), '$apiKey' => '123'));
+        $definition->setArguments(array(
+            2 => 'http://api.example.com',
+            '$apiKey' => '123',
+            0 => new Reference('foo'),
+        ));
         $definition->addMethodCall('setApiKey', array('$apiKey' => '123'));
 
         $pass = new ResolveNamedArgumentsPass();
         $pass->process($container);
 
-        $this->assertEquals(array(0 => new Reference('foo'), 1 => '123'), $definition->getArguments());
+        $this->assertEquals(array(0 => new Reference('foo'), 1 => '123', 2 => 'http://api.example.com'), $definition->getArguments());
         $this->assertEquals(array(array('setApiKey', array('123'))), $definition->getMethodCalls());
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedArgumentsDummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedArgumentsDummy.php
@@ -7,7 +7,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
  */
 class NamedArgumentsDummy
 {
-    public function __construct(CaseSensitiveClass $c, $apiKey)
+    public function __construct(CaseSensitiveClass $c, $apiKey, $hostName)
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n/a

While upgrading a project, this code suddenly broke:

```yml
services:
    ice_cream_service:
        class: AppBundle\Service\IceCreamService
        autowire: true
        arguments:
            1: 'http://api.example.com'
```

```php
class IceCreamService
{
    public function __construct(EntityManager $em, $apiUrl)
    {
    }
}
```

Suddenly, the index `1` was not being mapped to `$apiUrl`. This was valid in 3.2, but broke when `ResolveNamedArgumentsPass` accidentally re-set the index. Simple fix :). Ping @dunglas 

Cheers!