### PR TITLE
[HttpKernel] Inherit projectDir in the temporary kernel

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -207,6 +207,12 @@ EOF
         $class = substr($parentClass, 0, -1).'_';
         // the temp container class must be changed too
         $containerClass = var_export(substr(get_class($parent->getContainer()), 0, -1).'_', true);
+
+        $projectDir = '';
+        if (method_exists($parent, 'getProjectDir')) {
+            $projectDir = var_export(realpath($parent->getProjectDir()), true);
+        }
+
         $code = <<<EOF
 <?php
 
@@ -227,6 +233,11 @@ namespace $namespace
         public function getLogDir()
         {
             return $logDir;
+        }
+        
+        public function getProjectDir()
+        {
+            return $projectDir;
         }
 
         protected function getContainerClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Contrary to all other directories defined in the kernel, the `getProjectDir` method is not copied to the temporary kernel. This can lead to issues if the method is overridden in `AppKernel`. Unfortunately, the method is not (and obviously cannot be) in the `KernelInterface`, so `method_exists` was my only option to see if it can be called.