### PR TITLE
[Console] Fix descriptor tests

### DIFF
--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_default_inf_value.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_with_default_inf_value.md
@@ -1,7 +1,7 @@
-**argument_name:**
+#### `argument_name`
 
-* Name: argument_name
+argument description
+
 * Is required: no
 * Is array: no
-* Description: argument description
 * Default: `INF`

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_default_inf_value.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_with_default_inf_value.md
@@ -1,9 +1,8 @@
-**option_name:**
+#### `--option_name|-o`
 
-* Name: `--option_name`
-* Shortcut: `-o`
+option description
+
 * Accept value: yes
 * Is value required: no
 * Is multiple: no
-* Description: option description
 * Default: `INF`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

should make Console tests green from 3.3 up to master