### PR TITLE
[EventDispatcher] Add Debug\WrappingListenerInterface

### DIFF
--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+  * added Debug\WrappingListenerInterface
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappingListenerInterface.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappingListenerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Debug;
+
+interface WrappingListenerInterface
+{
+    /**
+     * Returns wrapped listener.
+     *
+     * @return callable
+     */
+    public function getWrappedListener();
+}

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/WrappedListenerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\Debug\WrappedListener;
+use Symfony\Component\EventDispatcher\Debug\WrappingListenerInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class WrappedListenerTest extends TestCase
+{
+    /**
+     * @dataProvider getListeners
+     */
+    public function testGetPretty($listener, $pretty)
+    {
+        $wrappedListener = new WrappedListener($listener, 'name', $this->createStopwatchMock());
+
+        $this->assertSame($pretty, $wrappedListener->getPretty());
+    }
+
+    /**
+     * @dataProvider getListeners
+     */
+    public function testStub($listener, $pretty)
+    {
+        $wrappedListener = new WrappedListener($listener, 'name', $this->createStopwatchMock());
+
+        $info = $wrappedListener->getInfo('event');
+        $this->assertSame($pretty.'()', (string) $info['stub']);
+    }
+
+    public function getListeners()
+    {
+        return array(
+            array(array($this, 'getListeners'), __METHOD__),
+            array(function () {}, 'closure'),
+            array(/** @closure-proxy App\Foo::bar */ function () {}, 'App\Foo::bar'),
+            array('strtolower', 'strtolower'),
+            array(new Listener(), Listener::class.'::__invoke'),
+            array(new DecoratedListener(), 'listener'),
+            array(new WrappedListener(new DecoratedListener(), 'name', $this->createStopwatchMock()), 'listener'),
+        );
+    }
+
+    private function createStopwatchMock()
+    {
+        return $this->getMockBuilder(Stopwatch::class)->getMock();
+    }
+}
+
+class Listener
+{
+    public function __invoke()
+    {
+    }
+}
+
+class DecoratedListener implements WrappingListenerInterface
+{
+    public function getWrappedListener()
+    {
+        return 'listener';
+    }
+
+    public function __invoke()
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Main goal of this PR is to provide a debug tool, that correct identify wrapped hooks/events from legacy system (e.g. wordpress, ...).