### PR TITLE
[DI] Fix test

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -516,15 +516,15 @@ class AutowirePassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('pdo_service', \PDO::class)
-            ->addArgument('sqlite:/foo.db')
+        $container->register('foo', \SplFileObject::class)
+            ->addArgument('foo.txt')
             ->setAutowired(true);
 
         (new AutowirePass())->process($container);
 
-        $definition = $container->getDefinition('pdo_service');
+        $definition = $container->getDefinition('foo');
         $this->assertEquals(
-            array('sqlite:/foo.db'),
+            array('foo.txt'),
             $definition->getArguments()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In php 5.5.9 (our lowest supported version), reflection says that the username argument is not optional (a bug that is fixed in 5.5.10 and up.)