### PR TITLE
[Security] Remove polyfill-util dependancy from security-core

### DIFF
--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -17,8 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/polyfill-php56": "~1.0",
-        "symfony/polyfill-util": "~1.0"
+        "symfony/polyfill-php56": "~1.0"
     },
     "require-dev": {
         "symfony/event-dispatcher": "~2.8|~3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Security-core no longer directly depends upon polyfill-util since #16382.

This does not change the existing dependancy tree as polyfill-util is
transitivly depended on via polyfill-php56.

