### PR TITLE
[PhpUnitBridge] Adjust PHPUnit class_alias check to also check for namespaced class

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 
-if (class_exists('PHPUnit_Framework_BaseTestListener')) {
+if (class_exists('PHPUnit_Framework_BaseTestListener') && !class_exists('PHPUnit\Framework\BaseTestListener')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListener', 'Symfony\Bridge\PhpUnit\SymfonyTestsListener');
 
     return;

--- a/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
@@ -13,7 +13,7 @@ namespace Symfony\Bridge\PhpUnit\TextUI;
 
 use PHPUnit\TextUI\Command as BaseCommand;
 
-if (class_exists('PHPUnit_TextUI_Command')) {
+if (class_exists('PHPUnit_TextUI_Command') && !class_exists('PHPUnit\TextUI\Command')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\Command', 'Symfony\Bridge\PhpUnit\TextUI\Command');
 
     return;

--- a/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\PhpUnit\TextUI;
 use PHPUnit\TextUI\TestRunner as BaseRunner;
 use Symfony\Bridge\PhpUnit\SymfonyTestsListener;
 
-if (class_exists('PHPUnit_TextUI_Command')) {
+if (class_exists('PHPUnit_TextUI_Command') && !class_exists('PHPUnit\TextUI\Command')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\TestRunner', 'Symfony\Bridge\PhpUnit\TextUI\TestRunner');
 
     return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Some projects, e.g. [Codeception](https://github.com/Codeception/Codeception/blob/2.3.2/shim.php#L47), also alias pre-PHPUnit namespaces leading to a collision and exceptions such as:

```
[PHPUnit\Framework\Exception (2)]
Cannot declare class Symfony\Bridge\PhpUnit\SymfonyTestsListener, because the name is 
already in use
```

This just add a check for the namespaced class, and exits if either aliased or exists.