### PR TITLE
[TwigBundle] Avoid line overflow with long arguments in exception page

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
@@ -106,7 +106,7 @@ header .container { display: flex; justify-content: space-between; }
 .trace-class { color: #B0413E; }
 .trace-type { padding: 0 2px; }
 .trace-method { color: #B0413E; color: #222; font-weight: bold; color: #B0413E; }
-.trace-arguments { color: #222; color: #999; font-weight: normal; color: #795da3; color: #777; padding-left: 2px; }
+.trace-arguments { color: #222; color: #999; font-weight: normal; color: #795da3; color: #777; padding-left: 2px; word-wrap: break-word; }
 
 .trace-code { background: #FFF; font-size: 12px; margin: 10px 0 2px; padding: 10px; overflow-x: auto; }
 .trace-code ol { margin: 0; float: left; }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master 
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
