### PR TITLE
Cache ipCheck (2.8)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\HttpFoundation;
  */
 class IpUtils
 {
+    private static $checkedIps = array();
+
     /**
      * This class should not be instantiated.
      */
@@ -61,26 +63,31 @@ class IpUtils
      */
     public static function checkIp4($requestIp, $ip)
     {
+        $cacheKey = $requestIp.'-'.$ip;
+        if (isset(self::$checkedIps[$cacheKey])) {
+            return self::$checkedIps[$cacheKey];
+        }
+
         if (!filter_var($requestIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
-            return false;
+            return self::$checkedIps[$cacheKey] = false;
         }
 
         if (false !== strpos($ip, '/')) {
             list($address, $netmask) = explode('/', $ip, 2);
 
             if ($netmask === '0') {
-                return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
+                return self::$checkedIps[$cacheKey] = filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
             }
 
             if ($netmask < 0 || $netmask > 32) {
-                return false;
+                return self::$checkedIps[$cacheKey] = false;
             }
         } else {
             $address = $ip;
             $netmask = 32;
         }
 
-        return 0 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask);
+        return self::$checkedIps[$cacheKey] = 0 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask);
     }
 
     /**
@@ -100,6 +107,11 @@ class IpUtils
      */
     public static function checkIp6($requestIp, $ip)
     {
+        $cacheKey = $requestIp.'-'.$ip;
+        if (isset(self::$checkedIps[$cacheKey])) {
+            return self::$checkedIps[$cacheKey];
+        }
+
         if (!((extension_loaded('sockets') && defined('AF_INET6')) || @inet_pton('::1'))) {
             throw new \RuntimeException('Unable to check Ipv6. Check that PHP was not compiled with option "disable-ipv6".');
         }
@@ -108,7 +120,7 @@ class IpUtils
             list($address, $netmask) = explode('/', $ip, 2);
 
             if ($netmask < 1 || $netmask > 128) {
-                return false;
+                return self::$checkedIps[$cacheKey] = false;
             }
         } else {
             $address = $ip;
@@ -119,7 +131,7 @@ class IpUtils
         $bytesTest = unpack('n*', @inet_pton($requestIp));
 
         if (!$bytesAddr || !$bytesTest) {
-            return false;
+            return self::$checkedIps[$cacheKey] = false;
         }
 
         for ($i = 1, $ceil = ceil($netmask / 16); $i <= $ceil; ++$i) {
@@ -127,10 +139,10 @@ class IpUtils
             $left = ($left <= 16) ? $left : 16;
             $mask = ~(0xffff >> $left) & 0xffff;
             if (($bytesAddr[$i] & $mask) != ($bytesTest[$i] & $mask)) {
-                return false;
+                return self::$checkedIps[$cacheKey] = false;
             }
         }
 
-        return true;
+        return self::$checkedIps[$cacheKey] = true;
     }
 }


### PR DESCRIPTION
In our app we use trusted proxies. Using Blackfire we found `IpUtils::checkIp` was being called 454 times taking 3.15ms. 
Caching the result saves those 3ms.

| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
