### PR TITLE
Improved the way long exception messages are displayed

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
@@ -16,7 +16,7 @@
     <div class="container">
         <div class="exception-message-wrapper">
             <h1 class="break-long-words exception-message {{ exception.message|length > 180 ? 'long' }}">
-                {{- exception.message|nl2br|format_file_from_text -}}
+                {{- exception.message|format_file_from_text -}}
             </h1>
 
             <div class="exception-illustration hidden-xs-down">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is just a proposal. Very long exceptions with `\n` inside them are uncommon, but we could improve how they look.

### Before

![before-exception](https://cloud.githubusercontent.com/assets/73419/26444887/7c9602fa-413e-11e7-98f5-2b96e30f2b1b.png)

### After

![after-exception](https://cloud.githubusercontent.com/assets/73419/26444892/806ca21c-413e-11e7-9f28-2ebb2e4b664a.png)
