### PR TITLE
Ignore memcached missing key error on session destroy

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
@@ -95,7 +95,9 @@ class MemcacheSessionHandler implements \SessionHandlerInterface
      */
     public function destroy($sessionId)
     {
-        return $this->memcache->delete($this->prefix.$sessionId);
+        $this->memcache->delete($this->prefix.$sessionId);
+
+        return true;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -101,7 +101,9 @@ class MemcachedSessionHandler implements \SessionHandlerInterface
      */
     public function destroy($sessionId)
     {
-        return $this->memcached->delete($this->prefix.$sessionId);
+        $result = $this->memcached->delete($this->prefix.$sessionId);
+
+        return $result || $this->memcached->getResultCode() == \Memcached::RES_NOTFOUND;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #18574
| License       | MIT
| Doc PR        | NA

Since PHP 7 session_regenerate_id triggers a warning when the session is not started. 

This PR, changes the behaviours of session_destroy in the `MemcachedSessionHandler` by returning true when the user try to delete a non-existing session.

Other handler:
- LegacyPdoSessionHandler  => don't check if key exists
- MongoDbSessionHandler  => don't check if key exists
- NullSessionHandler => always true
- PdoSessionHandler => don't check if key exists
