### PR TITLE
[TwigBundle] add back exception check

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -125,7 +125,7 @@ class ExceptionController
         // default to a generic HTML exception
         $request->setRequestFormat('html');
 
-        return new TemplateReference('TwigBundle', 'Exception', $name, 'html', 'twig');
+        return new TemplateReference('TwigBundle', 'Exception', $showException ? 'exception_full' : $name, 'html', 'twig');
     }
 
     // to be removed when the minimum required version of Twig is >= 3.0

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -48,6 +48,20 @@ class ExceptionControllerTest extends TestCase
         $this->assertEquals('html', $request->getRequestFormat());
     }
 
+    public function testFallbackToHtmlWithFullExceptionIfNoTemplateForRequestedFormatAndExceptionsShouldBeShown()
+    {
+        $twig = $this->createTwigEnv(array('TwigBundle:Exception:exception_full.html.twig' => '<html></html>'));
+
+        $request = $this->createRequest('txt');
+        $request->attributes->set('showException', true);
+        $exception = FlattenException::create(new \Exception());
+        $controller = new ExceptionController($twig, false);
+
+        $controller->showAction($request, $exception);
+
+        $this->assertEquals('html', $request->getRequestFormat());
+    }
+
     public function testResponseHasRequestedMimeType()
     {
         $twig = $this->createTwigEnv(array('TwigBundle:Exception:error.json.twig' => '{}'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23268
| License       | MIT
| Doc PR        | 

#23268 introduced a regression in that the full exception page was not shown anymore in case a template for the given format (if not `html`) could not be found.