### PR TITLE
[Dotenv] clean up before running assertions

### DIFF
--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -148,6 +148,13 @@ class DotenvTest extends TestCase
 
     public function testLoad()
     {
+        unset($_ENV['FOO']);
+        unset($_ENV['BAR']);
+        unset($_SERVER['FOO']);
+        unset($_SERVER['BAR']);
+        putenv('FOO');
+        putenv('BAR');
+
         @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
 
         $path1 = tempnam($tmpdir, 'sf-');
@@ -158,14 +165,17 @@ class DotenvTest extends TestCase
 
         (new DotEnv())->load($path1, $path2);
 
-        $this->assertSame('BAR', getenv('FOO'));
-        $this->assertSame('BAZ', getenv('BAR'));
+        $foo = getenv('FOO');
+        $bar = getenv('BAR');
 
         putenv('FOO');
         putenv('BAR');
         unlink($path1);
         unlink($path2);
         rmdir($tmpdir);
+
+        $this->assertSame('BAR', $foo);
+        $this->assertSame('BAZ', $bar);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

If one of the assertions failed, the clean up part would never happen.
