### PR TITLE
[Routing] allow HEAD method to be defined first

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -307,7 +307,7 @@ EOF;
                 if (in_array('GET', $methods)) {
                     // Since we treat HEAD requests like GET requests we don't need to match it.
                     $methodVariable = 'canonicalMethod';
-                    $methods = array_filter($methods, function ($method) { return 'HEAD' !== $method; });
+                    $methods = array_values(array_filter($methods, function ($method) { return 'HEAD' !== $method; }));
                 }
 
                 if (1 === count($methods)) {

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -57,6 +57,17 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
         not_head_and_get:
 
+        // get_and_head
+        if ('/get_and_head' === $pathinfo) {
+            if ('GET' !== $canonicalMethod) {
+                $allow[] = 'GET';
+                goto not_get_and_head;
+            }
+
+            return array('_route' => 'get_and_head');
+        }
+        not_get_and_head:
+
         // post_and_head
         if ('/post_and_get' === $pathinfo) {
             if (!in_array($requestMethod, array('POST', 'HEAD'))) {

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -297,6 +297,15 @@ class PhpMatcherDumperTest extends TestCase
             array(),
             '',
             array(),
+            array('HEAD', 'GET')
+        ));
+        $headMatchCasesCollection->add('get_and_head', new Route(
+            '/get_and_head',
+            array(),
+            array(),
+            array(),
+            '',
+            array(),
             array('GET', 'HEAD')
         ));
         $headMatchCasesCollection->add('post_and_head', new Route(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Since 3.3 it's no longer possible to set the allowed methods to HEAD followed by GET. If you try this you get an `Notice: Undefined offset: 0` error.

```
index:
  path: '/'
  defaults:
    _controller: AppBundle:Default:index
  methods: [HEAD, GET]
```

It works perfectly if you change the ordering of the allowed methods:

```
index:
  path: '/'
  defaults:
    _controller: AppBundle:Default:index
  methods: [GET, HEAD]
```

The problem has been added in this commit: https://github.com/symfony/symfony/commit/dd647ffc8a27048b39168e8e83c1c0ade149e84c#diff-3b72491a9ba1cff58442b845ae837eb3R297

After an `array_filter` the keys will not be reset. So the key `0` does not exist anymore and this check `if ('$methods[0]' !== \$$methodVariable) {` fails. A simple `array_values` ​​fix this issue.

