### PR TITLE
~2.6 makes that 2.8 be a valid version

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.6,>=2.6.7",
         "symfony/http-foundation": "~2.5,>=2.5.4",
-        "symfony/debug": "~2.6,>=2.6.2",
+        "symfony/debug": ">=2.6.2, <2.7",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
~2.6 makes that 2.8 be a valid version of this requirement but this makes update PHP to a newer version
All symfony 2.6 require PHP 5.3.3 minimum 
symfony add "symfony/http-kernel" 2.6.* version
symfony/http-kernel add symfony/debug 2.8.* (because ~2.6)
and symfony/debug 2.8.* require PHP 5.3.9 and that is the error 
I wanted fix that

| Q             | A
| ------------- | ---
| Branch?       | 2.6 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets |  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
