### PR TITLE
Release v3.2.11

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -7,6 +7,11 @@ in 3.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.2.0...v3.2.1
 
+* 3.2.11 (2017-07-05)
+
+ * bug #23390 [Cache] Handle APCu failures gracefully (nicolas-grekas)
+ * bug #23378 [FrameworkBundle] Do not remove files from assets dir (1ed)
+
 * 3.2.10 (2017-07-04)
 
  * bug #23366 [FrameworkBundle] Don't get() private services from debug:router (chalasr)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '3.2.11-DEV';
+    const VERSION = '3.2.11';
     const VERSION_ID = 30211;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 2;
     const RELEASE_VERSION = 11;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '07/2017';
     const END_OF_LIFE = '01/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.2.10...v3.2.11)

 * bug #23390 [Cache] Handle APCu failures gracefully (@nicolas-grekas)
 * bug #23378 [FrameworkBundle] Do not remove files from assets dir (@1ed)
