### PR TITLE
[Cache] Hash cache key on save

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -55,19 +55,20 @@ abstract class AbstractAdapter implements AdapterInterface, LoggerAwareInterface
             null,
             CacheItem::class
         );
+        $getId = function ($key) { return $this->getId((string) $key); };
         $this->mergeByLifetime = \Closure::bind(
-            function ($deferred, $namespace, &$expiredIds) {
+            function ($deferred, $namespace, &$expiredIds) use ($getId) {
                 $byLifetime = array();
                 $now = time();
                 $expiredIds = array();
 
                 foreach ($deferred as $key => $item) {
                     if (null === $item->expiry) {
-                        $byLifetime[0 < $item->defaultLifetime ? $item->defaultLifetime : 0][$namespace.$key] = $item->value;
+                        $byLifetime[0 < $item->defaultLifetime ? $item->defaultLifetime : 0][$getId($key)] = $item->value;
                     } elseif ($item->expiry > $now) {
-                        $byLifetime[$item->expiry - $now][$namespace.$key] = $item->value;
+                        $byLifetime[$item->expiry - $now][$getId($key)] = $item->value;
                     } else {
-                        $expiredIds[] = $namespace.$key;
+                        $expiredIds[] = $getId($key);
                     }
                 }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -22,6 +22,7 @@ class PhpArrayAdapterTest extends AdapterTestCase
 {
     protected $skippedTests = array(
         'testBasicUsage' => 'PhpArrayAdapter is read-only.',
+        'testBasicUsageWithLongKey' => 'PhpArrayAdapter is read-only.',
         'testClear' => 'PhpArrayAdapter is read-only.',
         'testClearWithDeferredItems' => 'PhpArrayAdapter is read-only.',
         'testDeleteItem' => 'PhpArrayAdapter is read-only.',

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Cache\Simple\PhpArrayCache;
 class PhpArrayCacheTest extends CacheTestCase
 {
     protected $skippedTests = array(
+        'testBasicUsageWithLongKey' => 'PhpArrayCache does no writes',
+
         'testDelete' => 'PhpArrayCache does no writes',
         'testDeleteMultiple' => 'PhpArrayCache does no writes',
         'testDeleteMultipleGenerator' => 'PhpArrayCache does no writes',
@@ -57,6 +59,7 @@ class PhpArrayCacheTest extends CacheTestCase
             FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');
         }
     }
+
     public function createSimpleCache()
     {
         return new PhpArrayCacheWrapper(self::$file, new NullCache());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ye
| Fixed tickets | n.A.
| License       | MIT
| Doc PR        | n.A.

Cache keys are not hashed right now in adapters extending from `AbstractAdapter`. This PR fixes this. I am not familiar enough with the cache test suite so I don't know where to add an regression test.