### PR TITLE
[WebProfilerBundle] Fixed options stub values display in form profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -624,7 +624,10 @@
                     <th>{{ option }}</th>
                     <td>{{ profiler_dump(value) }}</td>
                     <td>
-                        {% if data.resolved_options[option] == value %}
+                        {# values can be stubs #}
+                        {% set option_value = value.value|default(value) %}
+                        {% set resolved_option_value = data.resolved_options[option].value|default(data.resolved_options[option]) %}
+                        {% if resolved_option_value == option_value %}
                             <em class="font-normal text-muted">same as passed value</em>
                         {% else %}
                             {{ profiler_dump(data.resolved_options[option]) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Since 3.3 and #21638, serializing form options gives either a `CutStub` instance or a simple var, ref https://github.com/symfony/symfony/commit/ab716c64de1fdfc74bb07653666733e3f9406b62#diff-78ea21636d0319e1c804ccc1a33f68f3R271.

This breaks the form profiler panel.
