### PR TITLE
require the XML PHP extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
+        "ext-xml": "*",
         "doctrine/common": "~2.4",
         "paragonie/random_compat": "~1.0",
         "symfony/polyfill-apcu": "~1.1",

--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
+        "ext-xml": "*",
         "symfony/http-kernel": "~2.6",
         "symfony/twig-bridge": "~2.6",
         "symfony/var-dumper": "~2.6"

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
+        "ext-xml": "*",
         "symfony/security": "~2.7",
         "symfony/security-acl": "~2.7",
         "symfony/http-kernel": "~2.7"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/22676#issuecomment-300434331, symfony/symfony-standard#1099
| License       | MIT
| Doc PR        | 

I suggest to either revert #22676 or to be consistent and require the XML extension in all bundles as well as in the `symfony/symfony` package.