### PR TITLE
[Console] Log exit codes as debug messages instead of errors

### DIFF
--- a/src/Symfony/Component/Console/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/Console/EventListener/ErrorListener.php
@@ -59,10 +59,10 @@ class ErrorListener implements EventSubscriberInterface
         }
 
         if (!$inputString = $this->getInputString($event)) {
-            return $this->logger->error('The console exited with code "{code}"', array('code' => $exitCode));
+            return $this->logger->debug('The console exited with code "{code}"', array('code' => $exitCode));
         }
 
-        $this->logger->error('Command "{command}" exited with code "{code}"', array('command' => $inputString, 'code' => $exitCode));
+        $this->logger->debug('Command "{command}" exited with code "{code}"', array('command' => $inputString, 'code' => $exitCode));
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
@@ -61,7 +61,7 @@ class ErrorListenerTest extends TestCase
         $logger = $this->getLogger();
         $logger
             ->expects($this->once())
-            ->method('error')
+            ->method('debug')
             ->with('Command "{command}" exited with code "{code}"', array('command' => 'test:run', 'code' => 255))
         ;
 
@@ -74,7 +74,7 @@ class ErrorListenerTest extends TestCase
         $logger = $this->getLogger();
         $logger
             ->expects($this->never())
-            ->method('error')
+            ->method('debug')
         ;
 
         $listener = new ErrorListener($logger);
@@ -97,7 +97,7 @@ class ErrorListenerTest extends TestCase
         $logger = $this->getLogger();
         $logger
             ->expects($this->exactly(3))
-            ->method('error')
+            ->method('debug')
             ->with('Command "{command}" exited with code "{code}"', array('command' => 'test:run --foo=bar', 'code' => 255))
         ;
 
@@ -112,7 +112,7 @@ class ErrorListenerTest extends TestCase
         $logger = $this->getLogger();
         $logger
             ->expects($this->once())
-            ->method('error')
+            ->method('debug')
             ->with('Command "{command}" exited with code "{code}"', array('command' => 'test:run', 'code' => 255))
         ;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | n/a

Fixes #21003

This patch stops logging `exit_codes != 0` to _error_ and logs it to _debug_ instead, since it's not an error. The console application exited without uncaught exceptions, and the console application deliberately returned a specific exit code, therefore it shouldn't be logged as an error.

A valid use case would be to let a caller script in bash (the script spawning the console command) know what action to take based on the exit code. More specifically, exit codes other than 1, 2, 127+n isn't necessarily considered an error.

Monolog is hooked to our mailbox, so we can see what is happening in our production environment. However, it's currently being spammed for no reason because of #21003.
