### PR TITLE
[FrameworkBundle] Inject @controller_name_converter in debug:router

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -29,6 +29,15 @@ use Symfony\Component\Routing\Route;
  */
 class RouterDebugCommand extends ContainerAwareCommand
 {
+    private $controllerNameParser;
+
+    public function __construct(ControllerNameParser $controllerNameParser = null)
+    {
+        parent::__construct();
+
+        $this->controllerNameParser = $controllerNameParser;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -110,10 +119,12 @@ EOF
 
     private function convertController(Route $route)
     {
-        $nameParser = new ControllerNameParser($this->getApplication()->getKernel());
         if ($route->hasDefault('_controller')) {
+            if (null === $this->controllerNameParser) {
+                $this->controllerNameParser = new ControllerNameParser($this->getApplication()->getKernel());
+            }
             try {
-                $route->setDefault('_controller', $nameParser->build($route->getDefault('_controller')));
+                $route->setDefault('_controller', $this->controllerNameParser->build($route->getDefault('_controller')));
             } catch (\InvalidArgumentException $e) {
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -98,5 +98,11 @@
             <argument type="service" id="router.request_context" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+
+        <service id="router.command.debug" class="Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand" public="false">
+            <tag name="console.command" />
+            <argument type="service" id="controller_name_converter" />
+        </service>
+
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23371 
| License       | MIT
| Doc PR        | n/a

Keep using the service in case it is decorated, losing laziness for this dependency (running any command will make the ControllerNameParser instantiated, #22734 could fix that in 3.4).