### PR TITLE
[Security] Fix Firewall ExceptionListener priority

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -72,7 +72,7 @@ class ExceptionListener
      */
     public function register(EventDispatcherInterface $dispatcher)
     {
-        $dispatcher->addListener(KernelEvents::EXCEPTION, array($this, 'onKernelException'));
+        $dispatcher->addListener(KernelEvents::EXCEPTION, array($this, 'onKernelException'), 1);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23253 
| License       | MIT
| Doc PR        | n/a

When making EventDispatcher able to lazy load listeners, we stopped using `ContainerAwareEventDispatcher::addListenerService/addSubcriberService`, we use `EventDispatcher::addListener()` instead. This change makes that the order of listeners is different than before, because `ContainerAwareEventDispatcher` calls `addListener()` tardily so that factories are never stored in `EventDispatcher::$listeners`.

Example diff due to the behavior change in 3.3 (registering an `AppBundle\ExceptionListener::doCatch()` exception listener in the fullstack):

3.2
----

```php
array:5 
  0 => "Symfony\Component\Security\Http\Firewall\ExceptionListener::onKernelException"
  1 => "AppBundle\ExceptionListener::doCatch"
  2 => "Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelException"
  3 => "Symfony\Bundle\SwiftmailerBundle\EventListener\EmailSenderListener::onException"
  4 => "Symfony\Component\HttpKernel\EventListener\ExceptionListener::onKernelException"
]
```

3.3
----

```php
array:5 [
  0 => "AppBundle\ExceptionListener::doCatch"
  1 => "Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelException"
  2 => "Symfony\Bundle\SwiftmailerBundle\EventListener\EmailSenderListener::onException"
  3 => "Symfony\Component\Security\Http\Firewall\ExceptionListener::onKernelException"
  4 => "Symfony\Component\HttpKernel\EventListener\ExceptionListener::onKernelException"
]
```
(that is what breaks #23253, the lazy listener is called before the runtime firewall exception listener on dispatch).

This fixes the order by increasing the security exception listener priority.