### PR TITLE
[Security] Fix security.interactive_login event const doc block

### DIFF
--- a/src/Symfony/Component/Security/Http/SecurityEvents.php
+++ b/src/Symfony/Component/Security/Http/SecurityEvents.php
@@ -14,8 +14,11 @@ namespace Symfony\Component\Security\Http;
 final class SecurityEvents
 {
     /**
-     * The INTERACTIVE_LOGIN event occurs after a user is logged in
-     * interactively for authentication based on http, cookies or X509.
+     * The INTERACTIVE_LOGIN event occurs after a user has actively logged
+     * into your website. It is important to distinguish this action from
+     * non-interactive authentication methods, such as:
+     *   - authentication based on your session.
+     *   - authentication using a HTTP basic or HTTP digest header.
      *
      * The event listener method receives a
      * Symfony\Component\Security\Http\Event\InteractiveLoginEvent instance.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

I'd suggest to reuse the explanation we give about this event [on the docs](http://symfony.com/doc/2.7/components/security/authentication.html#security-events) because the current one in the code is misleading: this event is not triggered for http basic/digest authentication for instance.