### PR TITLE
[Ldap] Fix deprecated message

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -402,7 +402,7 @@ HttpKernel
 Ldap
 ----
 
- * The `RenameEntryInterface` has been deprecated, and merged with `EntryManagerInterface`
+ * The `RenameEntryInterface` has been removed, and merged with `EntryManagerInterface`
 
 Process
 -------

--- a/src/Symfony/Component/Ldap/Adapter/RenameEntryInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/RenameEntryInterface.php
@@ -5,9 +5,9 @@ namespace Symfony\Component\Ldap\Adapter;
 use Symfony\Component\Ldap\Entry;
 
 /**
- * @deprecated This interface will be deprecated in 4.0, and merged with `EntryManagerInterface`
- *
  * @author Kevin Schuurmans <kevin.schuurmans@freshheads.com>
+ *
+ * @deprecated since version 3.3, will be merged with {@link EntryManagerInterface} in 4.0.
  */
 interface RenameEntryInterface
 {

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.3.0
+-----
+
+* The `RenameEntryInterface` inferface is deprecated, and will be merged with `EntryManagerInterface` in 4.0.
+
 3.1.0
 -----
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20390 https://github.com/symfony/symfony/pull/23402
| License       | MIT
| Doc PR        | /

``RenameEntryInterface`` is **deprecated** in 3.3 and **removed/merged** in 4.0.