### PR TITLE
[Validator] Support for parsing PHP constants in yaml loader

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
 -----
 
  * deprecated `Tests\Constraints\AbstractContraintValidatorTest` in favor of `Test\ConstraintValidatorTestCase`
+ * added support for PHP constants in YAML configuration files
 
 3.1.0
 -----

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -116,7 +116,7 @@ class YamlFileLoader extends FileLoader
     private function parseFile($path)
     {
         try {
-            $classes = $this->yamlParser->parse(file_get_contents($path), Yaml::PARSE_KEYS_AS_STRINGS);
+            $classes = $this->yamlParser->parse(file_get_contents($path), Yaml::PARSE_KEYS_AS_STRINGS | Yaml::PARSE_CONSTANT);
         } catch (ParseException $e) {
             throw new \InvalidArgumentException(sprintf('The file "%s" does not contain valid YAML.', $path), 0, $e);
         }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -124,6 +124,19 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals($expected, $metadata);
     }
 
+    public function testLoadClassMetadataWithConstants()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/mapping-with-constants.yml');
+        $metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
+
+        $loader->loadClassMetadata($metadata);
+
+        $expected = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
+        $expected->addPropertyConstraint('firstName', new Range(array('max' => PHP_INT_MAX)));
+
+        $this->assertEquals($expected, $metadata);
+    }
+
     public function testLoadGroupSequenceProvider()
     {
         $loader = new YamlFileLoader(__DIR__.'/constraint-mapping.yml');

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/mapping-with-constants.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/mapping-with-constants.yml
@@ -1,0 +1,8 @@
+namespaces:
+  custom: Symfony\Component\Validator\Tests\Fixtures\
+
+Symfony\Component\Validator\Tests\Fixtures\Entity:
+  properties:
+    firstName:
+      - Range:
+          max: !php/const:PHP_INT_MAX


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        |  -

Yaml components supports PHP constants. It would be great if we could use it also in validator component.
