### PR TITLE
[DI] Fixing missing "exclude" functionality from PSR4 loader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -143,7 +143,7 @@ class XmlFileLoader extends FileLoader
         foreach ($services as $service) {
             if (null !== $definition = $this->parseDefinition($service, $file, $defaults)) {
                 if ('prototype' === $service->tagName) {
-                    $this->registerClasses($definition, (string) $service->getAttribute('namespace'), (string) $service->getAttribute('resource'));
+                    $this->registerClasses($definition, (string) $service->getAttribute('namespace'), (string) $service->getAttribute('resource'), (string) $service->getAttribute('exclude'));
                 } else {
                     $this->setDefinition((string) $service->getAttribute('id'), $definition);
                 }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -61,6 +61,7 @@ class YamlFileLoader extends FileLoader
 
     private static $prototypeKeywords = array(
         'resource' => 'resource',
+        'exclude' => 'exclude',
         'parent' => 'parent',
         'shared' => 'shared',
         'lazy' => 'lazy',
@@ -528,7 +529,8 @@ class YamlFileLoader extends FileLoader
             if (!is_string($service['resource'])) {
                 throw new InvalidArgumentException(sprintf('A "resource" attribute must be of type string for service "%s" in %s. Check your YAML syntax.', $id, $file));
             }
-            $this->registerClasses($definition, $id, $service['resource']);
+            $exclude = isset($service['exclude']) ? $service['exclude'] : null;
+            $this->registerClasses($definition, $id, $service['resource'], $exclude);
         } else {
             $this->setDefinition($id, $definition);
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -161,6 +161,7 @@
     </xsd:choice>
     <xsd:attribute name="namespace" type="xsd:string" use="required" />
     <xsd:attribute name="resource" type="xsd:string" use="required" />
+    <xsd:attribute name="exclude" type="xsd:string" />
     <xsd:attribute name="shared" type="boolean" />
     <xsd:attribute name="public" type="boolean" />
     <xsd:attribute name="lazy" type="boolean" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/AnotherSub/DeeperBaz.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/AnotherSub/DeeperBaz.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\AnotherSub;
+
+class DeeperBaz
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Baz.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Baz.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir;
+
+class Baz
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
-      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*" />
+      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*" exclude="../Prototype/{OtherDir}" />
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype.yml
@@ -1,3 +1,4 @@
 services:
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\:
         resource: ../Prototype
+        exclude: '../Prototype/{OtherDir}'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | TODO

When the PSR4 loader was added in #21289, @nicolas-grekas said this:

> given that glob() is powerful enough to include/exclude dirs, I removed the Test special exclusion (source: https://github.com/symfony/symfony/pull/21289#issuecomment-272821106)

But, I don't believe that's true! [Glob is all about inclusion, not exclusion](https://en.wikipedia.org/wiki/Glob_(programming)#Syntax) - the maximum you can exclude is a single character. Thus, I've marked this as a bug.

My motivation came from upgrading KnpU to the new 3.3 DI stuff. We have many directories (40) in `src/`, and listing them all one-by-one in `resource:` is crazy - the `resource` line would be ~350 characters long and quite unreadable. What I really want to do is include *everything* and then exclude few directories. I tried to do this with `glob`, but it's not possible.

This PR allows for something like this:

```yml
services:
    _defaults:
        public: false

    # ...
    AppBundle\:
        resource: '../../src/AppBundle/*'
        exclude: '../../src/AppBundle/{AppBundle.php,Entity}'
```

This works *beautifully* in practice. And even if I forget to exclude a directory - since the services are private -  **they're ultimately removed from the container anyways**. In fact, the *only* reason I need to exclude *anything* is because of the new "service argument resolver", which causes entities to not be properly removed from the compiled container.

Thanks!