### PR TITLE
[Validator] Fix IbanValidator for ukrainian IBANs

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -34,7 +34,7 @@ class IbanValidator extends ConstraintValidator
      * a BBAN (Basic Bank Account Number) which has a fixed length per country and,
      * included within it, a bank identifier with a fixed position and a fixed length per country
      *
-     * @see http://www.swift.com/dsp/resources/documents/IBAN_Registry.pdf
+     * @see https://www.swift.com/sites/default/files/resources/iban_registry.pdf
      *
      * @var array
      */
@@ -130,7 +130,7 @@ class IbanValidator extends ConstraintValidator
         'TL' => 'TL\d{2}\d{3}\d{14}\d{2}', // Timor-Leste
         'TN' => 'TN59\d{2}\d{3}\d{13}\d{2}', // Tunisia
         'TR' => 'TR\d{2}\d{5}[\dA-Z]{1}[\dA-Z]{16}', // Turkey
-        'UA' => 'UA\d{2}[A-Z]{6}[\dA-Z]{19}', // Ukraine
+        'UA' => 'UA\d{2}\d{6}[\dA-Z]{19}', // Ukraine
         'VG' => 'VG\d{2}[A-Z]{4}\d{16}', // Virgin Islands, British
         'WF' => 'FR\d{2}\d{5}\d{5}[\dA-Z]{11}\d{2}', // Wallis and Futuna Islands
         'XK' => 'XK\d{2}\d{4}\d{10}\d{2}', // Republic of Kosovo

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -118,7 +118,7 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
 
             //Extended country list
             //http://www.nordea.com/Our+services/International+products+and+services/Cash+Management/IBAN+countries/908462.html
-            // http://www.swift.com/dsp/resources/documents/IBAN_Registry.pdf
+            // https://www.swift.com/sites/default/files/resources/iban_registry.pdf
             array('AO06000600000100037131174'), //Angola
             array('AZ21NABZ00000000137010001944'), //Azerbaijan
             array('BH29BMAG1299123456BH00'), //Bahrain
@@ -156,6 +156,7 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
             array('TL380080012345678910157'), //Timor-Leste
             array('TN5914207207100707129648'), //Tunisia
             array('TR330006100519786457841326'), //Turkey
+            array('UA213223130000026007233566001'), //Ukraine
             array('AE260211000000230064016'), //United Arab Emirates
         );
     }
@@ -268,6 +269,7 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
             array('TL3800800123456789101571'), //Timor-Leste
             array('TN59142072071007071296481'), //Tunisia
             array('TR3300061005197864578413261'), //Turkey
+            array('UA21AAAA1300000260072335660012'), //Ukraine
             array('AE2602110000002300640161'), //United Arab Emirates
         );
     }
@@ -377,6 +379,7 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
             array('TL380080012345678910158'), //Timor-Leste
             array('TN5914207207100707129649'), //Tunisia
             array('TR330006100519786457841327'), //Turkey
+            array('UA213223130000026007233566002'), //Ukraine
             array('AE260211000000230064017'), //United Arab Emirates
         );
     }


### PR DESCRIPTION
The ukrainian bank identifier consists of six digits and not letters.
Also fixes the broken links to the current SWIFT IBAN registry pdf.

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a
