### PR TITLE
[Cache] Ignore missing annotations.php

### DIFF
--- a/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
@@ -126,6 +126,6 @@ EOF;
      */
     private function initialize()
     {
-        $this->values = @(include $this->file) ?: array();
+        $this->values = is_file($this->file) ? @(include $this->file) : array();
     }
 }

--- a/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
@@ -126,6 +126,6 @@ EOF;
      */
     private function initialize()
     {
-        $this->values = is_file($this->file) ? @(include $this->file) : array();
+        $this->values = false !== stream_resolve_include_path($this->file) ? @(include $this->file) : array();
     }
 }

--- a/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
@@ -126,6 +126,6 @@ EOF;
      */
     private function initialize()
     {
-        $this->values = false !== stream_resolve_include_path($this->file) ? @(include $this->file) : array();
+        $this->values = file_exists($this->file) ? (include $this->file ?: array()) : array();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes (different in 3.2)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Avoids the following notices if cache is not warmed up (i.e. `cache:clear --no-warmup` > hit the browser).

```
Warning: include(<base-path>/app/cache/<env>/annotations.php): failed to open stream: No such file or directory

Warning: include(): Failed opening '<base-path>/app/cache/<env>/annotations.php' for inclusion (include_path='.:/usr/share/pear:/usr/share/php')
```