### PR TITLE
[Security] Fix authentication.failure event not dispatched on AccountStatusException

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -83,9 +83,9 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
                     break;
                 }
             } catch (AccountStatusException $e) {
-                $e->setToken($token);
+                $lastException = $e;
 
-                throw $e;
+                break;
             } catch (AuthenticationException $e) {
                 $lastException = $e;
             }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Security\Core\Tests\Authentication;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager;
+use Symfony\Component\Security\Core\AuthenticationEvents;
+use Symfony\Component\Security\Core\Event\AuthenticationEvent;
+use Symfony\Component\Security\Core\Event\AuthenticationFailureEvent;
 use Symfony\Component\Security\Core\Exception\ProviderNotFoundException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\AccountStatusException;
@@ -122,6 +125,50 @@ class AuthenticationProviderManagerTest extends TestCase
 
         $token = $manager->authenticate($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());
         $this->assertEquals('bar', $token->getCredentials());
+    }
+
+    public function testAuthenticateDispatchesAuthenticationFailureEvent()
+    {
+        $token = new UsernamePasswordToken('foo', 'bar', 'key');
+        $provider = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface')->getMock();
+        $provider->expects($this->once())->method('supports')->willReturn(true);
+        $provider->expects($this->once())->method('authenticate')->willThrowException($exception = new AuthenticationException());
+
+        $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+        $dispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(AuthenticationEvents::AUTHENTICATION_FAILURE, $this->equalTo(new AuthenticationFailureEvent($token, $exception)));
+
+        $manager = new AuthenticationProviderManager(array($provider));
+        $manager->setEventDispatcher($dispatcher);
+
+        try {
+            $manager->authenticate($token);
+            $this->fail('->authenticate() should rethrow exceptions');
+        } catch (AuthenticationException $e) {
+            $this->assertSame($token, $exception->getToken());
+        }
+    }
+
+    public function testAuthenticateDispatchesAuthenticationSuccessEvent()
+    {
+        $token = new UsernamePasswordToken('foo', 'bar', 'key');
+
+        $provider = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface')->getMock();
+        $provider->expects($this->once())->method('supports')->willReturn(true);
+        $provider->expects($this->once())->method('authenticate')->willReturn($token);
+
+        $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
+        $dispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(AuthenticationEvents::AUTHENTICATION_SUCCESS, $this->equalTo(new AuthenticationEvent($token)));
+
+        $manager = new AuthenticationProviderManager(array($provider));
+        $manager->setEventDispatcher($dispatcher);
+
+        $this->assertSame($token, $manager->authenticate($token));
     }
 
     protected function getAuthenticationProvider($supports, $token = null, $exception = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/18807
| License       | MIT
| Doc PR        | n/a

Authentication fails if the user exists but its account is disabled/expired/locked, the failure event should be dispatched in this case, so that you can hook into as for any authentication exception.