### PR TITLE
[TwigBundle] service workflow.twig_extension should stay public

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -115,7 +115,7 @@
             <tag name="translation.extractor" alias="twig" />
         </service>
 
-        <service id="workflow.twig_extension" class="Symfony\Bridge\Twig\Extension\WorkflowExtension">
+        <service id="workflow.twig_extension" class="Symfony\Bridge\Twig\Extension\WorkflowExtension" public="true">
             <argument type="service" id="workflow.registry" />
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (3.3)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

While it's not really required for this service to be public AFAIK, it was not made private when introducing it in 3.2. Which means it should stay public in upper branches. But [since we now default to `public: false`](https://github.com/symfony/symfony/pull/22615) in every service config file, it's currently private in 3.3.

I had a quick look on commits merged after this PR and didn't find any other similar case.