### PR TITLE
[VarDumper] Test ReflectionCaster excluding verbosity

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Tests\Caster;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 use Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo;
 use Symfony\Component\VarDumper\Tests\Fixtures\NotLoadableClass;
@@ -77,11 +78,25 @@ Closure {
     \$b: & 123
   }
   file: "%sReflectionCasterTest.php"
-  line: "67 to 67"
+  line: "68 to 68"
 }
 EOTXT
             , $var
         );
+    }
+
+    public function testClosureCasterExcludingVerbosity()
+    {
+        $var = function () {};
+
+        $expectedDump = <<<EOTXT
+Closure {
+  class: "Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest"
+  this: Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest { …}
+}
+EOTXT;
+
+        $this->assertDumpEquals($expectedDump, $var, Caster::EXCLUDE_VERBOSE);
     }
 
     public function testReflectionParameter()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

Cover better ``ReflectionCaster`` in tests thanks to ``EXCLUDE_*`` filter which was added in https://github.com/symfony/symfony/pull/22588.