### PR TITLE
[Validator] Fix use of GroupSequenceProvider in child classes

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -381,6 +381,10 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
      */
     public function mergeConstraints(ClassMetadata $source)
     {
+        if ($source->isGroupSequenceProvider()) {
+            $this->setGroupSequenceProvider(true);
+        }
+
         foreach ($source->getConstraints() as $constraint) {
             $this->addConstraint(clone $constraint);
         }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/GroupSequenceProviderChildEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/GroupSequenceProviderChildEntity.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class GroupSequenceProviderChildEntity extends GroupSequenceProviderEntity
+{
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -309,13 +309,3 @@ class ClassMetadataTest extends TestCase
         $this->assertCount(0, $this->metadata->getPropertyMetadata('foo'), '->getPropertyMetadata() returns an empty collection if no metadata is configured for the given property');
     }
 }
-
-class ParentClass
-{
-    public $example = 0;
-}
-
-class ChildClass extends ParentClass
-{
-    public $example = 1;    // overrides parent property of same name
-}

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -24,6 +24,7 @@ class ClassMetadataTest extends TestCase
     const CLASSNAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
     const PARENTCLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
     const PROVIDERCLASS = 'Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderEntity';
+    const PROVIDERCHILDCLASS = 'Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderChildEntity';
 
     protected $metadata;
 
@@ -298,6 +299,17 @@ class ClassMetadataTest extends TestCase
     {
         $metadata = new ClassMetadata(self::PROVIDERCLASS);
         $metadata->setGroupSequenceProvider(true);
+        $this->assertTrue($metadata->isGroupSequenceProvider());
+    }
+
+    public function testMergeConstraintsMergesGroupSequenceProvider()
+    {
+        $parent = new ClassMetadata(self::PROVIDERCLASS);
+        $parent->setGroupSequenceProvider(true);
+
+        $metadata = new ClassMetadata(self::PROVIDERCHILDCLASS);
+        $metadata->mergeConstraints($parent);
+
         $this->assertTrue($metadata->isGroupSequenceProvider());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | not in real cases
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

For example validation of doctrine proxy objects fails.
