### PR TITLE
[VarDumper] Added setMinDepth to VarCloner

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * added `AbstractCloner::setMinDepth()` function to ensure minimum tree depth
+
 2.7.0
 -----
 

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -129,6 +129,7 @@ abstract class AbstractCloner implements ClonerInterface
 
     protected $maxItems = 2500;
     protected $maxString = -1;
+    protected $minDepth = 1;
     protected $useExt;
 
     private $casters = array();
@@ -168,7 +169,7 @@ abstract class AbstractCloner implements ClonerInterface
     }
 
     /**
-     * Sets the maximum number of items to clone past the first level in nested structures.
+     * Sets the maximum number of items to clone past the minimum depth in nested structures.
      *
      * @param int $maxItems
      */
@@ -185,6 +186,17 @@ abstract class AbstractCloner implements ClonerInterface
     public function setMaxString($maxString)
     {
         $this->maxString = (int) $maxString;
+    }
+
+    /**
+     * Sets the minimum tree depth where we are guaranteed to clone all the items.  After this
+     * depth is reached, only setMaxItems items will be cloned.
+     *
+     * @param int $minDepth
+     */
+    public function setMinDepth($minDepth)
+    {
+        $this->minDepth = (int) $minDepth;
     }
 
     /**

--- a/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
@@ -156,6 +156,261 @@ EOTXT;
         $this->assertStringMatchesFormat($expected, print_r($clone, true));
     }
 
+    public function testLimits()
+    {
+        // Level 0:
+        $data = array(
+            // Level 1:
+            array(
+                // Level 2:
+                array(
+                    // Level 3:
+                    'Level 3 Item 0',
+                    'Level 3 Item 1',
+                    'Level 3 Item 2',
+                    'Level 3 Item 3',
+                ),
+                array(
+                    'Level 3 Item 4',
+                    'Level 3 Item 5',
+                    'Level 3 Item 6',
+                ),
+                array(
+                    'Level 3 Item 7',
+                ),
+            ),
+            array(
+                array(
+                    'Level 3 Item 8',
+                ),
+                'Level 2 Item 0',
+            ),
+            array(
+                'Level 2 Item 1',
+            ),
+            'Level 1 Item 0',
+            array(
+                // Test setMaxString:
+                'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+                'SHORT',
+            ),
+        );
+
+        $cloner = new VarCloner();
+        $cloner->setMinDepth(2);
+        $cloner->setMaxItems(5);
+        $cloner->setMaxString(20);
+        $clone = $cloner->cloneVar($data);
+
+        $expected = <<<EOTXT
+Symfony\Component\VarDumper\Cloner\Data Object
+(
+    [data:Symfony\Component\VarDumper\Cloner\Data:private] => Array
+        (
+            [0] => Array
+                (
+                    [0] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => array
+                            [class] => indexed
+                            [value] => 5
+                            [cut] => 0
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 1
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                )
+
+            [1] => Array
+                (
+                    [0] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => array
+                            [class] => indexed
+                            [value] => 3
+                            [cut] => 0
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 2
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                    [1] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => array
+                            [class] => indexed
+                            [value] => 2
+                            [cut] => 0
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 3
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                    [2] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => array
+                            [class] => indexed
+                            [value] => 1
+                            [cut] => 0
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 4
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                    [3] => Level 1 Item 0
+                    [4] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => array
+                            [class] => indexed
+                            [value] => 2
+                            [cut] => 0
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 5
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                )
+
+            [2] => Array
+                (
+                    [0] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => array
+                            [class] => indexed
+                            [value] => 4
+                            [cut] => 0
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 6
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                    [1] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => array
+                            [class] => indexed
+                            [value] => 3
+                            [cut] => 2
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 7
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                    [2] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => array
+                            [class] => assoc
+                            [value] => 1
+                            [cut] => 1
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 0
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                )
+
+            [3] => Array
+                (
+                    [0] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => array
+                            [class] => assoc
+                            [value] => 1
+                            [cut] => 1
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 0
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                    [1] => Level 2 Item 0
+                )
+
+            [4] => Array
+                (
+                    [0] => Level 2 Item 1
+                )
+
+            [5] => Array
+                (
+                    [0] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => string
+                            [class] => utf8
+                            [value] => ABCDEFGHIJKLMNOPQRST
+                            [cut] => 6
+                            [handle] => 0
+                            [refCount] => 0
+                            [position] => 0
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                    [1] => SHORT
+                )
+
+            [6] => Array
+                (
+                    [0] => Level 3 Item 0
+                    [1] => Level 3 Item 1
+                    [2] => Level 3 Item 2
+                    [3] => Level 3 Item 3
+                )
+
+            [7] => Array
+                (
+                    [0] => Level 3 Item 4
+                )
+
+        )
+
+    [position:Symfony\Component\VarDumper\Cloner\Data:private] => 0
+    [key:Symfony\Component\VarDumper\Cloner\Data:private] => 0
+    [maxDepth:Symfony\Component\VarDumper\Cloner\Data:private] => 20
+    [maxItemsPerDepth:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+    [useRefHandles:Symfony\Component\VarDumper\Cloner\Data:private] => -1
+)
+
+EOTXT;
+        $this->assertStringMatchesFormat($expected, print_r($clone, true));
+    }
+
     public function testJsonCast()
     {
         if (ini_get('xdebug.overload_var_dump') == 2) {


### PR DESCRIPTION
This new function allows VarCloner users to specify a minimum tree
depth that must be fully explored before we start limiting the number of
cloned items via the existing setMaxItems functionality.

It’s useful for dumping arguments from a backtrace to ensure some
minimum level of detail, while keeping a very low setMaxItems value to
ensure fast performance at the deeper levels.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#8155 <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
