### PR TITLE
[Stopwatch] Add a reset method

### DIFF
--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -30,7 +30,7 @@ class Stopwatch
 
     public function __construct()
     {
-        $this->sections = $this->activeSections = array('__root__' => new Section('__root__'));
+        $this->reset();
     }
 
     /**
@@ -155,5 +155,13 @@ class Stopwatch
     public function getSectionEvents($id)
     {
         return isset($this->sections[$id]) ? $this->sections[$id]->getEvents() : array();
+    }
+
+    /**
+     * Resets the stopwatch to its original state.
+     */
+    public function reset()
+    {
+        $this->sections = $this->activeSections = array('__root__' => new Section('__root__'));
     }
 }

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -153,4 +153,16 @@ class StopwatchTest extends TestCase
         $stopwatch = new Stopwatch();
         $stopwatch->openSection('section');
     }
+
+    public function testReset()
+    {
+        $stopwatch = new Stopwatch();
+
+        $stopwatch->openSection();
+        $stopwatch->start('foo', 'cat');
+
+        $stopwatch->reset();
+
+        $this->assertEquals(new Stopwatch(), $stopwatch);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23284 
| License       | MIT
| Doc PR        | symfony/symfony-docs#8082

Let the Stopwatch to be reset to its original state, deleting all the data measured so far. This allows the stopwatch to be reusable, and emulates an actual stopwatch's reset button.
