### PR TITLE
[Cache] Handle APCu failures gracefully

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -15,6 +15,7 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
@@ -108,7 +109,9 @@ abstract class AbstractAdapter implements AdapterInterface, LoggerAwareInterface
         }
 
         $apcu = new ApcuAdapter($namespace, (int) $defaultLifetime / 5, $version);
-        if (null !== $logger) {
+        if ('cli' === PHP_SAPI && !ini_get('apc.enable_cli')) {
+            $apcu->setLogger(new NullLogger());
+        } elseif (null !== $logger) {
             $apcu->setLogger($logger);
         }
 

--- a/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
@@ -50,7 +50,7 @@ class ApcuAdapter extends AbstractAdapter
     protected function doFetch(array $ids)
     {
         try {
-            return apcu_fetch($ids);
+            return apcu_fetch($ids) ?: array();
         } catch (\Error $e) {
             throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
         }
@@ -92,7 +92,11 @@ class ApcuAdapter extends AbstractAdapter
     protected function doSave(array $values, $lifetime)
     {
         try {
-            return array_keys(apcu_store($values, null, $lifetime));
+            if (false === $failures = apcu_store($values, null, $lifetime)) {
+                $failures = $values;
+            }
+
+            return array_keys($failures);
         } catch (\Error $e) {
         } catch (\Exception $e) {
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23344
| License       | MIT
| Doc PR        | -

When APCu memory is full, or when APCu is used in CLI but `apc.enable_cli` is off, it behaves in a special way that this PR now handles.
When `apc.enable_cli` is off, we also completely silence failures with a `NullLogger` - that's just noise and that happens a lot during warmups, when filling the seeding FilesystemAdapter cache in the chain.