### PR TITLE
[FrameworkBundle][Validator] Move the PSR-11 factory to the component

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -203,11 +203,6 @@ FrameworkBundle
    deprecated and will be removed in 4.0. Use the `Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoPass`
    class instead.
 
- * The `ConstraintValidatorFactory::$validators` and `$container` properties
-   have been deprecated and will be removed in 4.0.
-
- * Extending `ConstraintValidatorFactory` is deprecated and won't be supported in 4.0.
-
  * Class parameters related to routing have been deprecated and will be removed in 4.0.
      * router.options.generator_class
      * router.options.generator_base_class
@@ -246,9 +241,9 @@ FrameworkBundle
    class has been deprecated and will be removed in 4.0. Use the
    `Symfony\Component\Workflow\DependencyInjection\ValidateWorkflowsPass` class instead.
 
- * Passing an array of validators or validator aliases as the second argument of 
-   `ConstraintValidatorFactory::__construct()` is deprecated since 3.3 and will 
-   be removed in 4.0. Use the service locator instead.
+ * The `Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory`
+   class has been deprecated and will be removed in 4.0.
+   Use `Symfony\Component\Validator\ContainerConstraintValidatorFactory` instead.
 
 HttpFoundation
 --------------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -294,15 +294,6 @@ FrameworkBundle
    removed. Use the `Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoPass`
    class instead.
 
- * The `ConstraintValidatorFactory::$validators` and `$container` properties
-   have been removed.
-
- * Extending `ConstraintValidatorFactory` is not supported anymore.
-
- * Passing an array of validators or validator aliases as the second argument of 
-   `ConstraintValidatorFactory::__construct()` has been removed.
-   Use the service locator instead.
-
  * Class parameters related to routing have been removed
     * router.options.generator_class
     * router.options.generator_base_class
@@ -335,6 +326,9 @@ FrameworkBundle
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ValidateWorkflowsPass` class
    has been removed. Use the `Symfony\Component\Workflow\DependencyInjection\ValidateWorkflowsPass`
    class instead.
+   
+ * The `Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory` class has been removed. 
+   Use `Symfony\Component\Validator\ContainerConstraintValidatorFactory` instead.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -31,7 +31,6 @@ CHANGELOG
  * Deprecated `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConfigCachePass`.
    Use `Symfony\Component\Console\DependencyInjection\ConfigCachePass` instead.
  * Deprecated `PropertyInfoPass`, use `Symfony\Component\PropertyInfo\DependencyInjection\PropertyInfoPass` instead
- * Deprecated extending `ConstraintValidatorFactory`
  * Deprecated `ControllerArgumentValueResolverPass`. Use
    `Symfony\Component\HttpKernel\DependencyInjection\ControllerArgumentValueResolverPass` instead
  * Deprecated `RoutingResolverPass`, use `Symfony\Component\Routing\DependencyInjection\RoutingResolverPass` instead
@@ -47,9 +46,10 @@ CHANGELOG
    `Symfony\Component\Validator\DependencyInjection\AddValidatorInitializersPass` instead
  * Deprecated `AddConstraintValidatorsPass`, use
    `Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass` instead
- * Deprecated `ValidateWorkflowsPass`, use 
+ * Deprecated `ValidateWorkflowsPass`, use
    `Symfony\Component\Workflow\DependencyInjection\ValidateWorkflowsPass` instead
- * Deprecated `ConstraintValidatorFactory::__construct()` second argument.
+ * Deprecated `ConstraintValidatorFactory`, use 
+   `Symfony\Component\Validator\ContainerConstraintValidatorFactory` instead.
 
 3.2.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -59,7 +59,7 @@
             </argument>
         </service>
 
-        <service id="validator.validator_factory" class="Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory">
+        <service id="validator.validator_factory" class="Symfony\Component\Validator\ContainerConstraintValidatorFactory">
             <argument /> <!-- Constraint validators locator -->
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -49,7 +49,7 @@
         "symfony/serializer": "~3.3",
         "symfony/translation": "~3.2",
         "symfony/templating": "~2.8|~3.0",
-        "symfony/validator": "~3.3",
+        "symfony/validator": "~3.3-rc2",
         "symfony/workflow": "~3.3",
         "symfony/yaml": "~3.2",
         "symfony/property-info": "~3.3",
@@ -69,7 +69,7 @@
         "symfony/property-info": "<3.3",
         "symfony/serializer": "<3.3",
         "symfony/translation": "<3.2",
-        "symfony/validator": "<3.3",
+        "symfony/validator": "<3.3-rc2",
         "symfony/workflow": "<3.3"
     },
     "suggest": {

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added `AddValidatorInitializersPass`
  * added `AddConstraintValidatorsPass`
+ * added `ContainerConstraintValidatorFactory`
 
 3.2.0
 -----

--- a/src/Symfony/Component/Validator/ContainerConstraintValidatorFactory.php
+++ b/src/Symfony/Component/Validator/ContainerConstraintValidatorFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\ValidatorException;
+
+/**
+ * Uses a service container to create constraint validators.
+ *
+ * @author Kris Wallsmith <kris@symfony.com>
+ */
+class ContainerConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
+{
+    private $container;
+    private $validators;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->validators = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ValidatorException      When the validator class does not exist
+     * @throws UnexpectedTypeException When the validator is not an instance of ConstraintValidatorInterface
+     */
+    public function getInstance(Constraint $constraint)
+    {
+        $name = $constraint->validatedBy();
+
+        if (!isset($this->validators[$name])) {
+            if ($this->container->has($name)) {
+                $this->validators[$name] = $this->container->get($name);
+            } else {
+                if (!class_exists($name)) {
+                    throw new ValidatorException(sprintf('Constraint validator "%s" does not exist or it is not enabled. Check the "validatedBy" method in your constraint class "%s".', $name, get_class($constraint)));
+                }
+
+                $this->validators[$name] = new $name();
+            }
+        }
+
+        if (!$this->validators[$name] instanceof ConstraintValidatorInterface) {
+            throw new UnexpectedTypeException($this->validators[$name], ConstraintValidatorInterface::class);
+        }
+
+        return $this->validators[$name];
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/ContainerConstraintValidatorFactoryTest.php
@@ -9,38 +9,35 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Tests\Validator;
+namespace Symfony\Component\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Blank as BlankConstraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\ContainerConstraintValidatorFactory;
 
-/**
- * @group legacy
- */
-class ConstraintValidatorFactoryTest extends TestCase
+class ContainerConstraintValidatorFactoryTest extends TestCase
 {
     public function testGetInstanceCreatesValidator()
     {
-        $class = get_class($this->getMockForAbstractClass('Symfony\\Component\\Validator\\ConstraintValidator'));
+        $class = get_class($this->getMockForAbstractClass(ConstraintValidator::class));
 
-        $constraint = $this->getMockBuilder('Symfony\\Component\\Validator\\Constraint')->getMock();
+        $constraint = $this->getMockBuilder(Constraint::class)->getMock();
         $constraint
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('validatedBy')
             ->will($this->returnValue($class));
 
-        $factory = new ConstraintValidatorFactory(new Container());
+        $factory = new ContainerConstraintValidatorFactory(new Container());
         $this->assertInstanceOf($class, $factory->getInstance($constraint));
     }
 
     public function testGetInstanceReturnsExistingValidator()
     {
-        $factory = new ConstraintValidatorFactory(new Container());
+        $factory = new ContainerConstraintValidatorFactory(new Container());
         $v1 = $factory->getInstance(new BlankConstraint());
         $v2 = $factory->getInstance(new BlankConstraint());
         $this->assertSame($v1, $v2);
@@ -66,35 +63,11 @@ class ConstraintValidatorFactoryTest extends TestCase
 
         $constraint = $this->getMockBuilder(Constraint::class)->getMock();
         $constraint
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('validatedBy')
             ->will($this->returnValue($service));
 
-        $factory = new ConstraintValidatorFactory($container);
-        $this->assertSame($validator, $factory->getInstance($constraint));
-    }
-
-    public function testGetInstanceReturnsServiceWithAlias()
-    {
-        $service = 'validator_constraint_service';
-        $alias = 'validator_constraint_alias';
-        $validator = $this->getMockForAbstractClass('Symfony\\Component\\Validator\\ConstraintValidator');
-
-        // mock ContainerBuilder b/c it implements TaggedContainerInterface
-        $container = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\ContainerBuilder')->setMethods(array('get'))->getMock();
-        $container
-            ->expects($this->once())
-            ->method('get')
-            ->with($service)
-            ->will($this->returnValue($validator));
-
-        $constraint = $this->getMockBuilder('Symfony\\Component\\Validator\\Constraint')->getMock();
-        $constraint
-            ->expects($this->once())
-            ->method('validatedBy')
-            ->will($this->returnValue($alias));
-
-        $factory = new ConstraintValidatorFactory($container, array('validator_constraint_alias' => 'validator_constraint_service'));
+        $factory = new ContainerConstraintValidatorFactory($container);
         $this->assertSame($validator, $factory->getInstance($constraint));
     }
 
@@ -103,13 +76,13 @@ class ConstraintValidatorFactoryTest extends TestCase
      */
     public function testGetInstanceInvalidValidatorClass()
     {
-        $constraint = $this->getMockBuilder('Symfony\\Component\\Validator\\Constraint')->getMock();
+        $constraint = $this->getMockBuilder(Constraint::class)->getMock();
         $constraint
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('validatedBy')
             ->will($this->returnValue('Fully\\Qualified\\ConstraintValidator\\Class\\Name'));
 
-        $factory = new ConstraintValidatorFactory(new Container());
+        $factory = new ContainerConstraintValidatorFactory(new Container());
         $factory->getInstance($constraint);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | yes <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22887#issuecomment-303765795 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Instead of the 3 following deprecations:
 * The `ConstraintValidatorFactory::$validators` and `$container` properties
   have been deprecated and will be removed in 4.0.
 * Extending `ConstraintValidatorFactory` is deprecated and won't be supported in 4.0.
* Passing an array of validators or validator aliases as the second argument of 
   `ConstraintValidatorFactory::__construct()` is deprecated since 3.3 and will 
   be removed in 4.0. Use the service locator instead.

I'd suggest simply deprecating the FrameworkBundle's class in favor of using a new `ContainerConstraintValidatorFactory`. To me, there is no reason anyone using the validator component without the framework bundle cannot use this PSR-11 compliant implementation, nor I see a reason to make it final.