### PR TITLE
[SecurityBundle] Show unique Inherited roles in profile panel

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -82,7 +82,7 @@ class SecurityDataCollector extends DataCollector
                 'token_class' => get_class($token),
                 'user' => $token->getUsername(),
                 'roles' => array_map(function (RoleInterface $role) { return $role->getRole(); }, $assignedRoles),
-                'inherited_roles' => array_map(function (RoleInterface $role) { return $role->getRole(); }, $inheritedRoles),
+                'inherited_roles' => array_unique(array_map(function (RoleInterface $role) { return $role->getRole(); }, $inheritedRoles)),
                 'supports_role_hierarchy' => null !== $this->roleHierarchy,
             );
         }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -111,6 +111,11 @@ class SecurityDataCollectorTest extends TestCase
                 array('ROLE_ADMIN'),
                 array('ROLE_USER', 'ROLE_ALLOWED_TO_SWITCH'),
             ),
+            array(
+                array('ROLE_ADMIN', 'ROLE_OPERATOR'),
+                array('ROLE_ADMIN', 'ROLE_OPERATOR'),
+                array('ROLE_USER', 'ROLE_ALLOWED_TO_SWITCH'),
+            ),
         );
     }
 
@@ -118,6 +123,7 @@ class SecurityDataCollectorTest extends TestCase
     {
         return new RoleHierarchy(array(
             'ROLE_ADMIN' => array('ROLE_USER', 'ROLE_ALLOWED_TO_SWITCH'),
+            'ROLE_OPERATOR' => array('ROLE_USER'),
         ));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

When more than one assigned role reaches the same inherited role then it's duplicated in the "Inherited roles" list.

The changes in the test case show the unexpected result before fix it:

```console
There was 1 failure:

1) Symfony\Bundle\SecurityBundle\Tests\DataCollector\SecurityDataCollectorTest::testCollectAuthenticationTokenAndRoles with data set #4 (array('ROLE_ADMIN', 'ROLE_OPERATOR'), array('ROLE_ADMIN', 'ROLE_OPERATOR'), array('ROLE_USER', 'ROLE_ALLOWED_TO_SWITCH'))
Failed asserting that Array &0 (
    0 => 'ROLE_USER'
    1 => 'ROLE_ALLOWED_TO_SWITCH'
    2 => 'ROLE_USER'
) is identical to Array &0 (
    0 => 'ROLE_USER'
    1 => 'ROLE_ALLOWED_TO_SWITCH'
)
```