### PR TITLE
[Security] Fix forced redirection to referer if use_referer is enabled

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -122,7 +122,7 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
             return $targetUrl;
         }
 
-        if ($this->options['use_referer'] && ($targetUrl = $request->headers->get('Referer')) && parse_url($targetUrl, PHP_URL_PATH) !== $this->httpUtils->generateUri($request, $this->options['login_path'])) {
+        if ($this->options['use_referer'] && ($targetUrl = $request->headers->get('Referer')) && parse_url($targetUrl, PHP_URL_PATH) !== parse_url($this->httpUtils->generateUri($request, $this->options['login_path']), PHP_URL_PATH)) {
             return $targetUrl;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -129,9 +129,13 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
 
         $this->request->headers->expects($this->once())
             ->method('get')->with('Referer')
-            ->will($this->returnValue('/dashboard'));
+            ->will($this->returnValue('http://example.com/dashboard'));
 
-        $response = $this->expectRedirectResponse('/dashboard');
+        $this->httpUtils->expects($this->once())
+            ->method('generateUri')->with($this->request, '/login')
+            ->will($this->returnValue('http://example.com/login'));
+
+        $response = $this->expectRedirectResponse('http://example.com/dashboard');
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, $options);
         $result = $handler->onAuthenticationSuccess($this->request, $this->token);
@@ -145,11 +149,11 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
 
         $this->request->headers->expects($this->any())
             ->method('get')->with('Referer')
-            ->will($this->returnValue('/login'));
+            ->will($this->returnValue('http://example.com/login'));
 
         $this->httpUtils->expects($this->once())
             ->method('generateUri')->with($this->request, '/login')
-            ->will($this->returnValue('/login'));
+            ->will($this->returnValue('http://example.com/login'));
 
         $response = $this->expectRedirectResponse('/');
 
@@ -165,11 +169,11 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
 
         $this->request->headers->expects($this->any())
             ->method('get')->with('Referer')
-            ->will($this->returnValue('/subfolder/login?t=1&p=2'));
+            ->will($this->returnValue('http://example.com/subfolder/login?t=1&p=2'));
 
         $this->httpUtils->expects($this->once())
             ->method('generateUri')->with($this->request, '/login')
-            ->will($this->returnValue('/subfolder/login'));
+            ->will($this->returnValue('http://example.com/subfolder/login'));
 
         $response = $this->expectRedirectResponse('/');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | bug introduced by #19026
| License       | MIT
| Doc PR        | -

If `use_referer` option is enabled, then the following comparison is always true:

```php
parse_url($request->headers->get('Referer'), PHP_URL_PATH) !== parse_url($this->httpUtils->generateUri($request, $this->options['login_path']), PHP_URL_PATH)
```

`parse_url(..., PHP_URL_PATH)` returns only the path part of an URL and `$this->httpUtils->generateUri(..., ...)` returns an absolute URL.