### PR TITLE
[Console] Fix catching exception type in QuestionHelper

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -111,8 +111,7 @@ class QuestionHelper extends Helper
      *
      * @return bool|mixed|null|string
      *
-     * @throws \Exception
-     * @throws \RuntimeException
+     * @throws RuntimeException In case the fallback is deactivated and the response cannot be hidden
      */
     public function doAsk(OutputInterface $output, Question $question)
     {
@@ -126,7 +125,7 @@ class QuestionHelper extends Helper
             if ($question->isHidden()) {
                 try {
                     $ret = trim($this->getHiddenResponse($output, $inputStream));
-                } catch (\RuntimeException $e) {
+                } catch (RuntimeException $e) {
                     if (!$question->isHiddenFallback()) {
                         throw $e;
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

When generic exceptions were replaced by domain exceptions in https://github.com/symfony/symfony/commit/dd17dc00eea7f1da051c91bd4ff376f41f782932 one catch statement was missed. The existing code works fine because a `RuntimeException` extends a `\RuntimeException`.