### PR TITLE
[Property Access] Fix Usage with anonymous classes

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -504,7 +504,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private function getReadAccessInfo($class, $property)
     {
-        $key = (false !== strpos($class, '@') ? rawurlencode($class) : $class ).'..'.$property;
+        $key = (false !== strpos($class, '@') ? rawurlencode($class) : $class).'..'.$property;
 
         if (isset($this->readPropertyCache[$key])) {
             $access = $this->readPropertyCache[$key];
@@ -672,7 +672,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private function getWriteAccessInfo($class, $property, $value)
     {
-        $key = (false !== strpos($class, '@') ? rawurlencode($class) : $class ).'..'.$property;
+        $key = (false !== strpos($class, '@') ? rawurlencode($class) : $class).'..'.$property;
 
         if (isset($this->writePropertyCache[$key])) {
             $access = $this->writePropertyCache[$key];

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -504,7 +504,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private function getReadAccessInfo($class, $property)
     {
-        $key = $class.'::'.$property;
+        $key = (false !== strpos($class, '@') ? rawurlencode($class) : $class ).'..'.$property;
 
         if (isset($this->readPropertyCache[$key])) {
             $access = $this->readPropertyCache[$key];
@@ -672,7 +672,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private function getWriteAccessInfo($class, $property, $value)
     {
-        $key = $class.'::'.$property;
+        $key = (false !== strpos($class, '@') ? rawurlencode($class) : $class ).'..'.$property;
 
         if (isset($this->writePropertyCache[$key])) {
             $access = $this->writePropertyCache[$key];

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -566,4 +566,74 @@ class PropertyAccessorTest extends TestCase
 
         $this->propertyAccessor->setValue($object, 'countable', 'This is a string, \Countable expected.');
     }
+
+
+    public function testAnonymousClassRead()
+    {
+        if (PHP_MAJOR_VERSION < 7) {
+            $this->markTestSkipped('Anonymous Classes are only supported on PHP7');
+            return;
+        }
+
+        $value = 'bar';
+
+        $obj = $this->generateAnonymousClass($value);
+
+        $propertyAccessor = new PropertyAccessor(false, false, new ArrayAdapter());
+
+        $this->assertEquals($value, $propertyAccessor->getValue($obj, 'foo'));
+
+    }
+
+    public function testAnonymousClassWrite()
+    {
+        if (PHP_MAJOR_VERSION < 7) {
+            $this->markTestSkipped('Anonymous Classes are only supported on PHP7');
+            return;
+        }
+
+        $value = 'bar';
+
+        $obj = $this->generateAnonymousClass('');
+
+        $propertyAccessor = new PropertyAccessor(false, false, new ArrayAdapter());
+        $propertyAccessor->setValue($obj, 'foo', $value);
+
+        $this->assertEquals($value, $propertyAccessor->getValue($obj, 'foo'));
+
+    }
+
+    /**
+     * @param $value
+     */
+    private function generateAnonymousClass($value)
+    {
+        $obj = new class($value)
+        {
+            private $foo;
+
+            public function __construct($foo)
+            {
+                $this->foo = $foo;
+            }
+
+            /**
+             * @return mixed
+             */
+            public function getFoo()
+            {
+                return $this->foo;
+            }
+
+            /**
+             * @param mixed $foo
+             */
+            public function setFoo($foo)
+            {
+                $this->foo = $foo;
+            }
+        };
+
+        return $obj;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23138 
| License       | MIT


Replace forbidden characters in the the class names of Anonymous Classes in form of
"class@anonymous /symfony/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php0x7f3f5f267ad5"

(cherry picked from commit 5483298)