### PR TITLE
Fixed absolute url generation for query strings and hash urls

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
@@ -73,9 +73,7 @@ class HttpFoundationExtension extends \Twig_Extension
                 if ('#' === $path[0]) {
                     $queryString = $this->requestContext->getQueryString();
                     $path = $this->requestContext->getPathInfo().($queryString ? '?'.$queryString : '').$path;
-                }
-
-                if ('?' === $path[0]) {
+                } elseif ('?' === $path[0]) {
                     $path = $this->requestContext->getPathInfo().$path;
                 }
 
@@ -91,9 +89,7 @@ class HttpFoundationExtension extends \Twig_Extension
 
         if ('#' === $path[0]) {
             $path = $request->getRequestUri().$path;
-        }
-
-        if ('?' === $path[0]) {
+        } elseif ('?' === $path[0]) {
             $path = $request->getPathInfo().$path;
         }
 

--- a/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpFoundationExtension.php
@@ -70,6 +70,15 @@ class HttpFoundationExtension extends \Twig_Extension
                     $port = ':'.$this->requestContext->getHttpsPort();
                 }
 
+                if ('#' === $path[0]) {
+                    $queryString = $this->requestContext->getQueryString();
+                    $path = $this->requestContext->getPathInfo().($queryString ? '?'.$queryString : '').$path;
+                }
+
+                if ('?' === $path[0]) {
+                    $path = $this->requestContext->getPathInfo().$path;
+                }
+
                 if ('/' !== $path[0]) {
                     $path = rtrim($this->requestContext->getBaseUrl(), '/').'/'.$path;
                 }
@@ -78,6 +87,14 @@ class HttpFoundationExtension extends \Twig_Extension
             }
 
             return $path;
+        }
+
+        if ('#' === $path[0]) {
+            $path = $request->getRequestUri().$path;
+        }
+
+        if ('?' === $path[0]) {
+            $path = $request->getPathInfo().$path;
         }
 
         if (!$path || '/' !== $path[0]) {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
@@ -47,6 +47,7 @@ class HttpFoundationExtensionTest extends \PHPUnit_Framework_TestCase
             array('http://localhost/foo/baz?baz=1', 'baz?baz=1', '/foo/bar?foo=1'),
 
             array('http://localhost/foo/bar#baz', '#baz', '/foo/bar'),
+            array('http://localhost/foo/bar?0#baz', '#baz', '/foo/bar?0'),
             array('http://localhost/foo/bar?baz=1#baz', '?baz=1#baz', '/foo/bar?foo=1'),
             array('http://localhost/foo/baz?baz=1#baz', 'baz?baz=1#baz', '/foo/bar?foo=1'),
         );

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpFoundationExtensionTest.php
@@ -41,6 +41,14 @@ class HttpFoundationExtensionTest extends \PHPUnit_Framework_TestCase
             array('http://example.com/baz', 'http://example.com/baz', '/'),
             array('https://example.com/baz', 'https://example.com/baz', '/'),
             array('//example.com/baz', '//example.com/baz', '/'),
+
+            array('http://localhost/foo/bar?baz', '?baz', '/foo/bar'),
+            array('http://localhost/foo/bar?baz=1', '?baz=1', '/foo/bar?foo=1'),
+            array('http://localhost/foo/baz?baz=1', 'baz?baz=1', '/foo/bar?foo=1'),
+
+            array('http://localhost/foo/bar#baz', '#baz', '/foo/bar'),
+            array('http://localhost/foo/bar?baz=1#baz', '?baz=1#baz', '/foo/bar?foo=1'),
+            array('http://localhost/foo/baz?baz=1#baz', 'baz?baz=1#baz', '/foo/bar?foo=1'),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7, ...
| Bug fix?      | yes
| New feature?  |no 
| BC breaks?    | yes? absolute_url will change its output but the old was incorrect
| Deprecations? |no 
| Tests pass?   | yes?
| Fixed tickets | fixes #23260
| License       | MIT

Fixed absolute url generation for query strings