### PR TITLE
restrict reflection doc block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
         "sensio/framework-extra-bundle": "^3.0.2"
     },
     "conflict": {
-        "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.1",
+        "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
         "phpdocumentor/type-resolver": "<0.2.0",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
     },

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
@@ -72,6 +72,7 @@ class PhpDocExtractorTest extends TestCase
             array('donotexist', null, null, null),
             array('staticGetter', null, null, null),
             array('staticSetter', null, null, null),
+            array('emptyVar', null, null, null),
         );
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
@@ -41,6 +41,7 @@ class ReflectionExtractorTest extends TestCase
                 'B',
                 'Guid',
                 'g',
+                'emptyVar',
                 'foo',
                 'foo2',
                 'foo3',
@@ -122,37 +123,63 @@ class ReflectionExtractorTest extends TestCase
         );
     }
 
-    public function testIsReadable()
+    /**
+     * @dataProvider getReadableProperties
+     */
+    public function testIsReadable($property, $expected)
     {
-        $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'bar', array()));
-        $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'baz', array()));
-        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'parent', array()));
-        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'a', array()));
-        $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'b', array()));
-        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'c', array()));
-        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'd', array()));
-        $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'e', array()));
-        $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'f', array()));
-        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'Id', array()));
-        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'id', array()));
-        $this->assertTrue($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'Guid', array()));
-        $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'guid', array()));
+        $this->assertSame(
+            $expected,
+            $this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property, array())
+        );
     }
 
-    public function testIsWritable()
+    public function getReadableProperties()
     {
-        $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'bar', array()));
-        $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'baz', array()));
-        $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'parent', array()));
-        $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'a', array()));
-        $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'b', array()));
-        $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'c', array()));
-        $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'd', array()));
-        $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'e', array()));
-        $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'f', array()));
-        $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'Id', array()));
-        $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'Guid', array()));
-        $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'guid', array()));
+        return array(
+            array('bar', false),
+            array('baz', false),
+            array('parent', true),
+            array('a', true),
+            array('b', false),
+            array('c', true),
+            array('d', true),
+            array('e', false),
+            array('f', false),
+            array('Id', true),
+            array('id', true),
+            array('Guid', true),
+            array('guid', false),
+        );
+    }
+
+    /**
+     * @dataProvider getWritableProperties
+     */
+    public function testIsWritable($property, $expected)
+    {
+        $this->assertSame(
+            $expected,
+            $this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property, array())
+        );
+    }
+
+    public function getWritableProperties()
+    {
+        return array(
+            array('bar', false),
+            array('baz', false),
+            array('parent', true),
+            array('a', false),
+            array('b', true),
+            array('c', false),
+            array('d', false),
+            array('e', true),
+            array('f', true),
+            array('Id', false),
+            array('Guid', true),
+            array('guid', false),
+        );
     }
 
     public function testSingularize()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -68,6 +68,13 @@ class Dummy extends ParentDummy
      */
     public $g;
 
+    /**
+     * This should not be removed.
+     *
+     * @var
+     */
+    public $emptyVar;
+
     public static function getStatic()
     {
     }

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -34,7 +34,7 @@
         "doctrine/annotations": "~1.0"
     },
     "conflict": {
-        "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.1",
+        "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
         "phpdocumentor/type-resolver": "<0.2.0",
         "symfony/dependency-injection": "<3.3"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1, 3.2, 3.3, master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

I think we should have same behavior on 2.8 and 3.0 but there `phpdocumentor/reflection` is required and i whanted to avoid conflicts.

### Reason:

The version 3.2.0 and 3.2.1 of phpdocumentor/reflection-docblock is really broken. All Annotations lide `@api`, means without any bracket, leads to errors like `Uninitialized string offset: 0`. We in the CMF do not require that bundle directly, but symfony does and so we get braking builds.