### PR TITLE
[Yaml] Deprecate using the non-specific tag

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -10,7 +10,7 @@ Finder
 ------
 
  * The `Symfony\Component\Finder\Iterator\FilterIterator` class has been
-   deprecated and will be removed in 4.0 as it used to fix a bug which existed 
+   deprecated and will be removed in 4.0 as it used to fix a bug which existed
    before version 5.5.23/5.6.7.
 
 Validator
@@ -18,3 +18,9 @@ Validator
 
  * Not setting the `strict` option of the `Choice` constraint to `true` is
    deprecated and will throw an exception in Symfony 4.0.
+
+Yaml
+----
+
+ * Using the non-specific tag `!` is deprecated and will have a different
+   behavior in 4.0. Use a plain integer or `!!float` instead.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -685,3 +685,6 @@ Yaml
 
  * The constructor arguments `$offset`, `$totalNumberOfLines` and
    `$skippedLineNumbers` of the `Parser` class were removed.
+
+ * The behavior of the non-specific tag `!` is changed and now forces
+   non-evaluating your values.

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * Deprecated using the non-specific tag `!` as its behavior will change in 4.0.
+   It will force non-evaluating your values in 4.0. Use plain integers or `!!float` instead.
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -611,6 +611,8 @@ class Inline
                     case 0 === strpos($scalar, '!str'):
                         return (string) substr($scalar, 5);
                     case 0 === strpos($scalar, '! '):
+                        @trigger_error('Using the non-specific tag "!" is deprecated since version 3.4 as its behavior will change in 4.0. It will force non-evaluating your values in 4.0. Use plain integers or !!float instead.', E_USER_DEPRECATED);
+
                         return (int) self::parseScalar(substr($scalar, 2), $flags);
                     case 0 === strpos($scalar, '!php/object:'):
                         if (self::$objectSupport) {

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
@@ -928,6 +928,7 @@ documents: 2
 
 ---
 test: Explicit typing
+deprecated: Using the non-specific tag "!" is deprecated since version 3.4 as its behavior will change in 4.0.
 yaml: |
    integer: 12
    also int: ! "12"

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -61,7 +61,7 @@ class ParserTest extends TestCase
             restore_error_handler();
 
             $this->assertCount(1, $deprecations);
-            $this->assertContains('Using the comma as a group separator for floats is deprecated since version 3.2 and will be removed in 4.0.', $deprecations[0]);
+            $this->assertContains(true !== $deprecated ? $deprecated : 'Using the comma as a group separator for floats is deprecated since version 3.2 and will be removed in 4.0.', $deprecations[0]);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Values tagged with the non-specific tag must not be transformed in an integer, this tag means that they must not be evaluated (see [the spec](http://www.yaml.org/spec/1.2/spec.html#tag/non-specific/)).

I applied this change in https://github.com/symfony/symfony/pull/22762 to comply with the spec.