### PR TITLE
[TwigBundle] Added auto namespacing for new templates directory structure

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -158,6 +158,9 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->prototype('variable')->end()
                 ->end()
+                ->scalarNode('default_path')
+                    ->defaultValue('%kernel.project_dir%/templates')
+                ->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -122,22 +122,15 @@ class TwigExtension extends Extension
             foreach ($bundle['paths'] as $path) {
                 $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
             }
+
+            $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($config['default_path'].'/bundles/'.$namespace, $namespace));
         }
 
         if ($container->fileExists($dir = $container->getParameter('kernel.root_dir').'/Resources/views', false)) {
             $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir));
         }
 
-        if ($container->fileExists($dir = $container->getParameter('kernel.project_dir').'/templates', false)) {
-            $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir));
-        }
-
-        if ($container->fileExists($dir = $container->getParameter('kernel.project_dir').'/templates/bundles', false)) {
-            foreach (glob($dir.'/*', GLOB_ONLYDIR) as $path) {
-                $parts = explode(DIRECTORY_SEPARATOR, $path);
-                $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, end($parts)));
-            }
-        }
+        $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($config['default_path']));
 
         if (!empty($config['globals'])) {
             $def = $container->getDefinition('twig');

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -128,6 +128,17 @@ class TwigExtension extends Extension
             $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir));
         }
 
+        if ($container->fileExists($dir = $container->getParameter('kernel.project_dir').'/templates', false)) {
+            $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir));
+        }
+
+        if ($container->fileExists($dir = $container->getParameter('kernel.project_dir').'/templates/bundles', false)) {
+            foreach (glob($dir.'/*', GLOB_ONLYDIR) as $path) {
+                $parts = explode(DIRECTORY_SEPARATOR, $path);
+                $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, end($parts)));
+            }
+        }
+
         if (!empty($config['globals'])) {
             $def = $container->getDefinition('twig');
             foreach ($config['globals'] as $key => $global) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | todo

Using `app/Resources/views` has never needed any configuration, and it was really easy to override any templates of a bundle by adding a folder for it like `app/Resources/TwigBundle/views`.

Using the new directory structure, every path needs to be added in Twig configuration, which can be handled "automatically" when installing the TwigBundle with Symfony Flex https://github.com/symfony/recipes/blob/master/symfony/twig-bundle/3.3/etc/packages/twig.yaml#L2, but this is not automatic when migrating an app to the new directory strucure.

Even with Flex, overriding templates needs to add an explicit path for each bundle (example https://github.com/EnMarche/en-marche.fr/blob/master/app/config/config.yml#L55).

Moreover, this can be very ugly to have many `*Bundle` among templates folders which most of the time match controllers structure with lower case (see https://github.com/EnMarche/en-marche.fr/tree/master/templates).

Thus to ease auto configuration, I propose to place overridden bundle templates in a `bundles` sub folder:
```
/templates/bundles/Twig
/templates/bundles/EasyAdmin
```

What do you think?