### PR TITLE
[VarDumper] fixes

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ResourceCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ResourceCaster.php
@@ -45,7 +45,7 @@ class ResourceCaster
 
     public static function castStreamContext($stream, array $a, Stub $stub, $isNested)
     {
-        return stream_context_get_params($stream);
+        return @stream_context_get_params($stream) ?: $a;
     }
 
     public static function castGd($gd, array $a, Stub $stub, $isNested)

--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -86,7 +86,7 @@ class SplCaster
         $storage = array();
         unset($a[Caster::PREFIX_DYNAMIC."\0gcdata"]); // Don't hit https://bugs.php.net/65967
 
-        foreach ($c as $obj) {
+        foreach (clone $c as $obj) {
             $storage[spl_object_hash($obj)] = array(
                 'object' => $obj,
                 'info' => $c->getInfo(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23115 and #23151 (hopefully)
| License       | MIT
| Doc PR        | -

it looks like stream_context_get_params can return false (looking at php-src and #23151)
and doing a foreach on SplObjectStorage changes its internal iterator state.