### PR TITLE
[FrameworkBundle] fix ValidatorCacheWarmer: use serializing ArrayAdapter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\Cache\Adapter\ProxyAdapter;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
+{
+    protected $phpArrayFile;
+    protected $fallbackPool;
+
+    /**
+     * @param string                 $phpArrayFile The PHP file where metadata are cached
+     * @param CacheItemPoolInterface $fallbackPool The pool where runtime-discovered metadata are cached
+     */
+    public function __construct($phpArrayFile, CacheItemPoolInterface $fallbackPool)
+    {
+        $this->phpArrayFile = $phpArrayFile;
+        if (!$fallbackPool instanceof AdapterInterface) {
+            $fallbackPool = new ProxyAdapter($fallbackPool);
+        }
+        $this->fallbackPool = $fallbackPool;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        $phpArrayAdapter = new PhpArrayAdapter($this->phpArrayFile, $this->fallbackPool);
+        $arrayAdapter = new ArrayAdapter();
+
+        spl_autoload_register(array($phpArrayAdapter, 'throwOnRequiredClass'));
+        try {
+            if (false === $this->doWarmUp($cacheDir, $phpArrayAdapter, $arrayAdapter)) {
+                return;
+            }
+        } finally {
+            spl_autoload_unregister(array($phpArrayAdapter, 'throwOnRequiredClass'));
+        }
+
+        // the ArrayAdapter stores the values serialized
+        // to avoid mutation of the data after it was written to the cache
+        // so here we un-serialize the values first
+        $values = array_map(function ($val) { return unserialize($val); }, array_filter($arrayAdapter->getValues()));
+        $phpArrayAdapter->warmUp($values);
+
+        foreach ($values as $k => $v) {
+            $item = $this->fallbackPool->getItem($k);
+            $this->fallbackPool->saveDeferred($item->set($v));
+        }
+        $this->fallbackPool->commit();
+    }
+
+    /**
+     * @param string          $cacheDir
+     * @param PhpArrayAdapter $phpArrayAdapter
+     * @param ArrayAdapter    $arrayAdapter
+     *
+     * @return bool|void false if there is nothing to warm-up
+     */
+    abstract protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter);
+}

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
@@ -57,9 +57,7 @@ abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
 
         spl_autoload_register(array($phpArrayAdapter, 'throwOnRequiredClass'));
         try {
-            if (false === $this->doWarmUp($cacheDir, $phpArrayAdapter, $arrayAdapter)) {
-                return;
-            }
+            $this->doWarmUp($cacheDir, $arrayAdapter);
         } finally {
             spl_autoload_unregister(array($phpArrayAdapter, 'throwOnRequiredClass'));
         }
@@ -83,11 +81,8 @@ abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
     }
 
     /**
-     * @param string          $cacheDir
-     * @param PhpArrayAdapter $phpArrayAdapter
-     * @param ArrayAdapter    $arrayAdapter
-     *
-     * @return bool|void false if there is nothing to warm-up
+     * @param string       $cacheDir
+     * @param ArrayAdapter $arrayAdapter
      */
-    abstract protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter);
+    abstract protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter);
 }

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
@@ -19,7 +19,7 @@ use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 /**
- * @internal This class is meant for internal use only.
+ * @internal
  */
 abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
 {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
@@ -23,8 +23,8 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
  */
 abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
 {
-    protected $phpArrayFile;
-    protected $fallbackPool;
+    private $phpArrayFile;
+    private $fallbackPool;
 
     /**
      * @param string                 $phpArrayFile The PHP file where metadata are cached

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -16,7 +16,6 @@ use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
 
 /**
@@ -43,14 +42,12 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
     /**
      * {@inheritdoc}
      */
-    protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter)
+    protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter)
     {
         $annotatedClassPatterns = $cacheDir.'/annotations.map';
 
         if (!is_file($annotatedClassPatterns)) {
-            $phpArrayAdapter->warmUp(array());
-
-            return false;
+            return;
         }
 
         $annotatedClasses = include $annotatedClassPatterns;

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -47,7 +47,7 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         $annotatedClassPatterns = $cacheDir.'/annotations.map';
 
         if (!is_file($annotatedClassPatterns)) {
-            return;
+            return true;
         }
 
         $annotatedClasses = include $annotatedClassPatterns;
@@ -69,6 +69,8 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
                  */
             }
         }
+
+        return true;
     }
 
     private function readAllComponents(Reader $reader, $class)

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -43,14 +43,6 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
     /**
      * {@inheritdoc}
      */
-    public function isOptional()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter)
     {
         $annotatedClassPatterns = $cacheDir.'/annotations.map';

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -15,12 +15,9 @@ use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
-use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
-use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 /**
  * Warms up annotation caches for classes found in composer's autoload class map
@@ -28,11 +25,9 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-class AnnotationsCacheWarmer implements CacheWarmerInterface
+class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
 {
     private $annotationReader;
-    private $phpArrayFile;
-    private $fallbackPool;
 
     /**
      * @param Reader                 $annotationReader
@@ -41,63 +36,8 @@ class AnnotationsCacheWarmer implements CacheWarmerInterface
      */
     public function __construct(Reader $annotationReader, $phpArrayFile, CacheItemPoolInterface $fallbackPool)
     {
+        parent::__construct($phpArrayFile, $fallbackPool);
         $this->annotationReader = $annotationReader;
-        $this->phpArrayFile = $phpArrayFile;
-        if (!$fallbackPool instanceof AdapterInterface) {
-            $fallbackPool = new ProxyAdapter($fallbackPool);
-        }
-        $this->fallbackPool = $fallbackPool;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function warmUp($cacheDir)
-    {
-        $adapter = new PhpArrayAdapter($this->phpArrayFile, $this->fallbackPool);
-        $annotatedClassPatterns = $cacheDir.'/annotations.map';
-
-        if (!is_file($annotatedClassPatterns)) {
-            $adapter->warmUp(array());
-
-            return;
-        }
-
-        $annotatedClasses = include $annotatedClassPatterns;
-
-        $arrayPool = new ArrayAdapter(0, false);
-        $reader = new CachedReader($this->annotationReader, new DoctrineProvider($arrayPool));
-
-        spl_autoload_register(array($adapter, 'throwOnRequiredClass'));
-        try {
-            foreach ($annotatedClasses as $class) {
-                try {
-                    $this->readAllComponents($reader, $class);
-                } catch (\ReflectionException $e) {
-                    // ignore failing reflection
-                } catch (AnnotationException $e) {
-                    /*
-                     * Ignore any AnnotationException to not break the cache warming process if an Annotation is badly
-                     * configured or could not be found / read / etc.
-                     *
-                     * In particular cases, an Annotation in your code can be used and defined only for a specific
-                     * environment but is always added to the annotations.map file by some Symfony default behaviors,
-                     * and you always end up with a not found Annotation.
-                     */
-                }
-            }
-        } finally {
-            spl_autoload_unregister(array($adapter, 'throwOnRequiredClass'));
-        }
-
-        $values = $arrayPool->getValues();
-        $adapter->warmUp($values);
-
-        foreach ($values as $k => $v) {
-            $item = $this->fallbackPool->getItem($k);
-            $this->fallbackPool->saveDeferred($item->set($v));
-        }
-        $this->fallbackPool->commit();
     }
 
     /**
@@ -106,6 +46,40 @@ class AnnotationsCacheWarmer implements CacheWarmerInterface
     public function isOptional()
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter)
+    {
+        $annotatedClassPatterns = $cacheDir.'/annotations.map';
+
+        if (!is_file($annotatedClassPatterns)) {
+            $phpArrayAdapter->warmUp(array());
+
+            return false;
+        }
+
+        $annotatedClasses = include $annotatedClassPatterns;
+        $reader = new CachedReader($this->annotationReader, new DoctrineProvider($arrayAdapter));
+
+        foreach ($annotatedClasses as $class) {
+            try {
+                $this->readAllComponents($reader, $class);
+            } catch (\ReflectionException $e) {
+                // ignore failing reflection
+            } catch (AnnotationException $e) {
+                /*
+                 * Ignore any AnnotationException to not break the cache warming process if an Annotation is badly
+                 * configured or could not be found / read / etc.
+                 *
+                 * In particular cases, an Annotation in your code can be used and defined only for a specific
+                 * environment but is always added to the annotations.map file by some Symfony default behaviors,
+                 * and you always end up with a not found Annotation.
+                 */
+            }
+        }
     }
 
     private function readAllComponents(Reader $reader, $class)

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
@@ -13,11 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
 use Doctrine\Common\Annotations\AnnotationException;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
-use Symfony\Component\Cache\Adapter\ProxyAdapter;
-use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
@@ -30,11 +27,9 @@ use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
  *
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-class SerializerCacheWarmer implements CacheWarmerInterface
+class SerializerCacheWarmer extends AbstractPhpFileCacheWarmer
 {
     private $loaders;
-    private $phpArrayFile;
-    private $fallbackPool;
 
     /**
      * @param LoaderInterface[]      $loaders      The serializer metadata loaders
@@ -43,53 +38,8 @@ class SerializerCacheWarmer implements CacheWarmerInterface
      */
     public function __construct(array $loaders, $phpArrayFile, CacheItemPoolInterface $fallbackPool)
     {
+        parent::__construct($phpArrayFile, $fallbackPool);
         $this->loaders = $loaders;
-        $this->phpArrayFile = $phpArrayFile;
-        if (!$fallbackPool instanceof AdapterInterface) {
-            $fallbackPool = new ProxyAdapter($fallbackPool);
-        }
-        $this->fallbackPool = $fallbackPool;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function warmUp($cacheDir)
-    {
-        if (!class_exists(CacheClassMetadataFactory::class) || !method_exists(XmlFileLoader::class, 'getMappedClasses') || !method_exists(YamlFileLoader::class, 'getMappedClasses')) {
-            return;
-        }
-
-        $adapter = new PhpArrayAdapter($this->phpArrayFile, $this->fallbackPool);
-        $arrayPool = new ArrayAdapter(0, false);
-
-        $metadataFactory = new CacheClassMetadataFactory(new ClassMetadataFactory(new LoaderChain($this->loaders)), $arrayPool);
-
-        spl_autoload_register(array($adapter, 'throwOnRequiredClass'));
-        try {
-            foreach ($this->extractSupportedLoaders($this->loaders) as $loader) {
-                foreach ($loader->getMappedClasses() as $mappedClass) {
-                    try {
-                        $metadataFactory->getMetadataFor($mappedClass);
-                    } catch (\ReflectionException $e) {
-                        // ignore failing reflection
-                    } catch (AnnotationException $e) {
-                        // ignore failing annotations
-                    }
-                }
-            }
-        } finally {
-            spl_autoload_unregister(array($adapter, 'throwOnRequiredClass'));
-        }
-
-        $values = $arrayPool->getValues();
-        $adapter->warmUp($values);
-
-        foreach ($values as $k => $v) {
-            $item = $this->fallbackPool->getItem($k);
-            $this->fallbackPool->saveDeferred($item->set($v));
-        }
-        $this->fallbackPool->commit();
     }
 
     /**
@@ -98,6 +48,30 @@ class SerializerCacheWarmer implements CacheWarmerInterface
     public function isOptional()
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter)
+    {
+        if (!class_exists(CacheClassMetadataFactory::class) || !method_exists(XmlFileLoader::class, 'getMappedClasses') || !method_exists(YamlFileLoader::class, 'getMappedClasses')) {
+            return false;
+        }
+
+        $metadataFactory = new CacheClassMetadataFactory(new ClassMetadataFactory(new LoaderChain($this->loaders)), $arrayAdapter);
+
+        foreach ($this->extractSupportedLoaders($this->loaders) as $loader) {
+            foreach ($loader->getMappedClasses() as $mappedClass) {
+                try {
+                    $metadataFactory->getMetadataFor($mappedClass);
+                } catch (\ReflectionException $e) {
+                    // ignore failing reflection
+                } catch (AnnotationException $e) {
+                    // ignore failing annotations
+                }
+            }
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
@@ -47,7 +47,7 @@ class SerializerCacheWarmer extends AbstractPhpFileCacheWarmer
     protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter)
     {
         if (!class_exists(CacheClassMetadataFactory::class) || !method_exists(XmlFileLoader::class, 'getMappedClasses') || !method_exists(YamlFileLoader::class, 'getMappedClasses')) {
-            return;
+            return false;
         }
 
         $metadataFactory = new CacheClassMetadataFactory(new ClassMetadataFactory(new LoaderChain($this->loaders)), $arrayAdapter);
@@ -63,6 +63,8 @@ class SerializerCacheWarmer extends AbstractPhpFileCacheWarmer
                 }
             }
         }
+
+        return true;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
@@ -45,14 +45,6 @@ class SerializerCacheWarmer extends AbstractPhpFileCacheWarmer
     /**
      * {@inheritdoc}
      */
-    public function isOptional()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter)
     {
         if (!class_exists(CacheClassMetadataFactory::class) || !method_exists(XmlFileLoader::class, 'getMappedClasses') || !method_exists(YamlFileLoader::class, 'getMappedClasses')) {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 use Doctrine\Common\Annotations\AnnotationException;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
@@ -45,10 +44,10 @@ class SerializerCacheWarmer extends AbstractPhpFileCacheWarmer
     /**
      * {@inheritdoc}
      */
-    protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter)
+    protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter)
     {
         if (!class_exists(CacheClassMetadataFactory::class) || !method_exists(XmlFileLoader::class, 'getMappedClasses') || !method_exists(YamlFileLoader::class, 'getMappedClasses')) {
-            return false;
+            return;
         }
 
         $metadataFactory = new CacheClassMetadataFactory(new ClassMetadataFactory(new LoaderChain($this->loaders)), $arrayAdapter);

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
@@ -49,7 +49,7 @@ class ValidatorCacheWarmer extends AbstractPhpFileCacheWarmer
     protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter)
     {
         if (!method_exists($this->validatorBuilder, 'getLoaders')) {
-            return;
+            return false;
         }
 
         $loaders = $this->validatorBuilder->getLoaders();
@@ -68,6 +68,8 @@ class ValidatorCacheWarmer extends AbstractPhpFileCacheWarmer
                 }
             }
         }
+
+        return true;
     }
 
     protected function warmUpPhpArrayAdapter(PhpArrayAdapter $phpArrayAdapter, array $values)

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
@@ -46,10 +46,10 @@ class ValidatorCacheWarmer extends AbstractPhpFileCacheWarmer
     /**
      * {@inheritdoc}
      */
-    protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter)
+    protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter)
     {
         if (!method_exists($this->validatorBuilder, 'getLoaders')) {
-            return false;
+            return;
         }
 
         $loaders = $this->validatorBuilder->getLoaders();

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
@@ -46,14 +46,6 @@ class ValidatorCacheWarmer extends AbstractPhpFileCacheWarmer
     /**
      * {@inheritdoc}
      */
-    public function isOptional()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function doWarmUp($cacheDir, PhpArrayAdapter $phpArrayAdapter, ArrayAdapter $arrayAdapter)
     {
         if (!method_exists($this->validatorBuilder, 'getLoaders')) {
@@ -76,6 +68,12 @@ class ValidatorCacheWarmer extends AbstractPhpFileCacheWarmer
                 }
             }
         }
+    }
+
+    protected function warmUpPhpArrayAdapter(PhpArrayAdapter $phpArrayAdapter, array $values)
+    {
+        // make sure we don't cache null values
+        parent::warmUpPhpArrayAdapter($phpArrayAdapter, array_filter($values));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
@@ -79,8 +79,9 @@ class ValidatorCacheWarmerTest extends TestCase
         $values = $fallbackPool->getValues();
 
         $this->assertInternalType('array', $values);
-        $this->assertCount(1, $values);
+        $this->assertCount(2, $values);
         $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Category', $values);
+        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.SubCategory', $values);
     }
 
     public function testWarmUpWithoutLoader()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
@@ -79,9 +79,8 @@ class ValidatorCacheWarmerTest extends TestCase
         $values = $fallbackPool->getValues();
 
         $this->assertInternalType('array', $values);
-        $this->assertCount(2, $values);
+        $this->assertCount(1, $values);
         $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Category', $values);
-        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.SubCategory', $values);
     }
 
     public function testWarmUpWithoutLoader()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/23544
| License       | MIT
| Doc PR        | -

The `ValidatorCacheWarmer` was using an `ArrayAdapter` with `$storeSerialized=false`. This is a problem as inside the `LazyLoadingMetadataFactory` the metaData objects are mutated (parent class constraints are merged into it) after they have been written into the cache.

So this means that currently when warming up the validator cache actually the merged metaData version is finally taken from the `ArrayAdapter` and written into the `PhpFilesAdapter`.

Which then caused some duplicate constraints as the parent constraints are merged again after fetching from the cache inside `LazyLoadingMetadataFactory`.

This fix makes sure we serialize objects into the `ArrayAdapter`.

Writing a test case for this does not seem easy to me. Any ideas?


EDIT: Maybe its even safer to just clone the object when writing it into the cache?

```diff
diff --git a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
index 79ad1f2..88eaf33 100644
--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -117,7 +117,7 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
         }
 
         if (null !== $this->cache) {
-            $this->cache->write($metadata);
+            $this->cache->write(clone $metadata);
         }
```

Opinions?