### PR TITLE
[FrameworkBundle] Add configuration for profiler log channels

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Processor;
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Processor\DebugProcessor;
+
+class DebugProcessorTest extends TestCase
+{
+    public function testNoChannelsAreFilteredByDefault()
+    {
+        $handler = new TestHandler();
+        $processor = new DebugProcessor();
+
+        $aLogger = new Logger('a', array($handler), array($processor));
+        $bLogger = new Logger('b', array($handler), array($processor));
+
+        $aLogger->info('test A');
+        $bLogger->info('test B');
+
+        $logs = $processor->getLogs();
+        $this->assertCount(2, $logs);
+
+        $this->assertEquals('a', $logs[0]['channel']);
+        $this->assertEquals('test A', $logs[0]['message']);
+
+        $this->assertEquals('b', $logs[1]['channel']);
+        $this->assertEquals('test B', $logs[1]['message']);
+    }
+
+    public function testExcludedChannels()
+    {
+        $handler = new TestHandler();
+
+        $processor = new DebugProcessor();
+        $processor->setFilterChannels(array('a'), true);
+
+        $aLogger = new Logger('a', array($handler), array($processor));
+        $bLogger = new Logger('b', array($handler), array($processor));
+
+        $aLogger->info('test A');
+        $bLogger->info('test B');
+
+        $logs = $processor->getLogs();
+        $this->assertCount(1, $logs);
+
+        $this->assertEquals('b', $logs[0]['channel']);
+        $this->assertEquals('test B', $logs[0]['message']);
+    }
+
+    public function testIncludedChannels()
+    {
+        $handler = new TestHandler();
+
+        $processor = new DebugProcessor();
+        $processor->setFilterChannels(array('a'), false);
+
+        $aLogger = new Logger('a', array($handler), array($processor));
+        $bLogger = new Logger('b', array($handler), array($processor));
+
+        $aLogger->info('test A');
+        $bLogger->info('test B');
+
+        $logs = $processor->getLogs();
+        $this->assertCount(1, $logs);
+
+        $this->assertEquals('a', $logs[0]['channel']);
+        $this->assertEquals('test A', $logs[0]['message']);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
    require symfony/stopwatch` in your `dev` environment.
  * Deprecated using the `KERNEL_DIR` environment variable with `KernelTestCase::getKernelClass()`.
  * Deprecated the `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()` methods.
+ * Added a configuration to exclude logging channels from the profiler by setting `framework.profiler.log_channels`.
 
 3.3.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

In larger projects, the amount of logs stored in the profiler can grow quickly and the web profiler takes quite some time to render the logs screen when having hundreds of event and db log entries. This PR adds a configuration entry to exclude/include certain log channels from the profiler. The format follows the `channels` configuration entry from the monolog bundle:

```
framework:
    profiler:
        log_channels: ["!event", "!doctrine"]

# more verbose
framework:
    profiler:
        log_channels:
            channels: ["!event", "!doctrine"]

# or profile only certain channels
framework:
    profiler:
        log_channels:
            channels: ["event", "doctrine"]
```

I'll be happy to add a doc PR if this is accepted.