### PR TITLE
[PropertyInfo][DoctrineBridge] The bigint Doctrine's type must be converted to string

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -174,13 +174,13 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
     {
         switch ($doctrineType) {
             case DBALType::SMALLINT:
-            case DBALType::BIGINT:
             case DBALType::INTEGER:
                 return Type::BUILTIN_TYPE_INT;
 
             case DBALType::FLOAT:
                 return Type::BUILTIN_TYPE_FLOAT;
 
+            case DBALType::BIGINT:
             case DBALType::STRING:
             case DBALType::TEXT:
             case DBALType::GUID:
@@ -196,9 +196,6 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
 
             case DBALType::OBJECT:
                 return Type::BUILTIN_TYPE_OBJECT;
-
-            default:
-                return;
         }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -55,6 +55,7 @@ class DoctrineExtractorTest extends TestCase
                 'bool',
                 'binary',
                 'customFoo',
+                'bigint',
                 'foo',
                 'bar',
                 'indexedBar',
@@ -76,6 +77,7 @@ class DoctrineExtractorTest extends TestCase
         return array(
             array('id', array(new Type(Type::BUILTIN_TYPE_INT))),
             array('guid', array(new Type(Type::BUILTIN_TYPE_STRING))),
+            array('bigint', array(new Type(Type::BUILTIN_TYPE_STRING))),
             array('float', array(new Type(Type::BUILTIN_TYPE_FLOAT))),
             array('decimal', array(new Type(Type::BUILTIN_TYPE_STRING))),
             array('bool', array(new Type(Type::BUILTIN_TYPE_BOOL))),

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures;
 
+use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
@@ -89,6 +90,11 @@ class DoctrineDummy
      * @Column(type="custom_foo")
      */
     private $customFoo;
+
+    /**
+     * @Column(type="bigint")
+     */
+    private $bigint;
 
     public $notMapped;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

According to the Doctrine's docs, the `bigint` type is converted to a `string`: http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#bigint

/cc @clementtalleu