### PR TITLE
[DI] Reintroduce !service_locator in favor of !iterator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/RewindableGenerator.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/RewindableGenerator.php
@@ -11,22 +11,41 @@
 
 namespace Symfony\Component\DependencyInjection\Argument;
 
+use Psr\Container\ContainerInterface;
+
 /**
  * @internal
  */
-class RewindableGenerator implements \IteratorAggregate, \Countable
+class RewindableGenerator implements ContainerInterface, \IteratorAggregate, \Countable
 {
+    private $factory;
     private $generator;
     private $count;
 
     /**
+     * @param callable     $factory
      * @param callable     $generator
      * @param int|callable $count
      */
-    public function __construct(callable $generator, $count)
+    public function __construct(callable $factory, callable $generator, $count)
     {
+        $this->factory = $factory;
         $this->generator = $generator;
         $this->count = $count;
+    }
+
+    public function has($id)
+    {
+        $factory = $this->factory;
+
+        return $factory($id, true);
+    }
+
+    public function get($id)
+    {
+        $factory = $this->factory;
+
+        return $factory($id);
     }
 
     public function getIterator()

--- a/src/Symfony/Component/DependencyInjection/Tests/Argument/RewindableGeneratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Argument/RewindableGeneratorTest.php
@@ -18,14 +18,16 @@ class RewindableGeneratorTest extends TestCase
 {
     public function testImplementsCountable()
     {
-        $this->assertInstanceOf(\Countable::class, new RewindableGenerator(function () {
+        $this->assertInstanceOf(\Countable::class, new RewindableGenerator(function ($k, $b = false) {
+        }, function () {
             yield 1;
         }, 1));
     }
 
     public function testCountUsesProvidedValue()
     {
-        $generator = new RewindableGenerator(function () {
+        $generator = new RewindableGenerator(function ($k, $b = false) {
+        }, function () {
             yield 1;
         }, 3);
 
@@ -35,7 +37,8 @@ class RewindableGeneratorTest extends TestCase
     public function testCountUsesProvidedValueAsCallback()
     {
         $called = 0;
-        $generator = new RewindableGenerator(function () {
+        $generator = new RewindableGenerator(function ($k, $b = false) {
+        }, function () {
             yield 1;
         }, function () use (&$called) {
             ++$called;
@@ -49,5 +52,19 @@ class RewindableGeneratorTest extends TestCase
         count($generator);
 
         $this->assertSame(1, $called, 'Count callback is called only once');
+    }
+
+    public function testPsrContainer()
+    {
+        $generator = new RewindableGenerator(function ($k, $b = false) {
+            return $b ? 'a' === $k : ('a' === $k ? 0 : 1);
+        }, function () {
+            yield 'a' => 0;
+        }, 1);
+
+        $this->assertTrue($generator->has('a'));
+        $this->assertFalse($generator->has('b'));
+        $this->assertSame(0, $generator->get('a'));
+        $this->assertSame(1, $generator->get('b'));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services31.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services31.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 /**
@@ -304,10 +305,21 @@ class ProjectServiceContainer extends Container
      */
     protected function getLazyContextService()
     {
-        return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function () {
+        return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function ($k, $b = false) {
+            switch ($k) {
+                case 'k1': $o = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}; break;
+                case 'k2': $o = $this; break;
+            }
+            if ($b) { return isset($o); }
+            if (isset($o)) { return $o; }
+            throw new ServiceNotFoundException($k, null, null, array(0 => 'k1', 1 => 'k2'));
+        }, function() {
             yield 'k1' => ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
             yield 'k2' => $this;
-        }, 2), new RewindableGenerator(function () {
+        }, 2), new RewindableGenerator(function ($k, $b = false) {
+            if ($b) { return false; }
+            throw new ServiceNotFoundException($k);
+        }, function() {
             return new \EmptyIterator();
         }, 0));
     }
@@ -322,14 +334,25 @@ class ProjectServiceContainer extends Container
      */
     protected function getLazyContextIgnoreInvalidRefService()
     {
-        return $this->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(function () {
+        return $this->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(function ($k, $b = false) {
+            switch ($k) {
+                case 0: $o = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}; break;
+                case 1: $o = $this->get('invalid', ContainerInterface::NULL_ON_INVALID_REFERENCE); break;
+            }
+            if ($b) { return isset($o); }
+            if (isset($o)) { return $o; }
+            throw new ServiceNotFoundException($k, null, null, array(0 => 0, 1 => 1));
+        }, function() {
             yield 0 => ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
             if ($this->has('invalid')) {
                 yield 1 => $this->get('invalid', ContainerInterface::NULL_ON_INVALID_REFERENCE);
             }
         }, function () {
             return 1 + (int) ($this->has('invalid'));
-        }), new RewindableGenerator(function () {
+        }), new RewindableGenerator(function ($k, $b = false) {
+            if ($b) { return false; }
+            throw new ServiceNotFoundException($k);
+        }, function() {
             return new \EmptyIterator();
         }, 0));
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**
@@ -307,10 +308,21 @@ class ProjectServiceContainer extends Container
      */
     protected function getLazyContextService()
     {
-        return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function () {
+        return $this->services['lazy_context'] = new \LazyContext(new RewindableGenerator(function ($k, $b = false) {
+            switch ($k) {
+                case 'k1': $o = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}; break;
+                case 'k2': $o = $this; break;
+            }
+            if ($b) { return isset($o); }
+            if (isset($o)) { return $o; }
+            throw new ServiceNotFoundException($k, null, null, array(0 => 'k1', 1 => 'k2'));
+        }, function() {
             yield 'k1' => ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
             yield 'k2' => $this;
-        }, 2), new RewindableGenerator(function () {
+        }, 2), new RewindableGenerator(function ($k, $b = false) {
+            if ($b) { return false; }
+            throw new ServiceNotFoundException($k);
+        }, function() {
             return new \EmptyIterator();
         }, 0));
     }
@@ -325,9 +337,19 @@ class ProjectServiceContainer extends Container
      */
     protected function getLazyContextIgnoreInvalidRefService()
     {
-        return $this->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(function () {
+        return $this->services['lazy_context_ignore_invalid_ref'] = new \LazyContext(new RewindableGenerator(function ($k, $b = false) {
+            switch ($k) {
+                case 0: $o = ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'}; break;
+            }
+            if ($b) { return isset($o); }
+            if (isset($o)) { return $o; }
+            throw new ServiceNotFoundException($k, null, null, array(0 => 0));
+        }, function() {
             yield 0 => ${($_ = isset($this->services['foo.baz']) ? $this->services['foo.baz'] : $this->get('foo.baz')) && false ?: '_'};
-        }, 1), new RewindableGenerator(function () {
+        }, 1), new RewindableGenerator(function ($k, $b = false) {
+            if ($b) { return false; }
+            throw new ServiceNotFoundException($k);
+        }, function() {
             return new \EmptyIterator();
         }, 0));
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | should be
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Basically merges `Di\Arg\RewindableGenerator` and `Di\ServiceLocator` into one. Introducing an internal god object that we can leverage to satisfy various typehints (think array, iterable, ContainerInterface). All lazy by default (well not array, we'd call `iterator_to_array` beforehand).

See https://github.com/symfony/symfony/pull/22200#issuecomment-315559043 for more info.

> i dont understand why we favor
>```
>!service { arguments: { k: '@ref' }, tags: [container.service_loc] }
>```
>over (simply)
>```
>!service_locator { k: '@ref' }
>!service_locator [ '@ref' ] # keys are arbitrary
>```
>What `!iterator` does actually

Thoughts?