### PR TITLE
Adding PSR6 session handler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * Added `Psr6SessionHandler`.
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/Psr6SessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/Psr6SessionHandler.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Session handler that supports a PSR6 cache implementation.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class Psr6SessionHandler implements \SessionHandlerInterface
+{
+    /**
+     * @type CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @type int Time to live in seconds
+     */
+    private $ttl;
+
+    /**
+     * @type string Key prefix for shared environments.
+     */
+    private $prefix;
+
+    /**
+     * List of available options:
+     *  * prefix: The prefix to use for the cache keys in order to avoid collision
+     *  * ttl: The time to live in seconds
+     *
+     * @param CacheItemPoolInterface $cache   A Cache instance
+     * @param array                  $options An associative array of cache options
+     */
+    public function __construct(CacheItemPoolInterface $cache, array $options = [])
+    {
+        $this->cache = $cache;
+
+        $this->ttl    = isset($options['ttl']) ? (int) $options['ttl'] : 86400;
+        $this->prefix = isset($options['prefix']) ? $options['prefix'] : 'sfPsr6sess_';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function open($savePath, $sessionName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($sessionId)
+    {
+        $item = $this->getCacheItem($sessionId);
+        if ($item->isHit()) {
+            return $item->get();
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($sessionId, $data)
+    {
+        $item = $this->getCacheItem($sessionId);
+        $item->set($data)
+            ->expiresAfter($this->ttl);
+
+        return $this->cache->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function destroy($sessionId)
+    {
+        return $this->cache->deleteItem($this->prefix.$sessionId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function gc($lifetime)
+    {
+        // not required here because cache will auto expire the records anyhow.
+        return true;
+    }
+
+    /**
+     * @param string $sessionId
+     *
+     * @return \Psr\Cache\CacheItemInterface
+     */
+    private function getCacheItem(string $sessionId)
+    {
+        return $this->cache->getItem($this->prefix.$sessionId);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/Psr6SessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/Psr6SessionHandler.php
@@ -21,33 +21,33 @@ use Psr\Cache\CacheItemPoolInterface;
 class Psr6SessionHandler implements \SessionHandlerInterface
 {
     /**
-     * @type CacheItemPoolInterface
+     * @var CacheItemPoolInterface
      */
     private $cache;
 
     /**
-     * @type int Time to live in seconds
+     * @var int Time to live in seconds
      */
     private $ttl;
 
     /**
-     * @type string Key prefix for shared environments.
+     * @var string Key prefix for shared environments.
      */
     private $prefix;
 
     /**
      * List of available options:
      *  * prefix: The prefix to use for the cache keys in order to avoid collision
-     *  * ttl: The time to live in seconds
+     *  * ttl: The time to live in seconds.
      *
      * @param CacheItemPoolInterface $cache   A Cache instance
      * @param array                  $options An associative array of cache options
      */
-    public function __construct(CacheItemPoolInterface $cache, array $options = [])
+    public function __construct(CacheItemPoolInterface $cache, array $options = array())
     {
         $this->cache = $cache;
 
-        $this->ttl    = isset($options['ttl']) ? (int) $options['ttl'] : 86400;
+        $this->ttl = isset($options['ttl']) ? (int) $options['ttl'] : 86400;
         $this->prefix = isset($options['prefix']) ? $options['prefix'] : 'sfPsr6sess_';
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/Psr6SessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/Psr6SessionHandler.php
@@ -114,7 +114,7 @@ class Psr6SessionHandler implements \SessionHandlerInterface
      *
      * @return \Psr\Cache\CacheItemInterface
      */
-    private function getCacheItem(string $sessionId)
+    private function getCacheItem($sessionId)
     {
         return $this->cache->getItem($this->prefix.$sessionId);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
@@ -38,7 +38,9 @@ class Psr6SessionHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->psr6 = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();
+        $this->psr6 = $this->getMockBuilder(CacheItemPoolInterface::class)
+            ->setMethods(['getItem', 'deleteItem'])
+            ->getMock();
         $this->handler = new Psr6SessionHandler($this->psr6, ['prefix' => self::PREFIX, 'ttl' => self::TTL]);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\Psr6SessionHandler;
 
 /**
@@ -38,8 +39,8 @@ class Psr6SessionHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->psr6 = $this->getMockBuilder(CacheItemPoolInterface::class)
-            ->setMethods(['getItem', 'deleteItem'])
+        $this->psr6 = $this->getMockBuilder(Cache::class)
+            ->setMethods(['getItem', 'deleteItem', 'save'])
             ->getMock();
         $this->handler = new Psr6SessionHandler($this->psr6, ['prefix' => self::PREFIX, 'ttl' => self::TTL]);
     }
@@ -133,4 +134,17 @@ class Psr6SessionHandlerTest extends TestCase
             ->setMethods(['isHit', 'getKey', 'get', 'set', 'expiresAt', 'expiresAfter'])
             ->getMock();
     }
+}
+
+class Cache implements CacheItemPoolInterface
+{
+    public function getItem($key) {}
+    public function getItems(array $keys = array()) {}
+    public function hasItem($key) {}
+    public function clear() {}
+    public function deleteItem($key) {}
+    public function deleteItems(array $keys) {}
+    public function save(CacheItemInterface $item) {}
+    public function saveDeferred(CacheItemInterface $item) {}
+    public function commit() {}
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\Psr6SessionHandler;
 
 /**
@@ -40,9 +39,9 @@ class Psr6SessionHandlerTest extends TestCase
         parent::setUp();
 
         $this->psr6 = $this->getMockBuilder(Cache::class)
-            ->setMethods(['getItem', 'deleteItem', 'save'])
+            ->setMethods(array('getItem', 'deleteItem', 'save'))
             ->getMock();
-        $this->handler = new Psr6SessionHandler($this->psr6, ['prefix' => self::PREFIX, 'ttl' => self::TTL]);
+        $this->handler = new Psr6SessionHandler($this->psr6, array('prefix' => self::PREFIX, 'ttl' => self::TTL));
     }
 
     public function testOpen()
@@ -131,20 +130,46 @@ class Psr6SessionHandlerTest extends TestCase
     private function getItemMock()
     {
         return $this->getMockBuilder(CacheItemInterface::class)
-            ->setMethods(['isHit', 'getKey', 'get', 'set', 'expiresAt', 'expiresAfter'])
+            ->setMethods(array('isHit', 'getKey', 'get', 'set', 'expiresAt', 'expiresAfter'))
             ->getMock();
     }
 }
 
 class Cache implements CacheItemPoolInterface
 {
-    public function getItem($key) {}
-    public function getItems(array $keys = array()) {}
-    public function hasItem($key) {}
-    public function clear() {}
-    public function deleteItem($key) {}
-    public function deleteItems(array $keys) {}
-    public function save(CacheItemInterface $item) {}
-    public function saveDeferred(CacheItemInterface $item) {}
-    public function commit() {}
+    public function getItem($key)
+    {
+    }
+
+    public function getItems(array $keys = array())
+    {
+    }
+
+    public function hasItem($key)
+    {
+    }
+
+    public function clear()
+    {
+    }
+
+    public function deleteItem($key)
+    {
+    }
+
+    public function deleteItems(array $keys)
+    {
+    }
+
+    public function save(CacheItemInterface $item)
+    {
+    }
+
+    public function saveDeferred(CacheItemInterface $item)
+    {
+    }
+
+    public function commit()
+    {
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\Psr6SessionHandler;
+
+/**
+ * @author Aaron Scherer <aequasi@gmail.com>
+ */
+class Psr6SessionHandlerTest extends TestCase
+{
+    const TTL = 100;
+    const PREFIX = 'pre';
+
+    /**
+     * @var Psr6SessionHandler
+     */
+    private $handler;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|CacheItemPoolInterface
+     */
+    private $psr6;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->psr6 = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();
+        $this->handler = new Psr6SessionHandler($this->psr6, ['prefix' => self::PREFIX, 'ttl' => self::TTL]);
+    }
+
+    public function testOpen()
+    {
+        $this->assertTrue($this->handler->open('foo', 'bar'));
+    }
+
+    public function testClose()
+    {
+        $this->assertTrue($this->handler->close());
+    }
+
+    public function testGc()
+    {
+        $this->assertTrue($this->handler->gc(4711));
+    }
+
+    public function testReadMiss()
+    {
+        $item = $this->getItemMock();
+        $item->expects($this->once())
+            ->method('isHit')
+            ->willReturn(false);
+        $this->psr6->expects($this->once())
+            ->method('getItem')
+            ->willReturn($item);
+
+        $this->assertEquals('', $this->handler->read('foo'));
+    }
+
+    public function testReadHit()
+    {
+        $item = $this->getItemMock();
+        $item->expects($this->once())
+            ->method('isHit')
+            ->willReturn(true);
+        $item->expects($this->once())
+            ->method('get')
+            ->willReturn('bar');
+        $this->psr6->expects($this->once())
+            ->method('getItem')
+            ->willReturn($item);
+
+        $this->assertEquals('bar', $this->handler->read('foo'));
+    }
+
+    public function testWrite()
+    {
+        $item = $this->getItemMock();
+
+        $item->expects($this->once())
+            ->method('set')
+            ->with('session value')
+            ->willReturnSelf();
+        $item->expects($this->once())
+            ->method('expiresAfter')
+            ->with(self::TTL)
+            ->willReturnSelf();
+
+        $this->psr6->expects($this->once())
+            ->method('getItem')
+            ->with(self::PREFIX.'foo')
+            ->willReturn($item);
+
+        $this->psr6->expects($this->once())
+            ->method('save')
+            ->with($item)
+            ->willReturn(true);
+
+        $this->assertTrue($this->handler->write('foo', 'session value'));
+    }
+
+    public function testDestroy()
+    {
+        $this->psr6->expects($this->once())
+            ->method('deleteItem')
+            ->with(self::PREFIX.'foo')
+            ->willReturn(true);
+
+        $this->assertTrue($this->handler->destroy('foo'));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getItemMock(): \PHPUnit_Framework_MockObject_MockObject
+    {
+        return $this->getMockBuilder(CacheItemInterface::class)
+            ->setMethods(['isHit', 'getKey', 'get', 'set', 'expiresAt', 'expiresAfter'])
+            ->getMock();
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Psr6SessionHandlerTest.php
@@ -128,7 +128,7 @@ class Psr6SessionHandlerTest extends TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getItemMock(): \PHPUnit_Framework_MockObject_MockObject
+    private function getItemMock()
     {
         return $this->getMockBuilder(CacheItemInterface::class)
             ->setMethods(['isHit', 'getKey', 'get', 'set', 'expiresAt', 'expiresAfter'])

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -20,7 +20,8 @@
         "symfony/polyfill-mbstring": "~1.1"
     },
     "require-dev": {
-        "symfony/expression-language": "~2.8|~3.0|~4.0"
+        "symfony/expression-language": "~2.8|~3.0|~4.0",
+        "psr/cache": "~1.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\HttpFoundation\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | On the way

It is very common that you store your session in Memcached or Redis. But instead of creating a RedisHandler we should be more abstract and go with a PSR6 handler. That will give the flexibility to use any storage. 

This PR **could** deprecate the Memcached, Memcache, MongoDB handlers.. But I left that decision to a separate PR. 