### PR TITLE
[Yaml] Add Yaml::parseFile()

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -9,6 +9,20 @@ CHANGELOG
  * Deprecated using the non-specific tag `!` as its behavior will change in 4.0.
    It will force non-evaluating your values in 4.0. Use plain integers or `!!float` instead.
 
+ * Added `Yaml::parseFile`:
+ 
+   Before:
+   
+   ```php
+   Yaml::parse(file_get_contents($path));
+   ```
+   
+   After:
+   
+   ```php
+   Yaml::parseFile($path);
+   ```
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Yaml/Tests/YamlTest.php
+++ b/src/Symfony/Component/Yaml/Tests/YamlTest.php
@@ -41,4 +41,19 @@ class YamlTest extends TestCase
     {
         Yaml::dump(array('lorem' => 'ipsum', 'dolor' => 'sit'), 2, -4);
     }
+
+    public function testParseFile()
+    {
+        $path = __DIR__.'/Fixtures/booleanMappingKeys.yml';
+        $this->assertEquals(Yaml::parse(file_get_contents($path)), Yaml::parseFile($path));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     * @expectedExceptionMessage file is not readable.
+     */
+    public function testParseFileException()
+    {
+        Yaml::parseFile('file/which/does/not/exist.yml');
+    }
 }

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -83,6 +83,23 @@ class Yaml
     }
 
     /**
+     * Parses YAML file into a PHP value.
+     *
+     * @param string $filePath A path to a file containing YAML
+     * @param int    $flags    A bit field of PARSE_* constants to customize the YAML parser behavior
+     *
+     * @return mixed The YAML converted to a PHP value
+     */
+    public static function parseFile($filePath, $flags = 0)
+    {
+        if (is_file($filePath) && is_readable($filePath)) {
+            return static::parse(file_get_contents($filePath), $flags);
+        }
+
+        throw new ParseException(sprintf('Unable to parse "%s" as the file is not readable.', $filePath));
+    }
+
+    /**
      * Dumps a PHP value to a YAML string.
      *
      * The dump method, when supplied with an array, will do its best


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I didn't manage to find explanation why was this functionality removed from Symfony 3, but I assume it was only because of SRP violation in Yaml::parse. I think loading Yaml from file is more common usage of this Facade than loading it from string though and such method should be here.