### PR TITLE
Close PHP code in phpt file

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_vendor.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_vendor.phpt
@@ -17,6 +17,8 @@ require PHPUNIT_COMPOSER_INSTALL;
 require_once __DIR__.'/../../bootstrap.php';
 require __DIR__.'/fake_vendor/autoload.php';
 require __DIR__.'/fake_vendor/acme/lib/deprecation_riddled.php';
+
+?>
 --EXPECTF--
 Unsilenced deprecation notices (2)
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes-ish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

that's the only phpt file that is not closing php code section
this causes linting via `php -l` to fail
