### PR TITLE
[SecurityBundle] Clarify deprecation in UserPasswordEncoderCommand::getContainer

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -443,7 +443,7 @@ SecurityBundle
 
  * The `UserPasswordEncoderCommand` class does not allow `null` as the first argument anymore.
 
- * `UserPasswordEncoderCommand` does not implement `ContainerAwareInterface` anymore.
+ * `UserPasswordEncoderCommand` does not extend `ContainerAwareCommand` nor implement `ContainerAwareInterface` anymore.
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Deprecated instantiating `UserPasswordEncoderCommand` without its constructor
    arguments fully provided.
  * Deprecated `UserPasswordEncoderCommand::getContainer()` and relying on the
-  `ContainerAwareInterface` interface for this command.
+  `ContainerAwareCommand` sub class or `ContainerAwareInterface` implementation for this command.
  * Deprecated the `FirewallMap::$map` and `$container` properties.
  * [BC BREAK] Keys of the `users` node for `in_memory` user provider are no longer normalized.
  * deprecated `FirewallContext::getListeners()`

--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -51,7 +51,7 @@ class UserPasswordEncoderCommand extends ContainerAwareCommand
      */
     protected function getContainer()
     {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.3 and "%s" won\'t implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareInterface::class), E_USER_DEPRECATED);
+        @trigger_error(sprintf('Method "%s" is deprecated since version 3.3 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
 
         return parent::getContainer();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

@ogizanagi in 4.0 it will simply extend `Command` right.. wdyt?

Also we dont deprecate `setContainer` is that intentional?