### PR TITLE
add some \ on PHP_VERSION_ID for 2.8

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -386,7 +386,7 @@ class CommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute(array());
 
-        if (PHP_VERSION_ID < 70000) {
+        if (\PHP_VERSION_ID < 70000) {
             // Cannot bind static closures in PHP 5
             $this->assertEquals('interact called'.PHP_EOL.'not bound'.PHP_EOL, $tester->getDisplay());
         } else {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -698,7 +698,7 @@ class ContainerTest extends TestCase
     {
         $class = new \ReflectionClass('Symfony\Component\DependencyInjection\Container');
         $clone = $class->getMethod('__clone');
-        if (PHP_VERSION_ID >= 50400) {
+        if (\PHP_VERSION_ID >= 50400) {
             $this->assertFalse($class->isCloneable());
         }
         $this->assertTrue($clone->isPrivate());

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1191,7 +1191,7 @@ class Crawler extends \SplObjectStorage
     private function triggerDeprecation($methodName, $useTrace = false)
     {
         if ($useTrace || defined('HHVM_VERSION')) {
-            if (PHP_VERSION_ID >= 50400) {
+            if (\PHP_VERSION_ID >= 50400) {
                 $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
             } else {
                 $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #22650 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->
