### PR TITLE
Release v3.3.5

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -7,6 +7,32 @@ in 3.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.3.0...v3.3.1
 
+* 3.3.5 (2017-07-17)
+
+ * bug #23549 [PropertyInfo] conflict for phpdocumentor/reflection-docblock 3.2 (xabbuh)
+ * bug #23513 [FrameworkBundle] Set default public directory on install assets (yceruto)
+ * security #23507 [Security] validate empty passwords again (xabbuh)
+ * bug #23526 [HttpFoundation] Set meta refresh time to 0 in RedirectResponse content (jnvsor)
+ * bug #23535 Make server:* commands work out of the box with the public/ root dir (fabpot)
+ * bug #23540 Disable inlining deprecated services (alekitto)
+ * bug #23498 [Process] Fixed issue between process builder and exec (lyrixx)
+ * bug #23490 [DependencyInjection] non-conflicting anonymous service ids across files (xabbuh)
+ * bug #23468 [DI] Handle root namespace in service definitions (ro0NL)
+ * bug #23477 [Process] Fix parsing args on Windows (nicolas-grekas)
+ * bug #23256 [Security] Fix authentication.failure event not dispatched on AccountStatusException (chalasr)
+ * bug #23461 Use rawurlencode() to transform the Cookie into a string (javiereguiluz)
+ * bug #23465 [HttpKernel][VarDumper] Truncate profiler data & optim perf (nicolas-grekas)
+ * bug #23457 [FrameworkBundle] check _controller attribute is a string before parsing it (alekitto)
+ * bug #23459 [TwigBundle] allow to configure custom formats in XML configs (xabbuh)
+ * bug #23460 Don't display the Symfony debug toolbar when printing the page (javiereguiluz)
+ * bug #23469 [FrameworkBundle] do not wire namespaces for the ArrayAdapter (xabbuh)
+ * bug #23434 [DotEnv] Fix variable substitution (brieucthomas)
+ * bug #23426 Fixed HttpOnly flag when using Cookie::fromString() (Toflar)
+ * bug #22439 [DX] [TwigBundle] Enhance the new exception page design (sustmi)
+ * bug #23417 [DI][Security] Prevent unwanted deprecation notices when using Expression Languages (dunglas)
+ * bug #23261 Fixed absolute url generation for query strings and hash urls (alexander-schranz)
+ * bug #23398 [Filesystem] Dont copy perms when origin is remote (nicolas-grekas)
+
 * 3.3.4 (2017-07-05)
 
  * bug #23413 [VarDumper] Reduce size of serialized Data objects (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -61,12 +61,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
     private $projectDir;
 
-    const VERSION = '3.3.5-DEV';
+    const VERSION = '3.3.5';
     const VERSION_ID = 30305;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 3;
     const RELEASE_VERSION = 5;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2018';
     const END_OF_LIFE = '07/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.3.4...v3.3.5)

 * bug #23549 [PropertyInfo] conflict for phpdocumentor/reflection-docblock 3.2 (@xabbuh)
 * bug #23513 [FrameworkBundle] Set default public directory on install assets (@yceruto)
 * security #23507 [Security] validate empty passwords again (@xabbuh)
 * bug #23526 [HttpFoundation] Set meta refresh time to 0 in RedirectResponse content (@jnvsor)
 * bug #23535 Make server:* commands work out of the box with the public/ root dir (@fabpot)
 * bug #23540 Disable inlining deprecated services (@alekitto)
 * bug #23498 [Process] Fixed issue between process builder and exec (@lyrixx)
 * bug #23490 [DependencyInjection] non-conflicting anonymous service ids across files (@xabbuh)
 * bug #23468 [DI] Handle root namespace in service definitions (@ro0NL)
 * bug #23477 [Process] Fix parsing args on Windows (@nicolas-grekas)
 * bug #23256 [Security] Fix authentication.failure event not dispatched on AccountStatusException (@chalasr)
 * bug #23461 Use rawurlencode() to transform the Cookie into a string (@javiereguiluz)
 * bug #23465 [HttpKernel][VarDumper] Truncate profiler data & optim perf (@nicolas-grekas)
 * bug #23457 [FrameworkBundle] check _controller attribute is a string before parsing it (@alekitto)
 * bug #23459 [TwigBundle] allow to configure custom formats in XML configs (@xabbuh)
 * bug #23460 Don't display the Symfony debug toolbar when printing the page (@javiereguiluz)
 * bug #23469 [FrameworkBundle] do not wire namespaces for the ArrayAdapter (@xabbuh)
 * bug #23434 [DotEnv] Fix variable substitution (@brieucthomas)
 * bug #23426 Fixed HttpOnly flag when using Cookie::fromString() (@Toflar)
 * bug #22439 [DX] [TwigBundle] Enhance the new exception page design (@sustmi)
 * bug #23417 [DI][Security] Prevent unwanted deprecation notices when using Expression Languages (@dunglas)
 * bug #23261 Fixed absolute url generation for query strings and hash urls (@alexander-schranz)
 * bug #23398 [Filesystem] Dont copy perms when origin is remote (@nicolas-grekas)
