### PR TITLE
Kernel::$projectDir is inconsistent

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,8 +58,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $name;
     protected $startTime;
     protected $loadClassCache;
-
-    private $projectDir;
+    protected $projectDir;
 
     const VERSION = '3.3.0-DEV';
     const VERSION_ID = 30300;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The new `Kernel::$projectDir` property is `private` instead of `protected`, which is inconsistent if you want to set the property in a child class.

```php
class AppKernel extends Kernel
{
    public function overwriteDirectories()
    {
        $this->rootDir = '…'; // works
        $this->projectDir = '…'; // does not work
    }
}
```

Since the Kernel class is almost always extended and since the project root dir is very likely to be overwritten (e.g. in the unit tests), the property should be `protected` IMHO.