### PR TITLE
[Security] Deprecated not being logged out after user change

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -269,6 +269,10 @@ SecurityBundle
     as first argument. Not passing it is deprecated and will throw a `TypeError`
     in 4.0.
 
+ * Added `logout_on_user_change` to the firewall options. This config item will
+   trigger a logout when the user has changed. Should be set to true to avoid
+   deprecations in the configuration.
+
 Translation
 -----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -642,6 +642,9 @@ Security
 
  * Support for defining voters that don't implement the `VoterInterface` has been removed.
 
+ * Calling `ContextListener::setLogoutOnUserChange(false)` won't have any
+   effect anymore.
+
 SecurityBundle
 --------------
 
@@ -659,6 +662,9 @@ SecurityBundle
  * `SetAclCommand::__construct()` now requires an instance of
    `Symfony\Component\Security\Acl\Model\MutableAclProviderInterfaceConnection`
     as first argument.
+
+ * The firewall option `logout_on_user_change` is now always true, which will
+   trigger a logout if the user changes between requests.
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -13,6 +13,9 @@ CHANGELOG
  * `SetAclCommand::__construct()` now takes an instance of
    `Symfony\Component\Security\Acl\Model\MutableAclProviderInterfaceConnection`
    as first argument
+ * Added `logout_on_user_change` to the firewall options. This config item will
+   trigger a logout when the user has changed. Should be set to true to avoid
+   deprecations in the configuration.
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -252,6 +252,10 @@ class MainConfiguration implements ConfigurationInterface
             ->scalarNode('provider')->end()
             ->booleanNode('stateless')->defaultFalse()->end()
             ->scalarNode('context')->cannotBeEmpty()->end()
+            ->booleanNode('logout_on_user_change')
+                ->defaultFalse()
+                ->info('When true, it will trigger a logout for the user if something has changed. This will be the default behavior as of Syfmony 4.0.')
+            ->end()
             ->arrayNode('logout')
                 ->treatTrueLike(array())
                 ->canBeUnset()
@@ -338,6 +342,17 @@ class MainConfiguration implements ConfigurationInterface
                     }
 
                     return $firewall;
+                })
+            ->end()
+            ->validate()
+                ->ifTrue(function ($v) {
+                    return (isset($v['stateless']) && true === $v['stateless']) || (isset($v['security']) && false === $v['security']);
+                })
+                ->then(function ($v) {
+                    // this option doesn't change behavior when true when stateless, so prevent deprecations
+                    $v['logout_on_user_change'] = true;
+
+                    return $v;
                 })
             ->end()
         ;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -265,14 +265,14 @@ class SecurityExtension extends Extension
         $providerIds = $this->createUserProviders($config, $container);
 
         // make the ContextListener aware of the configured user providers
-        $definition = $container->getDefinition('security.context_listener');
-        $arguments = $definition->getArguments();
+        $contextListenerDefinition = $container->getDefinition('security.context_listener');
+        $arguments = $contextListenerDefinition->getArguments();
         $userProviders = array();
         foreach ($providerIds as $userProviderId) {
             $userProviders[] = new Reference($userProviderId);
         }
         $arguments[1] = new IteratorArgument($userProviders);
-        $definition->setArguments($arguments);
+        $contextListenerDefinition->setArguments($arguments);
 
         $customUserChecker = false;
 
@@ -283,6 +283,12 @@ class SecurityExtension extends Extension
             if (isset($firewall['user_checker']) && 'security.user_checker' !== $firewall['user_checker']) {
                 $customUserChecker = true;
             }
+
+            if (!isset($firewall['logout_on_user_change']) || !$firewall['logout_on_user_change']) {
+                @trigger_error('Setting logout_on_user_change to false is deprecated as of 3.4 and will always be true in 4.0. Set logout_on_user_change to true in your firewall configuration.', E_USER_DEPRECATED);
+            }
+
+            $contextListenerDefinition->addMethodCall('setLogoutOnUserChange', array($firewall['logout_on_user_change']));
 
             $configId = 'security.firewall.map.config.'.$name;
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -73,6 +73,7 @@ $container->loadFromExtension('security', array(
             'logout' => true,
             'remember_me' => array('secret' => 'TheSecret'),
             'user_checker' => null,
+            'logout_on_user_change' => true,
         ),
         'host' => array(
             'pattern' => '/test',
@@ -80,11 +81,13 @@ $container->loadFromExtension('security', array(
             'methods' => array('GET', 'POST'),
             'anonymous' => true,
             'http_basic' => true,
+            'logout_on_user_change' => true,
         ),
         'with_user_checker' => array(
             'user_checker' => 'app.user_checker',
             'anonymous' => true,
             'http_basic' => true,
+            'logout_on_user_change' => true,
         ),
     ),
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_provider.php
@@ -15,10 +15,12 @@ $container->loadFromExtension('security', array(
         'main' => array(
             'provider' => 'default',
             'form_login' => true,
+            'logout_on_user_change' => true,
         ),
         'other' => array(
             'provider' => 'with-dash',
             'form_login' => true,
+            'logout_on_user_change' => true,
         ),
     ),
 ));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_undefined_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/firewall_undefined_provider.php
@@ -12,6 +12,7 @@ $container->loadFromExtension('security', array(
         'main' => array(
             'provider' => 'undefined',
             'form_login' => true,
+            'logout_on_user_change' => true,
         ),
     ),
 ));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_provider.php
@@ -11,6 +11,7 @@ $container->loadFromExtension('security', array(
     'firewalls' => array(
         'main' => array(
             'form_login' => array('provider' => 'default'),
+            'logout_on_user_change' => true,
         ),
     ),
 ));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_undefined_provider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/listener_undefined_provider.php
@@ -11,6 +11,7 @@ $container->loadFromExtension('security', array(
     'firewalls' => array(
         'main' => array(
             'form_login' => array('provider' => 'undefined'),
+            'logout_on_user_change' => true,
         ),
     ),
 ));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge.php
@@ -11,6 +11,7 @@ $container->loadFromExtension('security', array(
         'main' => array(
             'form_login' => false,
             'http_basic' => null,
+            'logout_on_user_change' => true,
         ),
     ),
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge_import.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/merge_import.php
@@ -6,6 +6,7 @@ $container->loadFromExtension('security', array(
             'form_login' => array(
                 'login_path' => '/login',
             ),
+        'logout_on_user_change' => true,
         ),
     ),
     'role_hierarchy' => array(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
@@ -12,7 +12,8 @@ $container->loadFromExtension('security', array(
     ),
     'firewalls' => array(
         'simple' => array('pattern' => '/login', 'security' => false),
-        'secure' => array('stateless' => true,
+        'secure' => array(
+            'stateless' => true,
             'http_basic' => true,
             'http_digest' => array('secret' => 'TheSecret'),
             'form_login' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/remember_me_options.php
@@ -13,6 +13,7 @@ $container->loadFromExtension('security', array(
                 'catch_exceptions' => false,
                 'token_provider' => 'token_provider_id',
             ),
+            'logout_on_user_change' => true,
         ),
     ),
 ));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -60,12 +60,12 @@
             <remember-me secret="TheSecret"/>
         </firewall>
 
-        <firewall name="host" pattern="/test" host="foo\.example\.org" methods="GET,POST">
+        <firewall name="host" pattern="/test" host="foo\.example\.org" methods="GET,POST" logout-on-user-change="true">
             <anonymous />
             <http-basic />
         </firewall>
 
-        <firewall name="with_user_checker">
+        <firewall name="with_user_checker" logout-on-user-change="true">
             <anonymous />
             <http-basic />
             <user-checker>app.user_checker</user-checker>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_provider.xml
@@ -11,7 +11,7 @@
         </sec:providers>
 
         <sec:firewalls>
-            <sec:firewall name="main" provider="with-dash">
+            <sec:firewall name="main" provider="with-dash" logout-on-user-change="true">
                 <sec:form_login />
             </sec:firewall>
         </sec:firewalls>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_undefined_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/firewall_undefined_provider.xml
@@ -11,7 +11,7 @@
         </sec:providers>
 
         <sec:firewalls>
-            <sec:firewall name="main" provider="undefined">
+            <sec:firewall name="main" provider="undefined" logout-on-user-change="true">
                 <sec:form_login />
             </sec:firewall>
         </sec:firewalls>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_provider.xml
@@ -11,7 +11,7 @@
         </sec:providers>
 
         <sec:firewalls>
-            <sec:firewall name="main">
+            <sec:firewall name="main" logout-on-user-change="true">
                 <sec:form_login provider="default" />
             </sec:firewall>
         </sec:firewalls>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_undefined_provider.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/listener_undefined_provider.xml
@@ -11,7 +11,7 @@
         </sec:providers>
 
         <sec:firewalls>
-            <sec:firewall name="main">
+            <sec:firewall name="main" logout-on-user-change="true">
                 <sec:form_login provider="undefined" />
             </sec:firewall>
         </sec:firewalls>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge.xml
@@ -12,7 +12,7 @@
     <sec:config>
         <sec:provider name="default" id="foo" />
 
-        <sec:firewall name="main" form-login="false">
+        <sec:firewall name="main" form-login="false" logout-on-user-change="true">
             <sec:http-basic />
         </sec:firewall>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge_import.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/merge_import.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <config>
-        <firewall name="main">
+        <firewall name="main" logout-on-user-change="true">
             <form-login login-path="/login" />
         </firewall>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/remember_me_options.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/remember_me_options.xml
@@ -9,7 +9,7 @@
         <sec:providers>
             <sec:default id="foo"/>
         </sec:providers>
-        <sec:firewall name="main">
+        <sec:firewall name="main" logout-on-user-change="true">
             <sec:form-login/>
             <sec:remember-me secret="TheSecret" catch-exceptions="false" token-provider="token_provider_id" />
         </sec:firewall>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -64,11 +64,13 @@ security:
             methods: [GET,POST]
             anonymous: true
             http_basic: true
+            logout_on_user_change: true
 
         with_user_checker:
             anonymous: ~
             http_basic: ~
             user_checker: app.user_checker
+            logout_on_user_change: true
 
     role_hierarchy:
         ROLE_ADMIN:       ROLE_USER

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_provider.yml
@@ -11,6 +11,8 @@ security:
         main:
             provider: default
             form_login: true
+            logout_on_user_change: true
         other:
             provider: with-dash
             form_login: true
+            logout_on_user_change: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_undefined_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/firewall_undefined_provider.yml
@@ -8,3 +8,4 @@ security:
         main:
             provider: undefined
             form_login: true
+            logout_on_user_change: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_provider.yml
@@ -8,3 +8,4 @@ security:
         main:
             form_login:
                 provider: default
+            logout_on_user_change: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_undefined_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/listener_undefined_provider.yml
@@ -8,3 +8,4 @@ security:
         main:
             form_login:
                 provider: undefined
+            logout_on_user_change: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge.yml
@@ -9,6 +9,7 @@ security:
         main:
             form_login: false
             http_basic: ~
+            logout_on_user_change: true
 
     role_hierarchy:
         FOO: [MOO]

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge_import.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/merge_import.yml
@@ -3,6 +3,7 @@ security:
         main:
             form_login:
                 login_path: /login
+            logout_on_user_change: true
 
     role_hierarchy:
         FOO: BAR

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/remember_me_options.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/remember_me_options.yml
@@ -10,3 +10,4 @@ security:
                 secret: TheSecret
                 catch_exceptions: false
                 token_provider: token_provider_id
+            logout_on_user_change: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -31,6 +31,7 @@ class MainConfigurationTest extends TestCase
         ),
         'firewalls' => array(
             'stub' => array(),
+            'logout_on_user_change' => true,
         ),
     );
 
@@ -78,6 +79,7 @@ class MainConfigurationTest extends TestCase
                         'csrf_token_generator' => 'a_token_generator',
                         'csrf_token_id' => 'a_token_id',
                     ),
+                    'logout_on_user_change' => true,
                 ),
             ),
         );
@@ -107,6 +109,7 @@ class MainConfigurationTest extends TestCase
             'firewalls' => array(
                 'stub' => array(
                     'user_checker' => 'app.henk_checker',
+                    'logout_on_user_change' => true,
                 ),
             ),
         );

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -38,6 +38,7 @@ class SecurityExtensionTest extends TestCase
                     'form_login' => array(
                         'check_path' => '/some_area/login_check',
                     ),
+                    'logout_on_user_change' => true,
                 ),
             ),
         ));
@@ -61,6 +62,7 @@ class SecurityExtensionTest extends TestCase
             'firewalls' => array(
                 'some_firewall' => array(
                     'pattern' => '/.*',
+                    'logout_on_user_change' => true,
                 ),
             ),
         ));
@@ -88,6 +90,7 @@ class SecurityExtensionTest extends TestCase
                 'some_firewall' => array(
                     'pattern' => '/.*',
                     'http_basic' => array(),
+                    'logout_on_user_change' => true,
                 ),
             ),
         ));
@@ -110,6 +113,7 @@ class SecurityExtensionTest extends TestCase
                 'some_firewall' => array(
                     'pattern' => '/.*',
                     'http_basic' => null,
+                    'logout_on_user_change' => true,
                 ),
             ),
         ));
@@ -117,6 +121,31 @@ class SecurityExtensionTest extends TestCase
         $container->compile();
 
         $this->assertFalse($container->hasDefinition('security.access.role_hierarchy_voter'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Setting logout_on_user_change to false is deprecated as of 3.4 and will always be true in 4.0. Set logout_on_user_change to true in your firewall configuration.
+     */
+    public function testDeprecationForUserLogout()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', array(
+            'providers' => array(
+                'default' => array('id' => 'foo'),
+            ),
+
+            'firewalls' => array(
+                'some_firewall' => array(
+                    'pattern' => '/.*',
+                    'http_basic' => null,
+                    'logout_on_user_change' => false,
+                ),
+            ),
+        ));
+
+        $container->compile();
     }
 
     protected function getRawContainer()

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -6,6 +6,10 @@ CHANGELOG
 
  * Using voters that do not implement the `VoterInterface`is now deprecated in
    the `AccessDecisionManager` and this functionality will be removed in 4.0.
+ * Using the `ContextListener` without setting the `logoutOnUserChange`
+   property will trigger a deprecation when the user has changed. As of 4.0
+   the user will always be logged out when the user has changed between
+   requests.
 
 3.3.0
 -----

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -37,6 +37,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class ContextListener implements ListenerInterface
 {
     private $tokenStorage;
+    private $contextKey;
     private $sessionKey;
     private $logger;
     private $userProviders;
@@ -61,6 +62,7 @@ class ContextListener implements ListenerInterface
 
         $this->tokenStorage = $tokenStorage;
         $this->userProviders = $userProviders;
+        $this->contextKey = $contextKey;
         $this->sessionKey = '_security_'.$contextKey;
         $this->logger = $logger;
         $this->dispatcher = $dispatcher;

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -220,7 +220,7 @@ class ContextListener implements ListenerInterface
         }
 
         if ($userNotFoundByProvider) {
-            return null;
+            return;
         }
 
         throw new \RuntimeException(sprintf('There is no user provider for user "%s".', get_class($user)));

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -249,7 +249,11 @@ class ContextListenerTest extends TestCase
         $listener->handle($event);
     }
 
-    public function testTryAllUserProvidersUntilASupportingUserProviderIsFound()
+    /**
+     * @group legacy
+     * @expectedDeprecation Refreshing a deauthenticated user is deprecated as of 3.4 and will trigger a logout in 4.0.
+     */
+    public function testIfTokenIsDeauthenticatedTriggersDeprecations()
     {
         $tokenStorage = new TokenStorage();
         $refreshedUser = new User('foobar', 'baz');
@@ -258,11 +262,29 @@ class ContextListenerTest extends TestCase
         $this->assertSame($refreshedUser, $tokenStorage->getToken()->getUser());
     }
 
+    public function testIfTokenIsDeauthenticated()
+    {
+        $tokenStorage = new TokenStorage();
+        $refreshedUser = new User('foobar', 'baz');
+        $this->handleEventWithPreviousSession($tokenStorage, array(new NotSupportingUserProvider(), new SupportingUserProvider($refreshedUser)), null, true);
+
+        $this->assertNull($tokenStorage->getToken());
+    }
+
+    public function testTryAllUserProvidersUntilASupportingUserProviderIsFound()
+    {
+        $tokenStorage = new TokenStorage();
+        $refreshedUser = new User('foobar', 'baz');
+        $this->handleEventWithPreviousSession($tokenStorage, array(new NotSupportingUserProvider(), new SupportingUserProvider($refreshedUser)), $refreshedUser);
+
+        $this->assertSame($refreshedUser, $tokenStorage->getToken()->getUser());
+    }
+
     public function testNextSupportingUserProviderIsTriedIfPreviousSupportingUserProviderDidNotLoadTheUser()
     {
         $tokenStorage = new TokenStorage();
         $refreshedUser = new User('foobar', 'baz');
-        $this->handleEventWithPreviousSession($tokenStorage, array(new SupportingUserProvider(), new SupportingUserProvider($refreshedUser)));
+        $this->handleEventWithPreviousSession($tokenStorage, array(new SupportingUserProvider(), new SupportingUserProvider($refreshedUser)), $refreshedUser);
 
         $this->assertSame($refreshedUser, $tokenStorage->getToken()->getUser());
     }
@@ -287,7 +309,7 @@ class ContextListenerTest extends TestCase
     {
         $tokenStorage = new TokenStorage();
         $refreshedUser = new User('foobar', 'baz');
-        $this->handleEventWithPreviousSession($tokenStorage, new \ArrayObject(array(new NotSupportingUserProvider(), new SupportingUserProvider($refreshedUser))));
+        $this->handleEventWithPreviousSession($tokenStorage, new \ArrayObject(array(new NotSupportingUserProvider(), new SupportingUserProvider($refreshedUser))), $refreshedUser);
 
         $this->assertSame($refreshedUser, $tokenStorage->getToken()->getUser());
     }
@@ -320,16 +342,18 @@ class ContextListenerTest extends TestCase
         return $session;
     }
 
-    private function handleEventWithPreviousSession(TokenStorageInterface $tokenStorage, $userProviders)
+    private function handleEventWithPreviousSession(TokenStorageInterface $tokenStorage, $userProviders, UserInterface $user = null, $logoutOnUserChange = false)
     {
+        $user = $user ?: new User('foo', 'bar');
         $session = new Session(new MockArraySessionStorage());
-        $session->set('_security_context_key', serialize(new UsernamePasswordToken(new User('foo', 'bar'), '', 'context_key')));
+        $session->set('_security_context_key', serialize(new UsernamePasswordToken($user, '', 'context_key', array('ROLE_USER'))));
 
         $request = new Request();
         $request->setSession($session);
         $request->cookies->set('MOCKSESSID', true);
 
         $listener = new ContextListener($tokenStorage, $userProviders, 'context_key');
+        $listener->setLogoutOnUserChange($logoutOnUserChange);
         $listener->handle(new GetResponseEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $request, HttpKernelInterface::MASTER_REQUEST));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #17023
| License       | MIT
| Doc PR        | ~

This PR is an alternative approach to #19033. Due to a behavioral change that could break a lot of applications and websites, I've decided to trigger a deprecation instead of actually changing the behavior as that can be done for 4.0.

Whenever a user object is considered changed (`AbstractToken::hasUserChanged`) when setting a new user object after refreshing, it will now throw a deprecation, paving the way for a behavioral change in 4.0. The idea is that in 4.0 Symfony will simply trigger a logout when this case is encountered.