### PR TITLE
Fix cache clear PHP7.1 warnings 

### DIFF
--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -47,7 +47,7 @@ class SimpleXMLElement extends \SimpleXMLElement
             if (isset($arg['name'])) {
                 $arg['key'] = (string) $arg['name'];
             }
-            $key = isset($arg['key']) ? (string) $arg['key'] : (!$arguments ? 0 : max(array_keys($arguments)) + 1);
+            $key = isset($arg['key']) ? (string) $arg['key'] : (!$arguments ? 0 : (int) max(array_keys($arguments)) + 1);
 
             // parameter keys are case insensitive
             if ('parameter' == $name && $lowercase) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.3 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Running cache clear result in couple of warnings because PHP 7.1 will not coerce variable type. We need to cast it to integer before we use MAX() php function
