### PR TITLE
[DI] Minor dumping logic simplification

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1608,7 +1608,7 @@ EOF;
             $code = sprintf('$this->get(\'%s\')', $id);
         }
 
-        if ($this->container->hasDefinition($id) && (!$this->container->getDefinition($id)->isPublic() || $this->container->getDefinition($id)->isShared())) {
+        if ($this->container->hasDefinition($id) && $this->container->getDefinition($id)->isShared()) {
             // The following is PHP 5.5 syntax for what could be written as "(\$this->services['$id'] ?? $code)" on PHP>=7.0
 
             $code = "\${(\$_ = isset(\$this->services['$id']) ? \$this->services['$id'] : $code) && false ?: '_'}";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Likely not a bug fix because private services should be dealt with by some compiler pass, but anyway, locally, I don't get why non-shared private services should check the "$this->services" property.
Did I miss something?