### PR TITLE
Keep s-maxage when expiry and validation are used in combination

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
@@ -39,7 +39,7 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
      */
     public function add(Response $response)
     {
-        if ($response->isValidateable() || !$response->isCacheable()) {
+        if (!$response->isFresh() || !$response->isCacheable()) {
             $this->cacheable = false;
         } else {
             $maxAge = $response->getMaxAge();
@@ -70,6 +70,9 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
         if ($response->isValidateable()) {
             $response->setEtag(null);
             $response->setLastModified(null);
+        }
+
+        if (!$response->isFresh()) {
             $this->cacheable = false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

(Symfony) docs say that [expiration wins over validation](https://symfony.com/doc/current/http_cache/validation.html). So, 

a) when both the master and embedded response are public with an s-maxage, the result should be public as well and use the lower s-maxage of both, *also* in the case that the embedded response carries validation headers. (The cache may use those for revalidating the embedded response once it has become stale, but that does not impact expiration-based caching of the combined response.)

b) when both the master and embedded response are public with an s-maxage, the result should be public as well and use the lower s-maxage of both, *also* in the case that the master response carries validation headers. However, those *must not* be passed on to the client: They do not apply to the combined response, but may only be used by the cache itself to revalidate the (raw) master response.
