### PR TITLE
use Precise on Travis to keep PHP LDAP support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 
+dist: precise
 sudo: false
 
 git:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Travis CI [started to roll out Ubuntu Trusty](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) as the default distribution. However, it seems that the PHP LDAP extension is missing on Trusty (see travis-ci/travis-ci#7067) starting to make our builds fail. Thus, I suggest to keep using Precise until the linked issue has been fixed.
