### PR TITLE
[Workflow] add guard is_valid() method support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/WorkflowGuardListenerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/WorkflowGuardListenerPass.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
 class WorkflowGuardListenerPass implements CompilerPassInterface
 {
@@ -31,20 +32,17 @@ class WorkflowGuardListenerPass implements CompilerPassInterface
 
         $container->getParameterBag()->remove('workflow.has_guard_listeners');
 
-        if (!$container->has('security.token_storage')) {
-            throw new LogicException('The "security.token_storage" service is needed to be able to use the workflow guard listener.');
-        }
+        $servicesNeeded = array(
+            'security.token_storage',
+            'security.authorization_checker',
+            'security.authentication.trust_resolver',
+            'security.role_hierarchy',
+        );
 
-        if (!$container->has('security.authorization_checker')) {
-            throw new LogicException('The "security.authorization_checker" service is needed to be able to use the workflow guard listener.');
-        }
-
-        if (!$container->has('security.authentication.trust_resolver')) {
-            throw new LogicException('The "security.authentication.trust_resolver" service is needed to be able to use the workflow guard listener.');
-        }
-
-        if (!$container->has('security.role_hierarchy')) {
-            throw new LogicException('The "security.role_hierarchy" service is needed to be able to use the workflow guard listener.');
+        foreach ($servicesNeeded as $service) {
+            if (!$container->has($service)) {
+                throw new LogicException(sprintf('The "%s" service is needed to be able to use the workflow guard listener.', $service));
+            }
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -85,6 +85,7 @@ use Symfony\Component\Translation\Command\XliffLintCommand as BaseXliffLintComma
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\ObjectInitializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Symfony\Component\Workflow;
 use Symfony\Component\Yaml\Command\LintCommand as BaseYamlLintCommand;

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -752,6 +752,7 @@ class FrameworkExtension extends Extension
                     new Reference('security.authorization_checker'),
                     new Reference('security.authentication.trust_resolver'),
                     new Reference('security.role_hierarchy'),
+                    new Reference('validator', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 ));
 
                 $container->setDefinition(sprintf('%s.listener.guard', $workflowId), $guard);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/WorkflowGuardListenerPassTest.php
@@ -14,12 +14,11 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\WorkflowGuardListenerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
-use Symfony\Component\Workflow\EventListener\GuardListener;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class WorkflowGuardListenerPassTest extends TestCase
 {
@@ -29,53 +28,37 @@ class WorkflowGuardListenerPassTest extends TestCase
     protected function setUp()
     {
         $this->container = new ContainerBuilder();
-        $this->container->register('foo.listener.guard', GuardListener::class);
-        $this->container->register('bar.listener.guard', GuardListener::class);
         $this->compilerPass = new WorkflowGuardListenerPass();
     }
 
-    public function testListenersAreNotRemovedIfParameterIsNotSet()
+    public function testNoExeptionIfParameterIsNotSet()
     {
         $this->compilerPass->process($this->container);
-
-        $this->assertTrue($this->container->hasDefinition('foo.listener.guard'));
-        $this->assertTrue($this->container->hasDefinition('bar.listener.guard'));
-    }
-
-    public function testParameterIsRemovedWhenThePassIsProcessed()
-    {
-        $this->container->setParameter('workflow.has_guard_listeners', array('foo.listener.guard', 'bar.listener.guard'));
-
-        try {
-            $this->compilerPass->process($this->container);
-        } catch (LogicException $e) {
-            // Here, we are not interested in the exception handling. This is tested further down.
-        }
 
         $this->assertFalse($this->container->hasParameter('workflow.has_guard_listeners'));
     }
 
-    public function testListenersAreNotRemovedIfAllDependenciesArePresent()
+    public function testNoExeptionIfAllDependenciesArePresent()
     {
-        $this->container->setParameter('workflow.has_guard_listeners', array('foo.listener.guard', 'bar.listener.guard'));
+        $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);
         $this->container->register('security.authentication.trust_resolver', AuthenticationTrustResolverInterface::class);
         $this->container->register('security.role_hierarchy', RoleHierarchy::class);
+        $this->container->register('validator', ValidatorInterface::class);
 
         $this->compilerPass->process($this->container);
 
-        $this->assertTrue($this->container->hasDefinition('foo.listener.guard'));
-        $this->assertTrue($this->container->hasDefinition('bar.listener.guard'));
+        $this->assertFalse($this->container->hasParameter('workflow.has_guard_listeners'));
     }
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
      * @expectedExceptionMessage The "security.token_storage" service is needed to be able to use the workflow guard listener.
      */
-    public function testListenersAreRemovedIfTheTokenStorageServiceIsNotPresent()
+    public function testExceptionIfTheTokenStorageServiceIsNotPresent()
     {
-        $this->container->setParameter('workflow.has_guard_listeners', array('foo.listener.guard', 'bar.listener.guard'));
+        $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);
         $this->container->register('security.authentication.trust_resolver', AuthenticationTrustResolverInterface::class);
         $this->container->register('security.role_hierarchy', RoleHierarchy::class);
@@ -87,9 +70,9 @@ class WorkflowGuardListenerPassTest extends TestCase
      * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
      * @expectedExceptionMessage The "security.authorization_checker" service is needed to be able to use the workflow guard listener.
      */
-    public function testListenersAreRemovedIfTheAuthorizationCheckerServiceIsNotPresent()
+    public function testExceptionIfTheAuthorizationCheckerServiceIsNotPresent()
     {
-        $this->container->setParameter('workflow.has_guard_listeners', array('foo.listener.guard', 'bar.listener.guard'));
+        $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authentication.trust_resolver', AuthenticationTrustResolverInterface::class);
         $this->container->register('security.role_hierarchy', RoleHierarchy::class);
@@ -101,9 +84,9 @@ class WorkflowGuardListenerPassTest extends TestCase
      * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
      * @expectedExceptionMessage The "security.authentication.trust_resolver" service is needed to be able to use the workflow guard listener.
      */
-    public function testListenersAreRemovedIfTheAuthenticationTrustResolverServiceIsNotPresent()
+    public function testExceptionIfTheAuthenticationTrustResolverServiceIsNotPresent()
     {
-        $this->container->setParameter('workflow.has_guard_listeners', array('foo.listener.guard', 'bar.listener.guard'));
+        $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);
         $this->container->register('security.role_hierarchy', RoleHierarchy::class);
@@ -115,9 +98,9 @@ class WorkflowGuardListenerPassTest extends TestCase
      * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
      * @expectedExceptionMessage The "security.role_hierarchy" service is needed to be able to use the workflow guard listener.
      */
-    public function testListenersAreRemovedIfTheRoleHierarchyServiceIsNotPresent()
+    public function testExceptionIfTheRoleHierarchyServiceIsNotPresent()
     {
-        $this->container->setParameter('workflow.has_guard_listeners', array('foo.listener.guard', 'bar.listener.guard'));
+        $this->container->setParameter('workflow.has_guard_listeners', true);
         $this->container->register('security.token_storage', TokenStorageInterface::class);
         $this->container->register('security.authorization_checker', AuthorizationCheckerInterface::class);
         $this->container->register('security.authentication.trust_resolver', AuthenticationTrustResolverInterface::class);

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
- * Add guard `is_valid()` method support
+ * Added guard `is_valid()` method support.
  * Added support for `Event::getWorkflowName()` for "announce" events.
  * Added `workflow.completed` events which are fired after a transition is completed.
 

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
+ * Add guard `is_valid()` method support
  * Added support for `Event::getWorkflowName()` for "announce" events.
  * Added `workflow.completed` events which are fired after a transition is completed.
 

--- a/src/Symfony/Component/Workflow/EventListener/ExpressionLanguage.php
+++ b/src/Symfony/Component/Workflow/EventListener/ExpressionLanguage.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Workflow\EventListener;
 
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage as BaseExpressionLanguage;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Workflow\Exception\RuntimeException;
 
 /**
  * Adds some function to the default Symfony Security ExpressionLanguage.
@@ -28,6 +30,18 @@ class ExpressionLanguage extends BaseExpressionLanguage
             return sprintf('$auth_checker->isGranted(%s, %s)', $attributes, $object);
         }, function (array $variables, $attributes, $object = null) {
             return $variables['auth_checker']->isGranted($attributes, $object);
+        });
+
+        $this->register('is_valid', function ($object = 'null', $groups = 'null') {
+            return sprintf('0 === count($validator->validate(%s, null, %s))', $object, $groups);
+        }, function (array $variables, $object = null, $groups = null) {
+            if (!$variables['validator'] instanceof ValidatorInterface) {
+                throw new RuntimeException('Validator not defined, did you install the component?');
+            }
+
+            $errors = $variables['validator']->validate($object, null, $groups);
+
+            return 0 === count($errors);
         });
     }
 }

--- a/src/Symfony/Component/Workflow/EventListener/ExpressionLanguage.php
+++ b/src/Symfony/Component/Workflow/EventListener/ExpressionLanguage.php
@@ -36,7 +36,7 @@ class ExpressionLanguage extends BaseExpressionLanguage
             return sprintf('0 === count($validator->validate(%s, null, %s))', $object, $groups);
         }, function (array $variables, $object = null, $groups = null) {
             if (!$variables['validator'] instanceof ValidatorInterface) {
-                throw new RuntimeException('Validator not defined, did you install the component?');
+                throw new RuntimeException('"is_valid" cannot be used as the Validator component is not installed.');
             }
 
             $errors = $variables['validator']->validate($object, null, $groups);

--- a/src/Symfony/Component/Workflow/EventListener/GuardListener.php
+++ b/src/Symfony/Component/Workflow/EventListener/GuardListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverIn
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Workflow\Event\GuardEvent;
 
 /**
@@ -28,8 +29,9 @@ class GuardListener
     private $authenticationChecker;
     private $trustResolver;
     private $roleHierarchy;
+    private $validator;
 
-    public function __construct($configuration, ExpressionLanguage $expressionLanguage, TokenStorageInterface $tokenStorage, AuthorizationCheckerInterface $authenticationChecker, AuthenticationTrustResolverInterface $trustResolver, RoleHierarchyInterface $roleHierarchy = null)
+    public function __construct($configuration, ExpressionLanguage $expressionLanguage, TokenStorageInterface $tokenStorage, AuthorizationCheckerInterface $authenticationChecker, AuthenticationTrustResolverInterface $trustResolver, RoleHierarchyInterface $roleHierarchy = null, ValidatorInterface $validator = null)
     {
         $this->configuration = $configuration;
         $this->expressionLanguage = $expressionLanguage;
@@ -37,6 +39,7 @@ class GuardListener
         $this->authenticationChecker = $authenticationChecker;
         $this->trustResolver = $trustResolver;
         $this->roleHierarchy = $roleHierarchy;
+        $this->validator = $validator;
     }
 
     public function onTransition(GuardEvent $event, $eventName)
@@ -72,6 +75,8 @@ class GuardListener
             'auth_checker' => $this->authenticationChecker,
             // needed for the is_* expression function
             'trust_resolver' => $this->trustResolver,
+            // needed for the is_valid expression function
+            'validator' => $this->validator,
         );
 
         return $variables;

--- a/src/Symfony/Component/Workflow/Exception/RuntimeException.php
+++ b/src/Symfony/Component/Workflow/Exception/RuntimeException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Exception;
+
+/**
+ * Base RuntimeException for the Workflow component.
+ *
+ * @author Alain Flaus <alain.flaus@gmail.com>
+ */
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -28,7 +28,8 @@
         "symfony/dependency-injection": "~2.8|~3.0|~4.0",
         "symfony/event-dispatcher": "~2.1|~3.0|~4.0",
         "symfony/expression-language": "~2.8|~3.0|~4.0",
-        "symfony/security-core": "~2.8|~3.0|~4.0"
+        "symfony/security-core": "~2.8|~3.0|~4.0",
+        "symfony/validator": "~2.8|~3.4|~4.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Workflow\\": "" }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | Yes
| License       | MIT

Workflow guard configuration support expression language like **is_fully_authenticated()**, **has_role()** or **is_granted()**, etc...
I would like to add the support for a new **is_valid()** expression. 
Configuration allow to validate subject against specific validation groups to check if a transition can be applied.

In the next configuration exemple, my issue must validate "affectable" validation group to apply "affect" transistion:

```yaml
framework:
    workflows:
        issue:
            marking_store:
                type: single_state
                arguments:
                    - state
            supports: AppBundle\Entity\Issue
            initial_place: created
            places:
                - created
                - affected
                - closed
            transitions:
                affect:
                    guard: "is_valid(subject, ['affectable'])"
                    from: created
                    to:   affected
                close:
                    from: completed
                    to: closed
```
