### PR TITLE
Combine multiple isset() calls when possible

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -125,7 +125,7 @@ class TwigExtension extends Extension
             $config['extensions']
         );
 
-        if (isset($config['autoescape_service']) && isset($config['autoescape_service_method'])) {
+        if (isset($config['autoescape_service'], $config['autoescape_service_method'])) {
             $config['autoescape'] = array(new Reference($config['autoescape_service']), $config['autoescape_service_method']);
         }
         unset($config['autoescape_service'], $config['autoescape_service_method']);

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -254,7 +254,7 @@ EOF
                         if ($trace['function']) {
                             $content .= sprintf('at %s%s%s(%s)', $this->formatClass($trace['class']), $trace['type'], $trace['function'], $this->formatArgs($trace['args']));
                         }
-                        if (isset($trace['file']) && isset($trace['line'])) {
+                        if (isset($trace['file'], $trace['line'])) {
                             $content .= $this->formatPath($trace['file'], $trace['line']);
                         }
                         $content .= "</li>\n";

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -131,12 +131,12 @@ class FormRenderer implements FormRendererInterface
         }
 
         // Merge the passed with the existing attributes
-        if (isset($variables['attr']) && isset($scopeVariables['attr'])) {
+        if (isset($variables['attr'], $scopeVariables['attr'])) {
             $variables['attr'] = array_replace($scopeVariables['attr'], $variables['attr']);
         }
 
         // Merge the passed with the exist *label* attributes
-        if (isset($variables['label_attr']) && isset($scopeVariables['label_attr'])) {
+        if (isset($variables['label_attr'], $scopeVariables['label_attr'])) {
             $variables['label_attr'] = array_replace($scopeVariables['label_attr'], $variables['label_attr']);
         }
 
@@ -261,12 +261,12 @@ class FormRenderer implements FormRendererInterface
         }
 
         // Merge the passed with the existing attributes
-        if (isset($variables['attr']) && isset($scopeVariables['attr'])) {
+        if (isset($variables['attr'], $scopeVariables['attr'])) {
             $variables['attr'] = array_replace($scopeVariables['attr'], $variables['attr']);
         }
 
         // Merge the passed with the exist *label* attributes
-        if (isset($variables['label_attr']) && isset($scopeVariables['label_attr'])) {
+        if (isset($variables['label_attr'], $scopeVariables['label_attr'])) {
             $variables['label_attr'] = array_replace($scopeVariables['label_attr'], $variables['label_attr']);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

`isset($a) && isset($b)` is the same as `isset($a, $b)`, so we can save some function calls.