### PR TITLE
[DebugBundle] Reword an outdated comment about var dumper wiring

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DebugBundle.php
+++ b/src/Symfony/Bundle/DebugBundle/DebugBundle.php
@@ -27,8 +27,10 @@ class DebugBundle extends Bundle
             $container = $this->container;
 
             // This code is here to lazy load the dump stack. This default
-            // configuration for CLI mode is overridden in HTTP mode on
-            // 'kernel.request' event
+            // configuration is overridden in CLI mode on 'console.command' event.
+            // The dump data collector is used by default, so dump output is sent to
+            // the WDT. In a CLI context, if dump is used too soon, the data collector
+            // will buffer it, and release it at the end of the script.
             VarDumper::setHandler(function ($var) use ($container) {
                 $dumper = $container->get('data_collector.dump');
                 $cloner = $container->get('var_dumper.cloner');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | no
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This comment is outdated since #19647, as the default config is now the one used all the way through in HTTP mode, while it's overridden in CLI mode by the `DumpListener` on `console.command` event.