### PR TITLE
Github template: Remove EOM 3.2 from branch suggestion

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 | Q             | A
 | ------------- | ---
-| Branch?       | 3.4 or master / 2.7, 2.8, 3.2 or 3.3 <!-- see comment below -->
+| Branch?       | 3.4 or master / 2.7, 2.8 or 3.3 <!-- see comment below -->
 | Bug fix?      | yes/no
 | New feature?  | yes/no <!-- don't forget updating src/**/CHANGELOG.md files -->
 | BC breaks?    | yes/no


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

As 3.2 is EOM since the 31 July (appart for security fixes of course)