### PR TITLE
[Serializer] Improve CircularReference detection message

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -228,7 +228,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
             return call_user_func($this->circularReferenceHandler, $object);
         }
 
-        throw new CircularReferenceException(sprintf('A circular reference has been detected (configured limit: %d).', $this->circularReferenceLimit));
+        throw new CircularReferenceException(sprintf('A circular reference has been detected when serializing the object of class "%s" (configured limit: %d)', get_class($object), $this->circularReferenceLimit));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Hi,
I've get a CircularReferenceException error while serializing object with nested levels. Detect a CircularReference is great, but having more information about the object that generate this exception is better.

I simply suggest to add a `get_class` of the current object in the error message.

Before:
`A circular reference has been detected (configured limit: 1).`

After (edit)
`A circular reference has been detected when serializing the object of class "App\Domain\User" (configured limit: 1).`
