### PR TITLE
[Translation][FrameworkBundle] Fix resource loading order inconsistency reported in #23034

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -135,6 +135,51 @@ class TranslatorTest extends TestCase
         $this->assertSame('en', $translator->getLocale());
     }
 
+    /** @dataProvider getDebugModeAndCacheDirCombinations */
+    public function testResourceFilesOptionLoadsBeforeOtherAddedResources($debug, $enableCache)
+    {
+        $someCatalogue = $this->getCatalogue('some_locale', array());
+
+        $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')->getMock();
+
+        $loader->expects($this->at(0))
+            ->method('load')
+            /* The "messages.some_locale.loader" is passed via the resource_file option and shall be loaded first */
+            ->with('messages.some_locale.loader', 'some_locale', 'messages')
+            ->willReturn($someCatalogue);
+
+        $loader->expects($this->at(1))
+            ->method('load')
+            /* This resource is added by an addResource() call and shall be loaded after the resource_files */
+            ->with('second_resource.some_locale.loader', 'some_locale', 'messages')
+            ->willReturn($someCatalogue);
+
+        $options = array(
+            'resource_files' => array('some_locale' => array('messages.some_locale.loader')),
+            'debug' => $debug
+        );
+
+        if ($enableCache) {
+            $options['cache_dir'] = $this->tmpDir;
+        }
+
+        /** @var Translator $translator */
+        $translator = $this->createTranslator($loader, $options);
+        $translator->addResource('loader', 'second_resource.some_locale.loader', 'some_locale', 'messages');
+
+        $translator->trans('some_message', array(), null, 'some_locale');
+    }
+
+    public function getDebugModeAndCacheDirCombinations()
+    {
+        return array(
+            array(false, false),
+            array(true, false),
+            array(false, true),
+            array(true, true),
+        );
+    }
+
     protected function getCatalogue($locale, $messages, $resources = array())
     {
         $catalogue = new MessageCatalogue($locale);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -156,7 +156,7 @@ class TranslatorTest extends TestCase
 
         $options = array(
             'resource_files' => array('some_locale' => array('messages.some_locale.loader')),
-            'debug' => $debug
+            'debug' => $debug,
         );
 
         if ($enableCache) {

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -38,13 +38,12 @@ class Translator extends BaseTranslator implements WarmableInterface
     private $resourceLocales;
 
     /**
-     * Holds parameters from addResource() calls so we can add these resources
-     * after the ones passed in the resource_files option (which are added
-     * lazily in loadResources() as well).
+     * Holds parameters from addResource() calls so we can defer the acutal
+     * parent::addResource() calls until initialize() is executed.
      *
      * @var array
      */
-    private $otherResources = array();
+    private $resources = array();
 
     /**
      * Constructor.
@@ -74,9 +73,7 @@ class Translator extends BaseTranslator implements WarmableInterface
 
         $this->options = array_merge($this->options, $options);
         $this->resourceLocales = array_keys($this->options['resource_files']);
-        if (null !== $this->options['cache_dir'] && $this->options['debug']) {
-            $this->loadResources();
-        }
+        $this->addResourceFiles($this->options['resource_files']);
 
         parent::__construct($container->getParameter('kernel.default_locale'), $selector, $this->options['cache_dir'], $this->options['debug']);
     }
@@ -104,7 +101,7 @@ class Translator extends BaseTranslator implements WarmableInterface
 
     public function addResource($format, $resource, $locale, $domain = null)
     {
-        $this->otherResources[] = array($format, $resource, $locale, $domain);
+        $this->resources[] = array($format, $resource, $locale, $domain);
     }
 
     /**
@@ -118,7 +115,12 @@ class Translator extends BaseTranslator implements WarmableInterface
 
     protected function initialize()
     {
-        $this->loadResources();
+        foreach ($this->resources as $key => $params) {
+            list($format, $resource, $locale, $domain) = $params;
+            parent::addResource($format, $resource, $locale, $domain);
+        }
+        $this->resources = array();
+
         foreach ($this->loaderIds as $id => $aliases) {
             foreach ($aliases as $alias) {
                 $this->addLoader($alias, $this->container->get($id));
@@ -126,21 +128,14 @@ class Translator extends BaseTranslator implements WarmableInterface
         }
     }
 
-    private function loadResources()
+    private function addResourceFiles($filesByLocale)
     {
-        foreach ($this->options['resource_files'] as $locale => $files) {
+        foreach ($filesByLocale as $locale => $files) {
             foreach ($files as $key => $file) {
                 // filename is domain.locale.format
                 list($domain, $locale, $format) = explode('.', basename($file), 3);
-                parent::addResource($format, $file, $locale, $domain);
-                unset($this->options['resource_files'][$locale][$key]);
+                $this->addResource($format, $file, $locale, $domain);
             }
-        }
-
-        foreach ($this->otherResources as $key => $params) {
-            list($format, $resource, $locale, $domain) = $params;
-            parent::addResource($format, $resource, $locale, $domain);
-            unset($this->otherResources[$key]);
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -38,6 +38,15 @@ class Translator extends BaseTranslator implements WarmableInterface
     private $resourceLocales;
 
     /**
+     * Holds parameters from addResource() calls so we can add these resources
+     * after the ones passed in the resource_files option (which are added
+     * lazily in loadResources() as well).
+     *
+     * @var array
+     */
+    private $otherResources = array();
+
+    /**
      * Constructor.
      *
      * Available options:
@@ -93,6 +102,11 @@ class Translator extends BaseTranslator implements WarmableInterface
         }
     }
 
+    public function addResource($format, $resource, $locale, $domain = null)
+    {
+        $this->otherResources[] = array($format, $resource, $locale, $domain);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -118,9 +132,15 @@ class Translator extends BaseTranslator implements WarmableInterface
             foreach ($files as $key => $file) {
                 // filename is domain.locale.format
                 list($domain, $locale, $format) = explode('.', basename($file), 3);
-                $this->addResource($format, $file, $locale, $domain);
+                parent::addResource($format, $file, $locale, $domain);
                 unset($this->options['resource_files'][$locale][$key]);
             }
+        }
+
+        foreach ($this->otherResources as $key => $params) {
+            list($format, $resource, $locale, $domain) = $params;
+            parent::addResource($format, $resource, $locale, $domain);
+            unset($this->otherResources[$key]);
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -38,7 +38,7 @@ class Translator extends BaseTranslator implements WarmableInterface
     private $resourceLocales;
 
     /**
-     * Holds parameters from addResource() calls so we can defer the acutal
+     * Holds parameters from addResource() calls so we can defer the actual
      * parent::addResource() calls until initialize() is executed.
      *
      * @var array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23034
| License       | MIT
| Doc PR        | 

Fixes the bug reported in #23034:

When mixing `addResource()` calls and providing the `resource_files` option, the order in which resources are loaded depends on the `kernel.debug` setting and whether a cache is used.

In particular, when several loaders provide translations for the same message, the one that "wins" may change between development and production mode.
