### PR TITLE
[DI][Bug] Autowiring thinks optional args on core classes are required

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -273,6 +273,12 @@ class AutowirePass extends AbstractRecursivePass
 
                 // no default value? Then fail
                 if (!$parameter->isDefaultValueAvailable()) {
+                    // For core classes, isDefaultValueAvailable() can
+                    // be false when isOptional() returns true. If the
+                    // argument *is* optional, allow it to be missing
+                    if ($parameter->isOptional()) {
+                        continue;
+                    }
                     throw new AutowiringFailedException($this->currentId, sprintf('Cannot autowire service "%s": argument "$%s" of method "%s()" must have a type-hint or be given a value explicitly.', $this->currentId, $parameter->name, $class !== $this->currentId ? $class.'::'.$method : $method));
                 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -512,6 +512,23 @@ class AutowirePassTest extends TestCase
         );
     }
 
+    public function testOptionalArgsNoRequiredForCoreClasses()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('pdo_service', \PDO::class)
+            ->addArgument('sqlite:/foo.db')
+            ->setAutowired(true);
+
+        (new AutowirePass())->process($container);
+
+        $definition = $container->getDefinition('pdo_service');
+        $this->assertEquals(
+            array('sqlite:/foo.db'),
+            $definition->getArguments()
+        );
+    }
+
     public function testSetterInjection()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3,3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n/a

Currently, the following fails:

```yml
services:
    PDO:
        class: PDO
        arguments:
            - 'sqlite:/foo.db'
```

The error:

> Cannot autowire service "PDO": argument "$username" of method "__construct()" must have a type-hint or be given a value explicitly

`$username` is the second argument to `PDO`, and it's optional. Here's the reason: it appears that `$parameter->isDefaultValueAvailable()` returns false for optional arguments of core classes. But, `$parameter->isOptional()` returns true.

This allows optional arguments to not throw an exception. I can't think of any edge cases this will cause - but it's possible I'm not thinking of something :).

Cheers!