### PR TITLE
Fixed the exception page design in responsive mode

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
@@ -80,7 +80,7 @@ header .container { display: flex; justify-content: space-between; }
 .exception-hierarchy .icon svg { height: 13px; width: 13px; vertical-align: -2px; }
 
 .exception-without-message .exception-message-wrapper { display: none; }
-.exception-message-wrapper .container { display: flex; align-items: flex-start; min-height: 70px; padding: 10px 0 8px; }
+.exception-message-wrapper .container { display: flex; align-items: flex-start; min-height: 70px; padding: 10px 15px 8px; }
 .exception-message { flex-grow: 1; }
 .exception-message, .exception-message a { color: #FFF; font-size: 21px; font-weight: 400; margin: 0; }
 .exception-message.long { font-size: 18px; }
@@ -107,11 +107,11 @@ header .container { display: flex; justify-content: space-between; }
 .trace-line .icon svg { height: 16px; width: 16px; }
 .trace-line-header { padding-left: 36px; }
 
-.trace-file-path, .trace-file-path a { color: #999; color: #795da3; color: #B0413E; color: #222; font-size: 13px; }
+.trace-file-path, .trace-file-path a { color: #222; font-size: 13px; }
 .trace-class { color: #B0413E; }
 .trace-type { padding: 0 2px; }
-.trace-method { color: #B0413E; color: #222; font-weight: bold; color: #B0413E; }
-.trace-arguments { color: #222; color: #999; font-weight: normal; color: #795da3; color: #777; padding-left: 2px; }
+.trace-method { color: #B0413E; font-weight: bold; }
+.trace-arguments { color: #777; font-weight: normal; padding-left: 2px; }
 
 .trace-code { background: #FFF; font-size: 12px; margin: 10px 10px 2px 10px; padding: 10px; overflow-x: auto; white-space: nowrap; }
 .trace-code ol { margin: 0; float: left; }

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -320,11 +320,11 @@ EOF;
 
             .trace-message { font-size: 14px; font-weight: normal; margin: .5em 0 0; }
 
-            .trace-file-path, .trace-file-path a { margin-top: 3px; color: #999; color: #795da3; color: #B0413E; color: #222; font-size: 13px; }
+            .trace-file-path, .trace-file-path a { color: #222; margin-top: 3px; font-size: 13px; }
             .trace-class { color: #B0413E; }
             .trace-type { padding: 0 2px; }
-            .trace-method { color: #B0413E; color: #222; font-weight: bold; color: #B0413E; }
-            .trace-arguments { color: #222; color: #999; font-weight: normal; color: #795da3; color: #777; padding-left: 2px; }
+            .trace-method { color: #B0413E; font-weight: bold; }
+            .trace-arguments { color: #777; font-weight: normal; padding-left: 2px; }
 
             @media (min-width: 575px) {
                 .hidden-xs-down { display: initial; }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I broke the design of the exception pages in responsive mode between Symfony 3.3.5 and 3.3.6:

### Symfony 3.3.5

![sf-335](https://user-images.githubusercontent.com/73419/29074568-127cbf92-7c50-11e7-9e4e-51ad1c61e03c.png)

### Symfony 3.3.6

![sf-336](https://user-images.githubusercontent.com/73419/29074567-11d38b48-7c50-11e7-9114-036cbe4d07e9.png)

---

This PR fixes the issue and also removes some CSS leftovers used during the redesign.
