### PR TITLE
[DI] Mark service_container a private service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -43,7 +43,7 @@ class TestAbstractController extends AbstractController
         $expected = self::getSubscribedServices();
 
         foreach ($container->getServiceIds() as $id) {
-            if ('service_container' === $id) {
+            if ('service_container' === $id) { // to be removed in 4.0
                 continue;
             }
             if (!isset($expected[$id])) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -31,6 +31,9 @@ class WebProfilerExtensionTest extends TestCase
     {
         $errors = array();
         foreach ($container->getServiceIds() as $id) {
+            if ('service_container' === $id) { // to be removed in 4.0
+                continue;
+            }
             try {
                 $container->get($id);
             } catch (\Exception $e) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -39,7 +39,7 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
     {
         foreach ($container->getDefinitions() as $id => $definition) {
             // synthetic service is public
-            if ($definition->isSynthetic() && !$definition->isPublic()) {
+            if ($definition->isSynthetic() && !$definition->isPublic() && 'service_container' !== $id) {
                 throw new RuntimeException(sprintf('A synthetic service ("%s") must be public.', $id));
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -64,6 +64,10 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
      */
     private function isInlineableDefinition($id, Definition $definition, ServiceReferenceGraph $graph)
     {
+        if ('service_container' === $id) {
+            return false;
+        }
+
         if (!$definition->isShared()) {
             return true;
         }

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -189,7 +189,7 @@ class Container implements ResettableContainerInterface
         $id = $this->normalizeId($id);
 
         if ('service_container' === $id) {
-            throw new InvalidArgumentException('You cannot set service "service_container".');
+            throw new InvalidArgumentException('You cannot set the private service "service_container".');
         }
 
         if (isset($this->aliases[$id])) {
@@ -229,6 +229,8 @@ class Container implements ResettableContainerInterface
     {
         for ($i = 2;;) {
             if ('service_container' === $id) {
+                @trigger_error('Checking for the existence of the "service_container" private service is deprecated since Symfony 3.4 and won\'t be supported anymore in Symfony 4.0.', E_USER_DEPRECATED);
+
                 return true;
             }
             if (isset($this->aliases[$id])) {
@@ -288,6 +290,8 @@ class Container implements ResettableContainerInterface
         // calling $this->normalizeId($id) unless necessary.
         for ($i = 2;;) {
             if ('service_container' === $id) {
+                @trigger_error('Requesting the "service_container" private service is deprecated since Symfony 3.4 and won\'t be supported anymore in Symfony 4.0.', E_USER_DEPRECATED);
+
                 return $this;
             }
             if (isset($this->aliases[$id])) {
@@ -363,6 +367,8 @@ class Container implements ResettableContainerInterface
         $id = $this->normalizeId($id);
 
         if ('service_container' === $id) {
+            @trigger_error('Checking for the initialization of the "service_container" private service is deprecated since Symfony 3.4 and won\'t be supported anymore in Symfony 4.0.', E_USER_DEPRECATED);
+
             return false;
         }
 
@@ -401,7 +407,7 @@ class Container implements ResettableContainerInterface
                 }
             }
         }
-        $ids[] = 'service_container';
+        $ids[] = 'service_container'; // to be removed in 4.0
 
         return array_unique(array_merge($ids, array_keys($this->methodMap), array_keys($this->services)));
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -187,13 +187,15 @@ class GraphvizDumper extends Dumper
         }
 
         foreach ($container->getServiceIds() as $id) {
+            if ('service_container' === $id) { // to be removed in 4.0
+                continue;
+            }
             if (array_key_exists($id, $container->getAliases())) {
                 continue;
             }
 
             if (!$container->hasDefinition($id)) {
-                $class = get_class('service_container' === $id ? $this->container : $container->get($id));
-                $nodes[$id] = array('class' => str_replace('\\', '\\\\', $class), 'attributes' => $this->options['node.instance']);
+                $nodes[$id] = array('class' => str_replace('\\', '\\\\', get_class($container->get($id))), 'attributes' => $this->options['node.instance']);
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -54,6 +54,7 @@ class ContainerBuilderTest extends TestCase
         $definition = $builder->getDefinition('service_container');
         $this->assertInstanceOf(Definition::class, $definition);
         $this->assertTrue($definition->isSynthetic());
+        $this->assertFalse($definition->isPublic());
         $this->assertSame(ContainerInterface::class, $definition->getClass());
         $this->assertTrue($builder->hasAlias(PsrContainerInterface::class));
         $this->assertTrue($builder->hasAlias(ContainerInterface::class));

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -20,11 +20,18 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 class ContainerTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecation Requesting the "service_container" private service is deprecated since Symfony 3.4 and won't be supported anymore in Symfony 4.0.
+     */
     public function testConstructor()
     {
         $sc = new Container();
         $this->assertSame($sc, $sc->get('service_container'), '__construct() automatically registers itself as a service');
+    }
 
+    public function testConstructorWithParameters()
+    {
         $sc = new Container(new ParameterBag(array('foo' => 'bar')));
         $this->assertEquals(array('foo' => 'bar'), $sc->getParameterBag()->all(), '__construct() takes an array of parameters as its first argument');
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
@@ -72,8 +72,6 @@ class CrossCheckTest extends TestCase
             $services2[$id] = serialize($service);
         }
 
-        unset($services1['service_container'], $services2['service_container']);
-
         $this->assertEquals($services2, $services1, 'Iterator on the containers returns the same services');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -70,7 +70,7 @@ class XmlDumperTest extends TestCase
         $this->assertEquals('<?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
-    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="false" synthetic="true"/>
     <service id="foo" class="FooClass">
       <argument type="service">
         <service class="BarClass">
@@ -94,7 +94,7 @@ class XmlDumperTest extends TestCase
         $this->assertEquals("<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <container xmlns=\"http://symfony.com/schema/dic/services\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd\">
   <services>
-    <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" synthetic=\"true\"/>
+    <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"false\" synthetic=\"true\"/>
     <service id=\"foo\" class=\"FooClass\Foo\">
       <tag name=\"foo&quot;bar\bar\" foo=\"foo&quot;barřž€\"/>
       <argument>foo&lt;&gt;&amp;bar</argument>
@@ -123,7 +123,7 @@ class XmlDumperTest extends TestCase
             array("<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <container xmlns=\"http://symfony.com/schema/dic/services\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd\">
   <services>
-    <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" synthetic=\"true\"/>
+    <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"false\" synthetic=\"true\"/>
     <service id=\"foo\" class=\"FooClass\Foo\" decorates=\"bar\" decoration-inner-name=\"bar.woozy\"/>
     <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
     <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
@@ -133,7 +133,7 @@ class XmlDumperTest extends TestCase
             array("<?xml version=\"1.0\" encoding=\"utf-8\"?>
 <container xmlns=\"http://symfony.com/schema/dic/services\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd\">
   <services>
-    <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" synthetic=\"true\"/>
+    <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"false\" synthetic=\"true\"/>
     <service id=\"foo\" class=\"FooClass\Foo\" decorates=\"bar\"/>
     <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
     <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services13.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services13.dot
@@ -3,7 +3,6 @@ digraph sc {
   node [fontsize="11" fontname="Arial" shape="record"];
   edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
 
-  node_service_container [label="service_container\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo [label="foo\nFooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_bar [label="bar\nBarClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_foo -> node_bar [label="" style="filled"];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -30,6 +30,9 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'bar' => 'getBarService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -64,6 +64,7 @@ class ProjectServiceContainer extends Container
             'factory_simple' => true,
             'inlined' => true,
             'new_factory' => true,
+            'service_container' => true,
         );
         $this->aliases = array(
             'Psr\\Container\\ContainerInterface' => 'service_container',

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -50,6 +50,9 @@ class ProjectServiceContainer extends Container
             'new_factory_service' => 'getNewFactoryServiceService',
             'service_from_static_method' => 'getServiceFromStaticMethodService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
         $this->aliases = array(
             'alias_for_alias' => 'foo',
             'alias_for_foo' => 'foo',

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services1.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Symfony\Component\DependencyInjection\ContainerInterface" id="service_container" synthetic="true"/>
+        <service class="Symfony\Component\DependencyInjection\ContainerInterface" id="service_container" public="false" synthetic="true"/>
         <service alias="service_container" id="Psr\Container\ContainerInterface" public="false"/>
         <service alias="service_container" id="Symfony\Component\DependencyInjection\ContainerInterface" public="false"/>
     </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services2.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services2.xml
@@ -28,4 +28,9 @@
     </parameter>
     <parameter key="constant" type="constant">PHP_EOL</parameter>
   </parameters>
+  <services>
+    <service class="Symfony\Component\DependencyInjection\ContainerInterface" id="service_container" public="false" synthetic="true"/>
+    <service alias="service_container" id="Psr\Container\ContainerInterface" public="false"/>
+    <service alias="service_container" id="Symfony\Component\DependencyInjection\ContainerInterface" public="false"/>
+  </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
-    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="false" synthetic="true"/>
     <service id="foo" class="Foo">
       <factory method="createFoo">
         <service class="FooFactory">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
-    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="false" synthetic="true"/>
     <service id="foo" class="Foo" autowire="true"/>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -4,6 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
+    <service class="Symfony\Component\DependencyInjection\ContainerInterface" id="service_container" public="false" synthetic="true"/>
+    <service alias="service_container" id="Psr\Container\ContainerInterface" public="false"/>
+    <service alias="service_container" id="Symfony\Component\DependencyInjection\ContainerInterface" public="false"/>
     <service id="foo" class="FooClass" />
     <service id="baz" class="BazClass" />
     <service id="not_shared" class="FooClass" shared="false" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
@@ -20,7 +20,7 @@
     </parameter>
   </parameters>
   <services>
-    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="false" synthetic="true"/>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -6,7 +6,7 @@
     <parameter key="foo">bar</parameter>
   </parameters>
   <services>
-    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="false" synthetic="true"/>
     <service id="foo" class="Bar\FooClass">
       <tag name="foo" foo="foo"/>
       <tag name="foo" bar="bar" baz="baz"/>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
@@ -1,6 +1,7 @@
 services:
     service_container:
         class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: false
         synthetic: true
     Psr\Container\ContainerInterface:
         alias: service_container

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
@@ -2,6 +2,7 @@
 services:
     service_container:
         class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: false
         synthetic: true
     foo:
         class: Foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
@@ -8,6 +8,7 @@ parameters:
 services:
     service_container:
         class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: false
         synthetic: true
     Psr\Container\ContainerInterface:
         alias: service_container

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -6,6 +6,7 @@ parameters:
 services:
     service_container:
         class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: false
         synthetic: true
     foo:
         class: Bar\FooClass

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -664,9 +664,6 @@ class XmlFileLoaderTest extends TestCase
         $this->assertFalse($container->getDefinition('child_def')->isAutowired());
 
         $definitions = $container->getDefinitions();
-        $this->assertSame('service_container', key($definitions));
-
-        array_shift($definitions);
         $this->assertStringStartsWith('1_', key($definitions));
 
         $anonymous = current($definitions);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

follow up of #21627 and marks the `service_container`definition private thus simplifies code, i think it makes sense :)