### PR TITLE
Make server:* commands work out of the box with the public/ root dir

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
@@ -97,12 +97,6 @@ EOF
             $documentRoot = $this->documentRoot;
         }
 
-        if (!is_dir($documentRoot)) {
-            $io->error(sprintf('The document root directory "%s" does not exist.', $documentRoot));
-
-            return 1;
-        }
-
         if (!$env = $this->environment) {
             if ($input->hasOption('env') && !$env = $input->getOption('env')) {
                 $io->error('The environment must be either passed as second argument of the constructor or through the "--env" input option.');

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
@@ -88,6 +88,12 @@ EOF
     {
         $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
 
+        // deprecated, logic to be removed in 4.0
+        // this allows the commands to work out of the box with web/ and public/
+        if ($this->documentRoot && !is_dir($this->documentRoot) && is_dir(dirname($this->documentRoot).'/web')) {
+            $this->documentRoot = dirname($this->documentRoot).'/web';
+        }
+
         if (null === $documentRoot = $input->getOption('docroot')) {
             if (!$this->documentRoot) {
                 $io->error('The document root directory must be either passed as first argument of the constructor or through the "--docroot" input option.');

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -100,6 +100,12 @@ EOF
             return 1;
         }
 
+        // deprecated, logic to be removed in 4.0
+        // this allows the commands to work out of the box with web/ and public/
+        if ($this->documentRoot && !is_dir($this->documentRoot) && is_dir(dirname($this->documentRoot).'/web')) {
+            $this->documentRoot = dirname($this->documentRoot).'/web';
+        }
+
         if (null === $documentRoot = $input->getOption('docroot')) {
             if (!$this->documentRoot) {
                 $io->error('The document root directory must be either passed as first argument of the constructor or through the "docroot" input option.');

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -109,12 +109,6 @@ EOF
             $documentRoot = $this->documentRoot;
         }
 
-        if (!is_dir($documentRoot)) {
-            $io->error(sprintf('The document root directory "%s" does not exist.', $documentRoot));
-
-            return 1;
-        }
-
         if (!$env = $this->environment) {
             if ($input->hasOption('env') && !$env = $input->getOption('env')) {
                 $io->error('The environment must be either passed as second argument of the constructor or through the "--env" input option.');

--- a/src/Symfony/Bundle/WebServerBundle/Resources/config/webserver.xml
+++ b/src/Symfony/Bundle/WebServerBundle/Resources/config/webserver.xml
@@ -8,13 +8,13 @@
         <defaults public="false" />
 
         <service id="web_server.command.server_run" class="Symfony\Bundle\WebServerBundle\Command\ServerRunCommand">
-            <argument>%kernel.project_dir%/web</argument>
+            <argument>%kernel.project_dir%/public</argument>
             <argument>%kernel.environment%</argument>
             <tag name="console.command" />
         </service>
 
         <service id="web_server.command.server_start" class="Symfony\Bundle\WebServerBundle\Command\ServerStartCommand">
-            <argument>%kernel.project_dir%/web</argument>
+            <argument>%kernel.project_dir%/public</argument>
             <argument>%kernel.environment%</argument>
             <tag name="console.command" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The first commit removes code that is not needed as the WebserverConfig class already throws the exact same error and the display is exactly the same in that case.

The second commit adds support for `public/` along side `web/`.

