### PR TITLE
[DI] Removed deprecated setting private/pre-defined services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -19,6 +19,8 @@ CHANGELOG
  * removed `ContainerBuilder::addClassResource()`, use the `addObjectResource()` or the `getReflectionClass()` method instead.
  * removed support for top-level anonymous services
  * removed silent behavior for unused attributes and elements
+ * removed support for setting and accessing private services in `Container`
+ * removed support for setting pre-defined services in `Container`
 
 3.4.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -151,30 +151,25 @@ class Container implements ResettableContainerInterface
             throw new InvalidArgumentException('You cannot set service "service_container".');
         }
 
+        if (isset($this->privates[$id])) {
+            throw new InvalidArgumentException(sprintf('You cannot set the private service "%s".', $id));
+        }
+
+        if (isset($this->methodMap[$id])) {
+            throw new InvalidArgumentException(sprintf('You cannot set the pre-defined service "%s".', $id));
+        }
+
         if (isset($this->aliases[$id])) {
             unset($this->aliases[$id]);
         }
 
-        $this->services[$id] = $service;
-
         if (null === $service) {
             unset($this->services[$id]);
+
+            return;
         }
 
-        if (isset($this->privates[$id])) {
-            if (null === $service) {
-                @trigger_error(sprintf('Unsetting the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
-                unset($this->privates[$id]);
-            } else {
-                @trigger_error(sprintf('Setting the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
-            }
-        } elseif (isset($this->methodMap[$id])) {
-            if (null === $service) {
-                @trigger_error(sprintf('Unsetting the "%s" pre-defined service is deprecated since Symfony 3.3 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
-            } else {
-                @trigger_error(sprintf('Setting the "%s" pre-defined service is deprecated since Symfony 3.3 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
-            }
-        }
+        $this->services[$id] = $service;
     }
 
     /**
@@ -187,7 +182,7 @@ class Container implements ResettableContainerInterface
     public function has($id)
     {
         if (isset($this->privates[$id])) {
-            @trigger_error(sprintf('Checking for the existence of the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
+            return false;
         }
         if ('service_container' === $id) {
             return true;
@@ -226,7 +221,11 @@ class Container implements ResettableContainerInterface
     public function get($id, $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE)
     {
         if (isset($this->privates[$id])) {
-            @trigger_error(sprintf('Requesting the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
+            if (self::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
+                throw new ServiceNotFoundException($id);
+            }
+
+            return;
         }
         if ('service_container' === $id) {
             return $this;
@@ -295,7 +294,7 @@ class Container implements ResettableContainerInterface
         }
 
         if (isset($this->privates[$id])) {
-            @trigger_error(sprintf('Checking for the initialization of the "%s" private service is deprecated since Symfony 3.4 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
+            return false;
         }
 
         if (isset($this->aliases[$id])) {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -147,6 +147,7 @@ class ContainerTest extends TestCase
     public function testSetWithNullResetTheService()
     {
         $sc = new Container();
+        $sc->set('foo', new \stdClass());
         $sc->set('foo', null);
         $this->assertFalse($sc->has('foo'), '->set() with null service resets the service');
     }
@@ -157,22 +158,6 @@ class ContainerTest extends TestCase
 
         $c->set('alias', $foo = new \stdClass());
         $this->assertSame($foo, $c->get('alias'), '->set() replaces an existing alias');
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation Unsetting the "bar" pre-defined service is deprecated since Symfony 3.3 and won't be supported anymore in Symfony 4.0.
-     */
-    public function testSetWithNullResetPredefinedService()
-    {
-        $sc = new Container();
-        $sc->set('foo', new \stdClass());
-        $sc->set('foo', null);
-        $this->assertFalse($sc->has('foo'), '->set() with null service resets the service');
-
-        $sc = new ProjectServiceContainer();
-        $sc->set('bar', null);
-        $this->assertTrue($sc->has('bar'), '->set() with null service resets the pre-defined service');
     }
 
     public function testGet()
@@ -275,15 +260,11 @@ class ContainerTest extends TestCase
         $this->assertTrue($sc->initialized('alias'), '->initialized() returns true for alias if aliased service is initialized');
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Checking for the initialization of the "internal" private service is deprecated since Symfony 3.4 and won't be supported anymore in Symfony 4.0.
-     */
     public function testInitializedWithPrivateService()
     {
         $sc = new ProjectServiceContainer();
         $sc->get('internal_dependency');
-        $this->assertTrue($sc->initialized('internal'));
+        $this->assertFalse($sc->initialized('internal'));
     }
 
     public function testReset()
@@ -360,42 +341,37 @@ class ContainerTest extends TestCase
     }
 
     /**
-     * @group legacy
-     * @expectedDeprecation Unsetting the "internal" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage You cannot set the private service "internal".
      */
-    public function testUnsetInternalPrivateServiceIsDeprecated()
+    public function testUnsetInternalPrivateService()
     {
         $c = new ProjectServiceContainer();
         $c->set('internal', null);
     }
 
     /**
-     * @group legacy
-     * @expectedDeprecation Setting the "internal" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage You cannot set the private service "internal".
      */
-    public function testChangeInternalPrivateServiceIsDeprecated()
+    public function testChangeInternalPrivateService()
     {
         $c = new ProjectServiceContainer();
-        $c->set('internal', $internal = new \stdClass());
-        $this->assertSame($c->get('internal'), $internal);
+        $c->set('internal', new \stdClass());
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Checking for the existence of the "internal" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
-     */
-    public function testCheckExistenceOfAnInternalPrivateServiceIsDeprecated()
+    public function testCheckExistenceOfAnInternalPrivateService()
     {
         $c = new ProjectServiceContainer();
         $c->get('internal_dependency');
-        $this->assertTrue($c->has('internal'));
+        $this->assertFalse($c->has('internal'));
     }
 
     /**
-     * @group legacy
-     * @expectedDeprecation Requesting the "internal" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     * @expectedExceptionMessage You have requested a non-existent service "internal".
      */
-    public function testRequestAnInternalSharedPrivateServiceIsDeprecated()
+    public function testRequestAnInternalSharedPrivateService()
     {
         $c = new ProjectServiceContainer();
         $c->get('internal_dependency');
@@ -403,16 +379,13 @@ class ContainerTest extends TestCase
     }
 
     /**
-     * @group legacy
-     * @expectedDeprecation Setting the "bar" pre-defined service is deprecated since Symfony 3.3 and won't be supported anymore in Symfony 4.0.
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage You cannot set the pre-defined service "bar".
      */
-    public function testReplacingAPreDefinedServiceIsDeprecated()
+    public function testReplacingAPreDefinedService()
     {
         $c = new ProjectServiceContainer();
         $c->set('bar', new \stdClass());
-        $c->set('bar', $bar = new \stdClass());
-
-        $this->assertSame($bar, $c->get('bar'), '->set() replaces a pre-defined service');
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -267,8 +267,8 @@ class PhpDumperTest extends TestCase
     }
 
     /**
-     * @group legacy
-     * @expectedDeprecation Setting the "bar" pre-defined service is deprecated since Symfony 3.3 and won't be supported anymore in Symfony 4.0.
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage You cannot set the pre-defined service "bar".
      */
     public function testOverrideServiceWhenUsingADumpedContainer()
     {
@@ -277,25 +277,6 @@ class PhpDumperTest extends TestCase
 
         $container = new \ProjectServiceContainer();
         $container->set('bar', $bar = new \stdClass());
-        $container->setParameter('foo_bar', 'foo_bar');
-
-        $this->assertSame($bar, $container->get('bar'), '->set() overrides an already defined service');
-    }
-
-    /**
-     * @group legacy
-     * @expectedDeprecation Setting the "bar" pre-defined service is deprecated since Symfony 3.3 and won't be supported anymore in Symfony 4.0.
-     */
-    public function testOverrideServiceWhenUsingADumpedContainerAndServiceIsUsedFromAnotherOne()
-    {
-        require_once self::$fixturesPath.'/php/services9.php';
-        require_once self::$fixturesPath.'/includes/foo.php';
-        require_once self::$fixturesPath.'/includes/classes.php';
-
-        $container = new \ProjectServiceContainer();
-        $container->set('bar', $bar = new \stdClass());
-
-        $this->assertSame($bar, $container->get('foo')->bar, '->set() overrides an already defined service');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

See #21533, #19708 and #19146

@nicolas-grekas privates should be excluded from `getServiceIds` right? i also wondered.. did we forget to deprecate checking privates with `initialized()`?