### PR TITLE
[HttpKernel] Support unknown format in LoggerDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -138,6 +138,9 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         $logs = array();
         foreach (file($file, FILE_IGNORE_NEW_LINES) as $log) {
             $log = explode(': ', $log, 2);
+            if (!isset($log[1]) || !preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $log[0])) {
+                $log = array('Unknown Compiler Pass', implode(': ', $log));
+            }
 
             $logs[$log[0]][] = array('message' => $log[1]);
         }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/Compiler.log
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/Compiler.log
@@ -1,0 +1,4 @@
+Symfony\Component\DependencyInjection\Compiler\RemovePrivateAliasesPass: Removed service "Psr\Container\ContainerInterface"; reason: private alias.
+Symfony\Component\DependencyInjection\Compiler\RemovePrivateAliasesPass: Removed service "Symfony\Component\DependencyInjection\ContainerInterface"; reason: private alias.
+Some custom logging message
+With ending :


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22952
| License       | MIT
| Doc PR        | ~

The new expected format for the compiler log is `CompilerPassClass: Message`. However, this is not enforced by the old logging method as seen in schmittjoh/JMSDiExtraBundle#276

This PR adds the ability to read those lines without crashing with `Uncaught Notice: Undefined offset: 1`.

Please note that I have not tested this in an application so testers are welcome to confirm this fix!