### PR TITLE
Revert "feature #21038 [FrameworkBundle] deprecated cache:clear with warmup (fabpot)"

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -165,9 +165,6 @@ Form
 FrameworkBundle
 ---------------
 
- * The `cache:clear` command should always be called with the `--no-warmup` option.
-   Warmup should be done via the `cache:warmup` command.
-
  * [BC BREAK] The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies"
    parameter have been removed. Use the Request::setTrustedProxies() method in your front controller instead.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -223,9 +223,6 @@ Form
 FrameworkBundle
 ---------------
 
- * The `cache:clear` command does not warmup the cache anymore. Warmup should
-   be done via the `cache:warmup` command.
-
  * The "framework.trusted_proxies" configuration option and the corresponding "kernel.trusted_proxies" parameter have been removed. Use the `Request::setTrustedProxies()` method in your front controller instead.
 
  * The default value of the `framework.workflows.[name].type` configuration options is now `state_machine`.

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -14,7 +14,6 @@ CHANGELOG
    the same helpers as the `Controller` class, but does not allow accessing the dependency
    injection container, in order to encourage explicit dependency declarations.
  * Added support for the `controller.service_arguments` tag, for injecting services into controllers' actions
- * Deprecated `cache:clear` with warmup (always call it with `--no-warmup`)
  * Changed default configuration for
    assets/forms/validation/translation/serialization/csrf from `canBeEnabled()` to
    `canBeDisabled()` when Flex is used

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -77,12 +77,6 @@ EOF
         if ($input->getOption('no-warmup')) {
             $filesystem->rename($realCacheDir, $oldCacheDir);
         } else {
-            $warning = 'Calling cache:clear without the --no-warmup option is deprecated since version 3.3. Cache warmup should be done with the cache:warmup command instead.';
-
-            @trigger_error($warning, E_USER_DEPRECATED);
-
-            $io->warning($warning);
-
             $this->warmupCache($input, $output, $realCacheDir, $oldCacheDir);
         }
 
@@ -132,8 +126,6 @@ EOF
      * @param string $warmupDir
      * @param string $realCacheDir
      * @param bool   $enableOptionalWarmers
-     *
-     * @internal to be removed in 4.0
      */
     protected function warmup($warmupDir, $realCacheDir, $enableOptionalWarmers = true)
     {
@@ -200,8 +192,6 @@ EOF
      * @param string          $warmupDir
      *
      * @return KernelInterface
-     *
-     * @internal to be removed in 4.0
      */
     protected function getTempKernel(KernelInterface $parent, $namespace, $parentClass, $warmupDir)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -43,9 +43,6 @@ class CacheClearCommandTest extends TestCase
         $this->fs->remove($this->rootDir);
     }
 
-    /**
-     * @group legacy
-     */
     public function testCacheIsFreshAfterCacheClearedWithWarmup()
     {
         $input = new ArrayInput(array('cache:clear'));


### PR DESCRIPTION
This reverts commit 3495b35e4fcdb2bf90b8aea443c1216c161dd469, reversing
changes made to 7f7b897ee275d4cbbd4284dbdd05f1d207699fac.

| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21038
| License       | MIT
| Doc PR        | -

Sibling to #23792: there is no need to trigger the deprecation in 3.3 if we un-deprecate in 3.4.