### PR TITLE
[FrameworkBundle] [Command] Clean bundle directory, fixes #23177

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -78,6 +78,11 @@ EOT
 
         // Create the bundles directory otherwise symlink will fail.
         $bundlesDir = $targetArg.'/bundles/';
+
+        if ($filesystem->exists($bundlesDir)) {
+            $filesystem->remove($bundlesDir);
+        }
+
         $filesystem->mkdir($bundlesDir, 0777);
 
         // relative implies symlink


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23177 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Clean bundle folder when using assets:install command to prevent broken symlinks & avoid unused folders.
