### PR TITLE
[FrameworkBundle] Allow micro kernel to subscribe events easily

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Kernel;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
 /**
@@ -67,6 +68,13 @@ trait MicroKernelTrait
                     'type' => 'service',
                 ),
             ));
+
+            if ($this instanceof EventSubscriberInterface) {
+                $container->register('kernel', static::class)
+                    ->setSynthetic(true)
+                    ->addTag('kernel.event_subscriber')
+                ;
+            }
 
             $this->configureContainer($container, $loader);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -28,4 +28,15 @@ class MicroKernelTraitTest extends TestCase
         $this->assertEquals('Have a great day!', $kernel->getContainer()->getParameter('halloween'));
         $this->assertInstanceOf('stdClass', $kernel->getContainer()->get('halloween'));
     }
+
+    public function testAsEventSubscriber()
+    {
+        $kernel = new ConcreteMicroKernel('test', true);
+        $kernel->boot();
+
+        $request = Request::create('/danger');
+        $response = $kernel->handle($request);
+
+        $this->assertSame('It\'s dangerous to go alone. Take this ⚔', $response->getContent());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #16982 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

just by implementing `EventSubscriberInterface`. See related issue for other implementation suggestions.