### PR TITLE
Feature #23583  Add current and fallback locales in WDT / Profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -13,6 +13,12 @@
 
         {% set text %}
             <div class="sf-toolbar-info-piece">
+                <b>Locale</b>
+                <span class="sf-toolbar-status">
+                    {{ collector.locale|default('-') }}
+                </span>
+            </div>
+            <div class="sf-toolbar-info-piece">
                 <b>Missing messages</b>
                 <span class="sf-toolbar-status sf-toolbar-status-{{ collector.countMissings ? 'red' }}">
                     {{ collector.countMissings }}
@@ -61,6 +67,20 @@
 {% endblock %}
 
 {% block panelContent %}
+
+    <h2>Translation Locales</h2>
+
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">{{ collector.locale|default('-') }}</span>
+            <span class="label">Locale</span>
+        </div>
+        <div class="metric">
+            <span class="value">{{ collector.fallbackLocales|join(', ')|default('-') }}</span>
+            <span class="label">Fallback locales</span>
+        </div>
+    </div>
+
     <h2>Translation Metrics</h2>
 
     <div class="metrics">

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -45,6 +45,9 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
         $this->data = $this->computeCount($messages);
         $this->data['messages'] = $messages;
 
+        $this->data['locale'] = $this->translator->getLocale();
+        $this->data['fallback_locales'] = $this->translator->getFallbackLocales();
+
         $this->data = $this->cloneVar($this->data);
     }
 
@@ -85,6 +88,16 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
     public function getCountDefines()
     {
         return isset($this->data[DataCollectorTranslator::MESSAGE_DEFINED]) ? $this->data[DataCollectorTranslator::MESSAGE_DEFINED] : 0;
+    }
+
+    public function getLocale()
+    {
+        return !empty($this->data['locale']) ? $this->data['locale'] : null;
+    }
+
+    public function getFallbackLocales()
+    {
+        return (isset($this->data['fallback_locales']) && count($this->data['fallback_locales']) > 0) ? $this->data['fallback_locales'] : array();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      |  no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23583
| License       | MIT
| Doc PR        | -

The goal of this PR is to add informations about the locale and the fallback locales in the translation WDT panel / and profiler