### PR TITLE
Automatically enable the routing annotation loader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,8 +98,7 @@
         "symfony/phpunit-bridge": "~3.2",
         "symfony/polyfill-apcu": "~1.1",
         "symfony/security-acl": "~2.8|~3.0",
-        "phpdocumentor/reflection-docblock": "^3.0",
-        "sensio/framework-extra-bundle": "^3.0.2"
+        "phpdocumentor/reflection-docblock": "^3.0"
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0",

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -48,7 +48,7 @@ CHANGELOG
    `Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass` instead
  * Deprecated `ValidateWorkflowsPass`, use
    `Symfony\Component\Workflow\DependencyInjection\ValidateWorkflowsPass` instead
- * Deprecated `ConstraintValidatorFactory`, use 
+ * Deprecated `ConstraintValidatorFactory`, use
    `Symfony\Component\Validator\ContainerConstraintValidatorFactory` instead.
 
 3.2.0

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\Reader;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Config\FileLocator;
@@ -48,6 +49,8 @@ use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
+use Symfony\Component\Routing\Loader\AnnotationFileLoader;
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
@@ -691,6 +694,29 @@ class FrameworkExtension extends Extension
                 'Symfony\\Bundle\\FrameworkBundle\\Routing\\RedirectableUrlMatcher',
                 $container->findDefinition('router.default')->getClass(),
             ));
+        }
+
+        if ($this->annotationsConfigEnabled) {
+            $container->register('routing.loader.annotation', AnnotatedRouteControllerLoader::class)
+                ->setPublic(false)
+                ->addTag('routing.loader', array('priority' => -10))
+                ->addArgument(new Reference('annotation_reader'));
+
+            $container->register('routing.loader.directory', AnnotationDirectoryLoader::class)
+                ->setPublic(false)
+                ->addTag('routing.loader', array('priority' => -10))
+                ->setArguments(array(
+                    new Reference('file_locator'),
+                    new Reference('routing.loader.annotation'),
+                ));
+
+            $container->register('routing.loader.file', AnnotationFileLoader::class)
+                ->setPublic(false)
+                ->addTag('routing.loader', array('priority' => -10))
+                ->setArguments(array(
+                    new Reference('file_locator'),
+                    new Reference('routing.loader.annotation'),
+                ));
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/AnnotatedRouteControllerLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/AnnotatedRouteControllerLoader.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Routing;
+
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
+use Symfony\Component\Routing\Route;
+
+/**
+ * AnnotatedRouteControllerLoader is an implementation of AnnotationClassLoader
+ * that sets the '_controller' default based on the class and method names.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AnnotatedRouteControllerLoader extends AnnotationClassLoader
+{
+    /**
+     * Configures the _controller default parameter of a given Route instance.
+     *
+     * @param mixed $annot The annotation class instance
+     */
+    protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
+    {
+        $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+    }
+
+    /**
+     * Makes the default route name more sane by removing common keywords.
+     *
+     * @return string
+     */
+    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
+    {
+        return preg_replace(array(
+            '/(bundle|controller)_/',
+            '/action(_\d+)?$/',
+            '/__/',
+        ), array(
+            '_',
+            '\\1',
+            '_',
+        ), parent::getDefaultRouteName($class, $method));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AnnotatedController/bundles.php
@@ -11,10 +11,8 @@
 
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
-use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 
 return array(
     new FrameworkBundle(),
     new TestBundle(),
-    new SensioFrameworkExtraBundle(),
 );

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
-        "symfony/routing": "~3.3|~4.0",
+        "symfony/routing": "~3.4|~4.0",
         "symfony/stopwatch": "~2.8|~3.0|~4.0",
         "doctrine/cache": "~1.0"
     },
@@ -57,8 +57,7 @@
         "symfony/web-link": "~3.3|~4.0",
         "doctrine/annotations": "~1.0",
         "phpdocumentor/reflection-docblock": "^3.0",
-        "twig/twig": "~1.34|~2.4",
-        "sensio/framework-extra-bundle": "^3.0.2"
+        "twig/twig": "~1.34|~2.4"
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0",

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * Added support for prioritized routing loaders.
+
 3.3.0
 -----
 
@@ -19,7 +24,7 @@ CHANGELOG
 
  * Added support for `bool`, `int`, `float`, `string`, `list` and `map` defaults in XML configurations.
  * Added support for UTF-8 requirements
-  
+
 2.8.0
 -----
 

--- a/src/Symfony/Component/Routing/DependencyInjection/RoutingResolverPass.php
+++ b/src/Symfony/Component/Routing/DependencyInjection/RoutingResolverPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Routing\DependencyInjection;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 
 /**
  * Adds tagged routing.loader services to routing.resolver service.
@@ -22,6 +23,8 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
  */
 class RoutingResolverPass implements CompilerPassInterface
 {
+    use PriorityTaggedServiceTrait;
+
     private $resolverServiceId;
     private $loaderTag;
 
@@ -39,7 +42,7 @@ class RoutingResolverPass implements CompilerPassInterface
 
         $definition = $container->getDefinition($this->resolverServiceId);
 
-        foreach ($container->findTaggedServiceIds($this->loaderTag, true) as $id => $attributes) {
+        foreach ($this->findAndSortTaggedServices($this->loaderTag, $container) as $id) {
             $definition->addMethodCall('addLoader', array(new Reference($id)));
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | there's probably one but I didn't find it
| License       | MIT
| Doc PR        | 

Thanks to fqcn services, most of the time, we don't need the SensioFrameworkExtraBundle to use `@Route`.
So I suggest to automatically enable it when annotations are enabled. This way we could simplify https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/etc/routing.yaml#L5.

Note: I added priority support for routing loaders to make sure sensio loaders are executed before ours.