### PR TITLE
[Dotenv] Add support for a magic __DIR__ variable

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -24,7 +24,7 @@ use Symfony\Component\Process\Process;
  */
 final class Dotenv
 {
-    const VARNAME_REGEX = '(?i:[A-Z][A-Z0-9_]*+)';
+    const VARNAME_REGEX = '(?i:[A-Z_][A-Z0-9_]*+)';
     const STATE_VARNAME = 0;
     const STATE_VALUE = 1;
 
@@ -95,7 +95,7 @@ final class Dotenv
         $this->cursor = 0;
         $this->end = strlen($this->data);
         $this->state = self::STATE_VARNAME;
-        $this->values = array();
+        $this->values = array('__DIR__' => dirname(realpath($path) ?: $path));
         $name = $value = '';
 
         $this->skipEmptyLines();
@@ -117,6 +117,8 @@ final class Dotenv
         if (self::STATE_VALUE === $this->state) {
             $this->values[$name] = '';
         }
+
+        unset($this->values['__DIR__']);
 
         try {
             return $this->values;

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -214,4 +214,12 @@ class DotenvTest extends TestCase
 
         $this->assertSame('original_value', getenv('TEST_ENV_VAR'));
     }
+
+    public function testMagicDirVar()
+    {
+        $dotenv = new DotEnv();
+        $vars = $dotenv->parse('DATABASE_URL=${__DIR__}/var/data/db.sqlite', '/tmp/symfony/.env');
+
+        $this->assertSame('/tmp/symfony/var/data/db.sqlite', $vars['DATABASE_URL']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

In the Symfony demo application (see symfony/symfony-demo#617) we need to set an absolute path to a database, but we can't get it in the .env file. This PR adds support for a "magic" environment variable `__DIR__` which can be used to get the absolute path in the current `.env` file.

Example:
```sh
# .env
DATABASE_URL="sqlite:///${__DIR__}/var/data/blog.sqlite"
```
