### PR TITLE
[Security] Fix exclusion of login_path in determineTargetUrl

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -130,7 +130,7 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
     }
 
     /**
-     * Generates path part of URL, based on the given path, absolute URL or route
+     * Generates path part of URL, based on the given path, absolute URL or route.
      *
      * @param Request $request A Request instance
      * @param string  $path    A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -122,7 +122,13 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
             return $targetUrl;
         }
 
-        if ($this->options['use_referer'] && ($targetUrl = $request->headers->get('Referer')) && parse_url($targetUrl, PHP_URL_PATH) !== $this->httpUtils->generateUri($request, $this->options['login_path'])) {
+        if ($this->options['use_referer']
+            && ($targetUrl = $request->headers->get('Referer'))
+            && parse_url($targetUrl, PHP_URL_PATH) !== parse_url(
+                $this->httpUtils->generateUri($request, $this->options['login_path']),
+                PHP_URL_PATH
+            )
+        ) {
             return $targetUrl;
         }
 

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -122,16 +122,25 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
             return $targetUrl;
         }
 
-        if ($this->options['use_referer']
-            && ($targetUrl = $request->headers->get('Referer'))
-            && parse_url($targetUrl, PHP_URL_PATH) !== parse_url(
-                $this->httpUtils->generateUri($request, $this->options['login_path']),
-                PHP_URL_PATH
-            )
-        ) {
+        if ($this->options['use_referer'] && ($targetUrl = $request->headers->get('Referer')) && parse_url($targetUrl, PHP_URL_PATH) !== $this->generateUrlPath($request, $this->options['login_path'])) {
             return $targetUrl;
         }
 
         return $this->options['default_target_path'];
+    }
+
+    /**
+     * Generates path part of URL, based on the given path, absolute URL or route
+     *
+     * @param Request $request A Request instance
+     * @param string  $path    A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
+     *
+     * @return string url path
+     *
+     * @throws \LogicException
+     */
+    private function generateUrlPath($request, $path)
+    {
+        return parse_url($this->httpUtils->generateUri($request, $path), PHP_URL_PATH);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -169,7 +169,7 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
 
         $this->httpUtils->expects($this->once())
             ->method('generateUri')->with($this->request, '/login')
-            ->will($this->returnValue('/subfolder/login'));
+            ->will($this->returnValue('http://localhost/subfolder/login'));
 
         $response = $this->expectRedirectResponse('/');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

This would fix problem in scenario when:
in `security.yml` `default_target_path` is set to some route
user uses login form **without referer**
currently he would be incorrectly redirected to login page
after this fix he would be redirected to `default_target_path` value

`generateUri` always returns absolute URL (with host),
while `parse_url($targetUrl, PHP_URL_PATH)` is only returning path (without host)
so entire statement will always evaluate to true, and never to false:
```
parse_url($targetUrl, PHP_URL_PATH) !== $this->httpUtils->generateUri($request, $this->options['login_path'])
```

Worked correctly in 3.2, broken by commit: https://github.com/symfony/symfony/commit/bafa8e29e05e3dda0bf13fbcd85673a9986f57f7