### PR TITLE
[VarDumper] Fix tests with phpredis 3.1.3

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php
@@ -61,8 +61,7 @@ Redis {
 EODUMP;
         } else {
             $xCast = <<<'EODUMP'
-Redis {
-  +"socket": Redis Socket Buffer resource
+Redis {%A
   isConnected: true
   host: "127.0.0.1"
   port: 6379


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The "socket" property is gone with phpredis 3.1.3.