### PR TITLE
[AssetsBundle] Separated from framework bundle

### DIFF
--- a/src/Symfony/Bundle/AssetsBundle/AssetsBundle.php
+++ b/src/Symfony/Bundle/AssetsBundle/AssetsBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\AssetsBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class AssetsBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/AssetsBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/AssetsBundle/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+3.4.0
+-----
+
+ * Added bundle

--- a/src/Symfony/Bundle/AssetsBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/AssetsBundle/Command/AssetsInstallCommand.php
@@ -1,0 +1,256 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\AssetsBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Command that places bundle web assets into a given directory.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Gábor Egyed <gabor.egyed@gmail.com>
+ */
+class AssetsInstallCommand extends Command
+{
+    const METHOD_COPY = 'copy';
+    const METHOD_ABSOLUTE_SYMLINK = 'absolute symlink';
+    const METHOD_RELATIVE_SYMLINK = 'relative symlink';
+
+    private $kernel;
+    private $filesystem;
+
+    public function __construct(KernelInterface $kernel, Filesystem $filesystem = null)
+    {
+        $this->kernel = $kernel;
+        $this->filesystem = $filesystem ?: new Filesystem();
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('assets:install')
+            ->setDefinition(array(
+                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'web'),
+            ))
+            ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
+            ->addOption('relative', null, InputOption::VALUE_NONE, 'Make relative symlinks')
+            ->setDescription('Installs bundles web assets under a public web directory')
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command installs bundle assets into a given
+directory (e.g. the <comment>web</comment> directory).
+
+  <info>php %command.full_name% web</info>
+
+A "bundles" directory will be created inside the target directory and the
+"Resources/public" directory of each bundle will be copied into it.
+
+To create a symlink to each bundle instead of copying its assets, use the
+<info>--symlink</info> option (will fall back to hard copies when symbolic links aren't possible:
+
+  <info>php %command.full_name% web --symlink</info>
+
+To make symlink relative, add the <info>--relative</info> option:
+
+  <info>php %command.full_name% web --symlink --relative</info>
+
+EOT
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $targetArg = rtrim($input->getArgument('target'), '/');
+
+        if (!is_dir($targetArg)) {
+            $targetArg = $this->kernel->getRootDir().'../'.$targetArg;
+
+            if (!is_dir($targetArg)) {
+                throw new \InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $input->getArgument('target')));
+            }
+        }
+
+        // Create the bundles directory otherwise symlink will fail.
+        $bundlesDir = $targetArg.'/bundles/';
+        $this->filesystem->mkdir($bundlesDir, 0777);
+
+        $io = new SymfonyStyle($input, $output);
+        $io->newLine();
+
+        if ($input->getOption('relative')) {
+            $expectedMethod = self::METHOD_RELATIVE_SYMLINK;
+            $io->text('Trying to install assets as <info>relative symbolic links</info>.');
+        } elseif ($input->getOption('symlink')) {
+            $expectedMethod = self::METHOD_ABSOLUTE_SYMLINK;
+            $io->text('Trying to install assets as <info>absolute symbolic links</info>.');
+        } else {
+            $expectedMethod = self::METHOD_COPY;
+            $io->text('Installing assets as <info>hard copies</info>.');
+        }
+
+        $io->newLine();
+
+        $rows = array();
+        $copyUsed = false;
+        $exitCode = 0;
+        foreach ($this->kernel->getBundles() as $bundle) {
+            if (!is_dir($originDir = $bundle->getPath().'/Resources/public')) {
+                continue;
+            }
+
+            $targetDir = $bundlesDir.preg_replace('/bundle$/', '', strtolower($bundle->getName()));
+
+            if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
+                $message = sprintf("%s\n-> %s", $bundle->getName(), $targetDir);
+            } else {
+                $message = $bundle->getName();
+            }
+
+            try {
+                $this->filesystem->remove($targetDir);
+
+                if (self::METHOD_RELATIVE_SYMLINK === $expectedMethod) {
+                    $method = $this->relativeSymlinkWithFallback($originDir, $targetDir);
+                } elseif (self::METHOD_ABSOLUTE_SYMLINK === $expectedMethod) {
+                    $method = $this->absoluteSymlinkWithFallback($originDir, $targetDir);
+                } else {
+                    $method = $this->hardCopy($originDir, $targetDir);
+                }
+
+                if (self::METHOD_COPY === $method) {
+                    $copyUsed = true;
+                }
+
+                if ($method === $expectedMethod) {
+                    $rows[] = array(sprintf('<fg=green;options=bold>%s</>', '\\' === DIRECTORY_SEPARATOR ? 'OK' : "\xE2\x9C\x94" /* HEAVY CHECK MARK (U+2714) */), $message, $method);
+                } else {
+                    $rows[] = array(sprintf('<fg=yellow;options=bold>%s</>', '\\' === DIRECTORY_SEPARATOR ? 'WARNING' : '!'), $message, $method);
+                }
+            } catch (\Exception $e) {
+                $exitCode = 1;
+                $rows[] = array(sprintf('<fg=red;options=bold>%s</>', '\\' === DIRECTORY_SEPARATOR ? 'ERROR' : "\xE2\x9C\x98" /* HEAVY BALLOT X (U+2718) */), $message, $e->getMessage());
+            }
+        }
+
+        $io->table(array('', 'Bundle', 'Method / Error'), $rows);
+
+        if (0 !== $exitCode) {
+            $io->error('Some errors occurred while installing assets.');
+        } else {
+            if ($copyUsed) {
+                $io->note('Some assets were installed via copy. If you make changes to these assets you have to run this command again.');
+            }
+            $io->success('All assets were successfully installed.');
+        }
+
+        return $exitCode;
+    }
+
+    /**
+     * Try to create relative symlink.
+     *
+     * Falling back to absolute symlink and finally hard copy.
+     *
+     * @param string $originDir
+     * @param string $targetDir
+     *
+     * @return string
+     */
+    private function relativeSymlinkWithFallback($originDir, $targetDir)
+    {
+        try {
+            $this->symlink($originDir, $targetDir, true);
+            $method = self::METHOD_RELATIVE_SYMLINK;
+        } catch (IOException $e) {
+            $method = $this->absoluteSymlinkWithFallback($originDir, $targetDir);
+        }
+
+        return $method;
+    }
+
+    /**
+     * Try to create absolute symlink.
+     *
+     * Falling back to hard copy.
+     *
+     * @param string $originDir
+     * @param string $targetDir
+     *
+     * @return string
+     */
+    private function absoluteSymlinkWithFallback($originDir, $targetDir)
+    {
+        try {
+            $this->symlink($originDir, $targetDir);
+            $method = self::METHOD_ABSOLUTE_SYMLINK;
+        } catch (IOException $e) {
+            // fall back to copy
+            $method = $this->hardCopy($originDir, $targetDir);
+        }
+
+        return $method;
+    }
+
+    /**
+     * Creates symbolic link.
+     *
+     * @param string $originDir
+     * @param string $targetDir
+     * @param bool   $relative
+     *
+     * @throws IOException If link can not be created.
+     */
+    private function symlink($originDir, $targetDir, $relative = false)
+    {
+        if ($relative) {
+            $originDir = $this->filesystem->makePathRelative($originDir, realpath(dirname($targetDir)));
+        }
+        $this->filesystem->symlink($originDir, $targetDir);
+        if (!file_exists($targetDir)) {
+            throw new IOException(sprintf('Symbolic link "%s" was created but appears to be broken.', $targetDir), 0, null, $targetDir);
+        }
+    }
+
+    /**
+     * Copies origin to target.
+     *
+     * @param string $originDir
+     * @param string $targetDir
+     *
+     * @return string
+     */
+    private function hardCopy($originDir, $targetDir)
+    {
+        $this->filesystem->mkdir($targetDir, 0777);
+        // We use a custom iterator to ignore VCS files
+        $this->filesystem->mirror($originDir, $targetDir, Finder::create()->ignoreDotFiles(false)->in($originDir));
+
+        return self::METHOD_COPY;
+    }
+}

--- a/src/Symfony/Bundle/AssetsBundle/DependencyInjection/AssetsExtension.php
+++ b/src/Symfony/Bundle/AssetsBundle/DependencyInjection/AssetsExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\AssetsBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+
+/**
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class AssetsExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('assets.xml');
+    }
+}

--- a/src/Symfony/Bundle/AssetsBundle/LICENSE
+++ b/src/Symfony/Bundle/AssetsBundle/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-2017 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Bundle/AssetsBundle/README.md
+++ b/src/Symfony/Bundle/AssetsBundle/README.md
@@ -1,0 +1,12 @@
+AssetsBundle
+============
+
+
+
+Resources
+---------
+
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Bundle/AssetsBundle/Resources/config/assets.xml
+++ b/src/Symfony/Bundle/AssetsBundle/Resources/config/assets.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="false" />
+
+        <service id="assets.command.assets_install" class="Symfony\Bundle\AssetsBundle\Command\AssetsInstallCommand">
+            <argument type="service" id="kernel" />
+            <argument on-invalid="null" type="service" id="filesystem" />
+            <tag name="console.command" />
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Bundle/AssetsBundle/composer.json
+++ b/src/Symfony/Bundle/AssetsBundle/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "symfony/assets-bundle",
+    "type": "symfony-bundle",
+    "description": "Symfony AssetsBundle",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.5.9",
+        "symfony/console": "~3.3",
+        "symfony/filesystem": "~2.8|~3.0",
+        "symfony/finder": "~2.8|~3.0",
+        "symfony/http-kernel": "~2.8|~3.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Bundle\\AssetsBundle\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "conflict": {
+        "symfony/dependency-injection": "<3.3"
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.3-dev"
+        }
+    }
+}

--- a/src/Symfony/Bundle/AssetsBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/AssetsBundle/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony AssetsBundle Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | probably?
| Tests pass?   | yes/no
| Fixed tickets | https://github.com/symfony/flex/issues/17
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Curious if it was possible.. and i was surprised to see how fast it worked :) (it currently conflicts with assets:install in the framework bundle though; i locally tmp. renamed it).

This more or less follows the trend of the webserver bundle.

Not to be confused with the assets component or framework.assets config, so perhaps this bundle needs a better name?