### PR TITLE
[WebProfilerBundle] Fix full sized dump hovering in toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -350,13 +350,12 @@
     100% { background: #222; }
 }
 
-.sf-toolbar-block.sf-toolbar-block-dump {
-    position: static;
-}
-
 .sf-toolbar-block.sf-toolbar-block-dump .sf-toolbar-info {
     max-width: none;
-    right: 0;
+    width: 100%;
+    position: fixed;
+    box-sizing: border-box;
+    left: 0;
 }
 
 .sf-toolbar-block-dump pre.sf-dump {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #23563 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Since #22953, the dump block shown on hovering the toolbar item takes the full width. But at least on OS X chrome, safari and firefox, the behavior is buggy and makes it unusable as the cursor can't reach the dumped content: 

![juin-29-2017 21-09-38](https://user-images.githubusercontent.com/2211145/27705877-b25c1496-5d0f-11e7-8fff-169e080e335c.gif)

Honestly, I don't really understand the issue here and tried some tweaks until it works everywhere, (including trying to add a `.no-resize` class on `sf-toolbar-info` to avoid executing the related js event listener in case it was conflicting).

As shown in the screenshot, it also fixes the case where the dump wasn't full width under a certain size.
