### PR TITLE
[Serializer] AbstractObjectNormalizer: Allow to disable type enforcement

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * added `AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT` context option
+   to disable throwing an `UnexpectedValueException` on a type mismatch
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -33,6 +33,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     const ENABLE_MAX_DEPTH = 'enable_max_depth';
     const DEPTH_KEY_PATTERN = 'depth_%s::%s';
     const ALLOW_EXTRA_ATTRIBUTES = 'allow_extra_attributes';
+    const DISABLE_TYPE_ENFORCEMENT = 'disable_type_enforcement';
 
     private $propertyTypeExtractor;
     private $attributesCache = array();
@@ -287,6 +288,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             if (call_user_func('is_'.$builtinType, $data)) {
                 return $data;
             }
+        }
+
+        if (isset($context[self::DISABLE_TYPE_ENFORCEMENT]) && $context[self::DISABLE_TYPE_ENFORCEMENT]) {
+            return $data;
         }
 
         throw new UnexpectedValueException(sprintf('The type of the "%s" attribute for class "%s" must be one of "%s" ("%s" given).', $attribute, $currentClass, implode('", "', array_keys($expectedTypes)), gettype($data)));

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -628,6 +628,16 @@ class ObjectNormalizerTest extends TestCase
         $serializer->denormalize(array('inners' => array('a' => array('foo' => 1))), ObjectOuter::class);
     }
 
+    public function testDoNotRejectInvalidTypeOnDisableTypeEnforcementContextOption()
+    {
+        $extractor = new PropertyInfoExtractor(array(), array(new PhpDocExtractor()));
+        $normalizer = new ObjectNormalizer(null, null, null, $extractor);
+        $serializer = new Serializer(array($normalizer));
+        $context = array(ObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true);
+
+        $this->assertSame('foo', $serializer->denormalize(array('number' => 'foo'), JsonNumber::class, null, $context)->number);
+    }
+
     public function testExtractAttributesRespectsFormat()
     {
         $normalizer = new FormatAndContextAwareNormalizer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes (failure unrelated)
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This allows to denormalize simple DTOs with public properties using the property-info component and the `ObjectNormalizer`. The raised exception is not really useful in such cases, as it cannot be easily handled gracefully to build a proper violation response (too generic and no real hint on the complete attribute path for instance).
Instead, I use the validator component to validate my DTOs and the properties' types, get a proper violation list, and build a response from it.

I wasn't really inspired for the `DISABLE_TYPE_ENFORCEMENT` name.