### PR TITLE
Add support to ValueToDuplicatesTransformer for comparing objects

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -65,7 +65,13 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
 
         foreach ($this->keys as $key) {
             if (isset($array[$key]) && '' !== $array[$key] && false !== $array[$key] && array() !== $array[$key]) {
-                if ($array[$key] !== $result) {
+                if (is_object($array[$key]) && is_object($result)) {
+                    if ((string)$array[$key] !== (string)$result) {
+                        throw new TransformationFailedException(
+                            'All values in the array should be the same'
+                        );
+                    }
+                } else if ($array[$key] !== $result) {
                     throw new TransformationFailedException(
                         'All values in the array should be the same'
                     );

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -66,12 +66,12 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
         foreach ($this->keys as $key) {
             if (isset($array[$key]) && '' !== $array[$key] && false !== $array[$key] && array() !== $array[$key]) {
                 if (is_object($array[$key]) && is_object($result)) {
-                    if ((string)$array[$key] !== (string)$result) {
+                    if ((string) $array[$key] !== (string) $result) {
                         throw new TransformationFailedException(
                             'All values in the array should be the same'
                         );
                     }
-                } else if ($array[$key] !== $result) {
+                } elseif ($array[$key] !== $result) {
                     throw new TransformationFailedException(
                         'All values in the array should be the same'
                     );


### PR DESCRIPTION
It's possible when using the \Symfony\Component\Form\Extension\Core\Type\RepeatedType the field being duplicated contains an object.
This checks if the values being compared are both objects and compares the __toString() method of the objects, if they are not equal it throws a TransformationFailedException.

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
