### PR TITLE
[FrameworkBundle][Translation] fix docblock position

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -48,10 +48,11 @@ class Translator extends BaseTranslator implements WarmableInterface
      *   * debug:     Whether to enable debugging or not (false by default)
      *   * resource_files: List of translation resources available grouped by locale.
      *
-     * @param ContainerInterface $container A ContainerInterface instance
-     * @param MessageSelector    $selector  The message selector for pluralization
-     * @param array              $loaderIds An array of loader Ids
-     * @param array              $options   An array of options
+     * @param ContainerInterface $container     A ContainerInterface instance
+     * @param MessageSelector    $selector      The message selector for pluralization
+     * @param string             $defaultLocale
+     * @param array              $loaderIds     An array of loader Ids
+     * @param array              $options       An array of options
      *
      * @throws InvalidArgumentException
      */

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -74,11 +74,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     /**
      * Constructor.
      *
-     * @param string               $locale        The locale
-     * @param MessageSelector|null $selector      The message selector for pluralization
-     * @param string               $defaultLocale
-     * @param string|null          $cacheDir      The directory to use for the cache
-     * @param bool                 $debug         Use cache in debug mode ?
+     * @param string               $locale   The locale
+     * @param MessageSelector|null $selector The message selector for pluralization
+     * @param string|null          $cacheDir The directory to use for the cache
+     * @param bool                 $debug    Use cache in debug mode ?
      *
      * @throws InvalidArgumentException If a locale contains invalid characters
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22822
| License       | MIT
| Doc PR        | 

The `$defaultLocale` argument is present in the `Translator` class of
the FrameworkBundle, but is not part of the Translation component.