### PR TITLE
[PropertyAccess] Fixed compatibility with preg_match in PHP 7.2

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -99,7 +99,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         $pattern = '/^(([^\.\[]++)|\[([^\]]++)\])(.*)/';
 
         while (preg_match($pattern, $remaining, $matches)) {
-            if ('' !== $matches[2]) {
+            if ('' !== $matches[2] && null !== $matches[2]) {
                 $element = $matches[2];
                 $this->isIndex[] = false;
             } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22667
| License       | MIT

Fix for compatibility with PCRE change in PHP 7.2.
`preg_*` will return `null` instead of empty string for unmatched patterns.
Broken in php/php-src#1303.