### PR TITLE
[Yaml] deprecate the !str tag

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -61,5 +61,7 @@ Validator
 Yaml
 ----
 
+ * Support for the `!str` tag is deprecated, use the `!!str` tag instead.
+
  * Using the non-specific tag `!` is deprecated and will have a different
    behavior in 4.0. Use a plain integer or `!!float` instead.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -575,6 +575,8 @@ Workflow
 Yaml
 ----
 
+ * Support for the `!str` tag was removed, use the `!!str` tag instead.
+
  * Starting an unquoted string with a question mark followed by a space
    throws a `ParseException`.
 

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.4.0
 -----
 
+ * Support for the `!str` tag is deprecated, use the `!!str` tag instead.
+
  * Deprecated using the non-specific tag `!` as its behavior will change in 4.0.
    It will force non-evaluating your values in 4.0. Use plain integers or `!!float` instead.
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -609,7 +609,11 @@ class Inline
             case $scalar[0] === '!':
                 switch (true) {
                     case 0 === strpos($scalar, '!str'):
+                        @trigger_error('Support for the !str tag is deprecated since version 3.4. Use the !!str tag instead.', E_USER_DEPRECATED);
+
                         return (string) substr($scalar, 5);
+                    case 0 === strpos($scalar, '!!str '):
+                        return (string) substr($scalar, 6);
                     case 0 === strpos($scalar, '! '):
                         @trigger_error('Using the non-specific tag "!" is deprecated since version 3.4 as its behavior will change in 4.0. It will force non-evaluating your values in 4.0. Use plain integers or !!float instead.', E_USER_DEPRECATED);
 

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
@@ -592,7 +592,7 @@ test: Various explicit families
 todo: true
 spec: 2.23
 yaml: |
-  not-date: !str 2002-04-28
+  not-date: !!str 2002-04-28
   picture: !binary |
    R0lGODlhDAAMAIQAAP//9/X
    17unp5WZmZgAAAOfn515eXv
@@ -932,7 +932,7 @@ deprecated: Using the non-specific tag "!" is deprecated since version 3.4 as it
 yaml: |
    integer: 12
    also int: ! "12"
-   string: !str 12
+   string: !!str 12
 php: |
    array( 'integer' => 12, 'also int' => 12, 'string' => '12' )
 ---
@@ -964,7 +964,7 @@ documents: 2
 test: Type family under yaml.org
 yaml: |
   # The URI is 'tag:yaml.org,2002:str'
-  - !str a Unicode string
+  - !!str a Unicode string
 php: |
   array( 'a Unicode string' )
 ---
@@ -1351,7 +1351,7 @@ yaml: |
 
    second: 12          ## This is an integer.
 
-   third: !str 12      ## This is a string.
+   third: !!str 12      ## This is a string.
 
    span: this contains
          six spaces
@@ -1420,7 +1420,7 @@ yaml: |
    # The following scalars
    # are loaded to the
    # string value '1' '2'.
-   - !str 12
+   - !!str 12
    - '12'
    - "12"
    - "\

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsTypeTransfers.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsTypeTransfers.yml
@@ -52,10 +52,10 @@ php: |
 test: Forcing Strings
 brief: >
     Any YAML type can be forced into a string using the
-    explicit !str method.
+    explicit !!str method.
 yaml: |
-    date string: !str 2001-08-01
-    number string: !str 192
+    date string: !!str 2001-08-01
+    number string: !!str 192
 php: |
     array(
       'date string' => '2001-08-01',

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -755,4 +755,13 @@ class InlineTest extends TestCase
             'float' => array('{0.25: "foo"}', array('0.25' => 'foo')),
         );
     }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Support for the !str tag is deprecated since version 3.4. Use the !!str tag instead.
+     */
+    public function testDeprecatedStrTag()
+    {
+        $this->assertSame(array('foo' => 'bar'), Inline::parse('{ foo: !str bar }'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The tag specified in the YAML spec is actually !!str.