### PR TITLE
[DI] Autowiring exception thrown when inlined service is removed

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireExceptionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireExceptionPass.php
@@ -36,7 +36,7 @@ class AutowireExceptionPass implements CompilerPassInterface
             return;
         }
 
-        $inlinedIds = $this->inlineServicePass->getInlinedServiceIds();
+        $inlinedIds = $this->inlineServicePass->getInlinedServiceIdData();
         $exceptions = $this->autowirePass->getAutowiringExceptions();
 
         // free up references
@@ -44,9 +44,23 @@ class AutowireExceptionPass implements CompilerPassInterface
         $this->inlineServicePass = null;
 
         foreach ($exceptions as $exception) {
-            if ($container->hasDefinition($exception->getServiceId()) || in_array($exception->getServiceId(), $inlinedIds)) {
+            if ($this->doesServiceExistInTheContainer($exception->getServiceId(), $container, $inlinedIds)) {
                 throw $exception;
             }
         }
+    }
+
+    private function doesServiceExistInTheContainer($serviceId, ContainerBuilder $container, array $inlinedIds)
+    {
+        if ($container->hasDefinition($serviceId)) {
+            return true;
+        }
+
+        // was the service inlined? Of so, does its parent service exist?
+        if (isset($inlinedIds[$serviceId])) {
+            return $this->doesServiceExistInTheContainer($inlinedIds[$serviceId], $container, $inlinedIds);
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireExceptionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireExceptionPass.php
@@ -36,7 +36,7 @@ class AutowireExceptionPass implements CompilerPassInterface
             return;
         }
 
-        $inlinedIds = $this->inlineServicePass->getInlinedServiceIdData();
+        $inlinedIds = $this->inlineServicePass->getInlinedServiceIds();
         $exceptions = $this->autowirePass->getAutowiringExceptions();
 
         // free up references

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -36,20 +36,6 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
     /**
      * Returns an array of all services inlined by this pass.
      *
-     * @return array Service id strings
-     *
-     * @deprecated This method is deprecated as of 3.3 and will be removed in 4.0. Use getInlinedServiceIdData() instead.
-     */
-    public function getInlinedServiceIds()
-    {
-        @trigger_error(sprintf('%s is deprecated as of 3.3 and will be removed in 4.0. Use getInlinedServiceIdData() instead.', __METHOD__), E_USER_DEPRECATED);
-
-        return array_keys($this->inlinedServiceIds);
-    }
-
-    /**
-     * Returns an array of all services inlined by this pass.
-     *
      * The key is the inlined service id and its value is the service it was inlined into.
      *
      * @return array

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -40,7 +40,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
      *
      * @return array
      */
-    public function getInlinedServiceIdData()
+    public function getInlinedServiceIds()
     {
         return $this->inlinedServiceIds;
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -37,8 +37,24 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
      * Returns an array of all services inlined by this pass.
      *
      * @return array Service id strings
+     *
+     * @deprecated This method is deprecated as of 3.3 and will be removed in 4.0. Use getInlinedServiceIdData() instead.
      */
     public function getInlinedServiceIds()
+    {
+        @trigger_error(sprintf('%s is deprecated as of 3.3 and will be removed in 4.0. Use getInlinedServiceIdData() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return array_keys($this->inlinedServiceIds);
+    }
+
+    /**
+     * Returns an array of all services inlined by this pass.
+     *
+     * The key is the inlined service id and its value is the service it was inlined into.
+     *
+     * @return array
+     */
+    public function getInlinedServiceIdData()
     {
         return $this->inlinedServiceIds;
     }
@@ -57,7 +73,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
 
             if ($this->isInlineableDefinition($id, $definition, $this->container->getCompiler()->getServiceReferenceGraph())) {
                 $this->container->log($this, sprintf('Inlined service "%s" to "%s".', $id, $this->currentId));
-                $this->inlinedServiceIds[] = $id;
+                $this->inlinedServiceIds[$id] = $this->currentId;
 
                 if ($definition->isShared()) {
                     return $definition;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
@@ -33,7 +33,7 @@ class AutowireExceptionPassTest extends TestCase
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
-            ->method('getInlinedServiceIds')
+            ->method('getInlinedServiceIdData')
             ->will($this->returnValue(array()));
 
         $container = new ContainerBuilder();
@@ -54,7 +54,7 @@ class AutowireExceptionPassTest extends TestCase
         $autowirePass = $this->getMockBuilder(AutowirePass::class)
             ->getMock();
 
-        $autowireException = new AutowiringFailedException('foo_service_id', 'An autowiring exception message');
+        $autowireException = new AutowiringFailedException('a_service', 'An autowiring exception message');
         $autowirePass->expects($this->any())
             ->method('getAutowiringExceptions')
             ->will($this->returnValue(array($autowireException)));
@@ -62,11 +62,17 @@ class AutowireExceptionPassTest extends TestCase
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
-            ->method('getInlinedServiceIds')
-            ->will($this->returnValue(array('foo_service_id')));
+            ->method('getInlinedServiceIdData')
+            ->will($this->returnValue(array(
+                // a_service inlined into b_service
+                'a_service' => 'b_service',
+                // b_service inlined into c_service
+                'b_service' => 'c_service',
+            )));
 
-        // don't register the foo_service_id service
         $container = new ContainerBuilder();
+        // ONLY register c_service in the final container
+        $container->register('c_service', 'stdClass');
 
         $pass = new AutowireExceptionPass($autowirePass, $inlinePass);
 
@@ -76,6 +82,37 @@ class AutowireExceptionPassTest extends TestCase
         } catch (\Exception $e) {
             $this->assertSame($autowireException, $e);
         }
+    }
+
+    public function testDoNotThrowExceptionIfServiceInlinedButRemoved()
+    {
+        $autowirePass = $this->getMockBuilder(AutowirePass::class)
+            ->getMock();
+
+        $autowireException = new AutowiringFailedException('a_service', 'An autowiring exception message');
+        $autowirePass->expects($this->any())
+            ->method('getAutowiringExceptions')
+            ->will($this->returnValue(array($autowireException)));
+
+        $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
+            ->getMock();
+        $inlinePass->expects($this->any())
+            ->method('getInlinedServiceIdData')
+            ->will($this->returnValue(array(
+                // a_service inlined into b_service
+                'a_service' => 'b_service',
+                // b_service inlined into c_service
+                'b_service' => 'c_service',
+            )));
+
+        // do NOT register c_service in the container
+        $container = new ContainerBuilder();
+
+        $pass = new AutowireExceptionPass($autowirePass, $inlinePass);
+
+        $pass->process($container);
+        // mark the test as passed
+        $this->assertTrue(true);
     }
 
     public function testNoExceptionIfServiceRemoved()
@@ -91,7 +128,7 @@ class AutowireExceptionPassTest extends TestCase
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
-            ->method('getInlinedServiceIds')
+            ->method('getInlinedServiceIdData')
             ->will($this->returnValue(array()));
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireExceptionPassTest.php
@@ -33,7 +33,7 @@ class AutowireExceptionPassTest extends TestCase
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
-            ->method('getInlinedServiceIdData')
+            ->method('getInlinedServiceIds')
             ->will($this->returnValue(array()));
 
         $container = new ContainerBuilder();
@@ -62,7 +62,7 @@ class AutowireExceptionPassTest extends TestCase
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
-            ->method('getInlinedServiceIdData')
+            ->method('getInlinedServiceIds')
             ->will($this->returnValue(array(
                 // a_service inlined into b_service
                 'a_service' => 'b_service',
@@ -97,7 +97,7 @@ class AutowireExceptionPassTest extends TestCase
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
-            ->method('getInlinedServiceIdData')
+            ->method('getInlinedServiceIds')
             ->will($this->returnValue(array(
                 // a_service inlined into b_service
                 'a_service' => 'b_service',
@@ -128,7 +128,7 @@ class AutowireExceptionPassTest extends TestCase
         $inlinePass = $this->getMockBuilder(InlineServiceDefinitionsPass::class)
             ->getMock();
         $inlinePass->expects($this->any())
-            ->method('getInlinedServiceIdData')
+            ->method('getInlinedServiceIds')
             ->will($this->returnValue(array()));
 
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -252,7 +252,7 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $this->assertSame('inline', (string) $values[0]);
     }
 
-    public function testGetInlinedServiceIds()
+    public function testGetInlinedServiceIdData()
     {
         $container = new ContainerBuilder();
         $container
@@ -265,7 +265,7 @@ class InlineServiceDefinitionsPassTest extends TestCase
         ;
 
         $container
-            ->register('service')
+            ->register('other_service')
             ->setArguments(array(new Reference('inlinable.service')))
         ;
 
@@ -273,7 +273,7 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $repeatedPass = new RepeatedPass(array(new AnalyzeServiceReferencesPass(), $inlinePass));
         $repeatedPass->process($container);
 
-        $this->assertEquals(array('inlinable.service'), $inlinePass->getInlinedServiceIds());
+        $this->assertEquals(array('inlinable.service' => 'other_service'), $inlinePass->getInlinedServiceIdData());
     }
 
     protected function process(ContainerBuilder $container)

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -273,7 +273,7 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $repeatedPass = new RepeatedPass(array(new AnalyzeServiceReferencesPass(), $inlinePass));
         $repeatedPass->process($container);
 
-        $this->assertEquals(array('inlinable.service' => 'other_service'), $inlinePass->getInlinedServiceIdData());
+        $this->assertEquals(array('inlinable.service' => 'other_service'), $inlinePass->getInlinedServiceIds());
     }
 
     protected function process(ContainerBuilder $container)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes (on a new & internal method)
| Tests pass?   | yes
| Fixed tickets | #22977
| License       | MIT
| Doc PR        | n/a

We suppress autowiring exceptions if a service is ultimately removed from the container. This fixes a bug where we incorrectly report that a service was NOT removed, when really, it WAS removed. This happens when `ServiceA` is inlined in `ServiceB`... but then `ServiceB` is removed from the container for being unused.