### PR TITLE
[SecurityBundle] Add user impersonation info and exit action to the profiler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Bundle\SecurityBundle\Debug\TraceableFirewallListener;
 use Symfony\Component\Security\Core\Role\SwitchUserRole;
+use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
@@ -192,7 +193,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                 if ($this->data['impersonated'] && null !== $switchUserConfig = $firewallConfig->getSwitchUser()) {
                     $exitPath = $request->getRequestUri();
                     $exitPath .= null === $request->getQueryString() ? '?' : '&';
-                    $exitPath .= urlencode($switchUserConfig['parameter']).'=_exit';
+                    $exitPath .= sprintf('%s=%s', urlencode($switchUserConfig['parameter']), SwitchUserListener::EXIT_VALUE);
 
                     $this->data['impersonation_exit_path'] = $exitPath;
                 }

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -273,31 +273,16 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         return $this->data['authenticated'];
     }
 
-    /**
-     * Checks if the user is impersonated or not.
-     *
-     * @return bool true if the user is impersonated, false otherwise
-     */
     public function isImpersonated()
     {
         return $this->data['impersonated'];
     }
 
-    /**
-     * Returns the impersonation source user.
-     *
-     * @return string The username
-     */
     public function getImpersonatorUser()
     {
         return $this->data['impersonator_user'];
     }
 
-    /**
-     * Returns the exit impersonation path.
-     *
-     * @return string The URI path
-     */
     public function getImpersonationExitPath()
     {
         return $this->data['impersonation_exit_path'];

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Bundle\SecurityBundle\Debug\TraceableFirewallListener;
+use Symfony\Component\Security\Core\Role\SwitchUserRole;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
@@ -73,6 +74,9 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
             $this->data = array(
                 'enabled' => false,
                 'authenticated' => false,
+                'impersonated' => false,
+                'impersonator_user' => null,
+                'impersonation_exit_path' => null,
                 'token' => null,
                 'token_class' => null,
                 'logout_url' => null,
@@ -85,6 +89,9 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
             $this->data = array(
                 'enabled' => true,
                 'authenticated' => false,
+                'impersonated' => false,
+                'impersonator_user' => null,
+                'impersonation_exit_path' => null,
                 'token' => null,
                 'token_class' => null,
                 'logout_url' => null,
@@ -96,6 +103,14 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         } else {
             $inheritedRoles = array();
             $assignedRoles = $token->getRoles();
+
+            $impersonatorUser = null;
+            foreach ($assignedRoles as $role) {
+                if ($role instanceof SwitchUserRole) {
+                    $impersonatorUser = $role->getSource()->getUsername();
+                    break;
+                }
+            }
 
             if (null !== $this->roleHierarchy) {
                 $allRoles = $this->roleHierarchy->getReachableRoles($assignedRoles);
@@ -126,6 +141,9 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
             $this->data = array(
                 'enabled' => true,
                 'authenticated' => $token->isAuthenticated(),
+                'impersonated' => null !== $impersonatorUser,
+                'impersonator_user' => $impersonatorUser,
+                'impersonation_exit_path' => null,
                 'token' => $token,
                 'token_class' => $this->hasVarDumper ? new ClassStub(get_class($token)) : get_class($token),
                 'logout_url' => $logoutUrl,
@@ -169,6 +187,15 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                     'user_checker' => $firewallConfig->getUserChecker(),
                     'listeners' => $firewallConfig->getListeners(),
                 );
+
+                // generate exit impersonation path from current request
+                if ($this->data['impersonated'] && null !== $switchUserConfig = $firewallConfig->getSwitchUser()) {
+                    $exitPath = $request->getRequestUri();
+                    $exitPath .= null === $request->getQueryString() ? '?' : '&';
+                    $exitPath .= urlencode($switchUserConfig['parameter']).'=_exit';
+
+                    $this->data['impersonation_exit_path'] = $exitPath;
+                }
             }
         }
 
@@ -243,6 +270,36 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     public function isAuthenticated()
     {
         return $this->data['authenticated'];
+    }
+
+    /**
+     * Checks if the user is impersonated or not.
+     *
+     * @return bool true if the user is impersonated, false otherwise
+     */
+    public function isImpersonated()
+    {
+        return $this->data['impersonated'];
+    }
+
+    /**
+     * Returns the impersonation source user.
+     *
+     * @return string The username
+     */
+    public function getImpersonatorUser()
+    {
+        return $this->data['impersonator_user'];
+    }
+
+    /**
+     * Returns the exit impersonation path.
+     *
+     * @return string The URI path
+     */
+    public function getImpersonationExitPath()
+    {
+        return $this->data['impersonation_exit_path'];
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -448,6 +448,7 @@ class SecurityExtension extends Extension
         }
 
         $config->replaceArgument(10, $listenerKeys);
+        $config->replaceArgument(11, isset($firewall['switch_user']) ? $firewall['switch_user'] : null);
 
         return array($matcher, $listeners, $exceptionListener);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -136,6 +136,7 @@
             <argument />                   <!-- access_denied_handler -->
             <argument />                   <!-- access_denied_url -->
             <argument type="collection" /> <!-- listeners -->
+            <argument />                   <!-- switch_user -->
         </service>
 
         <service id="security.logout_url_generator" class="Symfony\Component\Security\Http\Logout\LogoutUrlGenerator">

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -16,47 +16,63 @@
     {% endset %}
 
     {% set text %}
-        {% if collector.enabled %}
-            {% if collector.token %}
+        {% if collector.impersonated %}
+            <div class="sf-toolbar-info-group">
                 <div class="sf-toolbar-info-piece">
-                    <b>Logged in as</b>
-                    <span>{{ collector.user }}</span>
+                    <b>Impersonator</b>
+                    <span>{{ collector.impersonatorUser }}</span>
                 </div>
-
-                <div class="sf-toolbar-info-piece">
-                    <b>Authenticated</b>
-                    <span class="sf-toolbar-status sf-toolbar-status-{{ is_authenticated ? 'green' : 'red' }}">{{ is_authenticated ? 'Yes' : 'No' }}</span>
-                </div>
-
-                <div class="sf-toolbar-info-piece">
-                    <b>Token class</b>
-                    <span>{{ collector.tokenClass|abbr_class }}</span>
-                </div>
-            {% else %}
-                <div class="sf-toolbar-info-piece">
-                    <b>Authenticated</b>
-                    <span class="sf-toolbar-status sf-toolbar-status-red">No</span>
-                </div>
-            {% endif %}
-
-            {% if collector.firewall %}
-                <div class="sf-toolbar-info-piece">
-                    <b>Firewall name</b>
-                    <span>{{ collector.firewall.name }}</span>
-                </div>
-            {% endif %}
-
-            {% if collector.token and collector.logoutUrl %}
-                <div class="sf-toolbar-info-piece">
-                    <b>Actions</b>
-                    <span><a href="{{ collector.logoutUrl }}">Logout</a></span>
-                </div>
-            {% endif %}
-        {% else %}
-            <div class="sf-toolbar-info-piece">
-                <span>The security is disabled.</span>
             </div>
         {% endif %}
+
+        <div class="sf-toolbar-info-group">
+            {% if collector.enabled %}
+                {% if collector.token %}
+                    <div class="sf-toolbar-info-piece">
+                        <b>Logged in as</b>
+                        <span>{{ collector.user }}</span>
+                    </div>
+
+                    <div class="sf-toolbar-info-piece">
+                        <b>Authenticated</b>
+                        <span class="sf-toolbar-status sf-toolbar-status-{{ is_authenticated ? 'green' : 'red' }}">{{ is_authenticated ? 'Yes' : 'No' }}</span>
+                    </div>
+
+                    <div class="sf-toolbar-info-piece">
+                        <b>Token class</b>
+                        <span>{{ collector.tokenClass|abbr_class }}</span>
+                    </div>
+                {% else %}
+                    <div class="sf-toolbar-info-piece">
+                        <b>Authenticated</b>
+                        <span class="sf-toolbar-status sf-toolbar-status-red">No</span>
+                    </div>
+                {% endif %}
+
+                {% if collector.firewall %}
+                    <div class="sf-toolbar-info-piece">
+                        <b>Firewall name</b>
+                        <span>{{ collector.firewall.name }}</span>
+                    </div>
+                {% endif %}
+
+                {% if collector.token and collector.logoutUrl %}
+                    <div class="sf-toolbar-info-piece">
+                        <b>Actions</b>
+                        <span>
+                            <a href="{{ collector.logoutUrl }}">Logout</a>
+                            {% if collector.impersonated and collector.impersonationExitPath %}
+                                | <a href="{{ collector.impersonationExitPath }}">Exit impersonation</a>
+                            {% endif %}
+                        </span>
+                    </div>
+                {% endif %}
+            {% else %}
+                <div class="sf-toolbar-info-piece">
+                    <span>The security is disabled.</span>
+                </div>
+            {% endif %}
+        </div>
     {% endset %}
 
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: color_code }) }}

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -27,6 +27,7 @@ final class FirewallConfig
     private $accessDeniedHandler;
     private $accessDeniedUrl;
     private $listeners;
+    private $switchUser;
 
     /**
      * @param string      $name
@@ -40,8 +41,9 @@ final class FirewallConfig
      * @param string|null $accessDeniedHandler
      * @param string|null $accessDeniedUrl
      * @param string[]    $listeners
+     * @param array|null  $switchUser
      */
-    public function __construct($name, $userChecker, $requestMatcher = null, $securityEnabled = true, $stateless = false, $provider = null, $context = null, $entryPoint = null, $accessDeniedHandler = null, $accessDeniedUrl = null, $listeners = array())
+    public function __construct($name, $userChecker, $requestMatcher = null, $securityEnabled = true, $stateless = false, $provider = null, $context = null, $entryPoint = null, $accessDeniedHandler = null, $accessDeniedUrl = null, $listeners = array(), $switchUser = null)
     {
         $this->name = $name;
         $this->userChecker = $userChecker;
@@ -54,6 +56,7 @@ final class FirewallConfig
         $this->accessDeniedHandler = $accessDeniedHandler;
         $this->accessDeniedUrl = $accessDeniedUrl;
         $this->listeners = $listeners;
+        $this->switchUser = $switchUser;
     }
 
     public function getName()
@@ -139,5 +142,13 @@ final class FirewallConfig
     public function getListeners()
     {
         return $this->listeners;
+    }
+
+    /**
+     * @return array|null The switch_user config if enabled, null otherwise
+     */
+    public function getSwitchUser()
+    {
+        return $this->switchUser;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -145,7 +145,7 @@ final class FirewallConfig
     }
 
     /**
-     * @return array|null The switch_user config if enabled, null otherwise
+     * @return array|null The switch_user parameters if configured, null otherwise
      */
     public function getSwitchUser()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
+use Symfony\Component\Security\Core\Role\SwitchUserRole;
 use Symfony\Component\Security\Http\FirewallMapInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
@@ -37,6 +38,9 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertSame('security', $collector->getName());
         $this->assertFalse($collector->isEnabled());
         $this->assertFalse($collector->isAuthenticated());
+        $this->assertFalse($collector->isImpersonated());
+        $this->assertNull($collector->getImpersonatorUser());
+        $this->assertNull($collector->getImpersonationExitPath());
         $this->assertNull($collector->getTokenClass());
         $this->assertFalse($collector->supportsRoleHierarchy());
         $this->assertCount(0, $collector->getRoles());
@@ -53,6 +57,9 @@ class SecurityDataCollectorTest extends TestCase
 
         $this->assertTrue($collector->isEnabled());
         $this->assertFalse($collector->isAuthenticated());
+        $this->assertFalse($collector->isImpersonated());
+        $this->assertNull($collector->getImpersonatorUser());
+        $this->assertNull($collector->getImpersonationExitPath());
         $this->assertNull($collector->getTokenClass());
         $this->assertTrue($collector->supportsRoleHierarchy());
         $this->assertCount(0, $collector->getRoles());
@@ -73,10 +80,40 @@ class SecurityDataCollectorTest extends TestCase
 
         $this->assertTrue($collector->isEnabled());
         $this->assertTrue($collector->isAuthenticated());
+        $this->assertFalse($collector->isImpersonated());
+        $this->assertNull($collector->getImpersonatorUser());
+        $this->assertNull($collector->getImpersonationExitPath());
         $this->assertSame('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', $collector->getTokenClass()->getValue());
         $this->assertTrue($collector->supportsRoleHierarchy());
         $this->assertSame($normalizedRoles, $collector->getRoles()->getValue(true));
         $this->assertSame($inheritedRoles, $collector->getInheritedRoles()->getValue(true));
+        $this->assertSame('hhamon', $collector->getUser());
+    }
+
+    public function testCollectImpersonatedToken()
+    {
+        $adminToken = new UsernamePasswordToken('yceruto', 'P4$$w0rD', 'provider', array('ROLE_ADMIN'));
+
+        $userRoles = array(
+            'ROLE_USER',
+            new SwitchUserRole('ROLE_PREVIOUS_ADMIN', $adminToken),
+        );
+
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken('hhamon', 'P4$$w0rD', 'provider', $userRoles));
+
+        $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy());
+        $collector->collect($this->getRequest(), $this->getResponse());
+        $collector->lateCollect();
+
+        $this->assertTrue($collector->isEnabled());
+        $this->assertTrue($collector->isAuthenticated());
+        $this->assertTrue($collector->isImpersonated());
+        $this->assertSame('yceruto', $collector->getImpersonatorUser());
+        $this->assertSame('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', $collector->getTokenClass()->getValue());
+        $this->assertTrue($collector->supportsRoleHierarchy());
+        $this->assertSame(array('ROLE_USER', 'ROLE_PREVIOUS_ADMIN'), $collector->getRoles()->getValue(true));
+        $this->assertSame(array(), $collector->getInheritedRoles()->getValue(true));
         $this->assertSame('hhamon', $collector->getUser());
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -107,6 +107,10 @@ abstract class CompleteConfigurationTest extends TestCase
                     'remember_me',
                     'anonymous',
                 ),
+                array(
+                    'parameter' => '_switch_user',
+                    'role' => 'ROLE_ALLOWED_TO_SWITCH',
+                ),
             ),
             array(
                 'host',
@@ -123,6 +127,7 @@ abstract class CompleteConfigurationTest extends TestCase
                     'http_basic',
                     'anonymous',
                 ),
+                null,
             ),
             array(
                 'with_user_checker',
@@ -139,6 +144,7 @@ abstract class CompleteConfigurationTest extends TestCase
                     'http_basic',
                     'anonymous',
                 ),
+                null,
             ),
         ), $configs);
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
+use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
+
 class SwitchUserTest extends WebTestCase
 {
     /**
@@ -42,7 +44,7 @@ class SwitchUserTest extends WebTestCase
         $client = $this->createAuthenticatedClient('user_can_switch');
 
         $client->request('GET', '/profile?_switch_user=user_cannot_switch_1');
-        $client->request('GET', '/profile?_switch_user=_exit');
+        $client->request('GET', '/profile?_switch_user='.SwitchUserListener::EXIT_VALUE);
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertEquals('user_can_switch', $client->getProfile()->getCollector('security')->getUser());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallConfigTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallConfigTest.php
@@ -29,6 +29,7 @@ class FirewallConfigTest extends TestCase
             'access_denied_url' => 'foo_access_denied_url',
             'access_denied_handler' => 'foo_access_denied_handler',
             'user_checker' => 'foo_user_checker',
+            'switch_user' => array('provider' => null, 'parameter' => '_switch_user', 'role' => 'ROLE_ALLOWED_TO_SWITCH'),
         );
 
         $config = new FirewallConfig(
@@ -42,7 +43,8 @@ class FirewallConfigTest extends TestCase
             $options['entry_point'],
             $options['access_denied_handler'],
             $options['access_denied_url'],
-            $listeners
+            $listeners,
+            $options['switch_user']
         );
 
         $this->assertSame('foo_firewall', $config->getName());
@@ -57,5 +59,6 @@ class FirewallConfigTest extends TestCase
         $this->assertSame($options['user_checker'], $config->getUserChecker());
         $this->assertTrue($config->allowsAnonymous());
         $this->assertSame($listeners, $config->getListeners());
+        $this->assertSame($options['switch_user'], $config->getSwitchUser());
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -38,6 +38,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class SwitchUserListener implements ListenerInterface
 {
+    const EXIT_VALUE = '_exit';
+
     private $tokenStorage;
     private $provider;
     private $userChecker;
@@ -80,7 +82,7 @@ class SwitchUserListener implements ListenerInterface
             return;
         }
 
-        if ('_exit' === $request->get($this->usernameParameter)) {
+        if (self::EXIT_VALUE === $request->get($this->usernameParameter)) {
             $this->tokenStorage->setToken($this->attemptExitUser($request));
         } else {
             try {

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -73,7 +73,7 @@ class SwitchUserListenerTest extends TestCase
         $token = new UsernamePasswordToken('username', '', 'key', array('ROLE_FOO'));
 
         $this->tokenStorage->setToken($token);
-        $this->request->query->set('_switch_user', '_exit');
+        $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
@@ -84,7 +84,7 @@ class SwitchUserListenerTest extends TestCase
         $originalToken = new UsernamePasswordToken('username', '', 'key', array());
         $this->tokenStorage->setToken(new UsernamePasswordToken('username', '', 'key', array(new SwitchUserRole('ROLE_PREVIOUS', $originalToken))));
 
-        $this->request->query->set('_switch_user', '_exit');
+        $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);
@@ -108,7 +108,7 @@ class SwitchUserListenerTest extends TestCase
             ->willReturn($refreshedUser);
         $originalToken = new UsernamePasswordToken($originalUser, '', 'key');
         $this->tokenStorage->setToken(new UsernamePasswordToken('username', '', 'key', array(new SwitchUserRole('ROLE_PREVIOUS', $originalToken))));
-        $this->request->query->set('_switch_user', '_exit');
+        $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
 
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $dispatcher
@@ -132,7 +132,7 @@ class SwitchUserListenerTest extends TestCase
             ->method('refreshUser');
         $originalToken = new UsernamePasswordToken($originalUser, '', 'key');
         $this->tokenStorage->setToken(new UsernamePasswordToken('username', '', 'key', array(new SwitchUserRole('ROLE_PREVIOUS', $originalToken))));
-        $this->request->query->set('_switch_user', '_exit');
+        $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
 
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $dispatcher


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/23094
| License       | MIT

Toolbar item result:

![toolbar](https://cloud.githubusercontent.com/assets/2028198/26724555/1b60320a-4768-11e7-8433-da935f7068e9.png)

I'm no sure if more information should be displayed from source token, wdyt?

Security profile panel result:

![security_token_profile_panel](https://cloud.githubusercontent.com/assets/2028198/26705860/f7a64054-4706-11e7-9eef-6cd6b7365738.png)