### PR TITLE
[Dotenv] Add support for overriding existing envs

### DIFF
--- a/src/Symfony/Component/Dotenv/CHANGELOG.md
+++ b/src/Symfony/Component/Dotenv/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * added support for overriding existing envs 
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -36,18 +36,6 @@ final class Dotenv
     private $state;
     private $values;
 
-    private $overrideExistingVars;
-
-    /**
-     * Constructor.
-     *
-     * @param bool $overrideExistingVars Override existing environment variables
-     */
-    public function __construct($overrideExistingVars = false)
-    {
-        $this->overrideExistingVars = $overrideExistingVars;
-    }
-
     /**
      * Loads one or several .env files.
      *
@@ -60,24 +48,34 @@ final class Dotenv
     public function load($path/*, ...$paths*/)
     {
         // func_get_args() to be replaced by a variadic argument for Symfony 4.0
-        foreach (func_get_args() as $path) {
-            if (!is_readable($path) || is_dir($path)) {
-                throw new PathException($path);
-            }
+        $this->doLoad(func_get_args(), false);
+    }
 
-            $this->populate($this->parse(file_get_contents($path), $path));
-        }
+    /**
+     * Loads one or several .env files with overriding existing vars.
+     *
+     * @param string    $path  A file to load
+     * @param ...string $paths A list of additional files to load
+     *
+     * @throws FormatException when a file has a syntax error
+     * @throws PathException   when a file does not exist or is not readable
+     */
+    public function overload($path/*, ...$paths*/)
+    {
+        // func_get_args() to be replaced by a variadic argument for Symfony 4.0
+        $this->doLoad(func_get_args(), true);
     }
 
     /**
      * Sets values as environment variables (via putenv, $_ENV, and $_SERVER).
      *
-     * @param array $values An array of env variables
+     * @param array $values               An array of env variables
+     * @param bool  $overrideExistingVars Override the existing env variables
      */
-    public function populate($values)
+    public function populate($values, $overrideExistingVars = false)
     {
         foreach ($values as $name => $value) {
-            if (!$this->overrideExistingVars && (isset($_ENV[$name]) || isset($_SERVER[$name]) || false !== getenv($name))) {
+            if (!$overrideExistingVars && (isset($_ENV[$name]) || isset($_SERVER[$name]) || false !== getenv($name))) {
                 continue;
             }
 
@@ -383,5 +381,16 @@ final class Dotenv
     private function createFormatException($message)
     {
         return new FormatException($message, new FormatExceptionContext($this->data, $this->path, $this->lineno, $this->cursor));
+    }
+
+    private function doLoad(array $paths, $overrideExistingVars = false)
+    {
+        foreach ($paths as $path) {
+            if (!is_readable($path) || is_dir($path)) {
+                throw new PathException($path);
+            }
+
+            $this->populate($this->parse(file_get_contents($path), $path), $overrideExistingVars);
+        }
     }
 }

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -36,6 +36,18 @@ final class Dotenv
     private $state;
     private $values;
 
+    private $overrideExistingVars;
+
+    /**
+     * Constructor.
+     *
+     * @param bool $overrideExistingVars Override existing environment variables
+     */
+    public function __construct($overrideExistingVars = false)
+    {
+        $this->overrideExistingVars = $overrideExistingVars;
+    }
+
     /**
      * Loads one or several .env files.
      *
@@ -60,14 +72,12 @@ final class Dotenv
     /**
      * Sets values as environment variables (via putenv, $_ENV, and $_SERVER).
      *
-     * Note that existing environment variables are never overridden.
-     *
      * @param array $values An array of env variables
      */
     public function populate($values)
     {
         foreach ($values as $name => $value) {
-            if (isset($_ENV[$name]) || isset($_SERVER[$name]) || false !== getenv($name)) {
+            if (!$this->overrideExistingVars && (isset($_ENV[$name]) || isset($_SERVER[$name]) || false !== getenv($name))) {
                 continue;
             }
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -186,6 +186,38 @@ class DotenvTest extends TestCase
         $this->assertSame('BAZ', $bar);
     }
 
+    public function testOverload()
+    {
+        unset($_ENV['FOO']);
+        unset($_SERVER['FOO']);
+        putenv('FOO');
+        $_ENV['BAR'] = 'BAR';
+        $_SERVER['BAR'] = 'BAR';
+        putenv('BAR=BAR');
+
+        @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
+
+        $path1 = tempnam($tmpdir, 'sf-');
+        $path2 = tempnam($tmpdir, 'sf-');
+
+        file_put_contents($path1, 'FOO=FOO');
+        file_put_contents($path2, 'BAR=BAZ');
+
+        (new DotEnv())->overload($path1, $path2);
+
+        $foo = getenv('FOO');
+        $bar = getenv('BAR');
+
+        putenv('FOO');
+        putenv('BAR');
+        unlink($path1);
+        unlink($path2);
+        rmdir($tmpdir);
+
+        $this->assertSame('FOO', $foo);
+        $this->assertSame('BAZ', $bar);
+    }
+
     /**
      * @expectedException \Symfony\Component\Dotenv\Exception\PathException
      */
@@ -219,8 +251,8 @@ class DotenvTest extends TestCase
     {
         putenv('TEST_ENV_VAR=original_value');
 
-        $dotenv = new DotEnv(true);
-        $dotenv->populate(array('TEST_ENV_VAR' => 'new_value'));
+        $dotenv = new DotEnv();
+        $dotenv->populate(array('TEST_ENV_VAR' => 'new_value'), true);
 
         $this->assertSame('new_value', getenv('TEST_ENV_VAR'));
     }

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -214,4 +214,14 @@ class DotenvTest extends TestCase
 
         $this->assertSame('original_value', getenv('TEST_ENV_VAR'));
     }
+
+    public function testOverrideEnvVar()
+    {
+        putenv('TEST_ENV_VAR=original_value');
+
+        $dotenv = new DotEnv(true);
+        $dotenv->populate(array('TEST_ENV_VAR' => 'new_value'));
+
+        $this->assertSame('new_value', getenv('TEST_ENV_VAR'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23723
| License       | MIT

Every time I changed my `.env` file I need to restart the WebServerBundle's server, because the Dotenv component doesn't override the existing environment variables. This PR adds a dedicated method to overload the environment variables.
Having an ability to overload the`.env` file, we could solve the issue like this:
```php
// public/index.php
if (getenv('APP_DEBUG') && file_exists(__DIR__.'/../.env')) {
    (new Dotenv())->overload(__DIR__.'/../.env');
} elseif (!getenv('APP_ENV')) {
    (new Dotenv())->load(__DIR__.'/../.env');
}

```