### PR TITLE
Revert "bug #22925 [PhpUnitBridge] Adjust PHPUnit class_alias check

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 
-if (class_exists('PHPUnit_Framework_BaseTestListener') && !class_exists('PHPUnit\Framework\BaseTestListener')) {
+if (class_exists('PHPUnit_Framework_BaseTestListener')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListener', 'Symfony\Bridge\PhpUnit\SymfonyTestsListener');
 
     return;

--- a/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
@@ -13,7 +13,7 @@ namespace Symfony\Bridge\PhpUnit\TextUI;
 
 use PHPUnit\TextUI\Command as BaseCommand;
 
-if (class_exists('PHPUnit_TextUI_Command') && !class_exists('PHPUnit\TextUI\Command')) {
+if (class_exists('PHPUnit_TextUI_Command')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\Command', 'Symfony\Bridge\PhpUnit\TextUI\Command');
 
     return;

--- a/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\PhpUnit\TextUI;
 use PHPUnit\TextUI\TestRunner as BaseRunner;
 use Symfony\Bridge\PhpUnit\SymfonyTestsListener;
 
-if (class_exists('PHPUnit_TextUI_Command') && !class_exists('PHPUnit\TextUI\Command')) {
+if (class_exists('PHPUnit_TextUI_Command')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\TestRunner', 'Symfony\Bridge\PhpUnit\TextUI\TestRunner');
 
     return;


### PR DESCRIPTION
This reverts commit cfb090d1c5d60a881bc30d32f4953eb2683439c6, reversing
changes made to 4e8f403a7c4c2859fa5116cc68f31c55288a9ca7.

| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

PR #22925 made the bridge fail with:
> Fatal error: Declaration of Symfony\Bridge\PhpUnit\SymfonyTestsListener::addSkippedTest() must be compatible with that of PHPUnit_Framework_TestListener::addSkippedTest() in /home/travis/build/symfony/symfony/vendor/symfony/phpunit-bridge/SymfonyTestsListener.php on line 32

See https://travis-ci.org/symfony/symfony/builds/236863221 on 3.3
and https://travis-ci.org/symfony/symfony/builds/236863238 on 3.4
