### PR TITLE
Fix login redirect when referer contains a query string

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -118,8 +118,14 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
             return $targetUrl;
         }
 
-        if ($this->options['use_referer'] && ($targetUrl = $request->headers->get('Referer')) && $targetUrl !== $this->httpUtils->generateUri($request, $this->options['login_path'])) {
-            return $targetUrl;
+        if ($this->options['use_referer']) {
+            $targetUrl = $request->headers->get('Referer');
+            if (false !== $pos = strpos($targetUrl, '?')) {
+                $targetUrl = substr($targetUrl, 0, $pos);
+            }
+            if ($targetUrl !== $this->httpUtils->generateUri($request, $this->options['login_path'])) {
+                return $targetUrl;
+            }
         }
 
         return $this->options['default_target_path'];

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -12,31 +12,28 @@
 namespace Symfony\Component\Security\Http\Tests\Authentication;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
 
 class DefaultAuthenticationSuccessHandlerTest extends TestCase
 {
     private $httpUtils = null;
-
-    private $request = null;
-
     private $token = null;
 
     protected function setUp()
     {
         $this->httpUtils = $this->getMockBuilder('Symfony\Component\Security\Http\HttpUtils')->getMock();
-        $this->request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
-        $this->request->headers = $this->getMockBuilder('Symfony\Component\HttpFoundation\HeaderBag')->getMock();
         $this->token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
     }
 
     public function testRequestIsRedirected()
     {
-        $response = $this->expectRedirectResponse('/');
+        $request = Request::create('/');
+        $response = $this->expectRedirectResponse($request, '/');
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, array());
-        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+        $result = $handler->onAuthenticationSuccess($request, $this->token);
 
         $this->assertSame($response, $result);
     }
@@ -48,24 +45,22 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
             'default_target_path' => '/dashboard',
         );
 
-        $response = $this->expectRedirectResponse('/dashboard');
+        $request = Request::create('/');
+        $response = $this->expectRedirectResponse($request, '/dashboard');
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, $options);
-        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+        $result = $handler->onAuthenticationSuccess($request, $this->token);
 
         $this->assertSame($response, $result);
     }
 
     public function testTargetPathIsPassedWithRequest()
     {
-        $this->request->expects($this->once())
-            ->method('get')->with('_target_path')
-            ->will($this->returnValue('/dashboard'));
-
-        $response = $this->expectRedirectResponse('/dashboard');
+        $request = Request::create('/?_target_path=/dashboard');
+        $response = $this->expectRedirectResponse($request, '/dashboard');
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, array());
-        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+        $result = $handler->onAuthenticationSuccess($request, $this->token);
 
         $this->assertSame($response, $result);
     }
@@ -73,15 +68,11 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
     public function testTargetPathParameterIsCustomised()
     {
         $options = array('target_path_parameter' => '_my_target_path');
-
-        $this->request->expects($this->once())
-            ->method('get')->with('_my_target_path')
-            ->will($this->returnValue('/dashboard'));
-
-        $response = $this->expectRedirectResponse('/dashboard');
+        $request = Request::create('/?_my_target_path=/dashboard');
+        $response = $this->expectRedirectResponse($request, '/dashboard');
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, $options);
-        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+        $result = $handler->onAuthenticationSuccess($request, $this->token);
 
         $this->assertSame($response, $result);
     }
@@ -95,16 +86,14 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
         $session->expects($this->once())
             ->method('remove')->with('_security.admin.target_path');
 
-        $this->request->expects($this->any())
-            ->method('getSession')
-            ->will($this->returnValue($session));
-
-        $response = $this->expectRedirectResponse('/admin/dashboard');
+        $request = Request::create('/?_my_target_path=/dashboard');
+        $request->setSession($session);
+        $response = $this->expectRedirectResponse($request, '/admin/dashboard');
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, array());
         $handler->setProviderKey('admin');
 
-        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+        $result = $handler->onAuthenticationSuccess($request, $this->token);
 
         $this->assertSame($response, $result);
     }
@@ -112,15 +101,12 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
     public function testTargetPathIsPassedAsReferer()
     {
         $options = array('use_referer' => true);
-
-        $this->request->headers->expects($this->once())
-            ->method('get')->with('Referer')
-            ->will($this->returnValue('/dashboard'));
-
-        $response = $this->expectRedirectResponse('/dashboard');
+        $request = Request::create('/');
+        $request->headers->set('Referer', '/dashboard');
+        $response = $this->expectRedirectResponse($request, '/dashboard');
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, $options);
-        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+        $result = $handler->onAuthenticationSuccess($request, $this->token);
 
         $this->assertSame($response, $result);
     }
@@ -128,41 +114,37 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
     public function testRefererHasToBeDifferentThatLoginUrl()
     {
         $options = array('use_referer' => true);
-
-        $this->request->headers->expects($this->any())
-            ->method('get')->with('Referer')
-            ->will($this->returnValue('/login'));
-
+        $request = Request::create('/');
+        $request->headers->set('Referer', '/login');
         $this->httpUtils->expects($this->once())
-            ->method('generateUri')->with($this->request, '/login')
+            ->method('generateUri')->with($request, '/login')
             ->will($this->returnValue('/login'));
 
-        $response = $this->expectRedirectResponse('/');
+        $response = $this->expectRedirectResponse($request, '/');
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, $options);
-        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+        $result = $handler->onAuthenticationSuccess($request, $this->token);
 
         $this->assertSame($response, $result);
     }
 
     public function testRefererTargetPathIsIgnoredByDefault()
     {
-        $this->request->headers->expects($this->never())->method('get');
-
-        $response = $this->expectRedirectResponse('/');
+        $request = Request::create('/');
+        $response = $this->expectRedirectResponse($request, '/');
 
         $handler = new DefaultAuthenticationSuccessHandler($this->httpUtils, array());
-        $result = $handler->onAuthenticationSuccess($this->request, $this->token);
+        $result = $handler->onAuthenticationSuccess($request, $this->token);
 
         $this->assertSame($response, $result);
     }
 
-    private function expectRedirectResponse($path)
+    private function expectRedirectResponse(Request $request, $path)
     {
         $response = new Response();
         $this->httpUtils->expects($this->once())
             ->method('createRedirectResponse')
-            ->with($this->request, $path)
+            ->with($request, $path)
             ->will($this->returnValue($response));
 
         return $response;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #19026, #23027, #23061, #23411, #23551
| License       | MIT
| Doc PR        | n/a

In 3.3, #19026 was merged to fix a bug that should have been fixed in 2.7. The fix was wrong anyway, so this PR fixes it the proper way.

The first two commits refactors test (using mocks for data objects is a bad idea and using too many mocks actually makes tests test nothing).

The actual fix is in the third commit.
