### PR TITLE
[Workflow] Adding workflow name to the announce event

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * Added support for `Event::getWorkflowName()` for "announce" events.
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -276,6 +276,35 @@ class WorkflowTest extends TestCase
         $this->assertSame($eventNameExpected, $eventDispatcher->dispatchedEvents);
     }
 
+    public function testEventName()
+    {
+        $definition = $this->createComplexWorkflowDefinition();
+        $subject = new \stdClass();
+        $subject->marking = null;
+        $eventDispatcher = new EventDispatcherMock();
+        $name = 'workflow_name';
+        $workflow = new Workflow($definition, new MultipleStateMarkingStore(), $eventDispatcher, $name);
+
+        $assertWorkflowName = function (Event $event) use ($name) {
+            $this->assertEquals($name, $event->getWorkflowName());
+        };
+
+        $eventNames = array(
+            'workflow.guard',
+            'workflow.leave',
+            'workflow.transition',
+            'workflow.enter',
+            'workflow.entered',
+            'workflow.announce',
+        );
+
+        foreach ($eventNames as $eventName) {
+            $eventDispatcher->addListener($eventName, $assertWorkflowName);
+        }
+
+        $marking = $workflow->apply($subject, 't1');
+    }
+
     public function testMarkingStateOnApplyWithEventDispatcher()
     {
         $definition = new Definition(range('a', 'f'), array(new Transition('t', range('a', 'c'), range('d', 'f'))));

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -281,9 +281,9 @@ class WorkflowTest extends TestCase
         $definition = $this->createComplexWorkflowDefinition();
         $subject = new \stdClass();
         $subject->marking = null;
-        $eventDispatcher = new EventDispatcherMock();
+        $dispatcher = new EventDispatcher();
         $name = 'workflow_name';
-        $workflow = new Workflow($definition, new MultipleStateMarkingStore(), $eventDispatcher, $name);
+        $workflow = new Workflow($definition, new MultipleStateMarkingStore(), $dispatcher, $name);
 
         $assertWorkflowName = function (Event $event) use ($name) {
             $this->assertEquals($name, $event->getWorkflowName());
@@ -299,10 +299,10 @@ class WorkflowTest extends TestCase
         );
 
         foreach ($eventNames as $eventName) {
-            $eventDispatcher->addListener($eventName, $assertWorkflowName);
+            $dispatcher->addListener($eventName, $assertWorkflowName);
         }
 
-        $marking = $workflow->apply($subject, 't1');
+        $workflow->apply($subject, 't1');
     }
 
     public function testMarkingStateOnApplyWithEventDispatcher()

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -298,7 +298,7 @@ class Workflow
             return;
         }
 
-        $event = new Event($subject, $marking, $initialTransition);
+        $event = new Event($subject, $marking, $initialTransition, $this->name);
 
         $this->dispatcher->dispatch('workflow.announce', $event);
         $this->dispatcher->dispatch(sprintf('workflow.%s.announce', $this->name), $event);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Im not sure why this as not been added before. When dispatching all other events we use the forth parameter to Event. 

Ping @lyrixx 
