### PR TITLE
[WebServer] Allow * to bind all interfaces (as INADDR_ANY)

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
- * 'WebServer can now use '*' as a wildcard to bind to 0.0.0.0 (INADDR_ANY)
+ * WebServer can now use '*' as a wildcard to bind to 0.0.0.0 (INADDR_ANY)
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * 'WebServer can now use '*' as a wildcard to bind to 0.0.0.0 (INADDR_ANY)
+
 3.3.0
 -----
 

--- a/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
@@ -54,7 +54,7 @@ class WebServerConfig
             $this->port = $this->findBestPort();
         } elseif (false !== $pos = strrpos($address, ':')) {
             $this->hostname = substr($address, 0, $pos);
-            if ($this->hostname == '*') {
+            if ('*' === $this->hostname) {
                 $this->hostname = '0.0.0.0';
             }
             $this->port = substr($address, $pos + 1);

--- a/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
@@ -54,6 +54,9 @@ class WebServerConfig
             $this->port = $this->findBestPort();
         } elseif (false !== $pos = strrpos($address, ':')) {
             $this->hostname = substr($address, 0, $pos);
+            if ($this->hostname == '*') {
+                $this->hostname = '0.0.0.0';
+            }
             $this->port = substr($address, $pos + 1);
         } elseif (ctype_digit($address)) {
             $this->hostname = '127.0.0.1';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no-tests
| Fixed tickets | ~
| License       | MIT
| Doc PR        |

In Python and elsewhere, binding to '*' means '0.0.0.0'  (INADDR_ANY).  I just added that to WebServer command.