### PR TITLE
[PropertyAccess] Fix TypeError discard

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -245,7 +245,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
     private static function throwInvalidArgumentException($message, $trace, $i)
     {
-        if (isset($trace[$i]['file']) && __FILE__ === $trace[$i]['file']) {
+        if (isset($trace[$i]['file']) && __FILE__ === $trace[$i]['file'] && isset($trace[$i]['args'][0])) {
             $pos = strpos($message, $delim = 'must be of the type ') ?: (strpos($message, $delim = 'must be an instance of ') ?: strpos($message, $delim = 'must implement interface '));
             $pos += strlen($delim);
             $type = $trace[$i]['args'][0];

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/ReturnTyped.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/ReturnTyped.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ReturnTyped
+{
+    public function getFoos(): array
+    {
+        return 'It doesn\'t respect the return type on purpose';
+    }
+
+    public function addFoo(\DateTime $dateTime)
+    {
+    }
+
+    public function removeFoo(\DateTime $dateTime)
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\PropertyAccess\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\ReturnTyped;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicCall;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicGet;
@@ -565,5 +566,17 @@ class PropertyAccessorTest extends TestCase
         $object = new TypeHinted();
 
         $this->propertyAccessor->setValue($object, 'countable', 'This is a string, \Countable expected.');
+    }
+
+    /**
+     * @requires PHP 7
+     *
+     * @expectedException \TypeError
+     */
+    public function testDoNotDiscardReturnTypeError()
+    {
+        $object = new ReturnTyped();
+
+        $this->propertyAccessor->setValue($object, 'foos', array(new \DateTime()));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Given the following code:

```php
class Bar
{
    private $foos = [];

    public function getFoos(): array
    {
        return 'It doesn\'t respect the return type';
    }

    public function addFoo(Foo $foo)
    {
        // ...
    }

    public function removeFoo(Foo $dateTime)
    {
        // ...
    }
}

$object = new Bar();
$this->propertyAccessor->setValue($object, 'foos', array(new \DateTime()));
```

The `PropertyAccessor` will  crash (`[Symfony\Component\Debug\Exception\ContextErrorException]  Notice: Undefined offset: 0`) instead of displaying the (valid) PHP error.

This PR fixes the issue.