### PR TITLE
[Cache] Remove extra arg in call to TraceableAdapter::start()

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -107,7 +107,7 @@ class TraceableAdapter implements AdapterInterface
      */
     public function getItems(array $keys = array())
     {
-        $event = $this->start(__FUNCTION__, $keys);
+        $event = $this->start(__FUNCTION__);
         try {
             $result = $this->pool->getItems($keys);
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Leftover from previous implementation