### PR TITLE
[DI] Dedup tags when using instanceof/autoconfigure

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -107,6 +107,9 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
             while (0 <= --$i) {
                 foreach ($instanceofTags[$i] as $k => $v) {
                     foreach ($v as $v) {
+                        if ($definition->hasTag($k) && in_array($v, $definition->getTag($k))) {
+                            continue;
+                        }
                         $definition->addTag($k, $v);
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes, failures unrelated (https://github.com/symfony/symfony/commit/8dc00bbe8d901d80c2916295607a82b0e0233ed9)
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This fixes uselessly duplicated tags shown when using the `debug:container` command, or in the dumped container in xml format:
<img width="554" alt="screenshot 2017-06-17 a 20 41 27" src="https://user-images.githubusercontent.com/2211145/27255375-de79fc4e-539d-11e7-98d9-c10074ddcffb.PNG">
<img width="494" alt="screenshot 2017-06-17 a 20 41 54" src="https://user-images.githubusercontent.com/2211145/27255376-de7ff5b8-539d-11e7-97ae-ccd31b1d5254.PNG">
<img width="1371" alt="screenshot 2017-06-17 a 20 42 33" src="https://user-images.githubusercontent.com/2211145/27255377-de869ba2-539d-11e7-8cd7-6005f8a499d6.PNG">

(duplicates here are explained by the twig namespaced and unnamespaced versions, and the controllers being tagged explicitly in https://github.com/symfony/symfony-demo/blob/master/app/config/services.yml#L25, while also being tagged by autoconfiguration ([which is expected](https://github.com/symfony/symfony-docs/pull/7921#discussion_r117585827)))