### PR TITLE
Fix AutowiringTypesTest transient tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
@@ -68,6 +68,6 @@ class WebTestCase extends BaseWebTestCase
 
     protected static function getVarDir()
     {
-        return substr(strrchr(get_called_class(), '\\'), 1);
+        return 'FB'.substr(strrchr(get_called_class(), '\\'), 1);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
@@ -68,6 +68,6 @@ class WebTestCase extends BaseWebTestCase
 
     protected static function getVarDir()
     {
-        return substr(strrchr(get_called_class(), '\\'), 1);
+        return 'SB'.substr(strrchr(get_called_class(), '\\'), 1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In 3.3, we have a race condition because FrameworkBundle and SecurityBundle use the same test folder for their respective AutowiringTypesTest.