### PR TITLE
[FrameworkBundle] Expose the AbstractController's container to its subclasses

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -35,7 +35,10 @@ abstract class AbstractController implements ServiceSubscriberInterface
 {
     use ControllerTrait;
 
-    private $container;
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
 
     /**
      * @internal


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This is useful if an application provides their own base Controller that
references items in the container. It also makes it simpler for that
base controller to add additional optional dependencies by only overriding
getSubscribedServices instead of having to reimplement setContainer and
use ControllerTrait.