### PR TITLE
[Profiler] Fix data collector getCasters() call

### DIFF
--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -16,7 +16,6 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
-use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Caster\ClassStub;
@@ -67,11 +66,6 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
      * @var array
      */
     private $formsByView;
-
-    /**
-     * @var ValueExporter
-     */
-    private $valueExporter;
 
     private $hasVarDumper;
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -69,7 +69,7 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
             if (class_exists(CutStub::class)) {
                 $this->cloner = new VarCloner();
                 $this->cloner->setMaxItems(-1);
-                $this->cloner->addCasters(self::getCasters());
+                $this->cloner->addCasters($this->getCasters());
             } else {
                 @trigger_error(sprintf('Using the %s() method without the VarDumper component is deprecated since version 3.2 and won\'t be supported in 4.0. Install symfony/var-dumper version 3.2 or above.', __METHOD__), E_USER_DEPRECATED);
                 $this->cloner = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Relates to https://github.com/symfony/symfony/pull/23465. Calling `DataCollector::getCasters()` using self results into overridden methods in child classes never been called.

Also removes an unused property.