### PR TITLE
[Console] Application is not responsible for setting the name of lazy commands

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -466,7 +466,6 @@ class Application
             $command = $this->commands[$name];
         } elseif ($this->commandLoader && $this->commandLoader->has($name)) {
             $command = $this->commandLoader->get($name);
-            $command->setName($name);
             $this->add($command);
         } else {
             throw new CommandNotFoundException(sprintf('The command "%s" does not exist.', $name));
@@ -647,7 +646,7 @@ class Application
             $commands = $this->commands;
             foreach ($this->commandLoader->getNames() as $name) {
                 if (!isset($commands[$name])) {
-                    $commands[$name] = $this->commandLoader->get($name);
+                    $commands[$name] = $this->get($name);
                 }
             }
 
@@ -664,7 +663,7 @@ class Application
         if ($this->commandLoader) {
             foreach ($this->commandLoader->getNames() as $name) {
                 if (!isset($commands[$name]) && $namespace === $this->extractNamespace($name, substr_count($namespace, ':') + 1)) {
-                    $commands[$name] = $this->commandLoader->get($name);
+                    $commands[$name] = $this->get($name);
                 }
             }
         }

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -87,6 +87,8 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 }
             }
 
+            $definition->addMethodCall('setName', array($commandName));
+
             if ($aliases) {
                 $definition->addMethodCall('setAliases', array($aliases));
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Fixes `all` not calling `get()` for lazy commands and stop setting the command name from Application (the command loader is responsible for returning valid commands).