### PR TITLE
[Security] Added tests to check referer URL with a login_path route name

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -179,6 +179,52 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
         $this->assertSame($response, $result);
     }
 
+    public function testRefererUrlAndLoginPathRouteNameHasToBeDifferentThanLoginUrl()
+    {
+        $options = array(
+            'login_path' => 'login_route',
+            'use_referer' => true,
+        );
+
+        $this->request->headers->expects($this->any())
+            ->method('get')->with('Referer')
+            ->will($this->returnValue('http://example.com/login'));
+
+        $this->httpUtils->expects($this->once())
+            ->method('generateUri')->with($this->request, 'login_route')
+            ->will($this->returnValue('http://example.com/login'));
+
+        $response = $this->expectRedirectResponse('/');
+
+        $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, $options);
+        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testRefererUrlWithoutParametersAndLoginPathRouteNameHasToBeDifferentThanLoginUrl()
+    {
+        $options = array(
+            'login_path' => 'login_route',
+            'use_referer' => true,
+        );
+
+        $this->request->headers->expects($this->any())
+            ->method('get')->with('Referer')
+            ->will($this->returnValue('http://example.com/subfolder/login?t=1&p=2'));
+
+        $this->httpUtils->expects($this->once())
+            ->method('generateUri')->with($this->request, 'login_route')
+            ->will($this->returnValue('http://example.com/subfolder/login'));
+
+        $response = $this->expectRedirectResponse('/');
+
+        $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, $options);
+        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+
+        $this->assertSame($response, $result);
+    }
+
     public function testRefererTargetPathIsIgnoredByDefault()
     {
         $this->request->headers->expects($this->never())->method('get');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | maybe?
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | none
| License       | MIT
| Doc PR        | N/A

Related to https://github.com/symfony/symfony/pull/19026
