### PR TITLE
[HttpKernel][Debug] Fix missing trace on deprecations collected during bootstrapping & silenced errors

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -100,6 +100,8 @@ class ErrorHandler
     private static $stackedErrors = array();
     private static $stackedErrorLevels = array();
     private static $toStringException = null;
+    private static $silencedErrorCache = array();
+    private static $silencedErrorCount = 0;
     private static $exitCode = 0;
 
     /**
@@ -407,7 +409,24 @@ class ErrorHandler
             $errorAsException = self::$toStringException;
             self::$toStringException = null;
         } elseif (!$throw && !($type & $level)) {
-            $errorAsException = new SilencedErrorContext($type, $file, $line);
+            if (isset(self::$silencedErrorCache[$message])) {
+                $lightTrace = null;
+                $errorAsException = self::$silencedErrorCache[$message];
+                ++$errorAsException->count;
+            } else {
+                $lightTrace = $this->tracedErrors & $type ? $this->cleanTrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), $type, $file, $line, false) : array();
+                $errorAsException = new SilencedErrorContext($type, $file, $line, $lightTrace);
+            }
+
+            if (100 < ++self::$silencedErrorCount) {
+                self::$silencedErrorCache = $lightTrace = array();
+                self::$silencedErrorCount = 1;
+            }
+            self::$silencedErrorCache[$message] = $errorAsException;
+
+            if (null === $lightTrace) {
+                return;
+            }
         } else {
             if ($scope) {
                 $errorAsException = new ContextErrorException($logMessage, 0, $type, $file, $line, $context);
@@ -418,19 +437,7 @@ class ErrorHandler
             // Clean the trace by removing function arguments and the first frames added by the error handler itself.
             if ($throw || $this->tracedErrors & $type) {
                 $backtrace = $backtrace ?: $errorAsException->getTrace();
-                $lightTrace = $backtrace;
-
-                for ($i = 0; isset($backtrace[$i]); ++$i) {
-                    if (isset($backtrace[$i]['file'], $backtrace[$i]['line']) && $backtrace[$i]['line'] === $line && $backtrace[$i]['file'] === $file) {
-                        $lightTrace = array_slice($lightTrace, 1 + $i);
-                        break;
-                    }
-                }
-                if (!($throw || $this->scopedErrors & $type)) {
-                    for ($i = 0; isset($lightTrace[$i]); ++$i) {
-                        unset($lightTrace[$i]['args']);
-                    }
-                }
+                $lightTrace = $this->cleanTrace($backtrace, $type, $file, $line, $throw);
                 $this->traceReflector->setValue($errorAsException, $lightTrace);
             } else {
                 $this->traceReflector->setValue($errorAsException, array());
@@ -686,5 +693,24 @@ class ErrorHandler
             new UndefinedMethodFatalErrorHandler(),
             new ClassNotFoundFatalErrorHandler(),
         );
+    }
+
+    private function cleanTrace($backtrace, $type, $file, $line, $throw)
+    {
+        $lightTrace = $backtrace;
+
+        for ($i = 0; isset($backtrace[$i]); ++$i) {
+            if (isset($backtrace[$i]['file'], $backtrace[$i]['line']) && $backtrace[$i]['line'] === $line && $backtrace[$i]['file'] === $file) {
+                $lightTrace = array_slice($lightTrace, 1 + $i);
+                break;
+            }
+        }
+        if (!($throw || $this->scopedErrors & $type)) {
+            for ($i = 0; isset($lightTrace[$i]); ++$i) {
+                unset($lightTrace[$i]['args']);
+            }
+        }
+
+        return $lightTrace;
     }
 }

--- a/src/Symfony/Component/Debug/Exception/SilencedErrorContext.php
+++ b/src/Symfony/Component/Debug/Exception/SilencedErrorContext.php
@@ -18,15 +18,20 @@ namespace Symfony\Component\Debug\Exception;
  */
 class SilencedErrorContext implements \JsonSerializable
 {
+    public $count = 1;
+
     private $severity;
     private $file;
     private $line;
+    private $trace;
 
-    public function __construct($severity, $file, $line)
+    public function __construct($severity, $file, $line, array $trace = array(), $count = 1)
     {
         $this->severity = $severity;
         $this->file = $file;
         $this->line = $line;
+        $this->trace = $trace;
+        $this->count = $count;
     }
 
     public function getSeverity()
@@ -44,12 +49,19 @@ class SilencedErrorContext implements \JsonSerializable
         return $this->line;
     }
 
+    public function getTrace()
+    {
+        return $this->trace;
+    }
+
     public function JsonSerialize()
     {
         return array(
             'severity' => $this->severity,
             'file' => $this->file,
             'line' => $this->line,
+            'trace' => $this->trace,
+            'count' => $this->count,
         );
     }
 }

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -221,12 +221,17 @@ class ErrorHandlerTest extends TestCase
 
             $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
-            $logArgCheck = function ($level, $message, $context) {
+            $line = null;
+            $logArgCheck = function ($level, $message, $context) use (&$line) {
                 $this->assertEquals('Notice: Undefined variable: undefVar', $message);
                 $this->assertArrayHasKey('exception', $context);
                 $exception = $context['exception'];
                 $this->assertInstanceOf(SilencedErrorContext::class, $exception);
                 $this->assertSame(E_NOTICE, $exception->getSeverity());
+                $this->assertSame(__FILE__, $exception->getFile());
+                $this->assertSame($line, $exception->getLine());
+                $this->assertNotEmpty($exception->getTrace());
+                $this->assertSame(1, $exception->count);
             };
 
             $logger
@@ -239,6 +244,7 @@ class ErrorHandlerTest extends TestCase
             $handler->setDefaultLogger($logger, E_NOTICE);
             $handler->screamAt(E_NOTICE);
             unset($undefVar);
+            $line = __LINE__ + 1;
             @$undefVar++;
 
             restore_error_handler();

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -545,11 +545,28 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                         return $previousHandler ? $previousHandler($type, $message, $file, $line) : false;
                     }
 
-                    $collectedLogs[] = array(
+                    if (isset($collectedLogs[$message])) {
+                        ++$collectedLogs[$message]['count'];
+
+                        return;
+                    }
+
+                    $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+                    // Clean the trace by removing first frames added by the error handler itself.
+                    for ($i = 0; isset($backtrace[$i]); ++$i) {
+                        if (isset($backtrace[$i]['file'], $backtrace[$i]['line']) && $backtrace[$i]['line'] === $line && $backtrace[$i]['file'] === $file) {
+                            $backtrace = array_slice($backtrace, 1 + $i);
+                            break;
+                        }
+                    }
+
+                    $collectedLogs[$message] = array(
                         'type' => $type,
                         'message' => $message,
                         'file' => $file,
                         'line' => $line,
+                        'trace' => $backtrace,
+                        'count' => 1,
                     );
                 });
             }
@@ -562,7 +579,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 if ($this->debug) {
                     restore_error_handler();
 
-                    file_put_contents($this->getCacheDir().'/'.$class.'Deprecations.log', serialize($collectedLogs));
+                    file_put_contents($this->getCacheDir().'/'.$class.'Deprecations.log', serialize(array_values($collectedLogs)));
                     file_put_contents($this->getCacheDir().'/'.$class.'Compiler.log', null !== $container ? implode("\n", $container->getCompiler()->getLog()) : '');
                 }
             }

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -83,7 +83,6 @@ class ExceptionCaster
     public static function castSilencedErrorContext(SilencedErrorContext $e, array $a, Stub $stub, $isNested)
     {
         $sPrefix = "\0".SilencedErrorContext::class."\0";
-        $xPrefix = "\0Exception\0";
 
         if (!isset($a[$s = $sPrefix.'severity'])) {
             return $a;
@@ -93,12 +92,17 @@ class ExceptionCaster
             $a[$s] = new ConstStub(self::$errorTypes[$a[$s]], $a[$s]);
         }
 
-        $trace = array(
+        $trace = array(array(
             'file' => $a[$sPrefix.'file'],
             'line' => $a[$sPrefix.'line'],
-        );
-        unset($a[$sPrefix.'file'], $a[$sPrefix.'line']);
-        $a[Caster::PREFIX_VIRTUAL.'trace'] = new TraceStub(array($trace));
+        ));
+
+        if (isset($a[$sPrefix.'trace'])) {
+            $trace = array_merge($trace, $a[$sPrefix.'trace']);
+        }
+
+        unset($a[$sPrefix.'file'], $a[$sPrefix.'line'], $a[$sPrefix.'trace']);
+        $a[Caster::PREFIX_VIRTUAL.'trace'] = new TraceStub($trace);
 
         return $a;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #22958 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

|Before|After|
|--|--|
|<img width="1086" alt="screenshot 2017-06-01 a 10 12 07" src="https://cloud.githubusercontent.com/assets/2211145/26670940/feb51b52-46b3-11e7-806f-e23e2eb248c1.PNG">|<img width="1094" alt="screenshot 2017-06-01 a 10 13 39" src="https://cloud.githubusercontent.com/assets/2211145/26670941/feb8bd66-46b3-11e7-8e54-cc4959487b7a.PNG">|

(failures unrelated or deps=high fixed when merged in upper branches)
