### PR TITLE
[Form][TwigBridge] Don't render _method in form_rest() for a child form

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -303,7 +303,7 @@
         {% endif %}
     {%- endfor %}
 
-    {% if not form.methodRendered and form.parent is empty %}
+    {% if not form.methodRendered and form.parent is null %}
         {%- do form.setMethodRendered() -%}
         {% set method = method|upper %}
         {%- if method in ["GET", "POST"] -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -303,7 +303,7 @@
         {% endif %}
     {%- endfor %}
 
-    {% if not form.methodRendered %}
+    {% if not form.methodRendered and form.parent is empty %}
         {%- do form.setMethodRendered() -%}
         {% set method = method|upper %}
         {%- if method in ["GET", "POST"] -%}


### PR DESCRIPTION
The hidden `_method` must only be generated if the form is the top most form.

Always generating the hidden `_method` breaks forms using the POST method when they have children using the PUT method. If `_method` is generated for such a child form, it overrides the parent method and the form fails to validate.

See issue #23254

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14261
| License       | MIT
| Doc PR        | 