### PR TITLE
Make as many services private as possible

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DeprecatePublicServicesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DeprecatePublicServicesPass.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ *
+ * @internal to be removed in 4.0
+ */
+class DeprecatePublicServicesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $services = array();
+        foreach ($container->findTaggedServiceIds('deprecated.public') as $id => $tags) {
+            $definition = $container->getDefinition($id);
+            if ($definition->isPublic()) {
+                throw new LogicException(sprintf('Mark the service "%s" private before deprecating public access to it.', $id));
+            }
+
+            $definition->clearTag('deprecated.public');
+            $services[$id] = new Reference($id);
+        }
+
+        if (!$services) {
+            return;
+        }
+
+        $container->getDefinition(ServiceLocatorTagPass::register($container, $services))
+            ->setPublic(true)
+            ->setDeprecated('The service "%service_id%" is internal and deprecated since Symfony 3.4 and will be removed in Symfony 4.0');
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -66,6 +66,7 @@ class PassConfig
             new CheckCircularReferencesPass(),
             new CheckReferenceValidityPass(),
             new CheckArgumentsValidityPass(),
+            new DeprecatePublicServicesPass(),
         ));
 
         $this->removingPasses = array(array(

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1111,6 +1111,23 @@ class ContainerBuilderTest extends TestCase
 
         $container->get('bar');
     }
+
+    public function testDeprecatePublicService()
+    {
+        $container = new ContainerBuilder();
+        $container->register('was_public', 'stdClass')
+            ->setPublic(false)
+            ->addTag('deprecated.public');
+        $container->register('ref_was_public', 'stdClass')
+            ->setPublic(true)
+            ->setProperty('foo', new Reference('was_public'));
+
+        $container->compile();
+
+        $this->assertTrue($container->has('was_public'));
+        $this->assertInstanceOf('stdClass', $service = $container->get('was_public'));
+        $this->assertSame($service, $container->get('ref_was_public')->foo);
+    }
 }
 
 class FooClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes/
| Tests pass?   | yes/no
| Fixed tickets | #23822
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Proof of concept for a config only approach to upgrade services from public to private. Perfect chance to go with class named services, where possible.

Perhaps, to ease things, we can automate this behavior so in an extension you can do `ContainerBuilder::expose(['new_id' => 'old_id'])` for example, but i wouldnt make it to big a feature.

Thoughts?