### PR TITLE
Improved how profiler errors are displayed on small screens

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -973,6 +973,18 @@ table.logs .sf-call-stack abbr {
         display: block;
     }
 
+    #sidebar:not(:hover):not(.expanded) .label .count {
+        border-radius: 50%;
+        border: 1px solid #eee;
+        height: 8px;
+        min-width: 0;
+        padding: 0;
+        right: 4px;
+        text-indent: -9999px;
+        top: 50%;
+        width: 8px;
+    }
+
     .visible-small {
         display: inherit;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This change only affects the profiler menu when displaying it on small screens and collapsed:

| BEFORE | AFTER
| --- | ---
| ![before](https://cloud.githubusercontent.com/assets/73419/26194914/483ad578-3bba-11e7-85bb-94f00876b89a.png) | ![after](https://cloud.githubusercontent.com/assets/73419/26194916/492598d8-3bba-11e7-8d7c-6f37a3b00098.png)

In action:

![profiler-menu-errors](https://cloud.githubusercontent.com/assets/73419/26194969/749e7a7a-3bba-11e7-9464-d3c75fa51315.gif)

