### PR TITLE
[VarDumper] Fix interval caster with PT3600S-like spec

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -52,6 +52,10 @@ class DateCaster
 
     private static function formatInterval(\DateInterval $i)
     {
+        if ($i->m >= 12 || $i->d >= 31 || $i->h >= 24 || $i->i >= 60 || $i->s >= 60) {
+            $i = date_diff($d = new \DateTime(), date_add(clone $d, $i));
+        }
+
         $format = '%R '
             .($i->y ? '%yy ' : '')
             .($i->m ? '%mm ' : '')

--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -52,15 +52,14 @@ class DateCaster
 
     private static function formatInterval(\DateInterval $i)
     {
-        if ($i->m >= 12 || $i->d >= 31 || $i->h >= 24 || $i->i >= 60 || $i->s >= 60) {
-            $i = date_diff($d = new \DateTime(), date_add(clone $d, $i));
-        }
+        $format = '%R ';
 
-        $format = '%R '
-            .($i->y ? '%yy ' : '')
-            .($i->m ? '%mm ' : '')
-            .($i->d ? '%dd ' : '')
-        ;
+        if ($i->m >= 12 || $i->d >= 28 || $i->h >= 24 || $i->i >= 60 || $i->s >= 60) {
+            $i = date_diff($d = new \DateTime(), date_add(clone $d, $i)); // recalculate carry over points
+            $format .= 0 < $i->days ? '%ad ' : '';
+        } else {
+            $format .= ($i->y ? '%yy ' : '').($i->m ? '%mm ' : '').($i->d ? '%dd ' : '');
+        }
 
         if (\PHP_VERSION_ID >= 70100 && isset($i->f)) {
             $format .= $i->h || $i->i || $i->s || $i->f ? '%H:%I:%S.%F' : '';

--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -54,7 +54,7 @@ class DateCaster
     {
         $format = '%R ';
 
-        if ($i->m >= 12 || $i->d >= 28 || $i->h >= 24 || $i->i >= 60 || $i->s >= 60) {
+        if ($i->y === 0 && $i->m === 0 && ($i->h >= 24 || $i->i >= 60 || $i->s >= 60)) {
             $i = date_diff($d = new \DateTime(), date_add(clone $d, $i)); // recalculate carry over points
             $format .= 0 < $i->days ? '%ad ' : '';
         } else {

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -173,6 +173,7 @@ EODUMP;
             array('P5M', 0, '+ 5m', null),
             array('P6Y', 0, '+ 6y', null),
             array('P1Y2M3DT4H5M6S', 0, '+ 1y 2m 3d 04:05:06'.$ms, null),
+            array('PT3600S', 0, '+ 01:00:00'.$ms, null),
 
             array('PT0S', 1, '0s', '0s'),
             array('PT1S', 1, '- 00:00:01'.$ms, '-1s'),
@@ -182,6 +183,7 @@ EODUMP;
             array('P5M', 1, '- 5m', null),
             array('P6Y', 1, '- 6y', null),
             array('P1Y2M3DT4H5M6S', 1, '- 1y 2m 3d 04:05:06'.$ms, null),
+            array('PT3600S', 1, '- 01:00:00'.$ms, null),
         );
     }
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -173,8 +173,10 @@ EODUMP;
             array('P5M', 0, '+ 5m', null),
             array('P6Y', 0, '+ 6y', null),
             array('P1Y2M3DT4H5M6S', 0, '+ 1y 2m 3d 04:05:06'.$ms, null),
-            array('PT3600S', 0, '+ 01:00:00'.$ms, null),
-            array('P60D', 0, '+ 60d', null),
+            array('PT1M60S', 0, '+ 00:02:00'.$ms, null),
+            array('PT1H60M', 0, '+ 02:00:00'.$ms, null),
+            array('P1DT24H', 0, '+ 2d', null),
+            array('P1M32D', 0, '+ 1m 32d', null),
 
             array('PT0S', 1, '0s', '0s'),
             array('PT1S', 1, '- 00:00:01'.$ms, '-1s'),
@@ -184,8 +186,10 @@ EODUMP;
             array('P5M', 1, '- 5m', null),
             array('P6Y', 1, '- 6y', null),
             array('P1Y2M3DT4H5M6S', 1, '- 1y 2m 3d 04:05:06'.$ms, null),
-            array('PT3600S', 1, '- 01:00:00'.$ms, null),
-            array('P60D', 1, '- 60d', null),
+            array('PT1M60S', 1, '- 00:02:00'.$ms, null),
+            array('PT1H60M', 1, '- 02:00:00'.$ms, null),
+            array('P1DT24H', 1, '- 2d', null),
+            array('P1M32D', 1, '- 1m 32d', null),
         );
     }
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -174,6 +174,7 @@ EODUMP;
             array('P6Y', 0, '+ 6y', null),
             array('P1Y2M3DT4H5M6S', 0, '+ 1y 2m 3d 04:05:06'.$ms, null),
             array('PT3600S', 0, '+ 01:00:00'.$ms, null),
+            array('P60D', 0, '+ 60d', null),
 
             array('PT0S', 1, '0s', '0s'),
             array('PT1S', 1, '- 00:00:01'.$ms, '-1s'),
@@ -184,6 +185,7 @@ EODUMP;
             array('P6Y', 1, '- 6y', null),
             array('P1Y2M3DT4H5M6S', 1, '- 1y 2m 3d 04:05:06'.$ms, null),
             array('PT3600S', 1, '- 01:00:00'.$ms, null),
+            array('P60D', 1, '- 60d', null),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

According [ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601):

> The standard does not prohibit date and time values in a duration representation from exceeding their "carry over points" except as noted below. Thus, "PT36H" could be used as well as "P1DT12H" for representing the same duration.

But this *breaks* ``interval`` representation, and this PR improves this.

```php
dump(new DateInterval('PT3600S'));

// before
DateInterval {
  interval: + 00:00:3600.0
}

// after
DateInterval {
  interval: + 01:00:00.0
}
```