### PR TITLE
[Intl] Fix bin/common.php PHP7 compatibility

### DIFF
--- a/src/Symfony/Component/Intl/Resources/bin/common.php
+++ b/src/Symfony/Component/Intl/Resources/bin/common.php
@@ -68,9 +68,10 @@ function get_icu_version_from_genrb($genrb)
     return $matches[1];
 }
 
-set_exception_handler(function (\Exception $exception) {
+set_exception_handler(function ($exception) {
     echo "\n";
 
+    /** @var \Exception|\Throwable $exception */
     $cause = $exception;
     $root = true;
 

--- a/src/Symfony/Component/Intl/Resources/bin/common.php
+++ b/src/Symfony/Component/Intl/Resources/bin/common.php
@@ -68,10 +68,9 @@ function get_icu_version_from_genrb($genrb)
     return $matches[1];
 }
 
-set_exception_handler(function ($exception) {
+set_exception_handler(function (\Throwable $exception) {
     echo "\n";
 
-    /** @var \Exception|\Throwable $exception */
     $cause = $exception;
     $root = true;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22735 
| License       | MIT

Created for Symfony 2.7 version which is the oldest maintained impacted branch. 