### PR TITLE
[WebProfilerBundle] Fix css trick used for offsetting html anchor from fixed header

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
@@ -64,7 +64,7 @@ a.doc:hover {
 
 .anchor {
     position: relative;
-    padding-top: 7em;
-    margin-top: -7em;
+    display: block;
+    top: -7em;
     visibility: hidden;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2 <!-- see comment below -->
| Bug fix?      | yes (minor DX)
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

The css trick used was incomplete (missing `display: block;`), which is probably why it has been changed in https://github.com/symfony/symfony/pull/22455/files#diff-7d417267ae50374356ab990c58233a9bR67. 
Despite the current version works well, it behaves quite ugly specifically on Chrome: 

|Before|After|
|--|--|
|![juin-25-2017 18-07-01](https://user-images.githubusercontent.com/2211145/27517785-60cbd3a4-59d2-11e7-8e82-b8bb29ae15bb.gif)|![juin-25-2017 18-07-26](https://user-images.githubusercontent.com/2211145/27517786-60d165f8-59d2-11e7-9d9e-83aa2211041d.gif)|

For ref about the trick: https://stackoverflow.com/questions/10732690/offsetting-an-html-anchor-to-adjust-for-fixed-header/13184714#13184714