### PR TITLE
[Security] Login: Only use referer URL if it differs from default login_path

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -122,7 +122,8 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
             return $targetUrl;
         }
 
-        if ($this->options['use_referer'] && ($targetUrl = $request->headers->get('Referer')) && parse_url($targetUrl, PHP_URL_PATH) !== $this->httpUtils->generateUri($request, $this->options['login_path'])) {
+        // Validate that we've got a valid referer URL and that it differs from the absolute URL generated for our (default) login_path
+        if ($this->options['use_referer'] && ($targetUrl = $request->headers->get('Referer')) && !empty($targetUrl) && false !== parse_url($targetUrl, PHP_URL_PATH) && $targetUrl !== $this->httpUtils->generateUri($request, $this->options['login_path'])) {
             return $targetUrl;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -139,39 +139,37 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
         $this->assertSame($response, $result);
     }
 
-    public function testRefererHasToBeDifferentThanLoginUrl()
+    public function getReferrerList()
     {
-        $options = array('use_referer' => true);
-
-        $this->request->headers->expects($this->any())
-            ->method('get')->with('Referer')
-            ->will($this->returnValue('/login'));
-
-        $this->httpUtils->expects($this->once())
-            ->method('generateUri')->with($this->request, '/login')
-            ->will($this->returnValue('/login'));
-
-        $response = $this->expectRedirectResponse('/');
-
-        $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, $options);
-        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
-
-        $this->assertSame($response, $result);
+        return array(
+            "absolute referrer URL" => array("http://domain.com/app_base_path/login?t=1&p=2", "http://domain.com/app_base_path/login?t=1&p=2", 1),
+            "absolute referrer path" => array("/app_base_path/login?t=1&p=2", "/app_base_path/login?t=1&p=2", 1),
+            "referrer is the same as login route" => array("/login", "/login", 1),
+            "no referrer" => array("", "/", 0),
+        );
     }
 
-    public function testRefererWithoutParametersHasToBeDifferentThanLoginUrl()
+
+    /**
+     * @dataProvider getReferrerList
+     *
+     * @param string $referrer
+     * @param string $expectedRedirectionTarget
+     * @param int    $generateUriCallCount
+     */
+    public function testRefererWithoutParametersHasToBeDifferentThanLoginUrl($referrer, $expectedRedirectionTarget, $generateUriCallCount)
     {
         $options = array('use_referer' => true);
 
         $this->request->headers->expects($this->any())
             ->method('get')->with('Referer')
-            ->will($this->returnValue('/subfolder/login?t=1&p=2'));
+            ->will($this->returnValue($referrer));
 
-        $this->httpUtils->expects($this->once())
+        $this->httpUtils->expects($this->exactly($generateUriCallCount))
             ->method('generateUri')->with($this->request, '/login')
-            ->will($this->returnValue('/subfolder/login'));
+            ->will($this->returnValue('/app_base_path/login'));
 
-        $response = $this->expectRedirectResponse('/');
+        $response = $this->expectRedirectResponse($expectedRedirectionTarget);
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, $options);
         $result = $handler->onAuthenticationSuccess($this->request, $this->token);

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -142,13 +142,12 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
     public function getReferrerList()
     {
         return array(
-            "absolute referrer URL" => array("http://domain.com/app_base_path/login?t=1&p=2", "http://domain.com/app_base_path/login?t=1&p=2", 1),
-            "absolute referrer path" => array("/app_base_path/login?t=1&p=2", "/app_base_path/login?t=1&p=2", 1),
-            "referrer is the same as login route" => array("/login", "/login", 1),
-            "no referrer" => array("", "/", 0),
+            'absolute referrer URL' => array('http://domain.com/app_base_path/login?t=1&p=2', 'http://domain.com/app_base_path/login?t=1&p=2', 1),
+            'absolute referrer path' => array('/app_base_path/login?t=1&p=2', '/app_base_path/login?t=1&p=2', 1),
+            'referrer is the same as login route' => array('/login', '/login', 1),
+            'no referrer' => array('', '/', 0),
         );
     }
-
 
     /**
      * @dataProvider getReferrerList


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | yes
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR fixes a strange behaviour by the `use_referer` logic inside the `DefaultAuthenticationSuccessHandler` inside the security component.

When `use_referer` is enabled in your `security.yml` for a given `firewall` like so:

```yaml
    firewalls:
        secured_area:
            pattern: ^/
            anonymous: ~
            form_login:
                login_path:          login
                check_path:          login_check
                default_target_path: admin
                username_parameter:  "login[username]"
                password_parameter:  "login[password]"
                csrf_parameter:      "login[_token]"
                csrf_token_id:       authenticate
                remember_me:         true
                use_referer:         true
```

And then follow the given workflow:

- Visit `/admin/login/`
- Enter credentials
- Get redirected to `/admin/login/` again with no message or whatsoever

But now if you follow the regular/normal workflow:

- Visit `/admin/`
- Get redirected to `/admin/login`
- Enter credentials
- Get redirected to `/admin/` and enjoy your website

The cause for this behaviour was the introduction of `parse_url` to `$targetUrl` in `DefaultAuthenticationSuccessHandler`'s `determineTargetUrl` in https://github.com/symfony/symfony/commit/ac9d75a09ef7ebd7776bc610f8799f92562dfd83#diff-a654f85d03c2e834cb8701bec08e2a4fR125. The code itself was testing a relative path against an absolute URL (e.g. `/admin/login/` vs. `http://domain.com/admin/login/`).