### PR TITLE
[HttpFoundation] Add decoding of JSON requests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * added support of decoding JSON content type requests `application/json` in `Request::createFromGlobals`
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -329,7 +329,7 @@ class Request
             $data = array();
 
             // only JSON objects are allowed
-            if ('{' === $content[0]) {
+            if ($content && '{' === $content[0]) {
                 $result = json_decode($content, true);
                 if ($result) {
                     $data = $result;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

A nice feature to have which this PR delivers is ability to decode requests with JSON content, 
 there're already bundles that does that, but it'd be nice to have it handled immediatly by symfony. As anyone can easily notice JSON became one of the major data interchange formats that can be handled by most available platforms. This PR may have the most meaning in API based project's, where front side is usually done in javascript (plain or using some framework).

Example
--------

Request:
```html
<form onsubmit="return submitForm(this)">
    <input type="text" name="name" />
    <input type="text" name="address[street]" />
    <input type="submit" value="Send" />
</form>
<script>
    function submitForm(form) {
        var req = new XMLHttpRequest(),
            model;
        
        model = {
            name: form.children.name.value,
            address: {
                street: form.children['address[street]'].value
            }
        };
    
        req.open('POST', '/api/users', true);
        req.setRequestHeader("Content-type", "application/json");
        req.send(JSON.stringify(model));
        
        return false;
    }
</script>
```

Situation in the front controller (let's suppose we're using the standard symfony edition):

```php
$request = Request::createFromGlobals();
print_r($request->request->all());
```

Will output:
```
Array
(
    [name] => foo
    [address] => Array
        (
            [street] => bar
        )
)
```

Of course the example above could be even much easier using some framework (e.g. Angular2 which does that more naturally).