### PR TITLE
[Config] Allow empty globs

### DIFF
--- a/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 
@@ -73,6 +74,21 @@ class FileLoaderTest extends TestCase
         $loader = new TestFileLoader($locatorMock);
 
         $this->assertSame('[foo]', $loader->import('[foo]'));
+    }
+
+    public function testImportWithNoGlobMatch()
+    {
+        $locatorMock = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
+        $loader = new TestFileLoader($locatorMock);
+
+        $this->assertNull($loader->import('./*.abc'));
+    }
+
+    public function testImportWithSimpleGlob()
+    {
+        $loader = new TestFileLoader(new FileLocator(__DIR__));
+
+        $this->assertSame(__FILE__, strtr($loader->import('FileLoaderTest.*'), '/', DIRECTORY_SEPARATOR));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22950
| License       | MIT
| Doc PR        | -

This considers globs as valid even if they return no matches when they have a prefix (and when that prefix exists, according to `$ignoreErrors`).
This means there is an edge-case:
`*.abc` with at least one match is OK, but when it has no match, it falls back to regular import, then usually will fil.
But rewriting this to `./*.abc` resolves the ambiguity and turns this into a glob that won't fail if no matches are found.

This should provide the expected behavior in most cases (but ambiguous described one of course).