### PR TITLE
[Dotenv][WebServerBundle] Override previously loaded variables

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/WebServer.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServer.php
@@ -154,6 +154,11 @@ class WebServer
         $process->setWorkingDirectory($config->getDocumentRoot());
         $process->setTimeout(null);
 
+        if (in_array('APP_ENV', explode(',', getenv('SYMFONY_DOTENV_VARS')))) {
+            $process->setEnv(array('APP_ENV' => false));
+            $process->inheritEnvironmentVariables();
+        }
+
         return $process;
     }
 

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -60,8 +60,6 @@ final class Dotenv
     /**
      * Sets values as environment variables (via putenv, $_ENV, and $_SERVER).
      *
-     * Existing environment variables are never overridden, unless they are listed in the SYMFONY_DOTENV_VARS env var.
-     *
      * @param array $values An array of env variables
      */
     public function populate($values)

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -60,21 +60,31 @@ final class Dotenv
     /**
      * Sets values as environment variables (via putenv, $_ENV, and $_SERVER).
      *
-     * Note that existing environment variables are never overridden.
+     * Existing environment variables are never overridden, unless they are listed in the SYMFONY_DOTENV_VARS env var.
      *
      * @param array $values An array of env variables
      */
     public function populate($values)
     {
+        $loadedVars = array_flip(explode(',', getenv('SYMFONY_DOTENV_VARS')));
+        unset($loadedVars['']);
+
         foreach ($values as $name => $value) {
-            if (isset($_ENV[$name]) || isset($_SERVER[$name]) || false !== getenv($name)) {
+            if (!isset($loadedVars[$name]) && (isset($_ENV[$name]) || isset($_SERVER[$name]) || false !== getenv($name))) {
                 continue;
             }
 
             putenv("$name=$value");
             $_ENV[$name] = $value;
             $_SERVER[$name] = $value;
+
+            $loadedVars[$name] = true;
         }
+
+        $loadedVars = implode(',', array_keys($loadedVars));
+        putenv("SYMFONY_DOTENV_VARS=$loadedVars");
+        $_ENV['SYMFONY_DOTENV_VARS'] = $loadedVars;
+        $_SERVER['SYMFONY_DOTENV_VARS'] = $loadedVars;
     }
 
     /**

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -60,6 +60,8 @@ final class Dotenv
     /**
      * Sets values as environment variables (via putenv, $_ENV, and $_SERVER).
      *
+     * Note that existing environment variables are not overridden.
+     *
      * @param array $values An array of env variables
      */
     public function populate($values)

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -81,10 +81,12 @@ final class Dotenv
             $loadedVars[$name] = true;
         }
 
-        $loadedVars = implode(',', array_keys($loadedVars));
-        putenv("SYMFONY_DOTENV_VARS=$loadedVars");
-        $_ENV['SYMFONY_DOTENV_VARS'] = $loadedVars;
-        $_SERVER['SYMFONY_DOTENV_VARS'] = $loadedVars;
+        if ($loadedVars) {
+            $loadedVars = implode(',', array_keys($loadedVars));
+            putenv("SYMFONY_DOTENV_VARS=$loadedVars");
+            $_ENV['SYMFONY_DOTENV_VARS'] = $loadedVars;
+            $_SERVER['SYMFONY_DOTENV_VARS'] = $loadedVars;
+        }
     }
 
     /**

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -214,4 +214,60 @@ class DotenvTest extends TestCase
 
         $this->assertSame('original_value', getenv('TEST_ENV_VAR'));
     }
+
+    public function testMemorizingLoadedVarsNamesInSpecialVar()
+    {
+        // Special variable not exists
+        unset($_ENV['SYMFONY_DOTENV_VARS']);
+        unset($_SERVER['SYMFONY_DOTENV_VARS']);
+        putenv('SYMFONY_DOTENV_VARS');
+
+        unset($_ENV['APP_DEBUG']);
+        unset($_SERVER['APP_DEBUG']);
+        putenv('APP_DEBUG');
+        unset($_ENV['DATABASE_URL']);
+        unset($_SERVER['DATABASE_URL']);
+        putenv('DATABASE_URL');
+
+        $dotenv = new DotEnv();
+        $dotenv->populate(array('APP_DEBUG' => '1', 'DATABASE_URL' => 'mysql://root@localhost/db'));
+
+        $this->assertSame('APP_DEBUG,DATABASE_URL', getenv('SYMFONY_DOTENV_VARS'));
+
+        // Special variable has a value
+        $_ENV['SYMFONY_DOTENV_VARS'] = 'APP_ENV';
+        $_SERVER['SYMFONY_DOTENV_VARS'] = 'APP_ENV';
+        putenv('SYMFONY_DOTENV_VARS=APP_ENV');
+
+        $_ENV['APP_DEBUG'] = '1';
+        $_SERVER['APP_DEBUG'] = '1';
+        putenv('APP_DEBUG=1');
+        unset($_ENV['DATABASE_URL']);
+        unset($_SERVER['DATABASE_URL']);
+        putenv('DATABASE_URL');
+
+        $dotenv = new DotEnv();
+        $dotenv->populate(array('APP_DEBUG' => '0', 'DATABASE_URL' => 'mysql://root@localhost/db'));
+        $dotenv->populate(array('DATABASE_URL' => 'sqlite:///somedb.sqlite'));
+
+        $this->assertSame('APP_ENV,DATABASE_URL', getenv('SYMFONY_DOTENV_VARS'));
+    }
+
+    public function testOverridingEnvVarsWithNamesMemorizedInSpecialVar()
+    {
+        putenv('SYMFONY_DOTENV_VARS=FOO,BAR,BAZ');
+
+        putenv('FOO=foo');
+        putenv('BAR=bar');
+        putenv('BAZ=baz');
+        putenv('DOCUMENT_ROOT=/var/www');
+
+        $dotenv = new DotEnv();
+        $dotenv->populate(array('FOO' => 'foo1', 'BAR' => 'bar1', 'BAZ' => 'baz1', 'DOCUMENT_ROOT' => '/boot'));
+
+        $this->assertSame('foo1', getenv('FOO'));
+        $this->assertSame('bar1', getenv('BAR'));
+        $this->assertSame('baz1', getenv('BAZ'));
+        $this->assertSame('/var/www', getenv('DOCUMENT_ROOT'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23723 
| License       | MIT

This PR implements @nicolas-grekas's idea about how we could refresh loaded environment variables. See his comment https://github.com/symfony/symfony/issues/23723#issuecomment-320455669
