### PR TITLE
Release v2.8.21

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,21 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.21 (2017-05-29)
+
+ * bug #22847 [Console] ChoiceQuestion must have choices (ro0NL)
+ * bug #22900 [FrameworkBundle][Console] Fix the override of a command registered by the kernel (aaa2000)
+ * bug #22910 [Filesystem] improve error handling in lock() (xabbuh)
+ * bug #22718 [Console] Fixed different behaviour of key and value user inputs in multiple choice question (borNfreee)
+ * bug #22901 Fix missing abstract key in XmlDumper (weaverryan)
+ * bug #22817 [PhpUnitBridge] optional error handler arguments (xabbuh)
+ * bug #22752 Improved how profiler errors are displayed on small screens (javiereguiluz)
+ * bug #22647 [VarDumper] Fix dumping of non-nested stubs (nicolas-grekas)
+ * bug #22584 [Security] Avoid unnecessary route lookup for empty logout path (ro0NL)
+ * bug #22690 [Console] Fix errors not rethrown even if not handled by console.error listeners (chalasr)
+ * bug #22669 [FrameworkBundle] AbstractConfigCommand: do not try registering bundles twice (ogizanagi)
+ * bug #22676 [FrameworkBundle] Adding the extension XML (flug)
+
 * 2.8.20 (2017-05-01)
 
  * bug #22550 Allow Upper Case property names in ObjectNormalizer (insekticid)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.21-DEV';
+    const VERSION = '2.8.21';
     const VERSION_ID = 20821;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
     const RELEASE_VERSION = 21;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';
     const END_OF_LIFE = '11/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.8.20...v2.8.21)

 * bug #22847 [Console] ChoiceQuestion must have choices (@ro0NL)
 * bug #22900 [FrameworkBundle][Console] Fix the override of a command registered by the kernel (@aaa2000)
 * bug #22910 [Filesystem] improve error handling in lock() (@xabbuh)
 * bug #22718 [Console] Fixed different behaviour of key and value user inputs in multiple choice question (@borNfreee)
 * bug #22901 Fix missing abstract key in XmlDumper (@weaverryan)
 * bug #22817 [PhpUnitBridge] optional error handler arguments (@xabbuh)
 * bug #22752 Improved how profiler errors are displayed on small screens (@javiereguiluz)
 * bug #22647 [VarDumper] Fix dumping of non-nested stubs (@nicolas-grekas)
 * bug #22584 [Security] Avoid unnecessary route lookup for empty logout path (@ro0NL)
 * bug #22690 [Console] Fix errors not rethrown even if not handled by console.error listeners (@chalasr)
 * bug #22669 [FrameworkBundle] AbstractConfigCommand: do not try registering bundles twice (@ogizanagi)
 * bug #22676 [FrameworkBundle] Adding the extension XML (@flug)
