### PR TITLE
[TwigBundle] Add Doctrine Cache to dev dependencies to fix failing unit tests

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -35,7 +35,8 @@
         "symfony/yaml": "~2.8|~3.0|~4.0",
         "symfony/framework-bundle": "^3.2.8|~4.0",
         "symfony/web-link": "~3.3|~4.0",
-        "doctrine/annotations": "~1.0"
+        "doctrine/annotations": "~1.0",
+        "doctrine/cache": "~1.0"
     },
     "conflict": {
         "symfony/dependency-injection": "<3.3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | None
| License       | MIT
| Doc PR        | N/A

Currently, the unit tests of TwigBundle are failing because Doctrine Cache is missing. Before the changes of #23131, this dependency was pulled via FrameworkBundle. This PR adds Doctrine Cache to the dev dependencies of TwigBundle, so the tests pass again.

```
There were 3 errors:

1) Symfony\Bundle\TwigBundle\Tests\CacheWarmingTest::testCacheIsProperlyWarmedWhenTemplatingIsAvailable
Symfony\Component\DependencyInjection\Exception\LogicException: Annotations cannot be enabled as the Doctrine Cache library is not installed.

2) Symfony\Bundle\TwigBundle\Tests\CacheWarmingTest::testCacheIsProperlyWarmedWhenTemplatingIsDisabled
Symfony\Component\DependencyInjection\Exception\LogicException: Annotations cannot be enabled as the Doctrine Cache library is not installed.

3) Symfony\Bundle\TwigBundle\Tests\NoTemplatingEntryTest::test
Symfony\Component\DependencyInjection\Exception\LogicException: Annotations cannot be enabled as the Doctrine Cache library is not installed.
```