### PR TITLE
[Filesystem] silence notice from tempnam on PHP7.1+

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1384,7 +1384,7 @@ class FilesystemTest extends FilesystemTestCase
         $scheme = 'file://';
         $dirname = $scheme.$this->workspace.DIRECTORY_SEPARATOR.'does_not_exist';
 
-        $filename = $this->filesystem->tempnam($dirname, 'bar');
+        $filename = @$this->filesystem->tempnam($dirname, 'bar');
         $realTempDir = realpath(sys_get_temp_dir());
         $this->assertStringStartsWith(rtrim($scheme.$realTempDir, DIRECTORY_SEPARATOR), $filename);
         $this->assertFileExists($filename);


### PR DESCRIPTION
PHP7.1 changed the behavior of tempnam() to report a notice when it
falls back to the system temp directory:
https://bugs.php.net/bug.php?id=69489. Silence the notice, as otherwise
a testcase failure occurs with PHP7.1+. This was seen while updating
Symfony on Ubuntu 17.04 (with PHP 7.1.5).

Signed-off-by: Nishanth Aravamudan <nish.aravamudan@canonical.com>

| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I am updating Symfony to match Debian (2.8.7) in Ubuntu 17.10. This mostly worked, with some additional backports, as we only support PHP7.1 in 17.10. However, it seems that PHP has changed tempnam() to emit a notice when it falls back, which leads to a testcase failure.