### PR TITLE
[Security] AuthenticationUtils::getLastUsername() return type inconsistency

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -65,6 +65,7 @@ Security
  * Using the `AdvancedUserInterface` is now deprecated. To use the existing
    functionality, create a custom user-checker based on the
    `Symfony\Component\Security\Core\User\UserChecker`.
+ * `AuthenticationUtils::getLastUsername()` now always returns a string.
 
 SecurityBundle
 --------------

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Using the AdvancedUserInterface is now deprecated. To use the existing
    functionality, create a custom user-checker based on the
    `Symfony\Component\Security\Core\User\UserChecker`.
+ * `AuthenticationUtils::getLastUsername()` now always returns a string.
 
 4.0.0
 -----

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
@@ -62,12 +62,12 @@ class AuthenticationUtils
         $request = $this->getRequest();
 
         if ($request->attributes->has(Security::LAST_USERNAME)) {
-            return $request->attributes->get(Security::LAST_USERNAME);
+            return $request->attributes->get(Security::LAST_USERNAME, '');
         }
 
         $session = $request->getSession();
 
-        return null === $session ? '' : $session->get(Security::LAST_USERNAME);
+        return null === $session ? '' : $session->get(Security::LAST_USERNAME, '');
     }
 
     /**


### PR DESCRIPTION
Always return `string`, never `null` according to the `@return` annotation tag.

| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Alternatively, string return might be nullable:

```php
return null === $session ? null : $session->get(Security::LAST_USERNAME);
```

Is test needed for this change?