### PR TITLE
[FrameworkBundle] call setContainer() for autowired controllers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -49,7 +49,19 @@ class ControllerResolver extends ContainerControllerResolver
             $controller = $this->parser->parse($controller);
         }
 
-        return parent::createController($controller);
+        $resolvedController = parent::createController($controller);
+
+        if (1 === substr_count($controller, ':') && is_array($resolvedController)) {
+            if ($resolvedController[0] instanceof ContainerAwareInterface) {
+                $resolvedController[0]->setContainer($this->container);
+            }
+
+            if ($resolvedController[0] instanceof AbstractController && null !== $previousContainer = $resolvedController[0]->setContainer($this->container)) {
+                $resolvedController[0]->setContainer($previousContainer);
+            }
+        }
+
+        return $resolvedController;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23200, FriendsOfSymfony/FOSRestBundle#1719
| License       | MIT
| Doc PR        | 

Previously, you either did not use controllers as services or you explicitly wired everything yourself. In case of a non-service controller the FrameworkBundle took care of calling `setContainer()` inside the `instantiateController()` method:

```php
protected function instantiateController($class)
{
    $controller = parent::instantiateController($class);

    if ($controller instanceof ContainerAwareInterface) {
        $controller->setContainer($this->container);
    }
    if ($controller instanceof AbstractController && null !== $previousContainer = $controller->setContainer($this->container)) {
        $controller->setContainer($previousContainer);
    }

    return $controller;
}
```

With the new autowired controllers as services this is no longer happening as controllers do not need to be instantiated anymore (the container already returns fully built objects).