### PR TITLE
[Webprofiler] Added blocks that allows extension of the profiler page.

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -82,7 +82,7 @@
 
     <h2>Translation Messages</h2>
 
-    {% block translation_messages %}
+    {% block messages %}
 
     {# sort translation messages in groups #}
     {% set messages_defined, messages_missing, messages_fallback = [], [], [] %}
@@ -161,7 +161,7 @@
         </div>
     </div>
 
-    {% endblock %}
+    {% endblock messages %}
 
 {% endblock %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -82,7 +82,7 @@
 
     <h2>Translation Messages</h2>
 
-    {% block panelContentHead %}{% endblock %}
+    {% block before_translation_messages %}{% endblock %}
 
     {# sort translation messages in groups #}
     {% set messages_defined, messages_missing, messages_fallback = [], [], [] %}
@@ -110,7 +110,7 @@
                         <p>None of the used translation messages are defined for the given locale.</p>
                     </div>
                 {% else %}
-                    {% block definedMessagesTable %}
+                    {% block defined_messages %}
                         {{ helper.render_table(messages_defined) }}
                     {% endblock %}
                 {% endif %}
@@ -131,7 +131,7 @@
                         <p>No fallback translation messages were used.</p>
                     </div>
                 {% else %}
-                    {% block fallbackMessagesTable %}
+                    {% block fallback_messages %}
                         {{ helper.render_table(messages_fallback) }}
                     {% endblock %}
                 {% endif %}
@@ -153,7 +153,7 @@
                         <p>There are no messages of this category.</p>
                     </div>
                 {% else %}
-                    {% block missingMessagesTable %}
+                    {% block missing_messages %}
                         {{ helper.render_table(messages_missing) }}
                     {% endblock %}
                 {% endif %}
@@ -161,7 +161,7 @@
         </div>
     </div>
 
-    {% block panelContentFooter %}{% endblock %}
+    {% block after_translation_messages %}{% endblock %}
 
 {% endblock %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -82,6 +82,8 @@
 
     <h2>Translation Messages</h2>
 
+    {% block panelContentHead %}{% endblock %}
+
     {# sort translation messages in groups #}
     {% set messages_defined, messages_missing, messages_fallback = [], [], [] %}
     {% for message in collector.messages %}
@@ -108,7 +110,9 @@
                         <p>None of the used translation messages are defined for the given locale.</p>
                     </div>
                 {% else %}
-                    {{ helper.render_table(messages_defined) }}
+                    {% block definedMessagesTable %}
+                        {{ helper.render_table(messages_defined) }}
+                    {% endblock %}
                 {% endif %}
             </div>
         </div>
@@ -127,7 +131,9 @@
                         <p>No fallback translation messages were used.</p>
                     </div>
                 {% else %}
-                    {{ helper.render_table(messages_fallback) }}
+                    {% block fallbackMessagesTable %}
+                        {{ helper.render_table(messages_fallback) }}
+                    {% endblock %}
                 {% endif %}
             </div>
         </div>
@@ -147,11 +153,16 @@
                         <p>There are no messages of this category.</p>
                     </div>
                 {% else %}
-                    {{ helper.render_table(messages_missing) }}
+                    {% block missingMessagesTable %}
+                        {{ helper.render_table(messages_missing) }}
+                    {% endblock %}
                 {% endif %}
             </div>
         </div>
     </div>
+
+    {% block panelContentFooter %}{% endblock %}
+
 {% endblock %}
 
 {% macro render_table(messages) %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -82,7 +82,7 @@
 
     <h2>Translation Messages</h2>
 
-    {% block before_translation_messages %}{% endblock %}
+    {% block translation_messages %}
 
     {# sort translation messages in groups #}
     {% set messages_defined, messages_missing, messages_fallback = [], [], [] %}
@@ -161,7 +161,7 @@
         </div>
     </div>
 
-    {% block after_translation_messages %}{% endblock %}
+    {% endblock %}
 
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 (to be retargeted)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Im not sure if we allow this but I thought I would try to submit this PR. 
The [TranslationBundle](https://github.com/php-translation/symfony-bundle) is extending the Symfony profiler page for translation. It would be great if it didn't have to replace all the contents but just replace some smaller blocks. 

