### PR TITLE
[DI] Rererence parameter arrays when possible

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1430,6 +1430,9 @@ EOF;
     private function dumpValue($value, $interpolate = true)
     {
         if (is_array($value)) {
+            if ($value && $interpolate && false !== $param = array_search($value, $this->container->getParameterBag()->all(), true)) {
+                return $this->dumpValue("%$param%");
+            }
             $code = array();
             foreach ($value as $k => $v) {
                 $code[] = sprintf('%s => %s', $this->dumpValue($k, $interpolate), $this->dumpValue($v, $interpolate));

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -607,7 +607,7 @@ class PhpDumperTest extends TestCase
         $container->setParameter('array_1', array(123));
         $container->setParameter('array_2', array(__DIR__));
         $container->register('bar', 'BarClass')
-            ->addMethodCall('setBaz', array('%array_1%', '%array_2%', '%%array_1%%'));
+            ->addMethodCall('setBaz', array('%array_1%', '%array_2%', '%%array_1%%', array(123)));
         $container->compile();
 
         $dumper = new PhpDumper($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -75,7 +75,7 @@ class ProjectServiceContainer extends Container
     {
         $this->services['bar'] = $instance = new \BarClass();
 
-        $instance->setBaz($this->parameters['array_1'], $this->getParameter('array_2'), '%array_1%');
+        $instance->setBaz($this->parameters['array_1'], $this->getParameter('array_2'), '%array_1%', $this->parameters['array_1']);
 
         return $instance;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no (perf optim)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This a minor optim that might save memory and CPU for cases where big array parameters are inlined by DI extensions. This re-references them when possible.