### PR TITLE
[Workflow] Added more events to the announce function

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -263,6 +263,8 @@ class WorkflowTest extends TestCase
             'workflow.workflow_name.entered.b',
             'workflow.workflow_name.entered.c',
             // Following events are fired because of announce() method
+            'workflow.announce',
+            'workflow.workflow_name.announce',
             'workflow.guard',
             'workflow.workflow_name.guard',
             'workflow.workflow_name.guard.t2',

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -263,11 +263,11 @@ class WorkflowTest extends TestCase
             'workflow.workflow_name.entered.b',
             'workflow.workflow_name.entered.c',
             // Following events are fired because of announce() method
+            'workflow.announce',
+            'workflow.workflow_name.announce',
             'workflow.guard',
             'workflow.workflow_name.guard',
             'workflow.workflow_name.guard.t2',
-            'workflow.announce',
-            'workflow.workflow_name.announce',
             'workflow.workflow_name.announce.t2',
         );
 

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -263,11 +263,11 @@ class WorkflowTest extends TestCase
             'workflow.workflow_name.entered.b',
             'workflow.workflow_name.entered.c',
             // Following events are fired because of announce() method
-            'workflow.announce',
-            'workflow.workflow_name.announce',
             'workflow.guard',
             'workflow.workflow_name.guard',
             'workflow.workflow_name.guard.t2',
+            'workflow.announce',
+            'workflow.workflow_name.announce',
             'workflow.workflow_name.announce.t2',
         );
 

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -300,6 +300,9 @@ class Workflow
 
         $event = new Event($subject, $marking, $initialTransition);
 
+        $this->dispatcher->dispatch('workflow.announce', $event);
+        $this->dispatcher->dispatch(sprintf('workflow.%s.announce', $this->name), $event);
+
         foreach ($this->getEnabledTransitions($subject) as $transition) {
             $this->dispatcher->dispatch(sprintf('workflow.%s.announce.%s', $this->name, $transition->getName()), $event);
         }

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -300,13 +300,10 @@ class Workflow
 
         $event = new Event($subject, $marking, $initialTransition);
 
-        $eventsDispatched = false;
+        $this->dispatcher->dispatch('workflow.announce', $event);
+        $this->dispatcher->dispatch(sprintf('workflow.%s.announce', $this->name), $event);
+
         foreach ($this->getEnabledTransitions($subject) as $transition) {
-            if (!$eventsDispatched) {
-                $this->dispatcher->dispatch('workflow.announce', $event);
-                $this->dispatcher->dispatch(sprintf('workflow.%s.announce', $this->name), $event);
-                $eventsDispatched = true;
-            }
             $this->dispatcher->dispatch(sprintf('workflow.%s.announce.%s', $this->name, $transition->getName()), $event);
         }
     }

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -300,10 +300,13 @@ class Workflow
 
         $event = new Event($subject, $marking, $initialTransition);
 
-        $this->dispatcher->dispatch('workflow.announce', $event);
-        $this->dispatcher->dispatch(sprintf('workflow.%s.announce', $this->name), $event);
-
+        $eventsDispatched = false;
         foreach ($this->getEnabledTransitions($subject) as $transition) {
+            if (!$eventsDispatched) {
+                $this->dispatcher->dispatch('workflow.announce', $event);
+                $this->dispatcher->dispatch(sprintf('workflow.%s.announce', $this->name), $event);
+                $eventsDispatched = true;
+            }
             $this->dispatcher->dispatch(sprintf('workflow.%s.announce.%s', $this->name, $transition->getName()), $event);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23275
| License       | MIT
| Doc PR        | #8087

This PR will fix #23275

The documentation states that we dispatch events `workflow.announce` and `workflow.[name].announce`. It was me who wrongly added it to the docs... sorry about that. 

We could either: Change the docs or add these events. I choose to add these event to the source since the same events are dispatched for "guard", "leave", "transition", "enter" and "entered". 

