### PR TITLE
[VarDumper] Allow HtmlDumper users to directly get the header

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 -----
 
  * added `AbstractCloner::setMinDepth()` function to ensure minimum tree depth
+ * added `HtmlDumper::markHeaderAsDumped()` function to prevent dumping HTML header
+ * increased visibility of `HtmlDumper::getDumpHeader()` function from protected to public
 
 2.7.0
 -----

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -118,11 +118,22 @@ class HtmlDumper extends CliDumper
     }
 
     /**
-     * Dumps the HTML header.
+     * Marks the HTML header for the current output stream as dumped, so it is not later
+     * automatically dumped when dump() or dumpLine() is called.  Note that this flag is reset to
+     * false if the output stream is changed (e.g. if a new output stream is provided to the dump()
+     * function).
      */
-    protected function getDumpHeader()
+    public function markHeaderAsDumped()
     {
         $this->headerIsDumped = null !== $this->outputStream ? $this->outputStream : $this->lineDumper;
+    }
+
+    /**
+     * Dumps the HTML header.
+     */
+    public function getDumpHeader()
+    {
+        $this->markHeaderAsDumped();
 
         if (null !== $this->dumpHeader) {
             return $this->dumpHeader;

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -161,4 +161,29 @@ EOTXT
             $out
         );
     }
+
+    public function testMarkHeaderAsDumped()
+    {
+        $out = fopen('php://memory', 'r+b');
+
+        $dumper = new HtmlDumper();
+        $dumper->setDumpHeader('<foo></foo>');
+        $dumper->setDumpBoundaries('<bar>', '</bar>');
+        $dumper->setOutput($out);
+        $dumper->markHeaderAsDumped();
+        $cloner = new VarCloner();
+
+        $dumper->dump($cloner->cloneVar(123));
+
+        $out = stream_get_contents($out, -1, 0);
+
+        $this->assertSame(<<<'EOTXT'
+<bar><span class=sf-dump-num>123</span>
+</bar>
+
+EOTXT
+            ,
+            $out
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

If the `HtmlDumper` is being embedded as part of a larger component, it may not be desirable to have the `HtmlDumper` automatically dump the header containing static assets.

Give `HtmlDumper` users more control by:

* Making `getDumpHeader` a public function, so that they can directly get the header without having to dump a variable.
* Add `markHeaderAsDumped`: this enables users to dump variables first without the header, if it's more convenient that way.  They can then call `getDumpHeader` at a later time.

Motivation: I'm integrating this with PHP Debug Bar; not having direct access to the dump header makes it difficult to properly include these assets in the page header along with the other debug bar static assets. Furthermore, actual variable dumps are only stored in string variables until they are later presented to the user via AJAX; we'd rather not have the dump header bundled with that.

Since this is a fairly minor/niche change, I'm not sure it's worth making any corresponding change in symfony-docs.

The following code from my own project is what motivated me to create this pull request: the `DebugBarHtmlDumper` class seems quite brittle and likely to break in future Symfony versions; I'd rather delete this class if this pull request can be accepted.

```
/**
 * We have to extend the base HtmlDumper class in order to get access to some of the protected-only
 * members, like getting only the dump header.
 */
class DebugBarHtmlDumper extends HtmlDumper implements AssetProvider
{
    public function getAssets() {
        return array(
            'inline_head' => array(
                'html_var_dumper' => $this->getDumpHeader(),
            ),
        );
    }

    public function markHeaderAsDumpedMine() {
        // TODO old versions of Symfony we just set this to true.
        // Copied from getDumpHeader() implementation:
        $this->headerIsDumped = null !== $this->outputStream ? $this->outputStream : $this->lineDumper;
    }
}

// Example class showing usage of DebugBarHtmlDumper:
class DebugBarVarDumper implements AssetProvider
{
<snip lots of code>
    // Dump data without the common header
    protected function dump(Data $data)
    {
        $dumper = $this->getDumper();
        $output = fopen('php://memory', 'r+b');
        $dumper->setOutput($output);
        $dumper->markHeaderAsDumpedMine();
        $dumper->dump($data, null, $this->getDisplayOptions());
        $result = stream_get_contents($output, -1, 0);
        fclose($output);
        return $result;
    }

    /**
     * Returns assets required for rendering variables.
     *
     * @return array
     */
    public function getAssets() {
        return $this->getDumper()->getAssets();
    }
}
```
