### PR TITLE
Avoid infinite loops when profiler data is malformed

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -144,11 +144,19 @@ class FileProfilerStorage implements ProfilerStorageInterface
             }
         }
 
+        $profileToken = $profile->getToken();
+        // when there are errors in sub-requests, the parent and/or children tokens
+        // may equal the profile token, resulting in infinite loops
+        $parentToken = $profile->getParentToken() !== $profileToken ? $profile->getParentToken() : null;
+        $childrenToken = array_filter(array_map(function ($p) use ($profileToken) {
+            return $profileToken !== $p->getToken() ? $p->getToken() : null;
+        }, $profile->getChildren()));
+
         // Store profile
         $data = array(
-            'token' => $profile->getToken(),
-            'parent' => $profile->getParentToken(),
-            'children' => array_map(function ($p) { return $p->getToken(); }, $profile->getChildren()),
+            'token' => $profileToken,
+            'parent' => $parentToken,
+            'children' => $childrenToken,
             'data' => $profile->getCollectors(),
             'ip' => $profile->getIp(),
             'method' => $profile->getMethod(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22963
| License       | MIT
| Doc PR        | -

Thanks to the bug reproducer provided by @Kyoushu, I could reproduce this error:

```
PHP 7.1.4 Development Server started at Thu Aug  3 22:13:26 2017
Listening on http://127.0.0.1:8000
Document root is projects/symfony-fileprofilerstorage-bug/web
Press Ctrl-C to quit.

[Thu Aug  3 22:13:26 2017] PHP Fatal error:
Allowed memory size of 2147483648 bytes exhausted (tried to allocate 282624 bytes) in
projects/symfony-fileprofilerstorage-bug/vendor/symfony/symfony/src/Symfony/Component/
HttpKernel/Profiler/FileProfilerStorage.php on line 124
```

After the changes proposed in this PR, the browser no longer exhausts the memory and you can see the exception page explaining the error. The web debug toolbar doesn't load, but it doesn't crash anything:

![error-profiler](https://user-images.githubusercontent.com/73419/28941732-3c7eb29c-7899-11e7-88e8-a16517d5bcf7.png)
