### PR TITLE
[FormBuilderInterface] Fixed PHPdoc return references

### DIFF
--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -27,7 +27,7 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      * @param string|FormTypeInterface        $type
      * @param array                           $options
      *
-     * @return $this
+     * @return self
      */
     public function add($child, $type = null, array $options = array());
 
@@ -58,7 +58,7 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      *
      * @param string $name
      *
-     * @return $this
+     * @return self
      */
     public function remove($name);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 and higher
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | N/A (phpdoc)
| License       | MIT

In a case where the method `createFormBuilder()` was used where the methods `add()` and `getForm()` were chained onto it, the final resulting object was no longer a FormBuilder object as the `add()` and `remove()` methods was using a return variable that didn't work.
Should reference `self` as interfaces do not have a `$this` object.