### PR TITLE
[Config] Always protected ClassExistenceResource against bad parents

### DIFF
--- a/src/Symfony/Component/Config/Tests/Resource/ClassExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ClassExistenceResourceTest.php
@@ -66,7 +66,7 @@ EOF
 
             $loadedClass = 123;
 
-            $res = new ClassExistenceResource('MissingFooClass', ClassExistenceResource::EXISTS_KO);
+            $res = new ClassExistenceResource('MissingFooClass', false);
 
             $this->assertSame(123, $loadedClass);
         } finally {
@@ -76,7 +76,7 @@ EOF
 
     public function testConditionalClass()
     {
-        $res = new ClassExistenceResource(ConditionalClass::class, ClassExistenceResource::EXISTS_KO_WITH_THROWING_AUTOLOADER);
+        $res = new ClassExistenceResource(ConditionalClass::class, false);
 
         $this->assertFalse($res->isFresh(0));
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -388,7 +388,7 @@ class AutowirePass extends AbstractRecursivePass
             unset($this->ambiguousServiceTypes[$type]);
         }
 
-        if ($definition->isDeprecated() || !$reflectionClass = $this->container->getReflectionClass($definition->getClass(), true)) {
+        if ($definition->isDeprecated() || !$reflectionClass = $this->container->getReflectionClass($definition->getClass())) {
             return;
         }
 
@@ -444,7 +444,7 @@ class AutowirePass extends AbstractRecursivePass
      */
     private function createAutowiredDefinition($type)
     {
-        if (!($typeHint = $this->container->getReflectionClass($type, true)) || !$typeHint->isInstantiable()) {
+        if (!($typeHint = $this->container->getReflectionClass($type)) || !$typeHint->isInstantiable()) {
             return;
         }
 
@@ -478,7 +478,7 @@ class AutowirePass extends AbstractRecursivePass
 
     private function createTypeNotFoundMessage(TypedReference $reference, $label)
     {
-        if (!$r = $this->container->getReflectionClass($type = $reference->getType(), true)) {
+        if (!$r = $this->container->getReflectionClass($type = $reference->getType())) {
             $message = sprintf('has type "%s" but this class does not exist.', $type);
         } else {
             $message = $this->container->has($type) ? 'this service is abstract' : 'no such service exists';

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -337,13 +337,12 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * Retrieves the requested reflection class and registers it for resource tracking.
      *
      * @param string $class
-     * @param bool   $koWithThrowingAutoloader Whether autoload should be protected against bad parents or not
      *
      * @return \ReflectionClass|null
      *
      * @final
      */
-    public function getReflectionClass($class, $koWithThrowingAutoloader = false)
+    public function getReflectionClass($class)
     {
         if (!$class = $this->getParameterBag()->resolveValue($class)) {
             return;
@@ -353,12 +352,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         try {
             if (isset($this->classReflectors[$class])) {
                 $classReflector = $this->classReflectors[$class];
-            } elseif ($koWithThrowingAutoloader) {
-                $resource = new ClassExistenceResource($class, ClassExistenceResource::EXISTS_KO_WITH_THROWING_AUTOLOADER);
-
-                $classReflector = $resource->isFresh(0) ? false : new \ReflectionClass($class);
             } else {
-                $classReflector = new \ReflectionClass($class);
+                $resource = new ClassExistenceResource($class, false);
+                $classReflector = $resource->isFresh(0) ? false : new \ReflectionClass($class);
             }
         } catch (\ReflectionException $e) {
             $classReflector = false;
@@ -366,7 +362,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
         if ($this->trackResources) {
             if (!$classReflector) {
-                $this->addResource($resource ?: new ClassExistenceResource($class, ClassExistenceResource::EXISTS_KO));
+                $this->addResource($resource ?: new ClassExistenceResource($class, false));
             } elseif (!$classReflector->isInternal()) {
                 $path = $classReflector->getFileName();
 

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -32,7 +32,7 @@
         "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
     },
     "conflict": {
-        "symfony/config": "<3.3",
+        "symfony/config": "<3.3.1",
         "symfony/finder": "<3.3",
         "symfony/yaml": "<3.3"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | (new hidden feat)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Let's always protected against bad or missing parents. The protection was conditional because the protection adds some perf overhead, but this was a micro optim really...

BC break is for a new feat, better not maintain this.