### PR TITLE
[HttpKernel][FrameworkBundle] Add RebootableInterface, fix and un-deprecate cache:clear with warmup

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -143,6 +143,9 @@ HttpKernel
            tags: ['console.command']
    ```
 
+ * The `getCacheDir()` method of your kernel should not be called while building the container.
+   Use the `%kernel.cache_dir%` parameter instead. Not doing so may break the `cache:clear` command.
+
 Process
 -------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -510,6 +510,9 @@ HttpKernel
    by Symfony. Use the `%env()%` syntax to get the value of any environment
    variable from configuration files instead.
 
+ * The `getCacheDir()` method of your kernel should not be called while building the container.
+   Use the `%kernel.cache_dir%` parameter instead. Not doing so may break the `cache:clear` command.
+
 Ldap
 ----
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
+ * added `RebootableInterface` and implemented it in `Kernel`
  * deprecated commands auto registration
  * added `AddCacheClearerPass`
  * added `AddCacheWarmerPass`

--- a/src/Symfony/Component/HttpKernel/RebootableInterface.php
+++ b/src/Symfony/Component/HttpKernel/RebootableInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel;
+
+/**
+ * Allows the Kernel to be rebooted using a temporary cache directory.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface RebootableInterface
+{
+    /**
+     * Reboots a kernel.
+     *
+     * The getCacheDir() method of a rebootable kernel should not be called
+     * while building the container. Use the %kernel.cache_dir% parameter instead.
+     *
+     * @param string|null $warmupDir pass null to reboot in the regular cache directory
+     */
+    public function reboot($warmupDir);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #23592, #8500
| License       | MIT
| Doc PR        | -

This PR fixes the reasons why we deprecated cache:clear without --no-warmup.

Internally, it requires some cooperation from the Kernel, so that a deprecation is needed.
This allows the same kernel instance to be rebooted under a new cache directory, used during the warmup.
It leverages the new capability to create two independent non colliding containers.