### PR TITLE
Made some SecurityBundle tests case-insensitive to prepare for future Symfony versions

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -81,11 +81,10 @@ abstract class CompleteConfigurationTest extends TestCase
             $configs[] = array_values($configDef->getArguments());
         }
 
-        // transform all $configs values to lower case so tests are case-insensitive and
-        // they also work in newer Symfony versions where service IDs are case-sensitive
-        array_walk_recursive($configs, function (&$value) {
-            $value = is_string($value) ? strtolower($value) : $value;
-        });
+        // the IDs of the services are case sensitive or insensitive depending on
+        // the Symfony version. Transform them to lowercase to simplify tests.
+        $configs[0][2] = strtolower($configs[0][2]);
+        $configs[2][2] = strtolower($configs[2][2]);
 
         $this->assertEquals(array(
             array(
@@ -118,7 +117,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 ),
                 array(
                     'parameter' => '_switch_user',
-                    'role' => 'role_allowed_to_switch',
+                    'role' => 'ROLE_ALLOWED_TO_SWITCH',
                 ),
             ),
             array(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -81,6 +81,12 @@ abstract class CompleteConfigurationTest extends TestCase
             $configs[] = array_values($configDef->getArguments());
         }
 
+        // transform all $configs values to lower case so tests are case-insensitive and
+        // they also work in newer Symfony versions where service IDs are case-sensitive
+        array_walk_recursive($configs, function (&$value) {
+            $value = is_string($value) ? strtolower($value) : $value;
+        });
+
         $this->assertEquals(array(
             array(
                 'simple',
@@ -112,7 +118,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 ),
                 array(
                     'parameter' => '_switch_user',
-                    'role' => 'ROLE_ALLOWED_TO_SWITCH',
+                    'role' => 'role_allowed_to_switch',
                 ),
             ),
             array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is what @nicolas-grekas [told me to do](https://github.com/symfony/symfony/pull/23797#issuecomment-320579781) to unlock #23797.