### PR TITLE
[WebProfilerBundle] Remove deprecated TemplateManager::getTemplates()

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -619,6 +619,11 @@ VarDumper
    VarDumperTestTrait::assertDumpMatchesFormat($dump, $data, $filter = 0, $message = '');
    ```
 
+WebProfilerBundle
+-----------------
+
+ * Removed the `getTemplates()` method of the `TemplateManager` class in favor of the ``getNames()`` method.
+
 Workflow
 --------
 

--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * removed the `WebProfilerExtension::dumpValue()` method
+ * removed the `getTemplates()` method of the `TemplateManager` class in favor of the ``getNames()`` method
 
 3.1.0
 -----

--- a/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
@@ -61,26 +61,6 @@ class TemplateManager
     }
 
     /**
-     * Gets the templates for a given profile.
-     *
-     * @param Profile $profile
-     *
-     * @return Template[]
-     *
-     * @deprecated not used anymore internally
-     */
-    public function getTemplates(Profile $profile)
-    {
-        $templates = $this->getNames($profile);
-
-        foreach ($templates as $name => $template) {
-            $templates[$name] = $this->twig->loadTemplate($template);
-        }
-
-        return $templates;
-    }
-
-    /**
      * Gets template names of templates that are present in the viewed profile.
      *
      * @param Profile $profile

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -79,28 +79,6 @@ class TemplateManagerTest extends TestCase
         $this->assertEquals('FooBundle:Collector:foo.html.twig', $this->templateManager->getName($profile, 'foo'));
     }
 
-    /**
-     * template should be loaded for 'foo' because other collectors are
-     * missing in profile or in profiler.
-     */
-    public function testGetTemplates()
-    {
-        $profile = $this->mockProfile();
-        $profile->expects($this->any())
-            ->method('hasCollector')
-            ->will($this->returnCallback(array($this, 'profilerHasCallback')));
-
-        $this->profiler->expects($this->any())
-            ->method('has')
-            ->withAnyParameters()
-            ->will($this->returnCallback(array($this, 'profileHasCollectorCallback')));
-
-        $result = $this->templateManager->getTemplates($profile);
-        $this->assertArrayHasKey('foo', $result);
-        $this->assertArrayNotHasKey('bar', $result);
-        $this->assertArrayNotHasKey('baz', $result);
-    }
-
     public function profilerHasCallback($panel)
     {
         switch ($panel) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20484
| License       | MIT
| Doc PR        | /