### PR TITLE
Use 0.0.0.0 as the server log command host default.

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
@@ -47,7 +47,7 @@ class ServerLogCommand extends Command
         }
 
         $this
-            ->addOption('host', null, InputOption::VALUE_REQUIRED, 'The server host', '0:9911')
+            ->addOption('host', null, InputOption::VALUE_REQUIRED, 'The server host', '0.0.0.0:9911')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The line format', ConsoleFormatter::SIMPLE_FORMAT)
             ->addOption('date-format', null, InputOption::VALUE_REQUIRED, 'The date format', ConsoleFormatter::SIMPLE_DATE)
             ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'An expression to filter log. Example: "level > 200 or channel in [\'app\', \'doctrine\']"')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | MIT

This fixes the `server:log` command on Windows when run with default settings. The current setting `0` has no meaning on Windows, and `0.0.0.0` is the standard "listen on all addresses/interfaces", so should be the most compatible. It works on both Linux and Windows for me this way.

I mentioned this in another PR where the logger config has the same issue on Windows:

https://github.com/symfony/symfony-standard/pull/1077
