### PR TITLE
Harden the debugging of Twig filters and functions

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -159,14 +159,20 @@ EOF
                 throw new \UnexpectedValueException('Unsupported callback type');
             }
 
-            // filter out context/environment args
-            $args = array_filter($refl->getParameters(), function ($param) use ($entity) {
-                if ($entity->needsContext() && $param->getName() === 'context') {
-                    return false;
-                }
+            $args = $refl->getParameters();
 
-                return !$param->getClass() || $param->getClass()->getName() !== 'Twig_Environment';
-            });
+            // filter out context/environment args
+            if ($entity->needsEnvironment()) {
+                array_shift($args);
+            }
+            if ($entity->needsContext()) {
+                array_shift($args);
+            }
+
+            if ($type === 'filters') {
+                // remove the value the filter is applied on
+                array_shift($args);
+            }
 
             // format args
             $args = array_map(function ($param) {
@@ -176,11 +182,6 @@ EOF
 
                 return $param->getName();
             }, $args);
-
-            if ($type === 'filters') {
-                // remove the value the filter is applied on
-                array_shift($args);
-            }
 
             return $args;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Removing the environment and context arguments is now based on Twig metadata rather than on some wild guessing which might go wrong:

- the environment argument may not be typehinted
- the context argument may not be named `$context`
- an argument may be named `$context` without being the special context argument
