### PR TITLE
Fixed typo in docblock in AuthenticationExpiredException

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationExpiredException.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Core\Exception;
 
 /**
- * AuthenticationServiceException is thrown when an authenticated token becomes un-authentcated between requests.
+ * AuthenticationServiceException is thrown when an authenticated token becomes un-authenticated between requests.
  *
  * In practice, this is due to the User changing between requests (e.g. password changes),
  * causes the token to become un-authenticated.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Found a small typo, applied it in the lowest branch possible.