### PR TITLE
Don't call count on non countable object

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
@@ -52,7 +52,7 @@ class IcuResFileDumper extends FileDumper
 
         $resOffset = $this->getPosition($data);
 
-        $data .= pack('v', count($messages))
+        $data .= pack('v', count($messages->all($domain)))
             .$indexes
             .$this->writePadding($data)
             .$resources
@@ -63,11 +63,11 @@ class IcuResFileDumper extends FileDumper
         $root = pack('V7',
             $resOffset + (2 << 28), // Resource Offset + Resource Type
             6,                      // Index length
-            $keyTop,                // Index keys top
-            $bundleTop,             // Index resources top
-            $bundleTop,             // Index bundle top
-            count($messages),       // Index max table length
-            0                       // Index attributes
+            $keyTop,                        // Index keys top
+            $bundleTop,                     // Index resources top
+            $bundleTop,                     // Index bundle top
+            count($messages->all($domain)), // Index max table length
+            0                               // Index attributes
         );
 
         $header = pack('vC2v4C12@32',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | 

From PHP 7.2, calling `count` on a non-countable object will emit a warning (https://wiki.php.net/rfc/counting_non_countables).
Based on the current test suit, this is the only place where I found this warning