### PR TITLE
[FrameworkBundle][Translator] Fix cache warmer translator lazy-loading

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
@@ -33,7 +32,6 @@ class LoggingTranslatorPass implements CompilerPassInterface
 
             if (is_subclass_of($class, 'Symfony\Component\Translation\TranslatorInterface') && is_subclass_of($class, 'Symfony\Component\Translation\TranslatorBagInterface')) {
                 $container->getDefinition('translator.logging')->setDecoratedService('translator');
-                $container->getDefinition('translation.warmer')->replaceArgument(0, new Reference('translator.logging.inner'));
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggingTranslatorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggingTranslatorPassTest.php
@@ -34,7 +34,7 @@ class LoggingTranslatorPassTest extends TestCase
             ->method('getAlias')
             ->will($this->returnValue('translation.default'));
 
-        $container->expects($this->exactly(3))
+        $container->expects($this->exactly(2))
             ->method('getDefinition')
             ->will($this->returnValue($definition));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Not really a bug fix, but in #23014, we expected to lazy load the cache warmer's translator by injecting the container instead. But the `LoggingTranslatorPass` replaces it, and [it results in a deprecation raised in 3.4](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TranslationsCacheWarmer.php#L42).

The issue with this patch and the original PR intent however is that the translator you get from the container might be a decorated one (`DataCollectorTranslator` for instance) which may not implement `WarmableInterface`, making the warmer ineffective...

Considering #23014 issue mainly was about the `TemplateCacheWarmer`, I'm torn between this patch, reverting changes in `TranslationsCacheWarmer` or finding some other ugly workarounds.