### PR TITLE
[DependencyInjection] Use more clear message when unused environment variables detected

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
@@ -134,7 +134,7 @@ class Compiler
             } while ($prev = $prev->getPrevious());
 
             if ($usedEnvs) {
-                $e = new EnvParameterException($usedEnvs, 'Incompatible use of dynamic environment variables "%s" found in parameters.', $e);
+                $e = new EnvParameterException($usedEnvs, $e);
             }
 
             throw $e;

--- a/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
@@ -134,7 +134,7 @@ class Compiler
             } while ($prev = $prev->getPrevious());
 
             if ($usedEnvs) {
-                $e = new EnvParameterException($usedEnvs, $e);
+                $e = new EnvParameterException($usedEnvs, 'Incompatible use of dynamic environment variables "%s" found in parameters.', $e);
             }
 
             throw $e;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -166,7 +166,7 @@ class PhpDumper extends Dumper
             }
         }
         if ($unusedEnvs) {
-            throw new EnvParameterException($unusedEnvs);
+            throw new EnvParameterException($unusedEnvs, 'Environment variables "%s" are never used. Please, check your container\'s configuration.');
         }
 
         return $code;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -166,7 +166,7 @@ class PhpDumper extends Dumper
             }
         }
         if ($unusedEnvs) {
-            throw new EnvParameterException($unusedEnvs, 'Environment variables "%s" are never used. Please, check your container\'s configuration.');
+            throw new EnvParameterException($unusedEnvs, null, 'Environment variables "%s" are never used. Please, check your container\'s configuration.');
         }
 
         return $code;

--- a/src/Symfony/Component/DependencyInjection/Exception/EnvParameterException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/EnvParameterException.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\DependencyInjection\Exception;
  */
 class EnvParameterException extends InvalidArgumentException
 {
-    public function __construct(array $envs, $message, \Exception $previous = null)
+    public function __construct(array $envs, \Exception $previous = null, $message = 'Incompatible use of dynamic environment variables "%s" found in parameters.')
     {
         parent::__construct(sprintf($message, implode('", "', $envs)), 0, $previous);
     }

--- a/src/Symfony/Component/DependencyInjection/Exception/EnvParameterException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/EnvParameterException.php
@@ -18,8 +18,8 @@ namespace Symfony\Component\DependencyInjection\Exception;
  */
 class EnvParameterException extends InvalidArgumentException
 {
-    public function __construct(array $usedEnvs, \Exception $previous = null)
+    public function __construct(array $envs, $message, \Exception $previous = null)
     {
-        parent::__construct(sprintf('Incompatible use of dynamic environment variables "%s" found in parameters.', implode('", "', $usedEnvs)), 0, $previous);
+        parent::__construct(sprintf($message, implode('", "', $envs)), 0, $previous);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -302,7 +302,7 @@ class PhpDumperTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvParameterException
-     * @expectedExceptionMessage Incompatible use of dynamic environment variables "FOO" found in parameters.
+     * @expectedExceptionMessage Environment variables "FOO" are never used. Please, check your container's configuration.
      */
     public function testUnusedEnvParameter()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |3.2
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22955
| License       | MIT

Old error message:
```
Incompatible use of dynamic environment variables "DATABASE_URL", "MAILER_URL" found in parameters.
```

New error message: 
```
Environment variables "DATABASE_URL", "MAILER_URL" are never used. Please, check your container's configuration.
```