### PR TITLE
[Profiler] Make the validator toolbar item consistent with the form one

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
@@ -6,7 +6,7 @@
         {% set icon %}
             {{ include('@WebProfiler/Icon/validator.svg') }}
             <span class="sf-toolbar-value">
-                {{ collector.violationsCount }}
+                {{ collector.violationsCount ?: collector.calls|length }}
             </span>
         {% endset %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

After more time experiencing it, I changed my mind about https://github.com/symfony/symfony/pull/22554#pullrequestreview-37818648.

I do think replicating the form toolbar item behavior is the best thing to do.
Displaying a different property under some conditions may seem to be a bad idea, but the difference is clearly expressed by the background color used:

|-|-|
|--|--|
|<img alt="screenshot 2017-08-09 a 15 59 56" src="https://user-images.githubusercontent.com/2211145/29125368-de340da4-7d1b-11e7-9b04-8ff395e118f0.PNG">| Red: something wrong happened. Shows the relevant information: the number of violations.|
|<img alt="screenshot 2017-08-09 a 16 00 05" src="https://user-images.githubusercontent.com/2211145/29125374-e28dd6a0-7d1b-11e7-8ed6-b0d7634a5b21.PNG">| Grey: Everything went fine. Acknowledge the validator calls were made and passed by showing the number of calls.|

In any case, everything is clear when hovering the toolbar item (and most users are probably already used to this behavior due to the form item):

|Violations|No violations|
|--|--|
|<img width="173" alt="screenshot 2017-08-09 a 15 51 18" src="https://user-images.githubusercontent.com/2211145/29125023-e35ca602-7d1a-11e7-82d5-0ff3c0d9c46c.PNG">|<img width="172" alt="screenshot 2017-08-09 a 15 51 31" src="https://user-images.githubusercontent.com/2211145/29125037-ebbf0614-7d1a-11e7-8cd2-de6cb963a282.PNG">| 