### PR TITLE
[Form] Add fieldset type

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -259,7 +259,8 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <label{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</label>
+        {%- set label_tag = label_tag|default('label') -%}
+        <{{ label_tag }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</{{ label_tag }}>
     {%- endif -%}
 {%- endblock form_label -%}
 
@@ -292,6 +293,18 @@
 {%- block hidden_row -%}
     {{ form_widget(form) }}
 {%- endblock hidden_row -%}
+
+{% block fieldset_row %}
+    <fieldset {{ block('widget_container_attributes') }}>
+        {%- set label_tag = label_tag|default('legend') %}
+        {{- block('form_label') -}}
+        {%- if form.parent is empty -%}
+            {{ form_errors(form) }}
+        {%- endif -%}
+        {{- block('form_rows') -}}
+        {{- form_rest(form) -}}
+    </fieldset>
+{% endblock %}
 
 {# Misc #}
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * added `FieldsetType`
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldsetType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldsetType.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class FieldsetType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('inherit_data', true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'fieldset';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #6584
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

```php
$prefs = new \stdClass();
$prefs->active = true;
$prefs->language = 'nl';
$prefs->timezone = 'Europe/Amsterdam';
$form = ($builder = $this->createFormBuilder($prefs))
    ->add('active', CheckboxType::class)
    ->add(
        $builder->create('settings', FieldsetType::class)
            ->add('language', LanguageType::class)
            ->add('timezone', TimezoneType::class)
    )
    ->getForm();
```

![image](https://user-images.githubusercontent.com/1047696/28580080-ca2178e2-715e-11e7-92b2-fe557755074d.png)

![image](https://user-images.githubusercontent.com/1047696/28582541-137a2672-7166-11e7-97d2-71d26b58c82e.png)

Same usecase is available as a [bundle](https://github.com/adamquaile/AdamQuaileFieldsetBundle) (not from me) yet it's real easy to provide this out-of-the-box, and the approach is a bit different.