### PR TITLE
[FrameworkBundle] Remove dependency on Doctrine cache

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -16,6 +16,9 @@ Finder
 FrameworkBundle
 ---------------
 
+ * The `doctrine/cache` dependency has been removed; require it via `composer
+   require doctrine/cache` if you are using Doctrine cache in your project.
+
  * The `validator.mapping.cache.doctrine.apc` service has been deprecated.
 
  * Using the `KERNEL_DIR` environment variable or the automatic guessing based

--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -16,6 +16,8 @@ Finder
 FrameworkBundle
 ---------------
 
+ * The `validator.mapping.cache.doctrine.apc` service has been deprecated.
+
  * Using the `KERNEL_DIR` environment variable or the automatic guessing based
    on the `phpunit.xml` / `phpunit.xml.dist` file location is deprecated since 3.4. 
    Set the `KERNEL_CLASS` environment variable to the fully-qualified class name

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -227,6 +227,8 @@ Form
 FrameworkBundle
 ---------------
 
+ * The `validator.mapping.cache.doctrine.apc` service has been removed.
+
  * The `cache:clear` command does not warmup the cache anymore. Warmup should
    be done via the `cache:warmup` command.
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.4.0
 -----
 
+* Removed `doctrine/cache` from the list of required dependencies in `composer.json`
+* Deprecated `validator.mapping.cache.doctrine.apc` service
 * Deprecated using the `KERNEL_DIR` environment variable with `KernelTestCase::getKernelClass()`.
 * Deprecated the `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()` methods.
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -663,9 +663,9 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('cache')
                             ->beforeNormalization()
-                                // Can be removed in 4.0, when validator.mapping.cache.apc is removed
+                                // Can be removed in 4.0, when validator.mapping.cache.doctrine.apc is removed
                                 ->ifString()->then(function ($v) {
-                                    if ('validator.mapping.cache.apc' === $v && !class_exists('Doctrine\Common\Cache\ApcCache')) {
+                                    if ('validator.mapping.cache.doctrine.apc' === $v && !class_exists('Doctrine\Common\Cache\ApcCache')) {
                                         throw new LogicException('Doctrine APC cache for the validator cannot be enabled as the Doctrine Cache package is not installed.');
                                     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -661,7 +661,18 @@ class Configuration implements ConfigurationInterface
                     ->info('validation configuration')
                     ->{!class_exists(FullStack::class) && class_exists(Validation::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                     ->children()
-                        ->scalarNode('cache')->end()
+                        ->scalarNode('cache')
+                            ->beforeNormalization()
+                                // Can be removed in 4.0, when validator.mapping.cache.apc is removed
+                                ->ifString()->then(function ($v) {
+                                    if ('validator.mapping.cache.apc' === $v && !class_exists('Doctrine\Common\Cache\ApcCache')) {
+                                        throw new LogicException('Doctrine APC cache for the validator cannot be enabled as the Doctrine Cache package is not installed.');
+                                    }
+
+                                    return $v;
+                                })
+                            ->end()
+                        ->end()
                         ->booleanNode('enable_annotations')->{!class_exists(FullStack::class) && class_exists(Annotation::class) ? 'defaultTrue' : 'defaultFalse'}()->end()
                         ->arrayNode('static_method')
                             ->defaultValue(array('loadValidatorMetadata'))

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1220,6 +1220,10 @@ class FrameworkExtension extends Extension
         $loader->load('annotations.xml');
 
         if ('none' !== $config['cache']) {
+            if (!class_exists('Doctrine\Common\Cache\CacheProvider')) {
+                throw new LogicException('Annotations cannot be enabled as the Doctrine Cache library is not installed.');
+            }
+
             $cacheService = $config['cache'];
 
             if ('php_array' === $config['cache']) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -57,6 +57,7 @@
                     </call>
                 </service>
             </argument>
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use a Psr6 cache like "validator.mapping.cache.symfony" instead.</deprecated>
         </service>
 
         <service id="validator.validator_factory" class="Symfony\Component\Validator\ContainerConstraintValidatorFactory">

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -29,10 +29,10 @@
         "symfony/filesystem": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
         "symfony/routing": "~3.4|~4.0",
-        "symfony/stopwatch": "~2.8|~3.0|~4.0",
-        "doctrine/cache": "~1.0"
+        "symfony/stopwatch": "~2.8|~3.0|~4.0"
     },
     "require-dev": {
+        "doctrine/cache": "~1.0",
         "fig/link-util": "^1.0",
         "symfony/asset": "~3.3|~4.0",
         "symfony/browser-kit": "~2.8|~3.0|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | related to symfony/flex#14
| License       | MIT
| Doc PR        | n/a

In our quest to remove hard dependencies, I propose to remove `doctrine/cache` from the default dependencies on the Framework bundle. That's possible now as we have PSR6 cache support in Symfony and because Doctrine cache is only used for the validator mapping cache.

The two other occurrences are for the serializer (already deprecated in 3.3) and for annotations, where we need to keep it, but as Doctrine annotations is already optional, that's not an issue.
