### PR TITLE
[HttpKernel] Garbage collection in LoggerDataCollector took about 50% of all execution time 

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -25,6 +25,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
 {
     private $logger;
     private $containerPathPrefix;
+    private static $serializeData;
 
     public function __construct($logger = null, $containerPathPrefix = null)
     {
@@ -46,9 +47,21 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
     /**
      * {@inheritdoc}
      */
+    public function serialize()
+    {
+        if (null === self::$serializeData) {
+            self::$serializeData = serialize($this->data);
+        }
+
+        return self::$serializeData;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function lateCollect()
     {
-        if (null !== $this->logger) {
+        if (null !== $this->logger && null === self::$serializeData) {
             $containerDeprecationLogs = $this->getContainerDeprecationLogs();
             $this->data = $this->computeErrorsCount($containerDeprecationLogs);
             $this->data['compiler_logs'] = $this->getContainerCompilerLogs();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When save the profiler, the method `LoggerDataCollector:lateCollect` called for each sub-request on the same sets of logs. For example I profile page with 70 sub-requests and 7k logs https://blackfire.io/profiles/bc726df2-ec8d-4f1b-bc1b-5b09a1f3f141/graph

After apply my fix I get more 80% performance
![selection_061](https://user-images.githubusercontent.com/21358010/28486528-3256cc68-6e8b-11e7-9445-19b8866f8490.png)

Thanks,
Vladimir



