### PR TITLE
[Translation] Adding the ability do dump <notes> in xliff2.0

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Added `TranslationDumperPass`
  * Added `TranslationExtractorPass`
  * Added `TranslatorPass`
+ * Added <notes> section to the Xliff 2.0 dumper. 
 
 3.2.0
 -----

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Added `TranslationDumperPass`
  * Added `TranslationExtractorPass`
  * Added `TranslatorPass`
- * Added <notes> section to the Xliff 2.0 dumper. 
+ * Added <notes> section to the Xliff 2.0 dumper.
 
 3.2.0
 -----

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -153,7 +153,7 @@ class XliffFileDumper extends FileDumper
                 $notesElement = $dom->createElement('notes');
                 foreach ($metadata['notes'] as $note) {
                     $n = $dom->createElement('note');
-                    $n->appendChild($dom->createTextNode($note['content'] ?? ''));
+                    $n->appendChild($dom->createTextNode(isset($note['content']) ? $note['content'] : ''));
                     unset($note['content']);
 
                     foreach ($note as $name => $value) {

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -146,6 +146,23 @@ class XliffFileDumper extends FileDumper
         foreach ($messages->all($domain) as $source => $target) {
             $translation = $dom->createElement('unit');
             $translation->setAttribute('id', strtr(substr(base64_encode(hash('sha256', $source, true)), 0, 7), '/+', '._'));
+            $metadata = $messages->getMetadata($source, $domain);
+
+            // Add notes section
+            if ($this->hasMetadataArrayInfo('notes', $metadata)) {
+                $notesElement = $dom->createElement('notes');
+                foreach ($metadata['notes'] as $note) {
+                    $n = $dom->createElement('note');
+                    $n->appendChild($dom->createTextNode($note['content'] ?? ''));
+                    unset($note['content']);
+
+                    foreach ($note as $name => $value) {
+                        $n->setAttribute($name, $value);
+                    }
+                    $notesElement->appendChild($n);
+                }
+                $translation->appendChild($notesElement);
+            }
 
             $segment = $translation->appendChild($dom->createElement('segment'));
 
@@ -156,7 +173,6 @@ class XliffFileDumper extends FileDumper
             $text = 1 === preg_match('/[&<>]/', $target) ? $dom->createCDATASection($target) : $dom->createTextNode($target);
 
             $targetElement = $dom->createElement('target');
-            $metadata = $messages->getMetadata($source, $domain);
             if ($this->hasMetadataArrayInfo('target-attributes', $metadata)) {
                 foreach ($metadata['target-attributes'] as $name => $value) {
                     $targetElement->setAttribute($name, $value);

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -87,4 +87,23 @@ class XliffFileDumperTest extends TestCase
             $dumper->formatCatalogue($catalogue, 'messages', array('default_locale' => 'fr_FR'))
         );
     }
+    public function testFormatCatalogueWithNotesMetadata()
+    {
+        $catalogue = new MessageCatalogue('en_US');
+        $catalogue->add(array(
+            'foo' => 'bar',
+        ));
+        $catalogue->setMetadata('foo', array('notes' => array(
+            array('category'=>'state', 'content' => 'new'),
+            array('category'=>'approved', 'content' => 'true'),
+            array('category'=>'section', 'content' => 'user login', 'priority'=>'1'),
+        )));
+
+        $dumper = new XliffFileDumper();
+
+        $this->assertStringEqualsFile(
+            __DIR__.'/../fixtures/resources-notes-meta.xlf',
+            $dumper->formatCatalogue($catalogue, 'messages', array('default_locale' => 'fr_FR', 'xliff_version'=>'2.0'))
+        );
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -87,6 +87,7 @@ class XliffFileDumperTest extends TestCase
             $dumper->formatCatalogue($catalogue, 'messages', array('default_locale' => 'fr_FR'))
         );
     }
+
     public function testFormatCatalogueWithNotesMetadata()
     {
         $catalogue = new MessageCatalogue('en_US');
@@ -94,16 +95,16 @@ class XliffFileDumperTest extends TestCase
             'foo' => 'bar',
         ));
         $catalogue->setMetadata('foo', array('notes' => array(
-            array('category'=>'state', 'content' => 'new'),
-            array('category'=>'approved', 'content' => 'true'),
-            array('category'=>'section', 'content' => 'user login', 'priority'=>'1'),
+            array('category' => 'state', 'content' => 'new'),
+            array('category' => 'approved', 'content' => 'true'),
+            array('category' => 'section', 'content' => 'user login', 'priority' => '1'),
         )));
 
         $dumper = new XliffFileDumper();
 
         $this->assertStringEqualsFile(
             __DIR__.'/../fixtures/resources-notes-meta.xlf',
-            $dumper->formatCatalogue($catalogue, 'messages', array('default_locale' => 'fr_FR', 'xliff_version'=>'2.0'))
+            $dumper->formatCatalogue($catalogue, 'messages', array('default_locale' => 'fr_FR', 'xliff_version' => '2.0'))
         );
     }
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources-notes-meta.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources-notes-meta.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
+  <file id="messages.en_US">
+    <unit id="LCa0a2j">
+      <notes>
+        <note category="state">new</note>
+        <note category="approved">true</note>
+        <note category="section" priority="1">user login</note>
+      </notes>
+      <segment>
+        <source>foo</source>
+        <target>bar</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | n/a

The Xliff2.0 dumper do not dump notes. The note section is the only place (as far as I can see) you can add arbitrary data. See [specification](http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html). 

This will be useful when you want to add data like "approved", "status" etc. I can see from the test code that a previous author intends to use attributes to the <target> for such data. That is [not allowed](http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html#target), not even with a custom namespace. 

If you want to validate my test fixture, here is the validator: http://okapi-lynx.appspot.com/validation