### PR TITLE
[TwigBundle] Add Doctrine Cache to dev dependencies to fix failing unit tests.

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -34,7 +34,8 @@
         "symfony/templating": "~2.8|~3.0",
         "symfony/yaml": "~2.8|~3.0",
         "symfony/framework-bundle": "^3.2.2",
-        "doctrine/annotations": "~1.0"
+        "doctrine/annotations": "~1.0",
+        "doctrine/cache": "~1.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\TwigBundle\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Backporting #23166 to the `3.2` branch should make the `deps=high` builds pass again.