### PR TITLE
[Cache] Handle serialization failures for Memcached

### DIFF
--- a/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
+++ b/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
@@ -26,6 +26,7 @@ trait MemcachedTrait
         'persistent_id' => null,
         'username' => null,
         'password' => null,
+        'serializer' => 'php',
     );
 
     private $client;
@@ -194,7 +195,14 @@ trait MemcachedTrait
      */
     protected function doFetch(array $ids)
     {
-        return $this->checkResultCode($this->client->getMulti($ids));
+        $unserializeCallbackHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
+        try {
+            return $this->checkResultCode($this->client->getMulti($ids));
+        } catch (\Error $e) {
+            throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
+        } finally {
+            ini_set('unserialize_callback_func', $unserializeCallbackHandler);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fixes two issues with serialization + memcached: with the memcached extension, the default serializer is automatically selected as igbinary when possible, native php otherwise. That creates obvious migration/portability issues (ie just installing igbinary wipes out the value of your cache.)

Then, handling unserializing failures (esp. "php_incomplete_class") is a paramount feature of the component. You must be able to deal with migrating you code base without being blocked by some legacy serialized data.