### PR TITLE
[FrameworkBundle] Commands as a service

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -100,7 +100,7 @@ EOF
         if (__CLASS__ !== get_class($this)) {
             $r = new \ReflectionMethod($this, 'getTwigEnvironment');
             if (__CLASS__ !== $r->getDeclaringClass()->getName()) {
-                @trigger_error(sprintf('Usage of method "%s" is deprecated since version 3.4 and will no longer be supported in 4.0.', get_class($this).'::getTwigEnvironment'), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Usage of method "%s" is deprecated since version 3.4 and will no longer be supported in 4.0. Construct the command with its required arguments instead.', get_class($this).'::getTwigEnvironment'), E_USER_DEPRECATED);
 
                 $this->twig = $this->getTwigEnvironment();
             }

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -105,7 +105,7 @@ EOF
         if (__CLASS__ !== get_class($this)) {
             $r = new \ReflectionMethod($this, 'getTwigEnvironment');
             if (__CLASS__ !== $r->getDeclaringClass()->getName()) {
-                @trigger_error(sprintf('Usage of method "%s" is deprecated since version 3.4 and will no longer be supported in 4.0.', get_class($this).'::getTwigEnvironment'), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Usage of method "%s" is deprecated since version 3.4 and will no longer be supported in 4.0. Construct the command with its required arguments instead.', get_class($this).'::getTwigEnvironment'), E_USER_DEPRECATED);
 
                 $this->twig = $this->getTwigEnvironment();
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -26,6 +27,18 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class AboutCommand extends ContainerAwareCommand
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated since version 3.4, to be removed in 4.0
+     */
+    protected function getContainer()
+    {
+        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
+
+        return parent::getContainer();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -45,7 +58,7 @@ class AboutCommand extends ContainerAwareCommand
         $io = new SymfonyStyle($input, $output);
 
         /** @var $kernel KernelInterface */
-        $kernel = $this->getContainer()->get('kernel');
+        $kernel = $this->getApplication()->getKernel();
 
         $io->table(array(), array(
             array('<info>Symfony</>'),

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
  * A console command to display information about the current installation.
  *
  * @author Roland Franssen <franssen.roland@gmail.com>
+ *
+ * @final since version 3.4
  */
 class AboutCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -31,18 +31,6 @@ class AboutCommand extends ContainerAwareCommand
 {
     /**
      * {@inheritdoc}
-     *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
      */
     protected function configure()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -31,7 +31,7 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         $headers = array('Bundle name', 'Extension alias');
         $rows = array();
 
-        $bundles = $this->getContainer()->get('kernel')->getBundles();
+        $bundles = $this->getApplication()->getKernel()->getBundles();
         usort($bundles, function ($bundleA, $bundleB) {
             return strcmp($bundleA->getName(), $bundleB->getName());
         });
@@ -117,7 +117,7 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         // Re-build bundle manually to initialize DI extensions that can be extended by other bundles in their build() method
         // as this method is not called when the container is loaded from the cache.
         $container = $this->getContainerBuilder();
-        $bundles = $this->getContainer()->get('kernel')->getBundles();
+        $bundles = $this->getApplication()->getKernel()->getBundles();
         foreach ($bundles as $bundle) {
             if ($extension = $bundle->getContainerExtension()) {
                 $container->registerExtension($extension);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -58,18 +58,6 @@ class AssetsInstallCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
-     *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -111,8 +99,8 @@ EOT
     {
         // BC to be removed in 4.0
         if (null === $this->filesystem) {
-            $this->filesystem = parent::getContainer()->get('filesystem');
-            $baseDir = parent::getContainer()->getParameter('kernel.project_dir');
+            $this->filesystem = $this->getContainer()->get('filesystem');
+            $baseDir = $this->getContainer()->getParameter('kernel.project_dir');
         }
 
         $kernel = $this->getApplication()->getKernel();

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -39,7 +39,7 @@ class AssetsInstallCommand extends ContainerAwareCommand
     private $filesystem;
 
     /**
-     * @param Filesystem|null $filesystem
+     * @param Filesystem $filesystem
      */
     public function __construct($filesystem = null)
     {
@@ -53,7 +53,7 @@ class AssetsInstallCommand extends ContainerAwareCommand
             return;
         }
 
-        $this->filesystem = $filesystem ?: new Filesystem();
+        $this->filesystem = $filesystem;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -27,6 +27,8 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Gábor Egyed <gabor.egyed@gmail.com>
+ *
+ * @final since version 3.4
  */
 class AssetsInstallCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -30,15 +30,13 @@ use Symfony\Component\Finder\Finder;
 class CacheClearCommand extends ContainerAwareCommand
 {
     private $cacheClearer;
-    private $cacheDir;
     private $filesystem;
 
     /**
      * @param CacheClearerInterface $cacheClearer
-     * @param string|null           $cacheDir
      * @param Filesystem|null       $filesystem
      */
-    public function __construct($cacheClearer = null, $cacheDir = null, Filesystem $filesystem = null)
+    public function __construct($cacheClearer = null, Filesystem $filesystem = null)
     {
         parent::__construct();
 
@@ -51,7 +49,6 @@ class CacheClearCommand extends ContainerAwareCommand
         }
 
         $this->cacheClearer = $cacheClearer;
-        $this->cacheDir = $cacheDir;
         $this->filesystem = $filesystem ?: new Filesystem();
     }
 
@@ -98,18 +95,14 @@ EOF
         // BC to be removed in 4.0
         if (null === $this->cacheClearer) {
             $this->cacheClearer = parent::getContainer()->get('cache_clearer');
-        }
-        if (null === $this->cacheDir) {
-            $this->cacheDir = parent::getContainer()->getParameter('kernel.cache_dir');
-        }
-        if (null === $this->filesystem) {
             $this->filesystem = parent::getContainer()->get('filesystem');
+            $realCacheDir = parent::getContainer()->getParameter('kernel.cache_dir');
         }
 
         $io = new SymfonyStyle($input, $output);
 
         $kernel = $this->getApplication()->getKernel();
-        $realCacheDir = null === $this->cacheDir ? $this->cacheDir : $kernel->getCacheDir();
+        $realCacheDir = isset($realCacheDir) ? $realCacheDir : $kernel->getContainer()->getParameter('kernel.cache_dir');
         // the old cache dir name must not be longer than the real one to avoid exceeding
         // the maximum length of a directory or file path within it (esp. Windows MAX_PATH)
         $oldCacheDir = substr($realCacheDir, 0, -1).('~' === substr($realCacheDir, -1) ? '+' : '~');

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -56,18 +56,6 @@ class CacheClearCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
-     *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -96,9 +84,9 @@ EOF
     {
         // BC to be removed in 4.0
         if (null === $this->cacheClearer) {
-            $this->cacheClearer = parent::getContainer()->get('cache_clearer');
-            $this->filesystem = parent::getContainer()->get('filesystem');
-            $realCacheDir = parent::getContainer()->getParameter('kernel.cache_dir');
+            $this->cacheClearer = $this->getContainer()->get('cache_clearer');
+            $this->filesystem = $this->getContainer()->get('filesystem');
+            $realCacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
         }
 
         $io = new SymfonyStyle($input, $output);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -26,6 +26,8 @@ use Symfony\Component\Finder\Finder;
  *
  * @author Francis Besset <francis.besset@gmail.com>
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since version 3.4
  */
 class CacheClearCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -15,6 +15,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Finder\Finder;
 
@@ -26,6 +29,44 @@ use Symfony\Component\Finder\Finder;
  */
 class CacheClearCommand extends ContainerAwareCommand
 {
+    private $cacheClearer;
+    private $cacheDir;
+    private $filesystem;
+
+    /**
+     * @param CacheClearerInterface $cacheClearer
+     * @param string|null           $cacheDir
+     * @param Filesystem|null       $filesystem
+     */
+    public function __construct($cacheClearer = null, $cacheDir = null, Filesystem $filesystem = null)
+    {
+        parent::__construct();
+
+        if (!$cacheClearer instanceof CacheClearerInterface) {
+            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+
+            $this->setName(null === $cacheClearer ? 'cache:clear' : $cacheClearer);
+
+            return;
+        }
+
+        $this->cacheClearer = $cacheClearer;
+        $this->cacheDir = $cacheDir;
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated since version 3.4, to be removed in 4.0
+     */
+    protected function getContainer()
+    {
+        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
+
+        return parent::getContainer();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -54,28 +95,38 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // BC to be removed in 4.0
+        if (null === $this->cacheClearer) {
+            $this->cacheClearer = parent::getContainer()->get('cache_clearer');
+        }
+        if (null === $this->cacheDir) {
+            $this->cacheDir = parent::getContainer()->getParameter('kernel.cache_dir');
+        }
+        if (null === $this->filesystem) {
+            $this->filesystem = parent::getContainer()->get('filesystem');
+        }
+
         $io = new SymfonyStyle($input, $output);
 
-        $realCacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
+        $kernel = $this->getApplication()->getKernel();
+        $realCacheDir = null === $this->cacheDir ? $this->cacheDir : $kernel->getCacheDir();
         // the old cache dir name must not be longer than the real one to avoid exceeding
         // the maximum length of a directory or file path within it (esp. Windows MAX_PATH)
         $oldCacheDir = substr($realCacheDir, 0, -1).('~' === substr($realCacheDir, -1) ? '+' : '~');
-        $filesystem = $this->getContainer()->get('filesystem');
 
         if (!is_writable($realCacheDir)) {
             throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $realCacheDir));
         }
 
-        if ($filesystem->exists($oldCacheDir)) {
-            $filesystem->remove($oldCacheDir);
+        if ($this->filesystem->exists($oldCacheDir)) {
+            $this->filesystem->remove($oldCacheDir);
         }
 
-        $kernel = $this->getContainer()->get('kernel');
         $io->comment(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
-        $this->getContainer()->get('cache_clearer')->clear($realCacheDir);
+        $this->cacheClearer->clear($realCacheDir);
 
         if ($input->getOption('no-warmup')) {
-            $filesystem->rename($realCacheDir, $oldCacheDir);
+            $this->filesystem->rename($realCacheDir, $oldCacheDir);
         } else {
             $warning = 'Calling cache:clear without the --no-warmup option is deprecated since version 3.3. Cache warmup should be done with the cache:warmup command instead.';
 
@@ -90,7 +141,7 @@ EOF
             $io->comment('Removing old cache directory...');
         }
 
-        $filesystem->remove($oldCacheDir);
+        $this->filesystem->remove($oldCacheDir);
 
         if ($output->isVerbose()) {
             $io->comment('Finished');
@@ -101,7 +152,6 @@ EOF
 
     private function warmupCache(InputInterface $input, OutputInterface $output, $realCacheDir, $oldCacheDir)
     {
-        $filesystem = $this->getContainer()->get('filesystem');
         $io = new SymfonyStyle($input, $output);
 
         // the warmup cache dir name must have the same length than the real one
@@ -109,11 +159,11 @@ EOF
         $realCacheDir = realpath($realCacheDir);
         $warmupDir = substr($realCacheDir, 0, -1).('_' === substr($realCacheDir, -1) ? '-' : '_');
 
-        if ($filesystem->exists($warmupDir)) {
+        if ($this->filesystem->exists($warmupDir)) {
             if ($output->isVerbose()) {
                 $io->comment('Clearing outdated warmup directory...');
             }
-            $filesystem->remove($warmupDir);
+            $this->filesystem->remove($warmupDir);
         }
 
         if ($output->isVerbose()) {
@@ -121,11 +171,11 @@ EOF
         }
         $this->warmup($warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
 
-        $filesystem->rename($realCacheDir, $oldCacheDir);
+        $this->filesystem->rename($realCacheDir, $oldCacheDir);
         if ('\\' === DIRECTORY_SEPARATOR) {
             sleep(1);  // workaround for Windows PHP rename bug
         }
-        $filesystem->rename($warmupDir, $realCacheDir);
+        $this->filesystem->rename($warmupDir, $realCacheDir);
     }
 
     /**
@@ -138,7 +188,7 @@ EOF
     protected function warmup($warmupDir, $realCacheDir, $enableOptionalWarmers = true)
     {
         // create a temporary kernel
-        $realKernel = $this->getContainer()->get('kernel');
+        $realKernel = $this->getApplication()->getKernel();
         $realKernelClass = get_class($realKernel);
         $namespace = '';
         if (false !== $pos = strrpos($realKernelClass, '\\')) {
@@ -274,7 +324,7 @@ namespace $namespace
     }
 }
 EOF;
-        $this->getContainer()->get('filesystem')->mkdir($warmupDir);
+        $this->filesystem->mkdir($warmupDir);
         file_put_contents($file = $warmupDir.'/kernel.tmp', $code);
         require_once $file;
         $class = "$namespace\\$class";

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
@@ -26,13 +26,11 @@ use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
 final class CachePoolClearCommand extends ContainerAwareCommand
 {
     private $poolClearer;
-    private $cacheDir;
 
     /**
      * @param Psr6CacheClearer $poolClearer
-     * @param string|null      $cacheDir
      */
-    public function __construct($poolClearer = null, $cacheDir = null)
+    public function __construct($poolClearer = null)
     {
         parent::__construct();
 
@@ -45,7 +43,6 @@ final class CachePoolClearCommand extends ContainerAwareCommand
         }
 
         $this->poolClearer = $poolClearer;
-        $this->cacheDir = $cacheDir;
     }
 
     /**
@@ -76,9 +73,7 @@ EOF
         // BC to be removed in 4.0
         if (null === $this->poolClearer) {
             $this->poolClearer = $this->getContainer()->get('cache.global_clearer');
-        }
-        if (null === $this->cacheDir) {
-            $this->cacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
+            $cacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
         }
 
         $io = new SymfonyStyle($input, $output);
@@ -104,7 +99,7 @@ EOF
 
         foreach ($clearers as $id => $clearer) {
             $io->comment(sprintf('Calling cache clearer: <info>%s</info>', $id));
-            $clearer->clear(null === $this->cacheDir ? $kernel->getCacheDir() : $this->cacheDir);
+            $clearer->clear(isset($cacheDir) ? $cacheDir : $kernel->getContainer()->getParameter('kernel.cache_dir'));
         }
 
         foreach ($pools as $id => $pool) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
  * Warmup the cache.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since version 3.4
  */
 class CacheWarmupCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -26,13 +26,11 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
 class CacheWarmupCommand extends ContainerAwareCommand
 {
     private $cacheWarmer;
-    private $cacheDir;
 
     /**
      * @param CacheWarmerAggregate $cacheWarmer
-     * @param string|null          $cacheDir
      */
-    public function __construct($cacheWarmer = null, $cacheDir = null)
+    public function __construct($cacheWarmer = null)
     {
         parent::__construct();
 
@@ -45,7 +43,6 @@ class CacheWarmupCommand extends ContainerAwareCommand
         }
 
         $this->cacheWarmer = $cacheWarmer;
-        $this->cacheDir = $cacheDir;
     }
 
     /**
@@ -94,9 +91,7 @@ EOF
         // BC to be removed in 4.0
         if (null === $this->cacheWarmer) {
             $this->cacheWarmer = parent::getContainer()->get('cache_warmer');
-        }
-        if (null === $this->cacheDir) {
-            $this->cacheDir = parent::getContainer()->getParameter('kernel.cache_dir');
+            $cacheDir = parent::getContainer()->getParameter('kernel.cache_dir');
         }
 
         $io = new SymfonyStyle($input, $output);
@@ -108,7 +103,7 @@ EOF
             $this->cacheWarmer->enableOptionalWarmers();
         }
 
-        $this->cacheWarmer->warmUp(null === $this->cacheDir ? $kernel->getCacheDir() : $this->cacheDir);
+        $this->cacheWarmer->warmUp(isset($cacheDir) ? $cacheDir : $kernel->getContainer()->getParameter('kernel.cache_dir'));
 
         $io->success(sprintf('Cache for the "%s" environment (debug=%s) was successfully warmed.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -49,18 +49,6 @@ class CacheWarmupCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
-     *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -92,8 +80,8 @@ EOF
     {
         // BC to be removed in 4.0
         if (null === $this->cacheWarmer) {
-            $this->cacheWarmer = parent::getContainer()->get('cache_warmer');
-            $cacheDir = parent::getContainer()->getParameter('kernel.cache_dir');
+            $this->cacheWarmer = $this->getContainer()->get('cache_warmer');
+            $cacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
         }
 
         $io = new SymfonyStyle($input, $output);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
 
 /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -111,7 +111,7 @@ EOF
 
     private function compileContainer()
     {
-        $kernel = clone $this->getContainer()->get('kernel');
+        $kernel = clone $this->getApplication()->getKernel();
         $kernel->boot();
 
         $method = new \ReflectionMethod($kernel, 'buildContainer');

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -23,6 +23,8 @@ use Symfony\Component\Yaml\Yaml;
  * A console command for dumping available configuration reference.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @final since version 3.4
  */
 class ConfigDebugCommand extends AbstractConfigCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -25,6 +25,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * @author Kevin Bond <kevinbond@gmail.com>
  * @author Wouter J <waldio.webdesign@gmail.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @final since version 3.4
  */
 class ConfigDumpReferenceCommand extends AbstractConfigCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -27,6 +27,8 @@ use Symfony\Component\Config\FileLocator;
  * A console command for retrieving information about services.
  *
  * @author Ryan Weaver <ryan@thatsquality.com>
+ *
+ * @final since version 3.4
  */
 class ContainerDebugCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -37,6 +37,18 @@ class ContainerDebugCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated since version 3.4, to be removed in 4.0
+     */
+    protected function getContainer()
+    {
+        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
+
+        return parent::getContainer();
+    }
+
+    /**
+     * {@inheritdoc}
      */
     protected function configure()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -28,7 +28,7 @@ use Symfony\Component\Config\FileLocator;
  *
  * @author Ryan Weaver <ryan@thatsquality.com>
  *
- * @final since version 3.4
+ * @internal since version 3.4
  */
 class ContainerDebugCommand extends ContainerAwareCommand
 {
@@ -36,18 +36,6 @@ class ContainerDebugCommand extends ContainerAwareCommand
      * @var ContainerBuilder|null
      */
     protected $containerBuilder;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -51,18 +51,6 @@ class EventDispatcherDebugCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
-     *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -95,16 +83,8 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // BC to be removed in 4.0
-        if (__CLASS__ !== get_class($this)) {
-            $r = new \ReflectionMethod($this, 'getEventDispatcher');
-            if (__CLASS__ !== $r->getDeclaringClass()->getName()) {
-                @trigger_error(sprintf('Usage of method "%s" is deprecated since version 3.4 and will no longer be supported in 4.0. Construct the command with its required arguments instead.', get_class($this).'::getEventDispatcher'), E_USER_DEPRECATED);
-
-                $this->dispatcher = $this->getEventDispatcher();
-            }
-        }
         if (null === $this->dispatcher) {
-            $this->dispatcher = parent::getContainer()->get('event_dispatcher');
+            $this->dispatcher = $this->getEventDispatcher();
         }
 
         $io = new SymfonyStyle($input, $output);
@@ -130,14 +110,12 @@ EOF
     /**
      * Loads the Event Dispatcher from the container.
      *
-     * @return EventDispatcherInterface
+     * BC to removed in 4.0
      *
-     * @deprecated since version 3.4, to be removed in 4.0
+     * @return EventDispatcherInterface
      */
     protected function getEventDispatcher()
     {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
-
-        return parent::getContainer()->get('event_dispatcher');
+        return $this->getContainer()->get('event_dispatcher');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -24,6 +24,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * A console command for retrieving information about event dispatcher.
  *
  * @author Matthieu Auger <mail@matthieuauger.com>
+ *
+ * @final since version 3.4
  */
 class EventDispatcherDebugCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -64,10 +64,11 @@ class RouterDebugCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
+     *
+     * BC to be removed in 4.0
      */
     public function isEnabled()
     {
-        // BC to be removed in 4.0
         if (null !== $this->router) {
             return parent::isEnabled();
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -55,18 +55,6 @@ class RouterDebugCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
-     *
      * BC to be removed in 4.0
      */
     public function isEnabled()
@@ -74,10 +62,10 @@ class RouterDebugCommand extends ContainerAwareCommand
         if (null !== $this->router) {
             return parent::isEnabled();
         }
-        if (!parent::getContainer()->has('router')) {
+        if (!$this->getContainer()->has('router')) {
             return false;
         }
-        $router = parent::getContainer()->get('router');
+        $router = $this->getContainer()->get('router');
         if (!$router instanceof RouterInterface) {
             return false;
         }
@@ -118,7 +106,7 @@ EOF
     {
         // BC to be removed in 4.0
         if (null === $this->router) {
-            $this->router = parent::getContainer()->get('router');
+            $this->router = $this->getContainer()->get('router');
         }
 
         $io = new SymfonyStyle($input, $output);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -27,6 +27,8 @@ use Symfony\Component\Routing\Route;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
+ *
+ * @final since version 3.4
  */
 class RouterDebugCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -53,18 +53,6 @@ class RouterMatchCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
-     *
      * BC to be removed in 4.0
      */
     public function isEnabled()
@@ -72,10 +60,10 @@ class RouterMatchCommand extends ContainerAwareCommand
         if (null !== $this->router) {
             return parent::isEnabled();
         }
-        if (!parent::getContainer()->has('router')) {
+        if (!$this->getContainer()->has('router')) {
             return false;
         }
-        $router = parent::getContainer()->get('router');
+        $router = $this->getContainer()->get('router');
         if (!$router instanceof RouterInterface) {
             return false;
         }
@@ -118,7 +106,7 @@ EOF
     {
         // BC to be removed in 4.0
         if (null === $this->router) {
-            $this->router = parent::getContainer()->get('router');
+            $this->router = $this->getContainer()->get('router');
         }
 
         $io = new SymfonyStyle($input, $output);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -62,10 +62,11 @@ class RouterMatchCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
+     *
+     * BC to be removed in 4.0
      */
     public function isEnabled()
     {
-        // BC to be removed in 4.0
         if (null !== $this->router) {
             return parent::isEnabled();
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -25,6 +25,8 @@ use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
  * A console command to test route matching.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since version 3.4
  */
 class RouterMatchCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -128,10 +128,11 @@ EOF
 
     /**
      * {@inheritdoc}
+     *
+     * BC to be removed in 4.0
      */
     public function isEnabled()
     {
-        // BC to be removed in 4.0
         if (null !== $this->translator) {
             return parent::isEnabled();
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -31,6 +31,8 @@ use Symfony\Component\Translation\TranslatorInterface;
  * and comparing them with the fallback ones.
  *
  * @author Florian Voutzinos <florian@voutzinos.com>
+ *
+ * @final since version 3.4
  */
 class TranslationDebugCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -17,12 +17,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Translation\Catalogue\MergeOperation;
+use Symfony\Component\Translation\Extractor\ExtractorInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\DataCollectorTranslator;
 use Symfony\Component\Translation\LoggingTranslator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Helps finding unused or missing translation messages in a given locale
@@ -32,9 +34,47 @@ use Symfony\Component\Translation\LoggingTranslator;
  */
 class TranslationDebugCommand extends ContainerAwareCommand
 {
+    private $translator;
+    private $loader;
+    private $extractor;
+
     const MESSAGE_MISSING = 0;
     const MESSAGE_UNUSED = 1;
     const MESSAGE_EQUALS_FALLBACK = 2;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param TranslationLoader   $loader
+     * @param ExtractorInterface  $extractor
+     */
+    public function __construct($translator = null, TranslationLoader $loader = null, ExtractorInterface $extractor = null)
+    {
+        parent::__construct();
+
+        if (!$translator instanceof TranslatorInterface) {
+            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+
+            $this->setName(null === $translator ? 'debug:translation' : $translator);
+
+            return;
+        }
+
+        $this->translator = $translator;
+        $this->loader = $loader;
+        $this->extractor = $extractor;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated since version 3.4, to be removed in 4.0
+     */
+    protected function getContainer()
+    {
+        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
+
+        return parent::getContainer();
+    }
 
     /**
      * {@inheritdoc}
@@ -91,6 +131,10 @@ EOF
      */
     public function isEnabled()
     {
+        // BC to be removed in 4.0
+        if (null !== $this->translator) {
+            return parent::isEnabled();
+        }
         if (!class_exists('Symfony\Component\Translation\Translator')) {
             return false;
         }
@@ -103,14 +147,23 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // BC to be removed in 4.0
+        if (null === $this->translator) {
+            $this->translator = parent::getContainer()->get('translator');
+        }
+        if (null === $this->loader) {
+            $this->loader = parent::getContainer()->get('translation.loader');
+        }
+        if (null === $this->extractor) {
+            $this->extractor = parent::getContainer()->get('translation.extractor');
+        }
+
         $io = new SymfonyStyle($input, $output);
 
         $locale = $input->getArgument('locale');
         $domain = $input->getOption('domain');
-        /** @var TranslationLoader $loader */
-        $loader = $this->getContainer()->get('translation.loader');
-        /** @var Kernel $kernel */
-        $kernel = $this->getContainer()->get('kernel');
+        /** @var KernelInterface $kernel */
+        $kernel = $this->getApplication()->getKernel();
 
         // Define Root Path to App folder
         $transPaths = array($kernel->getRootDir().'/Resources/');
@@ -142,7 +195,7 @@ EOF
         $extractedCatalogue = $this->extractMessages($locale, $transPaths);
 
         // Load defined messages
-        $currentCatalogue = $this->loadCurrentMessages($locale, $transPaths, $loader);
+        $currentCatalogue = $this->loadCurrentMessages($locale, $transPaths);
 
         // Merge defined and extracted messages to get all message ids
         $mergeOperation = new MergeOperation($extractedCatalogue, $currentCatalogue);
@@ -165,7 +218,7 @@ EOF
         }
 
         // Load the fallback catalogues
-        $fallbackCatalogues = $this->loadFallbackCatalogues($locale, $transPaths, $loader);
+        $fallbackCatalogues = $this->loadFallbackCatalogues($locale, $transPaths);
 
         // Display header line
         $headers = array('State', 'Domain', 'Id', sprintf('Message Preview (%s)', $locale));
@@ -271,7 +324,7 @@ EOF
         foreach ($transPaths as $path) {
             $path = $path.'views';
             if (is_dir($path)) {
-                $this->getContainer()->get('translation.extractor')->extract($path, $extractedCatalogue);
+                $this->extractor->extract($path, $extractedCatalogue);
             }
         }
 
@@ -279,19 +332,18 @@ EOF
     }
 
     /**
-     * @param string            $locale
-     * @param array             $transPaths
-     * @param TranslationLoader $loader
+     * @param string $locale
+     * @param array  $transPaths
      *
      * @return MessageCatalogue
      */
-    private function loadCurrentMessages($locale, $transPaths, TranslationLoader $loader)
+    private function loadCurrentMessages($locale, $transPaths)
     {
         $currentCatalogue = new MessageCatalogue($locale);
         foreach ($transPaths as $path) {
             $path = $path.'translations';
             if (is_dir($path)) {
-                $loader->loadMessages($path, $currentCatalogue);
+                $this->loader->loadMessages($path, $currentCatalogue);
             }
         }
 
@@ -299,18 +351,16 @@ EOF
     }
 
     /**
-     * @param string            $locale
-     * @param array             $transPaths
-     * @param TranslationLoader $loader
+     * @param string $locale
+     * @param array  $transPaths
      *
      * @return MessageCatalogue[]
      */
-    private function loadFallbackCatalogues($locale, $transPaths, TranslationLoader $loader)
+    private function loadFallbackCatalogues($locale, $transPaths)
     {
         $fallbackCatalogues = array();
-        $translator = $this->getContainer()->get('translator');
-        if ($translator instanceof Translator || $translator instanceof DataCollectorTranslator || $translator instanceof LoggingTranslator) {
-            foreach ($translator->getFallbackLocales() as $fallbackLocale) {
+        if ($this->translator instanceof Translator || $this->translator instanceof DataCollectorTranslator || $this->translator instanceof LoggingTranslator) {
+            foreach ($this->translator->getFallbackLocales() as $fallbackLocale) {
                 if ($fallbackLocale === $locale) {
                     continue;
                 }
@@ -319,7 +369,7 @@ EOF
                 foreach ($transPaths as $path) {
                     $path = $path.'translations';
                     if (is_dir($path)) {
-                        $loader->loadMessages($path, $fallbackCatalogue);
+                        $this->loader->loadMessages($path, $fallbackCatalogue);
                     }
                 }
                 $fallbackCatalogues[] = $fallbackCatalogue;

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -153,11 +153,7 @@ EOF
         // BC to be removed in 4.0
         if (null === $this->translator) {
             $this->translator = parent::getContainer()->get('translator');
-        }
-        if (null === $this->loader) {
             $this->loader = parent::getContainer()->get('translation.loader');
-        }
-        if (null === $this->extractor) {
             $this->extractor = parent::getContainer()->get('translation.extractor');
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -68,18 +68,6 @@ class TranslationDebugCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
-     *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -152,9 +140,9 @@ EOF
     {
         // BC to be removed in 4.0
         if (null === $this->translator) {
-            $this->translator = parent::getContainer()->get('translator');
-            $this->loader = parent::getContainer()->get('translation.loader');
-            $this->extractor = parent::getContainer()->get('translation.extractor');
+            $this->translator = $this->getContainer()->get('translator');
+            $this->loader = $this->getContainer()->get('translation.loader');
+            $this->extractor = $this->getContainer()->get('translation.extractor');
         }
 
         $io = new SymfonyStyle($input, $output);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -28,6 +28,8 @@ use Symfony\Component\Translation\Writer\TranslationWriter;
  * into the translation files.
  *
  * @author Michel Salib <michelsalib@hotmail.com>
+ *
+ * @final since version 3.4
  */
 class TranslationUpdateCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -64,18 +64,6 @@ class TranslationUpdateCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
-     *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -137,10 +125,10 @@ EOF
     {
         // BC to be removed in 4.0
         if (null === $this->writer) {
-            $this->writer = parent::getContainer()->get('translation.writer');
-            $this->loader = parent::getContainer()->get('translation.loader');
-            $this->extractor = parent::getContainer()->get('translation.extractor');
-            $this->defaultLocale = parent::getContainer()->getParameter('kernel.default_locale');
+            $this->writer = $this->getContainer()->get('translation.writer');
+            $this->loader = $this->getContainer()->get('translation.loader');
+            $this->extractor = $this->getContainer()->get('translation.extractor');
+            $this->defaultLocale = $this->getContainer()->getParameter('kernel.default_locale');
         }
 
         $io = new SymfonyStyle($input, $output);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -138,14 +138,8 @@ EOF
         // BC to be removed in 4.0
         if (null === $this->writer) {
             $this->writer = parent::getContainer()->get('translation.writer');
-        }
-        if (null === $this->loader) {
             $this->loader = parent::getContainer()->get('translation.loader');
-        }
-        if (null === $this->extractor) {
             $this->extractor = parent::getContainer()->get('translation.extractor');
-        }
-        if (null === $this->defaultLocale) {
             $this->defaultLocale = parent::getContainer()->getParameter('kernel.default_locale');
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -113,10 +113,11 @@ EOF
 
     /**
      * {@inheritdoc}
+     *
+     * BC to be removed in 4.0
      */
     public function isEnabled()
     {
-        // BC to be removed in 4.0
         if (null !== $this->writer) {
             return parent::isEnabled();
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -23,9 +23,22 @@ use Symfony\Component\Workflow\Marking;
  */
 class WorkflowDumpCommand extends ContainerAwareCommand
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated since version 3.4, to be removed in 4.0
+     */
+    protected function getContainer()
+    {
+        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
+
+        return parent::getContainer();
+    }
+
     public function isEnabled()
     {
-        return $this->getContainer()->has('workflow.registry');
+        // BC to be removed in 4.0
+        return parent::getContainer()->has('workflow.registry');
     }
 
     /**
@@ -56,7 +69,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $container = $this->getContainer();
+        $container = $this->getApplication()->getKernel()->getContainer();
         $serviceId = $input->getArgument('name');
         if ($container->has('workflow.'.$serviceId)) {
             $workflow = $container->get('workflow.'.$serviceId);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -28,23 +28,11 @@ class WorkflowDumpCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      *
-     * @deprecated since version 3.4, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.4 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
-    }
-
-    /**
-     * {@inheritdoc}
-     *
      * BC to be removed in 4.0
      */
     public function isEnabled()
     {
-        return parent::getContainer()->has('workflow.registry');
+        return $this->getContainer()->has('workflow.registry');
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -20,6 +20,8 @@ use Symfony\Component\Workflow\Marking;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @final since version 3.4
  */
 class WorkflowDumpCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -35,9 +35,13 @@ class WorkflowDumpCommand extends ContainerAwareCommand
         return parent::getContainer();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * BC to be removed in 4.0
+     */
     public function isEnabled()
     {
-        // BC to be removed in 4.0
         return parent::getContainer()->has('workflow.registry');
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/XliffLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/XliffLintCommand.php
@@ -22,6 +22,8 @@ use Symfony\Component\Translation\Command\XliffLintCommand as BaseLintCommand;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @final since version 3.4
  */
 class XliffLintCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -21,6 +21,8 @@ use Symfony\Component\Yaml\Command\LintCommand as BaseLintCommand;
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Robin Chalas <robin.chalas@gmail.com>
+ *
+ * @final since version 3.4
  */
 class YamlLintCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -231,11 +231,7 @@ class FrameworkExtension extends Extension
         $this->registerCacheConfiguration($config['cache'], $container);
         $this->registerWorkflowConfiguration($config['workflows'], $container, $loader);
         $this->registerDebugConfiguration($config['php_errors'], $container, $loader);
-
-        if ($this->isConfigEnabled($container, $config['router'])) {
-            $this->registerRouterConfiguration($config['router'], $container, $loader);
-        }
-
+        $this->registerRouterConfiguration($config['router'], $container, $loader);
         $this->registerAnnotationsConfiguration($config['annotations'], $container, $loader);
         $this->registerPropertyAccessConfiguration($config['property_access'], $container);
 
@@ -519,6 +515,10 @@ class FrameworkExtension extends Extension
     private function registerWorkflowConfiguration(array $workflows, ContainerBuilder $container, XmlFileLoader $loader)
     {
         if (!$workflows) {
+            if (!class_exists(Workflow\Workflow::class)) {
+                $container->removeDefinition('console.command.workflow_dump');
+            }
+
             return;
         }
 
@@ -695,6 +695,13 @@ class FrameworkExtension extends Extension
      */
     private function registerRouterConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
+        if (!$this->isConfigEnabled($container, $config)) {
+            $container->removeDefinition('console.command.router_debug');
+            $container->removeDefinition('console.command.router_match');
+
+            return;
+        }
+
         $loader->load('routing.xml');
 
         $container->setParameter('router.resource', $config['resource']);
@@ -1028,6 +1035,9 @@ class FrameworkExtension extends Extension
     private function registerTranslatorConfiguration(array $config, ContainerBuilder $container, LoaderInterface $loader)
     {
         if (!$this->isConfigEnabled($container, $config)) {
+            $container->removeDefinition('console.command.translation_debug');
+            $container->removeDefinition('console.command.translation_update');
+
             return;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -13,6 +13,11 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
 use Doctrine\Common\Annotations\Reader;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
+use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
+use Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand;
+use Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand;
+use Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand;
+use Symfony\Bundle\FrameworkBundle\Command\WorkflowDumpCommand;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
@@ -516,7 +521,7 @@ class FrameworkExtension extends Extension
     {
         if (!$workflows) {
             if (!class_exists(Workflow\Workflow::class)) {
-                $container->removeDefinition('console.command.workflow_dump');
+                $container->removeDefinition(WorkflowDumpCommand::class);
             }
 
             return;
@@ -696,8 +701,8 @@ class FrameworkExtension extends Extension
     private function registerRouterConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         if (!$this->isConfigEnabled($container, $config)) {
-            $container->removeDefinition('console.command.router_debug');
-            $container->removeDefinition('console.command.router_match');
+            $container->removeDefinition(RouterDebugCommand::class);
+            $container->removeDefinition(RouterMatchCommand::class);
 
             return;
         }
@@ -1035,8 +1040,8 @@ class FrameworkExtension extends Extension
     private function registerTranslatorConfiguration(array $config, ContainerBuilder $container, LoaderInterface $loader)
     {
         if (!$this->isConfigEnabled($container, $config)) {
-            $container->removeDefinition('console.command.translation_debug');
-            $container->removeDefinition('console.command.translation_update');
+            $container->removeDefinition(TranslationDebugCommand::class);
+            $container->removeDefinition(TranslationUpdateCommand::class);
 
             return;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -25,6 +25,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddExpressionLan
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\UnusedTagsPass;
 use Symfony\Component\Config\DependencyInjection\ConfigCachePass;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
 use Symfony\Component\HttpKernel\DependencyInjection\AddCacheClearerPass;
 use Symfony\Component\HttpKernel\DependencyInjection\AddCacheWarmerPass;
@@ -128,5 +129,10 @@ class FrameworkBundle extends Bundle
         if (class_exists($class)) {
             $container->addCompilerPass(new $class(), $type, $priority);
         }
+    }
+
+    public function registerCommands(Application $application)
+    {
+        // noop
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -100,11 +100,6 @@
             </call>
         </service>
 
-        <service id="cache.command.pool_pruner" class="Symfony\Bundle\FrameworkBundle\Command\CachePoolPruneCommand">
-            <argument type="iterator" />
-            <tag name="console.command" command="cache:pool:prune" />
-        </service>
-
         <service id="cache.default_clearer" class="Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer" public="true">
             <tag name="kernel.cache_clearer" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -18,15 +18,12 @@
         </service>
 
         <service id="console.command.assets_install" class="Symfony\Bundle\FrameworkBundle\Command\AssetsInstallCommand">
-            <argument>%kernel.project_dir%</argument>
             <argument type="service" id="filesystem" />
-            <argument>true</argument> <!-- BC to be removed in 4.0 -->
             <tag name="console.command" command="assets:install" />
         </service>
 
         <service id="console.command.cache_clear" class="Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand">
             <argument type="service" id="cache_clearer" />
-            <argument>null</argument>
             <argument type="service" id="filesystem" />
             <tag name="console.command" command="cache:clear" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -13,71 +13,71 @@
             <tag name="monolog.logger" channel="console" />
         </service>
 
-        <service id="console.command.about" class="Symfony\Bundle\FrameworkBundle\Command\AboutCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\AboutCommand">
             <tag name="console.command" command="about" />
         </service>
 
-        <service id="console.command.assets_install" class="Symfony\Bundle\FrameworkBundle\Command\AssetsInstallCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\AssetsInstallCommand">
             <argument type="service" id="filesystem" />
             <tag name="console.command" command="assets:install" />
         </service>
 
-        <service id="console.command.cache_clear" class="Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand">
             <argument type="service" id="cache_clearer" />
             <argument type="service" id="filesystem" />
             <tag name="console.command" command="cache:clear" />
         </service>
 
-        <service id="console.command.cache_pool_clear" class="Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand">
             <argument type="service" id="cache.global_clearer" />
             <tag name="console.command" command="cache:pool:clear" />
         </service>
 
-        <service id="console.command.cache_pool_pruner" class="Symfony\Bundle\FrameworkBundle\Command\CachePoolPruneCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\CachePoolPruneCommand">
             <argument type="iterator" />
             <tag name="console.command" command="cache:pool:prune" />
         </service>
 
-        <service id="console.command.cache_warmup" class="Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand">
             <argument type="service" id="cache_warmer" />
             <tag name="console.command" command="cache:warmup" />
         </service>
 
-        <service id="console.command.config_debug" class="Symfony\Bundle\FrameworkBundle\Command\ConfigDebugCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\ConfigDebugCommand">
             <tag name="console.command" command="debug:config" />
         </service>
 
-        <service id="console.command.config_dump_reference" class="Symfony\Bundle\FrameworkBundle\Command\ConfigDumpReferenceCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\ConfigDumpReferenceCommand">
             <tag name="console.command" command="config:dump-reference" />
         </service>
 
-        <service id="console.command.container_debug" class="Symfony\Bundle\FrameworkBundle\Command\ContainerDebugCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\ContainerDebugCommand">
             <tag name="console.command" command="debug:container" />
         </service>
 
-        <service id="console.command.event_dispatcher_debug" class="Symfony\Bundle\FrameworkBundle\Command\EventDispatcherDebugCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\EventDispatcherDebugCommand">
             <argument type="service" id="event_dispatcher" />
             <tag name="console.command" command="debug:event-dispatcher" />
         </service>
 
-        <service id="console.command.router_debug" class="Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand">
             <argument type="service" id="router" />
             <tag name="console.command" command="debug:router" />
         </service>
 
-        <service id="console.command.router_match" class="Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand">
             <argument type="service" id="router" />
             <tag name="console.command" command="router:match" />
         </service>
 
-        <service id="console.command.translation_debug" class="Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand">
             <argument type="service" id="translator" />
             <argument type="service" id="translation.loader" />
             <argument type="service" id="translation.extractor" />
             <tag name="console.command" command="debug:translation" />
         </service>
 
-        <service id="console.command.translation_update" class="Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand">
             <argument type="service" id="translation.writer" />
             <argument type="service" id="translation.loader" />
             <argument type="service" id="translation.extractor" />
@@ -85,15 +85,15 @@
             <tag name="console.command" command="translation:update" />
         </service>
 
-        <service id="console.command.workflow_dump" class="Symfony\Bundle\FrameworkBundle\Command\WorkflowDumpCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\WorkflowDumpCommand">
             <tag name="console.command" command="workflow:dump" />
         </service>
 
-        <service id="console.command.xliff_lint" class="Symfony\Bundle\FrameworkBundle\Command\XliffLintCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\XliffLintCommand">
             <tag name="console.command" command="lint:xliff" />
         </service>
 
-        <service id="console.command.yaml_lint" class="Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand">
+        <service id="Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand">
             <tag name="console.command" command="lint:yaml" />
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -96,26 +96,5 @@
         <service id="console.command.yaml_lint" class="Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand">
             <tag name="console.command" command="lint:yaml" />
         </service>
-
-        <!-- BC to be removed in 4.0 -->
-        <service id="console.command.symfony_bundle_frameworkbundle_command_translationdebugcommand" class="Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand" public="true">
-            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.translation_debug" instead.</deprecated>
-        </service>
-
-        <service id="console.command.symfony_bundle_frameworkbundle_command_translationupdatecommand" class="Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand" public="true">
-            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.translation_update" instead.</deprecated>
-        </service>
-
-        <service id="console.command.symfony_bundle_frameworkbundle_command_workflowdumpcommand" class="Symfony\Bundle\FrameworkBundle\Command\WorkflowDumpCommand" public="true">
-            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.workflow_dump" instead.</deprecated>
-        </service>
-
-        <service id="console.command.symfony_bundle_frameworkbundle_command_xlifflintcommand" class="Symfony\Bundle\FrameworkBundle\Command\XliffLintCommand" public="true">
-            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.xliff_lint" instead.</deprecated>
-        </service>
-
-        <service id="console.command.symfony_bundle_frameworkbundle_command_yamllintcommand" class="Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand" public="true">
-            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.yaml_lint" instead.</deprecated>
-        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -33,6 +33,11 @@
             <tag name="console.command" command="cache:pool:clear" />
         </service>
 
+        <service id="console.command.cache_pool_pruner" class="Symfony\Bundle\FrameworkBundle\Command\CachePoolPruneCommand">
+            <argument type="iterator" />
+            <tag name="console.command" command="cache:pool:prune" />
+        </service>
+
         <service id="console.command.cache_warmup" class="Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand">
             <argument type="service" id="cache_warmer" />
             <tag name="console.command" command="cache:warmup" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -12,5 +12,108 @@
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="console" />
         </service>
+
+        <service id="console.command.about" class="Symfony\Bundle\FrameworkBundle\Command\AboutCommand">
+            <tag name="console.command" command="about" />
+        </service>
+
+        <service id="console.command.assets_install" class="Symfony\Bundle\FrameworkBundle\Command\AssetsInstallCommand">
+            <argument>%kernel.project_dir%</argument>
+            <argument type="service" id="filesystem" />
+            <argument>true</argument> <!-- BC to be removed in 4.0 -->
+            <tag name="console.command" command="assets:install" />
+        </service>
+
+        <service id="console.command.cache_clear" class="Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand">
+            <argument type="service" id="cache_clearer" />
+            <argument>null</argument>
+            <argument type="service" id="filesystem" />
+            <tag name="console.command" command="cache:clear" />
+        </service>
+
+        <service id="console.command.cache_pool_clear" class="Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand">
+            <argument type="service" id="cache.global_clearer" />
+            <tag name="console.command" command="cache:pool:clear" />
+        </service>
+
+        <service id="console.command.cache_warmup" class="Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand">
+            <argument type="service" id="cache_warmer" />
+            <tag name="console.command" command="cache:warmup" />
+        </service>
+
+        <service id="console.command.config_debug" class="Symfony\Bundle\FrameworkBundle\Command\ConfigDebugCommand">
+            <tag name="console.command" command="debug:config" />
+        </service>
+
+        <service id="console.command.config_dump_reference" class="Symfony\Bundle\FrameworkBundle\Command\ConfigDumpReferenceCommand">
+            <tag name="console.command" command="config:dump-reference" />
+        </service>
+
+        <service id="console.command.container_debug" class="Symfony\Bundle\FrameworkBundle\Command\ContainerDebugCommand">
+            <tag name="console.command" command="debug:container" />
+        </service>
+
+        <service id="console.command.event_dispatcher_debug" class="Symfony\Bundle\FrameworkBundle\Command\EventDispatcherDebugCommand">
+            <argument type="service" id="event_dispatcher" />
+            <tag name="console.command" command="debug:event-dispatcher" />
+        </service>
+
+        <service id="console.command.router_debug" class="Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand">
+            <argument type="service" id="router" />
+            <tag name="console.command" command="debug:router" />
+        </service>
+
+        <service id="console.command.router_match" class="Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand">
+            <argument type="service" id="router" />
+            <tag name="console.command" command="router:match" />
+        </service>
+
+        <service id="console.command.translation_debug" class="Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand">
+            <argument type="service" id="translator" />
+            <argument type="service" id="translation.loader" />
+            <argument type="service" id="translation.extractor" />
+            <tag name="console.command" command="debug:translation" />
+        </service>
+
+        <service id="console.command.translation_update" class="Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand">
+            <argument type="service" id="translation.writer" />
+            <argument type="service" id="translation.loader" />
+            <argument type="service" id="translation.extractor" />
+            <argument>%kernel.default_locale%</argument>
+            <tag name="console.command" command="translation:update" />
+        </service>
+
+        <service id="console.command.workflow_dump" class="Symfony\Bundle\FrameworkBundle\Command\WorkflowDumpCommand">
+            <tag name="console.command" command="workflow:dump" />
+        </service>
+
+        <service id="console.command.xliff_lint" class="Symfony\Bundle\FrameworkBundle\Command\XliffLintCommand">
+            <tag name="console.command" command="lint:xliff" />
+        </service>
+
+        <service id="console.command.yaml_lint" class="Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand">
+            <tag name="console.command" command="lint:yaml" />
+        </service>
+
+        <!-- BC to be removed in 4.0 -->
+        <service id="console.command.symfony_bundle_frameworkbundle_command_translationdebugcommand" class="Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand" public="true">
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.translation_debug" instead.</deprecated>
+        </service>
+
+        <service id="console.command.symfony_bundle_frameworkbundle_command_translationupdatecommand" class="Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand" public="true">
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.translation_update" instead.</deprecated>
+        </service>
+
+        <service id="console.command.symfony_bundle_frameworkbundle_command_workflowdumpcommand" class="Symfony\Bundle\FrameworkBundle\Command\WorkflowDumpCommand" public="true">
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.workflow_dump" instead.</deprecated>
+        </service>
+
+        <service id="console.command.symfony_bundle_frameworkbundle_command_xlifflintcommand" class="Symfony\Bundle\FrameworkBundle\Command\XliffLintCommand" public="true">
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.xliff_lint" instead.</deprecated>
+        </service>
+
+        <service id="console.command.symfony_bundle_frameworkbundle_command_yamllintcommand" class="Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand" public="true">
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "command.yaml_lint" instead.</deprecated>
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -42,18 +42,36 @@ class RouterMatchCommandTest extends TestCase
     }
 
     /**
-     * @return CommandTester
+     * @group legacy
+     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
+     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
      */
-    private function createCommandTester()
+    public function testLegacyMatchCommand()
     {
         $application = new Application($this->getKernel());
         $application->add(new RouterMatchCommand());
         $application->add(new RouterDebugCommand());
 
+        $tester = new CommandTester($application->find('router:match'));
+
+        $tester->execute(array('path_info' => '/'));
+
+        $this->assertContains('None of the routes match the path "/"', $tester->getDisplay());
+    }
+
+    /**
+     * @return CommandTester
+     */
+    private function createCommandTester()
+    {
+        $application = new Application($this->getKernel());
+        $application->add(new RouterMatchCommand($this->getRouter()));
+        $application->add(new RouterDebugCommand($this->getRouter()));
+
         return new CommandTester($application->find('router:match'));
     }
 
-    private function getKernel()
+    private function getRouter()
     {
         $routeCollection = new RouteCollection();
         $routeCollection->add('foo', new Route('foo'));
@@ -62,14 +80,17 @@ class RouterMatchCommandTest extends TestCase
         $router
             ->expects($this->any())
             ->method('getRouteCollection')
-            ->will($this->returnValue($routeCollection))
-        ;
+            ->will($this->returnValue($routeCollection));
         $router
             ->expects($this->any())
             ->method('getContext')
-            ->will($this->returnValue($requestContext))
-        ;
+            ->will($this->returnValue($requestContext));
 
+        return $router;
+    }
+
+    private function getKernel()
+    {
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container
             ->expects($this->atLeastOnce())
@@ -85,7 +106,9 @@ class RouterMatchCommandTest extends TestCase
         $container
             ->expects($this->any())
             ->method('get')
-            ->willReturn($router);
+            ->with('router')
+            ->willReturn($this->getRouter())
+        ;
 
         $kernel = $this->getMockBuilder(KernelInterface::class)->getMock();
         $kernel

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -12,11 +12,10 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\DependencyInjection;
 use Symfony\Component\HttpKernel;
 
 class TranslationUpdateCommandTest extends TestCase
@@ -26,7 +25,7 @@ class TranslationUpdateCommandTest extends TestCase
 
     public function testDumpMessagesAndClean()
     {
-        $tester = $this->createCommandTester($this->getContainer(array('messages' => array('foo' => 'foo'))));
+        $tester = $this->createCommandTester(array('messages' => array('foo' => 'foo')));
         $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true));
         $this->assertRegExp('/foo/', $tester->getDisplay());
         $this->assertRegExp('/1 message was successfully extracted/', $tester->getDisplay());
@@ -34,7 +33,7 @@ class TranslationUpdateCommandTest extends TestCase
 
     public function testDumpTwoMessagesAndClean()
     {
-        $tester = $this->createCommandTester($this->getContainer(array('messages' => array('foo' => 'foo', 'bar' => 'bar'))));
+        $tester = $this->createCommandTester(array('messages' => array('foo' => 'foo', 'bar' => 'bar')));
         $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true));
         $this->assertRegExp('/foo/', $tester->getDisplay());
         $this->assertRegExp('/bar/', $tester->getDisplay());
@@ -43,7 +42,7 @@ class TranslationUpdateCommandTest extends TestCase
 
     public function testDumpMessagesForSpecificDomain()
     {
-        $tester = $this->createCommandTester($this->getContainer(array('messages' => array('foo' => 'foo'), 'mydomain' => array('bar' => 'bar'))));
+        $tester = $this->createCommandTester(array('messages' => array('foo' => 'foo'), 'mydomain' => array('bar' => 'bar')));
         $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--domain' => 'mydomain'));
         $this->assertRegExp('/bar/', $tester->getDisplay());
         $this->assertRegExp('/1 message was successfully extracted/', $tester->getDisplay());
@@ -51,14 +50,14 @@ class TranslationUpdateCommandTest extends TestCase
 
     public function testWriteMessages()
     {
-        $tester = $this->createCommandTester($this->getContainer(array('messages' => array('foo' => 'foo'))));
+        $tester = $this->createCommandTester(array('messages' => array('foo' => 'foo')));
         $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--force' => true));
         $this->assertRegExp('/Translation files were successfully updated./', $tester->getDisplay());
     }
 
     public function testWriteMessagesForSpecificDomain()
     {
-        $tester = $this->createCommandTester($this->getContainer(array('messages' => array('foo' => 'foo'), 'mydomain' => array('bar' => 'bar'))));
+        $tester = $this->createCommandTester(array('messages' => array('foo' => 'foo'), 'mydomain' => array('bar' => 'bar')));
         $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--force' => true, '--domain' => 'mydomain'));
         $this->assertRegExp('/Translation files were successfully updated./', $tester->getDisplay());
     }
@@ -79,18 +78,7 @@ class TranslationUpdateCommandTest extends TestCase
     /**
      * @return CommandTester
      */
-    private function createCommandTester(DependencyInjection\ContainerInterface $container)
-    {
-        $command = new TranslationUpdateCommand();
-        $command->setContainer($container);
-
-        $application = new Application();
-        $application->add($command);
-
-        return new CommandTester($application->find('translation:update'));
-    }
-
-    private function getContainer($extractedMessages = array(), $loadedMessages = array(), HttpKernel\KernelInterface $kernel = null)
+    private function createCommandTester($extractedMessages = array(), $loadedMessages = array(), HttpKernel\KernelInterface $kernel = null)
     {
         $translator = $this->getMockBuilder('Symfony\Component\Translation\Translator')
             ->disableOriginalConstructor()
@@ -147,6 +135,42 @@ class TranslationUpdateCommandTest extends TestCase
             ->method('getRootDir')
             ->will($this->returnValue($this->translationDir));
 
+        $kernel
+            ->expects($this->any())
+            ->method('getBundles')
+            ->will($this->returnValue(array()));
+
+        $kernel
+            ->expects($this->any())
+            ->method('getContainer')
+            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock()));
+
+        $command = new TranslationUpdateCommand($writer, $loader, $extractor, 'en');
+
+        $application = new Application($kernel);
+        $application->add($command);
+
+        return new CommandTester($application->find('translation:update'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
+     */
+    public function testLegacyUpdateCommand()
+    {
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $extractor = $this->getMockBuilder('Symfony\Component\Translation\Extractor\ExtractorInterface')->getMock();
+        $loader = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader')->getMock();
+        $writer = $this->getMockBuilder('Symfony\Component\Translation\Writer\TranslationWriter')->getMock();
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
+        $kernel
+            ->expects($this->any())
+            ->method('getBundles')
+            ->will($this->returnValue(array()));
+
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container
             ->expects($this->any())
@@ -159,7 +183,21 @@ class TranslationUpdateCommandTest extends TestCase
                 array('kernel', 1, $kernel),
             )));
 
-        return $container;
+        $kernel
+            ->expects($this->any())
+            ->method('getContainer')
+            ->will($this->returnValue($container));
+
+        $command = new TranslationUpdateCommand();
+        $command->setContainer($container);
+
+        $application = new Application($kernel);
+        $application->add($command);
+
+        $tester = new CommandTester($application->find('translation:update'));
+        $tester->execute(array('locale' => 'en'));
+
+        $this->assertContains('You must choose one of --force or --dump-messages', $tester->getDisplay());
     }
 
     private function getBundle($path)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -977,6 +977,7 @@ abstract class FrameworkExtensionTest extends TestCase
             'kernel.bundles' => array('FrameworkBundle' => 'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle'),
             'kernel.bundles_metadata' => array('FrameworkBundle' => array('namespace' => 'Symfony\\Bundle\\FrameworkBundle', 'path' => __DIR__.'/../..', 'parent' => null)),
             'kernel.cache_dir' => __DIR__,
+            'kernel.project_dir' => __DIR__,
             'kernel.debug' => false,
             'kernel.environment' => 'test',
             'kernel.name' => 'kernel',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -74,11 +75,28 @@ class CachePoolClearCommandTest extends WebTestCase
             ->execute(array('pools' => array('unknown_pool')), array('decorated' => false));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
+     */
+    public function testLegacyClearCommand()
+    {
+        $application = new Application(static::$kernel);
+        $application->add(new CachePoolClearCommand());
+
+        $tester = new CommandTester($application->find('cache:pool:clear'));
+
+        $tester->execute(array('pools' => array()));
+
+        $this->assertContains('Cache was successfully cleared', $tester->getDisplay());
+    }
+
     private function createCommandTester()
     {
-        $command = new CachePoolClearCommand();
-        $command->setContainer(static::$kernel->getContainer());
+        $container = static::$kernel->getContainer();
+        $application = new Application(static::$kernel);
+        $application->add(new CachePoolClearCommand($container->get('cache.global_clearer')));
 
-        return new CommandTester($command);
+        return new CommandTester($application->find('cache:pool:clear'));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -20,6 +20,8 @@ use Doctrine\DBAL\Schema\SchemaException;
  * Installs the tables required by the ACL system.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @final since version 3.4
  */
 class InitAclCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/SecurityBundle/Command/SetAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/SetAclCommand.php
@@ -27,6 +27,8 @@ use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
  * Sets ACL for objects.
  *
  * @author Kévin Dunglas <kevin@les-tilleuls.coop>
+ *
+ * @final since version 3.4
  */
 class SetAclCommand extends ContainerAwareCommand
 {

--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -28,6 +28,8 @@ use Symfony\Component\Security\Core\User\User;
  * Encode a user's password.
  *
  * @author Sarah Khalil <mkhalil.sarah@gmail.com>
+ *
+ * @final since version 3.4
  */
 class UserPasswordEncoderCommand extends ContainerAwareCommand
 {
@@ -44,18 +46,6 @@ class UserPasswordEncoderCommand extends ContainerAwareCommand
         $this->userClasses = $userClasses;
 
         parent::__construct();
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated since version 3.3, to be removed in 4.0
-     */
-    protected function getContainer()
-    {
-        @trigger_error(sprintf('Method "%s" is deprecated since version 3.3 and "%s" won\'t extend "%s" nor implement "%s" anymore in 4.0.', __METHOD__, __CLASS__, ContainerAwareCommand::class, ContainerAwareInterface::class), E_USER_DEPRECATED);
-
-        return parent::getContainer();
     }
 
     /**
@@ -125,7 +115,7 @@ EOF
         $userClass = $this->getUserClass($input, $io);
         $emptySalt = $input->getOption('empty-salt');
 
-        $encoderFactory = $this->encoderFactory ?: parent::getContainer()->get('security.encoder_factory');
+        $encoderFactory = $this->encoderFactory ?: $this->getContainer()->get('security.encoder_factory');
         $encoder = $encoderFactory->getEncoder($userClass);
         $bcryptWithoutEmptySalt = !$emptySalt && $encoder instanceof BCryptPasswordEncoder;
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
+use Symfony\Bundle\SecurityBundle\Command\UserPasswordEncoderCommand;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -107,7 +108,7 @@ class SecurityExtension extends Extension
 
         if (class_exists(Application::class)) {
             $loader->load('console.xml');
-            $container->getDefinition('security.console.user_password_encoder_command')->replaceArgument(1, array_keys($config['encoders']));
+            $container->getDefinition(UserPasswordEncoderCommand::class)->replaceArgument(1, array_keys($config['encoders']));
         }
 
         // load ACL

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/console.xml
@@ -7,7 +7,15 @@
     <services>
         <defaults public="false" />
 
-        <service id="security.console.user_password_encoder_command" class="Symfony\Bundle\SecurityBundle\Command\UserPasswordEncoderCommand">
+        <service id="Symfony\Bundle\SecurityBundle\Command\InitAclCommand">
+            <tag name="console.command" command="init:acl" />
+        </service>
+
+        <service id="Symfony\Bundle\SecurityBundle\Command\SetAclCommand">
+            <tag name="console.command" command="acl:set" />
+        </service>
+
+        <service id="Symfony\Bundle\SecurityBundle\Command\UserPasswordEncoderCommand">
             <argument type="service" id="security.encoder_factory"/>
             <argument type="collection" /> <!-- encoders' user classes -->
             <tag name="console.command" command="security:encode-password" />

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginFactory;
+use Symfony\Component\Console\Application;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
@@ -57,5 +58,10 @@ class SecurityBundle extends Bundle
         $extension->addUserProviderFactory(new InMemoryFactory());
         $extension->addUserProviderFactory(new LdapFactory());
         $container->addCompilerPass(new AddSecurityVotersPass());
+    }
+
+    public function registerCommands(Application $application)
+    {
+        // noop
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Command\UserPasswordEncoderCommand;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
@@ -355,7 +356,7 @@ abstract class CompleteConfigurationTest extends TestCase
 
     public function testUserPasswordEncoderCommandIsRegistered()
     {
-        $this->assertTrue($this->getContainer('remember_me_options')->has('security.console.user_password_encoder_command'));
+        $this->assertTrue($this->getContainer('remember_me_options')->has(UserPasswordEncoderCommand::class));
     }
 
     public function testDefaultAccessDecisionManagerStrategyIsAffirmative()

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/console.xml
@@ -7,19 +7,14 @@
     <services>
         <defaults public="false" />
 
-        <service id="twig.command.debug" class="Symfony\Bridge\Twig\Command\DebugCommand">
+        <service id="Symfony\Bridge\Twig\Command\DebugCommand">
             <argument type="service" id="twig" />
             <tag name="console.command" command="debug:twig" />
         </service>
 
-        <service id="twig.command.lint" class="Symfony\Bundle\TwigBundle\Command\LintCommand">
+        <service id="Symfony\Bundle\TwigBundle\Command\LintCommand">
             <argument type="service" id="twig" />
             <tag name="console.command" command="lint:twig" />
-        </service>
-
-        <!-- BC to be removed in 4.0 -->
-        <service id="console.command.symfony_bundle_twigbundle_command_debugcommand" class="Symfony\Bundle\TwigBundle\Command\DebugCommand" public="true">
-            <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "twig.command.debug" instead.</deprecated>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/TwigBundle.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigBundle.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -36,5 +37,10 @@ class TwigBundle extends Bundle
         $container->addCompilerPass(new TwigLoaderPass());
         $container->addCompilerPass(new ExceptionListenerPass());
         $container->addCompilerPass(new RuntimeLoaderPass(), PassConfig::TYPE_BEFORE_REMOVING);
+    }
+
+    public function registerCommands(Application $application)
+    {
+        // noop
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Next step towards #23488

It's a work in progress if we want to do all commands at once (im fine :)). But i think we should review `assets:install` first.

Also im assuming framework commands can rely on `getApplication()->getKernel()` from the framework application (we already do that in some commands). That saves a dep on `@kernel`.

And filesystem as a service; perhaps drop that as well :)