### PR TITLE
[VarDumper] Reduce size of serialized Data objects

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -414,7 +414,7 @@ class ErrorHandler
                 $errorAsException = self::$silencedErrorCache[$message];
                 ++$errorAsException->count;
             } else {
-                $lightTrace = $this->tracedErrors & $type ? $this->cleanTrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), $type, $file, $line, false) : array();
+                $lightTrace = $this->tracedErrors & $type ? $this->cleanTrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3), $type, $file, $line, false) : array();
                 $errorAsException = new SilencedErrorContext($type, $file, $line, $lightTrace);
             }
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -120,6 +120,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
             $log['priorityName'] = 'DEBUG';
             $log['channel'] = '-';
             $log['scream'] = false;
+            unset($log['type'], $log['file'], $log['line'], $log['trace'], $log['trace'], $log['count']);
             $logs[] = $log;
         }
 
@@ -251,7 +252,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         }
 
         foreach ($containerDeprecationLogs as $deprecationLog) {
-            $count['deprecation_count'] += $deprecationLog['count'];
+            $count['deprecation_count'] += $deprecationLog['context']['exception']->count;
         }
 
         ksort($count['priorities']);

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -551,7 +551,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                         return;
                     }
 
-                    $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+                    $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
                     // Clean the trace by removing first frames added by the error handler itself.
                     for ($i = 0; isset($backtrace[$i]); ++$i) {
                         if (isset($backtrace[$i]['file'], $backtrace[$i]['line']) && $backtrace[$i]['line'] === $line && $backtrace[$i]['file'] === $file) {

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -50,7 +50,7 @@ class DumpDataCollectorTest extends TestCase
         );
         $this->assertEquals($xDump, $dump);
 
-        $this->assertStringMatchesFormat('a:3:{i:0;a:5:{s:4:"data";O:39:"Symfony\Component\VarDumper\Cloner\Data":%a', $collector->serialize());
+        $this->assertStringMatchesFormat('a:3:{i:0;a:5:{s:4:"data";%c:39:"Symfony\Component\VarDumper\Cloner\Data":%a', $collector->serialize());
         $this->assertSame(0, $collector->getDumpsCount());
         $this->assertSame('a:2:{i:0;b:0;i:1;s:5:"UTF-8";}', $collector->serialize());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #23233
| License       | MIT
| Doc PR        | -

By using `Stub` objects a lot, especially for arrays, `Data` objects generate heavy serialized strings.
By implemeting `Serializable` on `Data`, this PR removes most of the boilerplate.

This PR also removes duplicate data in `LoggerDataCollector`, and reduces the backtrace of silenced errors to their 3 last items - which should be enough - and is otherwise responsible for a significant portion of the serialized payloads.

This is not the last possible step towards shrinking serialized profiles, but the next one is more complex -and maybe this one is good enough? Please give feedback if you can.