### PR TITLE
Explicitly return null in getUser()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -376,12 +376,12 @@ trait ControllerTrait
         }
 
         if (null === $token = $this->container->get('security.token_storage')->getToken()) {
-            return;
+            return null;
         }
 
         if (!is_object($user = $token->getUser())) {
             // e.g. anonymous authentication
-            return;
+            return null;
         }
 
         return $user;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Practically, `return;` and `return null;` is the same, but it's a good practice to explicitly return `null` if the method could return something. It's fine to have just `return;` in methods that simply do some operations and return nothing, i.e. doesn't have `@return` annotation. Actually, PhpStorm suggests the same.