### PR TITLE
[Yaml] fix the displayed line number

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -145,7 +145,7 @@ EOF
         } catch (Error $e) {
             $twig->setLoader($realLoader);
 
-            return array('template' => $template, 'file' => $file, 'valid' => false, 'exception' => $e);
+            return array('template' => $template, 'file' => $file, 'line' => $e->getTemplateLine(), 'valid' => false, 'exception' => $e);
         }
 
         return array('template' => $template, 'file' => $file, 'valid' => true);

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -105,7 +105,7 @@ EOF
     {
         $prevErrorHandler = set_error_handler(function ($level, $message, $file, $line) use (&$prevErrorHandler) {
             if (E_USER_DEPRECATED === $level) {
-                throw new ParseException($message, $this->getParser()->getLastLineNumberBeforeDeprecation());
+                throw new ParseException($message, $this->getParser()->getRealCurrentLineNb() + 1);
             }
 
             return $prevErrorHandler ? $prevErrorHandler($level, $message, $file, $line) : false;

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -105,7 +105,7 @@ EOF
     {
         $prevErrorHandler = set_error_handler(function ($level, $message, $file, $line) use (&$prevErrorHandler) {
             if (E_USER_DEPRECATED === $level) {
-                throw new ParseException($message);
+                throw new ParseException($message, $this->getParser()->getLastLineNumberBeforeDeprecation());
             }
 
             return $prevErrorHandler ? $prevErrorHandler($level, $message, $file, $line) : false;
@@ -114,7 +114,7 @@ EOF
         try {
             $this->getParser()->parse($content, Yaml::PARSE_CONSTANT);
         } catch (ParseException $e) {
-            return array('file' => $file, 'valid' => false, 'message' => $e->getMessage());
+            return array('file' => $file, 'line' => $e->getParsedLine(), 'valid' => false, 'message' => $e->getMessage());
         } finally {
             restore_error_handler();
         }

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -124,16 +124,6 @@ class Parser
         return $data;
     }
 
-    /**
-     * @internal
-     *
-     * @return int
-     */
-    public function getLastLineNumberBeforeDeprecation()
-    {
-        return $this->getRealCurrentLineNb();
-    }
-
     private function doParse($value, $flags)
     {
         $this->currentLineNb = -1;
@@ -463,9 +453,11 @@ class Parser
     /**
      * Returns the current line number (takes the offset into account).
      *
+     * @internal
+     *
      * @return int The current line number
      */
-    private function getRealCurrentLineNb()
+    public function getRealCurrentLineNb()
     {
         $realCurrentLineNumber = $this->currentLineNb + $this->offset;
 

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -124,6 +124,16 @@ class Parser
         return $data;
     }
 
+    /**
+     * @internal
+     *
+     * @return int
+     */
+    public function getLastLineNumberBeforeDeprecation()
+    {
+        return $this->getRealCurrentLineNb();
+    }
+
     private function doParse($value, $flags)
     {
         $this->currentLineNb = -1;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23294
| License       | MIT
| Doc PR        | 

First, this PR backports #23294 to the `3.4` branch.

Secondly, `getRealCurrentLineNb()` returns line numbers index by 0 (as they serve as array indexes internally). I removed the `getLastLineNumberBeforeDeprecation()` method added in #23294 as we can just expose the already existing `getRealCurrentLineNb()` method.