### PR TITLE
[FrameworkBundle] Display a proper warning on cache:clear without the --no-warmup option

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -77,7 +77,11 @@ EOF
         if ($input->getOption('no-warmup')) {
             $filesystem->rename($realCacheDir, $oldCacheDir);
         } else {
-            @trigger_error('Calling cache:clear without the --no-warmup option is deprecated since version 3.3. Cache warmup should be done with the cache:warmup command instead.', E_USER_DEPRECATED);
+            $warning = 'Calling cache:clear without the --no-warmup option is deprecated since version 3.3. Cache warmup should be done with the cache:warmup command instead.';
+
+            @trigger_error($warning, E_USER_DEPRECATED);
+
+            $io->warning($warning);
 
             $this->warmupCache($input, $output, $realCacheDir, $oldCacheDir);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/recipes/pull/105 and others reports related to cache warming issues with final/custom kernel classes <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

I'd suggest to simply make this more obvious for everyone, as the deprecation is only shown when executing the command with `-vv` or by inspecting logs otherwise:

<img width="970" alt="screenshot 2017-06-29 a 20 08 21" src="https://user-images.githubusercontent.com/2211145/27703182-db734150-5d06-11e7-9306-f5837bf240ed.PNG">
