### PR TITLE
[WebProfilerBundle] Sticky ajax window

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -252,6 +252,10 @@
     line-height: 17px;
 }
 
+.sf-toolbar-block-ajax .sf-toolbar-icon {
+    cursor: pointer;
+}
+
 .sf-toolbar-status-green .sf-toolbar-label,
 .sf-toolbar-status-yellow .sf-toolbar-label,
 .sf-toolbar-status-red .sf-toolbar-label {
@@ -295,15 +299,19 @@
     margin-left: 4px;
 }
 
-.sf-toolbar-block:hover {
+.sf-toolbar-block:hover,
+.sf-toolbar-block.hover {
     position: relative;
 }
-.sf-toolbar-block:hover .sf-toolbar-icon {
+.sf-toolbar-block:hover .sf-toolbar-icon,
+.sf-toolbar-block.hover .sf-toolbar-icon
+{
     background-color: #444;
     position: relative;
     z-index: 10002;
 }
-.sf-toolbar-block:hover .sf-toolbar-info {
+.sf-toolbar-block:hover .sf-toolbar-info,
+.sf-toolbar-block.hover .sf-toolbar-info {
     display: block;
     padding: 10px;
     max-width: 480px;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -304,8 +304,7 @@
     position: relative;
 }
 .sf-toolbar-block:hover .sf-toolbar-icon,
-.sf-toolbar-block.hover .sf-toolbar-icon
-{
+.sf-toolbar-block.hover .sf-toolbar-icon {
     background-color: #444;
     position: relative;
     z-index: 10002;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -93,6 +93,11 @@
                     Sfjs.setPreference('toolbar/displayState', 'block');
                 });
                 Sfjs.renderAjaxRequests();
+                Sfjs.addEventListener(document.querySelector('.sf-toolbar-block-ajax > .sf-toolbar-icon'), 'click', function(event) {
+                    event.preventDefault();
+
+                    Sfjs.toggleClass(this.parentNode, 'hover');
+                });
             },
             function(xhr) {
                 if (xhr.status !== 0) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -93,7 +93,7 @@
                     Sfjs.setPreference('toolbar/displayState', 'block');
                 });
                 Sfjs.renderAjaxRequests();
-                Sfjs.addEventListener(document.querySelector('.sf-toolbar-block-ajax > .sf-toolbar-icon'), 'click', function(event) {
+                Sfjs.addEventListener(document.querySelector('.sf-toolbar-block-ajax > .sf-toolbar-icon'), 'click', function (event) {
                     event.preventDefault();
 
                     Sfjs.toggleClass(this.parentNode, 'hover');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23125
| License       | MIT
| Doc PR        | -

This toggles the ajax toolbar block being sticky on click. I find it quite useful in heavy ajax apps :)

Not sure the state needs to be persisted in local storage or so, could be done :) however for our app all the navigating happens via react router, hence no real need for us to persist it between requests.