### PR TITLE
[Profiler][Validator] ValidatorDataCollector: use new DataCollector::getCasters() method

### DIFF
--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -22,8 +22,8 @@
     },
     "require-dev": {
         "symfony/http-foundation": "~2.8|~3.0|~4.0",
-        "symfony/http-kernel": "~2.8|~3.0|~4.0.0",
-        "symfony/var-dumper": "~3.3|~4.0.0",
+        "symfony/http-kernel": "^3.3.5|~4.0",
+        "symfony/var-dumper": "~3.3|~4.0",
         "symfony/intl": "^2.8.18|^3.2.5|~4.0",
         "symfony/yaml": "~3.3|~4.0",
         "symfony/config": "~2.8|~3.0|~4.0",
@@ -38,6 +38,7 @@
     "conflict": {
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
         "symfony/dependency-injection": "<3.3",
+        "symfony/http-kernel": "<3.3.5",
         "symfony/yaml": "<3.3"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/23465#discussion_r126382240 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

~~First commit targets 3.3; see https://github.com/symfony/symfony/pull/23516.~~

I didn't re-used the `ConstraintViolationInterface` caster used in the form collector, as it's the purpose of the validator collector to show the constraints data.