### PR TITLE
[Console] Fix merge issue: duplicated use Helper directive

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -32,7 +32,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\Helper\HelperSet;
-use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | https://github.com/symfony/symfony/commit/428b9bfa4fea0c9427d216ebcd293a9b2bf4d885#commitcomment-22107296
| License       | MIT
| Doc PR        | N/A

Fix [3.2 to master merge commit issue](https://github.com/symfony/symfony/commit/428b9bfa4fea0c9427d216ebcd293a9b2bf4d885) 

> Fatal error: Cannot use Symfony\Component\Console\Helper\Helper as Helper because the name is already in use

as `Helper` was already imported on master on contrary of lower branches.