### PR TITLE
[Yaml] Deprecate tags using colon

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -37,13 +37,13 @@ FrameworkBundle
    require symfony/stopwatch` in your `dev` environment.
 
  * Using the `KERNEL_DIR` environment variable or the automatic guessing based
-   on the `phpunit.xml` / `phpunit.xml.dist` file location is deprecated since 3.4. 
+   on the `phpunit.xml` / `phpunit.xml.dist` file location is deprecated since 3.4.
    Set the `KERNEL_CLASS` environment variable to the fully-qualified class name
-   of your Kernel instead. Not setting the `KERNEL_CLASS` environment variable 
-   will throw an exception on 4.0 unless you override the `KernelTestCase::createKernel()` 
+   of your Kernel instead. Not setting the `KERNEL_CLASS` environment variable
+   will throw an exception on 4.0 unless you override the `KernelTestCase::createKernel()`
    or `KernelTestCase::getKernelClass()` method.
-   
- * The `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()` 
+
+ * The `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()`
    methods are deprecated since 3.4 and will be removed in 4.0.
 
  * The `--no-prefix` option of the `translation:update` command is deprecated and
@@ -90,7 +90,7 @@ TwigBridge
  * deprecated the `Symfony\Bridge\Twig\Form\TwigRenderer` class, use the `FormRenderer`
    class from the Form component instead
 
- * deprecated `Symfony\Bridge\Twig\Command\DebugCommand::set/getTwigEnvironment` and the ability 
+ * deprecated `Symfony\Bridge\Twig\Command\DebugCommand::set/getTwigEnvironment` and the ability
    to pass a command name as first argument
 
  * deprecated `Symfony\Bridge\Twig\Command\LintCommand::set/getTwigEnvironment` and the ability
@@ -102,7 +102,7 @@ TwigBundle
  * deprecated the `Symfony\Bundle\TwigBundle\Command\DebugCommand` class, use the `DebugCommand`
    class from the Twig bridge instead
 
- * deprecated relying on the `ContainerAwareInterface` implementation for 
+ * deprecated relying on the `ContainerAwareInterface` implementation for
    `Symfony\Bundle\TwigBundle\Command\LintCommand`
 
 Validator
@@ -113,6 +113,24 @@ Validator
 
 Yaml
 ----
+
+ * using the `!php/object:` tag is deprecated and won't be supported in 4.0. Use
+   the `!php/object` tag (without the colon) instead.
+
+ * using the `!php/const:` tag is deprecated and won't be supported in 4.0. Use
+   the `!php/const` tag (without the colon) instead.
+
+   Before:
+
+   ```yml
+   !php/const:PHP_INT_MAX
+   ```
+
+   After:
+
+   ```yml
+   !php/const PHP_INT_MAX
+   ```
 
  * Support for the `!str` tag is deprecated, use the `!!str` tag instead.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -345,9 +345,9 @@ FrameworkBundle
    class instead.
 
  * Using the `KERNEL_DIR` environment variable and the automatic guessing based
-   on the `phpunit.xml` file location have been removed from the `KernelTestCase::getKernelClass()` 
+   on the `phpunit.xml` file location have been removed from the `KernelTestCase::getKernelClass()`
    method implementation. Set the `KERNEL_CLASS` environment variable to the
-   fully-qualified class name of your Kernel or override the `KernelTestCase::createKernel()` 
+   fully-qualified class name of your Kernel or override the `KernelTestCase::createKernel()`
    or `KernelTestCase::getKernelClass()` method instead.
 
  * The `Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory` class has been removed.
@@ -356,10 +356,10 @@ FrameworkBundle
  * The `--no-prefix` option of the `translation:update` command has
    been removed.
 
- * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheClearerPass` class has been removed. 
+ * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheClearerPass` class has been removed.
    Use the `Symfony\Component\HttpKernel\DependencyInjection\AddCacheClearerPass` class instead.
 
- * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheWarmerPass` class has been removed. 
+ * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheWarmerPass` class has been removed.
    Use the `Symfony\Component\HttpKernel\DependencyInjection\AddCacheWarmerPass` class instead.
 
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationDumperPass`
@@ -561,7 +561,7 @@ TwigBridge
  * The `TwigRendererEngine::setEnvironment()` method has been removed.
    Pass the Twig Environment as second argument of the constructor instead.
 
- * Removed `Symfony\Bridge\Twig\Command\DebugCommand::set/getTwigEnvironment` and the ability 
+ * Removed `Symfony\Bridge\Twig\Command\DebugCommand::set/getTwigEnvironment` and the ability
    to pass a command name as first argument.
 
  * Removed `Symfony\Bridge\Twig\Command\LintCommand::set/getTwigEnvironment` and the ability
@@ -773,3 +773,21 @@ Yaml
 
  * The behavior of the non-specific tag `!` is changed and now forces
    non-evaluating your values.
+
+ * The `!php/object:` tag was removed in favor of the `!php/object` tag (without
+   the colon).
+
+ * The `!php/const:` tag was removed in favor of the `!php/const` tag (without
+   the colon).
+
+   Before:
+
+   ```yml
+   !php/const:PHP_INT_MAX
+   ```
+
+   After:
+
+   ```yml
+   !php/const PHP_INT_MAX
+   ```

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services2.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services2.yml
@@ -5,7 +5,7 @@ parameters:
         - false
         - 0
         - 1000.3
-        - !php/const:PHP_INT_MAX
+        - !php/const PHP_INT_MAX
     bar: foo
     escape: '@@escapeme'
     foo_bar: '@foo_bar'

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -20,7 +20,7 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "symfony/yaml": "~3.3|~4.0",
+        "symfony/yaml": "~3.4|~4.0",
         "symfony/config": "~3.3|~4.0",
         "symfony/expression-language": "~2.8|~3.0|~4.0"
     },
@@ -35,7 +35,7 @@
         "symfony/config": "<3.3.1",
         "symfony/finder": "<3.3",
         "symfony/proxy-manager-bridge": "<3.4",
-        "symfony/yaml": "<3.3"
+        "symfony/yaml": "<3.4"
     },
     "provide": {
         "psr/container-implementation": "1.0"

--- a/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
@@ -61,9 +61,9 @@ class YamlEncoderTest extends TestCase
         $obj = new \stdClass();
         $obj->bar = 2;
 
-        $this->assertEquals("    foo: !php/object:O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}\n", $encoder->encode(array('foo' => $obj), 'yaml'));
+        $this->assertEquals("    foo: !php/object 'O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}'\n", $encoder->encode(array('foo' => $obj), 'yaml'));
         $this->assertEquals('  { foo: null }', $encoder->encode(array('foo' => $obj), 'yaml', array('yaml_inline' => 0, 'yaml_indent' => 2, 'yaml_flags' => 0)));
-        $this->assertEquals(array('foo' => $obj), $encoder->decode('foo: !php/object:O:8:"stdClass":1:{s:3:"bar";i:2;}', 'yaml'));
-        $this->assertEquals(array('foo' => null), $encoder->decode('foo: !php/object:O:8:"stdClass":1:{s:3:"bar";i:2;}', 'yaml', array('yaml_flags' => 0)));
+        $this->assertEquals(array('foo' => $obj), $encoder->decode("foo: !php/object 'O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}'", 'yaml'));
+        $this->assertEquals(array('foo' => null), $encoder->decode("foo: !php/object 'O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}'", 'yaml', array('yaml_flags' => 0)));
     }
 }

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.5.9"
     },
     "require-dev": {
-        "symfony/yaml": "~3.3|~4.0",
+        "symfony/yaml": "~3.4|~4.0",
         "symfony/config": "~2.8|~3.0|~4.0",
         "symfony/property-access": "~2.8|~3.0|~4.0",
         "symfony/http-foundation": "~2.8|~3.0|~4.0",
@@ -34,7 +34,7 @@
         "symfony/dependency-injection": "<3.2",
         "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
         "symfony/property-info": "<3.1",
-        "symfony/yaml": "<3.3"
+        "symfony/yaml": "<3.4"
     },
     "suggest": {
         "psr/cache-implementation": "For using the metadata cache.",

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/mapping-with-constants.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/mapping-with-constants.yml
@@ -5,4 +5,4 @@ Symfony\Component\Validator\Tests\Fixtures\Entity:
   properties:
     firstName:
       - Range:
-          max: !php/const:PHP_INT_MAX
+          max: !php/const PHP_INT_MAX

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -25,7 +25,7 @@
         "symfony/http-kernel": "^3.3.5|~4.0",
         "symfony/var-dumper": "~3.3|~4.0",
         "symfony/intl": "^2.8.18|^3.2.5|~4.0",
-        "symfony/yaml": "~3.3|~4.0",
+        "symfony/yaml": "~3.4|~4.0",
         "symfony/config": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~3.3|~4.0",
         "symfony/expression-language": "~2.8|~3.0|~4.0",
@@ -39,7 +39,7 @@
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
         "symfony/dependency-injection": "<3.3",
         "symfony/http-kernel": "<3.3.5",
-        "symfony/yaml": "<3.3"
+        "symfony/yaml": "<3.4"
     },
     "suggest": {
         "psr/cache-implementation": "For using the metadata cache.",

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -4,10 +4,10 @@ CHANGELOG
 3.4.0
 -----
 
- * Deprecated the tag`!php/object:` tag which will be replaced by the
+ * Deprecated the `!php/object:` tag which will be replaced by the
    `!php/object` tag (without the colon) in 4.0.
 
- * Deprecated the tag`!php/const:` tag which will be replaced by the
+ * Deprecated the `!php/const:` tag which will be replaced by the
    `!php/const` tag (without the colon) in 4.0.
 
  * Support for the `!str` tag is deprecated, use the `!!str` tag instead.

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -4,6 +4,12 @@ CHANGELOG
 3.4.0
 -----
 
+ * Deprecated the tag`!php/object:` tag which will be replaced by the
+   `!php/object` tag (without the colon) in 4.0.
+
+ * Deprecated the tag`!php/const:` tag which will be replaced by the
+   `!php/const` tag (without the colon) in 4.0.
+
  * Support for the `!str` tag is deprecated, use the `!!str` tag instead.
 
  * Deprecated using the non-specific tag `!` as its behavior will change in 4.0.

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -667,7 +667,6 @@ class Inline
                         }
 
                         return;
-
                     case 0 === strpos($scalar, '!php/const'):
                         if (self::$constantSupport) {
                             if (defined($const = self::parseScalar(substr($scalar, 11)))) {

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -208,7 +208,7 @@ class Parser
                     $this->refs[$isRef] = end($data);
                 }
             } elseif (
-                self::preg_match('#^(?P<key>'.Inline::REGEX_QUOTED_STRING.'|(?:!?!php/const:)?(?:![^\s]++\s++)?[^ \'"\[\{!].*?) *\:(\s++(?P<value>.+))?$#u', rtrim($this->currentLine), $values)
+                self::preg_match('#^(?P<key>(?:![^\s]++\s++)?(?:'.Inline::REGEX_QUOTED_STRING.'|(?:!?!php/const:)?[^ \'"\[\{!].*?)) *\:(\s++(?P<value>.+))?$#u', rtrim($this->currentLine), $values)
                 && (false === strpos($values['key'], ' #') || in_array($values['key'][0], array('"', "'")))
             ) {
                 if ($context && 'sequence' == $context) {

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -54,7 +54,7 @@ bar';
     public function testConstantAsKey()
     {
         $yaml = <<<YAML
-!php/const:Symfony\Component\Yaml\Tests\Command\Foo::TEST: bar
+!php/const 'Symfony\Component\Yaml\Tests\Command\Foo::TEST': bar
 YAML;
         $ret = $this->createCommandTester()->execute(array('filename' => $this->createFile($yaml)), array('verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false));
         $this->assertSame(0, $ret, 'lint:yaml exits with code 0 in case of success');

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -210,7 +210,7 @@ EOF;
     {
         $dump = $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, Yaml::DUMP_OBJECT);
 
-        $this->assertEquals('{ foo: !php/object:O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}, bar: 1 }', $dump, '->dump() is able to dump objects');
+        $this->assertEquals('{ foo: !php/object \'O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}\', bar: 1 }', $dump, '->dump() is able to dump objects');
     }
 
     /**
@@ -220,7 +220,7 @@ EOF;
     {
         $dump = $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, false, true);
 
-        $this->assertEquals('{ foo: !php/object:O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}, bar: 1 }', $dump, '->dump() is able to dump objects');
+        $this->assertEquals('{ foo: !php/object \'O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}\', bar: 1 }', $dump, '->dump() is able to dump objects');
     }
 
     public function testObjectSupportDisabledButNoExceptions()

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -49,10 +49,10 @@ class InlineTest extends TestCase
     public function getTestsForParsePhpConstants()
     {
         return array(
-            array('!php/const:Symfony\Component\Yaml\Yaml::PARSE_CONSTANT', Yaml::PARSE_CONSTANT),
-            array('!php/const:PHP_INT_MAX', PHP_INT_MAX),
-            array('[!php/const:PHP_INT_MAX]', array(PHP_INT_MAX)),
-            array('{ foo: !php/const:PHP_INT_MAX }', array('foo' => PHP_INT_MAX)),
+            array('!php/const Symfony\Component\Yaml\Yaml::PARSE_CONSTANT', Yaml::PARSE_CONSTANT),
+            array('!php/const PHP_INT_MAX', PHP_INT_MAX),
+            array('[!php/const PHP_INT_MAX]', array(PHP_INT_MAX)),
+            array('{ foo: !php/const PHP_INT_MAX }', array('foo' => PHP_INT_MAX)),
         );
     }
 
@@ -62,16 +62,25 @@ class InlineTest extends TestCase
      */
     public function testParsePhpConstantThrowsExceptionWhenUndefined()
     {
-        Inline::parse('!php/const:WRONG_CONSTANT', Yaml::PARSE_CONSTANT);
+        Inline::parse('!php/const WRONG_CONSTANT', Yaml::PARSE_CONSTANT);
     }
 
     /**
      * @expectedException \Symfony\Component\Yaml\Exception\ParseException
-     * @expectedExceptionMessageRegExp #The string "!php/const:PHP_INT_MAX" could not be parsed as a constant.*#
+     * @expectedExceptionMessageRegExp #The string "!php/const PHP_INT_MAX" could not be parsed as a constant.*#
      */
     public function testParsePhpConstantThrowsExceptionOnInvalidType()
     {
-        Inline::parse('!php/const:PHP_INT_MAX', Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
+        Inline::parse('!php/const PHP_INT_MAX', Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The !php/const: tag to indicate dumped PHP constants is deprecated since version 3.4 and will be removed in 4.0. Use the !php/const (without the colon) tag instead.
+     */
+    public function testDeprecatedConstantTag()
+    {
+        Inline::parse('!php/const:PHP_INT_MAX', Yaml::PARSE_CONSTANT);
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -469,7 +469,7 @@ EOF;
     public function testObjectSupportEnabled()
     {
         $input = <<<'EOF'
-foo: !php/object:O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
+foo: !php/object O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
 bar: 1
 EOF;
         $this->assertEquals(array('foo' => new B(), 'bar' => 1), $this->parser->parse($input, Yaml::PARSE_OBJECT), '->parse() is able to parse objects');
@@ -489,14 +489,29 @@ EOF;
 
     /**
      * @group legacy
+     * @dataProvider deprecatedObjectValueProvider
      */
-    public function testObjectSupportEnabledWithDeprecatedTag()
+    public function testObjectSupportEnabledWithDeprecatedTag($yaml)
     {
-        $input = <<<'EOF'
+        $this->assertEquals(array('foo' => new B(), 'bar' => 1), $this->parser->parse($yaml, Yaml::PARSE_OBJECT), '->parse() is able to parse objects');
+    }
+
+    public function deprecatedObjectValueProvider()
+    {
+        return array(
+            array(
+                <<<YAML
 foo: !!php/object:O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
 bar: 1
-EOF;
-        $this->assertEquals(array('foo' => new B(), 'bar' => 1), $this->parser->parse($input, Yaml::PARSE_OBJECT), '->parse() is able to parse objects');
+YAML
+            ),
+            array(
+                <<<YAML
+foo: !php/object:O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
+bar: 1
+YAML
+            ),
+        );
     }
 
     /**
@@ -1824,6 +1839,35 @@ YAML;
     {
         $yaml = <<<YAML
 transitions:
+    !php/const 'Symfony\Component\Yaml\Tests\B::FOO':
+        from:
+            - !php/const 'Symfony\Component\Yaml\Tests\B::BAR'
+        to: !php/const 'Symfony\Component\Yaml\Tests\B::BAZ'
+YAML;
+        $expected = array(
+            'transitions' => array(
+                'foo' => array(
+                    'from' => array(
+                        'bar',
+                    ),
+                    'to' => 'baz',
+                ),
+            ),
+        );
+
+        $this->assertSame($expected, $this->parser->parse($yaml, Yaml::PARSE_CONSTANT));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The !php/const: tag to indicate dumped PHP constants is deprecated since version 3.4 and will be removed in 4.0. Use the !php/const (without the colon) tag instead.
+     * @expectedDeprecation The !php/const: tag to indicate dumped PHP constants is deprecated since version 3.4 and will be removed in 4.0. Use the !php/const (without the colon) tag instead.
+     * @expectedDeprecation The !php/const: tag to indicate dumped PHP constants is deprecated since version 3.4 and will be removed in 4.0. Use the !php/const (without the colon) tag instead.
+     */
+    public function testDeprecatedPhpConstantTagMappingKey()
+    {
+        $yaml = <<<YAML
+transitions:
     !php/const:Symfony\Component\Yaml\Tests\B::FOO:
         from:
             - !php/const:Symfony\Component\Yaml\Tests\B::BAR
@@ -1847,10 +1891,10 @@ YAML;
     {
         $yaml = <<<YAML
 transitions:
-    !php/const:Symfony\Component\Yaml\Tests\B::FOO:
+    !php/const 'Symfony\Component\Yaml\Tests\B::FOO':
         from:
-            - !php/const:Symfony\Component\Yaml\Tests\B::BAR
-        to: !php/const:Symfony\Component\Yaml\Tests\B::BAZ
+            - !php/const 'Symfony\Component\Yaml\Tests\B::BAR'
+        to: !php/const 'Symfony\Component\Yaml\Tests\B::BAZ'
 YAML;
         $expected = array(
             'transitions' => array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Using a colon in a tag doesn't look like yaml and causes trouble (see https://github.com/symfony/symfony/pull/22878), so I propose to just deprecate these tags in favor of more consistent tags.

```yml
- !php/const:PHP_INT_MAX
- !php/object:O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}
```
would become
```yml
- !php/const PHP_INT_MAX
- !php/object O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}
```