### PR TITLE
[FrameworkBundle] Deprecate useless --no-prefix option

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -34,6 +34,10 @@ FrameworkBundle
  * The `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()` 
    methods are deprecated since 3.4 and will be removed in 4.0.
 
+ * The `--no-prefix` option of the `translation:update` command is deprecated and
+   will be removed in 4.0. Use the `--prefix` option with an empty string as value
+   instead (e.g. `--prefix=""`)
+
 Process
 -------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -345,6 +345,9 @@ FrameworkBundle
  * The `Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory` class has been removed.
    Use `Symfony\Component\Validator\ContainerConstraintValidatorFactory` instead.
 
+ * The `--no-prefix` option of the `translation:update` command has
+   been removed.
+
 HttpFoundation
 --------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -39,7 +39,7 @@ class TranslationUpdateCommand extends ContainerAwareCommand
                 new InputArgument('locale', InputArgument::REQUIRED, 'The locale'),
                 new InputArgument('bundle', InputArgument::OPTIONAL, 'The bundle name or directory where to load the messages, defaults to app/Resources folder'),
                 new InputOption('prefix', null, InputOption::VALUE_OPTIONAL, 'Override the default prefix', '__'),
-                new InputOption('no-prefix', null, InputOption::VALUE_NONE, 'If set, no prefix is added to the translations'),
+                new InputOption('no-prefix', null, InputOption::VALUE_NONE, '[DEPRECATED] If set, no prefix is added to the translations'),
                 new InputOption('output-format', null, InputOption::VALUE_OPTIONAL, 'Override the default output format', 'yml'),
                 new InputOption('dump-messages', null, InputOption::VALUE_NONE, 'Should the messages be dumped in the console'),
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Should the update be done'),
@@ -135,7 +135,13 @@ EOF
         $extractedCatalogue = new MessageCatalogue($input->getArgument('locale'));
         $errorIo->comment('Parsing templates...');
         $extractor = $this->getContainer()->get('translation.extractor');
-        $extractor->setPrefix($input->getOption('no-prefix') ? '' : $input->getOption('prefix'));
+        $prefix = $input->getOption('prefix');
+        // @deprecated since version 3.4, to be removed in 4.0 along with the --no-prefix option
+        if ($input->getOption('no-prefix')) {
+            @trigger_error('The "--no-prefix" option is deprecated since version 3.4 and will be removed in 4.0. Use the "--prefix" option with an empty string as value instead.', E_USER_DEPRECATED);
+            $prefix = '';
+        }
+        $extractor->setPrefix($prefix);
         foreach ($transPaths as $path) {
             $path .= 'views';
             if (is_dir($path)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

It was a workaround, not needed since https://github.com/symfony/symfony/pull/21228. Let's deprecate it and remove it in 4.0.