### PR TITLE
Fix files property type: array of FileBag objects

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -97,7 +97,7 @@ class Request
     /**
      * Uploaded files ($_FILES).
      *
-     * @var \Symfony\Component\HttpFoundation\FileBag
+     * @var \Symfony\Component\HttpFoundation\FileBag[]
      */
     public $files;
 


### PR DESCRIPTION
[HttpFoundation] [Request] Fix $files property type from FileBag object to array of FileBag objects

Q | A
-- | --
Branch? | 3.5
Bug fix? | no
New feature? | no
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets |  
License | MIT
Doc PR

