### PR TITLE
[Console] Improve warning signal color for SymfonyStyle

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -193,7 +193,7 @@ class SymfonyStyle extends OutputStyle
      */
     public function warning($message)
     {
-        $this->block($message, 'WARNING', 'fg=white;bg=red', ' ', true);
+        $this->block($message, 'WARNING', 'fg=black;bg=yellow', ' ', true);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | sort of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Warnings look the same as errors, which IMO is not the right signal color to use. As i noticed today running `cache:clear` thinking something went terribly wrong :) (there's some delay between the 2 blocks).

Before

![image](https://user-images.githubusercontent.com/1047696/27840382-b2088762-60f8-11e7-8918-4514e38e3786.png)

After

![image](https://user-images.githubusercontent.com/1047696/27840386-c0900d1e-60f8-11e7-8cf2-761dd2340170.png)

Thoughts?