### PR TITLE
[DI][ProxyManager] Pass the factory code to execute to DumperInterface::getProxyFactoryCode()

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -65,7 +65,7 @@ class ProxyDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProxyFactoryCode(Definition $definition, $id, $methodName = null)
+    public function getProxyFactoryCode(Definition $definition, $id, $factoryCode = null)
     {
         $instantiation = 'return';
 
@@ -73,11 +73,12 @@ class ProxyDumper implements DumperInterface
             $instantiation .= " \$this->services['$id'] =";
         }
 
-        if (func_num_args() >= 3) {
-            $methodName = func_get_arg(2);
-        } else {
-            @trigger_error(sprintf('You must use the third argument of %s to define the method to call to construct your service since version 3.1, not using it won\'t be supported in 4.0.', __METHOD__), E_USER_DEPRECATED);
-            $methodName = 'get'.Container::camelize($id).'Service';
+        if (null === $factoryCode) {
+            @trigger_error(sprintf('The "%s()" method expects a third argument defining the code to execute to construct your service since version 3.4, providing it will be required in 4.0.', __METHOD__), E_USER_DEPRECATED);
+            $factoryCode = '$this->get'.Container::camelize($id).'Service(false)';
+        } elseif (false === strpos($factoryCode, '(')) {
+            @trigger_error(sprintf('The "%s()" method expects its third argument to define the code to execute to construct your service since version 3.4, providing it will be required in 4.0.', __METHOD__), E_USER_DEPRECATED);
+            $factoryCode = "\$this->$factoryCode(false)";
         }
         $proxyClass = $this->getProxyClassName($definition);
 
@@ -92,7 +93,7 @@ class ProxyDumper implements DumperInterface
 
             $instantiation $constructorCall(
                 function (&\$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface \$proxy) {
-                    \$wrappedInstance = \$this->$methodName(false);
+                    \$wrappedInstance = $factoryCode;
 
                     \$proxy->setProxyInitializer(null);
 

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -67,7 +67,7 @@ class ProxyDumperTest extends TestCase
 
         $definition->setLazy(true);
 
-        $code = $this->dumper->getProxyFactoryCode($definition, 'foo', 'getFoo2Service');
+        $code = $this->dumper->getProxyFactoryCode($definition, 'foo', '$this->getFoo2Service(false)');
 
         $this->assertStringMatchesFormat(
             '%wif ($lazyLoad) {%wreturn $this->services[\'foo\'] =%s'

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -639,7 +639,7 @@ class PhpDumper extends Dumper
 
 EOF;
 
-        $code .= $isProxyCandidate ? $this->getProxyDumper()->getProxyFactoryCode($definition, $id, $methodName) : '';
+        $code .= $isProxyCandidate ? $this->getProxyDumper()->getProxyFactoryCode($definition, $id, "\$this->$methodName(false)") : '';
 
         if ($definition->isDeprecated()) {
             $code .= sprintf("        @trigger_error(%s, E_USER_DEPRECATED);\n\n", $this->export($definition->getDeprecationMessage($id)));

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
@@ -33,12 +33,12 @@ interface DumperInterface
      * Generates the code to be used to instantiate a proxy in the dumped factory code.
      *
      * @param Definition $definition
-     * @param string     $id         service identifier
-     * @param string     $methodName the method name to get the service, will be added to the interface in 4.0
+     * @param string     $id          service identifier
+     * @param string     $factoryCode the code to execute to create the service, will be added to the interface in 4.0
      *
      * @return string
      */
-    public function getProxyFactoryCode(Definition $definition, $id/**, $methodName = null */);
+    public function getProxyFactoryCode(Definition $definition, $id/**, $factoryCode = null */);
 
     /**
      * Generates the code for the lazy proxy.

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
@@ -33,7 +33,7 @@ class NullDumper implements DumperInterface
     /**
      * {@inheritdoc}
      */
-    public function getProxyFactoryCode(Definition $definition, $id, $methodName = null)
+    public function getProxyFactoryCode(Definition $definition, $id, $factoryCode = null)
     {
         return '';
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
@@ -88,7 +88,7 @@ class DummyProxyDumper implements ProxyDumper
         return false;
     }
 
-    public function getProxyFactoryCode(Definition $definition, $id, $methodName = null)
+    public function getProxyFactoryCode(Definition $definition, $id, $factoryCall = null)
     {
         return '';
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/NullDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/NullDumperTest.php
@@ -28,7 +28,7 @@ class NullDumperTest extends TestCase
         $definition = new Definition('stdClass');
 
         $this->assertFalse($dumper->isProxyCandidate($definition));
-        $this->assertSame('', $dumper->getProxyFactoryCode($definition, 'foo'));
+        $this->assertSame('', $dumper->getProxyFactoryCode($definition, 'foo', '(false)'));
         $this->assertSame('', $dumper->getProxyCode($definition));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -34,6 +34,7 @@
     "conflict": {
         "symfony/config": "<3.3.1",
         "symfony/finder": "<3.3",
+        "symfony/proxy-manager-bridge": "<3.4",
         "symfony/yaml": "<3.3"
     },
     "provide": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Passing the full code to call the factory is more flexible, as spotted while working on #23678.