### PR TITLE
Release v2.8.25

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,19 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.25 (2017-07-17)
+
+ * security #23507 [Security] validate empty passwords again (xabbuh)
+ * bug #23526 [HttpFoundation] Set meta refresh time to 0 in RedirectResponse content (jnvsor)
+ * bug #23540 Disable inlining deprecated services (alekitto)
+ * bug #23468 [DI] Handle root namespace in service definitions (ro0NL)
+ * bug #23256 [Security] Fix authentication.failure event not dispatched on AccountStatusException (chalasr)
+ * bug #23461 Use rawurlencode() to transform the Cookie into a string (javiereguiluz)
+ * bug #23459 [TwigBundle] allow to configure custom formats in XML configs (xabbuh)
+ * bug #23460 Don't display the Symfony debug toolbar when printing the page (javiereguiluz)
+ * bug #23261 Fixed absolute url generation for query strings and hash urls (alexander-schranz)
+ * bug #23398 [Filesystem] Dont copy perms when origin is remote (nicolas-grekas)
+
 * 2.8.24 (2017-07-05)
 
  * bug #23378 [FrameworkBundle] Do not remove files from assets dir (1ed)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.25-DEV';
+    const VERSION = '2.8.25';
     const VERSION_ID = 20825;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
     const RELEASE_VERSION = 25;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';
     const END_OF_LIFE = '11/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.8.24...v2.8.25)

 * security #23507 [Security] validate empty passwords again (@xabbuh)
 * bug #23526 [HttpFoundation] Set meta refresh time to 0 in RedirectResponse content (@jnvsor)
 * bug #23540 Disable inlining deprecated services (@alekitto)
 * bug #23468 [DI] Handle root namespace in service definitions (@ro0NL)
 * bug #23256 [Security] Fix authentication.failure event not dispatched on AccountStatusException (@chalasr)
 * bug #23461 Use rawurlencode() to transform the Cookie into a string (@javiereguiluz)
 * bug #23459 [TwigBundle] allow to configure custom formats in XML configs (@xabbuh)
 * bug #23460 Don't display the Symfony debug toolbar when printing the page (@javiereguiluz)
 * bug #23261 Fixed absolute url generation for query strings and hash urls (@alexander-schranz)
 * bug #23398 [Filesystem] Dont copy perms when origin is remote (@nicolas-grekas)
