### PR TITLE
Add support for microseconds in Stopwatch

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -652,7 +652,7 @@ class FrameworkExtension extends Extension
         $loader->load('debug_prod.xml');
 
         if (class_exists(Stopwatch::class)) {
-            $container->register('debug.stopwatch', Stopwatch::class);
+            $container->register('debug.stopwatch', Stopwatch::class)->addArgument('true');
             $container->setAlias(Stopwatch::class, 'debug.stopwatch');
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -652,7 +652,7 @@ class FrameworkExtension extends Extension
         $loader->load('debug_prod.xml');
 
         if (class_exists(Stopwatch::class)) {
-            $container->register('debug.stopwatch', Stopwatch::class)->addArgument('true');
+            $container->register('debug.stopwatch', Stopwatch::class)->addArgument(true);
             $container->setAlias(Stopwatch::class, 'debug.stopwatch');
         }
 

--- a/src/Symfony/Component/Stopwatch/CHANGELOG.md
+++ b/src/Symfony/Component/Stopwatch/CHANGELOG.md
@@ -5,5 +5,5 @@ CHANGELOG
 -----
 
  * added the `Stopwatch::reset()` method
- * allowed to measure sub-millisecond times by introducing a third argument to
-   the constructor of `StopwatchPeriod`
+ * allowed to measure sub-millisecond times by introducing an argument to the
+   constructor of `Stopwatch`

--- a/src/Symfony/Component/Stopwatch/CHANGELOG.md
+++ b/src/Symfony/Component/Stopwatch/CHANGELOG.md
@@ -5,3 +5,5 @@ CHANGELOG
 -----
 
  * added the `Stopwatch::reset()` method
+ * allowed to measure sub-millisecond times by introducing a third argument to
+   the constructor of `StopwatchPeriod`

--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -29,6 +29,11 @@ class Section
     private $origin;
 
     /**
+     * @var bool
+     */
+    private $morePrecision;
+
+    /**
      * @var string
      */
     private $id;
@@ -41,11 +46,13 @@ class Section
     /**
      * Constructor.
      *
-     * @param float|null $origin Set the origin of the events in this section, use null to set their origin to their start time
+     * @param float|null $origin        Set the origin of the events in this section, use null to set their origin to their start time
+     * @param bool       $morePrecision If true, time is stored as float to keep the original microsecond precision
      */
-    public function __construct($origin = null)
+    public function __construct($origin = null, /* bool */ $morePrecision = false)
     {
         $this->origin = is_numeric($origin) ? $origin : null;
+        $this->morePrecision = $morePrecision;
     }
 
     /**
@@ -74,7 +81,7 @@ class Section
     public function open($id)
     {
         if (null === $session = $this->get($id)) {
-            $session = $this->children[] = new self(microtime(true) * 1000);
+            $session = $this->children[] = new self(microtime(true) * 1000, $this->morePrecision);
         }
 
         return $session;
@@ -113,7 +120,7 @@ class Section
     public function startEvent($name, $category)
     {
         if (!isset($this->events[$name])) {
-            $this->events[$name] = new StopwatchEvent($this->origin ?: microtime(true) * 1000, $category);
+            $this->events[$name] = new StopwatchEvent($this->origin ?: microtime(true) * 1000, $category, $this->morePrecision);
         }
 
         return $this->events[$name]->start();

--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -49,7 +49,7 @@ class Section
      * @param float|null $origin        Set the origin of the events in this section, use null to set their origin to their start time
      * @param bool       $morePrecision If true, time is stored as float to keep the original microsecond precision
      */
-    public function __construct($origin = null, /* bool */ $morePrecision = false)
+    public function __construct($origin = null, $morePrecision = false)
     {
         $this->origin = is_numeric($origin) ? $origin : null;
         $this->morePrecision = $morePrecision;

--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -19,6 +19,11 @@ namespace Symfony\Component\Stopwatch;
 class Stopwatch
 {
     /**
+     * @var bool
+     */
+    private $morePrecision;
+
+    /**
      * @var Section[]
      */
     private $sections;
@@ -28,9 +33,13 @@ class Stopwatch
      */
     private $activeSections;
 
-    public function __construct()
+    /**
+     * @param bool $morePrecision If true, time is stored as float to keep the original microsecond precision
+     */
+    public function __construct(/* bool */ $morePrecision = false)
     {
         $this->reset();
+        $this->morePrecision = $morePrecision;
     }
 
     /**
@@ -162,6 +171,6 @@ class Stopwatch
      */
     public function reset()
     {
-        $this->sections = $this->activeSections = array('__root__' => new Section('__root__'));
+        $this->sections = $this->activeSections = array('__root__' => new Section('__root__', $this->morePrecision));
     }
 }

--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -36,7 +36,7 @@ class Stopwatch
     /**
      * @param bool $morePrecision If true, time is stored as float to keep the original microsecond precision
      */
-    public function __construct(/* bool */ $morePrecision = false)
+    public function __construct($morePrecision = false)
     {
         $this->reset();
         $this->morePrecision = $morePrecision;

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -34,6 +34,11 @@ class StopwatchEvent
     private $category;
 
     /**
+     * @var bool
+     */
+    private $morePrecision;
+
+    /**
      * @var float[]
      */
     private $started = array();
@@ -41,15 +46,17 @@ class StopwatchEvent
     /**
      * Constructor.
      *
-     * @param float       $origin   The origin time in milliseconds
-     * @param string|null $category The event category or null to use the default
+     * @param float       $origin        The origin time in milliseconds
+     * @param string|null $category      The event category or null to use the default
+     * @param bool        $morePrecision If true, time is stored as float to keep the original microsecond precision
      *
      * @throws \InvalidArgumentException When the raw time is not valid
      */
-    public function __construct($origin, $category = null)
+    public function __construct($origin, $category = null, /* bool */ $morePrecision = false)
     {
         $this->origin = $this->formatTime($origin);
         $this->category = is_string($category) ? $category : 'default';
+        $this->morePrecision = $morePrecision;
     }
 
     /**
@@ -97,7 +104,7 @@ class StopwatchEvent
             throw new \LogicException('stop() called but start() has not been called before.');
         }
 
-        $this->periods[] = new StopwatchPeriod(array_pop($this->started), $this->getNow(), true);
+        $this->periods[] = new StopwatchPeriod(array_pop($this->started), $this->getNow(), $this->morePrecision);
 
         return $this;
     }
@@ -177,7 +184,7 @@ class StopwatchEvent
 
         for ($i = 0; $i < $left; ++$i) {
             $index = $stopped + $i;
-            $periods[] = new StopwatchPeriod($this->started[$index], $this->getNow(), true);
+            $periods[] = new StopwatchPeriod($this->started[$index], $this->getNow(), $this->morePrecision);
         }
 
         $total = 0;

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -97,7 +97,7 @@ class StopwatchEvent
             throw new \LogicException('stop() called but start() has not been called before.');
         }
 
-        $this->periods[] = new StopwatchPeriod(array_pop($this->started), $this->getNow());
+        $this->periods[] = new StopwatchPeriod(array_pop($this->started), $this->getNow(), true);
 
         return $this;
     }
@@ -177,7 +177,7 @@ class StopwatchEvent
 
         for ($i = 0; $i < $left; ++$i) {
             $index = $stopped + $i;
-            $periods[] = new StopwatchPeriod($this->started[$index], $this->getNow());
+            $periods[] = new StopwatchPeriod($this->started[$index], $this->getNow(), true);
         }
 
         $total = 0;

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -52,7 +52,7 @@ class StopwatchEvent
      *
      * @throws \InvalidArgumentException When the raw time is not valid
      */
-    public function __construct($origin, $category = null, /* bool */ $morePrecision = false)
+    public function __construct($origin, $category = null, $morePrecision = false)
     {
         $this->origin = $this->formatTime($origin);
         $this->category = is_string($category) ? $category : 'default';

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -29,10 +29,10 @@ class StopwatchPeriod
      * @param int|float $end           The relative time of the end of the period (in milliseconds)
      * @param bool      $morePrecision If true, time is stored as float to keep the original microsecond precision
      */
-    public function __construct($start, $end, /* bool */ $morePrecision = false)
+    public function __construct($start, $end, $morePrecision = false)
     {
-        $this->start = $morePrecision ? $start : (int) $start;
-        $this->end = $morePrecision ? $end : (int) $end;
+        $this->start = $morePrecision ? (float) $start : (int) $start;
+        $this->end = $morePrecision ? (float) $end : (int) $end;
         $this->memory = memory_get_usage(true);
     }
 

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -25,19 +25,14 @@ class StopwatchPeriod
     /**
      * Constructor.
      *
-     * @param int|float $start The relative time of the start of the period (in milliseconds)
-     * @param int|float $end   The relative time of the end of the period (in milliseconds)
+     * @param int|float $start         The relative time of the start of the period (in milliseconds)
+     * @param int|float $end           The relative time of the end of the period (in milliseconds)
+     * @param bool      $morePrecision If true, time is stored as float to keep the original microsecond precision
      */
-    public function __construct($start, $end /*, $useMicroPrecision = false*/)
+    public function __construct($start, $end, /* bool */ $morePrecision = false)
     {
-        if (func_num_args() > 2 && true === func_get_arg(2)) {
-            $this->start = $start;
-            $this->end = $end;
-        } else {
-            $this->start = (int) $start;
-            $this->end = (int) $end;
-        }
-
+        $this->start = $morePrecision ? $start : (int) $start;
+        $this->end = $morePrecision ? $end : (int) $end;
         $this->memory = memory_get_usage(true);
     }
 

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -29,10 +29,10 @@ class StopwatchPeriod
      * @param int|float $end           The relative time of the end of the period (in milliseconds)
      * @param bool      $morePrecision If true, time is stored as float to keep the original microsecond precision
      */
-    public function __construct($start, $end, /* bool */ $morePrecision = false)
+    public function __construct($start, $end)
     {
-        $this->start = $morePrecision ? $start : (int) $start;
-        $this->end = $morePrecision ? $end : (int) $end;
+        $this->start = $start;
+        $this->end = $end;
         $this->memory = memory_get_usage(true);
     }
 
@@ -41,9 +41,13 @@ class StopwatchPeriod
      *
      * @return int|float The time (in milliseconds)
      */
-    public function getStartTime()
+    public function getStartTime(/*bool $morePrecision = false*/)
     {
-        return $this->start;
+        if (func_num_args() > 0 && true === func_get_arg(0)) {
+            return $this->start;
+        }
+
+        return (int) $this->start;
     }
 
     /**
@@ -51,9 +55,13 @@ class StopwatchPeriod
      *
      * @return int|float The time (in milliseconds)
      */
-    public function getEndTime()
+    public function getEndTime(/*bool $morePrecision = false*/)
     {
-        return $this->end;
+        if (func_num_args() > 0 && true === func_get_arg(0)) {
+            return $this->end;
+        }
+
+        return (int) $this->end;
     }
 
     /**
@@ -61,9 +69,15 @@ class StopwatchPeriod
      *
      * @return int|float The period duration (in milliseconds)
      */
-    public function getDuration()
+    public function getDuration(/*bool $morePrecision = false*/)
     {
-        return $this->end - $this->start;
+        $duration = $this->end - $this->start;
+
+        if (func_num_args() > 0 && true === func_get_arg(0)) {
+            return $duration;
+        }
+
+        return (int) $duration;
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -29,10 +29,10 @@ class StopwatchPeriod
      * @param int|float $end           The relative time of the end of the period (in milliseconds)
      * @param bool      $morePrecision If true, time is stored as float to keep the original microsecond precision
      */
-    public function __construct($start, $end)
+    public function __construct($start, $end, /* bool */ $morePrecision = false)
     {
-        $this->start = $start;
-        $this->end = $end;
+        $this->start = $morePrecision ? $start : (int) $start;
+        $this->end = $morePrecision ? $end : (int) $end;
         $this->memory = memory_get_usage(true);
     }
 
@@ -41,13 +41,9 @@ class StopwatchPeriod
      *
      * @return int|float The time (in milliseconds)
      */
-    public function getStartTime(/*bool $morePrecision = false*/)
+    public function getStartTime()
     {
-        if (func_num_args() > 0 && true === func_get_arg(0)) {
-            return $this->start;
-        }
-
-        return (int) $this->start;
+        return $this->start;
     }
 
     /**
@@ -55,13 +51,9 @@ class StopwatchPeriod
      *
      * @return int|float The time (in milliseconds)
      */
-    public function getEndTime(/*bool $morePrecision = false*/)
+    public function getEndTime()
     {
-        if (func_num_args() > 0 && true === func_get_arg(0)) {
-            return $this->end;
-        }
-
-        return (int) $this->end;
+        return $this->end;
     }
 
     /**
@@ -69,15 +61,9 @@ class StopwatchPeriod
      *
      * @return int|float The period duration (in milliseconds)
      */
-    public function getDuration(/*bool $morePrecision = false*/)
+    public function getDuration()
     {
-        $duration = $this->end - $this->start;
-
-        if (func_num_args() > 0 && true === func_get_arg(0)) {
-            return $duration;
-        }
-
-        return (int) $duration;
+        return $this->end - $this->start;
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -25,20 +25,20 @@ class StopwatchPeriod
     /**
      * Constructor.
      *
-     * @param int $start The relative time of the start of the period (in milliseconds)
-     * @param int $end   The relative time of the end of the period (in milliseconds)
+     * @param float $start The relative time of the start of the period (in milliseconds)
+     * @param float $end   The relative time of the end of the period (in milliseconds)
      */
     public function __construct($start, $end)
     {
-        $this->start = (int) $start;
-        $this->end = (int) $end;
+        $this->start = $start;
+        $this->end = $end;
         $this->memory = memory_get_usage(true);
     }
 
     /**
      * Gets the relative time of the start of the period.
      *
-     * @return int The time (in milliseconds)
+     * @return float The time (in milliseconds)
      */
     public function getStartTime()
     {
@@ -48,7 +48,7 @@ class StopwatchPeriod
     /**
      * Gets the relative time of the end of the period.
      *
-     * @return int The time (in milliseconds)
+     * @return float The time (in milliseconds)
      */
     public function getEndTime()
     {
@@ -58,7 +58,7 @@ class StopwatchPeriod
     /**
      * Gets the time spent in this period.
      *
-     * @return int The period duration (in milliseconds)
+     * @return float The period duration (in milliseconds)
      */
     public function getDuration()
     {

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -25,20 +25,26 @@ class StopwatchPeriod
     /**
      * Constructor.
      *
-     * @param float $start The relative time of the start of the period (in milliseconds)
-     * @param float $end   The relative time of the end of the period (in milliseconds)
+     * @param int|float $start The relative time of the start of the period (in milliseconds)
+     * @param int|float $end   The relative time of the end of the period (in milliseconds)
      */
-    public function __construct($start, $end)
+    public function __construct($start, $end /*, $useMicroPrecision = false*/)
     {
-        $this->start = $start;
-        $this->end = $end;
+        if (func_num_args() > 2 && true === func_get_arg(2)) {
+            $this->start = $start;
+            $this->end = $end;
+        } else {
+            $this->start = (int) $start;
+            $this->end = (int) $end;
+        }
+
         $this->memory = memory_get_usage(true);
     }
 
     /**
      * Gets the relative time of the start of the period.
      *
-     * @return float The time (in milliseconds)
+     * @return int|float The time (in milliseconds)
      */
     public function getStartTime()
     {
@@ -48,7 +54,7 @@ class StopwatchPeriod
     /**
      * Gets the relative time of the end of the period.
      *
-     * @return float The time (in milliseconds)
+     * @return int|float The time (in milliseconds)
      */
     public function getEndTime()
     {
@@ -58,7 +64,7 @@ class StopwatchPeriod
     /**
      * Gets the time spent in this period.
      *
-     * @return float The period duration (in milliseconds)
+     * @return int|float The period duration (in milliseconds)
      */
     public function getDuration()
     {

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
@@ -21,8 +21,8 @@ class StopwatchPeriodTest extends TestCase
      */
     public function testGetStartTime($start, $useMorePrecision, $expected)
     {
-        $period = new StopwatchPeriod($start, $start);
-        $this->assertSame($expected, $period->getStartTime($useMorePrecision));
+        $period = new StopwatchPeriod($start, $start, $useMorePrecision);
+        $this->assertSame($expected, $period->getStartTime());
     }
 
     /**
@@ -30,8 +30,8 @@ class StopwatchPeriodTest extends TestCase
      */
     public function testGetEndTime($end, $useMorePrecision, $expected)
     {
-        $period = new StopwatchPeriod($end, $end);
-        $this->assertSame($expected, $period->getEndTime($useMorePrecision));
+        $period = new StopwatchPeriod($end, $end, $useMorePrecision);
+        $this->assertSame($expected, $period->getEndTime());
     }
 
     /**
@@ -39,8 +39,8 @@ class StopwatchPeriodTest extends TestCase
      */
     public function testGetDuration($start, $end, $useMorePrecision, $duration)
     {
-        $period = new StopwatchPeriod($start, $end);
-        $this->assertSame($duration, $period->getDuration($useMorePrecision));
+        $period = new StopwatchPeriod($start, $end, $useMorePrecision);
+        $this->assertSame($duration, $period->getDuration());
     }
 
     public function provideTimeValues()
@@ -61,7 +61,7 @@ class StopwatchPeriodTest extends TestCase
         yield array(0.0, 0.0, true, 0.0);
         yield array(2, 3.14, false, 1);
         yield array(2, 3.14, true, 1.14);
-        yield array(2.71, 3.14, false, 0);
+        yield array(2.71, 3.14, false, 1);
         yield array(2.71, 3.14, true, 0.43);
     }
 }

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Stopwatch\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Stopwatch\StopwatchPeriod;
+
+class StopwatchPeriodTest extends TestCase
+{
+    /**
+     * @dataProvider provideTimeValues
+     */
+    public function testGetStartTime($start, $end)
+    {
+        $period = new StopwatchPeriod($start, $end);
+        $this->assertSame($start, $period->getStartTime());
+    }
+
+    /**
+     * @dataProvider provideTimeValues
+     */
+    public function testGetEndTime($start, $end)
+    {
+        $period = new StopwatchPeriod($start, $end);
+        $this->assertSame($end, $period->getEndTime());
+    }
+
+    /**
+     * @dataProvider provideTimeValues
+     */
+    public function testGetDuration($start, $end, $duration)
+    {
+        $period = new StopwatchPeriod($start, $end);
+        $this->assertSame($duration, $period->getDuration());
+    }
+
+    public function provideTimeValues()
+    {
+        yield [0, 0, 0];
+        yield [0.0, 0.0, 0.0];
+        yield [0.0, 2.7182, 2.7182];
+        yield [3, 7, 4];
+        yield [3, 3.14, 0.14];
+        yield [3.10, 3.14, 0.04];
+    }
+}

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
@@ -45,11 +45,11 @@ class StopwatchPeriodTest extends TestCase
 
     public function provideTimeValues()
     {
-        yield [0, 0, 0];
-        yield [0.0, 0.0, 0.0];
-        yield [0.0, 2.7182, 2.7182];
-        yield [3, 7, 4];
-        yield [3, 3.14, 0.14];
-        yield [3.10, 3.14, 0.04];
+        yield array(0, 0, 0);
+        yield array(0.0, 0.0, 0.0);
+        yield array(0.0, 2.7182, 2.7182);
+        yield array(3, 7, 4);
+        yield array(3, 3.14, 0.14);
+        yield array(3.10, 3.14, 0.04);
     }
 }

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
@@ -46,7 +46,7 @@ class StopwatchPeriodTest extends TestCase
     public function provideTimeValues()
     {
         yield array(0, false, 0);
-        yield array(0, true, 0);
+        yield array(0, true, 0.0);
         yield array(0.0, false, 0);
         yield array(0.0, true, 0.0);
         yield array(2.71, false, 2);
@@ -56,7 +56,7 @@ class StopwatchPeriodTest extends TestCase
     public function provideDurationValues()
     {
         yield array(0, 0, false, 0);
-        yield array(0, 0, true, 0);
+        yield array(0, 0, true, 0.0);
         yield array(0.0, 0.0, false, 0);
         yield array(0.0, 0.0, true, 0.0);
         yield array(2, 3.14, false, 1);

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
@@ -19,37 +19,49 @@ class StopwatchPeriodTest extends TestCase
     /**
      * @dataProvider provideTimeValues
      */
-    public function testGetStartTime($start, $end)
+    public function testGetStartTime($start, $useMorePrecision, $expected)
     {
-        $period = new StopwatchPeriod($start, $end);
-        $this->assertSame($start, $period->getStartTime());
+        $period = new StopwatchPeriod($start, $start, $useMorePrecision);
+        $this->assertSame($expected, $period->getStartTime());
     }
 
     /**
      * @dataProvider provideTimeValues
      */
-    public function testGetEndTime($start, $end)
+    public function testGetEndTime($end, $useMorePrecision, $expected)
     {
-        $period = new StopwatchPeriod($start, $end);
-        $this->assertSame($end, $period->getEndTime());
+        $period = new StopwatchPeriod($end, $end, $useMorePrecision);
+        $this->assertSame($expected, $period->getEndTime());
     }
 
     /**
-     * @dataProvider provideTimeValues
+     * @dataProvider provideDurationValues
      */
-    public function testGetDuration($start, $end, $duration)
+    public function testGetDuration($start, $end, $useMorePrecision, $duration)
     {
-        $period = new StopwatchPeriod($start, $end);
+        $period = new StopwatchPeriod($start, $end, $useMorePrecision);
         $this->assertSame($duration, $period->getDuration());
     }
 
     public function provideTimeValues()
     {
-        yield array(0, 0, 0);
-        yield array(0.0, 0.0, 0.0);
-        yield array(0.0, 2.7182, 2.7182);
-        yield array(3, 7, 4);
-        yield array(3, 3.14, 0.14);
-        yield array(3.10, 3.14, 0.04);
+        yield array(0, false, 0);
+        yield array(0, true, 0);
+        yield array(0.0, false, 0);
+        yield array(0.0, true, 0.0);
+        yield array(2.71, false, 2);
+        yield array(2.71, true, 2.71);
+    }
+
+    public function provideDurationValues()
+    {
+        yield array(0, 0, false, 0);
+        yield array(0, 0, true, 0);
+        yield array(0.0, 0.0, false, 0);
+        yield array(0.0, 0.0, true, 0.0);
+        yield array(2, 3.14, false, 1);
+        yield array(2, 3.14, true, 1.14);
+        yield array(2.71, 3.14, false, 1);
+        yield array(2.71, 3.14, true, 0.43);
     }
 }

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchPeriodTest.php
@@ -21,8 +21,8 @@ class StopwatchPeriodTest extends TestCase
      */
     public function testGetStartTime($start, $useMorePrecision, $expected)
     {
-        $period = new StopwatchPeriod($start, $start, $useMorePrecision);
-        $this->assertSame($expected, $period->getStartTime());
+        $period = new StopwatchPeriod($start, $start);
+        $this->assertSame($expected, $period->getStartTime($useMorePrecision));
     }
 
     /**
@@ -30,8 +30,8 @@ class StopwatchPeriodTest extends TestCase
      */
     public function testGetEndTime($end, $useMorePrecision, $expected)
     {
-        $period = new StopwatchPeriod($end, $end, $useMorePrecision);
-        $this->assertSame($expected, $period->getEndTime());
+        $period = new StopwatchPeriod($end, $end);
+        $this->assertSame($expected, $period->getEndTime($useMorePrecision));
     }
 
     /**
@@ -39,8 +39,8 @@ class StopwatchPeriodTest extends TestCase
      */
     public function testGetDuration($start, $end, $useMorePrecision, $duration)
     {
-        $period = new StopwatchPeriod($start, $end, $useMorePrecision);
-        $this->assertSame($duration, $period->getDuration());
+        $period = new StopwatchPeriod($start, $end);
+        $this->assertSame($duration, $period->getDuration($useMorePrecision));
     }
 
     public function provideTimeValues()
@@ -61,7 +61,7 @@ class StopwatchPeriodTest extends TestCase
         yield array(0.0, 0.0, true, 0.0);
         yield array(2, 3.14, false, 1);
         yield array(2, 3.14, true, 1.14);
-        yield array(2.71, 3.14, false, 1);
+        yield array(2.71, 3.14, false, 0);
         yield array(2.71, 3.14, true, 0.43);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #18756
| License       | MIT
| Doc PR        | -

Stopwatch component already supports microseconds (and nanoseconds, etc.) ... but the problem is that it converts the millisecond times to integers, so anything smaller to 1 millisecond is lost. This PR changes that to fix issues like the one explained in #18756.

### Before
![before-stopwatch](https://user-images.githubusercontent.com/73419/27279393-c745db54-54e4-11e7-8f26-01e2063604ce.png)

### After

![after-stopwatch](https://user-images.githubusercontent.com/73419/27279396-c8894dac-54e4-11e7-9a3a-bff027377047.png)