### PR TITLE
[DI] Deprecate XML services without ID

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -1,15 +1,20 @@
 UPGRADE FROM 3.3 to 3.4
 =======================
 
+DependencyInjection
+-------------------
+
+  * Top-level anonymous services in XML are deprecated and will throw an exception in Symfony 4.0.
+
 Finder
 ------
 
  * The `Symfony\Component\Finder\Iterator\FilterIterator` class has been
    deprecated and will be removed in 4.0 as it used to fix a bug which existed 
-   before version 5.5.23/5.6.7
+   before version 5.5.23/5.6.7.
 
 Validator
 ---------
 
- * not setting the `strict` option of the `Choice` constraint to `true` is
-   deprecated and will throw an exception in Symfony 4.0
+ * Not setting the `strict` option of the `Choice` constraint to `true` is
+   deprecated and will throw an exception in Symfony 4.0.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -128,6 +128,8 @@ DependencyInjection
  * The ``strict`` attribute in service arguments has been removed.
    The attribute is ignored since 3.0, so you can simply remove it.
 
+ * Top-level anonymous services in XML are no longer supported.
+
 EventDispatcher
 ---------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -66,12 +66,12 @@
             <argument /> <!-- resource checkers -->
         </service>
 
-        <service class="Symfony\Component\DependencyInjection\Config\ContainerParametersResourceChecker">
+        <service id="Symfony\Component\DependencyInjection\Config\ContainerParametersResourceChecker">
             <argument type="service" id="service_container" />
             <tag name="config_cache.resource_checker" priority="-980" />
         </service>
 
-        <service class="Symfony\Component\Config\Resource\SelfCheckingResourceChecker">
+        <service id="Symfony\Component\Config\Resource\SelfCheckingResourceChecker">
             <tag name="config_cache.resource_checker" priority="-990" />
         </service>
     </services>

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * deprecated the ability to check for the initialization of a private service with the `Container::initialized()` method
+ * deprecated support for top-level anonymous services in XML
 
 3.3.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -413,6 +413,8 @@ class XmlFileLoader extends FileLoader
         // anonymous services "in the wild"
         if (false !== $nodes = $xpath->query('//container:services/container:service[not(@id)]')) {
             foreach ($nodes as $node) {
+                @trigger_error(sprintf('Top-level anonymous services are deprecated since Symfony 3.4, the "id" attribute will be required in version 4.0 in %s at line %d.', $file, $node->getLineNo()), E_USER_DEPRECATED);
+
                 // give it a unique name
                 $id = sprintf('%d_%s', ++$count, hash('sha256', $file));
                 $node->setAttribute('id', $id);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/nested_service_without_id.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/nested_service_without_id.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="FooClass">
+      <argument type="service">
+        <service class="BarClass" />
+      </argument>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services28.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services28.xml
@@ -5,7 +5,7 @@
             <tag name="foo" />
         </defaults>
 
-        <service class="Bar" public="true" />
+        <service id="bar" class="Bar" public="true" />
         <service id="with_defaults" class="Foo" />
         <service id="no_defaults" class="Foo" public="true" autowire="false" />
         <service id="child_def" parent="with_defaults" public="true" autowire="false" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services5.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services5.xml
@@ -18,7 +18,7 @@
       </property>
     </service>
     <service id="bar" parent="foo" />
-    <service class="BizClass">
+    <service id="biz" class="BizClass">
         <tag name="biz_tag" />
     </service>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_without_id.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_without_id.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service class="FooClass"/>
+    <service id="FooClass">
+      <argument type="service">
+        <service class="BarClass" />
+      </argument>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -230,6 +230,28 @@ class XmlFileLoaderTest extends TestCase
         $this->assertSame($fooArgs[0], $barArgs[0]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Top-level anonymous services are deprecated since Symfony 3.4, the "id" attribute will be required in version 4.0 in %sservices_without_id.xml at line 4.
+     */
+    public function testLoadAnonymousServicesWithoutId()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_without_id.xml');
+    }
+
+    public function testLoadAnonymousNestedServices()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('nested_service_without_id.xml');
+
+        $this->assertTrue($container->hasDefinition('FooClass'));
+        $arguments = $container->getDefinition('FooClass')->getArguments();
+        $this->assertInstanceOf(Reference::class, array_shift($arguments));
+    }
+
     public function testLoadServices()
     {
         $container = new ContainerBuilder();
@@ -667,9 +689,8 @@ class XmlFileLoaderTest extends TestCase
         $this->assertSame('service_container', key($definitions));
 
         array_shift($definitions);
-        $this->assertStringStartsWith('1_', key($definitions));
-
         $anonymous = current($definitions);
+        $this->assertSame('bar', key($definitions));
         $this->assertTrue($anonymous->isPublic());
         $this->assertTrue($anonymous->isAutowired());
         $this->assertSame(array('foo' => array(array())), $anonymous->getTags());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no, confusing though
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

On slack someone had a issue with class named services;

> So, probably should have done this sooner, I stepped through with a debugger and it looks like \Symfony\Component\DependencyInjection\Loader\XmlFileLoader::processAnonymousServices assigns a sha256 to services that don't have any IDs
> When my manually wired service is registered, it has an ID that looks like 1_344b468f6069ffe8c32092409d99c59abc218f41071ce4c4230c198876129bc0, so it doesn't override the auto-loaded one
> I swear I read that IDs default to the class name now...

The fix was easy; doing `<service id="ClassName"/>` instead of `<service class="ClassName"/>`. However the thing is... i made the exact same mistake trying to reproduce :sweat_smile: 

I think given the recent developments (dropping type based autowiring and class named services) it makes sense to force XML service to specify an ID attribute (the top level ones). This would be consistent with YAML and PHP as well.

Fixing deprecations is also easy, just change `class` attribute to `id` like i've done for the frameworkbundle in this PR.

Any thoughts?