### PR TITLE
[DI] Fix keys resolution in ResolveParameterPlaceHoldersPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -65,10 +65,14 @@ class ResolveParameterPlaceHoldersPass extends AbstractRecursivePass
             if (isset($changes['file'])) {
                 $value->setFile($this->bag->resolveValue($value->getFile()));
             }
-            $value->setProperties($this->bag->resolveValue($value->getProperties()));
-            $value->setMethodCalls($this->bag->resolveValue($value->getMethodCalls()));
         }
 
-        return parent::processValue($value, $isRoot);
+        $value = parent::processValue($value, $isRoot);
+
+        if ($value && is_array($value)) {
+            $value = array_combine($this->bag->resolveValue(array_keys($value)), $value);
+        }
+
+        return $value;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -41,12 +41,12 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
 
     public function testArgumentParametersShouldBeResolved()
     {
-        $this->assertSame(array('bar', 'baz'), $this->fooDefinition->getArguments());
+        $this->assertSame(array('bar', array('bar' => 'baz')), $this->fooDefinition->getArguments());
     }
 
     public function testMethodCallParametersShouldBeResolved()
     {
-        $this->assertSame(array(array('foobar', array('bar', 'baz'))), $this->fooDefinition->getMethodCalls());
+        $this->assertSame(array(array('foobar', array('bar', array('bar' => 'baz')))), $this->fooDefinition->getMethodCalls());
     }
 
     public function testPropertyParametersShouldBeResolved()
@@ -71,7 +71,7 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
         $containerBuilder->setParameter('foo.class', 'Foo');
         $containerBuilder->setParameter('foo.factory.class', 'FooFactory');
         $containerBuilder->setParameter('foo.arg1', 'bar');
-        $containerBuilder->setParameter('foo.arg2', 'baz');
+        $containerBuilder->setParameter('foo.arg2', array('%foo.arg1%' => 'baz'));
         $containerBuilder->setParameter('foo.method', 'foobar');
         $containerBuilder->setParameter('foo.property.name', 'bar');
         $containerBuilder->setParameter('foo.property.value', 'baz');
@@ -80,7 +80,7 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
 
         $fooDefinition = $containerBuilder->register('foo', '%foo.class%');
         $fooDefinition->setFactory(array('%foo.factory.class%', 'getFoo'));
-        $fooDefinition->setArguments(array('%foo.arg1%', '%foo.arg2%'));
+        $fooDefinition->setArguments(array('%foo.arg1%', array('%foo.arg1%' => 'baz')));
         $fooDefinition->addMethodCall('%foo.method%', array('%foo.arg1%', '%foo.arg2%'));
         $fooDefinition->setProperty('%foo.property.name%', '%foo.property.value%');
         $fooDefinition->setFile('%foo.file%');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Keys are resolved in 3.2, but we broke that when moving to AbstractRecursivePass.