### PR TITLE
[WebProfilerBundle] Add replay action in profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -15,6 +15,7 @@
             <argument>%web_profiler.debug_toolbar.position%</argument>
             <argument type="service" id="web_profiler.csp.handler" />
             <argument>null</argument>
+            <argument type="service" id="kernel" />
         </service>
 
         <service id="web_profiler.controller.router" class="Symfony\Bundle\WebProfilerBundle\Controller\RouterController" public="true">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -32,6 +32,10 @@
         <default key="_controller">web_profiler.controller.profiler:panelAction</default>
     </route>
 
+    <route id="_profiler_replay" path="/{token}/replay" methods="POST">
+        <default key="_controller">web_profiler.controller.profiler:replayAction</default>
+    </route>
+
     <route id="_profiler_router" path="/{token}/router">
         <default key="_controller">web_profiler.controller.router:panelAction</default>
     </route>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -76,7 +76,16 @@
                             <dd>{{ profile.time|date('r') }}</dd>
 
                             <dt>Token</dt>
-                            <dd>{{ profile.token }}</dd>
+                            <dd>
+                                {{ profile.token }}
+                                {% if can_replay %}
+                                    <form action="{{ path('_profiler_replay', { token: token, panel: request.query.get('panel', 'request') }) }}" method="post" style="display: inline-block;">
+                                        <div class="form-group">
+                                            <button type="submit" class="btn btn-sm">Replay</button>
+                                        </div>
+                                    </form>
+                                {% endif %}
+                            </dd>
                         </dl>
                     </div>
                 </div>

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -166,14 +166,14 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         return $this->data['path_info'];
     }
 
-    public function getRequestRequest()
+    public function getRequestRequest($raw = false)
     {
-        return new ParameterBag($this->data['request_request']->getValue());
+        return new ParameterBag($this->data['request_request']->getValue($raw));
     }
 
-    public function getRequestQuery()
+    public function getRequestQuery($raw = false)
     {
-        return new ParameterBag($this->data['request_query']->getValue());
+        return new ParameterBag($this->data['request_query']->getValue($raw));
     }
 
     public function getRequestHeaders()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

When we debug an controller action, it's sometimes hard/annoying to reproduce the failed action in the browser and open the new token in profiler in the appropriate panel. I suggest to add a shortcut button to **replay the current token directly from the profiler**.

![screencast from 06-22-2017 10-16-38 pm](https://user-images.githubusercontent.com/4578773/27454036-cc7c12e4-5798-11e7-9764-2e6c35ba4f19.gif)