### PR TITLE
[SecurityBundle] Prevent auto-registration of UserPasswordEncoderCommand

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -98,11 +98,11 @@ class SecurityExtension extends Extension
 
         if ($config['encoders']) {
             $this->createEncoders($config['encoders'], $container);
+        }
 
-            if (class_exists(Application::class)) {
-                $loader->load('console.xml');
-                $container->getDefinition('security.console.user_password_encoder_command')->replaceArgument(1, array_keys($config['encoders']));
-            }
+        if (class_exists(Application::class)) {
+            $loader->load('console.xml');
+            $container->getDefinition('security.console.user_password_encoder_command')->replaceArgument(1, array_keys($config['encoders']));
         }
 
         // load ACL

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -345,6 +345,11 @@ abstract class CompleteConfigurationTest extends TestCase
         $this->assertEquals('security.user_checker', $this->getContainer('container1')->getAlias('security.user_checker.secure'));
     }
 
+    public function testUserPasswordEncoderCommandIsRegistered()
+    {
+        $this->assertTrue($this->getContainer('remember_me_options')->has('security.console.user_password_encoder_command'));
+    }
+
     protected function getContainer($file)
     {
         $file = $file.'.'.$this->getFileExtension();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22855 
| License       | MIT
| Doc PR        | n/a

Always registers the command as a service even if no encoders are configured so that it is not auto-registered via reflection. 
Prevents an irrelevant deprecation when no encoders are configured and, if a day the per-convention command registration is removed, ensures that the command always exists (leading to an exception saying that you have no configured encoder, better than nothing).
ping @ogizanagi 