### PR TITLE
[Bridge\ProxyManager] Dont call __destruct() on non-instantiated services

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/LazyLoadingValueHolderFactoryV1.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/LazyLoadingValueHolderFactoryV1.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\ProxyManager\LazyProxy\Instantiator;
+
+use ProxyManager\Factory\LazyLoadingValueHolderFactory as BaseFactory;
+use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\LazyLoadingValueHolderGenerator;
+
+/**
+ * @internal
+ */
+class LazyLoadingValueHolderFactoryV1 extends BaseFactory
+{
+    private $generatorV1;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGenerator()
+    {
+        return $this->generatorV1 ?: $this->generatorV1 = new LazyLoadingValueHolderGenerator();
+    }
+}

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/LazyLoadingValueHolderFactoryV2.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/LazyLoadingValueHolderFactoryV2.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\ProxyManager\LazyProxy\Instantiator;
+
+use ProxyManager\ProxyGenerator\ProxyGeneratorInterface;
+use ProxyManager\Factory\LazyLoadingValueHolderFactory as BaseFactory;
+use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\LazyLoadingValueHolderGenerator;
+
+/**
+ * @internal
+ */
+class LazyLoadingValueHolderFactoryV2 extends BaseFactory
+{
+    private $generator;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGenerator(): ProxyGeneratorInterface
+    {
+        return $this->generator ?: $this->generator = new LazyLoadingValueHolderGenerator();
+    }
+}

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
@@ -36,7 +36,11 @@ class RuntimeInstantiator implements InstantiatorInterface
         $config = new Configuration();
         $config->setGeneratorStrategy(new EvaluatingGeneratorStrategy());
 
-        $this->factory = new LazyLoadingValueHolderFactory($config);
+        if (method_exists('ProxyManager\Version', 'getVersion')) {
+            $this->factory = new LazyLoadingValueHolderFactoryV2($config);
+        } else {
+            $this->factory = new LazyLoadingValueHolderFactoryV1($config);
+        }
     }
 
     /**

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/LazyLoadingValueHolderGenerator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/LazyLoadingValueHolderGenerator.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper;
+
+use ProxyManager\ProxyGenerator\LazyLoadingValueHolderGenerator as BaseGenerator;
+use Zend\Code\Generator\ClassGenerator;
+
+/**
+ * @internal
+ */
+class LazyLoadingValueHolderGenerator extends BaseGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(\ReflectionClass $originalClass, ClassGenerator $classGenerator)
+    {
+        parent::generate($originalClass, $classGenerator);
+
+        if ($classGenerator->hasMethod('__destruct')) {
+            $destructor = $classGenerator->getMethod('__destruct');
+            $body = $destructor->getBody();
+            $newBody = preg_replace('/^(\$this->initializer[a-zA-Z0-9]++) && .*;\n\nreturn (\$this->valueHolder)/', '$1 || $2', $body);
+
+            if ($body === $newBody) {
+                throw new \UnexpectedValueException(sprintf('Unexpected lazy-proxy format generated for method %s::__destruct()', $originalClass->name));
+            }
+
+            $destructor->setBody($newBody);
+        }
+    }
+}

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -13,7 +13,6 @@ namespace Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper;
 
 use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\GeneratorStrategy\BaseGeneratorStrategy;
-use ProxyManager\ProxyGenerator\LazyLoadingValueHolderGenerator;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/ContainerBuilderTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/ContainerBuilderTest.php
@@ -39,6 +39,9 @@ class ContainerBuilderTest extends TestCase
         /* @var $foo1 \ProxyManager\Proxy\LazyLoadingInterface|\ProxyManager\Proxy\ValueHolderInterface */
         $foo1 = $builder->get('foo1');
 
+        $foo1->__destruct();
+        $this->assertSame(0, $foo1::$destructorCount);
+
         $this->assertSame($foo1, $builder->get('foo1'), 'The same proxy is retrieved on multiple subsequent calls');
         $this->assertInstanceOf('\ProxyManagerBridgeFooClass', $foo1);
         $this->assertInstanceOf('\ProxyManager\Proxy\LazyLoadingInterface', $foo1);
@@ -50,5 +53,8 @@ class ContainerBuilderTest extends TestCase
         $this->assertTrue($foo1->isProxyInitialized());
         $this->assertInstanceOf('\ProxyManagerBridgeFooClass', $foo1->getWrappedValueHolderValue());
         $this->assertNotInstanceOf('\ProxyManager\Proxy\LazyLoadingInterface', $foo1->getWrappedValueHolderValue());
+
+        $foo1->__destruct();
+        $this->assertSame(1, $foo1::$destructorCount);
     }
 }

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/includes/foo.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/includes/foo.php
@@ -2,6 +2,8 @@
 
 class ProxyManagerBridgeFooClass
 {
+    public static $destructorCount = 0;
+
     public $foo;
     public $moo;
 
@@ -37,5 +39,10 @@ class ProxyManagerBridgeFooClass
     public function setBar($value = null)
     {
         $this->bar = $value;
+    }
+
+    public function __destruct()
+    {
+        ++self::$destructorCount;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23813
| License       | MIT
| Doc PR        | -

While working on making #23678 green, I discovered that if a lazy service implements `__destruct`, then that service is not lazy anymore: it is created at destruct time.
That behavior is documented at https://github.com/Ocramius/ProxyManager/issues/258 (+related issues).

While I may understand why this behavior is the default for ProxyManager, it does not fit our "lazy-services" use case to me. Typically, nobody wants a database connection to be created to destruct the uninitialized lazy-proxy.

Blocks #23678