### PR TITLE
Use hasser before getter if available

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -80,6 +80,11 @@ class PropertyAccessor implements PropertyAccessorInterface
     /**
      * @internal
      */
+    const ACCESS_PRESENCE = 6;
+
+    /**
+     * @internal
+     */
     const ACCESS_TYPE_METHOD = 0;
 
     /**
@@ -480,6 +485,10 @@ class PropertyAccessor implements PropertyAccessorInterface
         $access = $this->getReadAccessInfo(get_class($object), $property);
 
         if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
+            if (isset($access[self::ACCESS_PRESENCE]) && !$object->{$access[self::ACCESS_PRESENCE]}()) {
+                return $result;
+            }
+
             $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]}();
         } elseif (self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]) {
             $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]};
@@ -549,6 +558,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         if ($reflClass->hasMethod($getter) && $reflClass->getMethod($getter)->isPublic()) {
             $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
             $access[self::ACCESS_NAME] = $getter;
+            $access[self::ACCESS_PRESENCE] = $reflClass->hasMethod($hasser) && $reflClass->getMethod($hasser)->isPublic() ? $hasser : null;
         } elseif ($reflClass->hasMethod($getsetter) && $reflClass->getMethod($getsetter)->isPublic()) {
             $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_METHOD;
             $access[self::ACCESS_NAME] = $getsetter;

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassGetValueTyped.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassGetValueTyped.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class TestClassGetValueTyped
+{
+    protected $value;
+
+    public function hasValue(): bool
+    {
+        return $this->value !== null;
+    }
+
+    public function getValue(): TestClassGetValueTyped
+    {
+        return $this->value;
+    }
+
+    public function setValue(TestClassGetValueTyped $value)
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassGetValueTyped;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicCall;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicGet;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\Ticket5775Object;
@@ -577,5 +578,14 @@ class PropertyAccessorTest extends TestCase
         $object = new TypeHinted();
 
         $this->propertyAccessor->setValue($object, 'countable', 'This is a string, \Countable expected.');
+    }
+
+    public function testUseHasBeforeGetWhenAvailable()
+    {
+        $object = new TestClassGetValueTyped();
+        $this->assertNull($this->propertyAccessor->getValue($object, 'value'));
+
+        $object->setValue($object);
+        $this->assertSame($object, $this->propertyAccessor->getValue($object, 'value'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see comment below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets |  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |  <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

It's a huge pain to use Symphony's Forms with typed entities because type errors are being thrown left and right. Please consider the following example:

```php
class A
{
    protected $value;

    public function getValue(): A
    {
        return $this->value;
    }

    public function setValue(A $value)
    {
        $this->value = $value;
    }
}
```

`value` is required for the entity to be validated, but because `PropertyAccess` gets the value through `getValue()` a `TypeError`  is thrown because the method *must* return a `A` instance, not `null`.

This PR checks for a _has_ method prior to invoking the getter, and won't invoke it if _has_ returns `false`:

```php
class A
{
    protected $value;

    public function hasValue(): bool
    {
        return $this->value !== null;
    }

    public function getValue(): A
    {
        return $this->value;
    }

    public function setValue(A $value)
    {
        $this->value = $value;
    }
}
```
