### PR TITLE
Display a better error message when the toolbar cannot be displayed

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -57,8 +57,17 @@
                 }
             },
             function(xhr) {
+                var errorToolbarHtml = '
+                    <style>
+                        .sfErrorToolbar { background: #222; bottom: 0; color: #f5f5f5; font: 13px/36px Arial, sans-serif; height: 36px; padding: 0 15px; position: fixed; width: 100%; }
+                        .sfErrorToolbar a { color: #99cdd8; margin-left: 5px; text-decoration: underline; }
+                        .sfErrorToolbar a:hover { text-decoration: none; }
+                    </style>
+                    <div class="sfErrorToolbar">An error occurred while loading the web debug toolbar. <a href="{{ path("_profiler", { "token": token }) }}">Open the web profiler.</a></div>
+                ';
+
                 if (xhr.status !== 0) {
-                    confirm('An error occurred while loading the web debug toolbar (' + xhr.status + ': ' + xhr.statusText + ').\n\nDo you want to open the profiler?') && (window.location = '{{ path("_profiler", { "token": token }) }}');
+                    window.document.body.insertAdjacentHTML('beforeend', errorToolbarHtml);
                 }
             },
             {'maxTries': 5}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23264
| License       | MIT
| Doc PR        | -

In action:

![profiler-error](https://user-images.githubusercontent.com/73419/27444352-5d0a1d60-5776-11e7-89c3-430cd6f38454.png)
