### PR TITLE
[Console] Fix registering lazy command services with autoconfigure enabled

### DIFF
--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -70,20 +70,15 @@ class AddConsoleCommandPass implements CompilerPassInterface
 
             $serviceIds[$commandId] = false;
             $commandName = $tags[0]['command'];
+            unset($tags[0]);
             $lazyCommandMap[$commandName] = $id;
             $lazyCommandRefs[$id] = new TypedReference($id, $class);
             $aliases = array();
 
             foreach ($tags as $tag) {
-                if (!isset($tag['command'])) {
-                    throw new InvalidArgumentException(sprintf('Missing "command" attribute on tag "%s" for service "%s".', $this->commandTag, $id));
-                }
-                if ($commandName !== $tag['command']) {
-                    throw new InvalidArgumentException(sprintf('The "command" attribute must be the same on each "%s" tag for service "%s".', $this->commandTag, $id));
-                }
-                if (isset($tag['alias'])) {
-                    $aliases[] = $tag['alias'];
-                    $lazyCommandMap[$tag['alias']] = $id;
+                if (isset($tag['command'])) {
+                    $aliases[] = $tag['command'];
+                    $lazyCommandMap[$tag['command']] = $id;
                 }
             }
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1431,8 +1431,9 @@ class ApplicationTest extends TestCase
         $container->addCompilerPass(new AddConsoleCommandPass());
         $container
             ->register('lazy-command', LazyCommand::class)
-            ->addTag('console.command', array('command' => 'lazy:command', 'alias' => 'lazy:alias'))
-            ->addTag('console.command', array('command' => 'lazy:command', 'alias' => 'lazy:alias2'));
+            ->addTag('console.command', array('command' => 'lazy:command'))
+            ->addTag('console.command', array('command' => 'lazy:alias'))
+            ->addTag('console.command', array('command' => 'lazy:alias2'));
         $container->compile();
 
         $application = new Application();

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -56,13 +56,14 @@ class AddConsoleCommandPassTest extends TestCase
         $this->assertSame(array($alias => $id), $container->getParameter('console.command.ids'));
     }
 
-    public function testProcessRegisterLazyCommands()
+    public function testProcessRegistersLazyCommands()
     {
         $container = new ContainerBuilder();
-        $container
+        $command = $container
             ->register('my-command', MyCommand::class)
             ->setPublic(false)
-            ->addTag('console.command', array('command' => 'my:command', 'alias' => 'my:alias'))
+            ->addTag('console.command', array('command' => 'my:command'))
+            ->addTag('console.command', array('command' => 'my:alias'))
         ;
 
         (new AddConsoleCommandPass())->process($container);
@@ -74,6 +75,7 @@ class AddConsoleCommandPassTest extends TestCase
         $this->assertSame(array('my:command' => 'my-command', 'my:alias' => 'my-command'), $commandLoader->getArgument(1));
         $this->assertEquals(array(array('my-command' => new ServiceClosureArgument(new TypedReference('my-command', MyCommand::class)))), $commandLocator->getArguments());
         $this->assertSame(array('console.command.symfony_component_console_tests_dependencyinjection_mycommand' => false), $container->getParameter('console.command.ids'));
+        $this->assertSame(array(array('setName', array('my:command')), array('setAliases', array(array('my:alias')))), $command->getMethodCalls());
     }
 
     public function visibilityProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

For
```yaml
_defaults:
    autoconfigure: true

App\:
    resource: '../../src/*'

App\Command\FooCommand:
    tags:
        - { name: console.command, command: foo }
```

Before you get the following error:
> Missing "command" attribute on tag "console.command" for service "App\Command\FooCommand"

Now the command is lazy.

----
Btw, @Tobion's https://github.com/symfony/symfony/pull/22734#discussion_r127410411 
> Wouldn't it be more straightforward if aliases are just the additional tags using the command attribute as well?
Then there is no need for an alias property at all and this strange condition doesn't apply either.

Partially addressed here by removing the need for repeating the `command` attribute on each `console.command` tag
```yaml
# before
tags:
    - { name: console.command, command: foo }
    - { name: console.command, command: foo, alias: foobar }

# after
tags:
    - { name: console.command, command: foo }
    - { name: console.command, alias: foobar }
```

Tobias proposal:

```yaml
tags:
    - { name: console.command, command: app:my-command }
    - { name: console.command, command: app:my-alias }
```

I wanted to propose exactly the same at first, but finally found more clear to add a specific attribute for aliases, especially because relying on the order on which tags are defined sounds less good to me. Please tell me about your preference.

(And sorry for the noise around this feature, I want to polish it for 3.4)