### PR TITLE
[Workflow] Remove final from Definition class

### DIFF
--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -19,7 +19,7 @@ use Symfony\Component\Workflow\Exception\LogicException;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class Definition
+class Definition
 {
     private $places = array();
     private $transitions = array();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Please don't make this class final. As a value holder object it's very restrictive to disallow users to do any extension of such object, since you don't even provide any interface for it. Will at least partially ease up current limitations highlighted by https://github.com/symfony/symfony/issues/23257