### PR TITLE
[OptionsResolver] Support array of types in allowed type

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `OptionsResolverIntrospector` to inspect options definitions inside an `OptionsResolver` instance
+ * added array of types support in allowed types (e.g int[])
 
 2.6.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17032, #15524
| License       | MIT
| Doc PR        | TBD

This replaces #17032 with a simpler approach to allow an array of types in the allowed types for the options resolver

Note: This implementation doesn't support nested values (I.E `int[][]`), but if there is a strong need for it, I'll add it in another PR