### PR TITLE
Release v3.2.12

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -7,6 +7,22 @@ in 3.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.2.0...v3.2.1
 
+* 3.2.12 (2017-07-17)
+
+ * bug #23549 [PropertyInfo] conflict for phpdocumentor/reflection-docblock 3.2 (xabbuh)
+ * security #23507 [Security] validate empty passwords again (xabbuh)
+ * bug #23526 [HttpFoundation] Set meta refresh time to 0 in RedirectResponse content (jnvsor)
+ * bug #23540 Disable inlining deprecated services (alekitto)
+ * bug #23468 [DI] Handle root namespace in service definitions (ro0NL)
+ * bug #23256 [Security] Fix authentication.failure event not dispatched on AccountStatusException (chalasr)
+ * bug #23461 Use rawurlencode() to transform the Cookie into a string (javiereguiluz)
+ * bug #23459 [TwigBundle] allow to configure custom formats in XML configs (xabbuh)
+ * bug #23460 Don't display the Symfony debug toolbar when printing the page (javiereguiluz)
+ * bug #23469 [FrameworkBundle] do not wire namespaces for the ArrayAdapter (xabbuh)
+ * bug #23417 [DI][Security] Prevent unwanted deprecation notices when using Expression Languages (dunglas)
+ * bug #23261 Fixed absolute url generation for query strings and hash urls (alexander-schranz)
+ * bug #23398 [Filesystem] Dont copy perms when origin is remote (nicolas-grekas)
+
 * 3.2.11 (2017-07-05)
 
  * bug #23390 [Cache] Handle APCu failures gracefully (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '3.2.12-DEV';
+    const VERSION = '3.2.12';
     const VERSION_ID = 30212;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 2;
     const RELEASE_VERSION = 12;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '07/2017';
     const END_OF_LIFE = '01/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.2.11...v3.2.12)

 * bug #23549 [PropertyInfo] conflict for phpdocumentor/reflection-docblock 3.2 (@xabbuh)
 * security #23507 [Security] validate empty passwords again (@xabbuh)
 * bug #23526 [HttpFoundation] Set meta refresh time to 0 in RedirectResponse content (@jnvsor)
 * bug #23540 Disable inlining deprecated services (@alekitto)
 * bug #23468 [DI] Handle root namespace in service definitions (@ro0NL)
 * bug #23256 [Security] Fix authentication.failure event not dispatched on AccountStatusException (@chalasr)
 * bug #23461 Use rawurlencode() to transform the Cookie into a string (@javiereguiluz)
 * bug #23459 [TwigBundle] allow to configure custom formats in XML configs (@xabbuh)
 * bug #23460 Don't display the Symfony debug toolbar when printing the page (@javiereguiluz)
 * bug #23469 [FrameworkBundle] do not wire namespaces for the ArrayAdapter (@xabbuh)
 * bug #23417 [DI][Security] Prevent unwanted deprecation notices when using Expression Languages (@dunglas)
 * bug #23261 Fixed absolute url generation for query strings and hash urls (@alexander-schranz)
 * bug #23398 [Filesystem] Dont copy perms when origin is remote (@nicolas-grekas)
