### PR TITLE
[Console] Fixed different behaviour of key and value user inputs in multiple choice question

### DIFF
--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -135,7 +135,7 @@ class ChoiceQuestion extends Question
 
             if ($multiselect) {
                 // Check for a separated comma values
-                if (!preg_match('/^[a-zA-Z0-9_-]+(?:,[a-zA-Z0-9_-]+)*$/', $selectedChoices, $matches)) {
+                if (!preg_match('/^[^,]+(?:,[^,]+)*$/', $selectedChoices, $matches)) {
                     throw new \InvalidArgumentException(sprintf($errorMessage, $selected));
                 }
                 $selectedChoices = explode(',', $selectedChoices);

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -299,8 +299,8 @@ class QuestionHelperTest extends TestCase
     public function specialCharacterInMultipleChoice()
     {
         return array(
-            array('.', ['.']),
-            array('., src', ['.', 'src']),
+            array('.', array('.')),
+            array('., src', array('.', 'src')),
         );
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -274,6 +274,37 @@ class QuestionHelperTest extends TestCase
     }
 
     /**
+     * @dataProvider specialCharacterInMultipleChoice
+     */
+    public function testSpecialCharacterChoiceFromMultipleChoiceList($providedAnswer, $expectedValue)
+    {
+        $possibleChoices = array(
+            '.',
+            'src',
+        );
+
+        $dialog = new QuestionHelper();
+        $dialog->setInputStream($this->getInputStream($providedAnswer."\n"));
+        $helperSet = new HelperSet(array(new FormatterHelper()));
+        $dialog->setHelperSet($helperSet);
+
+        $question = new ChoiceQuestion('Please select the directory', $possibleChoices);
+        $question->setMaxAttempts(1);
+        $question->setMultiselect(true);
+        $answer = $dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question);
+
+        $this->assertSame($expectedValue, $answer);
+    }
+
+    public function specialCharacterInMultipleChoice()
+    {
+        return array(
+            array('.', ['.']),
+            array('., src', ['.', 'src']),
+        );
+    }
+
+    /**
      * @dataProvider mixedKeysChoiceListAnswerProvider
      */
     public function testChoiceFromChoicelistWithMixedKeys($providedAnswer, $expectedValue)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22706
| License       | MIT
| Doc PR        | -

Fixed a bug when value from multiple choice list could not be selected by user's input
while it could be selected by typing its index in the list.