### PR TITLE
[PropertyAccess] add naming strategy

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -722,6 +722,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('magic_call')->defaultFalse()->end()
                         ->booleanNode('throw_exception_on_invalid_index')->defaultFalse()->end()
+                        ->scalarNode('naming_strategy')->cannotBeEmpty()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1113,6 +1113,10 @@ class FrameworkExtension extends Extension
             ->replaceArgument(0, $config['magic_call'])
             ->replaceArgument(1, $config['throw_exception_on_invalid_index'])
         ;
+
+        if (isset($config['naming_strategy'])) {
+            $container->getDefinition('property_accessor')->addArgument(new Reference($config['naming_strategy']));
+        }
     }
 
     private function registerSecurityCsrfConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -217,6 +217,7 @@
     <xsd:complexType name="property_access">
         <xsd:attribute name="magic-call" type="xsd:boolean" />
         <xsd:attribute name="throw-exception-on-invalid-index" type="xsd:boolean" />
+        <xsd:attribute name="naming-strategy" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="serializer">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/property_accessor.php
@@ -4,5 +4,6 @@ $container->loadFromExtension('framework', array(
     'property_access' => array(
         'magic_call' => true,
         'throw_exception_on_invalid_index' => true,
+        'naming_strategy' => 'my_naming_strategy',
     ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_accessor.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/property_accessor.xml
@@ -7,6 +7,6 @@
                         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
-        <framework:property-access magic-call="true" throw-exception-on-invalid-index="true" />
+        <framework:property-access magic-call="true" throw-exception-on-invalid-index="true" naming-strategy="my_naming_strategy" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/property_accessor.yml
@@ -2,3 +2,4 @@ framework:
     property_access:
         magic_call: true
         throw_exception_on_invalid_index: true
+        naming_strategy: my_naming_strategy

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -78,6 +78,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $def = $container->getDefinition('property_accessor');
         $this->assertTrue($def->getArgument(0));
         $this->assertTrue($def->getArgument(1));
+        $this->assertEquals(new Reference('my_naming_strategy'), $def->getArgument(3));
     }
 
     public function testPropertyAccessCache()

--- a/src/Symfony/Component/PropertyAccess/NamingStrategy/CamelCaseStrategy.php
+++ b/src/Symfony/Component/PropertyAccess/NamingStrategy/CamelCaseStrategy.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\NamingStrategy;
+
+use Symfony\Component\Inflector\Inflector;
+
+/**
+ * @author David Badura <d.a.badura@gmail.com>
+ */
+class CamelCaseStrategy implements NamingStrategyInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getGetters(string $class, string $property): array
+    {
+        $camelProp = self::camelize($property);
+
+        return array(
+            'get'.$camelProp,
+            lcfirst($camelProp), // jQuery style, e.g. read: last(), write: last($item)
+            'is'.$camelProp,
+            'has'.$camelProp,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSetters(string $class, string $property): array
+    {
+        $camelized = self::camelize($property);
+
+        return array(
+            'set'.$camelized,
+            lcfirst($camelized), // jQuery style, e.g. read: last(), write: last($item)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAddersAndRemovers(string $class, string $property): array
+    {
+        $singulars = (array) Inflector::singularize(self::camelize($property));
+
+        return array_map(function ($singular) {
+            return array('add'.$singular, 'remove'.$singular);
+        }, $singulars);
+    }
+
+    private static function camelize(string $string): string
+    {
+        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/NamingStrategy/NamingStrategyInterface.php
+++ b/src/Symfony/Component/PropertyAccess/NamingStrategy/NamingStrategyInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\NamingStrategy;
+
+/**
+ * @author David Badura <d.a.badura@gmail.com>
+ */
+interface NamingStrategyInterface
+{
+    /**
+     * Returns all possible getters.
+     *
+     * @param string $class
+     * @param string $property
+     *
+     * @return array
+     */
+    public function getGetters(string $class, string $property): array;
+
+    /**
+     * Returns all possible setters.
+     *
+     * @param string $class
+     * @param string $property
+     *
+     * @return array
+     */
+    public function getSetters(string $class, string $property): array;
+
+    /**
+     * Returns all possible adders and removers.
+     *
+     * @param string $class
+     * @param string $property
+     *
+     * @return array
+     */
+    public function getAddersAndRemovers(string $class, string $property): array;
+}

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyAccess;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\PropertyAccess\NamingStrategy\NamingStrategyInterface;
 
 /**
  * A configurable builder to create a PropertyAccessor.
@@ -27,6 +28,11 @@ class PropertyAccessorBuilder
      * @var CacheItemPoolInterface|null
      */
     private $cacheItemPool;
+
+    /**
+     * @var NamingStrategyInterface|null
+     */
+    private $namingStrategy;
 
     /**
      * Enables the use of "__call" by the PropertyAccessor.
@@ -121,6 +127,18 @@ class PropertyAccessorBuilder
         return $this->cacheItemPool;
     }
 
+    public function setNamingStrategy(NamingStrategyInterface $namingStrategy = null): self
+    {
+        $this->namingStrategy = $namingStrategy;
+
+        return $this;
+    }
+
+    public function getNamingStrategy(): ?NamingStrategyInterface
+    {
+        return $this->namingStrategy;
+    }
+
     /**
      * Builds and returns a new PropertyAccessor object.
      *
@@ -128,6 +146,11 @@ class PropertyAccessorBuilder
      */
     public function getPropertyAccessor()
     {
-        return new PropertyAccessor($this->magicCall, $this->throwExceptionOnInvalidIndex, $this->cacheItemPool);
+        return new PropertyAccessor(
+            $this->magicCall,
+            $this->throwExceptionOnInvalidIndex,
+            $this->cacheItemPool,
+            $this->namingStrategy
+        );
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/NamingStrategy/CamelCaseStrategyTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/NamingStrategy/CamelCaseStrategyTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\NamingStrategy;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\NamingStrategy\CamelCaseStrategy;
+
+class CamelCaseStrategyTest extends TestCase
+{
+    /**
+     * @var CamelCaseStrategy
+     */
+    private $namingStrategy;
+
+    protected function setUp()
+    {
+        $this->namingStrategy = new CamelCaseStrategy();
+    }
+
+    public function getCamelCaseProperty()
+    {
+        return array(
+            array(
+                'test',
+                array('getTest', 'test', 'isTest', 'hasTest'),
+                array('setTest', 'test'),
+                array(
+                    array('addTest', 'removeTest'),
+                ),
+            ),
+            array(
+                'fooBar',
+                array('getFooBar', 'fooBar', 'isFooBar', 'hasFooBar'),
+                array('setFooBar', 'fooBar'),
+                array(
+                    array('addFooBar', 'removeFooBar'),
+                ),
+            ),
+            array(
+                'users',
+                array('getUsers', 'users', 'isUsers', 'hasUsers'),
+                array('setUsers', 'users'),
+                array(
+                    array('addUser', 'removeUser'),
+                ),
+            ),
+            array(
+                'userGroups',
+                array('getUserGroups', 'userGroups', 'isUserGroups', 'hasUserGroups'),
+                array('setUserGroups', 'userGroups'),
+                array(
+                    array('addUserGroup', 'removeUserGroup'),
+                ),
+            ),
+            array(
+                'circuses',
+                array('getCircuses', 'circuses', 'isCircuses', 'hasCircuses'),
+                array('setCircuses', 'circuses'),
+                array(
+                    array('addCircus', 'removeCircus'),
+                    array('addCircuse', 'removeCircuse'),
+                    array('addCircusis', 'removeCircusis'),
+                ),
+            ),
+        );
+    }
+
+    public function getUnderscoreProperty()
+    {
+        return array(
+            array(
+                'foo_bar',
+                array('getFooBar', 'fooBar', 'isFooBar', 'hasFooBar'),
+                array('setFooBar', 'fooBar'),
+                array(
+                    array('addFooBar', 'removeFooBar'),
+                ),
+            ),
+            array(
+                'user_groups',
+                array('getUserGroups', 'userGroups', 'isUserGroups', 'hasUserGroups'),
+                array('setUserGroups', 'userGroups'),
+                array(
+                    array('addUserGroup', 'removeUserGroup'),
+                ),
+            ),
+            array(
+                'super_circuses',
+                array('getSuperCircuses', 'superCircuses', 'isSuperCircuses', 'hasSuperCircuses'),
+                array('setSuperCircuses', 'superCircuses'),
+                array(
+                    array('addSuperCircus', 'removeSuperCircus'),
+                    array('addSuperCircuse', 'removeSuperCircuse'),
+                    array('addSuperCircusis', 'removeSuperCircusis'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getCamelCaseProperty
+     */
+    public function testCamelCaseProperty($property, $getters, $setters, $addersAndRemovers)
+    {
+        $this->assertSame($getters, $this->namingStrategy->getGetters('SomeClass', $property));
+        $this->assertSame($setters, $this->namingStrategy->getSetters('SomeClass', $property));
+        $this->assertSame($addersAndRemovers, $this->namingStrategy->getAddersAndRemovers('SomeClass', $property));
+    }
+
+    /**
+     * @dataProvider getUnderscoreProperty
+     */
+    public function testUnderscoreProperty($property, $getters, $setters, $addersAndRemovers)
+    {
+        $this->assertSame($getters, $this->namingStrategy->getGetters('SomeClass', $property));
+        $this->assertSame($setters, $this->namingStrategy->getSetters('SomeClass', $property));
+        $this->assertSame($addersAndRemovers, $this->namingStrategy->getAddersAndRemovers('SomeClass', $property));
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorBuilderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\PropertyAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\PropertyAccess\NamingStrategy\CamelCaseStrategy;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\PropertyAccessorBuilder;
 
@@ -61,6 +62,14 @@ class PropertyAccessorBuilderTest extends TestCase
         $cacheItemPool = new ArrayAdapter();
         $this->builder->setCacheItemPool($cacheItemPool);
         $this->assertEquals($cacheItemPool, $this->builder->getCacheItemPool());
+        $this->assertInstanceOf(PropertyAccessor::class, $this->builder->getPropertyAccessor());
+    }
+
+    public function testNamingStrategy()
+    {
+        $namingStrategy = new CamelCaseStrategy();
+        $this->builder->setNamingStrategy($namingStrategy);
+        $this->assertEquals($namingStrategy, $this->builder->getNamingStrategy());
         $this->assertInstanceOf(PropertyAccessor::class, $this->builder->getPropertyAccessor());
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\PropertyAccess\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
+use Symfony\Component\PropertyAccess\NamingStrategy\NamingStrategyInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicCall;
@@ -566,6 +567,22 @@ class PropertyAccessorTest extends TestCase
         $propertyAccessor->setValue($obj, 'publicGetSetter', 'bar');
         $propertyAccessor->setValue($obj, 'publicGetSetter', 'baz');
         $this->assertEquals('baz', $propertyAccessor->getValue($obj, 'publicGetSetter'));
+    }
+
+    public function testNamingStrategy()
+    {
+        $strategy = $this->getMockBuilder(NamingStrategyInterface::class)->getMock();
+        $strategy->method('getGetters')->with(TestClass::class, 'my_path1')->willReturn(array('getPublicAccessor'));
+        $strategy->method('getSetters')->with(TestClass::class, 'my_path2')->willReturn(array('setPublicAccessor'));
+        $strategy->method('getAddersAndRemovers')->with(TestClass::class, 'my_path2')->willReturn(array());
+
+        $obj = new TestClass('foo');
+
+        $propertyAccessor = new PropertyAccessor(false, false, null, $strategy);
+
+        $this->assertEquals('foo', $propertyAccessor->getValue($obj, 'my_path1'));
+        $propertyAccessor->setValue($obj, 'my_path2', 'baz');
+        $this->assertEquals('baz', $propertyAccessor->getValue($obj, 'my_path1'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22454, #21569, #9336, #5219 and others
| License       | MIT
| Doc PR        | todo <!--highly recommended for new features-->

I'm from issue #23656 which is about a problem with the PropertyAccessor. The problem is that the PropertyAccessor always camelizes properties before searching for the right methods.

The other referenced issues (above) are pointing out a lot more problems about how the PropertyAccessor creates the method names:

* wrong singularizing of properties
* only singluarizing in English
* hardcoded method prefixes
* etc.

#22190 & #22191 should fix all this, but:

* it's a huge PR and a big intervention for PropertyAccessor
* you need to add an annotation for all properties, if you want to change how it singularizes

The simplest way to solve these problems is to extract how the method names are created. The advatages of this method are:

* very small and flexible
* you can change naming in one place
* should be compatible with #22190 (with AnnotationStrategy or MetadataStrategy)

Simple override example:

```php
class MySpecialStrategy implements NamingStrategy 
{
    private $defaultStrategy;
    
    public function __constructor(NamingStrategyInterface $defaultStrategy) 
    {
        $this->defaultStrategy = $defaultStrategy;
    }
 
    public function getAddersAndRemovers($class, $property)
    {
        if ($class === 'Group' && $property == 'members') {
            return ['joinMember', 'leaveMember'];
        }
  
        return $this->defaultStrategy->getAddersAndRemovers($class, $property);
    }
    //...
}
```

An underscore strategy or a yaml based configuration strategy would also be possible.

What do you think about this solution?

---

Todos:

* [x] update PropertyAccessorBuilder
* [x] make it configurable
* [x] add CamelCaseStrategy tests
* [x] add PropertyAccess tests with another strategy
* [x] add PropertyAccessBuilder tests
* [x] rebase on master
* [x] add typehints