### PR TITLE
[FrameworkBundle] Add a framework aware base command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Command.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Command.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Console;
+
+use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Command\Command as BaseCommand;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Framework aware base command.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+abstract class Command extends BaseCommand
+{
+    public function setApplication(BaseApplication $application = null)
+    {
+        if (null !== $application && !$application instanceof Application) {
+            throw new \InvalidArgumentException(sprintf('Application must be an instance of "%s", got "%s"', Application::class, get_class($application)));
+        }
+
+        parent::setApplication($application);
+    }
+
+    /**
+     * @return Application
+     */
+    public function getApplication()
+    {
+        return parent::getApplication();
+    }
+
+    /**
+     * @return KernelInterface
+     */
+    protected function getKernel()
+    {
+        return $this->getApplication()->getKernel();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23529
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Enables deprecating `ContainerAwareCommand` (#21623) by providing a base command that is kernel aware, thus container aware.

Core could heavily use this as of 4.0, and basically fixes IDE's on `getApplication`.