### PR TITLE
[SecurityBundle] Lazy load security listeners

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -4,7 +4,7 @@ UPGRADE FROM 3.3 to 3.4
 DependencyInjection
 -------------------
 
-  * Top-level anonymous services in XML are deprecated and will throw an exception in Symfony 4.0.
+ * Top-level anonymous services in XML are deprecated and will throw an exception in Symfony 4.0.
 
 Finder
 ------
@@ -31,6 +31,11 @@ Process
 
  * The `Symfony\Component\Process\ProcessBuilder` class has been deprecated,
    use the `Symfony\Component\Process\Process` class directly instead.
+
+SecurityBundle
+--------------
+
+ * `FirewallContext::getListeners()` now returns `\Traversable|array`
 
 Validator
 ---------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * [BC BREAK] `FirewallContext::getListeners()` now returns `\Traversable|array`
+
 3.3.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -265,7 +265,7 @@ class SecurityExtension extends Extension
             $contextId = 'security.firewall.map.context.'.$name;
             $context = $container->setDefinition($contextId, new ChildDefinition('security.firewall.context'));
             $context
-                ->replaceArgument(0, $listeners)
+                ->replaceArgument(0, new IteratorArgument($listeners))
                 ->replaceArgument(1, $exceptionListener)
                 ->replaceArgument(2, new Reference($configId))
             ;

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
@@ -25,7 +25,12 @@ class FirewallContext
     private $exceptionListener;
     private $config;
 
-    public function __construct(array $listeners, ExceptionListener $exceptionListener = null, FirewallConfig $config = null)
+    /**
+     * @param \Traversable|array     $listeners
+     * @param ExceptionListener|null $exceptionListener
+     * @param FirewallConfig|null    $firewallConfig
+     */
+    public function __construct($listeners, ExceptionListener $exceptionListener = null, FirewallConfig $config = null)
     {
         $this->listeners = $listeners;
         $this->exceptionListener = $exceptionListener;
@@ -47,6 +52,9 @@ class FirewallContext
         return array($this->getListeners(), $this->getExceptionListener());
     }
 
+    /**
+     * @return \Traversable|array
+     */
     public function getListeners()
     {
         return $this->listeners;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -72,7 +72,7 @@ abstract class CompleteConfigurationTest extends TestCase
         foreach (array_keys($arguments[1]->getValues()) as $contextId) {
             $contextDef = $container->getDefinition($contextId);
             $arguments = $contextDef->getArguments();
-            $listeners[] = array_map('strval', $arguments['index_0']);
+            $listeners[] = array_map('strval', $arguments['index_0']->getValues());
 
             $configDef = $container->getDefinition((string) $arguments['index_2']);
             $configs[] = array_values($configDef->getArguments());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes (edge case)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Each of them is heavy and unused if a previous one sets a response or breaks in the middle.