### PR TITLE
[Cache] fix cleanup of expired items for PdoAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -195,7 +195,7 @@ class PdoAdapter extends AbstractAdapter
             foreach ($expired as $id) {
                 $stmt->bindValue(++$i, $id);
             }
-            $stmt->execute($expired);
+            $stmt->execute();
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/23313
| License       | MIT
| Doc PR        | -

This fixes the query being executed to cleanup expired items from the `cache_items` table using the `PdoAdapter`.

I also added a test case to make sure we do the cleanup successfully.
