### PR TITLE
[FrameworkBundle] check _controller attribute is a string before parsing it

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
@@ -33,7 +33,7 @@ class ResolveControllerNameSubscriber implements EventSubscriberInterface
     public function onKernelRequest(GetResponseEvent $event)
     {
         $controller = $event->getRequest()->attributes->get('_controller');
-        if ($controller && false === strpos($controller, '::') && 2 === substr_count($controller, ':')) {
+        if (is_string($controller) && false === strpos($controller, '::') && 2 === substr_count($controller, ':')) {
             // controller in the a:b:c notation then
             $event->getRequest()->attributes->set('_controller', $this->parser->parse($controller));
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/EventListener/ResolveControllerNameSubscriberTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/EventListener/ResolveControllerNameSubscriberTest.php
@@ -37,7 +37,10 @@ class ResolveControllerNameSubscriberTest extends TestCase
         $this->assertEquals('App\\Final\\Format::methodName', $request->attributes->get('_controller'));
     }
 
-    public function testSkipsOtherControllerFormats()
+    /**
+     * @dataProvider provideSkippedControllers
+     */
+    public function testSkipsOtherControllerFormats($controller)
     {
         $parser = $this->getMockBuilder(ControllerNameParser::class)->disableOriginalConstructor()->getMock();
         $parser->expects($this->never())
@@ -45,10 +48,16 @@ class ResolveControllerNameSubscriberTest extends TestCase
         $httpKernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
 
         $request = new Request();
-        $request->attributes->set('_controller', 'Other:format');
+        $request->attributes->set('_controller', $controller);
 
         $subscriber = new ResolveControllerNameSubscriber($parser);
         $subscriber->onKernelRequest(new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
-        $this->assertEquals('Other:format', $request->attributes->get('_controller'));
+        $this->assertEquals($controller, $request->attributes->get('_controller'));
+    }
+
+    public function provideSkippedControllers()
+    {
+        yield array('Other:format');
+        yield array(function () {});
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23456
| License       | MIT

Avoids an error to be raised in case described in issue #23456.