### PR TITLE
Add tests for ResponseCacheStrategy to document some more edge cases

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
@@ -76,7 +76,7 @@ class ResponseCacheStrategyTest extends TestCase
         $this->assertFalse($response->headers->hasCacheControlDirective('s-maxage'));
     }
 
-    public function testMasterResponseNotCacheableWhenEmbeddedResponseRequiresValdation()
+    public function testMasterResponseNotCacheableWhenEmbeddedResponseRequiresValidation()
     {
         $cacheStrategy = new ResponseCacheStrategy();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Adds some test cases for possible combinations of master/subrequest responses to better document behaviour in edge cases. Should now cover the entire `ResponseCacheStrategy`.

I hope 2.7 is the right target branch because having more tests for all releases should be a good thing:tm:.