### PR TITLE
Fix the design of the profiler exceptions when there is no message

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
@@ -1,4 +1,4 @@
-<div class="exception-summary">
+<div class="exception-summary {{ exception.message is empty ? 'exception-without-message' }}">
     <div class="exception-metadata">
         <div class="container">
             <h2 class="exception-hierarchy">
@@ -13,9 +13,9 @@
             </h2>
         </div>
     </div>
-    {% if exception.message is not empty %}
-    <div class="container">
-        <div class="exception-message-wrapper">
+
+    <div class="exception-message-wrapper">
+        <div class="container">
             <h1 class="break-long-words exception-message {{ exception.message|length > 180 ? 'long' }}">
                 {{- exception.message|nl2br|format_file_from_text -}}
             </h1>
@@ -25,7 +25,6 @@
             </div>
         </div>
     </div>
-    {% endif %}
 </div>
 
 <div class="container">

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
@@ -79,7 +79,8 @@ header .container { display: flex; justify-content: space-between; }
 .exception-hierarchy .icon { margin: 0 3px; opacity: .7; }
 .exception-hierarchy .icon svg { height: 13px; width: 13px; vertical-align: -2px; }
 
-.exception-message-wrapper { display: flex; align-items: flex-start; min-height: 70px; padding: 10px 0 8px; }
+.exception-without-message .exception-message-wrapper { display: none; }
+.exception-message-wrapper .container { display: flex; align-items: flex-start; min-height: 70px; padding: 10px 0 8px; }
 .exception-message { flex-grow: 1; }
 .exception-message, .exception-message a { color: #FFF; font-size: 21px; font-weight: 400; margin: 0; }
 .exception-message.long { font-size: 18px; }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.css.twig
@@ -16,6 +16,9 @@
     margin: 1em 0;
     padding: 10px;
 }
+.exception-summary.exception-without-message {
+    display: none;
+}
 
 .exception-message {
     color: #B0413E;
@@ -26,6 +29,6 @@
     display: none;
 }
 
-.exception-message-wrapper {
+.exception-message-wrapper .container {
     min-height: auto;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23433
| License       | MIT
| Doc PR        | -

This changes a bit the HTML structure of exception pages so we can show exceptions without messages in a better way inside the profiler.

### Before

![before](https://user-images.githubusercontent.com/73419/28358961-092f845e-6c71-11e7-8225-63d01a8011f0.png)

### After

![after](https://user-images.githubusercontent.com/73419/28358968-0e6cfba4-6c71-11e7-9b76-3d6eb7a9f0bc.png)
