### PR TITLE
Added missing service definition for session.storage.mock_array

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -45,6 +45,11 @@
 
         <service id="session.attribute_bag" class="%session.attribute_bag.class%" public="false" />
 
+        <service id="session.storage.mock_array" class="Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage">
+            <argument>MOCKSESSID</argument>
+            <argument type="service" id="session.storage.metadata_bag" />
+        </service>
+
         <service id="session.storage.mock_file" class="%session.storage.mock_file.class%" public="false">
             <argument>%kernel.cache_dir%/sessions</argument>
             <argument>MOCKSESSID</argument>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | - 
| License       | MIT
| Doc PR        | -

It seems there is no service definition for this class. On the one hand it has *mock* in its name implying it's exclusively for testing, but on the other, there is seemingly no way to disable sessions for those who don't want to use them so using this stub seems to be the best option and the class isn't in a test namespace so it should be available in the service container.