### PR TITLE
[Security] validate empty passwords again

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
@@ -91,6 +91,29 @@ abstract class UserPasswordValidatorTest extends AbstractConstraintValidatorTest
     }
 
     /**
+     * @dataProvider emptyPasswordData
+     */
+    public function testEmptyPasswordsAreNotValid($password)
+    {
+        $constraint = new UserPassword(array(
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate($password, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->assertRaised();
+    }
+
+    public function emptyPasswordData()
+    {
+        return array(
+            array(null),
+            array(''),
+        );
+    }
+
+    /**
      * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
      */
     public function testUserIsNotValid()

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -40,6 +40,8 @@ class UserPasswordValidator extends ConstraintValidator
         }
 
         if (null === $password || '' === $password) {
+            $this->context->addViolation($constraint->message);
+
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/23341#issuecomment-315341226
| License       | MIT
| Doc PR        | 

It looks like this part of #23341 causes serious security issues for some users who rely on the validator to also compare the empty string with their user's password (see for example https://github.com/symfony/symfony/pull/23341#issuecomment-315341226). Thus I suggest to revert this part of #23341.