### PR TITLE
[Cache] Dont use pipelining with RedisCluster

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
@@ -303,6 +303,14 @@ class RedisAdapter extends AbstractAdapter
             foreach ($results as $k => list($h, $c)) {
                 $results[$k] = $connections[$h][$c];
             }
+        } elseif ($this->redis instanceof \RedisCluster) {
+            // phpredis doesn't support pipelining with RedisCluster
+            // see https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#pipelining
+            $result = array();
+            foreach ($generator() as $command => $args) {
+                $ids[] = $args[0];
+                $result[] = call_user_func_array(array($this->redis, $command), $args);
+            }
         } else {
             $this->redis->multi(\Redis::PIPELINE);
             foreach ($generator() as $command => $args) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.é
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22922
| License       | MIT
| Doc PR        | -

phpredis doesn't support pipelining with RedisCluster
see https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#pipelining
and multiple operations (MSET/MGET) work but only "per-shard".

We have to fetch keys one by one for now at least.