### PR TITLE
[PropertyAccess] writeCollection: $key loop iterator as second parameter of $addMethod method called.

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -76,6 +76,11 @@ class PropertyAccessor implements PropertyAccessorInterface
     /**
      * @internal
      */
+    const ACCESS_ADDER_WITH_KEY = 6;
+
+    /**
+     * @internal
+     */
     const ACCESS_REMOVER = 5;
 
     /**
@@ -638,7 +643,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         } elseif (self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]) {
             $object->{$access[self::ACCESS_NAME]} = $value;
         } elseif (self::ACCESS_TYPE_ADDER_AND_REMOVER === $access[self::ACCESS_TYPE]) {
-            $this->writeCollection($zval, $property, $value, $access[self::ACCESS_ADDER], $access[self::ACCESS_REMOVER]);
+            $this->writeCollection($zval, $property, $value, $access[self::ACCESS_ADDER], $access[self::ACCESS_REMOVER], $access[self::ACCESS_ADDER_WITH_KEY]);
         } elseif (!$access[self::ACCESS_HAS_PROPERTY] && property_exists($object, $property)) {
             // Needed to support \stdClass instances. We need to explicitly
             // exclude $access[self::ACCESS_HAS_PROPERTY], otherwise if
@@ -659,13 +664,14 @@ class PropertyAccessor implements PropertyAccessorInterface
     /**
      * Adjusts a collection-valued property by calling add*() and remove*() methods.
      *
-     * @param array              $zval         The array containing the object to write to
-     * @param string             $property     The property to write
-     * @param array|\Traversable $collection   The collection to write
-     * @param string             $addMethod    The add*() method
-     * @param string             $removeMethod The remove*() method
+     * @param array              $zval               The array containing the object to write to
+     * @param string             $property           The property to write
+     * @param array|\Traversable $collection         The collection to write
+     * @param string             $addMethod          The add*() method
+     * @param string             $removeMethod       The remove*() method
+     * @param bool               $secondKeyParameter If the add*() method has a second parameter for specifying array key
      */
-    private function writeCollection($zval, $property, $collection, $addMethod, $removeMethod)
+    private function writeCollection($zval, $property, $collection, $addMethod, $removeMethod, $secondKeyParameter)
     {
         // At this point the add and remove methods have been found
         $previousValue = $this->readProperty($zval, $property);
@@ -688,8 +694,10 @@ class PropertyAccessor implements PropertyAccessorInterface
             $previousValue = false;
         }
 
-        foreach ($collection as $item) {
-            if (!$previousValue || !in_array($item, $previousValue, true)) {
+        foreach ($collection as $key => $item) {
+            if ($secondKeyParameter) {
+                $zval[self::VALUE]->{$addMethod}($item, $key);
+            } elseif (!$previousValue || !in_array($item, $previousValue, true)) {
                 $zval[self::VALUE]->{$addMethod}($item);
             }
         }
@@ -733,6 +741,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_ADDER_AND_REMOVER;
                 $access[self::ACCESS_ADDER] = $methods[0];
                 $access[self::ACCESS_REMOVER] = $methods[1];
+                $access[self::ACCESS_ADDER_WITH_KEY] = $methods[2];
             }
         }
 
@@ -831,7 +840,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @param \ReflectionClass $reflClass The reflection class for the given object
      * @param array            $singulars The singular form of the property name or null
      *
-     * @return array|null An array containing the adder and remover when found, null otherwise
+     * @return array|null An array containing the adder, remover when found and info about second key parameter, null otherwise
      */
     private function findAdderAndRemover(\ReflectionClass $reflClass, array $singulars)
     {
@@ -839,11 +848,13 @@ class PropertyAccessor implements PropertyAccessorInterface
             $addMethod = 'add'.$singular;
             $removeMethod = 'remove'.$singular;
 
-            $addMethodFound = $this->isMethodAccessible($reflClass, $addMethod, 1);
+            $addMethodFound = $this->isMethodAccessible($reflClass, $addMethod, 1, $addReflector);
             $removeMethodFound = $this->isMethodAccessible($reflClass, $removeMethod, 1);
 
             if ($addMethodFound && $removeMethodFound) {
-                return array($addMethod, $removeMethod);
+                $secondKeyParameter = $addReflector->getNumberOfParameters() > 1 && 'key' === $addReflector->getParameters()[1]->name;
+
+                return array($addMethod, $removeMethod, $secondKeyParameter);
             }
         }
     }
@@ -857,7 +868,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @return bool Whether the method is public and has $parameters required parameters
      */
-    private function isMethodAccessible(\ReflectionClass $class, $methodName, $parameters)
+    private function isMethodAccessible(\ReflectionClass $class, $methodName, $parameters, \ReflectionMethod &$method = null)
     {
         if ($class->hasMethod($methodName)) {
             $method = $class->getMethod($methodName);

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -43,6 +43,42 @@ class PropertyAccessorCollectionTest_Car
     }
 }
 
+class PropertyAccessorCollectionTest_CarAdderWithKey
+{
+    private $axes;
+
+    public function __construct($axes = null)
+    {
+        $this->axes = $axes;
+    }
+
+    // In the test, use a name that StringUtil can't uniquely singularify
+    public function addAxis($axis, $key = null)
+    {
+        if (null === $key) {
+            $this->axes[] = $axis;
+        } else {
+            $this->axes[$key] = $axis;
+        }
+    }
+
+    public function removeAxis($axis)
+    {
+        foreach ($this->axes as $key => $value) {
+            if ($value === $axis) {
+                unset($this->axes[$key]);
+
+                return;
+            }
+        }
+    }
+
+    public function getAxes()
+    {
+        return $this->axes;
+    }
+}
+
 class PropertyAccessorCollectionTest_CarOnlyAdder
 {
     public function addAxis($axis)
@@ -110,6 +146,25 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
         // Don't use a mock in order to test whether the collections are
         // modified while iterating them
         $car = new PropertyAccessorCollectionTest_Car($axesBefore);
+
+        $this->propertyAccessor->setValue($car, 'axes', $axesMerged);
+
+        $this->assertEquals($axesAfter, $car->getAxes());
+
+        // The passed collection was not modified
+        $this->assertEquals($axesMergedCopy, $axesMerged);
+    }
+
+    public function testSetValueCallsAdderWithKeyAndRemoverForCollections()
+    {
+        $axesBefore = $this->getContainer(array(1 => 'second', 3 => 'fourth', 4 => 'fifth'));
+        $axesMerged = $this->getContainer(array(1 => 'first', 2 => 'second', 3 => 'third'));
+        $axesAfter = $this->getContainer(array(1 => 'first', 2 => 'second', 3 => 'third'));
+        $axesMergedCopy = is_object($axesMerged) ? clone $axesMerged : $axesMerged;
+
+        // Don't use a mock in order to test whether the collections are
+        // modified while iterating them
+        $car = new PropertyAccessorCollectionTest_CarAdderWithKey($axesBefore);
 
         $this->propertyAccessor->setValue($car, 'axes', $axesMerged);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

In method writeCollection, added `$key` (loop index iterator) as second parameter of `{$addMethod}` method called.
This extra information allow to fix a problem in Symfony Form CollectionType that lose CollectionElement Index when adding new elements.

With this, when setting `by_reference` to `false` option in CollectionType it will prevent Form Error to lose its key reference the key element of the collection.
The `addMethod` of the entity will be structured like This.

```
 /**
 * Add blockArray
 *
 * @param PostBlock $blockArray
 * @param int       $index
 *
 * @return $this
 */
public function addBlockArray(PostBlock $blockArray, $index = NULL)
{
    if (NULL !== $index) {
        $this->blockArray[$index] = $blockArray;
    } else {
        $this->blockArray[] = $blockArray;
    }
    $blockArray->setPost($this);
    return $this;
}
```

I'm missing something or there is no strongest reason for not to pass `$key` as second parameter of `{$addMethod}`?
Thanks,
Cristoforo