### PR TITLE
[DI] Remove hasty verification of unused env variables

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1080,6 +1080,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Get statistics about env usage.
      *
+     * @deprecated unued and must be removed in some next release
+     *
      * @return int[] The number of time each env vars has been resolved
      */
     public function getEnvCounters()

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1080,7 +1080,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Get statistics about env usage.
      *
-     * @deprecated unued and must be removed in some next release
+     * @deprecated unused and must be removed in some next release
      *
      * @return int[] The number of time each env vars has been resolved
      */

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -159,16 +159,6 @@ class PhpDumper extends Dumper
         ;
         $this->targetDirRegex = null;
 
-        $unusedEnvs = array();
-        foreach ($this->container->getEnvCounters() as $env => $use) {
-            if (!$use) {
-                $unusedEnvs[] = $env;
-            }
-        }
-        if ($unusedEnvs) {
-            throw new EnvParameterException($unusedEnvs);
-        }
-
         return $code;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -299,19 +299,6 @@ class PhpDumperTest extends TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services26.php', $dumper->dump(), '->dump() dumps inline definitions which reference service_container');
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvParameterException
-     * @expectedExceptionMessage Incompatible use of dynamic environment variables "FOO" found in parameters.
-     */
-    public function testUnusedEnvParameter()
-    {
-        $container = new ContainerBuilder();
-        $container->getParameter('env(FOO)');
-        $container->compile();
-        $dumper = new PhpDumper($container);
-        $dumper->dump();
-    }
-
     public function testInlinedDefinitionReferencingServiceContainer()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  3.2 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #22561 
| License       | MIT
| Doc PR        | -

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

Hello,

After handling with problems reported on the issue #22561 and thinking about it, I decided to open this PR removing the verification that forces the use of every environment variable that was written at least once in some configuration file.

The code I want to remove was introduced in the PR #19681 that adds a nice and new feature, but in my opinion the verification of unused environment variables is hasty.

If there is some good argument to keep that verification, it should be done in a class that aims with the logic of the Dependency Injection component, not in a dumper class.

However, my vision is that the DI component MUST NOT force the use of any configuration set by the developer, because it is not matter of DI. If the developer wrote something unnecessary or wrong, it should be caught by environment tests after or during the build step.

> I also added `@deprecated` to the method `ContainerBuilder:: getEnvCounters`, because I noted that it is only used by the method `PhpDumper::dump`.

Thank you.

> Thanks @edudobay for helping me with some of the many english mistakes I did.