### PR TITLE
#22839 - changed debug toolbar dump section to relative and use full window width

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -350,6 +350,15 @@
     100% { background: #222; }
 }
 
+.sf-toolbar-block.sf-toolbar-block-dump {
+    position: static;
+}
+
+.sf-toolbar-block.sf-toolbar-block-dump .sf-toolbar-info {
+    max-width: none;
+    right: 0;
+}
+
 .sf-toolbar-block-dump pre.sf-dump {
     background-color: #222;
     border-color: #777;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22839 
| License       | MIT

My approach to fix #22839 - instead of adding min-width I have switched the section to fill the full available width:
![zrzut ekranu 2017-05-30 o 10 18 25](https://cloud.githubusercontent.com/assets/1044032/26574462/bf80b6dc-4521-11e7-96cc-bec0de075329.png)

