### PR TITLE
[FrameworkBundle] remove Security deps from the require section

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -29,8 +29,6 @@
         "symfony/filesystem": "~2.8|~3.0",
         "symfony/finder": "~2.8|~3.0",
         "symfony/routing": "~3.1.10|^3.2.3",
-        "symfony/security-core": "~2.8|~3.0",
-        "symfony/security-csrf": "~2.8|~3.0",
         "symfony/stopwatch": "~2.8|~3.0",
         "doctrine/cache": "~1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

These requirements have been moved in #20075 before and are still
present in the `require-dev` section.

see symfony/flex#14