### PR TITLE
[EventDispatcher] Remove dead code in WrappedListener

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -15,7 +15,6 @@ use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\VarDumper\Caster\ClassStub;
-use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -30,8 +29,7 @@ class WrappedListener
     private $dispatcher;
     private $pretty;
     private $stub;
-
-    private static $cloner;
+    private static $hasClassStub;
 
     public function __construct($listener, $name, Stopwatch $stopwatch, EventDispatcherInterface $dispatcher = null)
     {
@@ -58,8 +56,8 @@ class WrappedListener
             $this->name = $name;
         }
 
-        if (null === self::$cloner) {
-            self::$cloner = class_exists(ClassStub::class) ? new VarCloner() : false;
+        if (null === self::$hasClassStub) {
+            self::$hasClassStub = class_exists(ClassStub::class);
         }
     }
 
@@ -86,7 +84,7 @@ class WrappedListener
     public function getInfo($eventName)
     {
         if (null === $this->stub) {
-            $this->stub = false === self::$cloner ? $this->pretty.'()' : new ClassStub($this->pretty.'()', $this->listener);
+            $this->stub = self::$hasClassStub ? new ClassStub($this->pretty.'()', $this->listener) : $this->pretty.'()';
         }
 
         return array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The static `$cloner` property is unused since https://github.com/symfony/symfony/commit/ab716c64de1fdfc74bb07653666733e3f9406b62