### PR TITLE
[DI] Change "this" to "that" in `findAndSortTaggedServices` doc to reduce confusion

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -26,7 +26,7 @@ trait PriorityTaggedServiceTrait
      *
      * The order of additions must be respected for services having the same priority,
      * and knowing that the \SplPriorityQueue class does not respect the FIFO method,
-     * we should not use this class.
+     * we should not use that class.
      *
      * @see https://bugs.php.net/bug.php?id=53710
      * @see https://bugs.php.net/bug.php?id=60926


### PR DESCRIPTION
Continuation of PR #23578 which I royally messed up.....

| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | None

I know this is extremely minor, but reading the description of this method, I got confused. Wondering if it's just me.

Where it says:

> The order of additions must be respected for services having the same priority, and knowing that the \SplPriorityQueue class does not respect the FIFO method, we should not use **this** class.

Should it not say "we should not use **that** class"?