### PR TITLE
[Debug] Missing escape in debug output

### DIFF
--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -94,7 +94,7 @@ class ExceptionHandler
      *
      * @param string $format The format for links to source files
      *
-     * @return string The previous file link format.
+     * @return string The previous file link format
      */
     public function setFileLinkFormat($format)
     {
@@ -418,7 +418,7 @@ EOF;
                 $formattedValue = str_replace("\n", '', var_export($this->escapeHtml((string) $item[1]), true));
             }
 
-            $result[] = is_int($key) ? $formattedValue : sprintf("'%s' => %s", $key, $formattedValue);
+            $result[] = is_int($key) ? $formattedValue : sprintf("'%s' => %s", $this->escapeHtml($key), $formattedValue);
         }
 
         return implode(', ', $result);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

When pretty-printing an exception, the debug handler does not properly escape array keys.

The problem only occurs when debug output is enabled, so this is not considered a [security issue](http://symfony.com/doc/current/contributing/code/security.html) (according to @fabpot), because the debug tools [should not be used in production](https://symfony.com/doc/current/components/debug.html#usage).

A test for this is included in my patch for #18722.