### PR TITLE
[HttpFoundation] Allow "multipart/form-data" aside from "url-encoded"

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -280,7 +280,7 @@ class Request
 
         $request = self::createRequestFromFactory($_GET, $_POST, array(), $_COOKIE, $_FILES, $server);
 
-        if (0 === strpos($request->headers->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
+        if (in_array($request->headers->get('CONTENT_TYPE'), array('application/x-www-form-urlencoded', 'multipart/form-data'))
             && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('PUT', 'DELETE', 'PATCH'))
         ) {
             parse_str($request->getContent(), $data);

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1008,7 +1008,7 @@ class RequestTest extends TestCase
         $req = new Request(array(), array(), array(), array(), array(), array(), 'MyContent');
         $resource = $req->getContent(true);
 
-        $this->assertTrue(is_resource($resource));
+        $this->assertInternalType('resource', $resource);
         $this->assertEquals('MyContent', stream_get_contents($resource));
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1083,16 +1083,19 @@ class RequestTest extends TestCase
             array('PUT'),
             array('DELETE'),
             array('PATCH'),
-            array('put'),
-            array('delete'),
-            array('patch'),
+            array('put', 'multipart/form-data'),
+            array('delete', 'multipart/form-data'),
+            array('patch', 'multipart/form-data'),
         );
     }
 
     /**
+     * @param string $method      The HTTP method.
+     * @param string $contentType The HTTP Content-Type.
+     *
      * @dataProvider provideOverloadedMethods
      */
-    public function testCreateFromGlobals($method)
+    public function testCreateFromGlobals($method, $contentType = 'application/x-www-form-urlencoded')
     {
         $normalizedMethod = strtoupper($method);
 
@@ -1112,7 +1115,7 @@ class RequestTest extends TestCase
         unset($_GET['foo1'], $_POST['foo2'], $_COOKIE['foo3'], $_FILES['foo4'], $_SERVER['foo5']);
 
         $_SERVER['REQUEST_METHOD'] = $method;
-        $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+        $_SERVER['CONTENT_TYPE'] = $contentType;
         $request = RequestContentProxy::createFromGlobals();
         $this->assertEquals($normalizedMethod, $request->getMethod());
         $this->assertEquals('mycontent', $request->request->get('content'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #8518
| License       | MIT
| Doc PR        | No

Allow file upload with "PUT" HTTP method.
