### PR TITLE
[Routing] Revert the change in [#b42018] with respect to Routing/Route.php

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -116,7 +116,7 @@ class Route implements \Serializable
      */
     public function unserialize($serialized)
     {
-        $data = unserialize($serialized, array('allowed_classes' => array(CompiledRoute::class)));
+        $data = unserialize($serialized);
         $this->path = $data['path'];
         $this->host = $data['host'];
         $this->defaults = $data['defaults'];

--- a/src/Symfony/Component/Routing/Tests/Fixtures/CustomCompiledRoute.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/CustomCompiledRoute.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures;
+
+use Symfony\Component\Routing\CompiledRoute;
+
+class CustomCompiledRoute extends CompiledRoute {
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/CustomCompiledRoute.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/CustomCompiledRoute.php
@@ -13,5 +13,6 @@ namespace Symfony\Component\Routing\Tests\Fixtures;
 
 use Symfony\Component\Routing\CompiledRoute;
 
-class CustomCompiledRoute extends CompiledRoute {
+class CustomCompiledRoute extends CompiledRoute
+{
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/CustomRouteCompiler.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/CustomRouteCompiler.php
@@ -14,11 +14,13 @@ namespace Symfony\Component\Routing\Tests\Fixtures;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCompiler;
 
-class CustomRouteCompiler extends RouteCompiler {
-  /**
+class CustomRouteCompiler extends RouteCompiler
+{
+    /**
    * {@inheritdoc}
    */
-  public static function compile(Route $route) {
-    return new CustomCompiledRoute('', '', array(), array());
+  public static function compile(Route $route)
+  {
+      return new CustomCompiledRoute('', '', array(), array());
   }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/CustomRouteCompiler.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/CustomRouteCompiler.php
@@ -17,10 +17,10 @@ use Symfony\Component\Routing\RouteCompiler;
 class CustomRouteCompiler extends RouteCompiler
 {
     /**
-   * {@inheritdoc}
-   */
-  public static function compile(Route $route)
-  {
-      return new CustomCompiledRoute('', '', array(), array());
-  }
+     * {@inheritdoc}
+     */
+    public static function compile(Route $route)
+    {
+        return new CustomCompiledRoute('', '', array(), array());
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/CustomRouteCompiler.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/CustomRouteCompiler.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures;
+
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCompiler;
+
+class CustomRouteCompiler extends RouteCompiler {
+  /**
+   * {@inheritdoc}
+   */
+  public static function compile(Route $route) {
+    return new CustomCompiledRoute('', '', array(), array());
+  }
+}

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -221,18 +221,22 @@ class RouteTest extends TestCase
     }
 
     /**
-     * Tests that the compiled version does not fail when the Route refers to
-     * arbitrary classes.
+     * Tests that unserialization does not fail when the compiled Route is of a
+     * class other than CompiledRoute, such as a subclass of it.
      */
     public function testSerializeWhenCompiledWithClass()
     {
-        $testClass = new \Symfony\Component\Cache\CacheItem();
-        $route = new Route('/', array(), array(), array('foo' => $testClass));
+        $route = new Route('/', array(), array(), array('compiler_class' => '\Symfony\Component\Routing\Tests\Fixtures\CustomRouteCompiler'));
+        $this->assertInstanceOf('\Symfony\Component\Routing\Tests\Fixtures\CustomCompiledRoute', $route->compile(), '->compile() returned a proper route');
 
         $serialized = serialize($route);
-        $unserialized = unserialize($serialized);
-
-        $this->assertInstanceOf(get_class($testClass), $unserialized->getOption('foo'));
+        try {
+          $unserialized = unserialize($serialized);
+          $this->assertInstanceOf('\Symfony\Component\Routing\Tests\Fixtures\CustomCompiledRoute', $unserialized->compile(), 'the unserialized route compiled successfully');
+        }
+        catch (\Exception $except) {
+          $this->fail('unserializing a route which uses a custom compiled route class');
+        }
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -221,6 +221,21 @@ class RouteTest extends TestCase
     }
 
     /**
+     * Tests that the compiled version does not fail when the Route refers to
+     * arbitrary classes.
+     */
+    public function testSerializeWhenCompiledWithClass()
+    {
+        $testClass = new \Symfony\Component\Cache\CacheItem();
+        $route = new Route('/', array(), array(), array('foo' => $testClass));
+
+        $serialized = serialize($route);
+        $unserialized = unserialize($serialized);
+
+        $this->assertInstanceOf(get_class($testClass), $unserialized->getOption('foo'));
+    }
+
+    /**
      * Tests that the serialized representation of a route in one symfony version
      * also works in later symfony versions, i.e. the unserialized route is in the
      * same state as another, semantically equivalent, route.

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -233,7 +233,7 @@ class RouteTest extends TestCase
         try {
             $unserialized = unserialize($serialized);
             $this->assertInstanceOf('\Symfony\Component\Routing\Tests\Fixtures\CustomCompiledRoute', $unserialized->compile(), 'the unserialized route compiled successfully');
-        } catch (\Exception $except) {
+        } catch (\Exception $e) {
             $this->fail('unserializing a route which uses a custom compiled route class');
         }
     }

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -231,11 +231,10 @@ class RouteTest extends TestCase
 
         $serialized = serialize($route);
         try {
-          $unserialized = unserialize($serialized);
-          $this->assertInstanceOf('\Symfony\Component\Routing\Tests\Fixtures\CustomCompiledRoute', $unserialized->compile(), 'the unserialized route compiled successfully');
-        }
-        catch (\Exception $except) {
-          $this->fail('unserializing a route which uses a custom compiled route class');
+            $unserialized = unserialize($serialized);
+            $this->assertInstanceOf('\Symfony\Component\Routing\Tests\Fixtures\CustomCompiledRoute', $unserialized->compile(), 'the unserialized route compiled successfully');
+        } catch (\Exception $except) {
+            $this->fail('unserializing a route which uses a custom compiled route class');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21090 #23109
| License       | MIT
| Doc PR        | 

...because it breaks BC with third-party code which, for instance, might use a subclass of CompiledRoute within the options portion of the Route. Refers to https://github.com/symfony/symfony/pull/21090 and https://github.com/symfony/symfony/issues/23109