### PR TITLE
[2.8] Modify 2.8 upgrade doc - key option is deprecated.

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -549,6 +549,92 @@ Security
    
  * The the `key` setting of `anonymous`, `remember_me` and `http_digest`
    is deprecated, and will be removed in 3.0.  Use `secret` instead.
+   
+    Before:
+
+   ```yaml
+   security:
+       # ...
+       firewalls:
+           default:
+               # ...
+               anonymous: { key: "%secret%" }
+               remember_me:
+                   key: "%secret%"
+               http_digest:
+                   key: "%secret%"
+   ```
+
+   ```xml
+   <!-- ... -->
+   <config>
+       <!-- ... -->
+
+       <firewall>
+           <!-- ... -->
+
+           <anonymous key="%secret%"/>
+           <remember-me key="%secret%"/>
+           <http-digest key="%secret%"/>
+       </firewall>
+   </config>
+   ```
+
+   ```php
+   // ...
+   $container->loadFromExtension('security', array(
+       // ...
+       'firewalls' => array(
+           // ...
+           'anonymous' => array('key' => '%secret%'),
+           'remember_me' => array('key' => '%secret%'),
+           'http_digest' => array('key' => '%secret%'),
+       ),
+   ));
+   ```
+
+   After:
+
+   ```yaml
+   security:
+       # ...
+       firewalls:
+           default:
+               # ...
+               anonymous: { secret: "%secret%" }
+               remember_me:
+                   secret: "%secret%"
+               http_digest:
+                   secret: "%secret%"
+   ```
+
+   ```xml
+   <!-- ... -->
+   <config>
+       <!-- ... -->
+
+       <firewall>
+           <!-- ... -->
+
+           <anonymous secret="%secret%"/>
+           <remember-me secret="%secret%"/>
+           <http-digest secret="%secret%"/>
+       </firewall>
+   </config>
+   ```
+
+   ```php
+   // ...
+   $container->loadFromExtension('security', array(
+       // ...
+       'firewalls' => array(
+           // ...
+           'anonymous' => array('secret' => '%secret%'),
+           'remember_me' => array('secret' => '%secret%'),
+           'http_digest' => array('secret' => '%secret%'),
+       ),
+   ));
+   ```
 
  * The `intention` option is deprecated for all the authentication listeners,
    and will be removed in 3.0. Use the `csrf_token_id` option instead.

--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -546,6 +546,9 @@ Security
 
  * The `VoterInterface::supportsClass` and `supportsAttribute` methods were
    deprecated and will be removed from the interface in 3.0.
+   
+ * The the `key` setting of `anonymous`, `remember_me` and `http_digest`
+   is deprecated, and will be removed in 3.0.  Use `secret` instead.
 
  * The `intention` option is deprecated for all the authentication listeners,
    and will be removed in 3.0. Use the `csrf_token_id` option instead.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no, but this is only a documentation change - I don't think it's my change that has broken them.
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The 2.8.0 section of the [CHANGELOG for the Security bundle](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md#280) has two items in it
> * deprecated the `key` setting of `anonymous`, `remember_me` and `http_digest` in favor of the `secret` setting.
>  * deprecated the `intention` firewall listener setting in favor of the `csrf_token_id`.

The first of these isn't also in the Symfony upgrade guide, but the second is.

This PR adds the missing item (deprecated `key` setting) into the Symfony upgrade guide.