### PR TITLE
[PropertyInfo] conflict for phpdocumentor/reflection-docblock 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "sensio/framework-extra-bundle": "^3.0.2"
     },
     "conflict": {
-        "phpdocumentor/reflection-docblock": "<3.0",
+        "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0",
         "phpdocumentor/type-resolver": "<0.2.0",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
     },

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -33,7 +33,7 @@
         "doctrine/annotations": "~1.0"
     },
     "conflict": {
-        "phpdocumentor/reflection-docblock": "<3.0",
+        "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0",
         "phpdocumentor/type-resolver": "<0.2.0"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

`phpdocumentor/reflection-docblock` included a change in release 3.2.0
which required a tag to be followed by a space. This conflicts with our
use of the `@Group` annotation:

```php
/**
 * @var \DateTime[]
 * @Groups({"a", "b"})
 */
public $collection;
```
