### PR TITLE
[HttpKernel] Add ability to configure catching exceptions for Client

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * added `AddCacheClearerPass`
  * added `AddCacheWarmerPass`
  * deprecated `EnvParametersResource`
+ * added `Symfony\Component\HttpKernel\Client::catchExceptions()`
 
 3.3.0
 -----

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpFoundation\Response;
 class Client extends BaseClient
 {
     protected $kernel;
+    private $catchExceptions = true;
 
     /**
      * Constructor.
@@ -50,6 +51,16 @@ class Client extends BaseClient
     }
 
     /**
+     * Sets whether to catch exceptions when the kernel is handling a request.
+     *
+     * @param bool $catchExceptions Whether to catch exceptions
+     */
+    public function catchExceptions($catchExceptions)
+    {
+        $this->catchExceptions = $catchExceptions;
+    }
+
+    /**
      * Makes a request.
      *
      * @param Request $request A Request instance
@@ -58,7 +69,7 @@ class Client extends BaseClient
      */
     protected function doRequest($request)
     {
-        $response = $this->kernel->handle($request);
+        $response = $this->kernel->handle($request, HttpKernelInterface::MASTER_REQUEST, $this->catchExceptions);
 
         if ($this->kernel instanceof TerminableInterface) {
             $this->kernel->terminate($request, $response);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Debugging exceptions in functional tests is difficult as you need to look at the logs to see which exception was thrown. Disabling catching of exceptions in the client would allow the exception to bubble up to phpunit  and make it easier to see what exception was thrown.