### PR TITLE
add \ before PHP_VERSION_ID fixes #22650

### DIFF
--- a/.github/build-packages.php
+++ b/.github/build-packages.php
@@ -11,7 +11,7 @@ array_shift($dirs);
 $mergeBase = trim(shell_exec(sprintf('git merge-base %s HEAD', array_shift($dirs))));
 
 $packages = array();
-$flags = PHP_VERSION_ID >= 50400 ? JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE : 0;
+$flags = \PHP_VERSION_ID >= 50400 ? JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE : 0;
 
 foreach ($dirs as $k => $dir) {
     if (!system("git diff --name-only $mergeBase -- $dir", $exitStatus)) {

--- a/phpunit
+++ b/phpunit
@@ -7,7 +7,7 @@ if (!file_exists(__DIR__.'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
     echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\nPlease run `composer update` before running this command.\n";
     exit(1);
 }
-if (PHP_VERSION_ID >= 70000 && !getenv('SYMFONY_PHPUNIT_VERSION')) {
+if (\PHP_VERSION_ID >= 70000 && !getenv('SYMFONY_PHPUNIT_VERSION')) {
     putenv('SYMFONY_PHPUNIT_VERSION=6.0');
 }
 putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -16,7 +16,7 @@
 error_reporting(-1);
 
 // PHPUnit 4.8 does not support PHP 7, while 5.1 requires PHP 5.6+
-$PHPUNIT_VERSION = PHP_VERSION_ID >= 50600 ? getenv('SYMFONY_PHPUNIT_VERSION') ?: '5.7' : '4.8';
+$PHPUNIT_VERSION = \PHP_VERSION_ID >= 50600 ? getenv('SYMFONY_PHPUNIT_VERSION') ?: '5.7' : '4.8';
 $oldPwd = getcwd();
 $PHPUNIT_DIR = getenv('SYMFONY_PHPUNIT_DIR') ?: (__DIR__.'/.phpunit');
 $PHP = defined('PHP_BINARY') ? PHP_BINARY : 'php';

--- a/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
+++ b/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
@@ -93,7 +93,7 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
     public function getProfile()
     {
         if (null === $this->profile) {
-            if (PHP_VERSION_ID >= 70000) {
+            if (\PHP_VERSION_ID >= 70000) {
                 $this->profile = unserialize($this->data['profile'], array('allowed_classes' => array('Twig_Profiler_Profile')));
             } else {
                 $this->profile = unserialize($this->data['profile']);

--- a/src/Symfony/Bridge/Twig/Tests/Node/DumpNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/DumpNodeTest.php
@@ -82,7 +82,7 @@ if ($this->env->isDebug()) {
 
 EOTXT;
 
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             $expected = preg_replace('/%(.*?)%/', '($context["$1"] ?? null)', $expected);
         } else {
             $expected = preg_replace('/%(.*?)%/', '(isset($context["$1"]) ? $context["$1"] : null)', $expected);
@@ -113,7 +113,7 @@ if ($this->env->isDebug()) {
 
 EOTXT;
 
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             $expected = preg_replace('/%(.*?)%/', '($context["$1"] ?? null)', $expected);
         } else {
             $expected = preg_replace('/%(.*?)%/', '(isset($context["$1"]) ? $context["$1"] : null)', $expected);

--- a/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php
@@ -67,7 +67,7 @@ class FormThemeTest extends TestCase
 
     protected function getVariableGetter($name)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             return sprintf('($context["%s"] ?? null)', $name, $name);
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -264,7 +264,7 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
     protected function getVariableGetter($name)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             return sprintf('($context["%s"] ?? null)', $name, $name);
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
@@ -40,7 +40,7 @@ class TransNodeTest extends TestCase
 
     protected function getVariableGetterWithoutStrictCheck($name)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             return sprintf('($context["%s"] ?? null)', $name, $name);
         }
 
@@ -53,7 +53,7 @@ class TransNodeTest extends TestCase
             return sprintf('(isset($context["%s"]) || array_key_exists("%s", $context) ? $context["%s"] : (function () { throw new Twig_Error_Runtime(\'Variable "%s" does not exist.\', 0, $this->getSourceContext()); })())', $name, $name, $name, $name);
         }
 
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             return sprintf('($context["%s"] ?? $this->getContext($context, "%s"))', $name, $name, $name);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
@@ -27,7 +27,7 @@ class ClassCacheCacheWarmer implements CacheWarmerInterface
 
     public function __construct(array $declaredClasses = null)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             @trigger_error('The '.__CLASS__.' class is deprecated since version 3.3 and will be removed in 4.0.', E_USER_DEPRECATED);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -105,7 +105,7 @@ class FrameworkExtension extends Extension
             $definition->setArguments(array());
         }
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             $definition = $container->getDefinition('kernel.class_cache.cache_warmer');
             $definition->addTag('kernel.cache_warmer');
             // Ignore deprecation for PHP versions below 7.0
@@ -298,7 +298,7 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(ObjectInitializerInterface::class)
             ->addTag('validator.initializer');
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(
                 'Symfony\\Component\\Config\\ConfigCache',
                 'Symfony\\Component\\Config\\FileLocator',
@@ -683,7 +683,7 @@ class FrameworkExtension extends Extension
         $container->setParameter('request_listener.http_port', $config['http_port']);
         $container->setParameter('request_listener.https_port', $config['https_port']);
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(
                 'Symfony\\Component\\Routing\\Generator\\UrlGenerator',
                 'Symfony\\Component\\Routing\\RequestContext',
@@ -734,7 +734,7 @@ class FrameworkExtension extends Extension
 
         $container->setParameter('session.save_path', $config['save_path']);
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(
                 'Symfony\\Component\\HttpKernel\\EventListener\\SessionListener',
                 'Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage',
@@ -819,7 +819,7 @@ class FrameworkExtension extends Extension
             $container->setDefinition('templating.loader', $loaderCache);
         }
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(
                 'Symfony\\Bundle\\FrameworkBundle\\Templating\\GlobalVariables',
                 'Symfony\\Bundle\\FrameworkBundle\\Templating\\TemplateReference',
@@ -859,7 +859,7 @@ class FrameworkExtension extends Extension
                 $container->setAlias('debug.templating.engine.php', 'templating.engine.php');
             }
 
-            if (PHP_VERSION_ID < 70000) {
+            if (\PHP_VERSION_ID < 70000) {
                 $this->addClassesToCompile(array(
                     'Symfony\\Component\\Templating\\Storage\\FileStorage',
                     'Symfony\\Bundle\\FrameworkBundle\\Templating\\PhpEngine',
@@ -1200,7 +1200,7 @@ class FrameworkExtension extends Extension
                 $definition = $container->findDefinition('annotations.cache_warmer');
                 $definition->addTag('kernel.cache_warmer');
 
-                if (PHP_VERSION_ID < 70000) {
+                if (\PHP_VERSION_ID < 70000) {
                     $this->addClassesToCompile(array(
                         'Symfony\Component\Cache\Adapter\PhpArrayAdapter',
                         'Symfony\Component\Cache\DoctrineProvider',
@@ -1457,7 +1457,7 @@ class FrameworkExtension extends Extension
             }
         }
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(
                 'Symfony\Component\Cache\Adapter\ApcuAdapter',
                 'Symfony\Component\Cache\Adapter\FilesystemAdapter',

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
@@ -85,7 +85,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
         foreach ($files as $file) {
             $this->parseTokens(token_get_all(file_get_contents($file)), $catalog);
 
-            if (PHP_VERSION_ID >= 70000) {
+            if (\PHP_VERSION_ID >= 70000) {
                 // PHP 7 memory manager will not release after token_get_all(), see https://bugs.php.net/70098
                 gc_mem_caches();
             }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -113,7 +113,7 @@ class SecurityExtension extends Extension
         $container->registerForAutoconfiguration(VoterInterface::class)
             ->addTag('security.voter');
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             // add some required classes for compilation
             $this->addClassesToCompile(array(
                 'Symfony\Component\Security\Http\Firewall',
@@ -204,7 +204,7 @@ class SecurityExtension extends Extension
             return;
         }
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(
                 'Symfony\\Component\\Security\\Http\\AccessMap',
             ));

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -149,7 +149,7 @@ class TwigExtension extends Extension
         $container->registerForAutoconfiguration(\Twig_LoaderInterface::class)
             ->addTag('twig.loader');
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(
                 'Twig_Environment',
                 'Twig_Extension',

--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -65,7 +65,7 @@ class PhpArrayAdapter implements AdapterInterface
     public static function create($file, CacheItemPoolInterface $fallbackPool)
     {
         // Shared memory is available in PHP 7.0+ with OPCache enabled and in HHVM
-        if ((PHP_VERSION_ID >= 70000 && ini_get('opcache.enable')) || defined('HHVM_VERSION')) {
+        if ((\PHP_VERSION_ID >= 70000 && ini_get('opcache.enable')) || defined('HHVM_VERSION')) {
             if (!$fallbackPool instanceof AdapterInterface) {
                 $fallbackPool = new ProxyAdapter($fallbackPool);
             }

--- a/src/Symfony/Component/Cache/Simple/PhpArrayCache.php
+++ b/src/Symfony/Component/Cache/Simple/PhpArrayCache.php
@@ -48,7 +48,7 @@ class PhpArrayCache implements CacheInterface
     public static function create($file, CacheInterface $fallbackPool)
     {
         // Shared memory is available in PHP 7.0+ with OPCache enabled and in HHVM
-        if ((PHP_VERSION_ID >= 70000 && ini_get('opcache.enable')) || defined('HHVM_VERSION')) {
+        if ((\PHP_VERSION_ID >= 70000 && ini_get('opcache.enable')) || defined('HHVM_VERSION')) {
             return new static($file, $fallbackPool);
         }
 

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\ClassLoader;
 
-if (PHP_VERSION_ID >= 70000) {
+if (\PHP_VERSION_ID >= 70000) {
     @trigger_error('The '.__NAMESPACE__.'\ClassCollectionLoader class is deprecated since version 3.3 and will be removed in 4.0.', E_USER_DEPRECATED);
 }
 
@@ -262,7 +262,7 @@ REGEX;
 
         $output .= self::compressCode($rawChunk);
 
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             // PHP 7 memory manager will not release after token_get_all(), see https://bugs.php.net/70098
             unset($tokens, $rawChunk);
             gc_mem_caches();

--- a/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
+++ b/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
@@ -68,7 +68,7 @@ class ClassMapGenerator
 
             $classes = self::findClasses($path);
 
-            if (PHP_VERSION_ID >= 70000) {
+            if (\PHP_VERSION_ID >= 70000) {
                 // PHP 7 memory manager will not release after token_get_all(), see https://bugs.php.net/70098
                 gc_mem_caches();
             }

--- a/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
@@ -124,10 +124,10 @@ EOPHP;
         yield array(0, 8, '/** priv docblock */');
         yield array(0, 9, 'private $priv = 123;');
         yield array(1, 10, '/** pub docblock */');
-        if (PHP_VERSION_ID >= 50600) {
+        if (\PHP_VERSION_ID >= 50600) {
             yield array(1, 11, 'public function pub(...$arg) {}');
         }
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             yield array(1, 11, 'public function pub($arg = null): Foo {}');
         }
         yield array(0, 11, "public function pub(\$arg = null) {\nreturn 123;\n}");

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -286,7 +286,7 @@ class Command
         if ($code instanceof \Closure) {
             $r = new \ReflectionFunction($code);
             if (null === $r->getClosureThis()) {
-                if (PHP_VERSION_ID < 70000) {
+                if (\PHP_VERSION_ID < 70000) {
                     // Bug in PHP5: https://bugs.php.net/bug.php?id=64761
                     // This means that we cannot bind static closures and therefore we must
                     // ignore any errors here.  There is no way to test if the closure is

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -150,7 +150,7 @@ class ArgvInput extends Input
             if (0 === strlen($value = substr($name, $pos + 1))) {
                 // if no value after "=" then substr() returns "" since php7 only, false before
                 // see http://php.net/manual/fr/migration70.incompatible.php#119151
-                if (PHP_VERSION_ID < 70000 && false === $value) {
+                if (\PHP_VERSION_ID < 70000 && false === $value) {
                     $value = '';
                 }
                 array_unshift($this->parsed, $value);

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -392,7 +392,7 @@ class CommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute(array());
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             // Cannot bind static closures in PHP 5
             $this->assertEquals('interact called'.PHP_EOL.'not bound'.PHP_EOL, $tester->getDisplay());
         } else {

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -61,7 +61,7 @@ class DebugClassLoaderTest extends TestCase
 
     public function testUnsilencing()
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('PHP7 throws exceptions, unsilencing is not required anymore.');
         }
         if (defined('HHVM_VERSION')) {
@@ -109,7 +109,7 @@ class DebugClassLoaderTest extends TestCase
         } catch (\ErrorException $exception) {
             // if an exception is thrown, the test passed
             $this->assertStringStartsWith(__FILE__, $exception->getFile());
-            if (PHP_VERSION_ID < 70000) {
+            if (\PHP_VERSION_ID < 70000) {
                 $this->assertRegExp('/^Runtime Notice: Declaration/', $exception->getMessage());
                 $this->assertEquals(E_STRICT, $exception->getSeverity());
             } else {
@@ -245,7 +245,7 @@ class DebugClassLoaderTest extends TestCase
 
     public function testReservedForPhp7()
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('PHP7 already prevents using reserved names.');
         }
 

--- a/src/Symfony/Component/DependencyInjection/Config/AutowireServiceResource.php
+++ b/src/Symfony/Component/DependencyInjection/Config/AutowireServiceResource.php
@@ -65,7 +65,7 @@ class AutowireServiceResource implements SelfCheckingResourceInterface, \Seriali
 
     public function unserialize($serialized)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             list($this->class, $this->filePath, $this->autowiringMetadata) = unserialize($serialized, array('allowed_classes' => false));
         } else {
             list($this->class, $this->filePath, $this->autowiringMetadata) = unserialize($serialized);

--- a/src/Symfony/Component/Finder/Iterator/FilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilterIterator.php
@@ -31,7 +31,7 @@ abstract class FilterIterator extends \FilterIterator
      */
     public function rewind()
     {
-        if (PHP_VERSION_ID > 50607 || (PHP_VERSION_ID > 50523 && PHP_VERSION_ID < 50600)) {
+        if (\PHP_VERSION_ID > 50607 || (\PHP_VERSION_ID > 50523 && \PHP_VERSION_ID < 50600)) {
             parent::rewind();
 
             return;

--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -119,7 +119,7 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
         }
 
         // @see https://bugs.php.net/68557
-        if (PHP_VERSION_ID < 50523 || PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50607) {
+        if (\PHP_VERSION_ID < 50523 || \PHP_VERSION_ID >= 50600 && \PHP_VERSION_ID < 50607) {
             parent::next();
         }
 

--- a/src/Symfony/Component/Form/FormError.php
+++ b/src/Symfony/Component/Form/FormError.php
@@ -185,7 +185,7 @@ class FormError implements \Serializable
      */
     public function unserialize($serialized)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             list($this->message, $this->messageTemplate, $this->messageParameters, $this->messagePluralization, $this->cause) = unserialize($serialized, array('allowed_classes' => false));
         } else {
             list($this->message, $this->messageTemplate, $this->messageParameters, $this->messagePluralization, $this->cause) = unserialize($serialized);

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1577,7 +1577,7 @@ class Request
     public function getContent($asResource = false)
     {
         $currentContentIsResource = is_resource($this->content);
-        if (PHP_VERSION_ID < 50600 && false === $this->content) {
+        if (\PHP_VERSION_ID < 50600 && false === $this->content) {
             throw new \LogicException('getContent() can only be called once when using the resource return type and PHP below 5.6.');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1057,7 +1057,7 @@ class RequestTest extends TestCase
      */
     public function testGetContentCantBeCalledTwiceWithResources($first, $second)
     {
-        if (PHP_VERSION_ID >= 50600) {
+        if (\PHP_VERSION_ID >= 50600) {
             $this->markTestSkipped('PHP >= 5.6 allows to open php://input several times.');
         }
 

--- a/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
+++ b/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
@@ -72,7 +72,7 @@ class EnvParametersResource implements SelfCheckingResourceInterface, \Serializa
 
     public function unserialize($serialized)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             $unserialized = unserialize($serialized, array('allowed_classes' => false));
         } else {
             $unserialized = unserialize($serialized);

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -63,7 +63,7 @@ class FileLinkFormatter implements \Serializable
 
     public function unserialize($serialized)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             $this->fileLinkFormat = unserialize($serialized, array('allowed_classes' => false));
         } else {
             $this->fileLinkFormat = unserialize($serialized);

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/AddAnnotatedClassesToCachePass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/AddAnnotatedClassesToCachePass.php
@@ -40,7 +40,7 @@ class AddAnnotatedClassesToCachePass implements CompilerPassInterface
         $annotatedClasses = array();
         foreach ($container->getExtensions() as $extension) {
             if ($extension instanceof Extension) {
-                if (PHP_VERSION_ID < 70000) {
+                if (\PHP_VERSION_ID < 70000) {
                     $classes = array_merge($classes, $extension->getClassesToCompile());
                 }
                 $annotatedClasses = array_merge($annotatedClasses, $extension->getAnnotatedClassesToCompile());
@@ -49,7 +49,7 @@ class AddAnnotatedClassesToCachePass implements CompilerPassInterface
 
         $existingClasses = $this->getClassesInComposerClassMaps();
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             $classes = $container->getParameterBag()->resolveValue($classes);
             $this->kernel->setClassCache($this->expandClasses($classes, $existingClasses));
         }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
@@ -32,7 +32,7 @@ abstract class Extension extends BaseExtension
      */
     public function getClassesToCompile()
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             @trigger_error(__METHOD__.'() is deprecated since version 3.3, to be removed in 4.0.', E_USER_DEPRECATED);
         }
 
@@ -58,7 +58,7 @@ abstract class Extension extends BaseExtension
      */
     public function addClassesToCompile(array $classes)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             @trigger_error(__METHOD__.'() is deprecated since version 3.3, to be removed in 4.0.', E_USER_DEPRECATED);
         }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -354,7 +354,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     public function loadClassCache($name = 'classes', $extension = '.php')
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             @trigger_error(__METHOD__.'() is deprecated since version 3.3, to be removed in 4.0.', E_USER_DEPRECATED);
         }
 
@@ -368,7 +368,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     public function setClassCache(array $classes)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             @trigger_error(__METHOD__.'() is deprecated since version 3.3, to be removed in 4.0.', E_USER_DEPRECATED);
         }
 
@@ -420,7 +420,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     protected function doLoadClassCache($name, $extension)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             @trigger_error(__METHOD__.'() is deprecated since version 3.3, to be removed in 4.0.', E_USER_DEPRECATED);
         }
 
@@ -822,7 +822,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
         $output .= $rawChunk;
 
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             // PHP 7 memory manager will not release after token_get_all(), see https://bugs.php.net/70098
             unset($tokens, $rawChunk);
             gc_mem_caches();
@@ -838,7 +838,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
     public function unserialize($data)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             list($environment, $debug) = unserialize($data, array('allowed_classes' => false));
         } else {
             list($environment, $debug) = unserialize($data);

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -435,7 +435,7 @@ abstract class AbstractIntlDateFormatterTest extends TestCase
 
     public function testFormatWithDateTimeZoneGmtOffset()
     {
-        if (defined('HHVM_VERSION_ID') || PHP_VERSION_ID <= 50509) {
+        if (defined('HHVM_VERSION_ID') || \PHP_VERSION_ID <= 50509) {
             $this->markTestSkipped('DateTimeZone GMT offsets are supported since 5.5.10. See https://github.com/facebook/hhvm/issues/5875 for HHVM.');
         }
 

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -60,7 +60,7 @@ class SemaphoreStore implements StoreInterface
 
         $resource = sem_get(crc32($key));
 
-        if (PHP_VERSION_ID < 50601) {
+        if (\PHP_VERSION_ID < 50601) {
             if (!$blocking) {
                 throw new NotSupportedException(sprintf('The store "%s" does not supports non blocking locks.', get_class($this)));
             }

--- a/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
@@ -37,7 +37,7 @@ trait BlockingStoreTestTrait
         // Amount a microsecond used to order async actions
         $clockDelay = 50000;
 
-        if (PHP_VERSION_ID < 50600 || defined('HHVM_VERSION_ID')) {
+        if (\PHP_VERSION_ID < 50600 || defined('HHVM_VERSION_ID')) {
             $this->markTestSkipped('The PHP engine does not keep resource in child forks');
 
             return;

--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -27,7 +27,7 @@ class SemaphoreStoreTest extends AbstractStoreTest
      */
     protected function getStore()
     {
-        if (PHP_VERSION_ID < 50601) {
+        if (\PHP_VERSION_ID < 50601) {
             $this->markTestSkipped('Non blocking semaphore are supported by PHP version greater or equals than 5.6.1');
         }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -195,7 +195,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         $overwrite = true;
 
         try {
-            if (PHP_VERSION_ID < 70000 && false === self::$previousErrorHandler) {
+            if (\PHP_VERSION_ID < 70000 && false === self::$previousErrorHandler) {
                 self::$previousErrorHandler = set_error_handler(self::$errorHandler);
             }
 
@@ -245,7 +245,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         } catch (\TypeError $e) {
             self::throwInvalidArgumentException($e->getMessage(), $e->getTrace(), 0);
         } finally {
-            if (PHP_VERSION_ID < 70000 && false !== self::$previousErrorHandler) {
+            if (\PHP_VERSION_ID < 70000 && false !== self::$previousErrorHandler) {
                 restore_error_handler();
                 self::$previousErrorHandler = false;
             }

--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -73,7 +73,7 @@ class CompiledRoute implements \Serializable
      */
     public function unserialize($serialized)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             $data = unserialize($serialized, array('allowed_classes' => false));
         } else {
             $data = unserialize($serialized);

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -64,7 +64,7 @@ class AnnotationFileLoader extends FileLoader
             $collection->addResource(new FileResource($path));
             $collection->addCollection($this->loader->load($class, $type));
         }
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             // PHP 7 memory manager will not release after token_get_all(), see https://bugs.php.net/70098
             gc_mem_caches();
         }

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -116,7 +116,7 @@ class Route implements \Serializable
      */
     public function unserialize($serialized)
     {
-        if (PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             $data = unserialize($serialized, array('allowed_classes' => array(CompiledRoute::class)));
         } else {
             $data = unserialize($serialized);

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -476,7 +476,7 @@ EOTXT
      */
     public function testBuggyRefs()
     {
-        if (PHP_VERSION_ID >= 50600) {
+        if (\PHP_VERSION_ID >= 50600) {
             $this->markTestSkipped('PHP 5.6 fixed refs counting');
         }
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -575,7 +575,7 @@ class InlineTest extends TestCase
         $expected->setTimeZone(new \DateTimeZone('UTC'));
         $expected->setDate($year, $month, $day);
 
-        if (PHP_VERSION_ID >= 70100) {
+        if (\PHP_VERSION_ID >= 70100) {
             $expected->setTime($hour, $minute, $second, 1000000 * ($second - (int) $second));
         } else {
             $expected->setTime($hour, $minute, $second);
@@ -604,7 +604,7 @@ class InlineTest extends TestCase
         $expected = new \DateTime($yaml);
         $expected->setTimeZone(new \DateTimeZone('UTC'));
         $expected->setDate($year, $month, $day);
-        if (PHP_VERSION_ID >= 70100) {
+        if (\PHP_VERSION_ID >= 70100) {
             $expected->setTime($hour, $minute, $second, 1000000 * ($second - (int) $second));
         } else {
             $expected->setTime($hour, $minute, $second);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #22650
| License       | MIT

this PR adds a \ before all  PHP_VERSION_ID
