### PR TITLE
Create an interface for TranslationWriter

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -131,8 +131,9 @@ SecurityBundle
 Translation
 -----------
 
- * Deprecated `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations` 
-   function, use `Symfony\Component\Translation\Writer\TranslationWriter::write` instead. 
+ * `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations` has been deprecated 
+   and will be removed in 4.0, use `Symfony\Component\Translation\Writer\TranslationWriter::write` 
+   instead. 
 
 TwigBridge
 ----------

--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -128,6 +128,12 @@ SecurityBundle
 
  * `FirewallContext::getListeners()` now returns `\Traversable|array`
 
+Translation
+-----------
+
+ * Deprecated `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations` 
+   function, use `Symfony\Component\Translation\Writer\TranslationWriter::write` instead. 
+
 TwigBridge
 ----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -555,7 +555,8 @@ Translation
 
  * Removed the backup feature from the file dumper classes.
  
- * Deprecated `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations`     function, use `Symfony\Component\Translation\Writer\TranslationWriter::write` instead. 
+ * Removed `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations`, 
+   use `Symfony\Component\Translation\Writer\TranslationWriter::write` instead. 
 
 TwigBundle
 ----------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -554,6 +554,8 @@ Translation
 -----------
 
  * Removed the backup feature from the file dumper classes.
+ 
+ * Deprecated `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations`     function, use `Symfony\Component\Translation\Writer\TranslationWriter::write` instead. 
 
 TwigBundle
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -276,7 +276,7 @@ EOF
                 $bundleTransPath = end($transPaths).'translations';
             }
 
-            $this->writer->writeTranslations($operation->getResult(), $input->getOption('output-format'), array('path' => $bundleTransPath, 'default_locale' => $this->defaultLocale));
+            $this->writer->write($operation->getResult(), $input->getOption('output-format'), array('path' => $bundleTransPath, 'default_locale' => $this->defaultLocale));
 
             if (true === $input->getOption('dump-messages')) {
                 $resultMessage .= ' and translation files were updated';

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Translation\Extractor\ExtractorInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Writer\TranslationWriter;
+use Symfony\Component\Translation\Writer\TranslationWriterInterface;
 
 /**
  * A command that parses templates to extract translation messages and adds them
@@ -39,14 +40,14 @@ class TranslationUpdateCommand extends ContainerAwareCommand
     private $defaultLocale;
 
     /**
-     * @param TranslationWriter  $writer
-     * @param TranslationLoader  $loader
-     * @param ExtractorInterface $extractor
-     * @param string             $defaultLocale
+     * @param TranslationWriterInterface $writer
+     * @param TranslationLoader          $loader
+     * @param ExtractorInterface         $extractor
+     * @param string                     $defaultLocale
      */
     public function __construct($writer = null, TranslationLoader $loader = null, ExtractorInterface $extractor = null, $defaultLocale = null)
     {
-        if (!$writer instanceof TranslationWriter) {
+        if (!$writer instanceof TranslationWriterInterface) {
             @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
 
             parent::__construct($writer);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -21,7 +21,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Translation\Extractor\ExtractorInterface;
 use Symfony\Component\Translation\MessageCatalogue;
-use Symfony\Component\Translation\Writer\TranslationWriter;
 use Symfony\Component\Translation\Writer\TranslationWriterInterface;
 
 /**

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Added `TranslationDumperPass`
  * Added `TranslationExtractorPass`
  * Added `TranslatorPass`
+ * Added `TranslationWriterInterface`
 
 3.2.0
 -----

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Added `TranslationExtractorPass`
  * Added `TranslatorPass`
  * Added `TranslationWriterInterface`
+ * Deprecated `TranslationWriter::writeTranslations` in favor of `TranslationWriter::write`
 
 3.2.0
 -----

--- a/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Translation\Writer\TranslationWriter;
 
 class TranslationWriterTest extends TestCase
 {
-    public function testWriteTranslations()
+    public function testWrite()
     {
         $dumper = $this->getMockBuilder('Symfony\Component\Translation\Dumper\DumperInterface')->getMock();
         $dumper
@@ -27,7 +27,7 @@ class TranslationWriterTest extends TestCase
 
         $writer = new TranslationWriter();
         $writer->addDumper('test', $dumper);
-        $writer->writeTranslations(new MessageCatalogue(array()), 'test');
+        $writer->write(new MessageCatalogue(array()), 'test');
     }
 
     public function testDisableBackup()

--- a/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
@@ -18,7 +18,11 @@ use Symfony\Component\Translation\Writer\TranslationWriter;
 
 class TranslationWriterTest extends TestCase
 {
-    public function testWrite()
+    /**
+     * @group legacy
+     * @expectedDeprecation Method writeTranslations() is deprecated. Use write() instead.
+     */
+    public function testWriteTranslations()
     {
         $dumper = $this->getMockBuilder('Symfony\Component\Translation\Dumper\DumperInterface')->getMock();
         $dumper
@@ -27,7 +31,7 @@ class TranslationWriterTest extends TestCase
 
         $writer = new TranslationWriter();
         $writer->addDumper('test', $dumper);
-        $writer->write(new MessageCatalogue(array()), 'test');
+        $writer->writeTranslations(new MessageCatalogue(array()), 'test');
     }
 
     public function testDisableBackup()

--- a/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
@@ -34,6 +34,18 @@ class TranslationWriterTest extends TestCase
         $writer->writeTranslations(new MessageCatalogue(array()), 'test');
     }
 
+    public function testWrite()
+    {
+        $dumper = $this->getMockBuilder('Symfony\Component\Translation\Dumper\DumperInterface')->getMock();
+        $dumper
+            ->expects($this->once())
+            ->method('dump');
+
+        $writer = new TranslationWriter();
+        $writer->addDumper('test', $dumper);
+        $writer->write(new MessageCatalogue(array()), 'test');
+    }
+
     public function testDisableBackup()
     {
         $nonBackupDumper = new NonBackupDumper();

--- a/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
@@ -20,7 +20,7 @@ class TranslationWriterTest extends TestCase
 {
     /**
      * @group legacy
-     * @expectedDeprecation Method writeTranslations() is deprecated. Use write() instead.
+     * @expectedDeprecation Method Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations() is deprecated since version 3.4 and will be removed in 4.0. Use write() instead.
      */
     public function testWriteTranslations()
     {

--- a/src/Symfony/Component/Translation/Writer/TranslationWriter.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriter.php
@@ -90,6 +90,8 @@ class TranslationWriter implements TranslationWriterInterface
     }
 
     /**
+     * Writes translation from the catalogue according to the selected format.
+     *
      * @param MessageCatalogue $catalogue The message catalogue to write
      * @param string           $format    The format to use to dump the messages
      * @param array            $options   Options that are passed to the dumper
@@ -100,7 +102,7 @@ class TranslationWriter implements TranslationWriterInterface
      */
     public function writeTranslations(MessageCatalogue $catalogue, $format, $options = array())
     {
-        @trigger_error('Method writeTranslations() is deprecated. Use write() instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('Method %s() is deprecated since version 3.4 and will be removed in 4.0. Use write() instead.', __METHOD__), E_USER_DEPRECATED);
         $this->write($catalogue, $format, $options);
     }
 }

--- a/src/Symfony/Component/Translation/Writer/TranslationWriter.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriter.php
@@ -21,7 +21,7 @@ use Symfony\Component\Translation\Exception\RuntimeException;
  *
  * @author Michel Salib <michelsalib@hotmail.com>
  */
-class TranslationWriter
+class TranslationWriter implements TranslationWriterInterface
 {
     /**
      * Dumpers used for export.

--- a/src/Symfony/Component/Translation/Writer/TranslationWriter.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriter.php
@@ -66,13 +66,13 @@ class TranslationWriter implements TranslationWriterInterface
     /**
      * Writes translation from the catalogue according to the selected format.
      *
-     * @param MessageCatalogue $catalogue The message catalogue to dump
+     * @param MessageCatalogue $catalogue The message catalogue to write
      * @param string           $format    The format to use to dump the messages
      * @param array            $options   Options that are passed to the dumper
      *
      * @throws InvalidArgumentException
      */
-    public function writeTranslations(MessageCatalogue $catalogue, $format, $options = array())
+    public function write(MessageCatalogue $catalogue, $format, $options = array())
     {
         if (!isset($this->dumpers[$format])) {
             throw new InvalidArgumentException(sprintf('There is no dumper associated with format "%s".', $format));
@@ -87,5 +87,20 @@ class TranslationWriter implements TranslationWriterInterface
 
         // save
         $dumper->dump($catalogue, $options);
+    }
+
+    /**
+     * @param MessageCatalogue $catalogue The message catalogue to write
+     * @param string           $format    The format to use to dump the messages
+     * @param array            $options   Options that are passed to the dumper
+     *
+     * @throws InvalidArgumentException
+     *
+     * @deprecated since 3.4 will be removed in 4.0. Use write instead.
+     */
+    public function writeTranslations(MessageCatalogue $catalogue, $format, $options = array())
+    {
+        @trigger_error('Method writeTranslations() is deprecated. Use write() instead.', E_USER_DEPRECATED);
+        $this->write($catalogue, $format, $options);
     }
 }

--- a/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Writer;
+
+use Symfony\Component\Translation\Exception\InvalidArgumentException;
+use Symfony\Component\Translation\MessageCatalogue;
+
+
+/**
+ * TranslationWriter writes translation messages.
+ *
+ * @author Michel Salib <michelsalib@hotmail.com>
+ */
+interface TranslationWriterInterface
+{
+    /**
+     * Writes translation from the catalogue according to the selected format.
+     *
+     * @param MessageCatalogue $catalogue The message catalogue to dump
+     * @param string $format The format to use to dump the messages
+     * @param array $options Options that are passed to the dumper
+     *
+     * @throws InvalidArgumentException
+     */
+    public function writeTranslations(MessageCatalogue $catalogue, $format, $options = array());
+}

--- a/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
@@ -24,11 +24,11 @@ interface TranslationWriterInterface
     /**
      * Writes translation from the catalogue according to the selected format.
      *
-     * @param MessageCatalogue $catalogue The message catalogue to dump
+     * @param MessageCatalogue $catalogue The message catalogue to write
      * @param string           $format    The format to use to dump the messages
      * @param array            $options   Options that are passed to the dumper
      *
      * @throws InvalidArgumentException
      */
-    public function writeTranslations(MessageCatalogue $catalogue, $format, $options = array());
+    public function write(MessageCatalogue $catalogue, $format, $options = array());
 }

--- a/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Translation\Writer;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Component\Translation\MessageCatalogue;
 
-
 /**
  * TranslationWriter writes translation messages.
  *
@@ -26,8 +25,8 @@ interface TranslationWriterInterface
      * Writes translation from the catalogue according to the selected format.
      *
      * @param MessageCatalogue $catalogue The message catalogue to dump
-     * @param string $format The format to use to dump the messages
-     * @param array $options Options that are passed to the dumper
+     * @param string           $format    The format to use to dump the messages
+     * @param array            $options   Options that are passed to the dumper
      *
      * @throws InvalidArgumentException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | ~~~no~~~ yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

We should provide an interface for the TranslationWriter. This allows other libraries (php-translation) that depend on the Translation component provide different implementations. 