### PR TITLE
Fix the conditional definition of the SymfonyTestsListener

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -18,53 +18,53 @@ use PHPUnit\Framework\Warning;
 
 if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListener', 'Symfony\Bridge\PhpUnit\SymfonyTestsListener');
-
-    return;
-}
-
-/**
- * Collects and replays skipped tests.
- *
- * @author Nicolas Grekas <p@tchwork.com>
- *
- * @final
- */
-class SymfonyTestsListener extends BaseTestListener
-{
-    private $trait;
-
-    public function __construct(array $mockedNamespaces = array())
+// Using an early return instead of a else does not work when using the PHPUnit phar due to some weird PHP behavior (the class
+// gets defined without executing the code before it and so the definition is not properly conditional)
+} else {
+    /**
+     * Collects and replays skipped tests.
+     *
+     * @author Nicolas Grekas <p@tchwork.com>
+     *
+     * @final
+     */
+    class SymfonyTestsListener extends BaseTestListener
     {
-        $this->trait = new Legacy\SymfonyTestsListenerTrait($mockedNamespaces);
-    }
+        private $trait;
 
-    public function globalListenerDisabled()
-    {
-        $this->trait->globalListenerDisabled();
-    }
+        public function __construct(array $mockedNamespaces = array())
+        {
+            $this->trait = new Legacy\SymfonyTestsListenerTrait($mockedNamespaces);
+        }
 
-    public function startTestSuite(TestSuite $suite)
-    {
-        return $this->trait->startTestSuite($suite);
-    }
+        public function globalListenerDisabled()
+        {
+            $this->trait->globalListenerDisabled();
+        }
 
-    public function addSkippedTest(Test $test, \Exception $e, $time)
-    {
-        return $this->trait->addSkippedTest($test, $e, $time);
-    }
+        public function startTestSuite(TestSuite $suite)
+        {
+            return $this->trait->startTestSuite($suite);
+        }
 
-    public function startTest(Test $test)
-    {
-        return $this->trait->startTest($test);
-    }
+        public function addSkippedTest(Test $test, \Exception $e, $time)
+        {
+            return $this->trait->addSkippedTest($test, $e, $time);
+        }
 
-    public function addWarning(Test $test, Warning $e, $time)
-    {
-        return $this->trait->addWarning($test, $e, $time);
-    }
+        public function startTest(Test $test)
+        {
+            return $this->trait->startTest($test);
+        }
 
-    public function endTest(Test $test, $time)
-    {
-        return $this->trait->endTest($test, $time);
+        public function addWarning(Test $test, Warning $e, $time)
+        {
+            return $this->trait->addWarning($test, $e, $time);
+        }
+
+        public function endTest(Test $test, $time)
+        {
+            return $this->trait->endTest($test, $time);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This is a continuation of the attempts at fixing the PHPUnit 5 compatibility layer for the listener.
The signature mismatch error still happened when using the PHPUnit PHAR instead of a source install (hint: people using `simple-phpunit` are using a source install).

It looks like the class definition gets loaded by PHP before executing the code placed above it (and so the early return breaks). Putting the code inside a `else` instead works fine (the class definition probably cannot bubble up).

The known difference between the PHAR and a source install is that the source install relies on autoloading while the PHAR loads all PHPUnit classes through `require_once` eagerly (and so the parent class already exists when using the Symfony file).

@jpauli is it an expected behavior that early returns before class definitions don't work consistently ?

Regarding the patch itself, an alternative would be to move the PHPUnit 6+ implementation to a dedicated class instead, and use a `class_alias` for the else clause too. But I don't think it is worth it.