### PR TITLE
[Console] Improve Table performance

### DIFF
--- a/src/Symfony/Component/Console/Helper/TableRows.php
+++ b/src/Symfony/Component/Console/Helper/TableRows.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Helper;
+
+/**
+ * @internal
+ */
+class TableRows implements \IteratorAggregate
+{
+    private $generator;
+
+    public function __construct(callable $generator)
+    {
+        $this->generator = $generator;
+    }
+
+    public function getIterator()
+    {
+        $g = $this->generator;
+
+        return $g();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | might
| New feature?  | might as well
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Little memory gain for console tables :)

`setRows(array_fill(0, 1000000, [str_repeat('x', 100)]))` 

Before: +-20ms / +- 900mb
After: +- 20ms / +- 530mb

Next step could be to open public API for `iterable`, although we pre-iterate rows for calculation interally, it could be a nice feature :)