### PR TITLE
[PropertyInfo] Made ReflectionExtractor's prefix lists instance variables

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -53,11 +53,35 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
      */
     private $phpDocTypeHelper;
 
-    public function __construct(DocBlockFactoryInterface $docBlockFactory = null)
+    /**
+     * @var string[]
+     */
+    private $mutatorPrefixes;
+
+    /**
+     * @var string[]
+     */
+    private $accessorPrefixes;
+
+    /**
+     * @var string[]
+     */
+    private $arrayMutatorPrefixes;
+
+    /**
+     * @param DocBlockFactoryInterface $docBlockFactory
+     * @param string[]|null            $mutatorPrefixes
+     * @param string[]|null            $accessorPrefixes
+     * @param string[]|null            $arrayMutatorPrefixes
+     */
+    public function __construct(DocBlockFactoryInterface $docBlockFactory = null, array $mutatorPrefixes = null, array $accessorPrefixes = null, array $arrayMutatorPrefixes = null)
     {
         $this->docBlockFactory = $docBlockFactory ?: DocBlockFactory::createInstance();
         $this->contextFactory = new ContextFactory();
         $this->phpDocTypeHelper = new PhpDocTypeHelper();
+        $this->mutatorPrefixes = null !== $mutatorPrefixes ? $mutatorPrefixes : ReflectionExtractor::$defaultMutatorPrefixes;
+        $this->accessorPrefixes = null !== $accessorPrefixes ? $accessorPrefixes : ReflectionExtractor::$defaultAccessorPrefixes;
+        $this->arrayMutatorPrefixes = null !== $arrayMutatorPrefixes ? $arrayMutatorPrefixes : ReflectionExtractor::$defaultArrayMutatorPrefixes;
     }
 
     /**
@@ -137,7 +161,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             return;
         }
 
-        if (!in_array($prefix, ReflectionExtractor::$arrayMutatorPrefixes)) {
+        if (!in_array($prefix, $this->arrayMutatorPrefixes)) {
             return $types;
         }
 
@@ -217,7 +241,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
      */
     private function getDocBlockFromMethod($class, $ucFirstProperty, $type)
     {
-        $prefixes = $type === self::ACCESSOR ? ReflectionExtractor::$accessorPrefixes : ReflectionExtractor::$mutatorPrefixes;
+        $prefixes = $type === self::ACCESSOR ? $this->accessorPrefixes : $this->mutatorPrefixes;
         $prefix = null;
 
         foreach ($prefixes as $prefix) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
@@ -40,6 +40,26 @@ class PhpDocExtractorTest extends TestCase
         $this->assertSame($longDescription, $this->extractor->getLongDescription('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
     }
 
+    /**
+     * @dataProvider typesWithCustomPrefixesProvider
+     */
+    public function testExtractTypesWithCustomPrefixes($property, array $type = null)
+    {
+        $customExtractor = new PhpDocExtractor(null, array('add', 'remove'), array('is', 'can'));
+
+        $this->assertEquals($type, $customExtractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
+    }
+
+    /**
+     * @dataProvider typesWithNoPrefixesProvider
+     */
+    public function testExtractTypesWithNoPrefixes($property, array $type = null)
+    {
+        $noPrefixExtractor = new PhpDocExtractor(null, array(), array(), array());
+
+        $this->assertEquals($type, $noPrefixExtractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
+    }
+
     public function typesProvider()
     {
         return array(
@@ -68,6 +88,76 @@ class PhpDocExtractorTest extends TestCase
             array('d', array(new Type(Type::BUILTIN_TYPE_BOOL)), null, null),
             array('e', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_RESOURCE))), null, null),
             array('f', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))), null, null),
+            array('g', array(new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)), 'Nullable array.', null),
+            array('donotexist', null, null, null),
+            array('staticGetter', null, null, null),
+            array('staticSetter', null, null, null),
+        );
+    }
+
+    public function typesWithCustomPrefixesProvider()
+    {
+        return array(
+            array('foo', null, 'Short description.', 'Long description.'),
+            array('bar', array(new Type(Type::BUILTIN_TYPE_STRING)), 'This is bar', null),
+            array('baz', array(new Type(Type::BUILTIN_TYPE_INT)), 'Should be used.', null),
+            array('foo2', array(new Type(Type::BUILTIN_TYPE_FLOAT)), null, null),
+            array('foo3', array(new Type(Type::BUILTIN_TYPE_CALLABLE)), null, null),
+            array('foo4', array(new Type(Type::BUILTIN_TYPE_NULL)), null, null),
+            array('foo5', null, null, null),
+            array(
+                'files',
+                array(
+                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'SplFileInfo')),
+                    new Type(Type::BUILTIN_TYPE_RESOURCE),
+                ),
+                null,
+                null,
+            ),
+            array('bal', array(new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')), null, null),
+            array('parent', array(new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')), null, null),
+            array('collection', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))), null, null),
+            array('a', null, 'A.', null),
+            array('b', null, 'B.', null),
+            array('c', array(new Type(Type::BUILTIN_TYPE_BOOL, true)), null, null),
+            array('d', array(new Type(Type::BUILTIN_TYPE_BOOL)), null, null),
+            array('e', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_RESOURCE))), null, null),
+            array('f', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))), null, null),
+            array('g', array(new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)), 'Nullable array.', null),
+            array('donotexist', null, null, null),
+            array('staticGetter', null, null, null),
+            array('staticSetter', null, null, null),
+        );
+    }
+
+    public function typesWithNoPrefixesProvider()
+    {
+        return array(
+            array('foo', null, 'Short description.', 'Long description.'),
+            array('bar', array(new Type(Type::BUILTIN_TYPE_STRING)), 'This is bar', null),
+            array('baz', array(new Type(Type::BUILTIN_TYPE_INT)), 'Should be used.', null),
+            array('foo2', array(new Type(Type::BUILTIN_TYPE_FLOAT)), null, null),
+            array('foo3', array(new Type(Type::BUILTIN_TYPE_CALLABLE)), null, null),
+            array('foo4', array(new Type(Type::BUILTIN_TYPE_NULL)), null, null),
+            array('foo5', null, null, null),
+            array(
+                'files',
+                array(
+                    new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'SplFileInfo')),
+                    new Type(Type::BUILTIN_TYPE_RESOURCE),
+                ),
+                null,
+                null,
+            ),
+            array('bal', array(new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')), null, null),
+            array('parent', array(new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')), null, null),
+            array('collection', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))), null, null),
+            array('a', null, 'A.', null),
+            array('b', null, 'B.', null),
+            array('c', null, null, null),
+            array('d', null, null, null),
+            array('e', null, null, null),
+            array('f', null, null, null),
             array('g', array(new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)), 'Nullable array.', null),
             array('donotexist', null, null, null),
             array('staticGetter', null, null, null),

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
@@ -60,6 +60,56 @@ class ReflectionExtractorTest extends TestCase
         );
     }
 
+    public function testGetPropertiesWithCustomPrefixes()
+    {
+        $customExtractor = new ReflectionExtractor(array('add', 'remove'), array('is', 'can'));
+
+        $this->assertSame(
+            array(
+                'bal',
+                'parent',
+                'collection',
+                'B',
+                'Guid',
+                'g',
+                'foo',
+                'foo2',
+                'foo3',
+                'foo4',
+                'foo5',
+                'files',
+                'c',
+                'd',
+                'e',
+                'f',
+            ),
+            $customExtractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')
+        );
+    }
+
+    public function testGetPropertiesWithNoPrefixes()
+    {
+        $noPrefixExtractor = new ReflectionExtractor(array(), array(), array());
+
+        $this->assertSame(
+            array(
+                'bal',
+                'parent',
+                'collection',
+                'B',
+                'Guid',
+                'g',
+                'foo',
+                'foo2',
+                'foo3',
+                'foo4',
+                'foo5',
+                'files',
+            ),
+            $noPrefixExtractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')
+        );
+    }
+
     /**
      * @dataProvider typesProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `3.4`
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR makes `ReflectionExtractor`'s mutator/accessor prefixes instance variables in order to be able to override them to change its behavior.