### PR TITLE
[VarDumper] Use "C" locale when using "comma" flags

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -123,6 +123,10 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
      */
     public function dump(Data $data, $output = null)
     {
+        if ($locale = $this->flags & (self::DUMP_COMMA_SEPARATOR | self::DUMP_TRAILING_COMMA) ? setlocale(LC_NUMERIC, 0) : null) {
+            setlocale(LC_NUMERIC, 'C');
+        }
+
         if ($returnDump = true === $output) {
             $output = fopen('php://memory', 'r+b');
         }
@@ -142,6 +146,9 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
         } finally {
             if ($output) {
                 $this->setOutput($prevOutput);
+            }
+            if ($locale) {
+                setlocale(LC_NUMERIC, $locale);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23572
| License       | MIT
| Doc PR        | -

Adding trailing comma implicitly requires a C locale.