### PR TITLE
[DI] Validate env vars in config

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -11,6 +11,7 @@ Console
 -------
 
  * Deprecated the `setCrossingChar()` method in favor of the `setDefaultCrossingChar()` method in `TableStyle`.
+ * The `Processor` class has been made final
 
 DependencyInjection
 -------------------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -5,6 +5,7 @@ Config
 ------
 
  * Added the `getChildNodeDefinitions()` method to `ParentNodeDefinitionInterface`.
+ * The `Processor` class has been made final
 
 Console
 -------

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added `setPathSeparator` method to `NodeBuilder` class
  * added third `$pathSeparator` constructor argument to `BaseNode`
+ * the `Processor` class has been made final
 
 4.0.0
 -----

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -390,4 +390,12 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
         return $leftSide;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function allowPlaceholders(): bool
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -88,6 +88,8 @@ abstract class BaseNode implements NodeInterface
 
     /**
      * Resets all current placeholders available.
+     *
+     * @internal
      */
     public static function resetPlaceholders(): void
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -61,6 +61,8 @@ abstract class BaseNode implements NodeInterface
      *
      * Matching configuration values will be processed with a provided value, one by one. After a provided value is
      * successfully processed the configuration value is returned as is, thus preserving the placeholder.
+     *
+     * @internal
      */
     public static function setPlaceholder(string $placeholder, array $values): void
     {
@@ -76,6 +78,8 @@ abstract class BaseNode implements NodeInterface
      *
      * Matching configuration values will be skipped from being processed and are returned as is, thus preserving the
      * placeholder. An exact match provided by {@see setPlaceholder()} might take precedence.
+     *
+     * @internal
      */
     public static function setPlaceholderUniquePrefix(string $prefix): void
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -483,7 +483,7 @@ abstract class BaseNode implements NodeInterface
                 return self::$placeholders[$value];
             }
 
-            if (0 === strpos($value, self::$placeholderUniquePrefix, 0)) {
+            if (0 === strpos($value, self::$placeholderUniquePrefix)) {
                 return array();
             }
         }
@@ -493,7 +493,7 @@ abstract class BaseNode implements NodeInterface
 
     private static function getType($value): string
     {
-        switch ($type = gettype($value)) {
+        switch ($type = \gettype($value)) {
             case 'boolean':
                 return 'bool';
             case 'double':

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -57,9 +57,10 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Register possible (dummy) values for a dynamic placeholder value. Matching configuration values will be processed
-     * with a provided value, one by one. After a provided value is successfully processed the configuration value is
-     * returned as is, thus preserving the placeholder.
+     * Register possible (dummy) values for a dynamic placeholder value.
+     *
+     * Matching configuration values will be processed with a provided value, one by one. After a provided value is
+     * successfully processed the configuration value is returned as is, thus preserving the placeholder.
      */
     public static function setPlaceholder(string $placeholder, array $values): void
     {
@@ -71,9 +72,10 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Set a common prefix for dynamic placeholder values. Matching configuration values will be skipped from being
-     * processed and are returned as is, thus preserving the placeholder. An exact match provided by {@see setPlaceholder()}
-     * might take precedence.
+     * Sets a common prefix for dynamic placeholder values.
+     *
+     * Matching configuration values will be skipped from being processed and are returned as is, thus preserving the
+     * placeholder. An exact match provided by {@see setPlaceholder()} might take precedence.
      */
     public static function setPlaceholderUniquePrefix(string $prefix): void
     {
@@ -81,7 +83,7 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Reset all current placeholders available.
+     * Resets all current placeholders available.
      */
     public static function resetPlaceholders(): void
     {
@@ -461,7 +463,7 @@ abstract class BaseNode implements NodeInterface
     abstract protected function finalizeValue($value);
 
     /**
-     * Test if placeholder values are allowed for this node.
+     * Tests if placeholder values are allowed for this node.
      */
     protected function allowPlaceholders(): bool
     {
@@ -469,7 +471,7 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Get allowed dynamic types for this node.
+     * Gets allowed dynamic types for this node.
      */
     protected function getValidPlaceholderTypes(): array
     {

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -48,4 +48,12 @@ class BooleanNode extends ScalarNode
         // a boolean value cannot be empty
         return false;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getValidPlaceholderTypes(): array
+    {
+        return array('bool');
+    }
 }

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -55,4 +55,12 @@ class EnumNode extends ScalarNode
 
         return $value;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function allowPlaceholders(): bool
+    {
+        return false;
+    }
 }

--- a/src/Symfony/Component/Config/Definition/FloatNode.php
+++ b/src/Symfony/Component/Config/Definition/FloatNode.php
@@ -40,4 +40,12 @@ class FloatNode extends NumericNode
             throw $ex;
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getValidPlaceholderTypes(): array
+    {
+        return array('float');
+    }
 }

--- a/src/Symfony/Component/Config/Definition/IntegerNode.php
+++ b/src/Symfony/Component/Config/Definition/IntegerNode.php
@@ -35,4 +35,12 @@ class IntegerNode extends NumericNode
             throw $ex;
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getValidPlaceholderTypes(): array
+    {
+        return array('int');
+    }
 }

--- a/src/Symfony/Component/Config/Definition/Processor.php
+++ b/src/Symfony/Component/Config/Definition/Processor.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Config\Definition;
  * This class is the entry point for config normalization/merging/finalization.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @final since version 4.1
  */
 class Processor
 {

--- a/src/Symfony/Component/Config/Definition/ScalarNode.php
+++ b/src/Symfony/Component/Config/Definition/ScalarNode.php
@@ -54,4 +54,12 @@ class ScalarNode extends VariableNode
     {
         return null === $value || '' === $value;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getValidPlaceholderTypes(): array
+    {
+        return array('bool', 'int', 'float', 'string');
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added PSR-11 `ContainerBagInterface` and its `ContainerBag` implementation to access parameters as-a-service
  * added support for service's decorators autowiring
  * deprecated the `TypedReference::canBeAutoregistered()` and  `TypedReference::getRequiringClass()` methods
+ * environment variables are validated when used in extension configuration
 
 4.0.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -49,6 +49,7 @@ class PassConfig
         );
 
         $this->optimizationPasses = array(array(
+            new ValidateEnvPlaceholdersPass(),
             new ResolveChildDefinitionsPass(),
             new ServiceLocatorTagPass(),
             new DecoratorServicePass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+/**
+ * Validates environment variable placeholders used in extension configuration with dummy values.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class ValidateEnvPlaceholdersPass implements CompilerPassInterface
+{
+    private static $typeFixtures = array('array' => array(), 'bool' => false, 'float' => 0.0, 'int' => 0, 'string' => '');
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!class_exists(BaseNode::class) || !$extensions = $container->getExtensions()) {
+            return;
+        }
+
+        $resolvingBag = $container->getParameterBag();
+        if (!$resolvingBag instanceof EnvPlaceholderParameterBag) {
+            return;
+        }
+
+        $defaultBag = new ParameterBag($container->getParameterBag()->all());
+        $envTypes = $resolvingBag->getProvidedTypes();
+        try {
+            foreach ($resolvingBag->getEnvPlaceholders() + $resolvingBag->getUnusedEnvPlaceholders() as $env => $placeholders) {
+                $prefix = (false === $i = strpos($env, ':')) ? 'string' : substr($env, 0, $i);
+                $types = $envTypes[$prefix] ?? array('string');
+                $default = ($hasEnv = (false === $i && $defaultBag->has("env($env)"))) ? $defaultBag->get("env($env)") : null;
+
+                if (null !== $default && !in_array($type = self::getType($default), $types, true)) {
+                    throw new LogicException(sprintf('Invalid type for env parameter "env(%s)". Expected "%s", but got "%s".', $env, implode('", "', $types), $type));
+                }
+
+                $values = array();
+                foreach ($types as $type) {
+                    $values[$type] = $hasEnv ? $default : self::$typeFixtures[$type] ?? null;
+                }
+                foreach ($placeholders as $placeholder) {
+                    BaseNode::setPlaceholder($placeholder, $values);
+                }
+            }
+
+            $processor = new Processor();
+
+            foreach ($extensions as $name => $extension) {
+                if (!$extension instanceof ConfigurationExtensionInterface || !$config = $container->getExtensionConfig($name)) {
+                    // this extension has no semantic configuration or was not called
+                    continue;
+                }
+
+                $config = $resolvingBag->resolveValue($config);
+
+                if (null === $configuration = $extension->getConfiguration($config, $container)) {
+                    continue;
+                }
+
+                $processor->processConfiguration($configuration, $config);
+            }
+        } finally {
+            BaseNode::resetPlaceholders();
+        }
+    }
+
+    private static function getType($value): string
+    {
+        switch ($type = gettype($value)) {
+            case 'boolean':
+                return 'bool';
+            case 'double':
+                return 'float';
+            case 'integer':
+                return 'int';
+        }
+
+        return $type;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
@@ -86,7 +86,7 @@ class ValidateEnvPlaceholdersPass implements CompilerPassInterface
 
     private static function getType($value): string
     {
-        switch ($type = gettype($value)) {
+        switch ($type = \gettype($value)) {
             case 'boolean':
                 return 'bool';
             case 'double':

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -69,7 +69,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
      */
     public function getEnvPlaceholderUniquePrefix(): string
     {
-        return $this->envPlaceholderUniquePrefix ?? $this->envPlaceholderUniquePrefix = 'env_'.bin2hex(random_bytes(16));
+        return $this->envPlaceholderUniquePrefix ?? $this->envPlaceholderUniquePrefix = 'env_'.bin2hex(random_bytes(8));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -19,7 +19,9 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  */
 class EnvPlaceholderParameterBag extends ParameterBag
 {
+    private $envPlaceholderUniquePrefix;
     private $envPlaceholders = array();
+    private $unusedEnvPlaceholders = array();
     private $providedTypes = array();
 
     /**
@@ -32,6 +34,11 @@ class EnvPlaceholderParameterBag extends ParameterBag
 
             if (isset($this->envPlaceholders[$env])) {
                 foreach ($this->envPlaceholders[$env] as $placeholder) {
+                    return $placeholder; // return first result
+                }
+            }
+            if (isset($this->unusedEnvPlaceholders[$env])) {
+                foreach ($this->unusedEnvPlaceholders[$env] as $placeholder) {
                     return $placeholder; // return first result
                 }
             }
@@ -48,13 +55,21 @@ class EnvPlaceholderParameterBag extends ParameterBag
             }
 
             $uniqueName = md5($name.uniqid(mt_rand(), true));
-            $placeholder = sprintf('env_%s_%s', str_replace(':', '_', $env), $uniqueName);
+            $placeholder = sprintf('%s_%s_%s', $this->getEnvPlaceholderUniquePrefix(), str_replace(':', '_', $env), $uniqueName);
             $this->envPlaceholders[$env][$placeholder] = $placeholder;
 
             return $placeholder;
         }
 
         return parent::get($name);
+    }
+
+    /**
+     * Gets the common env placeholder prefix for env vars created by this bag.
+     */
+    public function getEnvPlaceholderUniquePrefix(): string
+    {
+        return $this->envPlaceholderUniquePrefix ?? $this->envPlaceholderUniquePrefix = 'env_'.bin2hex(random_bytes(16));
     }
 
     /**
@@ -67,6 +82,11 @@ class EnvPlaceholderParameterBag extends ParameterBag
         return $this->envPlaceholders;
     }
 
+    public function getUnusedEnvPlaceholders(): array
+    {
+        return $this->unusedEnvPlaceholders;
+    }
+
     /**
      * Merges the env placeholders of another EnvPlaceholderParameterBag.
      */
@@ -77,6 +97,14 @@ class EnvPlaceholderParameterBag extends ParameterBag
 
             foreach ($newPlaceholders as $env => $placeholders) {
                 $this->envPlaceholders[$env] += $placeholders;
+            }
+        }
+
+        if ($newUnusedPlaceholders = $bag->getUnusedEnvPlaceholders()) {
+            $this->unusedEnvPlaceholders += $newUnusedPlaceholders;
+
+            foreach ($newUnusedPlaceholders as $env => $placeholders) {
+                $this->unusedEnvPlaceholders[$env] += $placeholders;
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -1,0 +1,249 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
+use Symfony\Component\DependencyInjection\Compiler\RegisterEnvVarProcessorsPass;
+use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+class ValidateEnvPlaceholdersPassTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\LogicException
+     * @expectedExceptionMessage Invalid type for env parameter "env(FOO)". Expected "string", but got "bool".
+     */
+    public function testDefaultEnvIsValidatedByType()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('env(FOO)', true);
+        $container->registerExtension(new EnvExtension());
+        $container->prependExtensionConfig('env_extension', array(
+            'scalar_node' => '%env(FOO)%',
+        ));
+
+        $this->doProcess($container);
+    }
+
+    public function testEnvsAreValidatedInConfig()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('env(NULLED)', null);
+        $container->registerExtension($ext = new EnvExtension());
+        $container->prependExtensionConfig('env_extension', $expected = array(
+            'scalar_node' => '%env(NULLED)%',
+            'int_node' => '%env(int:FOO)%',
+            'float_node' => '%env(float:BAR)%',
+            'bool_node' => '%env(const:BAZ)%',
+        ));
+
+        $this->doProcess($container);
+
+        $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
+     * @expectedExceptionMessage Invalid type for path "env_extension.int_node". Expected int, but got array.
+     */
+    public function testInvalidEnvInConfig()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new EnvExtension());
+        $container->prependExtensionConfig('env_extension', array(
+            'int_node' => '%env(json:FOO)%',
+        ));
+
+        $this->doProcess($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
+     * @expectedExceptionMessage Invalid type for path "env_extension.int_node". Expected int, but got NULL.
+     */
+    public function testNulledEnvInConfig()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('env(NULLED)', null);
+        $container->registerExtension(new EnvExtension());
+        $container->prependExtensionConfig('env_extension', array(
+            'int_node' => '%env(NULLED)%',
+        ));
+
+        $this->doProcess($container);
+    }
+
+    public function testValidateEnvOnMerge()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension());
+        $container->prependExtensionConfig('env_extension', array(
+            'int_node' => '%env(const:FOO)%',
+            'bool_node' => true,
+        ));
+        $container->prependExtensionConfig('env_extension', array(
+            'int_node' => '%env(int:BAR)%',
+            'bool_node' => '%env(bool:int:BAZ)%',
+            'scalar_node' => '%env(BAZ)%',
+        ));
+
+        $this->doProcess($container);
+
+        $expected = array(
+            'int_node' => '%env(const:FOO)%',
+            'bool_node' => true,
+            'scalar_node' => '%env(BAZ)%',
+        );
+
+        $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
+    }
+
+    public function testConcatenatedEnvInConfig()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension());
+        $container->prependExtensionConfig('env_extension', array(
+            'scalar_node' => $expected = 'foo %env(BAR)% baz',
+        ));
+
+        $this->doProcess($container);
+
+        $this->assertSame(array('scalar_node' => $expected), $container->resolveEnvPlaceholders($ext->getConfig()));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage A dynamic value is not compatible with a "Symfony\Component\Config\Definition\EnumNode" node type at path "env_extension.enum_node".
+     */
+    public function testEnvIsIncompatibleWithEnumNode()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new EnvExtension());
+        $container->prependExtensionConfig('env_extension', array(
+            'enum_node' => '%env(FOO)%',
+        ));
+
+        $this->doProcess($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage A dynamic value is not compatible with a "Symfony\Component\Config\Definition\ArrayNode" node type at path "env_extension.simple_array_node".
+     */
+    public function testEnvIsIncompatibleWithArrayNode()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new EnvExtension());
+        $container->prependExtensionConfig('env_extension', array(
+            'simple_array_node' => '%env(json:FOO)%',
+        ));
+
+        $this->doProcess($container);
+    }
+
+    public function testNormalizedEnvIsCompatibleWithArrayNode()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension());
+        $container->prependExtensionConfig('env_extension', array(
+            'array_node' => $expected = '%env(CHILD)%',
+        ));
+
+        $this->doProcess($container);
+
+        $this->assertSame(array('array_node' => array('child_node' => $expected)), $container->resolveEnvPlaceholders($ext->getConfig()));
+    }
+
+    public function testEnvIsNotUnset()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension());
+        $container->prependExtensionConfig('env_extension', $expected = array(
+            'array_node' => array('int_unset_at_zero' => '%env(int:CHILD)%'),
+        ));
+
+        $this->doProcess($container);
+
+        $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
+    }
+
+    private function doProcess(ContainerBuilder $container): void
+    {
+        (new MergeExtensionConfigurationPass())->process($container);
+        (new RegisterEnvVarProcessorsPass())->process($container);
+        (new ValidateEnvPlaceholdersPass())->process($container);
+    }
+}
+
+class EnvConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('env_extension');
+        $rootNode
+            ->children()
+                ->scalarNode('scalar_node')->end()
+                ->integerNode('int_node')->end()
+                ->floatNode('float_node')->end()
+                ->booleanNode('bool_node')->end()
+                ->arrayNode('array_node')
+                    ->beforeNormalization()
+                        ->ifTrue(function ($value) { return !is_array($value); })
+                        ->then(function ($value) { return array('child_node' => $value); })
+                    ->end()
+                    ->children()
+                        ->scalarNode('child_node')->end()
+                        ->integerNode('int_unset_at_zero')
+                            ->validate()
+                                ->ifTrue(function ($value) { return 0 === $value; })
+                                ->thenUnset()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('simple_array_node')->end()
+                ->enumNode('enum_node')->values(array('a', 'b'))->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}
+
+class EnvExtension extends Extension
+{
+    private $config;
+
+    public function getAlias()
+    {
+        return 'env_extension';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new EnvConfiguration();
+    }
+
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $this->config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
+    }
+
+    public function getConfig()
+    {
+        return $this->config;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -47,6 +47,22 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
             'scalar_node' => '%env(NULLED)%',
             'int_node' => '%env(int:FOO)%',
             'float_node' => '%env(float:BAR)%',
+        ));
+
+        $this->doProcess($container);
+
+        $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
+     * @expectedExceptionMessage Invalid type for path "env_extension.bool_node". Expected "bool", but got one of "bool", "int", "float", "string", "array".
+     */
+    public function testEnvsAreValidatedInConfigWithInvalidPlaceholder()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension());
+        $container->prependExtensionConfig('env_extension', $expected = array(
             'bool_node' => '%env(const:BAZ)%',
         ));
 
@@ -57,7 +73,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidTypeException
-     * @expectedExceptionMessage Invalid type for path "env_extension.int_node". Expected int, but got array.
+     * @expectedExceptionMessage Invalid type for path "env_extension.int_node". Expected "int", but got "array".
      */
     public function testInvalidEnvInConfig()
     {
@@ -91,7 +107,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->registerExtension($ext = new EnvExtension());
         $container->prependExtensionConfig('env_extension', array(
-            'int_node' => '%env(const:FOO)%',
+            'int_node' => '%env(int:const:FOO)%',
             'bool_node' => true,
         ));
         $container->prependExtensionConfig('env_extension', array(
@@ -103,7 +119,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->doProcess($container);
 
         $expected = array(
-            'int_node' => '%env(const:FOO)%',
+            'int_node' => '%env(int:const:FOO)%',
             'bool_node' => true,
             'scalar_node' => '%env(BAZ)%',
         );

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "symfony/yaml": "~3.4|~4.0",
-        "symfony/config": "~3.4|~4.0",
+        "symfony/config": "~4.1",
         "symfony/expression-language": "~3.4|~4.0"
     },
     "suggest": {
@@ -32,7 +32,7 @@
         "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
     },
     "conflict": {
-        "symfony/config": "<3.4",
+        "symfony/config": "<4.1",
         "symfony/finder": "<3.4",
         "symfony/proxy-manager-bridge": "<3.4",
         "symfony/yaml": "<3.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1/master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22151, #25868
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/issues/8382

This PR registers the env placeholders in `Config\BaseNode` with its default value or an empty string. It doesnt request real env vars during compilation,

What it does is if a config value exactly matches a env placeholder, we validate/normalize the default value/empty string but we keep returning the env placeholder as usual. If a placeholder occurs in the middle of a string it also proceeds as usual.

The latter to me is OK as you need to expect any string value during runtime anyway,  including the empty string.