### PR TITLE
[VarDumper] Adapt to php 7.2 changes

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -54,7 +54,7 @@ class Caster
         if ($a) {
             $p = array_keys($a);
             foreach ($p as $i => $k) {
-                if (isset($k[0]) && "\0" !== $k[0] && !$reflector->hasProperty($k)) {
+                if (isset($k[0]) ? "\0" !== $k[0] && !$reflector->hasProperty($k) : \PHP_VERSION_ID >= 70200) {
                     $p[$i] = self::PREFIX_DYNAMIC.$k;
                 } elseif (isset($k[16]) && "\0" === $k[16] && 0 === strpos($k, "\0class@anonymous\0")) {
                     $p[$i] = "\0".$reflector->getParentClass().'@anonymous'.strrchr($k, "\0");

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -141,8 +141,22 @@ EOTXT
         $var[] = &$v;
         $var[''] = 2;
 
-        $this->assertDumpMatchesFormat(
-            <<<'EOTXT'
+        if (\PHP_VERSION_ID >= 70200) {
+            $this->assertDumpMatchesFormat(
+                <<<'EOTXT'
+array:4 [
+  0 => {}
+  1 => &1 null
+  2 => &1 null
+  "" => 2
+]
+EOTXT
+                ,
+                $var
+            );
+        } else {
+            $this->assertDumpMatchesFormat(
+                <<<'EOTXT'
 array:4 [
   "0" => {}
   "1" => &1 null
@@ -150,9 +164,10 @@ array:4 [
   "" => 2
 ]
 EOTXT
-            ,
-            $var
-        );
+                ,
+                $var
+            );
+        }
     }
 
     public function testObjectCast()
@@ -160,16 +175,28 @@ EOTXT
         $var = (object) array(1 => 1);
         $var->{1} = 2;
 
-        $this->assertDumpMatchesFormat(
-            <<<'EOTXT'
+        if (\PHP_VERSION_ID >= 70200) {
+            $this->assertDumpMatchesFormat(
+                <<<'EOTXT'
+{
+  +"1": 2
+}
+EOTXT
+                ,
+                $var
+            );
+        } else {
+            $this->assertDumpMatchesFormat(
+                <<<'EOTXT'
 {
   +1: 1
   +"1": 2
 }
 EOTXT
-            ,
-            $var
-        );
+                ,
+                $var
+            );
+        }
     }
 
     public function testClosedResource()

--- a/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
@@ -203,7 +203,7 @@ object(Symfony\Component\VarDumper\Cloner\Data)#%i (4) {
 EOTXT;
         ob_start();
         var_dump($clone);
-        $this->assertStringMatchesFormat($expected, ob_get_clean());
+        $this->assertStringMatchesFormat(\PHP_VERSION_ID >= 70200 ? str_replace('"1"', '1', $expected) : $expected, ob_get_clean());
     }
 
     public function testCaster()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As required by this change on PHP 7.2:
https://wiki.php.net/rfc/convert_numeric_keys_in_object_array_casts

Tests pass locally (until we add 7.2 to Travis)