### PR TITLE
Fix the usage of FrameworkBundle in debug mode without Stopwatch

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -647,6 +647,10 @@ class FrameworkExtension extends Extension
 
         $debug = $container->getParameter('kernel.debug');
 
+        if ($debug) {
+            $container->setParameter('debug.container.dump', '%kernel.cache_dir%/%kernel.container_class%.xml');
+        }
+
         if ($debug && class_exists(Stopwatch::class)) {
             $loader->load('debug.xml');
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -4,10 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="debug.container.dump">%kernel.cache_dir%/%kernel.container_class%.xml</parameter>
-    </parameters>
-
     <services>
         <defaults public="false" />
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

https://github.com/symfony/symfony/pull/23148 removed the loading of the debug.xml file when Stopwatch is not installed.
While all services defined in it are related to Stopwatch, the parameter was not (it is related to dumping the debug container in the compiler pass), which was breaking the usage of the bundle in debug mode without Stopwatch (exception triggered in the compiler pass)
