### PR TITLE
[FrameworkBundle][Validator] Deprecate passing validator instances/aliases over using the service locator

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -244,6 +244,10 @@ FrameworkBundle
    class has been deprecated and will be removed in 4.0. Use the
    `Symfony\Component\Workflow\DependencyInjection\ValidateWorkflowsPass` class instead.
 
+ * Passing an array of validators or validator aliases as the second argument of 
+   `ConstraintValidatorFactory::__construct()` is deprecated since 3.3 and will 
+   be removed in 4.0. Use the service locator instead.
+
 HttpFoundation
 --------------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -299,6 +299,10 @@ FrameworkBundle
 
  * Extending `ConstraintValidatorFactory` is not supported anymore.
 
+ * Passing an array of validators or validator aliases as the second argument of 
+   `ConstraintValidatorFactory::__construct()` has been removed.
+   Use the service locator instead.
+
  * Class parameters related to routing have been removed
     * router.options.generator_class
     * router.options.generator_base_class

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -49,6 +49,7 @@ CHANGELOG
    `Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass` instead
  * Deprecated `ValidateWorkflowsPass`, use 
    `Symfony\Component\Workflow\DependencyInjection\ValidateWorkflowsPass` instead
+ * Deprecated `ConstraintValidatorFactory::__construct()` second argument.
 
 3.2.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
@@ -14,7 +14,10 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Validator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Blank as BlankConstraint;
+use Symfony\Component\Validator\ConstraintValidator;
 
 class ConstraintValidatorFactoryTest extends TestCase
 {
@@ -41,6 +44,38 @@ class ConstraintValidatorFactoryTest extends TestCase
     }
 
     public function testGetInstanceReturnsService()
+    {
+        $service = 'validator_constraint_service';
+        $validator = $this->getMockForAbstractClass(ConstraintValidator::class);
+
+        // mock ContainerBuilder b/c it implements TaggedContainerInterface
+        $container = $this->getMockBuilder(ContainerBuilder::class)->setMethods(array('get', 'has'))->getMock();
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($service)
+            ->willReturn($validator);
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with($service)
+            ->willReturn(true);
+
+        $constraint = $this->getMockBuilder(Constraint::class)->getMock();
+        $constraint
+            ->expects($this->once())
+            ->method('validatedBy')
+            ->will($this->returnValue($service));
+
+        $factory = new ConstraintValidatorFactory($container);
+        $this->assertSame($validator, $factory->getInstance($constraint));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing an array of validators or validator aliases as the second argument of "Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory::__construct" is deprecated since 3.3 and will be removed in 4.0. Use the service locator instead.
+     */
+    public function testGetInstanceReturnsServiceWithAlias()
     {
         $service = 'validator_constraint_service';
         $alias = 'validator_constraint_alias';

--- a/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php
@@ -45,15 +45,16 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
     protected $container;
     protected $validators;
 
-    /**
-     * Constructor.
-     *
-     * @param ContainerInterface $container  The service container
-     * @param array              $validators An array of validators
-     */
-    public function __construct(ContainerInterface $container, array $validators = array())
+    public function __construct(ContainerInterface $container, array $validators = null)
     {
         $this->container = $container;
+
+        if (null !== $validators) {
+            @trigger_error(sprintf('Passing an array of validators or validator aliases as the second argument of "%s" is deprecated since 3.3 and will be removed in 4.0. Use the service locator instead.', __METHOD__), E_USER_DEPRECATED);
+        } else {
+            $validators = array();
+        }
+
         $this->validators = $validators;
     }
 
@@ -82,6 +83,7 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
                 $this->validators[$name] = new $name();
             }
         } elseif (is_string($this->validators[$name])) {
+            // To be removed in 4.0
             $this->validators[$name] = $this->container->get($this->validators[$name]);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | yes <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22800#issuecomment-302865630 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A