### PR TITLE
[Console] Set an empty msg as default with writeln()

### DIFF
--- a/src/Symfony/Component/Console/Output/NullOutput.php
+++ b/src/Symfony/Component/Console/Output/NullOutput.php
@@ -108,8 +108,12 @@ class NullOutput implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function writeln($messages, $options = self::OUTPUT_NORMAL)
+    public function writeln($messages /* = '' */, $options = self::OUTPUT_NORMAL)
     {
+        if (func_num_args() === 1 && '' === $messages) {
+            @trigger_error('Passing an empty message to write a newline is deprecated since version 3.4 because the default argument value will be an empty string in 4.0.', E_USER_DEPRECATED);
+        }
+
         // do nothing
     }
 

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -129,8 +129,12 @@ abstract class Output implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function writeln($messages, $options = self::OUTPUT_NORMAL)
+    public function writeln($messages /* = '' */, $options = self::OUTPUT_NORMAL)
     {
+        if (func_num_args() === 1 && '' === $messages) {
+            @trigger_error('Passing an empty message to write a newline is deprecated since version 3.4 because the default argument value will be an empty string in 4.0.', E_USER_DEPRECATED);
+        }
+
         $this->write($messages, true, $options);
     }
 

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -45,7 +45,7 @@ interface OutputInterface
      * @param string|array $messages The message as an array of lines of a single string
      * @param int          $options  A bitmask of options (one of the OUTPUT or VERBOSITY constants), 0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
      */
-    public function writeln($messages, $options = 0);
+    public function writeln($messages /* = '' */, $options = 0);
 
     /**
      * Sets the verbosity of the output.

--- a/src/Symfony/Component/Console/Style/OutputStyle.php
+++ b/src/Symfony/Component/Console/Style/OutputStyle.php
@@ -62,7 +62,7 @@ abstract class OutputStyle implements OutputInterface, StyleInterface
     /**
      * {@inheritdoc}
      */
-    public function writeln($messages, $type = self::OUTPUT_NORMAL)
+    public function writeln($messages /* = '' */, $type = self::OUTPUT_NORMAL)
     {
         $this->output->writeln($messages, $type);
     }

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -310,7 +310,7 @@ class SymfonyStyle extends OutputStyle
     /**
      * {@inheritdoc}
      */
-    public function writeln($messages, $type = self::OUTPUT_NORMAL)
+    public function writeln($messages /* = '' */, $type = self::OUTPUT_NORMAL)
     {
         parent::writeln($messages, $type);
         $this->bufferedOutput->writeln($this->reduceBuffer($messages), $type);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

The easiest way to write a new line is to write an empty line, like pressing the Enter key. I propose to set empty message ``''`` as default value. It's similar to [``System.out.println()``](https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#println--) in Java which allows a call without argument.

```php
// before
$output->writeln('');

// after
$output->writeln();
```