### PR TITLE
[DomCrawler] Add method flatText()

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+* Added `flatText` method to get node value with spaces and newlines normalized.
+
 3.1.0
 -----
 

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
-* Added `flatText` method to get node value with spaces and newlines normalized.
+* Added flag to the `text` method, to strip surrounding and consecutive spaces/newlines.
 
 3.1.0
 -----

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -558,36 +558,23 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the node value of the first node of the list.
      *
+     * @param bool $stripSpaces Whether to strip surrounding and consecutive spaces/newlines
+     *
      * @return string The node value
      *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function text()
+    public function text($stripSpaces = false)
     {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        if ($stripSpaces) {
+            return trim(preg_replace('/\s+/', ' ', $this->getNode(0)->nodeValue));
         }
 
         return $this->getNode(0)->nodeValue;
-    }
-
-    /**
-     * Returns the flattened node value of the first node of the list.
-     *
-     * Surrounding spaces/newlines are removed,
-     * and consecutive spaces/newlines are reduced to one space.
-     *
-     * @return string The flattened node value
-     *
-     * @throws \InvalidArgumentException When current node is empty
-     */
-    public function flatText()
-    {
-        if (!$this->nodes) {
-            throw new \InvalidArgumentException('The current node list is empty.');
-        }
-
-        return trim(preg_replace('/\s+/', ' ', $this->getNode(0)->nodeValue));
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -572,6 +572,25 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
+     * Returns the flattened node value of the first node of the list.
+     *
+     * Surrounding spaces/newlines are removed,
+     * and consecutive spaces/newlines are reduced to one space.
+     *
+     * @return string The flattened node value
+     *
+     * @throws \InvalidArgumentException When current node is empty
+     */
+    public function flatText()
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        return trim(preg_replace('/\s+/', ' ', $this->getNode(0)->nodeValue));
+    }
+
+    /**
      * Returns the first node of the list as HTML.
      *
      * @return string The node html

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -394,15 +394,15 @@ EOF
         }
     }
 
-    public function testFlatText()
+    public function testStrippedText()
     {
-        $this->assertEquals('Fabien\'s Foo', $this->createTestCrawler()->filterXPath('//a[2]')->flatText(), '->flatText() returns the flattened node value of the first element of the node list');
+        $this->assertEquals('Fabien\'s Foo', $this->createTestCrawler()->filterXPath('//a[2]')->text(true), '->text(true) returns the stripped node value of the first element of the node list');
 
         try {
-            $this->createTestCrawler()->filterXPath('//ol')->flatText();
-            $this->fail('->flatText() throws an \InvalidArgumentException if the node list is empty');
+            $this->createTestCrawler()->filterXPath('//ol')->text(true);
+            $this->fail('->text(true) throws an \InvalidArgumentException if the node list is empty');
         } catch (\InvalidArgumentException $e) {
-            $this->assertTrue(true, '->flatText() throws an \InvalidArgumentException if the node list is empty');
+            $this->assertTrue(true, '->text(true) throws an \InvalidArgumentException if the node list is empty');
         }
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -394,6 +394,18 @@ EOF
         }
     }
 
+    public function testFlatText()
+    {
+        $this->assertEquals('Fabien\'s Foo', $this->createTestCrawler()->filterXPath('//a[2]')->flatText(), '->flatText() returns the flattened node value of the first element of the node list');
+
+        try {
+            $this->createTestCrawler()->filterXPath('//ol')->flatText();
+            $this->fail('->flatText() throws an \InvalidArgumentException if the node list is empty');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertTrue(true, '->flatText() throws an \InvalidArgumentException if the node list is empty');
+        }
+    }
+
     public function testHtml()
     {
         $this->assertEquals('<img alt="Bar">', $this->createTestCrawler()->filterXPath('//a[5]')->html());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 (to be rebased from master)
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21302
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Similar to `text()`, with some normalization applied to the value: surrounding spaces/newlines are removed, and consecutive spaces/newlines are reduced to one. Helpful if you don't want your code to choke because of the HTML source formatting.

This is a follow-up to #11470 and #21302. ping @javiereguiluz, @jpetitcolas.

<br>Quoting https://github.com/symfony/symfony/issues/21302#issuecomment-299241618:

> Personally I'm extending the Crawler class, I couldn't anymore clutter my code all over with this:
> ```php
> $ref = preg_replace('/\s+/', ' ', trim($node
>     ->filter('div.numero_ref')
>     ->text()));
> ```
>
> Now I just have to do:
> ```php
> $ref = $node
>     ->filter('div.numero_ref')
>     ->cleanText();
> ```
