### PR TITLE
[Security] Add InteractiveLoginFailureEvent

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Using voters that do not implement the `VoterInterface`is now deprecated in
    the `AccessDecisionManager` and this functionality will be removed in 4.0.
+ * Added `InteractiveLoginFailure` event
 
 3.3.0
 -----

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationFailureEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationFailureEvent.php
@@ -23,11 +23,11 @@ class AuthenticationFailureEvent extends AuthenticationEvent
 {
     private $authenticationException;
 
-    public function __construct(TokenInterface $token, AuthenticationException $ex)
+    public function __construct(TokenInterface $token, AuthenticationException $authenticationException)
     {
         parent::__construct($token);
 
-        $this->authenticationException = $ex;
+        $this->authenticationException = $authenticationException;
     }
 
     public function getAuthenticationException()

--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
@@ -20,6 +20,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\Event\InteractiveLoginFailureEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 
 /**
@@ -122,6 +123,10 @@ class GuardAuthenticatorHandler
         $token = $this->tokenStorage->getToken();
         if ($token instanceof PostAuthenticationGuardToken && $providerKey === $token->getProviderKey()) {
             $this->tokenStorage->setToken(null);
+        }
+
+        if (null !== $this->dispatcher) {
+            $this->dispatcher->dispatch(SecurityEvents::INTERACTIVE_LOGIN_FAILURE, new InteractiveLoginFailureEvent($request, $authenticationException));
         }
 
         $response = $guardAuthenticator->onAuthenticationFailure($request, $authenticationException);

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -14,9 +14,10 @@ namespace Symfony\Component\Security\Guard\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\Event\InteractiveLoginFailureEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 
 class GuardAuthenticatorHandlerTest extends TestCase
@@ -72,6 +73,12 @@ class GuardAuthenticatorHandlerTest extends TestCase
             ->method('onAuthenticationFailure')
             ->with($this->request, $authException)
             ->will($this->returnValue($response));
+
+        $loginFailureEvent = new InteractiveLoginFailureEvent($this->request, $authException);
+        $this->dispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->equalTo(SecurityEvents::INTERACTIVE_LOGIN_FAILURE), $this->equalTo($loginFailureEvent));
 
         $handler = new GuardAuthenticatorHandler($this->tokenStorage, $this->dispatcher);
         $actualResponse = $handler->handleAuthenticationFailure($authException, $this->request, $this->guardAuthenticator, 'firewall_provider_key');

--- a/src/Symfony/Component/Security/Guard/composer.json
+++ b/src/Symfony/Component/Security/Guard/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/security-core": "~2.8|~3.0|~4.0",
-        "symfony/security-http": "~3.1|~4.0"
+        "symfony/security-http": "~3.4|~4.0"
     },
     "require-dev": {
         "psr/log": "~1.0"

--- a/src/Symfony/Component/Security/Http/Event/InteractiveLoginFailureEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/InteractiveLoginFailureEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * @author Gabriel Ostrolucký <gabriel.ostrolucky@gmail.com>
+ */
+class InteractiveLoginFailureEvent extends Event
+{
+    private $request;
+    private $authenticationException;
+
+    /**
+     * @param Request                 $request
+     * @param AuthenticationException $authenticationException
+     */
+    public function __construct(Request $request, AuthenticationException $authenticationException)
+    {
+        $this->request = $request;
+        $this->authenticationException = $authenticationException;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @return AuthenticationException
+     */
+    public function getAuthenticationException()
+    {
+        return $this->authenticationException;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Symfony\Component\Security\Http\Event\InteractiveLoginFailureEvent;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
@@ -199,6 +200,10 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
         $token = $this->tokenStorage->getToken();
         if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey()) {
             $this->tokenStorage->setToken(null);
+        }
+
+        if (null !== $this->dispatcher) {
+            $this->dispatcher->dispatch(SecurityEvents::INTERACTIVE_LOGIN_FAILURE, new InteractiveLoginFailureEvent($request, $failed));
         }
 
         $response = $this->failureHandler->onAuthenticationFailure($request, $failed);

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\Event\InteractiveLoginFailureEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Psr\Log\LoggerInterface;
@@ -92,6 +93,9 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             }
         } catch (AuthenticationException $e) {
             $this->clearToken($e);
+            if (null !== $this->dispatcher) {
+                $this->dispatcher->dispatch(SecurityEvents::INTERACTIVE_LOGIN_FAILURE, new InteractiveLoginFailureEvent($request, $e));
+            }
         }
     }
 

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Event\InteractiveLoginFailureEvent;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
@@ -98,6 +99,10 @@ class RememberMeListener implements ListenerInterface
                    .' AuthenticationManager rejected the AuthenticationToken returned'
                    .' by the RememberMeServices.', array('exception' => $e)
                 );
+            }
+
+            if (null !== $this->dispatcher) {
+                $this->dispatcher->dispatch(SecurityEvents::INTERACTIVE_LOGIN_FAILURE, new InteractiveLoginFailureEvent($request, $e));
             }
 
             $this->rememberMeServices->loginFail($request, $e);

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -31,6 +31,7 @@ use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\Event\InteractiveLoginFailureEvent;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\SecurityEvents;
 
@@ -170,6 +171,10 @@ class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
         $token = $this->tokenStorage->getToken();
         if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey()) {
             $this->tokenStorage->setToken(null);
+        }
+
+        if (null !== $this->eventDispatcher) {
+            $this->eventDispatcher->dispatch(SecurityEvents::INTERACTIVE_LOGIN_FAILURE, new InteractiveLoginFailureEvent($request, $failed));
         }
 
         if (!$this->failureHandler) {

--- a/src/Symfony/Component/Security/Http/SecurityEvents.php
+++ b/src/Symfony/Component/Security/Http/SecurityEvents.php
@@ -24,6 +24,16 @@ final class SecurityEvents
     const INTERACTIVE_LOGIN = 'security.interactive_login';
 
     /**
+     * The INTERACTIVE_LOGIN_FAILURE event occurs after a user fails to log in
+     * interactively for authentication based on http, cookies or X509.
+     *
+     * @Event("Symfony\Component\Security\Http\Event\InteractiveLoginFailureEvent")
+     *
+     * @var string
+     */
+    const INTERACTIVE_LOGIN_FAILURE = 'security.interactive_login_failure';
+
+    /**
      * The SWITCH_USER event occurs before switch to another user and
      * before exit from an already switched user.
      *

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\Event\InteractiveLoginFailureEvent;
 use Symfony\Component\Security\Http\Firewall\SimplePreAuthenticationListener;
 use Symfony\Component\Security\Http\SecurityEvents;
 
@@ -86,6 +87,14 @@ class SimplePreAuthenticationListenerTest extends TestCase
             ->method('createToken')
             ->with($this->equalTo($this->request), $this->equalTo('secured_area'))
             ->will($this->returnValue($this->token))
+        ;
+
+        $loginFailureEvent = new InteractiveLoginFailureEvent($this->request, $exception);
+
+        $this->dispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->equalTo(SecurityEvents::INTERACTIVE_LOGIN_FAILURE), $this->equalTo($loginFailureEvent))
         ;
 
         $listener = new SimplePreAuthenticationListener($this->tokenStorage, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21427
| License       | MIT
| Doc PR        | -

I believe logging IP addresses/other informations from request upon login failure is common enough use case to warrant new event. It will also make current events more consistent.