### PR TITLE
[Config] Fix ** GlobResource on Windows

### DIFF
--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -134,7 +134,7 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface,
 
         $prefixLen = strlen($this->prefix);
         foreach ($finder->followLinks()->sortByName()->in($this->prefix) as $path => $info) {
-            if (preg_match($regex, substr($path, $prefixLen)) && $info->isFile()) {
+            if (preg_match($regex, substr('\\' === \DIRECTORY_SEPARATOR ? str_replace('\\', '/', $path) : $path, $prefixLen)) && $info->isFile()) {
                 yield $path => $info;
             }
         }

--- a/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
@@ -36,6 +36,15 @@ class GlobResourceTest extends TestCase
         $this->assertEquals(array($file => new \SplFileInfo($file)), $paths);
         $this->assertInstanceOf('SplFileInfo', current($paths));
         $this->assertSame($dir, $resource->getPrefix());
+
+        $resource = new GlobResource($dir, '/**/Resource', true);
+
+        $paths = iterator_to_array($resource);
+
+        $file = $dir.DIRECTORY_SEPARATOR.'Resource'.DIRECTORY_SEPARATOR.'ConditionalClass.php';
+        $this->assertEquals(array($file => $file), $paths);
+        $this->assertInstanceOf('SplFileInfo', current($paths));
+        $this->assertSame($dir, $resource->getPrefix());
     }
 
     public function testIsFreshNonRecursiveDetectsNewFile()

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -20,10 +20,12 @@
         "symfony/filesystem": "~2.8|~3.0"
     },
     "require-dev": {
+        "symfony/finder": "~3.3",
         "symfony/yaml": "~3.0",
         "symfony/dependency-injection": "~3.3"
     },
     "conflict": {
+        "symfony/finder": "<3.3",
         "symfony/dependency-injection": "<3.3"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23103
| License       | MIT
| Doc PR        | -

We cannot tell Finder to use RecursiveDirectoryIterator::UNIX_PATHS so we have to fix paths on Windows.