### PR TITLE
[Route] adds support for several @Route annotations in class scope

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -219,7 +219,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
         $annotations = $this->reader->getClassAnnotations($class);
 
         // BC workaround: interface of Doctrine is broken, it returns NULL instead of empty array if nothing was found
-        if ($annotations === NULL) {
+        if ($annotations === null) {
             $annotations = [];
         }
 

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -144,6 +144,10 @@ abstract class AnnotationClassLoader implements LoaderInterface
             $name = $this->getDefaultRouteName($class, $method);
         }
 
+        if (!empty($globals['name'])) {
+            $name .= '_' . $globals['name'];
+        }
+
         $defaults = array_replace($globals['defaults'], $annot->getDefaults());
         foreach ($method->getParameters() as $param) {
             if (false !== strpos($globals['path'].$annot->getPath(), sprintf('{%s}', $param->getName())) && !isset($defaults[$param->getName()]) && $param->isDefaultValueAvailable()) {
@@ -218,7 +222,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
         $globals = [];
         $annotations = $this->reader->getClassAnnotations($class);
 
-        // BC workaround: interface of Doctrine is broken, it returns NULL instead of empty array if nothing was found
+        // Workaround: interface of Doctrine returns NULL instead of empty array if nothing was found
         if ($annotations === null) {
             $annotations = [];
         }
@@ -226,6 +230,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
         foreach ($annotations as $annotation) {
             if ($annotation instanceof $this->routeAnnotationClass) {
                 $globals[] = [
+                    'name'         => null !== $annotation->getName()         ? $annotation->getName()         : '',
                     'path'         => null !== $annotation->getPath()         ? $annotation->getPath()         : '',
                     'requirements' => null !== $annotation->getRequirements() ? $annotation->getRequirements() : [],
                     'options'      => null !== $annotation->getOptions()      ? $annotation->getOptions()      : [],
@@ -241,6 +246,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
         // Add default globals if nothing was provided in class annotation
         if (empty($globals)) {
             $globals[] = [
+                'name' => '',
                 'path' => '',
                 'requirements' => [],
                 'options' => [],

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -163,8 +163,8 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 
         $this->reader
             ->expects($this->once())
-            ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
+            ->method('getClassAnnotations')
+            ->will($this->returnValue([$this->getAnnotatedRoute($classRouteData)]))
         ;
         $this->reader
             ->expects($this->once())
@@ -190,7 +190,13 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         );
 
         $this->reader
-            ->expects($this->exactly(2))
+            ->expects($this->once())
+            ->method('getClassAnnotations')
+            ->will($this->returnValue([$this->getAnnotatedRoute($classRouteData)]))
+        ;
+
+        $this->reader
+            ->expects($this->once())
             ->method('getClassAnnotation')
             ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
         ;
@@ -226,8 +232,8 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 
         $this->reader
             ->expects($this->once())
-            ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
+            ->method('getClassAnnotations')
+            ->will($this->returnValue([$this->getAnnotatedRoute($classRouteData)]))
         ;
         $this->reader
             ->expects($this->once())


### PR DESCRIPTION
adds support for several @Route annotations in class scope

Tested only on its particular unit test

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| New feature?  | yes
| BC breaks?    | *possibly yes*
| Deprecations? | no
| Tests pass?   | *yes* (modified)
| Fixed tickets | #22812
| License       | MIT
| Doc PR        | 


BC break changes on first look

1. AnnotationClassLoader::getGlobals returned array, now returns array of arrays 
2. AnnotationClassLoader::load() __invoke , I lack knowledge on this behavior, probably I'm breaking something, even tests are good
3. Another unknown behavior for me when only class scope route exists and with name - then SF takes its name for route. Now it doubles its name (because I append it)
4. Related tests are failing due to different amount of methods usage, I do lack knowledge to make any further changes.

