### PR TITLE
[FrameworkBundle] Only override getProjectDir if it exists in the kernel

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -199,15 +199,27 @@ EOF
      */
     protected function getTempKernel(KernelInterface $parent, $namespace, $parentClass, $warmupDir)
     {
+        $projectDir = '';
         $cacheDir = var_export($warmupDir, true);
         $rootDir = var_export(realpath($parent->getRootDir()), true);
-        $projectDir = var_export(realpath($parent->getProjectDir()), true);
         $logDir = var_export(realpath($parent->getLogDir()), true);
         // the temp kernel class name must have the same length than the real one
         // to avoid the many problems in serialized resources files
         $class = substr($parentClass, 0, -1).'_';
         // the temp container class must be changed too
         $containerClass = var_export(substr(get_class($parent->getContainer()), 0, -1).'_', true);
+
+        if (method_exists($parent, 'getProjectDir')) {
+            $projectDir = var_export(realpath($parent->getProjectDir()), true);
+            $projectDir = <<<EOF
+        public function getProjectDir()
+        {
+            return $projectDir;
+        }
+        
+EOF;
+        };
+
         $code = <<<EOF
 <?php
 
@@ -225,11 +237,7 @@ namespace $namespace
             return $rootDir;
         }
 
-        public function getProjectDir()
-        {
-            return $projectDir;
-        }
-
+        $projectDir
         public function getLogDir()
         {
             return $logDir;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22872, #2289
| License       | MIT
| Doc PR        | -

As discussed with @nicolas-grekas, the `getProjectDir` method does not belong to `KernelInterface` so it can't just be called. I think we should also not add the method to the kernel if it does not exist in the parent, because we would not have a useful value to return.