### PR TITLE
[WebProfilerBundle] Add configuration entry to disable JS confirm dialog on error

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -45,6 +45,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->booleanNode('intercept_redirects')->defaultFalse()->end()
+                ->booleanNode('show_error_confirmation')->defaultTrue()->end()
                 ->scalarNode('excluded_ajax_paths')->defaultValue('^/(app(_[\\w]+)?\\.php/)?_wdt')->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -48,7 +48,10 @@ class WebProfilerExtension extends Extension
 
         if ($config['toolbar'] || $config['intercept_redirects']) {
             $loader->load('toolbar.xml');
-            $container->getDefinition('web_profiler.debug_toolbar')->replaceArgument(5, $config['excluded_ajax_paths']);
+            $container->getDefinition('web_profiler.debug_toolbar')
+                ->replaceArgument(5, $config['excluded_ajax_paths'])
+                ->addMethodCall('setShowErrorConfirmation', array($config['show_error_confirmation']));
+
             $container->setParameter('web_profiler.debug_toolbar.intercept_redirects', $config['intercept_redirects']);
             $container->setParameter('web_profiler.debug_toolbar.mode', $config['toolbar'] ? WebDebugToolbarListener::ENABLED : WebDebugToolbarListener::DISABLED);
         }

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -42,6 +42,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     protected $mode;
     protected $position;
     protected $excludedAjaxPaths;
+    protected $showErrorConfirmation = true;
     private $cspHandler;
 
     public function __construct(Environment $twig, $interceptRedirects = false, $mode = self::ENABLED, $position = 'bottom', UrlGeneratorInterface $urlGenerator = null, $excludedAjaxPaths = '^/bundles|^/_wdt', ContentSecurityPolicyHandler $cspHandler = null)
@@ -58,6 +59,11 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     public function isEnabled()
     {
         return self::DISABLED !== $this->mode;
+    }
+
+    public function setShowErrorConfirmation($showErrorConfirmation)
+    {
+        $this->showErrorConfirmation = (bool) $showErrorConfirmation;
     }
 
     public function onKernelResponse(FilterResponseEvent $event)
@@ -130,6 +136,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
                     'request' => $request,
                     'csp_script_nonce' => isset($nonces['csp_script_nonce']) ? $nonces['csp_script_nonce'] : null,
                     'csp_style_nonce' => isset($nonces['csp_style_nonce']) ? $nonces['csp_style_nonce'] : null,
+                    'show_error_confirmation' => $this->showErrorConfirmation,
                 )
             ))."\n";
             $content = substr($content, 0, $pos).$toolbar.substr($content, $pos);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/schema/webprofiler-1.0.xsd
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/schema/webprofiler-1.0.xsd
@@ -10,6 +10,7 @@
     <xsd:complexType name="config">
         <xsd:attribute name="toolbar" type="xsd:boolean" />
         <xsd:attribute name="intercept-redirects" type="xsd:boolean" />
+        <xsd:attribute name="show-error-confirmation" type="xsd:boolean" />
         <xsd:attribute name="position" type="positions" />
     </xsd:complexType>
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -100,7 +100,7 @@
                 });
             },
             function(xhr) {
-                if (xhr.status !== 0) {
+                if (xhr.status !== 0 && {{ show_error_confirmation ? 'true' : 'false' }}) {
                     confirm('An error occurred while loading the web debug toolbar (' + xhr.status + ': ' + xhr.statusText + ').\n\nDo you want to open the profiler?') && (window.location = '{{ path("_profiler", { "token": token }) }}');
                 }
             },

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -32,12 +32,14 @@ class ConfigurationTest extends TestCase
     public function getDebugModes()
     {
         return array(
-            array(array(), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('position' => 'top'), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'top', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('excluded_ajax_paths' => 'test'), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => 'test')),
+            array(array(), array('intercept_redirects' => false, 'toolbar' => false, 'show_error_confirmation' => true, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
+            array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'show_error_confirmation' => true, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
+            array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'show_error_confirmation' => true, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
+            array(array('show_error_confirmation' => true), array('intercept_redirects' => false, 'toolbar' => false, 'show_error_confirmation' => true, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
+            array(array('show_error_confirmation' => false), array('intercept_redirects' => false, 'toolbar' => false, 'show_error_confirmation' => false, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
+            array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'show_error_confirmation' => true, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
+            array(array('position' => 'top'), array('intercept_redirects' => false, 'toolbar' => false, 'show_error_confirmation' => true, 'position' => 'top', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
+            array(array('excluded_ajax_paths' => 'test'), array('intercept_redirects' => false, 'toolbar' => false, 'show_error_confirmation' => true, 'position' => 'bottom', 'excluded_ajax_paths' => 'test')),
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This adds the possibility to disable the JS confirmation dialog ("Do you want to open the profiler?") if loading of the profiler toolbar fails. In certain environments with many logs/db queries the profiler might fail regularly and having the dialog popping up on every request makes debugging tedious. With this change you can disable the confirmation - the toolbar will just silently fail instead of showing the dialog:

```
web_profiler:
    show_error_confirmation: false
```