### PR TITLE
[PropertyInfo] Use rawurlencode to escape PSR-6 keys

### DIFF
--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -106,7 +106,8 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface
             return call_user_func_array(array($this->propertyInfoExtractor, $method), $arguments);
         }
 
-        $key = $this->escape($method.'.'.$serializedArguments);
+        // Calling rawurlencode escapes special characters not allowed in PSR-6's keys
+        $key = rawurlencode($method.'.'.$serializedArguments);
 
         if (array_key_exists($key, $this->arrayCache)) {
             return $this->arrayCache[$key];
@@ -123,30 +124,5 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface
         $this->cacheItemPool->save($item);
 
         return $this->arrayCache[$key] = $value;
-    }
-
-    /**
-     * Escapes a key according to PSR-6.
-     *
-     * Replaces characters forbidden by PSR-6 and the _ char by the _ char followed by the ASCII
-     * code of the escaped char.
-     *
-     * @param string $key
-     *
-     * @return string
-     */
-    private function escape($key)
-    {
-        return strtr($key, array(
-            '{' => '_123',
-            '}' => '_125',
-            '(' => '_40',
-            ')' => '_41',
-            '/' => '_47',
-            '\\' => '_92',
-            '@' => '_64',
-            ':' => '_58',
-            '_' => '_95',
-        ));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
@@ -61,29 +61,4 @@ class PropertyInfoCacheExtractorTest extends AbstractPropertyInfoExtractorTest
         parent::testGetProperties();
         parent::testGetProperties();
     }
-
-    /**
-     * @dataProvider escapeDataProvider
-     */
-    public function testEscape($toEscape, $expected)
-    {
-        $reflectionMethod = new \ReflectionMethod($this->propertyInfo, 'escape');
-        $reflectionMethod->setAccessible(true);
-
-        $this->assertSame($expected, $reflectionMethod->invoke($this->propertyInfo, $toEscape));
-    }
-
-    public function escapeDataProvider()
-    {
-        return array(
-            array('foo_bar', 'foo_95bar'),
-            array('foo_95bar', 'foo_9595bar'),
-            array('foo{bar}', 'foo_123bar_125'),
-            array('foo(bar)', 'foo_40bar_41'),
-            array('foo/bar', 'foo_47bar'),
-            array('foo\bar', 'foo_92bar'),
-            array('foo@bar', 'foo_64bar'),
-            array('foo:bar', 'foo_58bar'),
-        );
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  |no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Use `rawurlenode` instead of my custom escaper as suggested by @nicolas-grekas: https://twitter.com/nicolasgrekas/status/887728384469590016