### PR TITLE
[VarDumper] Test ExceptionCaster excluding verbosity

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Tests\Caster;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Caster\ExceptionCaster;
 use Symfony\Component\VarDumper\Caster\FrameStub;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
@@ -43,9 +44,9 @@ Exception {
   #message: "foo"
   #code: 0
   #file: "%sExceptionCasterTest.php"
-  #line: 27
+  #line: 28
   trace: {
-    %sExceptionCasterTest.php:27: {
+    %sExceptionCasterTest.php:28: {
       : {
       :     return new \Exception(''.$msg);
       : }
@@ -72,7 +73,7 @@ EODUMP;
 
         $expectedDump = <<<'EODUMP'
 {
-  %sExceptionCasterTest.php:27: {
+  %sExceptionCasterTest.php:28: {
     : {
     :     return new \Exception(''.$msg);
     : }
@@ -101,9 +102,9 @@ Exception {
   #message: "1"
   #code: 0
   #file: "%sExceptionCasterTest.php"
-  #line: 27
+  #line: 28
   trace: {
-    %sExceptionCasterTest.php:27: {
+    %sExceptionCasterTest.php:28: {
       : {
       :     return new \Exception(''.$msg);
       : }
@@ -129,9 +130,9 @@ Exception {
   #message: "1"
   #code: 0
   #file: "%sExceptionCasterTest.php"
-  #line: 27
+  #line: 28
   trace: {
-    %sExceptionCasterTest.php: 27
+    %sExceptionCasterTest.php: 28
     %sExceptionCasterTest.php: %d
 %A
 EODUMP;
@@ -157,10 +158,10 @@ EODUMP;
   #<span class=sf-dump-protected title="Protected property">code</span>: <span class=sf-dump-num>0</span>
   #<span class=sf-dump-protected title="Protected property">file</span>: "<span class=sf-dump-str title="%sExceptionCasterTest.php
 %d characters"><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class=sf-dump-ellipsis>%e</span>Tests%eCaster%eExceptionCasterTest.php</span>"
-  #<span class=sf-dump-protected title="Protected property">line</span>: <span class=sf-dump-num>27</span>
+  #<span class=sf-dump-protected title="Protected property">line</span>: <span class=sf-dump-num>28</span>
   <span class=sf-dump-meta>trace</span>: {<samp>
     <span class=sf-dump-meta title="%sExceptionCasterTest.php
-Stack level %d."><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class=sf-dump-ellipsis>%e</span>Tests%eCaster%eExceptionCasterTest.php</span>: <span class=sf-dump-num>27</span>
+Stack level %d."><span class="sf-dump-ellipsis sf-dump-ellipsis-path">%s%eVarDumper</span><span class=sf-dump-ellipsis>%e</span>Tests%eCaster%eExceptionCasterTest.php</span>: <span class=sf-dump-num>28</span>
      &hellip;%d
   </samp>}
 </samp>}
@@ -221,5 +222,21 @@ array:2 [
 EODUMP;
 
         $this->assertDumpMatchesFormat($expectedDump, $f);
+    }
+
+    public function testExcludeVerbosity()
+    {
+        $e = $this->getTestException('foo');
+
+        $expectedDump = <<<'EODUMP'
+Exception {
+  #message: "foo"
+  #code: 0
+  #file: "%sExceptionCasterTest.php"
+  #line: 28
+}
+EODUMP;
+
+        $this->assertDumpMatchesFormat($expectedDump, $e, Caster::EXCLUDE_VERBOSE);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

Cover better ``ExceptionCaster`` in tests thanks to filter which was added in https://github.com/symfony/symfony/pull/22588.
