### PR TITLE
[WebProfilerBundle] Display trace and context in the logger profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -224,31 +224,33 @@
 {% endmacro %}
 
 {% macro render_log_message(category, log_index, log) %}
-    {% if log.context.exception.trace is defined %}
+    {% set has_context = log.context is defined and log.context is not empty %}
+    {% set has_trace = log.context.exception.trace is defined %}
+
+    {% if not has_context %}
+        {{ profiler_dump_log(log.message) }}
+    {% else %}
         {{ profiler_dump_log(log.message, log.context) }}
 
-        {% set context_id = 'context-' ~ category ~ '-' ~ log_index %}
+        <div class="text-small font-normal">
+            {% set context_id = 'context-' ~ category ~ '-' ~ log_index %}
+            <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ context_id }}" data-toggle-alt-content="Hide context">Show context</a>
 
-        <span class="metadata">
-             <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ context_id }}" data-toggle-alt-content="Hide trace">Show trace</a>
+            {% if has_trace %}
+                &nbsp;&nbsp;
+                {% set trace_id = 'trace-' ~ category ~ '-' ~ log_index %}
+                <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ trace_id }}" data-toggle-alt-content="Hide trace">Show trace</a>
+            {% endif %}
+        </div>
 
-            <div id="{{ context_id }}" class="context sf-toggle-content sf-toggle-hidden">
+        <div id="{{ context_id }}" class="context sf-toggle-content sf-toggle-hidden">
+            {{ profiler_dump(log.context, maxDepth=1) }}
+        </div>
+
+        {% if has_trace %}
+            <div id="{{ trace_id }}" class="context sf-toggle-content sf-toggle-hidden">
                 {{ profiler_dump(log.context.exception.trace, maxDepth=1) }}
             </div>
-        </span>
-    {% elseif log.context is defined and log.context is not empty %}
-        {{ profiler_dump_log(log.message, log.context) }}
-
-        {% set context_id = 'context-' ~ category ~ '-' ~ log_index %}
-
-        <span class="metadata">
-             <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ context_id }}" data-toggle-alt-content="Hide context">Show context</a>
-
-             <div id="{{ context_id }}" class="context sf-toggle-content sf-toggle-hidden">
-                {{ profiler_dump(log.context, maxDepth=1) }}
-            </div>
-        </span>
-    {% else %}
-        {{ profiler_dump_log(log.message) }}
+        {% endif %}
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Right now the behavior is not perfect. It can display only the trace **or** the context.
Some time, we want both.

More over, using `{{ profiler_dump_log(log.message, trace) }}` is wrong