### PR TITLE
[travis] Fix 3/4 cross tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ matrix:
           group: edge
         - php: 5.5
         - php: 5.6
-        - php: 7.0
-          env: deps=high
         - php: 7.1
+          env: deps=high
+        - php: 7.0
           env: deps=low
     fast_finish: true
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | needs #22892
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I just realized that using 7.0 to run deps=high test prevents loading 4.0 versions of deps.
