### PR TITLE
[WebServerBundle] Fix router script option BC

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
@@ -36,7 +36,18 @@ class WebServerConfig
 
         $this->documentRoot = $documentRoot;
         $this->env = $env;
-        $this->router = $router ?: __DIR__.'/Resources/router.php';
+
+        if (null !== $router) {
+            $absoluteRouterPath = realpath($router);
+
+            if (false === $absoluteRouterPath) {
+                throw new \InvalidArgumentException(sprintf('Router script "%s" does not exist.', $router));
+            }
+
+            $this->router = $absoluteRouterPath;
+        } else {
+            $this->router = __DIR__.'/Resources/router.php';
+        }
 
         if (null === $address) {
             $this->hostname = '127.0.0.1';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23206
| License       | MIT
| Doc PR        | -

Server commands does not work with router script given by a relative path eg.:
```
bin/console server:run -r router.php 
```
but, this was working before and was removed (by accident I guess) in https://github.com/symfony/symfony/pull/21039/files#diff-b915f83f99a4166eb34eab581a92501bL187