### PR TITLE
[Cache] Fix extensibility of TagAwareAdapter::TAGS_PREFIX

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -281,7 +281,7 @@ class TagAwareAdapter implements TagAwareAdapterInterface
 
         foreach ($items as $key => $item) {
             if (!$tagKeys) {
-                yield $key => $f($item, self::TAGS_PREFIX.$key, $itemTags);
+                yield $key => $f($item, static::TAGS_PREFIX.$key, $itemTags);
                 continue;
             }
             if (!isset($tagKeys[$key])) {
@@ -306,7 +306,7 @@ class TagAwareAdapter implements TagAwareAdapterInterface
                 $tagVersions = $tagKeys = null;
 
                 foreach ($bufferedItems as $key => $item) {
-                    yield $key => $f($item, self::TAGS_PREFIX.$key, $itemTags);
+                    yield $key => $f($item, static::TAGS_PREFIX.$key, $itemTags);
                 }
                 $bufferedItems = null;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

It seems that when MemcachedAdapter is used with TagAwareAdapter, it fails to fetch items, even though I thoroughly tested fetching items with the exact same keys under the same namespace.

Edit: Just to clarify, `CacheItem::isHit()` always returned `false`. This is what I meant with the above.

Turns out the issue lies in `const TAGS_PREFIX = "\0tags\0";` for unknown to me reasons. Hardcoding that to `'__tags__'` in my project did the trick and I've been using it for a couple of days now and it seems fine.

The reason I had to completely copy/paste this file in my local project is `self::` instead of `static::` usage. I am not sure whether that is a mistake or is done on purpose, but in order to have this work for me I need to be able to override that constant. Going with static:: seems like a good solution to me, then I can set whatever prefix I need for the tags.

PS: Not exactly sure what to do with tests. Any help would be appreciated.
