### PR TITLE
[Debug] Deprecate support for stacked errors

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -6,6 +6,11 @@ DependencyInjection
 
  * Top-level anonymous services in XML are deprecated and will throw an exception in Symfony 4.0.
 
+Debug
+-----
+
+ * Support for stacked errors in the `ErrorHandler` is deprecated and will be removed in Symfony 4.0.
+
 Finder
 ------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -70,6 +70,8 @@ Debug
  * `FlattenException::getTrace()` now returns additional type descriptions
    `integer` and `float`.
 
+ * Support for stacked errors in the `ErrorHandler` has been removed
+
 DependencyInjection
 -------------------
 

--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+* deprecated `ErrorHandler::stackErrors()` and `ErrorHandler::unstackErrors()`
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -136,7 +136,7 @@ class DebugClassLoader
      */
     public function loadClass($class)
     {
-        ErrorHandler::stackErrors();
+        $e = error_reporting(error_reporting() | E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR);
 
         try {
             if ($this->isFinder) {
@@ -148,7 +148,7 @@ class DebugClassLoader
                 $file = false;
             }
         } finally {
-            ErrorHandler::unstackErrors();
+            error_reporting($e);
         }
 
         $exists = class_exists($class, false) || interface_exists($class, false) || trait_exists($class, false);

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -648,17 +648,25 @@ class ErrorHandler
      *
      * The most important feature of this is to prevent
      * autoloading until unstackErrors() is called.
+     *
+     * @deprecated since version 3.4, to be removed in 4.0.
      */
     public static function stackErrors()
     {
+        @trigger_error('Support for stacking errors is deprecated since Symfony 3.4 and will be removed in 4.0.', E_USER_DEPRECATED);
+
         self::$stackedErrorLevels[] = error_reporting(error_reporting() | E_PARSE | E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR);
     }
 
     /**
      * Unstacks stacked errors and forwards to the logger.
+     *
+     * @deprecated since version 3.4, to be removed in 4.0.
      */
     public static function unstackErrors()
     {
+        @trigger_error('Support for unstacking errors is deprecated since Symfony 3.4 and will be removed in 4.0.', E_USER_DEPRECATED);
+
         $level = array_pop(self::$stackedErrorLevels);
 
         if (null !== $level) {

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -342,6 +342,9 @@ class ErrorHandlerTest extends TestCase
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function testErrorStacking()
     {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #22804
| License       | MIT
| Doc PR        | n/a

Per discussion in #22804 this deprecates support for error stacking.  // @nicolas-grekas 