### PR TITLE
[DoctrineBridge][PropertyInfo] Added support for Doctrine Embeddables

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -105,6 +105,16 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
             ));
         }
 
+        if (class_exists('Doctrine\ORM\Mapping\Embedded')) {
+            if ($metadata instanceof ClassMetadataInfo && isset($metadata->embeddedClasses[$property])) {
+                return array(new Type(
+                    Type::BUILTIN_TYPE_OBJECT,
+                    false,
+                    $metadata->embeddedClasses[$property]['class']
+                ));
+            }
+        }
+
         if ($metadata->hasField($property)) {
             $typeOfField = $metadata->getTypeOfField($property);
             $nullable = $metadata instanceof ClassMetadataInfo && $metadata->isNullable($property);

--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -53,7 +53,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
         $properties = array_merge($metadata->getFieldNames(), $metadata->getAssociationNames());
 
         if (class_exists('Doctrine\ORM\Mapping\Embedded')) {
-            if ($metadata instanceof ClassMetadataInfo && count($metadata->embeddedClasses) > 0) {
+            if ($metadata instanceof ClassMetadataInfo && $metadata->embeddedClasses) {
                 $properties = array_filter($properties, function ($property) {
                     return false === strpos($property, '.');
                 });

--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -50,7 +50,19 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
             return;
         }
 
-        return array_merge($metadata->getFieldNames(), $metadata->getAssociationNames());
+        $properties = array_merge($metadata->getFieldNames(), $metadata->getAssociationNames());
+
+        if (class_exists('Doctrine\ORM\Mapping\Embedded')) {
+            if ($metadata instanceof ClassMetadataInfo && count($metadata->embeddedClasses) > 0) {
+                $properties = array_filter($properties, function ($property) {
+                    return false === strpos($property, '.');
+                });
+
+                $properties = array_merge($properties, array_keys($metadata->embeddedClasses));
+            }
+        }
+
+        return $properties;
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -52,14 +52,12 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
 
         $properties = array_merge($metadata->getFieldNames(), $metadata->getAssociationNames());
 
-        if (class_exists('Doctrine\ORM\Mapping\Embedded')) {
-            if ($metadata instanceof ClassMetadataInfo && $metadata->embeddedClasses) {
-                $properties = array_filter($properties, function ($property) {
-                    return false === strpos($property, '.');
-                });
+        if (class_exists('Doctrine\ORM\Mapping\Embedded') && $metadata instanceof ClassMetadataInfo && $metadata->embeddedClasses) {
+            $properties = array_filter($properties, function ($property) {
+                return false === strpos($property, '.');
+            });
 
-                $properties = array_merge($properties, array_keys($metadata->embeddedClasses));
-            }
+            $properties = array_merge($properties, array_keys($metadata->embeddedClasses));
         }
 
         return $properties;
@@ -117,14 +115,8 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
             ));
         }
 
-        if (class_exists('Doctrine\ORM\Mapping\Embedded')) {
-            if ($metadata instanceof ClassMetadataInfo && isset($metadata->embeddedClasses[$property])) {
-                return array(new Type(
-                    Type::BUILTIN_TYPE_OBJECT,
-                    false,
-                    $metadata->embeddedClasses[$property]['class']
-                ));
-            }
+        if (class_exists('Doctrine\ORM\Mapping\Embedded') && $metadata instanceof ClassMetadataInfo && isset($metadata->embeddedClasses[$property])) {
+            return array(new Type(Type::BUILTIN_TYPE_OBJECT, false, $metadata->embeddedClasses[$property]['class']));
         }
 
         if ($metadata->hasField($property)) {

--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -52,7 +52,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
 
         $properties = array_merge($metadata->getFieldNames(), $metadata->getAssociationNames());
 
-        if (class_exists('Doctrine\ORM\Mapping\Embedded') && $metadata instanceof ClassMetadataInfo && $metadata->embeddedClasses) {
+        if ($metadata instanceof ClassMetadataInfo && class_exists('Doctrine\ORM\Mapping\Embedded') && $metadata->embeddedClasses) {
             $properties = array_filter($properties, function ($property) {
                 return false === strpos($property, '.');
             });
@@ -115,7 +115,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
             ));
         }
 
-        if (class_exists('Doctrine\ORM\Mapping\Embedded') && $metadata instanceof ClassMetadataInfo && isset($metadata->embeddedClasses[$property])) {
+        if ($metadata instanceof ClassMetadataInfo && class_exists('Doctrine\ORM\Mapping\Embedded') && isset($metadata->embeddedClasses[$property])) {
             return array(new Type(Type::BUILTIN_TYPE_OBJECT, false, $metadata->embeddedClasses[$property]['class']));
         }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -62,10 +62,10 @@ class DoctrineExtractorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testGetEmbeddableProperties()
+    public function testGetPropertiesWithEmbedded()
     {
         if (!class_exists('Doctrine\ORM\Mapping\Embedded')) {
-            return;
+            $this->markTestSkipped('@Embedded is not available in Doctrine ORM lower than 2.5.');
         }
 
         $this->assertEquals(
@@ -85,10 +85,10 @@ class DoctrineExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineDummy', $property, array()));
     }
 
-    public function testExtractEmbeddable()
+    public function testExtractWithEmbedded()
     {
         if (!class_exists('Doctrine\ORM\Mapping\Embedded')) {
-            return;
+            $this->markTestSkipped('@Embedded is not available in Doctrine ORM lower than 2.5.');
         }
 
         $expectedTypes = array(new Type(

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -70,6 +70,27 @@ class DoctrineExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineDummy', $property, array()));
     }
 
+    public function testExtractEmbeddable()
+    {
+        if (!class_exists('Doctrine\ORM\Mapping\Embedded')) {
+            return;
+        }
+
+        $expectedTypes = [new Type(
+            Type::BUILTIN_TYPE_OBJECT,
+            false,
+            'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineEmbeddable'
+        )];
+
+        $actualTypes = $this->extractor->getTypes(
+            'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineWithEmbedded',
+            'embedded',
+            array()
+        );
+
+        $this->assertEquals($expectedTypes, $actualTypes);
+    }
+
     public function typesProvider()
     {
         return array(

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -62,6 +62,21 @@ class DoctrineExtractorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testGetEmbeddableProperties()
+    {
+        if (!class_exists('Doctrine\ORM\Mapping\Embedded')) {
+            return;
+        }
+
+        $this->assertEquals(
+            array(
+                'id',
+                'embedded',
+            ),
+            $this->extractor->getProperties('Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineWithEmbedded')
+        );
+    }
+
     /**
      * @dataProvider typesProvider
      */

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -76,11 +76,11 @@ class DoctrineExtractorTest extends \PHPUnit_Framework_TestCase
             return;
         }
 
-        $expectedTypes = [new Type(
+        $expectedTypes = array(new Type(
             Type::BUILTIN_TYPE_OBJECT,
             false,
             'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineEmbeddable'
-        )];
+        ));
 
         $actualTypes = $this->extractor->getTypes(
             'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineWithEmbedded',

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineEmbeddable.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineEmbeddable.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
+
+/**
+ * @Embeddable
+ *
+ * @author Udaltsov Valentin <udaltsov.valentin@gmail.com>
+ */
+class DoctrineEmbeddable
+{
+    /**
+     * @Column(type="string")
+     */
+    protected $field;
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineWithEmbedded.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineWithEmbedded.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Embedded;
+
+/**
+ * @Entity
+ *
+ * @author Udaltsov Valentin <udaltsov.valentin@gmail.com>
+ */
+class DoctrineWithEmbedded
+{
+    /**
+     * @Id
+     * @Column(type="smallint")
+     */
+    public $id;
+
+    /**
+     * @Embedded(class="DoctrineEmbeddable")
+     */
+    protected $embedded;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8 and higher
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Note that [Embeddables appeared only in doctrine/orm 2.5](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/changelog/migration_2_5.html). I added class_exists checks for that.