### PR TITLE
[HttpFoundation] Set meta refresh time to 0 in RedirectResponse content

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -87,7 +87,7 @@ class RedirectResponse extends Response
 <html>
     <head>
         <meta charset="UTF-8" />
-        <meta http-equiv="refresh" content="1;url=%1$s" />
+        <meta http-equiv="refresh" content="0;url=%1$s" />
 
         <title>Redirecting to %1$s</title>
     </head>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23524
| License       | MIT

Set meta refresh time to 0 in RedirectResponse content