### PR TITLE
[Validator] Removes exception when validating non-traversable value with Composite constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/All.php
+++ b/src/Symfony/Component/Validator/Constraints/All.php
@@ -19,7 +19,14 @@ namespace Symfony\Component\Validator\Constraints;
  */
 class All extends Composite
 {
+    const WRONG_TYPE_ERROR = '824268b5-91c0-4730-983f-896fb0f971f0';
+
+    protected static $errorNames = array(
+        self::WRONG_TYPE_ERROR => 'WRONG_TYPE_ERROR',
+    );
+
     public $constraints = array();
+    public $wrongTypeMessage = 'This value should be an array.';
 
     public function getDefaultOption()
     {

--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -35,7 +35,11 @@ class AllValidator extends ConstraintValidator
         }
 
         if (!is_array($value) && !$value instanceof \Traversable) {
-            throw new UnexpectedTypeException($value, 'array or Traversable');
+            $this->context->buildViolation($constraint->wrongTypeMessage)
+                ->setCode(All::WRONG_TYPE_ERROR)
+                ->addViolation();
+
+            return;
         }
 
         $context = $this->context;

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -23,10 +23,12 @@ class Collection extends Composite
 {
     const MISSING_FIELD_ERROR = '2fa2158c-2a7f-484b-98aa-975522539ff8';
     const NO_SUCH_FIELD_ERROR = '7703c766-b5d5-4cef-ace7-ae0dd82304e9';
+    const WRONG_TYPE_ERROR = '212f9e68-bff4-404f-ab6d-9f29055139e2';
 
     protected static $errorNames = array(
         self::MISSING_FIELD_ERROR => 'MISSING_FIELD_ERROR',
         self::NO_SUCH_FIELD_ERROR => 'NO_SUCH_FIELD_ERROR',
+        self::WRONG_TYPE_ERROR => 'WRONG_TYPE_ERROR',
     );
 
     public $fields = array();
@@ -34,6 +36,7 @@ class Collection extends Composite
     public $allowMissingFields = false;
     public $extraFieldsMessage = 'This field was not expected.';
     public $missingFieldsMessage = 'This field is missing.';
+    public $wrongTypeMessage = 'This value should be an array.';
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -35,7 +35,11 @@ class CollectionValidator extends ConstraintValidator
         }
 
         if (!is_array($value) && !($value instanceof \Traversable && $value instanceof \ArrayAccess)) {
-            throw new UnexpectedTypeException($value, 'array or Traversable and ArrayAccess');
+            $this->context->buildViolation($constraint->wrongTypeMessage)
+                ->setCode(Collection::WRONG_TYPE_ERROR)
+                ->addViolation();
+
+            return;
         }
 
         // We need to keep the initialized context when CollectionValidator

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -36,12 +36,16 @@ class AllValidatorTest extends AbstractConstraintValidatorTest
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
-    public function testThrowsExceptionIfNotTraversable()
+    public function testAddViolationIfNotTraversable()
     {
-        $this->validator->validate('foo.barbar', new All(new Range(array('min' => 4))));
+        $this->validator->validate('foo.barbar', new All(array(
+            'constraints' => array(new Range(array('min' => 4))),
+            'wrongTypeMessage' => 'myMessage',
+        )));
+
+        $this->buildViolation('myMessage')
+            ->setCode(All::WRONG_TYPE_ERROR)
+            ->assertRaised();
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -57,14 +57,18 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
-    public function testThrowsExceptionIfNotTraversable()
+    public function testAddViolationIfNotTraversable()
     {
-        $this->validator->validate('foobar', new Collection(array('fields' => array(
-            'foo' => new Range(array('min' => 4)),
-        ))));
+        $this->validator->validate('foobar', new Collection(array(
+            'fields' => array(
+                'foo' => new Range(array('min' => 4)),
+            ),
+            'wrongTypeMessage' => 'myMessage',
+        )));
+
+        $this->buildViolation('myMessage')
+            ->setCode(Collection::WRONG_TYPE_ERROR)
+            ->assertRaised();
     }
 
     public function testWalkSingleConstraint()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16412
| License       | MIT
| Doc PR        | 

This PR aims to solve a problem (might be considered a bug) we encountered when validating some API input.
As stated in the related issue, when validating a value that is not an array-like type against a composite constraint (either All or Collection), we get an exception.

This obviously does not cause much harm when used with the Form component where you control the data structure but is quite an issue when you must validate freely formatted content.

One of the obvious solution would have been to add a Type Constraint together with the Composite constraint but the constraints not being lazy executed, the exception is thrown anyway.