### PR TITLE
[FrameworkBundle] mitigate BC break with empty trusted_proxies

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -67,7 +67,11 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('trusted_proxies') // @deprecated in version 3.3, to be removed in 4.0
                     ->beforeNormalization()
-                        ->always()
+                        ->ifTrue(function ($v) { return empty($v); })
+                        ->then(function () { @trigger_error('The "framework.trusted_proxies" configuration key has been removed in Symfony 3.3. Use the Request::setTrustedProxies() method in your front controller instead.', E_USER_DEPRECATED); })
+                    ->end()
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) { return !empty($v); })
                         ->thenInvalid('The "framework.trusted_proxies" configuration key has been removed in Symfony 3.3. Use the Request::setTrustedProxies() method in your front controller instead.')
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -43,6 +43,38 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(array('FrameworkBundle:Form'), $config['templating']['form']['resources']);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The "framework.trusted_proxies" configuration key has been removed in Symfony 3.3. Use the Request::setTrustedProxies() method in your front controller instead.
+     */
+    public function testTrustedProxiesSetToNullIsDeprecated()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+        $processor->processConfiguration($configuration, array(array('trusted_proxies' => null)));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The "framework.trusted_proxies" configuration key has been removed in Symfony 3.3. Use the Request::setTrustedProxies() method in your front controller instead.
+     */
+    public function testTrustedProxiesSetToEmptyArrayIsDeprecated()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+        $processor->processConfiguration($configuration, array(array('trusted_proxies' => array())));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testTrustedProxiesSetToNonEmptyArrayIsInvalid()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+        $processor->processConfiguration($configuration, array(array('trusted_proxies' => array('127.0.0.1'))));
+    }
+
     public function testAssetsCanBeEnabled()
     {
         $processor = new Processor();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | kind of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22238#issuecomment-305932238
| License       | MIT
| Doc PR        | 