### PR TITLE
[DI] Fix reading env vars from fastcgi params

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
@@ -54,20 +54,17 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
 
         $value->setArguments($arguments);
 
-        if ($public = $value->isPublic()) {
-            $value->setPublic(false);
-        }
         $id = 'service_locator.'.md5(serialize($value));
 
         if ($isRoot) {
             if ($id !== $this->currentId) {
-                $this->container->setAlias($id, new Alias($this->currentId, $public));
+                $this->container->setAlias($id, new Alias($this->currentId, false));
             }
 
             return $value;
         }
 
-        $this->container->setDefinition($id, $value);
+        $this->container->setDefinition($id, $value->setPublic(false));
 
         return new Reference($id);
     }

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -429,7 +429,7 @@ class Container implements ResettableContainerInterface
      *
      * @param string $name The name of the environment variable
      *
-     * @return scalar The value to use for the provided environment variable name
+     * @return mixed The value to use for the provided environment variable name
      *
      * @throws EnvNotFoundException When the environment variable is not found and has no default value
      */
@@ -437,6 +437,9 @@ class Container implements ResettableContainerInterface
     {
         if (isset($this->envCache[$name]) || array_key_exists($name, $this->envCache)) {
             return $this->envCache[$name];
+        }
+        if (0 !== strpos($name, 'HTTP_') && isset($_SERVER[$name])) {
+            return $this->envCache[$name] = $_SERVER[$name];
         }
         if (isset($_ENV[$name])) {
             return $this->envCache[$name] = $_ENV[$name];

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 class EnvPlaceholderParameterBag extends ParameterBag
 {
     private $envPlaceholders = array();
+    private $resolveEnvReferences = false;
 
     /**
      * {@inheritdoc}
@@ -100,5 +101,30 @@ class EnvPlaceholderParameterBag extends ParameterBag
                 throw new RuntimeException(sprintf('The default value of env parameter "%s" must be scalar or null, %s given.', $env, gettype($default)));
             }
         }
+    }
+
+    /**
+     * Replaces "%env(FOO)%" references by their placeholder, keeping regular "%parameters%" references as is.
+     */
+    public function resolveEnvReferences()
+    {
+        $this->resolveEnvReferences = true;
+        try {
+            $this->resolve();
+        } finally {
+            $this->resolveEnvReferences = false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveString($value, array $resolving = array())
+    {
+        if ($this->resolveEnvReferences) {
+            return preg_replace_callback('/%%|%(env\([^%\s]+\))%/', function ($match) { return isset($match[1]) ? $this->get($match[1]) : '%%'; }, $value);
+        }
+
+        return parent::resolveString($value, $resolving);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23348
| License       | MIT
| Doc PR        | -

Values in fastcgi_param populate `$_SERVER`, never `$_ENV`.
This PR makes `$container->getEnv()` read from `$_SERVER`, excluding any vars whose name start by `HTTP_` as that would be a security issue (values injection via HTTP headers.)

Embeds a few other fixes found meanwhile.