### PR TITLE
[Workflow] fixed InvalidDefinitionException message for StateMachineValidator

### DIFF
--- a/src/Symfony/Component/Workflow/Validator/StateMachineValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/StateMachineValidator.php
@@ -31,7 +31,7 @@ class StateMachineValidator implements DefinitionValidatorInterface
             // Make sure that each transition has exactly one FROM
             $froms = $transition->getFroms();
             if (1 !== count($froms)) {
-                throw new InvalidDefinitionException(sprintf('A transition in StateMachine can only have one input. But the transition "%s" in StateMachine "%s" has %d inputs.', $transition->getName(), $name, count($transition->getTos())));
+                throw new InvalidDefinitionException(sprintf('A transition in StateMachine can only have one input. But the transition "%s" in StateMachine "%s" has %d inputs.', $transition->getName(), $name, count($froms)));
             }
 
             // Enforcing uniqueness of the names of transitions starting at each node


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Little mistake in the exception message which can be lead to difficult debugging if we don't pay attention in the workflow definition.
