### PR TITLE
Adding autowire alias for AuthenticationUtils

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -68,6 +68,7 @@
         <service id="security.authentication_utils" class="Symfony\Component\Security\Http\Authentication\AuthenticationUtils" public="true">
             <argument type="service" id="request_stack" />
         </service>
+        <service id="Symfony\Component\Security\Http\Authentication\AuthenticationUtils" alias="security.authentication_utils" />
 
         <!-- Authorization related services -->
         <service id="security.access.decision_manager" class="Symfony\Component\Security\Core\Authorization\AccessDecisionManager">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

AuthenticationUtils is a public service (used commonly in your `loginAction`), so it should be autowireable.

We might need to do a full audio of public services to add aliases. Since we're moving in the direction of type-based autowiring, these aliases are sort of the new "public" - it's the list of things you're "supposed" to use.