### PR TITLE
[FrameworkBundle] Sessions: configurable "use_strict_mode" option for NativeSessionStorage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -348,6 +348,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('gc_divisor')->end()
                         ->scalarNode('gc_probability')->defaultValue(1)->end()
                         ->scalarNode('gc_maxlifetime')->end()
+                        ->booleanNode('use_strict_mode')->end()
                         ->scalarNode('save_path')->defaultValue('%kernel.cache_dir%/sessions')->end()
                         ->integerNode('metadata_update_threshold')
                             ->defaultValue('0')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -402,7 +402,7 @@ class FrameworkExtension extends Extension
         // session storage
         $container->setAlias('session.storage', $config['storage_id']);
         $options = array();
-        foreach (array('name', 'cookie_lifetime', 'cookie_path', 'cookie_domain', 'cookie_secure', 'cookie_httponly', 'gc_maxlifetime', 'gc_probability', 'gc_divisor') as $key) {
+        foreach (array('name', 'cookie_lifetime', 'cookie_path', 'cookie_domain', 'cookie_secure', 'cookie_httponly', 'gc_maxlifetime', 'gc_probability', 'gc_divisor', 'use_strict_mode') as $key) {
             if (isset($config[$key])) {
                 $options[$key] = $config[$key];
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -111,6 +111,7 @@
         <xsd:attribute name="gc-maxlifetime" type="xsd:string" />
         <xsd:attribute name="gc-divisor" type="xsd:string" />
         <xsd:attribute name="gc-probability" type="xsd:string" />
+        <xsd:attribute name="use-strict-mode" type="xsd:boolean" />
         <xsd:attribute name="save-path" type="xsd:string" />
     </xsd:complexType>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

It is currently not possible to configure the `use_strict_mode` option for `NativeSessionStorage` in a proper manner.

The reason of this PR: https://github.com/symfony/symfony/pull/22352#issuecomment-302113533

It could be considered a new feature, but I wish it wouldn't, as I don't want to do any ugly hacking to get it working.

What else could be done?

* implement more options from `NativeSessionStorage` in the config?
* get rid of duplication somehow (maybe a static method in `NativeSessionStorage` that would return the option list and could be used in `FrameworkExtension`?)
* update `FrameworkExtensionTest`?
* update `ConfigurationTest`?
* update [the docs](https://symfony.com/doc/current/reference/configuration/framework.html#session)?

I'm willing to do those if decided.