### PR TITLE
[TwigBundle] Added a RuntimeExtensionInterface to take advantage of autoconfigure

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Twig\Extension\ExtensionInterface;
+use Twig\Extension\RuntimeExtensionInterface;
 use Twig\Loader\LoaderInterface;
 
 /**
@@ -150,6 +151,7 @@ class TwigExtension extends Extension
         $container->registerForAutoconfiguration(\Twig_LoaderInterface::class)->addTag('twig.loader');
         $container->registerForAutoconfiguration(ExtensionInterface::class)->addTag('twig.extension');
         $container->registerForAutoconfiguration(LoaderInterface::class)->addTag('twig.loader');
+        $container->registerForAutoconfiguration(RuntimeExtensionInterface::class)->addTag('twig.runtime');
 
         if (\PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | - (asked by @nicolas-grekas)
| License       | MIT
| Doc PR        | -

---

Before:

```yaml
#app/config/services.yml
services:
    _defaults:
        autoconfigure: true
  
    AppBundle\Twig\HelloExtension:
        tags: ['twig.runtime']
```

After:

```yaml
#app/config/services.yml
services:
    _defaults:
        autoconfigure: true

#Yes, there are nothing anymore
```