### PR TITLE
[DI] Dont register normalized service id on read op

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -180,7 +180,7 @@ class Container implements ResettableContainerInterface
      */
     public function set($id, $service)
     {
-        $id = $this->normalizeId($id);
+        $id = $this->normalizeId($id, true);
 
         if ('service_container' === $id) {
             throw new InvalidArgumentException('You cannot set service "service_container".');
@@ -455,12 +455,13 @@ class Container implements ResettableContainerInterface
      * Returns the case sensitive id used at registration time.
      *
      * @param string $id
+     * @param bool   $register
      *
      * @return string
      *
      * @internal
      */
-    public function normalizeId($id)
+    public function normalizeId($id, $register = false)
     {
         if (!is_string($id)) {
             $id = (string) $id;
@@ -470,8 +471,10 @@ class Container implements ResettableContainerInterface
             if ($id !== $normalizedId) {
                 @trigger_error(sprintf('Service identifiers will be made case sensitive in Symfony 4.0. Using "%s" instead of "%s" is deprecated since version 3.3.', $id, $normalizedId), E_USER_DEPRECATED);
             }
-        } else {
+        } elseif ($register) {
             $normalizedId = $this->normalizedIds[$normalizedId] = $id;
+        } else {
+            $normalizedId = $id;
         }
 
         return $normalizedId;

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -505,7 +505,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function set($id, $service)
     {
-        $id = $this->normalizeId($id);
+        $id = $this->normalizeId($id, true);
 
         if ($this->isCompiled() && (isset($this->definitions[$id]) && !$this->definitions[$id]->isSynthetic())) {
             // setting a synthetic service on a compiled container is alright
@@ -793,7 +793,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function setAlias($alias, $id)
     {
-        $alias = $this->normalizeId($alias);
+        $alias = $this->normalizeId($alias, true);
 
         if (is_string($id)) {
             $id = new Alias($this->normalizeId($id));
@@ -943,7 +943,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             throw new BadMethodCallException('Adding definition to a compiled container is not allowed');
         }
 
-        $id = $this->normalizeId($id);
+        $id = $this->normalizeId($id, true);
 
         unset($this->aliasDefinitions[$id]);
 
@@ -1428,7 +1428,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     private function shareService(Definition $definition, $service, $id)
     {
         if (null !== $id && $definition->isShared()) {
-            $this->services[$this->normalizeId($id)] = $service;
+            $this->services[$this->normalizeId($id, true)] = $service;
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -236,6 +236,8 @@ class ContainerTest extends TestCase
     public function testNormalizeIdKeepsCase()
     {
         $sc = new ProjectServiceContainer();
+        $this->assertSame('foo', $sc->normalizeId('foo'));
+
         $sc->normalizeId('Foo', true);
         $this->assertSame('Foo', $sc->normalizeId('foo'));
     }
@@ -270,6 +272,18 @@ class ContainerTest extends TestCase
             $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException', $e, '->get() throws a ServiceNotFoundException exception if the service is empty');
         }
         $this->assertNull($sc->get('', ContainerInterface::NULL_ON_INVALID_REFERENCE), '->get() returns null if the service is empty');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testSetNormalizesId()
+    {
+        $sc = new ProjectServiceContainer();
+        $sc->has('Foo');
+        $sc->set('foo', new \stdClass());
+
+        $this->addToAssertionCount(1);
     }
 
     public function testGetThrowServiceNotFoundException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

I think we should only register the normalized id on a write operation, so that you dont get a deprecation when doing an arbitrary read op before.