### PR TITLE
[VarDumper] Remove hhvm compat in time zone caster

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -68,7 +68,7 @@ class DateCaster
     {
         $location = $timeZone->getLocation();
         $formatted = (new \Datetime('now', $timeZone))->format($location ? 'e (P)' : 'P');
-        $title = $location && extension_loaded('intl') ? \Locale::getDisplayRegion('-'.$location['country_code'], \Locale::getDefault()) : '';
+        $title = $location && extension_loaded('intl') ? \Locale::getDisplayRegion('-'.$location['country_code']) : '';
 
         $z = array(Caster::PREFIX_VIRTUAL.'timezone' => new ConstStub($formatted, $title));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

The 2nd arg of ``\Locale::getDisplayRegion()`` method is optional in PHP but required with HHVM.
See https://3v4l.org/eAigW.