### PR TITLE
[FrameworkBundle] Do not remove files from assets dir

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -92,7 +92,9 @@ EOT
         $validAssetDirs = array();
         foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
             if (is_dir($originDir = $bundle->getPath().'/Resources/public')) {
-                $targetDir = $bundlesDir.preg_replace('/bundle$/', '', strtolower($bundle->getName()));
+                $assetDir = preg_replace('/bundle$/', '', strtolower($bundle->getName()));
+                $targetDir = $bundlesDir.$assetDir;
+                $validAssetDirs[] = $assetDir;
 
                 $output->writeln(sprintf('Installing assets for <comment>%s</comment> into <comment>%s</comment>', $bundle->getNamespace(), $targetDir));
 
@@ -132,15 +134,12 @@ EOT
                 } else {
                     $this->hardCopy($originDir, $targetDir);
                 }
-                $validAssetDirs[] = $targetDir;
             }
         }
+
         // remove the assets of the bundles that no longer exist
-        foreach (new \FilesystemIterator($bundlesDir) as $dir) {
-            if (!in_array($dir, $validAssetDirs)) {
-                $filesystem->remove($dir);
-            }
-        }
+        $dirsToRemove = Finder::create()->depth(0)->directories()->exclude($validAssetDirs)->in($bundlesDir);
+        $filesystem->remove($dirsToRemove);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The patch introduced in https://github.com/symfony/symfony/pull/23195 removes files from `web/bundles` (eg. `.gitignore`) which is unintentional I think.