### PR TITLE
[HttpKernel] Deprecate Bundle::registerCommands()

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -143,6 +143,9 @@ HttpKernel
            tags: ['console.command']
    ```
 
+ * The `Bundle::registerCommands()` method has been deprecated and will
+   be removed in 4.0. Register commands as services instead.
+
 Process
 -------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -513,6 +513,9 @@ HttpKernel
    by Symfony. Use the `%env()%` syntax to get the value of any environment
    variable from configuration files instead.
 
+ * The `Bundle::registerCommands()` method has been deprecated and will
+   be removed in 4.0. Register commands as services instead.
+
 Ldap
 ----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -159,7 +159,7 @@ class Application extends BaseApplication
         foreach ($this->kernel->getBundles() as $bundle) {
             if ($bundle instanceof Bundle) {
                 try {
-                    $bundle->registerCommands($this);
+                    $bundle->registerCommands($this, false);
                 } catch (\Exception $e) {
                     $this->registrationErrors[] = $e;
                 } catch (\Throwable $e) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -25,6 +25,10 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class ApplicationTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.
+     */
     public function testBundleInterfaceImplementation()
     {
         $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
@@ -35,6 +39,10 @@ class ApplicationTest extends TestCase
         $application->doRun(new ArrayInput(array('list')), new NullOutput());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.
+     */
     public function testBundleCommandsAreRegistered()
     {
         $bundle = $this->createBundleMock(array());
@@ -48,6 +56,10 @@ class ApplicationTest extends TestCase
         $application->doRun(new ArrayInput(array('list')), new NullOutput());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.
+     */
     public function testBundleCommandsAreRetrievable()
     {
         $bundle = $this->createBundleMock(array());
@@ -61,6 +73,10 @@ class ApplicationTest extends TestCase
         $application->all();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.
+     */
     public function testBundleSingleCommandIsRetrievable()
     {
         $command = new Command('example');
@@ -74,6 +90,10 @@ class ApplicationTest extends TestCase
         $this->assertSame($command, $application->get('example'));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.
+     */
     public function testBundleCommandCanBeFound()
     {
         $command = new Command('example');
@@ -87,6 +107,10 @@ class ApplicationTest extends TestCase
         $this->assertSame($command, $application->find('example'));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.
+     */
     public function testBundleCommandCanBeFoundByAlias()
     {
         $command = new Command('example');
@@ -101,6 +125,10 @@ class ApplicationTest extends TestCase
         $this->assertSame($command, $application->find('alias'));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.
+     */
     public function testBundleCommandsHaveRightContainer()
     {
         $command = $this->getMockForAbstractClass('Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand', array('foo'), '', true, true, true, array('setContainer'));
@@ -120,6 +148,10 @@ class ApplicationTest extends TestCase
         $tester->run(array('command' => 'foo'));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.
+     */
     public function testBundleCommandCanOverriddeAPreExistingCommandWithTheSameName()
     {
         $command = new Command('example');
@@ -138,19 +170,18 @@ class ApplicationTest extends TestCase
     public function testRunOnlyWarnsOnUnregistrableCommand()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('console.command.ids', array(ThrowingCommand::class => ThrowingCommand::class, FineCommand::class => FineCommand::class));
         $container->register('event_dispatcher', EventDispatcher::class);
         $container->register(ThrowingCommand::class, ThrowingCommand::class);
-        $container->setParameter('console.command.ids', array(ThrowingCommand::class => ThrowingCommand::class));
+        $container->register(FineCommand::class, FineCommand::class);
 
         $kernel = $this->getMockBuilder(KernelInterface::class)->getMock();
         $kernel
-            ->method('getBundles')
-            ->willReturn(array($this->createBundleMock(
-                array((new Command('fine'))->setCode(function (InputInterface $input, OutputInterface $output) { $output->write('fine'); }))
-            )));
-        $kernel
             ->method('getContainer')
             ->willReturn($container);
+        $kernel
+            ->method('getBundles')
+            ->willReturn(array());
 
         $application = new Application($kernel);
         $application->setAutoExit(false);
@@ -230,5 +261,18 @@ class ThrowingCommand extends Command
     public function __construct()
     {
         throw new \Exception('throwing');
+    }
+}
+
+class FineCommand extends Command
+{
+    public function __construct()
+    {
+        parent::__construct('fine');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('fine');
     }
 }

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -161,9 +161,15 @@ abstract class Bundle implements BundleInterface
      * * Commands extend Symfony\Component\Console\Command\Command
      *
      * @param Application $application An Application instance
+     *
+     * @deprecated since version 3.4, to be removed in 4.0
      */
     public function registerCommands(Application $application)
     {
+        if (0 === func_num_args() || func_get_arg(0)) {
+            @trigger_error(sprintf('The %s() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         if (!is_dir($dir = $this->getPath().'/Command')) {
             return;
         }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * deprecated commands auto registration
  * added `AddCacheClearerPass`
  * added `AddCacheWarmerPass`
+ * deprecated `Bundle::registerCommands()`
 
 3.3.0
 -----

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -42,7 +42,7 @@ class BundleTest extends TestCase
         $app->expects($this->once())->method('add')->with($this->equalTo($cmd));
 
         $bundle = new ExtensionPresentBundle();
-        $bundle->registerCommands($app);
+        $bundle->registerCommands($app, false);
 
         $bundle2 = new ExtensionAbsentBundle();
 
@@ -59,6 +59,10 @@ class BundleTest extends TestCase
         $bundle->getContainerExtension();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands() method is deprecated since version 3.4 and will be removed in 4.0. Register commands as services instead.
+     */
     public function testHttpKernelRegisterCommandsIgnoresCommandsThatAreRegisteredAsServices()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Support for command as services exists in all our maintained branches and has been improved for 3.4. It's now clearly the way to go for registering commands using the framework.

Discussing about the recent changes with @nicolas-grekas (being the deprecation of convention based auto registration) it appears that the old approach can fully go away, and I think it should.