### PR TITLE
[FrameworkBundle] Add namespace as a cache pool configuration option

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
    `Symfony\Component\Translation\DependencyInjection\TranslationExtractorPass` instead
  * Deprecated `TranslatorPass`, use 
    `Symfony\Component\Translation\DependencyInjection\TranslatorPass` instead
+ * Added `namespace` as a cache pool configuration option.
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -809,6 +809,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('provider')
                                         ->info('The service name to use as provider when the specified adapter needs one.')
                                     ->end()
+                                    ->scalarNode('namespace')->end()
                                     ->scalarNode('clearer')->end()
                                 ->end()
                             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -249,6 +249,7 @@
         <xsd:attribute name="public" type="xsd:boolean" />
         <xsd:attribute name="default-lifetime" type="xsd:integer" />
         <xsd:attribute name="provider" type="xsd:string" />
+        <xsd:attribute name="namespace" type="xsd:string" />
         <xsd:attribute name="clearer" type="xsd:string" />
     </xsd:complexType>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
@@ -15,6 +15,7 @@ $container->loadFromExtension('framework', array(
             'cache.baz' => array(
                 'adapter' => 'cache.adapter.filesystem',
                 'default_lifetime' => 7,
+                'namespace' => 'qux',
             ),
             'cache.foobar' => array(
                 'adapter' => 'cache.adapter.psr6',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
@@ -9,7 +9,7 @@
         <framework:cache>
             <framework:pool name="cache.foo" adapter="cache.adapter.apcu" default-lifetime="30" />
             <framework:pool name="cache.bar" adapter="cache.adapter.doctrine" default-lifetime="5" provider="app.doctrine_cache_provider" />
-            <framework:pool name="cache.baz" adapter="cache.adapter.filesystem" default-lifetime="7" />
+            <framework:pool name="cache.baz" adapter="cache.adapter.filesystem" default-lifetime="7" namespace="qux" />
             <framework:pool name="cache.foobar" adapter="cache.adapter.psr6" default-lifetime="10" provider="app.cache_pool" />
             <framework:pool name="cache.def" default-lifetime="11" />
         </framework:cache>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
@@ -11,6 +11,7 @@ framework:
             cache.baz:
                 adapter: cache.adapter.filesystem
                 default_lifetime: 7
+                namespace: qux
             cache.foobar:
                 adapter: cache.adapter.psr6
                 default_lifetime: 10

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -966,7 +966,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foo', 'cache.adapter.apcu', 30);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.bar', 'cache.adapter.doctrine', 5);
-        $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.baz', 'cache.adapter.filesystem', 7);
+        $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.baz', 'cache.adapter.filesystem', 7, 'qux');
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foobar', 'cache.adapter.psr6', 10);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.def', 'cache.app', 11);
     }
@@ -1045,7 +1045,7 @@ abstract class FrameworkExtensionTest extends TestCase
         }
     }
 
-    private function assertCachePoolServiceDefinitionIsCreated(ContainerBuilder $container, $id, $adapter, $defaultLifetime)
+    private function assertCachePoolServiceDefinitionIsCreated(ContainerBuilder $container, $id, $adapter, $defaultLifetime, $namespace = null)
     {
         $this->assertTrue($container->has($id), sprintf('Service definition "%s" for cache pool of type "%s" is registered', $id, $adapter));
 
@@ -1059,6 +1059,13 @@ abstract class FrameworkExtensionTest extends TestCase
         $tag = $poolDefinition->getTag('cache.pool');
         $this->assertTrue(isset($tag[0]['default_lifetime']), 'The default lifetime is stored as an attribute of the "cache.pool" tag.');
         $this->assertSame($defaultLifetime, $tag[0]['default_lifetime'], 'The default lifetime is stored as an attribute of the "cache.pool" tag.');
+
+        if ($namespace) {
+            $this->assertTrue(isset($tag[0]['namespace']), 'The namespace is stored as an attribute of the "cache.pool" tag.');
+            $this->assertSame($namespace, $tag[0]['namespace'], 'The namespace is stored as an attribute of the "cache.pool" tag.');
+        } else {
+            $this->assertFalse(isset($tag[0]['namespace']), 'No namespace is stored as an attribute of the "cache.pool" tag.');
+        }
 
         $parentDefinition = $poolDefinition;
         do {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23438 (partially)
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/8140

Allows `namespace` to be set in the cache pool configuration.