### PR TITLE
Move the TranslationLoader to the Translation component.

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -42,6 +42,9 @@ FrameworkBundle
  * The `--no-prefix` option of the `translation:update` command is deprecated and
    will be removed in 4.0. Use the `--prefix` option with an empty string as value
    instead (e.g. `--prefix=""`)
+   
+ * The class `Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader` was 
+   moved to the Translation component (`Symfony\Component\Translation\Loader\TranslationLoader`)
 
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheClearerPass`
    class has been deprecated and will be removed in 4.0. Use the

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -348,6 +348,9 @@ FrameworkBundle
 
  * The `--no-prefix` option of the `translation:update` command has
    been removed.
+ 
+ * The class `Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader` was 
+   moved to the Translation component (`Symfony\Component\Translation\Loader\TranslationLoader`)
 
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheClearerPass` class has been removed. 
    Use the `Symfony\Component\HttpKernel\DependencyInjection\AddCacheClearerPass` class instead.

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -22,6 +22,8 @@ CHANGELOG
    name as value, using it makes the command lazy
  * Added `cache:pool:prune` command to allow manual stale cache item pruning of supported PSR-6 and PSR-16 cache pool
    implementations
+ * Deprecated `Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader`, use 
+   `Symfony\Component\Translation\Loader\TranslationLoader` instead
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader;
+use Symfony\Component\Translation\Loader\TranslationLoader;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -121,7 +121,7 @@
             <tag name="translation.extractor" alias="php" />
         </service>
 
-        <service id="translation.loader" class="Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader" public="true" />
+        <service id="translation.loader" class="Symfony\Component\Translation\Loader\TranslationLoader" public="true" />
 
         <service id="translation.extractor" class="Symfony\Component\Translation\Extractor\ChainExtractor" public="true" />
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -141,7 +141,7 @@ class TranslationDebugCommandTest extends TestCase
                 })
             );
 
-        $loader = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader')->getMock();
+        $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\TranslationLoader')->getMock();
         $loader
             ->expects($this->any())
             ->method('loadMessages')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -113,7 +113,7 @@ class TranslationUpdateCommandTest extends TestCase
                 })
             );
 
-        $loader = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader')->getMock();
+        $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\TranslationLoader')->getMock();
         $loader
             ->expects($this->any())
             ->method('loadMessages')

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -16,4 +16,8 @@ namespace Symfony\Bundle\FrameworkBundle\Translation;
  */
 class TranslationLoader extends \Symfony\Component\Translation\Loader\TranslationLoader
 {
+    public function __construct()
+    {
+        @trigger_error(sprintf('The class "%s" has been deprecated. Use "%s" instead. ', TranslationLoader::class, \Symfony\Component\Translation\Loader\TranslationLoader::class), E_USER_DEPRECATED);
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -11,13 +11,11 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Translation;
 
+@trigger_error(sprintf('The class "%s" has been deprecated. Use "%s" instead. ', self::class, \Symfony\Component\Translation\Loader\TranslationLoader::class), E_USER_DEPRECATED);
+
 /**
  * @deprecated Class moved to Symfony\Component\Translation\Loader\TranslationLoader
  */
 class TranslationLoader extends \Symfony\Component\Translation\Loader\TranslationLoader
 {
-    public function __construct()
-    {
-        @trigger_error(sprintf('The class "%s" has been deprecated. Use "%s" instead. ', self::class, \Symfony\Component\Translation\Loader\TranslationLoader::class), E_USER_DEPRECATED);
-    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -18,6 +18,6 @@ class TranslationLoader extends \Symfony\Component\Translation\Loader\Translatio
 {
     public function __construct()
     {
-        @trigger_error(sprintf('The class "%s" has been deprecated. Use "%s" instead. ', TranslationLoader::class, \Symfony\Component\Translation\Loader\TranslationLoader::class), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The class "%s" has been deprecated. Use "%s" instead. ', self::class, \Symfony\Component\Translation\Loader\TranslationLoader::class), E_USER_DEPRECATED);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -11,56 +11,9 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Translation;
 
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Translation\MessageCatalogue;
-use Symfony\Component\Translation\Loader\LoaderInterface;
-
 /**
- * TranslationLoader loads translation messages from translation files.
- *
- * @author Michel Salib <michelsalib@hotmail.com>
+ * @deprecated Class moved to Symfony\Component\Translation\Loader\TranslationLoader
  */
-class TranslationLoader
+class TranslationLoader extends \Symfony\Component\Translation\Loader\TranslationLoader
 {
-    /**
-     * Loaders used for import.
-     *
-     * @var array
-     */
-    private $loaders = array();
-
-    /**
-     * Adds a loader to the translation extractor.
-     *
-     * @param string          $format The format of the loader
-     * @param LoaderInterface $loader
-     */
-    public function addLoader($format, LoaderInterface $loader)
-    {
-        $this->loaders[$format] = $loader;
-    }
-
-    /**
-     * Loads translation messages from a directory to the catalogue.
-     *
-     * @param string           $directory the directory to look into
-     * @param MessageCatalogue $catalogue the catalogue
-     */
-    public function loadMessages($directory, MessageCatalogue $catalogue)
-    {
-        if (!is_dir($directory)) {
-            return;
-        }
-
-        foreach ($this->loaders as $format => $loader) {
-            // load any existing translation files
-            $finder = new Finder();
-            $extension = $catalogue->getLocale().'.'.$format;
-            $files = $finder->files()->name('*.'.$extension)->in($directory);
-            foreach ($files as $file) {
-                $domain = substr($file->getFilename(), 0, -1 * strlen($extension) - 1);
-                $catalogue->addCatalogue($loader->load($file->getPathname(), $catalogue->getLocale(), $domain));
-            }
-        }
-    }
 }

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Added `TranslationDumperPass`
  * Added `TranslationExtractorPass`
  * Added `TranslatorPass`
+ * Added class `Symfony\Component\Translation\Loader\TranslationLoader` from FrameworkBundle
 
 3.2.0
 -----

--- a/src/Symfony/Component/Translation/Loader/TranslationLoader.php
+++ b/src/Symfony/Component/Translation/Loader/TranslationLoader.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Loader;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * TranslationLoader loads translation messages from translation files.
+ *
+ * @author Michel Salib <michelsalib@hotmail.com>
+ */
+class TranslationLoader
+{
+    /**
+     * Loaders used for import.
+     *
+     * @var array
+     */
+    private $loaders = array();
+
+    /**
+     * Adds a loader to the translation extractor.
+     *
+     * @param string          $format The format of the loader
+     * @param LoaderInterface $loader
+     */
+    public function addLoader($format, LoaderInterface $loader)
+    {
+        $this->loaders[$format] = $loader;
+    }
+
+    /**
+     * Loads translation messages from a directory to the catalogue.
+     *
+     * @param string           $directory the directory to look into
+     * @param MessageCatalogue $catalogue the catalogue
+     */
+    public function loadMessages($directory, MessageCatalogue $catalogue)
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach ($this->loaders as $format => $loader) {
+            // load any existing translation files
+            $finder = new Finder();
+            $extension = $catalogue->getLocale().'.'.$format;
+            $files = $finder->files()->name('*.'.$extension)->in($directory);
+            foreach ($files as $file) {
+                $domain = substr($file->getFilename(), 0, -1 * strlen($extension) - 1);
+                $catalogue->addCatalogue($loader->load($file->getPathname(), $catalogue->getLocale(), $domain));
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -24,6 +24,7 @@
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/intl": "^2.8.18|^3.2.5|~4.0",
         "symfony/yaml": "~3.3|~4.0",
+        "symfony/finder": "~2.8|~3.0|~4.0",
         "psr/log": "~1.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Move the TranslationLoader away from the FrameworkBundle and to the Translation component where it belongs. Im not sure why it was put here in the first place. My guess is that we wanted to avoid adding Finder as a dependency in the Translation component. 

Btw, this is me making this suggestion very politely. I think it makes sense since third party libraries should not be forced to require all FrameworkBundle for this class. 