### PR TITLE
When a DotEnv file is missing, ignore it

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -49,11 +49,13 @@ final class Dotenv
     {
         // func_get_args() to be replaced by a variadic argument for Symfony 4.0
         foreach (func_get_args() as $path) {
-            if (!is_readable($path) || is_dir($path)) {
-                throw new PathException($path);
-            }
+            if (file_exists($path)) {
+                if (!is_readable($path) || is_dir($path)) {
+                    throw new PathException($path);
+                }
 
-            $this->populate($this->parse(file_get_contents($path), $path));
+                $this->populate($this->parse(file_get_contents($path), $path));
+            }
         }
     }
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -195,6 +195,13 @@ class DotenvTest extends TestCase
         $dotenv->load(__DIR__);
     }
 
+    public function testSilentlyIgnoreMissingFiles()
+    {
+        $dotenv = new Dotenv();
+        $dotenv->load('nothing-to-see-here');
+        $this->assertTrue(true); //no exception was thrown
+    }
+
     public function testServerSuperglobalIsNotOverriden()
     {
         $originalValue = $_SERVER['argc'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | not sure
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

A `.env` file isn't likely to be present in a new development
environment and should never be present in production.

If DotEnv::load() throws and exception when the files is missing then
the calling code must be bracketed with a defensive check. Which makes
this component harder to use.

I've treated this as a new feature as I'm not sure if it qualifies as a bugfix and I don't know if changing the exception behavior here is a BC break.
