### PR TITLE
[Debug] Trigger a deprecation when using an internal class/trait/interface

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/IdReader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/IdReader.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\Exception\RuntimeException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @internal This class is meant for internal use only.
+ * @internal
  */
 class IdReader
 {

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -27,6 +27,7 @@ class DebugClassLoader
     private $classLoader;
     private $isFinder;
     private static $caseCheck;
+    private static $internal = array();
     private static $final = array();
     private static $finalMethods = array();
     private static $deprecated = array();
@@ -166,10 +167,14 @@ class DebugClassLoader
             }
 
             $parent = get_parent_class($class);
+            $doc = $refl->getDocComment();
+            if (preg_match('#\n \* @internal(?: .+?)?\r?\n \*(?: @|/$)#s', $doc, $notice)) {
+                self::$internal[$name] = true;
+            }
 
             // Not an interface nor a trait
             if (class_exists($name, false)) {
-                if (preg_match('#\n \* @final(?:( .+?)\.?)?\r?\n \*(?: @|/$)#s', $refl->getDocComment(), $notice)) {
+                if (preg_match('#\n \* @final(?:( .+?)\.?)?\r?\n \*(?: @|/$)#s', $doc, $notice)) {
                     self::$final[$name] = isset($notice[1]) ? preg_replace('#\s*\r?\n \* +#', ' ', $notice[1]) : '';
                 }
 
@@ -203,50 +208,73 @@ class DebugClassLoader
 
             if (in_array(strtolower($refl->getShortName()), self::$php7Reserved)) {
                 @trigger_error(sprintf('The "%s" class uses the reserved name "%s", it will break on PHP 7 and higher', $name, $refl->getShortName()), E_USER_DEPRECATED);
-            } elseif (preg_match('#\n \* @deprecated (.*?)\r?\n \*(?: @|/$)#s', $refl->getDocComment(), $notice)) {
+            }
+            if (preg_match('#\n \* @deprecated (.*?)\r?\n \*(?: @|/$)#s', $refl->getDocComment(), $notice)) {
                 self::$deprecated[$name] = preg_replace('#\s*\r?\n \* +#', ' ', $notice[1]);
+            }
+
+            // Don't trigger deprecations for classes in the same vendor
+            if (2 > $len = 1 + (strpos($name, '\\', 1 + strpos($name, '\\')) ?: strpos($name, '_'))) {
+                $len = 0;
+                $ns = '';
             } else {
-                // Don't trigger deprecations for classes in the same vendor
-                if (2 > $len = 1 + (strpos($name, '\\', 1 + strpos($name, '\\')) ?: strpos($name, '_'))) {
-                    $len = 0;
-                    $ns = '';
-                } else {
-                    switch ($ns = substr($name, 0, $len)) {
-                        case 'Symfony\Bridge\\':
-                        case 'Symfony\Bundle\\':
-                        case 'Symfony\Component\\':
-                            $ns = 'Symfony\\';
-                            $len = strlen($ns);
-                            break;
+                switch ($ns = substr($name, 0, $len)) {
+                    case 'Symfony\Bridge\\':
+                    case 'Symfony\Bundle\\':
+                    case 'Symfony\Component\\':
+                        $ns = 'Symfony\\';
+                        $len = strlen($ns);
+                        break;
+                }
+            }
+
+            foreach (call_user_func(function () use ($name, $parent) {
+                if (isset(self::$internal[$parent])) {
+                    yield 'class' => $parent;
+                }
+
+                foreach (class_implements($name, false) as $interface) {
+                    if (isset(self::$internal[$interface])) {
+                        yield 'interface' => $interface;
                     }
                 }
 
-                if (!$parent || strncmp($ns, $parent, $len)) {
-                    if ($parent && isset(self::$deprecated[$parent]) && strncmp($ns, $parent, $len)) {
-                        @trigger_error(sprintf('The "%s" class extends "%s" that is deprecated %s', $name, $parent, self::$deprecated[$parent]), E_USER_DEPRECATED);
+                foreach (class_uses($name, false) as $use) {
+                    if (isset(self::$internal[$use])) {
+                        yield 'trait' => $use;
                     }
+                }
+            }) as $type => $internalUse) {
+                if (strncmp($ns, $internalUse, $len)) {
+                    @trigger_error(sprintf('The "%s" %s is considered internal. It may change without further notice. You should not use it from "%s".', $internalUse, $type, $name), E_USER_DEPRECATED);
+                }
+            }
 
-                    $parentInterfaces = array();
-                    $deprecatedInterfaces = array();
-                    if ($parent) {
-                        foreach (class_implements($parent) as $interface) {
-                            $parentInterfaces[$interface] = 1;
-                        }
+            if (!$parent || strncmp($ns, $parent, $len)) {
+                if ($parent && isset(self::$deprecated[$parent]) && strncmp($ns, $parent, $len)) {
+                    @trigger_error(sprintf('The "%s" class extends "%s" that is deprecated %s', $name, $parent, self::$deprecated[$parent]), E_USER_DEPRECATED);
+                }
+
+                $parentInterfaces = array();
+                $deprecatedInterfaces = array();
+                if ($parent) {
+                    foreach (class_implements($parent) as $interface) {
+                        $parentInterfaces[$interface] = 1;
                     }
+                }
 
-                    foreach ($refl->getInterfaceNames() as $interface) {
-                        if (isset(self::$deprecated[$interface]) && strncmp($ns, $interface, $len)) {
-                            $deprecatedInterfaces[] = $interface;
-                        }
-                        foreach (class_implements($interface) as $interface) {
-                            $parentInterfaces[$interface] = 1;
-                        }
+                foreach ($refl->getInterfaceNames() as $interface) {
+                    if (isset(self::$deprecated[$interface]) && strncmp($ns, $interface, $len)) {
+                        $deprecatedInterfaces[] = $interface;
                     }
+                    foreach (class_implements($interface) as $interface) {
+                        $parentInterfaces[$interface] = 1;
+                    }
+                }
 
-                    foreach ($deprecatedInterfaces as $interface) {
-                        if (!isset($parentInterfaces[$interface])) {
-                            @trigger_error(sprintf('The "%s" %s "%s" that is deprecated %s', $name, $refl->isInterface() ? 'interface extends' : 'class implements', $interface, self::$deprecated[$interface]), E_USER_DEPRECATED);
-                        }
+                foreach ($deprecatedInterfaces as $interface) {
+                    if (!isset($parentInterfaces[$interface])) {
+                        @trigger_error(sprintf('The "%s" %s "%s" that is deprecated %s', $name, $refl->isInterface() ? 'interface extends' : 'class implements', $interface, self::$deprecated[$interface]), E_USER_DEPRECATED);
                     }
                 }
             }

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -325,7 +325,7 @@ class DebugClassLoaderTest extends TestCase
         restore_error_handler();
 
         $this->assertSame($deprecations, array(
-            'The "Symfony\Component\Debug\Tests\Fixtures\InternalClass" class is considered internal. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
+            'The "Symfony\Component\Debug\Tests\Fixtures\InternalClass" class is considered internal since version 3.4. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
             'The "Symfony\Component\Debug\Tests\Fixtures\InternalInterface" interface is considered internal. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
             'The "Symfony\Component\Debug\Tests\Fixtures\InternalTrait" trait is considered internal. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
         ));

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -312,6 +312,24 @@ class DebugClassLoaderTest extends TestCase
 
         $this->assertSame($xError, $lastError);
     }
+
+    public function testInternalsUse()
+    {
+        $deprecations = array();
+        set_error_handler(function ($type, $msg) use (&$deprecations) { $deprecations[] = $msg; });
+        $e = error_reporting(E_USER_DEPRECATED);
+
+        class_exists('Test\\'.__NAMESPACE__.'\\ExtendsInternals', true);
+
+        error_reporting($e);
+        restore_error_handler();
+
+        $this->assertSame($deprecations, array(
+            'The "Symfony\Component\Debug\Tests\Fixtures\InternalClass" class is considered internal. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
+            'The "Symfony\Component\Debug\Tests\Fixtures\InternalInterface" interface is considered internal. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
+            'The "Symfony\Component\Debug\Tests\Fixtures\InternalTrait" trait is considered internal. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
+        ));
+    }
 }
 
 class ClassLoader
@@ -335,22 +353,12 @@ class ClassLoader
             eval('namespace '.__NAMESPACE__.'; class TestingStacking { function foo() {} }');
         } elseif (__NAMESPACE__.'\TestingCaseMismatch' === $class) {
             eval('namespace '.__NAMESPACE__.'; class TestingCaseMisMatch {}');
-        } elseif (__NAMESPACE__.'\Fixtures\CaseMismatch' === $class) {
-            return $fixtureDir.'CaseMismatch.php';
         } elseif (__NAMESPACE__.'\Fixtures\Psr4CaseMismatch' === $class) {
             return $fixtureDir.'psr4'.DIRECTORY_SEPARATOR.'Psr4CaseMismatch.php';
         } elseif (__NAMESPACE__.'\Fixtures\NotPSR0' === $class) {
             return $fixtureDir.'reallyNotPsr0.php';
         } elseif (__NAMESPACE__.'\Fixtures\NotPSR0bis' === $class) {
             return $fixtureDir.'notPsr0Bis.php';
-        } elseif (__NAMESPACE__.'\Fixtures\DeprecatedInterface' === $class) {
-            return $fixtureDir.'DeprecatedInterface.php';
-        } elseif (__NAMESPACE__.'\Fixtures\FinalClass' === $class) {
-            return $fixtureDir.'FinalClass.php';
-        } elseif (__NAMESPACE__.'\Fixtures\FinalMethod' === $class) {
-            return $fixtureDir.'FinalMethod.php';
-        } elseif (__NAMESPACE__.'\Fixtures\ExtendedFinalMethod' === $class) {
-            return $fixtureDir.'ExtendedFinalMethod.php';
         } elseif ('Symfony\Bridge\Debug\Tests\Fixtures\ExtendsDeprecatedParent' === $class) {
             eval('namespace Symfony\Bridge\Debug\Tests\Fixtures; class ExtendsDeprecatedParent extends \\'.__NAMESPACE__.'\Fixtures\DeprecatedClass {}');
         } elseif ('Test\\'.__NAMESPACE__.'\DeprecatedParentClass' === $class) {
@@ -363,6 +371,10 @@ class ClassLoader
             eval('namespace Test\\'.__NAMESPACE__.'; class Float {}');
         } elseif ('Test\\'.__NAMESPACE__.'\ExtendsFinalClass' === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsFinalClass extends \\'.__NAMESPACE__.'\Fixtures\FinalClass {}');
+        } elseif ('Test\\'.__NAMESPACE__.'\ExtendsInternals' === $class) {
+            eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsInternals extends \\'.__NAMESPACE__.'\Fixtures\InternalClass implements \\'.__NAMESPACE__.'\Fixtures\InternalInterface {
+                use \\'.__NAMESPACE__.'\Fixtures\InternalTrait;
+            }');
         }
     }
 }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalClass.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalClass.php
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Debug\Tests\Fixtures;
 
 /**
- * @internal this class is internal.
+ * @internal since version 3.4.
  */
 class InternalClass
 {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalClass.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+/**
+ * @internal this class is internal.
+ */
+class InternalClass
+{
+    use InternalTrait2;
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalInterface.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalInterface.php
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Debug\Tests\Fixtures;
 
 /**
- * @internal this interface is internal.
+ * @internal
  */
 interface InternalInterface
 {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalInterface.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+/**
+ * @internal this interface is internal.
+ */
+interface InternalInterface
+{
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+/**
+ * @internal this trait is internal.
+ */
+trait InternalTrait
+{
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait.php
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Debug\Tests\Fixtures;
 
 /**
- * @internal this trait is internal.
+ * @internal
  */
 trait InternalTrait
 {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait2.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait2.php
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Debug\Tests\Fixtures;
 
 /**
- * @internal this trait is internal but should not trigger a deprecation as it's used in the same vendor.
+ * @internal
  */
 trait InternalTrait2
 {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait2.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait2.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+/**
+ * @internal this trait is internal but should not trigger a deprecation as it's used in the same vendor.
+ */
+trait InternalTrait2
+{
+}

--- a/src/Symfony/Component/ExpressionLanguage/ParserCache/ParserCacheAdapter.php
+++ b/src/Symfony/Component/ExpressionLanguage/ParserCache/ParserCacheAdapter.php
@@ -18,7 +18,7 @@ use Symfony\Component\Cache\CacheItem;
 /**
  * @author Alexandre GESLIN <alexandre@gesl.in>
  *
- * @internal This class should be removed in Symfony 4.0.
+ * @internal and will be removed in Symfony 4.0.
  */
 class ParserCacheAdapter implements CacheItemPoolInterface
 {

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -185,7 +185,7 @@ class ArrayChoiceList implements ChoiceListInterface
      *                                   corresponding values
      * @param array    $structuredValues The values indexed by the original keys
      *
-     * @internal Must not be used by user-land code
+     * @internal
      */
     protected function flatten(array $choices, $value, &$choicesByValues, &$keysByValues, &$structuredValues)
     {

--- a/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
@@ -48,7 +48,7 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface
      *
      * @return string The SHA-256 hash
      *
-     * @internal Should not be used by user-land code.
+     * @internal
      */
     public static function generateHash($value, $namespace = '')
     {
@@ -71,7 +71,7 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface
      * @param array $array  The array to flatten
      * @param array $output The flattened output
      *
-     * @internal Should not be used by user-land code
+     * @internal
      */
     private static function flatten(array $array, &$output)
     {

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -30,8 +30,7 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
  *
  * @see ExecutionContextInterface
  *
- * @internal You should not instantiate or use this class. Code against
- *           {@link ExecutionContextInterface} instead.
+ * @internal since version 3.5. Code against ExecutionContextInterface instead.
  */
 class ExecutionContext implements ExecutionContextInterface
 {

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -30,7 +30,7 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
  *
  * @see ExecutionContextInterface
  *
- * @internal since version 3.5. Code against ExecutionContextInterface instead.
+ * @internal since version 2.5. Code against ExecutionContextInterface instead.
  */
 class ExecutionContext implements ExecutionContextInterface
 {

--- a/src/Symfony/Component/Validator/Context/ExecutionContextFactory.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextFactory.php
@@ -19,8 +19,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @internal You should not instantiate or use this class. Code against
- *           {@link ExecutionContextFactoryInterface} instead.
+ * @internal version 2.5. Code against ExecutionContextFactoryInterface instead.
  */
 class ExecutionContextFactory implements ExecutionContextFactoryInterface
 {

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -22,8 +22,7 @@ use Symfony\Component\Validator\Util\PropertyPath;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @internal You should not instantiate or use this class. Code against
- *           {@link ConstraintViolationBuilderInterface} instead.
+ * @internal since version 2.5. Code against ConstraintViolationBuilderInterface instead.
  */
 class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | not truly <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/23800
| License       | MIT
| Doc PR        | 

Trigger a deprecation when the user uses an internal class/trait/interface. 
The deprecation is not triggered when an `@internal` is used in the same vendor.