### PR TITLE
[DI] Check privates before resolving alias in Container::initialized

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -366,12 +366,12 @@ class Container implements ResettableContainerInterface
             return false;
         }
 
-        if (isset($this->aliases[$id])) {
-            $id = $this->aliases[$id];
-        }
-
         if (isset($this->privates[$id])) {
             @trigger_error(sprintf('Checking for the initialization of the "%s" private service is deprecated since Symfony 3.4 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
+        }
+
+        if (isset($this->aliases[$id])) {
+            $id = $this->aliases[$id];
         }
 
         return isset($this->services[$id]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no, fixes an existing one
| Tests pass?   | yes, we dont test this behavior :(
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Continuation of #22803, so it's consistent with logic in `has()` etc. 