### PR TITLE
Release v2.8.22

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,16 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.22 (2017-06-07)
+
+ * bug #23073 [TwigBridge] Fix namespaced classes (ogizanagi)
+ * bug #22936 [Form] Mix attr option between guessed options and user options (yceruto)
+ * bug #22988 [PropertyInfo][DoctrineBridge] The bigint Doctrine's type must be converted to string (dunglas)
+ * bug #23014 Fix optional cache warmers are always instantiated whereas they should be lazy-loaded (romainneutron)
+ * bug #23024 [EventDispatcher] Fix ContainerAwareEventDispatcher::hasListeners(null) (nicolas-grekas)
+ * bug #22996 [Form] Fix \IntlDateFormatter timezone parameter usage to bypass PHP bug #66323 (romainneutron)
+ * bug #22994 Harden the debugging of Twig filters and functions (stof)
+
 * 2.8.21 (2017-05-29)
 
  * bug #22847 [Console] ChoiceQuestion must have choices (ro0NL)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.22-DEV';
+    const VERSION = '2.8.22';
     const VERSION_ID = 20822;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
     const RELEASE_VERSION = 22;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';
     const END_OF_LIFE = '11/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.8.21...v2.8.22)

 * bug #23073 [TwigBridge] Fix namespaced classes (@ogizanagi)
 * bug #22936 [Form] Mix attr option between guessed options and user options (@yceruto)
 * bug #22988 [PropertyInfo][DoctrineBridge] The bigint Doctrine's type must be converted to string (@dunglas)
 * bug #23014 Fix optional cache warmers are always instantiated whereas they should be lazy-loaded (@romainneutron)
 * bug #23024 [EventDispatcher] Fix ContainerAwareEventDispatcher::hasListeners(null) (@nicolas-grekas)
 * bug #22996 [Form] Fix \IntlDateFormatter timezone parameter usage to bypass PHP bug #66323 (@romainneutron)
 * bug #22994 Harden the debugging of Twig filters and functions (@stof)
