### PR TITLE
[Config] extracted the xml parsing from XmlUtils::loadFile into XmlUtils::parse

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1743,3 +1743,4 @@ Symfony is the result of the work of many people who made the code better
  - Thomas BERTRAND (sevrahk)
  - Matej Žilák (teo_sk)
  - Vladislav Vlastovskiy (vlastv)
+ - Ole Rößner (basster)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1743,4 +1743,3 @@ Symfony is the result of the work of many people who made the code better
  - Thomas BERTRAND (sevrahk)
  - Matej Žilák (teo_sk)
  - Vladislav Vlastovskiy (vlastv)
- - Ole Rößner (basster)

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -55,7 +55,7 @@ class XmlUtilsTest extends TestCase
             XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate'));
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertRegExp('/The XML file "[\w\/\\\.]+" is not valid\./', $e->getMessage());
+            $this->assertRegExp('/The XML file "[\w:\/\\\.]+" is not valid\./', $e->getMessage());
         }
 
         $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate')));

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -55,11 +55,26 @@ class XmlUtilsTest extends TestCase
             XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate'));
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertContains('is not valid', $e->getMessage());
+            $this->assertRegExp('/The XML file "[\w\/\\\.]+" is not valid\./', $e->getMessage());
         }
 
         $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate')));
         $this->assertSame(array(), libxml_get_errors());
+    }
+
+    public function testLoad()
+    {
+        $fixtures = __DIR__.'/../Fixtures/Util/';
+
+        $mock = $this->getMockBuilder(__NAMESPACE__.'\Validator')->getMock();
+        $mock->expects($this->once())->method('validate')->will($this->onConsecutiveCalls(false, true));
+
+        try {
+            XmlUtils::load(file_get_contents($fixtures.'valid.xml'), array($mock, 'validate'));
+            $this->fail();
+        } catch (\InvalidArgumentException $e) {
+            $this->assertContains('The XML is not valid', $e->getMessage());
+        }
     }
 
     public function testLoadFileWithInternalErrorsEnabled()

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -62,7 +62,7 @@ class XmlUtilsTest extends TestCase
         $this->assertSame(array(), libxml_get_errors());
     }
 
-    public function testLoad()
+    public function testParse()
     {
         $fixtures = __DIR__.'/../Fixtures/Util/';
 
@@ -70,7 +70,7 @@ class XmlUtilsTest extends TestCase
         $mock->expects($this->once())->method('validate')->will($this->onConsecutiveCalls(false, true));
 
         try {
-            XmlUtils::load(file_get_contents($fixtures.'valid.xml'), array($mock, 'validate'));
+            XmlUtils::parse(file_get_contents($fixtures.'valid.xml'), array($mock, 'validate'));
             $this->fail();
         } catch (\InvalidArgumentException $e) {
             $this->assertContains('The XML is not valid', $e->getMessage());

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -34,7 +34,7 @@ class XmlUtilsTest extends TestCase
         $mock = $this->createValidatorMock(true);
 
         $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate')));
-        $this->assertSame([], libxml_get_errors());
+        $this->assertSame(array(), libxml_get_errors());
     }
 
     public function provideDataForTestLoadFileExceptions()
@@ -44,9 +44,9 @@ class XmlUtilsTest extends TestCase
         $mock = $this->createValidatorMock(false);
 
         return array(
-            'invalid' => array($fixtures . 'invalid.xml', '/ERROR 77/'),
-            'document_type' => array($fixtures. 'document_type.xml', '/Document types are not allowed/'),
-            'invalid_schema' => array($fixtures . 'schema.xsd', '/ERROR 1845/',$fixtures.'schema.xsd'),
+            'invalid' => array($fixtures.'invalid.xml', '/ERROR 77/'),
+            'document_type' => array($fixtures.'document_type.xml', '/Document types are not allowed/'),
+            'invalid_schema' => array($fixtures.'schema.xsd', '/ERROR 1845/', $fixtures.'schema.xsd'),
             'invalid_callback_or_file' => array($fixtures.'invalid_schema.xml', '/XSD file or callable/', 'invalid_callback_or_file'),
             'invalid_callback_validator' => array($fixtures.'valid.xml', '/The XML file "[\w:\/\\\.]+" is not valid\./', array($mock, 'validate')),
         );

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -16,40 +16,50 @@ use Symfony\Component\Config\Util\XmlUtils;
 
 class XmlUtilsTest extends TestCase
 {
-    /**
-     * @dataProvider provideDataForTestLoadFileExceptions
-     */
-    public function testLoadFileExceptions($fileName, $expectedMessagePattern, $schemaOrCallable = null)
-    {
-        $this->expectException('\InvalidArgumentException');
-        $this->expectExceptionMessageRegExp($expectedMessagePattern);
-
-        XmlUtils::loadFile($fileName, $schemaOrCallable);
-    }
-
-    public function testLoadWithValidator()
+    public function testLoadFile()
     {
         $fixtures = __DIR__.'/../Fixtures/Util/';
 
-        $mock = $this->createValidatorMock(true);
+        try {
+            XmlUtils::loadFile($fixtures.'invalid.xml');
+            $this->fail();
+        } catch (\InvalidArgumentException $e) {
+            $this->assertContains('ERROR 77', $e->getMessage());
+        }
+
+        try {
+            XmlUtils::loadFile($fixtures.'document_type.xml');
+            $this->fail();
+        } catch (\InvalidArgumentException $e) {
+            $this->assertContains('Document types are not allowed', $e->getMessage());
+        }
+
+        try {
+            XmlUtils::loadFile($fixtures.'invalid_schema.xml', $fixtures.'schema.xsd');
+            $this->fail();
+        } catch (\InvalidArgumentException $e) {
+            $this->assertContains('ERROR 1845', $e->getMessage());
+        }
+
+        try {
+            XmlUtils::loadFile($fixtures.'invalid_schema.xml', 'invalid_callback_or_file');
+            $this->fail();
+        } catch (\InvalidArgumentException $e) {
+            $this->assertContains('XSD file or callable', $e->getMessage());
+        }
+
+        $mock = $this->getMockBuilder(__NAMESPACE__.'\Validator')->getMock();
+        $mock->expects($this->exactly(2))->method('validate')->will($this->onConsecutiveCalls(false, true));
+
+        try {
+            XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate'));
+            $this->fail();
+        } catch (\InvalidArgumentException $e) {
+            $this->assertRegExp('/The XML file "[\w:\/\\\.]+" is not valid\./', $e->getMessage());
+        }
 
         $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate')));
         $this->assertSame(array(), libxml_get_errors());
-    }
-
-    public function provideDataForTestLoadFileExceptions()
-    {
-        $fixtures = __DIR__.'/../Fixtures/Util/';
-
-        $mock = $this->createValidatorMock(false);
-
-        return array(
-            'invalid' => array($fixtures.'invalid.xml', '/ERROR 77/'),
-            'document_type' => array($fixtures.'document_type.xml', '/Document types are not allowed/'),
-            'invalid_schema' => array($fixtures.'schema.xsd', '/ERROR 1845/', $fixtures.'schema.xsd'),
-            'invalid_callback_or_file' => array($fixtures.'invalid_schema.xml', '/XSD file or callable/', 'invalid_callback_or_file'),
-            'invalid_callback_validator' => array($fixtures.'valid.xml', '/The XML file "[\w:\/\\\.]+" is not valid\./', array($mock, 'validate')),
-        );
     }
 
     /**
@@ -60,7 +70,8 @@ class XmlUtilsTest extends TestCase
     {
         $fixtures = __DIR__.'/../Fixtures/Util/';
 
-        $mock = $this->createValidatorMock(false);
+        $mock = $this->getMockBuilder(__NAMESPACE__.'\Validator')->getMock();
+        $mock->expects($this->once())->method('validate')->willReturn(false);
 
         XmlUtils::parse(file_get_contents($fixtures.'valid.xml'), array($mock, 'validate'));
     }
@@ -197,19 +208,6 @@ class XmlUtilsTest extends TestCase
 
         // should not throw an exception
         XmlUtils::loadFile(__DIR__.'/../Fixtures/Util/valid.xml', __DIR__.'/../Fixtures/Util/schema.xsd');
-    }
-
-    /**
-     * @param $returnValue
-     *
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function createValidatorMock($returnValue)
-    {
-        $mock = $this->getMockBuilder(__NAMESPACE__.'\Validator')->getMock();
-        $mock->expects($this->once())->method('validate')->willReturn($returnValue);
-
-        return $mock;
     }
 }
 

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -63,10 +63,10 @@ class XmlUtilsTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Symfony\Component\Config\Util\Exception\InvalidXmlException
      * @expectedExceptionMessage The XML is not valid
      */
-    public function testParse()
+    public function testParseWithInvalidValidatorCallable()
     {
         $fixtures = __DIR__.'/../Fixtures/Util/';
 

--- a/src/Symfony/Component/Config/Util/Exception/InvalidXmlException.php
+++ b/src/Symfony/Component/Config/Util/Exception/InvalidXmlException.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Util\Exception;
+
+/**
+ * Exception class for when XML parsing with an XSD schema file path or a callable validator produces errors unrelated
+ * to the actual XML parsing.
+ *
+ * @author Ole Rößner <ole@roessner.it>
+ */
+class InvalidXmlException extends XmlParsingException
+{
+}

--- a/src/Symfony/Component/Config/Util/Exception/XmlParsingException.php
+++ b/src/Symfony/Component/Config/Util/Exception/XmlParsingException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Util\Exception;
+
+/**
+ * Exception class for when XML cannot be parsed properly.
+ *
+ * @author Ole Rößner <ole@roessner.it>
+ */
+class XmlParsingException extends \InvalidArgumentException
+{
+}

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -124,12 +124,11 @@ class XmlUtils
 
         try {
             return static::parse($content, $schemaOrCallable);
-        } catch (\InvalidArgumentException $ex) {
-            throw new \InvalidArgumentException(
-                str_replace('The XML is not valid.', sprintf('The XML file "%s" is not valid.', $file), $ex->getMessage()),
-                $ex->getCode(),
-                $ex->getPrevious()
-            );
+        } catch (\InvalidArgumentException $e) {
+            if ('The XML is not valid.' !== $e->getMessage()) {
+                throw $e;
+            }
+            throw new \InvalidArgumentException(sprintf('The XML file "%s" is not valid.', $file), 0, $e->getPrevious());
         }
     }
 

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -126,8 +126,7 @@ class XmlUtils
 
         try {
             return static::load($content, $schemaOrCallable);
-        }
-        catch (\InvalidArgumentException $ex) {
+        } catch (\InvalidArgumentException $ex) {
             throw new \InvalidArgumentException(
                 str_replace(self::XML_IS_NOT_VALID_MESSAGE, sprintf('The XML file "%s" is not valid.', $file), $ex->getMessage()),
                 $ex->getCode(),

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -22,8 +22,6 @@ namespace Symfony\Component\Config\Util;
  */
 class XmlUtils
 {
-    const XML_IS_NOT_VALID_MESSAGE = 'The XML is not valid.';
-
     /**
      * This class should not be instantiated.
      */
@@ -94,7 +92,7 @@ class XmlUtils
             if (!$valid) {
                 $messages = static::getXmlErrors($internalErrors);
                 if (empty($messages)) {
-                    $messages = array(self::XML_IS_NOT_VALID_MESSAGE);
+                    $messages = array('The XML is not valid.');
                 }
                 throw new \InvalidArgumentException(implode("\n", $messages), 0, $e);
             }
@@ -128,7 +126,7 @@ class XmlUtils
             return static::parse($content, $schemaOrCallable);
         } catch (\InvalidArgumentException $ex) {
             throw new \InvalidArgumentException(
-                str_replace(self::XML_IS_NOT_VALID_MESSAGE, sprintf('The XML file "%s" is not valid.', $file), $ex->getMessage()),
+                str_replace('The XML is not valid.', sprintf('The XML file "%s" is not valid.', $file), $ex->getMessage()),
                 $ex->getCode(),
                 $ex->getPrevious()
             );

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -42,7 +42,7 @@ class XmlUtils
      * @throws \InvalidArgumentException When loading of XML file returns error
      * @throws \RuntimeException         When DOM extension is missing
      */
-    public static function load($content, $schemaOrCallable = null)
+    public static function parse($content, $schemaOrCallable = null)
     {
         if (!extension_loaded('dom')) {
             throw new \RuntimeException('Extension DOM is required.');
@@ -125,7 +125,7 @@ class XmlUtils
         }
 
         try {
-            return static::load($content, $schemaOrCallable);
+            return static::parse($content, $schemaOrCallable);
         } catch (\InvalidArgumentException $ex) {
             throw new \InvalidArgumentException(
                 str_replace(self::XML_IS_NOT_VALID_MESSAGE, sprintf('The XML file "%s" is not valid.', $file), $ex->getMessage()),

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -42,7 +42,7 @@ class XmlUtils
      *
      * @throws \Symfony\Component\Config\Util\Exception\XmlParsingException When parsing of XML file returns error
      * @throws \Symfony\Component\Config\Util\Exception\InvalidXmlException When parsing of XML with schema or callable produces any errors unrelated to the XML parsing itself
-     * @throws \RuntimeException         When DOM extension is missing
+     * @throws \RuntimeException                                            When DOM extension is missing
      */
     public static function parse($content, $schemaOrCallable = null)
     {
@@ -117,8 +117,8 @@ class XmlUtils
      * @return \DOMDocument
      *
      * @throws \InvalidArgumentException                                    When loading of XML file returns error
-     * @throws \Symfony\Component\Config\Util\Exception\XmlParsingException When XML parsing returns any errors.
-     * @throws \RuntimeException         When DOM extension is missing
+     * @throws \Symfony\Component\Config\Util\Exception\XmlParsingException when XML parsing returns any errors
+     * @throws \RuntimeException                                            When DOM extension is missing
      */
     public static function loadFile($file, $schemaOrCallable = null)
     {

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -116,7 +116,7 @@ class XmlUtils
      *
      * @return \DOMDocument
      *
-     * @throws \InvalidArgumentException When loading of XML file returns error
+     * @throws \InvalidArgumentException                                    When loading of XML file returns error
      * @throws \Symfony\Component\Config\Util\Exception\XmlParsingException When XML parsing returns any errors.
      * @throws \RuntimeException         When DOM extension is missing
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

I needed the xml parsing for an XML string generated in memory, so I extracted the actual parsing from XmlUtils::loadFile into XmlUtils::load.

Re-opened after I messed some things up in #23482 