### PR TITLE
[HttpKernel] don't call getTrustedHeaderName() if possible

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -119,7 +119,11 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         // Sub-request object will point to localhost as client ip and real client ip
         // will be included into trusted header for client ip
         try {
-            if ($trustedHeaderName = Request::getTrustedHeaderName(Request::HEADER_CLIENT_IP, false)) {
+            if (Request::HEADER_X_FORWARDED_FOR & Request::getTrustedHeaderSet()) {
+                $currentXForwardedFor = $request->headers->get('X_FORWARDED_FOR', '');
+
+                $server['HTTP_X_FORWARDED_FOR'] = ($currentXForwardedFor ? $currentXForwardedFor.', ' : '').$request->getClientIp();
+            } elseif (method_exists(Request::class, 'getTrustedHeaderName') && $trustedHeaderName = Request::getTrustedHeaderName(Request::HEADER_CLIENT_IP, false)) {
                 $currentXForwardedFor = $request->headers->get($trustedHeaderName, '');
 
                 $server['HTTP_'.$trustedHeaderName] = ($currentXForwardedFor ? $currentXForwardedFor.', ' : '').$request->getClientIp();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://travis-ci.org/symfony/symfony/jobs/235008102 (failing tests of #22863)
| License       | MIT
| Doc PR        | 