### PR TITLE
Allow phpdocumentor/reflection-docblock 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "symfony/phpunit-bridge": "~3.2",
         "symfony/polyfill-apcu": "~1.1",
         "symfony/security-acl": "~2.8|~3.0",
-        "phpdocumentor/reflection-docblock": "^3.0",
+        "phpdocumentor/reflection-docblock": "^3.0|^4.0",
         "sensio/framework-extra-bundle": "^3.0.2"
     },
     "conflict": {

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -55,7 +55,7 @@
         "symfony/property-info": "~3.3",
         "symfony/web-link": "~3.3",
         "doctrine/annotations": "~1.0",
-        "phpdocumentor/reflection-docblock": "^3.0",
+        "phpdocumentor/reflection-docblock": "^3.0|^4.0",
         "twig/twig": "~1.34|~2.4",
         "sensio/framework-extra-bundle": "^3.0.2"
     },

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -30,7 +30,7 @@
         "symfony/serializer": "~2.8|~3.0",
         "symfony/cache": "~3.1",
         "symfony/dependency-injection": "~3.3",
-        "phpdocumentor/reflection-docblock": "^3.0",
+        "phpdocumentor/reflection-docblock": "^3.0|^4.0",
         "doctrine/annotations": "~1.0"
     },
     "conflict": {

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -28,7 +28,7 @@
         "doctrine/annotations": "~1.0",
         "symfony/dependency-injection": "~3.2",
         "doctrine/cache": "~1.0",
-        "phpdocumentor/reflection-docblock": "~3.0"
+        "phpdocumentor/reflection-docblock": "^3.0|^4.0"
     },
     "conflict": {
         "symfony/dependency-injection": "<3.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | N/A

The PHPDocumentor team bumped their reflection-docblock library to version 4 due to a breaking change that should not affect Symfony, as far as I can tell. This PR indicates compatibility with the new major version.