### PR TITLE
Show exception is checked twice in ExceptionController of twig

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -123,7 +123,7 @@ class ExceptionController
         // default to a generic HTML exception
         $request->setRequestFormat('html');
 
-        return sprintf('@Twig/Exception/%s.html.twig', $showException ? 'exception_full' : $name);
+        return sprintf('@Twig/Exception/%s.html.twig', $name);
     }
 
     // to be removed when the minimum required version of Twig is >= 3.0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | N/A

I think that the $showException variable is checked twice. Check line 105 of the same file. Hope I did not miss anythings since the tests are passing.
