### PR TITLE
[Framework Bundle] Allow to configure PSR6 cache for session

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
    require symfony/stopwatch` in your `dev` environment.
  * Deprecated using the `KERNEL_DIR` environment variable with `KernelTestCase::getKernelClass()`.
  * Deprecated the `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()` methods.
+ * Added support for `PSR6SessionHandler`.
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -437,10 +437,25 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('gc_maxlifetime')->end()
                         ->booleanNode('use_strict_mode')->end()
                         ->scalarNode('save_path')->defaultValue('%kernel.cache_dir%/sessions')->end()
+                        ->scalarNode('psr6_ttl')->defaultNull()->end()
+                        ->scalarNode('psr6_prefix')->defaultNull()->end()
+                        ->scalarNode('psr6_service')->defaultNull()->end()
                         ->integerNode('metadata_update_threshold')
                             ->defaultValue('0')
                             ->info('seconds to wait between 2 session metadata updates, it will also prevent the session handler to write if the session has not changed')
                         ->end()
+                    ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return $v['handler_id'] === 'session.handler.psr6' && !isset($v['psr6_service']);
+                        })
+                        ->thenInvalid('When handler_id="session.handler.psr6" you must also define a value for "psr6_service". Example "cache.app".')
+                    ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return $v['handler_id'] !== 'session.handler.psr6' && (isset($v['psr6_ttl']) || isset($v['psr6_prefix']) || isset($v['psr6_service']));
+                        })
+                        ->thenInvalid('You must specify handler_id="session.handler.psr6" when you use "psr6_ttl", "psr6_prefix" or "prr6_service".')
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -455,7 +455,7 @@ class Configuration implements ConfigurationInterface
                         ->ifTrue(function ($v) {
                             return $v['handler_id'] !== 'session.handler.psr6' && (isset($v['psr6_ttl']) || isset($v['psr6_prefix']) || isset($v['psr6_service']));
                         })
-                        ->thenInvalid('You must specify handler_id="session.handler.psr6" when you use "psr6_ttl", "psr6_prefix" or "prr6_service".')
+                        ->thenInvalid('You must specify handler_id="session.handler.psr6" when you use "psr6_ttl", "psr6_prefix" or "psr6_service".')
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -40,6 +40,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\FormTypeInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\Psr6SessionHandler;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
@@ -765,6 +766,13 @@ class FrameworkExtension extends Extension
             // Set the handler class to be null
             $container->getDefinition('session.storage.native')->replaceArgument(1, null);
             $container->getDefinition('session.storage.php_bridge')->replaceArgument(0, null);
+        } elseif ('session.handler.psr6' === $config['handler_id']) {
+            $container->register('session.handler.psr6', Psr6SessionHandler::class)
+                ->addArgument(new Reference($config['psr6_service']))
+                ->addArgument([
+                    'prefix' => $config['psr6_prefix'],
+                    'ttl' => $config['psr6_ttl'],
+                ]);
         } else {
             $handlerId = $config['handler_id'];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | On the way 

This is blocked by #23321

We should allow a easy way to configure PSR6SessionHandler. 

This will give some new options

```yaml
framework:
      session:
          handler_id:  'session.handler.psr6'
          psr6_service: 'cache.app' # Required
          psr6_prefix: 'foobar' 
          psr6_ttl: 86400
```

We will throw an exception if you are trying to use `psr6_*` options without `handler_id:  'session.handler.psr6'`