### PR TITLE
Pass command instance to code callback

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -255,7 +255,7 @@ class Command
         $input->validate();
 
         if ($this->code) {
-            $statusCode = call_user_func($this->code, $input, $output);
+            $statusCode = call_user_func($this->code, $input, $output, $this);
         } else {
             $statusCode = $this->execute($input, $output);
         }


### PR DESCRIPTION
This would allow access to application helpers from command callback set through Command::setCode();

Ref #23713.

