### PR TITLE
[Cache] ApcuAdapter::isSupported() should return true when apc.enable_cli=Off

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
@@ -21,7 +21,7 @@ class ApcuAdapter extends AbstractAdapter
 {
     public static function isSupported()
     {
-        return function_exists('apcu_fetch') && ini_get('apc.enabled') && !('cli' === PHP_SAPI && !ini_get('apc.enable_cli'));
+        return function_exists('apcu_fetch') && ini_get('apc.enabled');
     }
 
     public function __construct($namespace = '', $defaultLifetime = 0, $version = null)
@@ -69,7 +69,7 @@ class ApcuAdapter extends AbstractAdapter
      */
     protected function doClear($namespace)
     {
-        return isset($namespace[0]) && class_exists('APCuIterator', false)
+        return isset($namespace[0]) && class_exists('APCuIterator', false) && ('cli' !== PHP_SAPI || ini_get('apc.enable_cli'))
             ? apcu_delete(new \APCuIterator(sprintf('/^%s/', preg_quote($namespace, '/')), APC_ITER_KEY))
             : apcu_clear_cache();
     }

--- a/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
@@ -26,7 +26,7 @@ class PhpFilesAdapter extends AbstractAdapter
 
     public static function isSupported()
     {
-        return function_exists('opcache_compile_file') && ini_get('opcache.enable');
+        return function_exists('opcache_invalidate') && ini_get('opcache.enable');
     }
 
     public function __construct($namespace = '', $defaultLifetime = 0, $directory = null)
@@ -118,7 +118,7 @@ class PhpFilesAdapter extends AbstractAdapter
             $ok = $this->write($file, '<?php return '.var_export($data, true).';') && $ok;
 
             if ($allowCompile) {
-                @opcache_compile_file($file);
+                @opcache_invalidate($file, true);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

By being sensitive to apc.enable_cli, CLI cache warmup is broken when the setting is set to off because a PhpFilesAdapter will be warmed up by the CLI, whereas the Web mode will look at the FilesystemAdapter pools, which will be empty.