### PR TITLE
Add "executable" option to server:run console command

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * WebServer can now use '*' as a wildcard to bind to 0.0.0.0 (INADDR_ANY)
- * `server:run` command now has `executable` option that allows using custom executable for the commandline server (such as `php -c /path/to/ini`)
+ * Custom executable can be set using `SYMFONY_SERVER_EXECUTABLE` environment variable
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * WebServer can now use '*' as a wildcard to bind to 0.0.0.0 (INADDR_ANY)
+ * `server:run` command now has `executable` option that allows using custom executable for the commandline server (such as `php -c /path/to/ini`)
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
@@ -52,6 +52,7 @@ class ServerRunCommand extends Command
                 new InputArgument('addressport', InputArgument::OPTIONAL, 'The address to listen to (can be address:port, address, or port)'),
                 new InputOption('docroot', 'd', InputOption::VALUE_REQUIRED, 'Document root, usually where your front controllers are stored'),
                 new InputOption('router', 'r', InputOption::VALUE_REQUIRED, 'Path to custom router script'),
+                new InputOption('executable', 'e', InputOption::VALUE_REQUIRED, 'Custom executable for the PHP commandline webserver'),
             ))
             ->setDescription('Runs a local web server')
             ->setHelp(<<<'EOF'
@@ -76,6 +77,10 @@ Use the <info>--docroot</info> option to change the default docroot directory:
 Specify your own router script via the <info>--router</info> option:
 
   <info>%command.full_name% --router=app/config/router.php</info>
+
+Specify your own server executable via the <info>--executable</info> option:
+
+  <info>%command.full_name% --executable=/usr/bin/php7</info>
 
 See also: http://www.php.net/manual/en/features.commandline.webserver.php
 EOF
@@ -130,7 +135,13 @@ EOF
 
         try {
             $server = new WebServer();
-            $config = new WebServerConfig($documentRoot, $env, $input->getArgument('addressport'), $input->getOption('router'));
+            $config = new WebServerConfig(
+                $documentRoot,
+                $env,
+                $input->getArgument('addressport'),
+                $input->getOption('router'),
+                $input->getOption('executable')
+            );
 
             $io->success(sprintf('Server listening on http://%s', $config->getAddress()));
             $io->comment('Quit the server with CONTROL-C.');

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
@@ -52,7 +52,6 @@ class ServerRunCommand extends Command
                 new InputArgument('addressport', InputArgument::OPTIONAL, 'The address to listen to (can be address:port, address, or port)'),
                 new InputOption('docroot', 'd', InputOption::VALUE_REQUIRED, 'Document root, usually where your front controllers are stored'),
                 new InputOption('router', 'r', InputOption::VALUE_REQUIRED, 'Path to custom router script'),
-                new InputOption('executable', 'e', InputOption::VALUE_REQUIRED, 'Custom executable for the PHP commandline webserver'),
             ))
             ->setDescription('Runs a local web server')
             ->setHelp(<<<'EOF'
@@ -77,10 +76,8 @@ Use the <info>--docroot</info> option to change the default docroot directory:
 Specify your own router script via the <info>--router</info> option:
 
   <info>%command.full_name% --router=app/config/router.php</info>
-
-Specify your own server executable via the <info>--executable</info> option:
-
-  <info>%command.full_name% --executable=/usr/bin/php7</info>
+  
+Custom executable to run the server can be set using SYMFONY_SERVER_EXECUTABLE environment variable. 
 
 See also: http://www.php.net/manual/en/features.commandline.webserver.php
 EOF
@@ -135,13 +132,7 @@ EOF
 
         try {
             $server = new WebServer();
-            $config = new WebServerConfig(
-                $documentRoot,
-                $env,
-                $input->getArgument('addressport'),
-                $input->getOption('router'),
-                $input->getOption('executable')
-            );
+            $config = new WebServerConfig($documentRoot, $env, $input->getArgument('addressport'), $input->getOption('router'));
 
             $io->success(sprintf('Server listening on http://%s', $config->getAddress()));
             $io->comment('Quit the server with CONTROL-C.');

--- a/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/WebServerConfigTest.php
+++ b/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/WebServerConfigTest.php
@@ -22,7 +22,8 @@ class WebServerConfigTest extends TestCase
             __DIR__.'/fixtures',
             'dev',
             '85.111.31.18:8080',
-            __DIR__.'/fixtures/router.php'
+            __DIR__.'/fixtures/router.php',
+            '/usr/bin/php -c /tmp/custom/php.ini'
         );
 
         $this->assertSame(
@@ -36,6 +37,7 @@ class WebServerConfigTest extends TestCase
             $this->normalizePath(__DIR__.'/fixtures/router.php'),
             $this->normalizePath($config->getRouter())
         );
+        $this->assertSame('/usr/bin/php -c /tmp/custom/php.ini', $config->getExecutable());
     }
 
     public function testWillSetCorrectAddressAndPortAutomatically()
@@ -112,6 +114,14 @@ class WebServerConfigTest extends TestCase
             $this->normalizePath(dirname(dirname(__DIR__)).'/Resources/router.php'),
             $this->normalizePath($config->getRouter())
         );
+    }
+
+    public function testWillTryToFindExectuableIfNotPresent()
+    {
+        $config = new WebServerConfig(__DIR__.'/fixtures', 'dev');
+
+        // symplified as path will vary a lot on different systems
+        $this->assertNotEmpty($config->getExecutable());
     }
 
     /**

--- a/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/WebServerConfigTest.php
+++ b/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/WebServerConfigTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebServerBundle\Tests\WebServerConfig;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\WebServerBundle\WebServerConfig;
+
+class WebServerConfigTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $config = new WebServerConfig(
+            __DIR__.'/fixtures',
+            'dev',
+            '85.111.31.18:8080',
+            __DIR__.'/fixtures/router.php'
+        );
+
+        $this->assertSame(
+            $this->normalizePath(__DIR__.'/fixtures'),
+            $this->normalizePath($config->getDocumentRoot())
+        );
+        $this->assertSame('dev', $config->getEnv());
+        $this->assertSame('85.111.31.18:8080', $config->getAddress());
+        $this->assertEquals(8080, $config->getPort());
+        $this->assertSame(
+            $this->normalizePath(__DIR__.'/fixtures/router.php'),
+            $this->normalizePath($config->getRouter())
+        );
+    }
+
+    public function testWillSetCorrectAddressAndPortAutomatically()
+    {
+        $config = new WebServerConfig(__DIR__.'/fixtures', 'dev');
+
+        $this->assertEquals('127.0.0.1:8000', $config->getAddress());
+        $this->assertLessThanOrEqual(8100, $config->getPort());
+        $this->assertGreaterThanOrEqual(8000, $config->getPort());
+    }
+
+    public function testWillCorrectlyParseAsteriskAndPort()
+    {
+        $config = new WebServerConfig(__DIR__.'/fixtures', 'dev', '*:8080');
+
+        $this->assertSame('0.0.0.0:8080', $config->getAddress());
+        $this->assertEquals(8080, $config->getPort());
+    }
+
+    public function testWillParsePlainNumberAsPort()
+    {
+        $config = new WebServerConfig(__DIR__.'/fixtures', 'dev', '8080');
+
+        $this->assertSame('127.0.0.1:8080', $config->getAddress());
+        $this->assertEquals(8080, $config->getPort());
+    }
+
+    public function testWillFailForNonNumberPort()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Port "12a" is not valid.');
+
+        $config = new WebServerConfig(__DIR__.'/fixtures', 'dev', '127.0.0.1:12a');
+    }
+
+    public function testWillFailIfDocumentRootIsNotADirectory()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        // symplified to workaround directory separator issues
+        $this->expectExceptionMessage('The document root directory');
+
+        $config = new WebServerConfig(__DIR__.'/does-not-exist', 'dev');
+    }
+
+    public function testWillFailIfDocumentRootDoesNotContainFrontController()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        // symplified to workaround directory separator issues
+        $this->expectExceptionMessage('Unable to find the front controller under');
+
+        $config = new WebServerConfig(__DIR__.'/fixtures/not-containing-anything', 'dev');
+    }
+
+    public function testWillFailIfRouterDirectoryDoesNotContainRouter()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        // symplified to workaround directory separator issues
+        $this->expectExceptionMessage('Router script');
+
+        $config = new WebServerConfig(
+            __DIR__.'/fixtures',
+            'dev',
+            null,
+            __DIR__.'/fixtures/not-containing-anything/router.php'
+        );
+    }
+
+    public function testWillSetRouterToDeaultIfNotPresent()
+    {
+        $config = new WebServerConfig(__DIR__.'/fixtures', 'dev');
+
+        // router is relative to the WebServerConfig.php file (therefore two levels above)
+        $this->assertSame(
+            $this->normalizePath(dirname(dirname(__DIR__)).'/Resources/router.php'),
+            $this->normalizePath($config->getRouter())
+        );
+    }
+
+    /**
+     * Normalizes directory separators to what is native on the current platform.
+     *
+     * @param $path
+     *
+     * @return string
+     */
+    private function normalizePath($path)
+    {
+        return strtr($path, '/', DIRECTORY_SEPARATOR);
+    }
+}

--- a/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/WebServerConfigTest.php
+++ b/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/WebServerConfigTest.php
@@ -22,8 +22,7 @@ class WebServerConfigTest extends TestCase
             __DIR__.'/fixtures',
             'dev',
             '85.111.31.18:8080',
-            __DIR__.'/fixtures/router.php',
-            '/usr/bin/php -c /tmp/custom/php.ini'
+            __DIR__.'/fixtures/router.php'
         );
 
         $this->assertSame(
@@ -37,7 +36,6 @@ class WebServerConfigTest extends TestCase
             $this->normalizePath(__DIR__.'/fixtures/router.php'),
             $this->normalizePath($config->getRouter())
         );
-        $this->assertSame('/usr/bin/php -c /tmp/custom/php.ini', $config->getExecutable());
     }
 
     public function testWillSetCorrectAddressAndPortAutomatically()
@@ -114,14 +112,6 @@ class WebServerConfigTest extends TestCase
             $this->normalizePath(dirname(dirname(__DIR__)).'/Resources/router.php'),
             $this->normalizePath($config->getRouter())
         );
-    }
-
-    public function testWillTryToFindExectuableIfNotPresent()
-    {
-        $config = new WebServerConfig(__DIR__.'/fixtures', 'dev');
-
-        // symplified as path will vary a lot on different systems
-        $this->assertNotEmpty($config->getExecutable());
     }
 
     /**

--- a/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/fixtures/index.php
+++ b/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/fixtures/index.php
@@ -1,0 +1,3 @@
+<?php
+
+// dummy front controller

--- a/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/fixtures/router.php
+++ b/src/Symfony/Bundle/WebServerBundle/Tests/WebServerConfig/fixtures/router.php
@@ -1,0 +1,3 @@
+<?php
+
+// dummy router

--- a/src/Symfony/Bundle/WebServerBundle/WebServer.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServer.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\WebServerBundle;
 
-use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\RuntimeException;
 
@@ -146,13 +145,6 @@ class WebServer
     private function createServerProcess(WebServerConfig $config)
     {
         $executable = $config->getExecutable();
-
-        if ($executable === null) {
-            $finder = new PhpExecutableFinder();
-            if (false === $executable = $finder->find()) {
-                throw new \RuntimeException('Unable to find the PHP executable.');
-            }
-        }
 
         $process = new Process(array($executable, '-S', $config->getAddress(), $config->getRouter()));
         $process->setWorkingDirectory($config->getDocumentRoot());

--- a/src/Symfony/Bundle/WebServerBundle/WebServer.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServer.php
@@ -11,8 +11,9 @@
 
 namespace Symfony\Bundle\WebServerBundle;
 
-use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
 
 /**
  * Manages a local HTTP web server.
@@ -146,7 +147,16 @@ class WebServer
     {
         $executable = $config->getExecutable();
 
-        $process = new Process(array($executable, '-S', $config->getAddress(), $config->getRouter()));
+        // we need to separate the executable from the rest of the string as StringInput won't handle it
+        $firstPartOfCommand = explode(' ', $executable)[0];
+        // remove the executable and keep remainder of parameters
+        $remainder = substr($executable, strlen($firstPartOfCommand) + 1); //the one is a space
+
+        $input = new StringInput($remainder);
+        // newly added method to retrieve input parts
+        $executableArray = $input->getCommandLineArray();
+        $processArray = array_merge(array($firstPartOfCommand), $executableArray, array('-S', $config->getAddress(), $config->getRouter()));
+        $process = new Process($processArray);
         $process->setWorkingDirectory($config->getDocumentRoot());
         $process->setTimeout(null);
 

--- a/src/Symfony/Bundle/WebServerBundle/WebServer.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServer.php
@@ -145,12 +145,16 @@ class WebServer
      */
     private function createServerProcess(WebServerConfig $config)
     {
-        $finder = new PhpExecutableFinder();
-        if (false === $binary = $finder->find()) {
-            throw new \RuntimeException('Unable to find the PHP binary.');
+        $executable = $config->getExecutable();
+
+        if ($executable === null) {
+            $finder = new PhpExecutableFinder();
+            if (false === $executable = $finder->find()) {
+                throw new \RuntimeException('Unable to find the PHP executable.');
+            }
         }
 
-        $process = new Process(array($binary, '-S', $config->getAddress(), $config->getRouter()));
+        $process = new Process(array($executable, '-S', $config->getAddress(), $config->getRouter()));
         $process->setWorkingDirectory($config->getDocumentRoot());
         $process->setTimeout(null);
 

--- a/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
@@ -74,6 +74,13 @@ class WebServerConfig
         }
 
         if ($executable === null) {
+            $envExecutable = getenv('SYMFONY_SERVER_EXECUTABLE');
+            if ($envExecutable !== false) {
+                $executable = $envExecutable;
+            }
+        }
+
+        if ($executable === null) {
             $finder = new PhpExecutableFinder();
             if (false === $executable = $finder->find()) {
                 throw new \RuntimeException('Unable to find the PHP executable.');

--- a/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
@@ -25,7 +25,7 @@ class WebServerConfig
     private $router;
     private $executable;
 
-    public function __construct($documentRoot, $env, $address = null, $router = null, $executable = null)
+    public function __construct($documentRoot, $env, $address = null, $router = null)
     {
         if (!is_dir($documentRoot)) {
             throw new \InvalidArgumentException(sprintf('The document root directory "%s" does not exist.', $documentRoot));
@@ -73,11 +73,11 @@ class WebServerConfig
             throw new \InvalidArgumentException(sprintf('Port "%s" is not valid.', $this->port));
         }
 
-        if ($executable === null) {
-            $envExecutable = getenv('SYMFONY_SERVER_EXECUTABLE');
-            if ($envExecutable !== false) {
-                $executable = $envExecutable;
-            }
+        $executable = null;
+
+        $envExecutable = getenv('SYMFONY_SERVER_EXECUTABLE');
+        if ($envExecutable !== false) {
+            $executable = $envExecutable;
         }
 
         if ($executable === null) {

--- a/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
@@ -21,8 +21,9 @@ class WebServerConfig
     private $documentRoot;
     private $env;
     private $router;
+    private $executable;
 
-    public function __construct($documentRoot, $env, $address = null, $router = null)
+    public function __construct($documentRoot, $env, $address = null, $router = null, $executable = null)
     {
         if (!is_dir($documentRoot)) {
             throw new \InvalidArgumentException(sprintf('The document root directory "%s" does not exist.', $documentRoot));
@@ -69,6 +70,8 @@ class WebServerConfig
         if (!ctype_digit($this->port)) {
             throw new \InvalidArgumentException(sprintf('Port "%s" is not valid.', $this->port));
         }
+
+        $this->executable = $executable;
     }
 
     public function getDocumentRoot()
@@ -84,6 +87,11 @@ class WebServerConfig
     public function getRouter()
     {
         return $this->router;
+    }
+
+    public function getExecutable()
+    {
+        return $this->executable;
     }
 
     public function getHostname()

--- a/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServerConfig.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\WebServerBundle;
 
+use Symfony\Component\Process\PhpExecutableFinder;
+
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -69,6 +71,13 @@ class WebServerConfig
 
         if (!ctype_digit($this->port)) {
             throw new \InvalidArgumentException(sprintf('Port "%s" is not valid.', $this->port));
+        }
+
+        if ($executable === null) {
+            $finder = new PhpExecutableFinder();
+            if (false === $executable = $finder->find()) {
+                throw new \RuntimeException('Unable to find the PHP executable.');
+            }
         }
 
         $this->executable = $executable;

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -321,7 +321,17 @@ class ArgvInput extends Input
      */
     public function __toString()
     {
-        $tokens = array_map(function ($token) {
+        $tokens = $this->getCommandLineArray();
+
+        return implode(' ', $tokens);
+    }
+
+    /**
+     * @return array
+     */
+    public function getCommandLineArray()
+    {
+        return array_map(function ($token) {
             if (preg_match('{^(-[^=]+=)(.+)}', $token, $match)) {
                 return $match[1].$this->escapeToken($match[2]);
             }
@@ -332,7 +342,5 @@ class ArgvInput extends Input
 
             return $token;
         }, $this->tokens);
-
-        return implode(' ', $tokens);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | there are no relevant tests for WebServerBundle
| Fixed tickets | #22101
| License       | MIT
| Doc PR        | <!--symfony/symfony-docs#... --> will be added when finalized

The PR adds the "executable" option to `server:run` command to allow running server with custom executable (as in `bin\console server:run --executable="php -c /path/to/ini"`)

I'm having a hard time testing this. The webserver bundle does not have any tests. I tried to add the symfony repo locally to my other project to test it, but I got:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Can only install one of: symfony/symfony[dev-custom-server-executable, v3.3.3].
    - don't install symfony/web-server-bundle v3.3.3|don't install symfony/symfony dev-dev-custom-server-executable
    - Installation request for symfony/symfony dev-dev-custom-server-executable -> satisfiable by symfony/symfony[dev-dev-custom-server-executable].
    - Installation request for symfony/web-server-bundle 3.3.3 -> satisfiable by symfony/web-server-bundle[v3.3.3], symfony/symfony[v3.3.3].
```

Any pointers welcome. 