### PR TITLE
Release v2.7.30

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,36 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.30 (2017-07-03)
+
+ * bug #23341 [DoctrineBridge][Security][Validator] do not validate empty values (xabbuh)
+ * bug #23274 Display a better error design when the toolbar cannot be displayed (yceruto)
+ * bug #23333 [PropertyAccess] Fix TypeError discard (dunglas)
+ * bug #23345 [Console] fix description of INF default values (xabbuh)
+ * bug #23279 Don't call count on non countable object (pierredup)
+ * bug #23283 [TwigBundle] add back exception check (xabbuh)
+ * bug #23268 Show exception is checked twice in ExceptionController of twig (gmponos)
+ * bug #23266 Display a better error message when the toolbar cannot be displayed (javiereguiluz)
+ * bug #23271 [FrameworkBundle] allow SSI fragments configuration in XML files (xabbuh)
+ * bug #23254 [Form][TwigBridge] render hidden _method field in form_rest() (xabbuh)
+ * bug #23250 [Translation] return fallback locales whenever possible (xabbuh)
+ * bug #22732 [Security] fix switch user _exit without having current token (dmaicher)
+ * bug #22730 [FrameworkBundle] Sessions: configurable "use_strict_mode" option for NativeSessionStorage (MacDada)
+ * bug #23195 [FrameworkBundle] [Command] Clean bundle directory, fixes #23177 (NicolasPion)
+ * bug #23052 [TwigBundle] Add Content-Type header for exception response (rchoquet)
+ * bug #23199 Reset redirectCount when throwing exception (hvanoch)
+ * bug #23186 [TwigBundle] Move template.xml loading to a compiler pass (ogizanagi)
+ * bug #23130 Keep s-maxage when expiry and validation are used in combination (mpdude)
+ * bug #23129 Fix two edge cases in ResponseCacheStrategy (mpdude)
+ * feature #22636 [Routing] Expose request in route conditions, if needed and possible (ro0NL)
+ * bug #22636 [Routing] Expose request in route conditions, if needed and possible (ro0NL)
+ * bug #23057 [Translation][FrameworkBundle] Fix resource loading order inconsistency reported in #23034 (mpdude)
+ * bug #23092 [Filesystem] added workaround in Filesystem::rename for PHP bug (VolCh)
+ * bug #23128 [HttpFoundation] fix for Support for new 7.1 session options (vincentaubert)
+ * bug #23176 [VarDumper] fixes (nicolas-grekas)
+ * bug #23086 [FrameworkBundle] Fix perf issue in CacheClearCommand::warmup() (nicolas-grekas)
+ * bug #23098 Cache ipCheck (2.7) (gonzalovilaseca)
+
 * 2.7.29 (2017-06-07)
 
  * bug #23069 [SecurityBundle] Show unique Inherited roles in profile panel (yceruto)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,11 +20,11 @@ Symfony is the result of the work of many people who made the code better
  - Javier Eguiluz (javier.eguiluz)
  - Hugo Hamon (hhamon)
  - Abdellatif Ait boudad (aitboudad)
+ - Maxime Steinhausser (ogizanagi)
+ - Robin Chalas (chalas_r)
  - Romain Neutron (romain)
  - Pascal Borreli (pborreli)
  - Wouter De Jong (wouterj)
- - Robin Chalas (chalas_r)
- - Maxime Steinhausser (ogizanagi)
  - Grégoire Pineau (lyrixx)
  - Joseph Bielawski (stloyd)
  - Karma Dordrak (drak)
@@ -38,8 +38,8 @@ Symfony is the result of the work of many people who made the code better
  - Jules Pietri (heah)
  - Roland Franssen (ro0)
  - Sarah Khalil (saro0h)
- - Jonathan Wage (jwage)
  - Guilhem Niot (energetick)
+ - Jonathan Wage (jwage)
  - Diego Saint Esteben (dosten)
  - Alexandre Salomé (alexandresalome)
  - William Durand (couac)
@@ -48,24 +48,24 @@ Symfony is the result of the work of many people who made the code better
  - stealth35 ‏ (stealth35)
  - Alexander Mols (asm89)
  - Bulat Shakirzyanov (avalanche123)
- - Peter Rehm (rpet)
  - Iltar van der Berg (kjarli)
+ - Peter Rehm (rpet)
  - Saša Stamenković (umpirsky)
  - Henrik Bjørnskov (henrikbjorn)
  - Miha Vrhovnik
  - Diego Saint Esteben (dii3g0)
  - Konstantin Kudryashov (everzet)
+ - Matthias Pigulla (mpdude)
  - Bilal Amarni (bamarni)
  - Florin Patan (florinpatan)
- - Matthias Pigulla (mpdude)
+ - Gábor Egyed (1ed)
  - Kevin Bond (kbond)
  - Andrej Hudec (pulzarraider)
- - Gábor Egyed (1ed)
+ - Pierre du Plessis (pierredup)
  - Michel Weimerskirch (mweimerskirch)
  - Eric Clemmons (ericclemmons)
  - Charles Sarrazin (csarrazi)
  - Christian Raue
- - Pierre du Plessis (pierredup)
  - Arnout Boks (aboks)
  - Deni
  - Henrik Westphal (snc)
@@ -83,25 +83,27 @@ Symfony is the result of the work of many people who made the code better
  - Toni Uebernickel (havvg)
  - Bart van den Burg (burgov)
  - Jordan Alliot (jalliot)
+ - Jérôme Tamarelle (gromnan)
  - John Wards (johnwards)
  - Dariusz Ruminski
  - Fran Moreno (franmomu)
  - Antoine Hérault (herzult)
- - Jérôme Tamarelle (gromnan)
  - Paráda József (paradajozsef)
  - Arnaud Le Blanc (arnaud-lb)
  - Maxime STEINHAUSSER
+ - Alexander M. Turek (derrabus)
  - Michal Piotrowski (eventhorizon)
  - Issei Murasawa (issei_m)
  - Tim Nagel (merk)
  - Brice BERNARD (brikou)
- - Alexander M. Turek (derrabus)
  - Baptiste Clavié (talus)
+ - Vladimir Reznichenko (kalessil)
  - marc.weistroff
  - lenar
  - Włodzimierz Gajda (gajdaw)
- - Vladimir Reznichenko (kalessil)
+ - Yonel Ceruto González (yonelceruto)
  - Alexander Schwenn (xelaris)
+ - Jacob Dreesen (jdreesen)
  - Florian Voutzinos (florianv)
  - Colin Frei
  - Adrien Brault (adrienbrault)
@@ -109,10 +111,8 @@ Symfony is the result of the work of many people who made the code better
  - Peter Kokot (maastermedia)
  - David Buchmann (dbu)
  - excelwebzone
- - Jacob Dreesen (jdreesen)
  - Tobias Nyholm (tobias)
  - Tomáš Votruba (tomas_votruba)
- - Yonel Ceruto González (yonelceruto)
  - Fabien Pennequin (fabienpennequin)
  - Gordon Franke (gimler)
  - Eric GELOEN (gelo)
@@ -124,13 +124,13 @@ Symfony is the result of the work of many people who made the code better
  - Sebastiaan Stok (sstok)
  - Stefano Sala (stefano.sala)
  - Evgeniy (ewgraf)
+ - Vincent AUBERT (vincent)
  - Juti Noppornpitak (shiroyuki)
  - Tigran Azatyan (tigranazatyan)
  - Sebastian Hörl (blogsh)
  - Daniel Gomes (danielcsgomes)
  - Hidenori Goto (hidenorigoto)
  - Guilherme Blanco (guilhermeblanco)
- - Vincent AUBERT (vincent)
  - Pablo Godel (pgodel)
  - Jérémie Augustin (jaugustin)
  - Andréia Bohner (andreia)
@@ -147,6 +147,7 @@ Symfony is the result of the work of many people who made the code better
  - Thomas Rabaix (rande)
  - Rouven Weßling (realityking)
  - Teoh Han Hui (teohhanhui)
+ - David Maicher (dmaicher)
  - Jérôme Vasseur (jvasseur)
  - Clemens Tolboom
  - Helmer Aaviksoo
@@ -154,16 +155,16 @@ Symfony is the result of the work of many people who made the code better
  - Hiromi Hishida (77web)
  - Matthieu Ouellette-Vachon (maoueh)
  - Michał Pipa (michal.pipa)
+ - Dawid Nowak
  - Amal Raghav (kertz)
  - Jonathan Ingram (jonathaningram)
  - Artur Kotyrba
- - David Maicher (dmaicher)
  - jeremyFreeAgent (Jérémy Romey) (jeremyfreeagent)
  - James Halsall (jaitsu)
  - Warnar Boekkooi (boekkooi)
  - Dmitrii Chekaliuk (lazyhammer)
  - Clément JOBEILI (dator)
- - Dawid Nowak
+ - Lars Strojny (lstrojny)
  - Possum
  - Dorian Villet (gnutix)
  - Richard Miller (mr_r_miller)
@@ -175,12 +176,12 @@ Symfony is the result of the work of many people who made the code better
  - Chris Wilkinson (thewilkybarkid)
  - Andreas Hucks (meandmymonkey)
  - Noel Guilbert (noel)
- - Lars Strojny (lstrojny)
  - Stepan Anchugov (kix)
  - bronze1man
  - Daniel Espendiller
  - sun (sun)
  - Larry Garfield (crell)
+ - Oleg Voronkovich
  - Martin Schuhfuß (usefulthink)
  - apetitpa
  - Matthieu Bontemps (mbontemps)
@@ -242,7 +243,6 @@ Symfony is the result of the work of many people who made the code better
  - Uwe Jäger (uwej711)
  - Eugene Leonovich (rybakit)
  - Filippo Tessarotto
- - Oleg Voronkovich
  - Joseph Rouff (rouffj)
  - Félix Labrecque (woodspire)
  - GordonsLondon
@@ -294,6 +294,7 @@ Symfony is the result of the work of many people who made the code better
  - Victor Bocharsky (bocharsky_bw)
  - Jan Decavele (jandc)
  - Gustavo Piltcher
+ - Nikolay Labinskiy (e-moe)
  - Stepan Tanasiychuk (stfalcon)
  - Tiago Ribeiro (fixe)
  - Hidde Boomsma (hboomsma)
@@ -359,7 +360,6 @@ Symfony is the result of the work of many people who made the code better
  - Endre Fejes
  - Tobias Naumann (tna)
  - Daniel Beyer
- - Nikolay Labinskiy (e-moe)
  - Shein Alexey
  - Romain Gautier (mykiwi)
  - Joe Lencioni
@@ -609,6 +609,7 @@ Symfony is the result of the work of many people who made the code better
  - Kevin (oxfouzer)
  - Paweł Wacławczyk (pwc)
  - Oleg Zinchenko (cystbear)
+ - Baptiste Meyer (meyerbaptiste)
  - Johannes Klauss (cloppy)
  - Evan Villemez
  - fzerorubigd
@@ -671,6 +672,7 @@ Symfony is the result of the work of many people who made the code better
  - Benoit Lévêque (benoit_leveque)
  - Jeroen Fiege (fieg)
  - Krzysiek Łabuś
+ - George Mponos (gmponos)
  - Xavier Lacot (xavier)
  - possum
  - Denis Zunke (donalberto)
@@ -734,6 +736,7 @@ Symfony is the result of the work of many people who made the code better
  - Omar Yepez (oyepez003)
  - mwsaz
  - Jelle Kapitein
+ - Ben Scott
  - Benoît Bourgeois
  - mantulo
  - corphi
@@ -815,6 +818,7 @@ Symfony is the result of the work of many people who made the code better
  - ttomor
  - Mei Gwilym (meigwilym)
  - Michael H. Arieli (excelwebzone)
+ - Tom Panier (neemzy)
  - Fred Cox
  - Luciano Mammino (loige)
  - fabios
@@ -850,6 +854,7 @@ Symfony is the result of the work of many people who made the code better
  - Máximo Cuadros (mcuadros)
  - tamirvs
  - julien.galenski
+ - Israel J. Carberry
  - Bob van de Vijver
  - Christian Neff
  - Per Sandström (per)
@@ -888,7 +893,6 @@ Symfony is the result of the work of many people who made the code better
  - Eddie Jaoude
  - Antanas Arvasevicius
  - Haritz Iturbe (hizai)
- - Baptiste Meyer (meyerbaptiste)
  - Nerijus Arlauskas (nercury)
  - SPolischook
  - Diego Sapriza
@@ -910,8 +914,10 @@ Symfony is the result of the work of many people who made the code better
  - Marcin Chwedziak
  - hjkl
  - Tony Cosentino (tony-co)
+ - Dan Wilga
  - Alexander Cheprasov
  - Rodrigo Díez Villamuera (rodrigodiez)
+ - Malte Blättermann
  - e-ivanov
  - Jochen Bayer (jocl)
  - Jeremy Bush
@@ -923,12 +929,14 @@ Symfony is the result of the work of many people who made the code better
  - Péter Buri (burci)
  - Davide Borsatto (davide.borsatto)
  - kaiwa
+ - RJ Garcia
  - Charles Sanquer (csanquer)
  - Albert Ganiev (helios-ag)
  - Neil Katin
  - David Otton
  - Will Donohoe
  - peter
+ - Jaroslav Kuba
  - flip111
  - Jérémy Jourdin (jjk801)
  - BRAMILLE Sébastien (oktapodia)
@@ -936,6 +944,7 @@ Symfony is the result of the work of many people who made the code better
  - Gustavo Adrian
  - Yannick
  - spdionis
+ - rchoquet
  - Taras Girnyk
  - Eduardo García Sanz (coma)
  - James Gilliland
@@ -965,6 +974,7 @@ Symfony is the result of the work of many people who made the code better
  - Paul Matthews
  - Juan Traverso
  - Tarjei Huse (tarjei)
+ - tsufeki
  - Philipp Strube
  - Christian Sciberras
  - Clement Herreman (clemherreman)
@@ -1055,6 +1065,7 @@ Symfony is the result of the work of many people who made the code better
  - m.chwedziak
  - Philip Frank
  - Lance McNearney
+ - Gonzalo Vilaseca (gonzalovilaseca)
  - Giorgio Premi
  - Ian Carroll
  - caponica
@@ -1065,7 +1076,6 @@ Symfony is the result of the work of many people who made the code better
  - adev
  - Luis Galeas
  - Martin Pärtel
- - George Mponos (gmponos)
  - Patrick Daley (padrig)
  - Xavier Briand (xavierbriand)
  - Max Summe
@@ -1146,6 +1156,7 @@ Symfony is the result of the work of many people who made the code better
  - Hoffmann András
  - Olivier
  - pscheit
+ - Wybren Koelmans
  - Zdeněk Drahoš
  - Dan Harper
  - moldcraft
@@ -1233,6 +1244,7 @@ Symfony is the result of the work of many people who made the code better
  - Fabien LUCAS (flucas2)
  - Indra Gunawan (indragunawan)
  - Karim Cassam Chenaï (ka)
+ - Michal Kurzeja (mkurzeja)
  - Nicolas Bastien (nicolas_bastien)
  - Denis (yethee)
  - Andrew Zhilin (zhil)
@@ -1251,9 +1263,11 @@ Symfony is the result of the work of many people who made the code better
  - Warwick
  - VJ
  - Chris
+ - Florent Olivaud
  - JakeFr
  - Simon Sargeant
  - efeen
+ - Nicolas Pion
  - Muhammed Akbulut
  - Michał Dąbrowski (defrag)
  - Simone Fumagalli (hpatoio)
@@ -1270,6 +1284,7 @@ Symfony is the result of the work of many people who made the code better
  - Grinbergs Reinis (shima5)
  - Artem Lopata (bumz)
  - Nicole Cordes
+ - VolCh
  - Alexey Popkov
  - Gijs Kunze
  - Artyom Protaskin
@@ -1375,6 +1390,7 @@ Symfony is the result of the work of many people who made the code better
  - Dane Powell
  - Gerrit Drost
  - Linnaea Von Lavia
+ - Javan Eskander
  - Lenar Lõhmus
  - Cristian Gonzalez
  - AlberT
@@ -1423,7 +1439,6 @@ Symfony is the result of the work of many people who made the code better
  - Yanick Witschi
  - Ondrej Mirtes
  - akimsko
- - Ben Scott
  - Youpie
  - srsbiz
  - Taylan Kasap
@@ -1556,6 +1571,7 @@ Symfony is the result of the work of many people who made the code better
  - Dawid Nowak
  - Lesnykh Ilia
  - Karolis Daužickas
+ - Nicolas
  - Sergio Santoro
  - tirnanog06
  - phc
@@ -1689,6 +1705,7 @@ Symfony is the result of the work of many people who made the code better
  - Adam Elsodaney (archfizz)
  - Daniel Kolvik (dkvk)
  - Marc Lemay (flug)
+ - Henne Van Och (hennevo)
  - Jeroen De Dauw (jeroendedauw)
  - Maxime COLIN (maximecolin)
  - Muharrem Demirci (mdemirci)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.30-DEV';
+    const VERSION = '2.7.30';
     const VERSION_ID = 20730;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 30;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.7.29...v2.7.30)

 * bug #23341 [DoctrineBridge][Security][Validator] do not validate empty values (@xabbuh)
 * bug #23274 Display a better error design when the toolbar cannot be displayed (@yceruto)
 * bug #23333 [PropertyAccess] Fix TypeError discard (@dunglas)
 * bug #23345 [Console] fix description of INF default values (@xabbuh)
 * bug #23279 Don't call count on non countable object (@pierredup)
 * bug #23283 [TwigBundle] add back exception check (@xabbuh)
 * bug #23268 Show exception is checked twice in ExceptionController of twig (@gmponos)
 * bug #23266 Display a better error message when the toolbar cannot be displayed (@javiereguiluz)
 * bug #23271 [FrameworkBundle] allow SSI fragments configuration in XML files (@xabbuh)
 * bug #23254 [Form][TwigBridge] render hidden _method field in form_rest() (@xabbuh)
 * bug #23250 [Translation] return fallback locales whenever possible (@xabbuh)
 * bug #22732 [Security] fix switch user _exit without having current token (@dmaicher)
 * bug #22730 [FrameworkBundle] Sessions: configurable "use_strict_mode" option for NativeSessionStorage (@MacDada)
 * bug #23195 [FrameworkBundle] [Command] Clean bundle directory, fixes #23177 (@NicolasPion)
 * bug #23052 [TwigBundle] Add Content-Type header for exception response (@rchoquet)
 * bug #23199 Reset redirectCount when throwing exception (@hvanoch)
 * bug #23186 [TwigBundle] Move template.xml loading to a compiler pass (@ogizanagi)
 * bug #23130 Keep s-maxage when expiry and validation are used in combination (@mpdude)
 * bug #23129 Fix two edge cases in ResponseCacheStrategy (@mpdude)
 * feature #22636 [Routing] Expose request in route conditions, if needed and possible (@ro0NL)
 * bug #22636 [Routing] Expose request in route conditions, if needed and possible (@ro0NL)
 * bug #23057 [Translation][FrameworkBundle] Fix resource loading order inconsistency reported in #23034 (@mpdude)
 * bug #23092 [Filesystem] added workaround in Filesystem::rename for PHP bug (@VolCh)
 * bug #23128 [HttpFoundation] fix for Support for new 7.1 session options (@vincentaubert)
 * bug #23176 [VarDumper] fixes (@nicolas-grekas)
 * bug #23086 [FrameworkBundle] Fix perf issue in CacheClearCommand::warmup() (@nicolas-grekas)
 * bug #23098 Cache ipCheck (2.7) (@gonzalovilaseca)
