### PR TITLE
[HttpKernel] Deprecated commands auto-registration

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -127,7 +127,7 @@ HttpKernel
    services:
        # ...
 
-       # implicit commands registration
+       # implicit registration of all commands in the `Command` folder
    ```
 
    After:

--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -118,7 +118,7 @@ HttpKernel
 ----------
 
  * Relying on convention-based commands discovery has been deprecated and
-   won't be supported in 4.0. Use PSR-4 based Service Discovery instead.
+   won't be supported in 4.0. Use PSR-4 based service discovery instead.
 
    Before:
 

--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -117,8 +117,8 @@ FrameworkBundle
 HttpKernel
 ----------
 
- * Relying on commands auto-discovery has been deprecated and won't be supported
-   in 4.0. Use PSR-4 based Service Discovery instead.
+ * Relying on convention-based commands discovery has been deprecated and
+   won't be supported in 4.0. Use PSR-4 based Service Discovery instead.
 
    Before:
 

--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -114,6 +114,35 @@ FrameworkBundle
    class has been deprecated and will be removed in 4.0. Use the
    `Symfony\Component\Translation\DependencyInjection\TranslatorPass` class instead.
 
+HttpKernel
+----------
+
+ * Relying on commands auto-discovery has been deprecated and won't be supported
+   in 4.0. Use PSR-4 based Service Discovery instead.
+
+   Before:
+
+   ```yml
+   # app/config/services.yml
+   services:
+       # ...
+
+       # implicit commands registration
+   ```
+
+   After:
+
+   ```yml
+   # app/config/services.yml
+   services:
+       # ...
+
+       # explicit commands registration
+       AppBundle\Command:
+           resource: '../../src/AppBundle/Command/*'
+           tags: ['console.command']
+   ```
+
 Process
 -------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -452,6 +452,32 @@ HttpFoundation
 HttpKernel
 ----------
 
+ * Relying on commands auto-discovery has been deprecated and won't be supported
+   in 4.0. Use PSR-4 based Service Discovery instead.
+
+   Before:
+
+   ```yml
+   # app/config/services.yml
+   services:
+       # ...
+
+       # implicit commands registration
+   ```
+
+   After:
+
+   ```yml
+   # app/config/services.yml
+   services:
+       # ...
+
+       # explicit commands registration
+       AppBundle\Command:
+           resource: '../../src/AppBundle/Command/*'
+           tags: ['console.command']
+   ```
+
  * Removed the `kernel.root_dir` parameter. Use the `kernel.project_dir` parameter
    instead.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -452,8 +452,8 @@ HttpFoundation
 HttpKernel
 ----------
 
- * Relying on commands auto-discovery has been deprecated and won't be supported
-   in 4.0. Use PSR-4 based Service Discovery instead.
+ * Relying on convention-based commands discovery is not supported anymore.
+   Use PSR-4 based Service Discovery instead.
 
    Before:
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -453,7 +453,7 @@ HttpKernel
 ----------
 
  * Relying on convention-based commands discovery is not supported anymore.
-   Use PSR-4 based Service Discovery instead.
+   Use PSR-4 based service discovery instead.
 
    Before:
 
@@ -462,7 +462,7 @@ HttpKernel
    services:
        # ...
 
-       # implicit commands registration
+       # implicit registration of all commands in the `Command` folder
    ```
 
    After:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Acl/doctrine.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Acl/doctrine.yml
@@ -1,0 +1,5 @@
+# to be removed once https://github.com/doctrine/DoctrineBundle/pull/684 is merged
+services:
+    Doctrine\Bundle\DoctrineBundle\Command\:
+        resource: "@DoctrineBundle/Command/*"
+        tags: [console.command]

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\app;
 
+use Doctrine\ORM\Version;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
@@ -82,6 +83,11 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load($this->rootConfig);
+
+        // to be removed once https://github.com/doctrine/DoctrineBundle/pull/684 is merged
+        if ('Acl' === $this->testCase && class_exists(Version::class)) {
+            $loader->load(__DIR__.'/Acl/doctrine.yml');
+        }
     }
 
     public function serialize()

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -191,7 +191,7 @@ abstract class Bundle implements BundleInterface
             }
             $r = new \ReflectionClass($class);
             if ($r->isSubclassOf('Symfony\\Component\\Console\\Command\\Command') && !$r->isAbstract() && !$r->getConstructor()->getNumberOfRequiredParameters()) {
-                @trigger_error(sprintf('Auto-registration of the command "%s" is deprecated since Symfony 3.4 and won\'t be supported in 4.0. Use PSR-4 based Service Discovery instead.', $class), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Auto-registration of the command "%s" is deprecated since Symfony 3.4 and won\'t be supported in 4.0. Use PSR-4 based service discovery instead.', $class), E_USER_DEPRECATED);
 
                 $application->add($r->newInstance());
             }

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -191,6 +191,8 @@ abstract class Bundle implements BundleInterface
             }
             $r = new \ReflectionClass($class);
             if ($r->isSubclassOf('Symfony\\Component\\Console\\Command\\Command') && !$r->isAbstract() && !$r->getConstructor()->getNumberOfRequiredParameters()) {
+                @trigger_error(sprintf('Auto-registration of the command "%s" is deprecated since Symfony 3.4 and won\'t be supported in 4.0. Use PSR-4 based Service Discovery instead.', $class), E_USER_DEPRECATED);
+
                 $application->add($r->newInstance());
             }
         }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
+ * deprecated commands auto registration
  * added `AddCacheClearerPass`
  * added `AddCacheWarmerPass`
 

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -31,6 +31,10 @@ class BundleTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Auto-registration of the command "Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\Command\FooCommand" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based Service Discovery instead.
+     */
     public function testRegisterCommands()
     {
         $cmd = new FooCommand();

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -33,7 +33,7 @@ class BundleTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Auto-registration of the command "Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\Command\FooCommand" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based Service Discovery instead.
+     * @expectedDeprecation Auto-registration of the command "Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\Command\FooCommand" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based service discovery instead.
      */
     public function testRegisterCommands()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | yes <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/23488
| License       | MIT
| Doc PR        | 

Deprecates commands auto-registration. See https://github.com/symfony/symfony/issues/23488 for arguments.