### PR TITLE
[Filesystem] added workaround in Filesystem::rename for PHP bug

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -278,7 +278,7 @@ class Filesystem
         if (true !== @rename($origin, $target)) {
             if (is_dir($origin)) {
                 // See https://bugs.php.net/bug.php?id=54097 & http://php.net/manual/en/function.rename.php#113943
-                $this->mirror($origin, $target, null, ['override' => $overwrite, 'delete' => $overwrite]);
+                $this->mirror($origin, $target, null, array('override' => $overwrite, 'delete' => $overwrite));
                 $this->remove($origin);
 
                 return;

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -276,6 +276,13 @@ class Filesystem
         }
 
         if (true !== @rename($origin, $target)) {
+            if (is_dir($origin)) {
+                // See https://bugs.php.net/bug.php?id=54097 & http://php.net/manual/en/function.rename.php#113943
+                $this->mirror($origin, $target, null, ['override' => $overwrite, 'delete' => $overwrite]);
+                $this->remove($origin);
+
+                return;
+            }
             throw new IOException(sprintf('Cannot rename "%s" to "%s".', $origin, $target), 0, null, $target);
         }
     }


### PR DESCRIPTION
[Filesystem] added workaround in Filesystem::rename for https://bugs.php.net/bug.php?id=54097

Standard PHP rename() of dirs across devices/mounted filesystems  produces confusing copy error & throws IOException in Filesystem::rename. I got it during console cache:clear  in the Docker environment. This PR possible fixes https://github.com/symfony/symfony/issues/19851 and other environment related issues.

Workaround is on \rename() fails try to Filesystem::mirror & Filesystem::remove if $origin is directory

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 


