### PR TITLE
Process: Add methods for getting start/end/running time

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -863,6 +863,85 @@ class ProcessTest extends TestCase
         throw $e;
     }
 
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     */
+    public function testGetStartTimeOnNonStartedProcess()
+    {
+        $this->getProcess('')->getStartTime();
+    }
+
+    public function testGetStartTimeOnStartedProcess()
+    {
+        $process = $this->getProcess('sleep 3');
+        $start = microtime(true);
+        $process->start();
+        $this->assertLessThan(0.1, $process->getStartTime() - $start);
+        $process->stop(0);
+    }
+
+    public function testGetStartTimeOnTerminatedProcess()
+    {
+        $process = $this->getProcess('echo foo');
+        $start = microtime(true);
+        $process->run();
+        $this->assertLessThan(0.1, $process->getStartTime() - $start);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     */
+    public function testGetEndTimeOnNonStartedProcess()
+    {
+        $this->getProcess('')->getEndTime();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     */
+    public function testGetEndTimeOnStartedProcess()
+    {
+        $process = $this->getProcess('sleep 3');
+        $process->start();
+        $process->getEndTime();
+    }
+
+    public function testGetEndTimeOnTerminatedProcess()
+    {
+        $process = $this->getProcess('echo foo');
+        $process->run();
+        $this->assertLessThan(0.1, $process->getEndTime() - microtime(true));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\LogicException
+     */
+    public function testGetRunningTimeOnNonStartedProcess()
+    {
+        $this->getProcess('')->getRunningTime();
+    }
+
+    public function testGetRunningTimeOnStartedProcess()
+    {
+        $process = $this->getProcess('sleep 3');
+        $start = microtime(true);
+        $process->start();
+        usleep(100000);
+        $running = $process->getRunningTime();
+        $now = microtime(true);
+        $this->assertLessThan(0.1, ($now - $start) - $running);
+        $process->stop(0);
+    }
+
+    public function testGetRunningTimeOnTerminatedProcess()
+    {
+        $process = $this->getProcessForCode('usleep(1000);');
+        $process->run();
+        $start = $process->getStartTime();
+        $end = $process->getEndTime();
+        $this->assertEquals($end - $start, $process->getRunningTime());
+    }
+
     public function testGetPid()
     {
         $process = $this->getProcessForCode('sleep(36);');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master (?)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | ?

Hope i'm doing this right. The issue template says to submit features against `3.4`, but [Submitting a Patch](https://symfony.com/doc/current/contributing/code/patches.html) says to do it again `master`. I guess it's clean either way, idk.

Anyway. In using `Process`, i found myself wanting to know how long it took (or was taking) for a process to run. Obviously you can just wrap the execution in calls to `microtime()` and calculate it yourself, but it seemed like such an obvious feature to add to `Process` itself. So that's what this does. Specifically, it adds three new methods:

* `getStartTime()` — Returns the process start time (as produced by `microtime(true)` when the process started)

* `getEndTime()` — Returns the process end time (as produced by `microtime(true)` when the process finished)

* `getRunningTime()` — Returns the process running time, either `end - start` if it's finished or `now - start` if it's still running

I wasn't sure how to write the unit tests since the exact timing depends on the environment, but i think what i settled on should be close enough.

No 'Doc PR' right now, but i think i can figure out how to put one together if this is accepted.

Please let me know if you have any concerns/suggestions.