### PR TITLE
[Webprofiler] Improve sql explain table display

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -874,6 +874,13 @@ table.logs .metadata {
     margin: .5em 0;
     padding: 1em;
 }
+.sql-explain {
+    overflow-x: auto;
+    max-width: 920px;
+}
+.sql-explain table td, .sql-explain table tr {
+    word-break: normal;
+}
 .queries-table pre {
     {{ mixins.break_long_words|raw }}
     margin: 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 
| Bug fix?      | yes?
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Table which is shown in Weprofiler is not clean while values in sql explain table are long.
This PR adds horizontal scroll for long tables. 

**Related PR in Doctrine bundle:** https://github.com/doctrine/DoctrineBundle/pull/681
_(It does not cause any backward compatibility problems)_


**Before:**
![before](https://user-images.githubusercontent.com/2659069/28733410-0ca76826-73ed-11e7-9fea-b3c49a5442ed.gif)


**After:**
![after](https://user-images.githubusercontent.com/2659069/28733415-11b76ae6-73ed-11e7-9e1a-ace661a1cd44.gif)

