### PR TITLE
[FrameworkBundle] 3.3: Don't get() private services from debug:router

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -137,7 +137,7 @@ EOF
             }
         }
 
-        $nameParser = $this->getContainer()->get('controller_name_converter');
+        $nameParser = new ControllerNameParser($this->getApplication()->getKernel());
         try {
             $shortNotation = $nameParser->build($controller);
             $route->setDefault('_controller', $shortNotation);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #23366 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Same as https://github.com/symfony/symfony/pull/23366 but another place exist in upper branches.

However, the original fix prevents using the proper name parser in case it was replaced 😕 .