### PR TITLE
[Form] Removed useless argument $definition

### DIFF
--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -16,7 +16,6 @@ use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -53,12 +52,12 @@ class FormPass implements CompilerPassInterface
         if (new IteratorArgument(array()) != $definition->getArgument(2)) {
             return;
         }
-        $definition->replaceArgument(0, $this->processFormTypes($container, $definition));
+        $definition->replaceArgument(0, $this->processFormTypes($container));
         $definition->replaceArgument(1, $this->processFormTypeExtensions($container));
         $definition->replaceArgument(2, $this->processFormTypeGuessers($container));
     }
 
-    private function processFormTypes(ContainerBuilder $container, Definition $definition)
+    private function processFormTypes(ContainerBuilder $container)
     {
         // Get service locator argument
         $servicesMap = array();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

After https://github.com/symfony/symfony/pull/22175/files this argument is not used anymore.