### PR TITLE
Fixing a bug where abstract classes were wired with the prototype loader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -108,7 +108,8 @@ abstract class FileLoader extends BaseFileLoader
             if (!$r = $this->container->getReflectionClass($class)) {
                 throw new InvalidArgumentException(sprintf('Expected to find class "%s" in file "%s" while importing services from resource "%s", but it was not found! Check the namespace prefix used with the resource.', $class, $path, $pattern));
             }
-            if (!$r->isInterface() && !$r->isTrait()) {
+
+            if (!$r->isInterface() && !$r->isTrait() && !$r->isAbstract()) {
                 $classes[] = $class;
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Sub/NoLoadAbstractBar.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Sub/NoLoadAbstractBar.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub;
+
+abstract class NoLoadAbstractBar
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Sub/NoLoadBarInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Sub/NoLoadBarInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub;
+
+interface NoLoadBarInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Sub/NoLoadBarTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Sub/NoLoadBarTrait.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub;
+
+trait NoLoadBarTrait
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -84,7 +84,10 @@ class FileLoaderTest extends TestCase
 
         $loader->registerClasses(new Definition(), 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\\', 'Prototype/%sub_dir%/*');
 
-        $this->assertTrue($container->has(Bar::class));
+        $this->assertEquals(
+            array('service_container', Bar::class),
+            array_keys($container->getDefinitions())
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n/a

The prototype/PSR-4 loader currently tries to wire abstract classes. The problem is if, for example, you have, for example:

```php
abstract class BaseCommand extends Command
{
}
```

If this is registered as a service, and you have `autoconfigure`, then the console `Application` will try to use this a command.

Was there some reason abstract classes were originally allowed to be registered as services with the PSR4/prototype loader? I don't know if there is a real use-case for registering abstract classes. If you wanted to use that service as a parent service... then you'll probably be configuring it yourself anyways. We could also fix this by changing all tags compiler passes to skip classes that are abstract... *if* there is a use-case for Abstract classes being auto-registered.

Cheers!