### PR TITLE
[MonologBridge] Fix the Monlog ServerLogHandler from Hanging on Windows

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
@@ -55,7 +55,7 @@ class ServerLogHandler extends AbstractHandler
             $recordFormatted = $this->formatRecord($record);
 
             if (-1 === stream_socket_sendto($this->socket, $recordFormatted)) {
-                fclose($this->socket);
+                stream_socket_shutdown($this->socket, STREAM_SHUT_RDWR);
 
                 // Let's retry: the persistent connection might just be stale
                 if ($this->socket = $this->createSocket()) {

--- a/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
@@ -54,12 +54,12 @@ class ServerLogHandler extends AbstractHandler
 
             $recordFormatted = $this->formatRecord($record);
 
-            if (!fwrite($this->socket, $recordFormatted)) {
+            if (-1 === stream_socket_sendto($this->socket, $recordFormatted)) {
                 fclose($this->socket);
 
                 // Let's retry: the persistent connection might just be stale
                 if ($this->socket = $this->createSocket()) {
-                    fwrite($this->socket, $recordFormatted);
+                    stream_socket_sendto($this->socket, $recordFormatted);
                 }
             }
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | #22712
| License       | MIT

This resolves the issue discussed in https://github.com/symfony/symfony/issues/22712. This works on both Windows and Linux. Specifically it removes the additional hanging that was caused on Windows when attempting to write/close a TCP socket that's not open on the other end in asynchronous mode.