### PR TITLE
Add PHP nightly to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,10 @@ matrix:
           env: deps=high
         - php: 7.1
           env: deps=low
+        - php: nightly
     fast_finish: true
+    allow_failures:
+        - php: nightly
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_install:
       fi
 
       # Matrix lines for intermediate PHP versions are skipped for pull requests
-      if [[ ! $deps && ! $PHP = ${MIN_PHP%.*} && ! $PHP = hhvm* && $TRAVIS_PULL_REQUEST != false ]]; then
+      if [[ ! $deps && ! $PHP = ${MIN_PHP%.*} && ! $PHP = hhvm* && ! $PHP = nightly* && $TRAVIS_PULL_REQUEST != false ]]; then
           deps=skip
           skip=1
       else


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | N/A
| Fixed tickets | 
| License       | MIT
| Doc PR        | N/A

The current Travis tests doesn't run against PHP nightly (I.E PHP 7.2).
This could assist in picking up any regressions or issues with newer versions of PHP.
I'm not sure if there is a specific reason why PHP nightly is not included in Travis (I did a quick search but couldn't find anything)?