### PR TITLE
[PropertyAccess] Do not silence TypeErrors from client code.

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -244,6 +244,9 @@ class PropertyAccessor implements PropertyAccessorInterface
             }
         } catch (\TypeError $e) {
             self::throwInvalidArgumentException($e->getMessage(), $e->getTrace(), 0);
+
+            // It wasn't thrown in this class so rethrow it
+            throw $e;
         } finally {
             if (\PHP_VERSION_ID < 70000 && false !== self::$previousErrorHandler) {
                 restore_error_handler();

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassTypeErrorInsideCall.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClassTypeErrorInsideCall.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class TestClassTypeErrorInsideCall
+{
+    public function expectsDateTime(\DateTime $date)
+    {
+    }
+
+    public function getProperty()
+    {
+    }
+
+    public function setProperty($property)
+    {
+        $this->expectsDateTime(null); // throws TypeError
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicGet;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\Ticket5775Object;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassSetValue;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassIsWritable;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassTypeErrorInsideCall;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TypeHinted;
 
 class PropertyAccessorTest extends TestCase
@@ -577,5 +578,16 @@ class PropertyAccessorTest extends TestCase
         $object = new TypeHinted();
 
         $this->propertyAccessor->setValue($object, 'countable', 'This is a string, \Countable expected.');
+    }
+
+    /**
+     * @requires PHP 7.0
+     * @expectedException \TypeError
+     */
+    public function testThrowTypeErrorInsideSetterCall()
+    {
+        $object = new TestClassTypeErrorInsideCall();
+
+        $this->propertyAccessor->setValue($object, 'property', 'foo');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Fixes TypeError silencing in `setValue()` when said error is thrown inside setter/adder/etc.

An example is given in the included test, but more real-life story is botched accessors for a many-to-one association on a Doctrine entity:

```php
class B {
  function setA(A $a) { ... } // forgotten "= null" here
}

class A {
  function removeB(B $b) {
    if ($this->bs->contains($b)) {
      $this->bs->removeElement($b);
      $b->setA(null); // TypeError thrown
    }
    return $this;
  }
}
```

No error is shown to the user, even though removing doesn't work.

This bug is not present in 2.7 & 2.8.