### PR TITLE
[TwigBridge][Form] Support named arguments

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/NamedArgumentsResolverTrait.php
+++ b/src/Symfony/Bridge/Twig/Node/NamedArgumentsResolverTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Node;
+
+use Twig\Error\SyntaxError;
+use Twig\Node\Expression\ConstantExpression;
+
+/**
+ * @internal
+ */
+trait NamedArgumentsResolverTrait
+{
+    /**
+     * @param string   $functionName
+     * @param string[] $parametersNames
+     *
+     * @return array
+     */
+    private function resolveNamedArguments($functionName, array $parametersNames)
+    {
+        $arguments = array();
+
+        $hasNamedArguments = false;
+        foreach (iterator_to_array($this->getNode('arguments')) as $parameter => $node) {
+            if (!is_int($parameter)) {
+                $hasNamedArguments = true;
+
+                if (false === $position = array_search($parameter, $parametersNames, true)) {
+                    throw new \LogicException(sprintf('Unknown argument "%s" for function "%s".', $parameter, $functionName));
+                }
+
+                if (array_key_exists($position, $arguments)) {
+                    throw new SyntaxError(sprintf('Argument "%s" is defined twice for function "%s".', $parameter, $functionName));
+                }
+
+                $arguments[$position] = $node;
+
+                continue;
+            }
+
+            if ($hasNamedArguments) {
+                throw new SyntaxError(sprintf('Positional arguments cannot be used after named arguments for function "%s".', $functionName));
+            }
+
+            $arguments[] = $node;
+        }
+
+        if ($hasNamedArguments) {
+            for ($position = max(array_keys($arguments)) - 1; $position >= 0; --$position) {
+                if (!array_key_exists($position, $arguments)) {
+                    $arguments[$position] = new ConstantExpression(null, 0);
+                }
+            }
+
+            ksort($arguments);
+        }
+
+        return $arguments;
+    }
+}

--- a/src/Symfony/Bridge/Twig/Node/RenderBlockNode.php
+++ b/src/Symfony/Bridge/Twig/Node/RenderBlockNode.php
@@ -24,15 +24,18 @@ use Twig\Node\Expression\FunctionExpression;
  */
 class RenderBlockNode extends FunctionExpression
 {
+    use NamedArgumentsResolverTrait;
+
     public function compile(Compiler $compiler)
     {
         $compiler->addDebugInfo($this);
-        $arguments = iterator_to_array($this->getNode('arguments'));
+        $name = $this->getAttribute('name');
+        $arguments = $this->resolveNamedArguments($name, array('view', 'variables'));
         $compiler->write('$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->renderBlock(');
 
         if (isset($arguments[0])) {
             $compiler->subcompile($arguments[0]);
-            $compiler->raw(', \''.$this->getAttribute('name').'\'');
+            $compiler->raw(', \''.$name.'\'');
 
             if (isset($arguments[1])) {
                 $compiler->raw(', ');

--- a/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
+++ b/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
@@ -21,16 +21,28 @@ use Twig\Node\Expression\FunctionExpression;
  */
 class SearchAndRenderBlockNode extends FunctionExpression
 {
+    use NamedArgumentsResolverTrait;
+
     public function compile(Compiler $compiler)
     {
         $compiler->addDebugInfo($this);
         $compiler->raw('$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(');
 
-        preg_match('/_([^_]+)$/', $this->getAttribute('name'), $matches);
+        $name = $this->getAttribute('name');
+        preg_match('/_([^_]+)$/', $name, $matches);
+        $blockNameSuffix = $matches[1];
 
         $label = null;
-        $arguments = iterator_to_array($this->getNode('arguments'));
-        $blockNameSuffix = $matches[1];
+
+        $parameters = array('view');
+        if ('form_label' === $name) {
+            $parameters[] = 'label';
+        }
+        if ('form_errors' !== $name) {
+            $parameters[] = 'variables';
+        }
+
+        $arguments = $this->resolveNamedArguments($name, $parameters);
 
         if (isset($arguments[0])) {
             $compiler->subcompile($arguments[0]);

--- a/src/Symfony/Bridge/Twig/Tests/Node/RenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/RenderBlockNodeTest.php
@@ -1,0 +1,415 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Node;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Node\RenderBlockNode;
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\NameExpression;
+use Twig\Node\Node;
+
+class RenderBlockNodeTest extends TestCase
+{
+    /**
+     * @dataProvider getCompileFormCases
+     */
+    public function testCompileForm(Node $arguments)
+    {
+        $node = new RenderBlockNode('form', $arguments, 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->renderBlock(%s, \'form\')',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function getCompileFormCases()
+    {
+        yield array(new Node(array(
+            new NameExpression('form', 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileFormWithVariablesCases
+     */
+    public function testCompileFormWithVariables(Node $arguments)
+    {
+        $node = new RenderBlockNode('form', $arguments, 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->renderBlock(%s, \'form\', array("foo" => "bar"))',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function getCompileFormWithVariablesCases()
+    {
+        yield array(new Node(array(
+            new NameExpression('form', 0),
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    public function testCompileFormWithUnknownParameter()
+    {
+        $node = new RenderBlockNode('form', new Node(array(
+            'foo' => new NameExpression('form', 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'LogicException',
+            'Unknown argument "foo" for function "form".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileFormWithDuplicatedParameter()
+    {
+        $node = new RenderBlockNode('form', new Node(array(
+            new NameExpression('form', 0),
+            'view' => new NameExpression('form', 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Argument "view" is defined twice for function "form".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileFormWithPositionalParameterAfterNamedParameter()
+    {
+        $node = new RenderBlockNode('form', new Node(array(
+            'view' => new NameExpression('form', 0),
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Positional arguments cannot be used after named arguments for function "form".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    /**
+     * @dataProvider getCompileFormStartCases
+     */
+    public function testCompileFormStart(Node $arguments)
+    {
+        $node = new RenderBlockNode('form_start', $arguments, 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->renderBlock(%s, \'form_start\')',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function getCompileFormStartCases()
+    {
+        yield array(new Node(array(
+            new NameExpression('form', 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileFormStartWithVariablesCases
+     */
+    public function testCompileFormStartWithVariables(Node $arguments)
+    {
+        $node = new RenderBlockNode('form_start', $arguments, 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->renderBlock(%s, \'form_start\', array("foo" => "bar"))',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function getCompileFormStartWithVariablesCases()
+    {
+        yield array(new Node(array(
+            new NameExpression('form', 0),
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    public function testCompileFormStartWithUnknownParameter()
+    {
+        $node = new RenderBlockNode('form_start', new Node(array(
+            'foo' => new NameExpression('form', 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'LogicException',
+            'Unknown argument "foo" for function "form_start".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileFormStartWithDuplicatedParameter()
+    {
+        $node = new RenderBlockNode('form_start', new Node(array(
+            new NameExpression('form', 0),
+            'view' => new NameExpression('form', 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Argument "view" is defined twice for function "form_start".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileFormStartWithPositionalParameterAfterNamedParameter()
+    {
+        $node = new RenderBlockNode('form_start', new Node(array(
+            'view' => new NameExpression('form', 0),
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Positional arguments cannot be used after named arguments for function "form_start".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    /**
+     * @dataProvider getCompileFormEndCases
+     */
+    public function testCompileFormEnd(Node $arguments)
+    {
+        $node = new RenderBlockNode('form_end', $arguments, 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->renderBlock(%s, \'form_end\')',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function getCompileFormEndCases()
+    {
+        yield array(new Node(array(
+            new NameExpression('form', 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileFormEndWithVariablesCases
+     */
+    public function testCompileFormEndWithVariables(Node $arguments)
+    {
+        $node = new RenderBlockNode('form_end', $arguments, 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->renderBlock(%s, \'form_end\', array("foo" => "bar"))',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function getCompileFormEndWithVariablesCases()
+    {
+        yield array(new Node(array(
+            new NameExpression('form', 0),
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    public function testCompileFormEndWithUnknownParameter()
+    {
+        $node = new RenderBlockNode('form_end', new Node(array(
+            'foo' => new NameExpression('form', 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'LogicException',
+            'Unknown argument "foo" for function "form_end".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileFormEndWithDuplicatedParameter()
+    {
+        $node = new RenderBlockNode('form_end',
+            new Node(array(
+                new NameExpression('form', 0),
+                'view' => new NameExpression('form', 0),
+            )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Argument "view" is defined twice for function "form_end".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileFormEndWithPositionalParameterAfterNamedParameter()
+    {
+        $node = new RenderBlockNode('form_end', new Node(array(
+            'view' => new NameExpression('form', 0),
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Positional arguments cannot be used after named arguments for function "form_end".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    private function getVariableGetter($name)
+    {
+        if (PHP_VERSION_ID >= 70000) {
+            return sprintf('($context["%s"] ?? null)', $name, $name);
+        }
+
+        return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -23,12 +23,11 @@ use Twig\Node\Node;
 
 class SearchAndRenderBlockNodeTest extends TestCase
 {
-    public function testCompileWidget()
+    /**
+     * @dataProvider getCompileWidgetCases
+     */
+    public function testCompileWidget(Node $arguments)
     {
-        $arguments = new Node(array(
-            new NameExpression('form', 0),
-        ));
-
         $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
 
         $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
@@ -42,16 +41,22 @@ class SearchAndRenderBlockNodeTest extends TestCase
         );
     }
 
-    public function testCompileWidgetWithVariables()
+    public function getCompileWidgetCases()
     {
-        $arguments = new Node(array(
+        yield array(new Node(array(
             new NameExpression('form', 0),
-            new ArrayExpression(array(
-                new ConstantExpression('foo', 0),
-                new ConstantExpression('bar', 0),
-            ), 0),
-        ));
+        )));
 
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileWidgetWithVariablesCases
+     */
+    public function testCompileWidgetWithVariables(Node $arguments)
+    {
         $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
 
         $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
@@ -65,13 +70,91 @@ class SearchAndRenderBlockNodeTest extends TestCase
         );
     }
 
-    public function testCompileLabelWithLabel()
+    public function getCompileWidgetWithVariablesCases()
     {
-        $arguments = new Node(array(
+        yield array(new Node(array(
             new NameExpression('form', 0),
-            new ConstantExpression('my label', 0),
-        ));
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
 
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    public function testCompileWidgetWithUnknownParameter()
+    {
+        $node = new SearchAndRenderBlockNode('form_widget', new Node(array(
+            'foo' => new NameExpression('form', 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'LogicException',
+            'Unknown argument "foo" for function "form_widget".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileWidgetWithDuplicatedParameter()
+    {
+        $node = new SearchAndRenderBlockNode('form_widget', new Node(array(
+            new NameExpression('form', 0),
+            'view' => new NameExpression('form', 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Argument "view" is defined twice for function "form_widget".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileWidgetWithPositionalParameterAfterNamedParameter()
+    {
+        $node = new SearchAndRenderBlockNode('form_widget', new Node(array(
+            'view' => new NameExpression('form', 0),
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Positional arguments cannot be used after named arguments for function "form_widget".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    /**
+     * @dataProvider getCompileLabelWithLabelCases
+     */
+    public function testCompileLabelWithLabel(Node $arguments)
+    {
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
         $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
@@ -85,7 +168,28 @@ class SearchAndRenderBlockNodeTest extends TestCase
         );
     }
 
-    public function testCompileLabelWithNullLabel()
+    public function getCompileLabelWithLabelCases()
+    {
+        yield array(new Node(array(
+            new NameExpression('form', 0),
+            new ConstantExpression('my label', 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'label' => new ConstantExpression('my label', 0),
+        )));
+
+        yield array(new Node(array(
+            'label' => new ConstantExpression('my label', 0),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileLabelWithNullLabelCases
+     */
+    public function testCompileLabelWithNullLabel(Node $arguments)
     {
         $arguments = new Node(array(
             new NameExpression('form', 0),
@@ -107,34 +211,67 @@ class SearchAndRenderBlockNodeTest extends TestCase
         );
     }
 
-    public function testCompileLabelWithEmptyStringLabel()
+    public function getCompileLabelWithNullLabelCases()
     {
-        $arguments = new Node(array(
+        yield array(new Node(array(
+            new NameExpression('form', 0),
+            new ConstantExpression(null, 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'label' => new ConstantExpression(null, 0),
+        )));
+
+        yield array(new Node(array(
+            'label' => new ConstantExpression(null, 0),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileLabelWithEmptyStringLabelCases
+     */
+    public function testCompileLabelWithEmptyStringLabel(Node $arguments)
+    {
+        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
+
+        // "label" => null must not be included in the output!
+        // Otherwise the default label is overwritten with null.
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\')',
+                $this->getVariableGetter('form')
+            ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function getCompileLabelWithEmptyStringLabelCases()
+    {
+        yield array(new Node(array(
             new NameExpression('form', 0),
             new ConstantExpression('', 0),
-        ));
+        )));
 
-        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'label' => new ConstantExpression('', 0),
+        )));
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
-        // "label" => null must not be included in the output!
-        // Otherwise the default label is overwritten with null.
-        $this->assertEquals(
-            sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\')',
-                $this->getVariableGetter('form')
-            ),
-            trim($compiler->compile($node)->getSource())
-        );
+        yield array(new Node(array(
+            'label' => new ConstantExpression('', 0),
+            'view' => new NameExpression('form', 0),
+        )));
     }
 
-    public function testCompileLabelWithDefaultLabel()
+    /**
+     * @dataProvider getCompileLabelWithDefaultLabelCases
+     */
+    public function testCompileLabelWithDefaultLabel(Node $arguments)
     {
-        $arguments = new Node(array(
-            new NameExpression('form', 0),
-        ));
-
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
         $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
@@ -148,17 +285,22 @@ class SearchAndRenderBlockNodeTest extends TestCase
         );
     }
 
-    public function testCompileLabelWithAttributes()
+    public function getCompileLabelWithDefaultLabelCases()
     {
-        $arguments = new Node(array(
+        yield array(new Node(array(
             new NameExpression('form', 0),
-            new ConstantExpression(null, 0),
-            new ArrayExpression(array(
-                new ConstantExpression('foo', 0),
-                new ConstantExpression('bar', 0),
-            ), 0),
-        ));
+        )));
 
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileLabelWithAttributesCases
+     */
+    public function testCompileLabelWithAttributes(Node $arguments)
+    {
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
         $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
@@ -175,19 +317,93 @@ class SearchAndRenderBlockNodeTest extends TestCase
         );
     }
 
-    public function testCompileLabelWithLabelAndAttributes()
+    public function getCompileLabelWithAttributesCases()
     {
-        $arguments = new Node(array(
+        yield array(new Node(array(
             new NameExpression('form', 0),
-            new ConstantExpression('value in argument', 0),
+            new ConstantExpression(null, 0),
             new ArrayExpression(array(
                 new ConstantExpression('foo', 0),
                 new ConstantExpression('bar', 0),
-                new ConstantExpression('label', 0),
-                new ConstantExpression('value in attributes', 0),
             ), 0),
-        ));
+        )));
 
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'label' => new ConstantExpression(null, 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+            'label' => new ConstantExpression(null, 0),
+        )));
+
+        yield array(new Node(array(
+            'label' => new ConstantExpression(null, 0),
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'label' => new ConstantExpression(null, 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+            'label' => new ConstantExpression(null, 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+            'label' => new ConstantExpression(null, 0),
+            'view' => new NameExpression('form', 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileLabelWithLabelAndAttributesCases
+     */
+    public function testCompileLabelWithLabelAndAttributes(Node $arguments)
+    {
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
         $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
@@ -201,21 +417,91 @@ class SearchAndRenderBlockNodeTest extends TestCase
         );
     }
 
-    public function testCompileLabelWithLabelThatEvaluatesToNull()
+    public function getCompileLabelWithLabelAndAttributesCases()
     {
-        $arguments = new Node(array(
+        yield array(new Node(array(
             new NameExpression('form', 0),
-            new ConditionalExpression(
-                // if
-                new ConstantExpression(true, 0),
-                // then
-                new ConstantExpression(null, 0),
-                // else
-                new ConstantExpression(null, 0),
-                0
-            ),
-        ));
+            new ConstantExpression('value in argument', 0),
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+        )));
 
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'label' => new ConstantExpression('value in argument', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+            'label' => new ConstantExpression('value in argument', 0),
+        )));
+
+        yield array(new Node(array(
+            'label' => new ConstantExpression('value in argument', 0),
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'label' => new ConstantExpression('value in argument', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+            'label' => new ConstantExpression('value in argument', 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+            'label' => new ConstantExpression('value in argument', 0),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileLabelWithLabelThatEvaluatesToNullCases
+     */
+    public function testCompileLabelWithLabelThatEvaluatesToNull(Node $arguments)
+    {
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
         $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
@@ -232,9 +518,72 @@ class SearchAndRenderBlockNodeTest extends TestCase
         );
     }
 
-    public function testCompileLabelWithLabelThatEvaluatesToNullAndAttributes()
+    public function getCompileLabelWithLabelThatEvaluatesToNullCases()
     {
-        $arguments = new Node(array(
+        yield array(new Node(array(
+            new NameExpression('form', 0),
+            new ConditionalExpression(
+                // if
+                new ConstantExpression(true, 0),
+                // then
+                new ConstantExpression(null, 0),
+                // else
+                new ConstantExpression(null, 0),
+                0
+            ),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'label' => new ConditionalExpression(
+                // if
+                new ConstantExpression(true, 0),
+                // then
+                new ConstantExpression(null, 0),
+                // else
+                new ConstantExpression(null, 0),
+                0
+            ),
+        )));
+
+        yield array(new Node(array(
+            'label' => new ConditionalExpression(
+                // if
+                new ConstantExpression(true, 0),
+                // then
+                new ConstantExpression(null, 0),
+                // else
+                new ConstantExpression(null, 0),
+                0
+            ),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    /**
+     * @dataProvider getCompileLabelWithLabelThatEvaluatesToNullAndAttributesCases
+     */
+    public function testCompileLabelWithLabelThatEvaluatesToNullAndAttributes(Node $arguments)
+    {
+        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
+
+        // "label" => null must not be included in the output!
+        // Otherwise the default label is overwritten with null.
+        // https://github.com/symfony/symfony/issues/5029
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', array("foo" => "bar", "label" => "value in attributes") + (twig_test_empty($_label_ = ((true) ? (null) : (null))) ? array() : array("label" => $_label_)))',
+                $this->getVariableGetter('form')
+            ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function getCompileLabelWithLabelThatEvaluatesToNullAndAttributesCases()
+    {
+        yield array(new Node(array(
             new NameExpression('form', 0),
             new ConditionalExpression(
                 // if
@@ -251,22 +600,174 @@ class SearchAndRenderBlockNodeTest extends TestCase
                 new ConstantExpression('label', 0),
                 new ConstantExpression('value in attributes', 0),
             ), 0),
-        ));
+        )));
 
-        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
-
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
-        // "label" => null must not be included in the output!
-        // Otherwise the default label is overwritten with null.
-        // https://github.com/symfony/symfony/issues/5029
-        $this->assertEquals(
-            sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', array("foo" => "bar", "label" => "value in attributes") + (twig_test_empty($_label_ = ((true) ? (null) : (null))) ? array() : array("label" => $_label_)))',
-                $this->getVariableGetter('form')
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'label' => new ConditionalExpression(
+                // if
+                new ConstantExpression(true, 0),
+                // then
+                new ConstantExpression(null, 0),
+                // else
+                new ConstantExpression(null, 0),
+                0
             ),
-            trim($compiler->compile($node)->getSource())
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+            'label' => new ConditionalExpression(
+                // if
+                new ConstantExpression(true, 0),
+                // then
+                new ConstantExpression(null, 0),
+                // else
+                new ConstantExpression(null, 0),
+                0
+            ),
+        )));
+
+        yield array(new Node(array(
+            'label' => new ConditionalExpression(
+                // if
+                new ConstantExpression(true, 0),
+                // then
+                new ConstantExpression(null, 0),
+                // else
+                new ConstantExpression(null, 0),
+                0
+            ),
+            'view' => new NameExpression('form', 0),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+        )));
+
+        yield array(new Node(array(
+            'label' => new ConditionalExpression(
+                // if
+                new ConstantExpression(true, 0),
+                // then
+                new ConstantExpression(null, 0),
+                // else
+                new ConstantExpression(null, 0),
+                0
+            ),
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+            'view' => new NameExpression('form', 0),
+            'label' => new ConditionalExpression(
+                // if
+                new ConstantExpression(true, 0),
+                // then
+                new ConstantExpression(null, 0),
+                // else
+                new ConstantExpression(null, 0),
+                0
+            ),
+        )));
+
+        yield array(new Node(array(
+            'variables' => new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+                new ConstantExpression('label', 0),
+                new ConstantExpression('value in attributes', 0),
+            ), 0),
+            'label' => new ConditionalExpression(
+                // if
+                new ConstantExpression(true, 0),
+                // then
+                new ConstantExpression(null, 0),
+                // else
+                new ConstantExpression(null, 0),
+                0
+            ),
+            'view' => new NameExpression('form', 0),
+        )));
+    }
+
+    public function testCompileLabelWithUnknownParameter()
+    {
+        $node = new SearchAndRenderBlockNode('form_label', new Node(array(
+            'foo' => new NameExpression('form', 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'LogicException',
+            'Unknown argument "foo" for function "form_label".'
         );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileLabelWithDuplicatedParameter()
+    {
+        $node = new SearchAndRenderBlockNode('form_label', new Node(array(
+            new NameExpression('form', 0),
+            'view' => new NameExpression('form', 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Argument "view" is defined twice for function "form_label".'
+        );
+
+        $compiler->compile($node);
+    }
+
+    public function testCompileLabelWithPositionalParameterAfterNamedParameter()
+    {
+        $node = new SearchAndRenderBlockNode('form_label', new Node(array(
+            'view' => new NameExpression('form', 0),
+            new ArrayExpression(array(
+                new ConstantExpression('foo', 0),
+                new ConstantExpression('bar', 0),
+            ), 0),
+        )), 0);
+
+        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig_LoaderInterface')->getMock()));
+
+        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
+            'Twig_Error_Syntax',
+            'Positional arguments cannot be used after named arguments for function "form_label".'
+        );
+
+        $compiler->compile($node);
     }
 
     protected function getVariableGetter($name)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

#20744 was closed because using named arguments should be the way to go. But it seems named arguments support was never implemented for form functions.