### PR TITLE
[ProxyManager] Add FC layer

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -82,6 +82,8 @@ DependencyInjection
 
  * Autowiring services based on the types they implement is deprecated and won't be supported in version 4.0. Rename (or alias) your services to their FQCN id to make them autowirable.
 
+ * [BC BREAK] The `NullDumper` class has been made final
+
  * [BC BREAK] `_defaults` and `_instanceof` are now reserved service names in Yaml configurations. Please rename any services with that names.
 
  * [BC BREAK] non-numeric keys in methods and constructors arguments have never been supported and are now forbidden. Please remove them if you happen to have one.
@@ -300,6 +302,11 @@ Process
 
  * Extending `Process::run()`, `Process::mustRun()` and `Process::restart()` is
    deprecated and won't be supported in 4.0.
+
+ProxyManager
+------------
+
+ * [BC BREAK] The `ProxyDumper` class has been made final
 
 Security
 --------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -424,6 +424,11 @@ Process
  * Extending `Process::run()`, `Process::mustRun()` and `Process::restart()` is
    not supported anymore.
 
+ProxyManager
+------------
+
+ * The `ProxyDumper` class has been made final
+
 Security
 --------
 

--- a/src/Symfony/Bridge/ProxyManager/CHANGELOG.md
+++ b/src/Symfony/Bridge/ProxyManager/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.3.0
+-----
+
+ * [BC BREAK] The `ProxyDumper` class is now final
+
 2.3.0
 -----
 

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;
  * Generates dumped PHP code of proxies via reflection.
  *
  * @author Marco Pivetta <ocramius@gmail.com>
+ *
+ * @final since version 3.3
  */
 class ProxyDumper implements DumperInterface
 {
@@ -63,7 +65,7 @@ class ProxyDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProxyFactoryCode(Definition $definition, $id)
+    public function getProxyFactoryCode(Definition $definition, $id, $methodName = null)
     {
         $instantiation = 'return';
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -28,6 +28,7 @@ CHANGELOG
    will not be supported anymore in 4.0
  * deprecated the `DefinitionDecorator` class in favor of `ChildDefinition`
  * allow config files to be loaded using a glob pattern
+ * [BC BREAK] the `NullDumper` class is now final
 
 3.2.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes - minor
| Deprecations? | yes - made a class final
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This makes PRoxyDumper compatible with DumperInterface v4.0.
Technically, this is a BC break, but since I really don't expect anyone to extend ProxyDumper, I think we should do it - on 3.3 to close the gap as early as possible.
