### PR TITLE
[FrameworkBundle] Add an option allowing to ignore the .env file

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
  * Removed support of the `KERNEL_DIR` environment variable with `KernelTestCase::getKernelClass()`.
  * Removed the `KernelTestCase::getPhpUnitXmlDir()` and `KernelTestCase::getPhpUnitCliConfigArgument()` methods.
  * Removed the "framework.validation.cache" configuration option. Configure the "cache.validator" service under "framework.cache.pools" instead.
+ * Added a console option allowing to ignore the .env file.
 
 3.4.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -44,6 +44,7 @@ class Application extends BaseApplication
 
         $this->getDefinition()->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The environment name', $kernel->getEnvironment()));
         $this->getDefinition()->addOption(new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode'));
+        $this->getDefinition()->addOption(new InputOption('--ignore-dotenv', null, InputOption::VALUE_NONE, 'Ignore the .env file'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23723 
| License       | MIT

For example, this feature allows us to run the dev webserver without loading the `.env` fie.
```sh
$ php bin/console --ignore-dotenv server:start
```

The code that implements this feature is here: https://github.com/symfony/recipes/pull/138