### PR TITLE
[HttpFoundation] Remove obsolete ini settings for sessions

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -71,13 +71,10 @@ class NativeSessionStorage implements SessionStorageInterface
      * cookie_lifetime, "0"
      * cookie_path, "/"
      * cookie_secure, ""
-     * entropy_file, ""
-     * entropy_length, "0"
      * gc_divisor, "100"
      * gc_maxlifetime, "1440"
      * gc_probability, "1"
      * hash_bits_per_character, "4"
-     * hash_function, "0"
      * name, "PHPSESSID"
      * referer_check, ""
      * serialize_handler, "php"
@@ -328,9 +325,9 @@ class NativeSessionStorage implements SessionStorageInterface
         $validOptions = array_flip(array(
             'cache_limiter', 'cookie_domain', 'cookie_httponly',
             'cookie_lifetime', 'cookie_path', 'cookie_secure',
-            'entropy_file', 'entropy_length', 'gc_divisor',
-            'gc_maxlifetime', 'gc_probability', 'hash_bits_per_character',
-            'hash_function', 'name', 'referer_check',
+            'gc_divisor',
+            'gc_maxlifetime', 'gc_probability',
+            'name', 'referer_check',
             'serialize_handler', 'use_strict_mode', 'use_cookies',
             'use_only_cookies', 'use_trans_sid', 'upload_progress.enabled',
             'upload_progress.cleanup', 'upload_progress.prefix', 'upload_progress.name',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21606
| License       | MIT
| Doc PR        | n/a

As of PHP 7.1, those settings do not exist anymore. See http://php.net/manual/de/migration71.other-changes.php#migration71.other-changes.session-id-generation-without-hashing
