### PR TITLE
[Filesystem] mirror - fix copying content with same name as source/target.

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -444,6 +444,7 @@ class Filesystem
     {
         $targetDir = rtrim($targetDir, '/\\');
         $originDir = rtrim($originDir, '/\\');
+		$originDirLen = strlen($originDir);
 
         // Iterate in destination folder to remove obsolete entries
         if ($this->exists($targetDir) && isset($options['delete']) && $options['delete']) {
@@ -452,8 +453,9 @@ class Filesystem
                 $flags = \FilesystemIterator::SKIP_DOTS;
                 $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);
             }
+			$targetDirLen = strlen($targetDir);
             foreach ($deleteIterator as $file) {
-                $origin = str_replace($targetDir, $originDir, $file->getPathname());
+				$origin = $originDir.substr($file->getPathname(), $targetDirLen);
                 if (!$this->exists($origin)) {
                     $this->remove($file);
                 }
@@ -475,7 +477,7 @@ class Filesystem
         }
 
         foreach ($iterator as $file) {
-            $target = str_replace($originDir, $targetDir, $file->getPathname());
+            $target = $targetDir.substr($file->getPathname(), $originDirLen);
 
             if ($copyOnWindows) {
                 if (is_file($file)) {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -444,7 +444,7 @@ class Filesystem
     {
         $targetDir = rtrim($targetDir, '/\\');
         $originDir = rtrim($originDir, '/\\');
-		$originDirLen = strlen($originDir);
+        $originDirLen = strlen($originDir);
 
         // Iterate in destination folder to remove obsolete entries
         if ($this->exists($targetDir) && isset($options['delete']) && $options['delete']) {
@@ -453,9 +453,9 @@ class Filesystem
                 $flags = \FilesystemIterator::SKIP_DOTS;
                 $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);
             }
-			$targetDirLen = strlen($targetDir);
+            $targetDirLen = strlen($targetDir);
             foreach ($deleteIterator as $file) {
-				$origin = $originDir.substr($file->getPathname(), $targetDirLen);
+                $origin = $originDir.substr($file->getPathname(), $targetDirLen);
                 if (!$this->exists($origin)) {
                     $this->remove($file);
                 }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1009,6 +1009,36 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertEquals('\\' === DIRECTORY_SEPARATOR ? realpath($sourcePath.'\nested') : 'nested', readlink($targetPath.DIRECTORY_SEPARATOR.'link1'));
     }
 
+    public function testMirrorContentsWithSameNameAsSourceOrTarget()
+    {
+        $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
+
+        $oldPath = getcwd();
+        chdir($this->workspace);
+
+        mkdir($sourcePath);
+        touch($sourcePath.'source');
+		touch($sourcePath.'target');
+
+        $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
+
+        $this->filesystem->mirror('source', $targetPath);
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertFileExists($targetPath.'source');
+        $this->assertFileExists($targetPath.'target');
+
+		unlink($sourcePath.'target');
+
+        $this->filesystem->mirror('source', 'target', null, array('delete' => true));
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertFileExists($targetPath.'source');
+        $this->assertFileNotExists($targetPath.'target');
+
+        chdir($oldPath);
+	}
+
     /**
      * @dataProvider providePathsForIsAbsolutePath
      */

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1018,7 +1018,7 @@ class FilesystemTest extends FilesystemTestCase
 
         mkdir($sourcePath);
         touch($sourcePath.'source');
-		touch($sourcePath.'target');
+        touch($sourcePath.'target');
 
         $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
 
@@ -1028,7 +1028,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileExists($targetPath.'source');
         $this->assertFileExists($targetPath.'target');
 
-		unlink($sourcePath.'target');
+        unlink($sourcePath.'target');
 
         $this->filesystem->mirror('source', 'target', null, array('delete' => true));
 
@@ -1037,7 +1037,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileNotExists($targetPath.'target');
 
         chdir($oldPath);
-	}
+    }
 
     /**
      * @dataProvider providePathsForIsAbsolutePath

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1013,30 +1013,27 @@ class FilesystemTest extends FilesystemTestCase
     {
         $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
 
-        $oldPath = getcwd();
-        chdir($this->workspace);
-
         mkdir($sourcePath);
         touch($sourcePath.'source');
         touch($sourcePath.'target');
 
         $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
 
+        $oldPath = getcwd();
+        chdir($this->workspace);
+
         $this->filesystem->mirror('source', $targetPath);
+
+        chdir($oldPath);
 
         $this->assertTrue(is_dir($targetPath));
         $this->assertFileExists($targetPath.'source');
         $this->assertFileExists($targetPath.'target');
-
-        chdir($oldPath);
     }
 
     public function testMirrorContentsWithSameNameAsSourceOrTargetWithDeleteOption()
     {
         $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
-
-        $oldPath = getcwd();
-        chdir($this->workspace);
 
         mkdir($sourcePath);
         touch($sourcePath.'source');
@@ -1047,13 +1044,16 @@ class FilesystemTest extends FilesystemTestCase
         touch($targetPath.'source');
         touch($targetPath.'target');
 
+        $oldPath = getcwd();
+        chdir($this->workspace);
+
         $this->filesystem->mirror('source', 'target', null, array('delete' => true));
+
+        chdir($oldPath);
 
         $this->assertTrue(is_dir($targetPath));
         $this->assertFileExists($targetPath.'source');
         $this->assertFileNotExists($targetPath.'target');
-
-        chdir($oldPath);
     }
 
     /**

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1009,7 +1009,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertEquals('\\' === DIRECTORY_SEPARATOR ? realpath($sourcePath.'\nested') : 'nested', readlink($targetPath.DIRECTORY_SEPARATOR.'link1'));
     }
 
-    public function testMirrorContentsWithSameNameAsSourceOrTarget()
+    public function testMirrorContentsWithSameNameAsSourceOrTargetWithoutDeleteOption()
     {
         $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
 
@@ -1028,7 +1028,24 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileExists($targetPath.'source');
         $this->assertFileExists($targetPath.'target');
 
-        unlink($sourcePath.'target');
+        chdir($oldPath);
+    }
+
+    public function testMirrorContentsWithSameNameAsSourceOrTargetWithDeleteOption()
+    {
+        $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
+
+        $oldPath = getcwd();
+        chdir($this->workspace);
+
+        mkdir($sourcePath);
+        touch($sourcePath.'source');
+
+        $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
+
+        mkdir($targetPath);
+        touch($targetPath.'source');
+        touch($targetPath.'target');
 
         $this->filesystem->mirror('source', 'target', null, array('delete' => true));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23472
| License       | MIT
| Doc PR        | 

Uses `substr()` and lengths in `Filesystem::mirror()` rather than `str_replace()` to avoid multiple replacements.