### PR TITLE
[Console] Fix errors not rethrown even if not handled by console.error listeners

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -129,7 +129,7 @@ class Application
         }
 
         if (null !== $e) {
-            if (!$this->catchExceptions) {
+            if (!$this->catchExceptions || !$x instanceof \Exception) {
                 throw $x;
             }
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1170,6 +1170,29 @@ class ApplicationTest extends TestCase
 
         return $dispatcher;
     }
+
+    /**
+     * @requires PHP 7
+     */
+    public function testErrorIsRethrownIfNotHandledByConsoleErrorEventWithCatchingEnabled()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setDispatcher(new EventDispatcher());
+
+        $application->register('dym')->setCode(function (InputInterface $input, OutputInterface $output) {
+            new \UnknownClass();
+        });
+
+        $tester = new ApplicationTester($application);
+
+        try {
+            $tester->run(array('command' => 'dym'));
+            $this->fail('->run() should rethrow PHP errors if not handled via ConsoleErrorEvent.');
+        } catch (\Error $e) {
+            $this->assertSame($e->getMessage(), 'Class \'UnknownClass\' not found');
+        }
+    }
 }
 
 class CustomApplication extends Application


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/22678
| License       | MIT
| Doc PR        | n/a

https://github.com/symfony/symfony/pull/22261 has been squashed while revisiting error handling, this fixes it again while keeping latest changes intact.

__code__
```php
public function execute(InputInterface $input, OutputInterface $output) {
    $this->barr();
}

public function bar() { }
```

__before__
![before](http://image.prntscr.com/image/38aa3b46fed6439ead693908ab104fb3.png)

__after__
![after](http://image.prntscr.com/image/071322bfa52247c6a02eac6ef9d8284a.png)