### PR TITLE
Add .gitattributes files

### DIFF
--- a/src/Symfony/Bridge/Doctrine/.gitattributes
+++ b/src/Symfony/Bridge/Doctrine/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bridge/Monolog/.gitattributes
+++ b/src/Symfony/Bridge/Monolog/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bridge/PhpUnit/.gitattributes
+++ b/src/Symfony/Bridge/PhpUnit/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bridge/ProxyManager/.gitattributes
+++ b/src/Symfony/Bridge/ProxyManager/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bridge/Twig/.gitattributes
+++ b/src/Symfony/Bridge/Twig/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bundle/DebugBundle/.gitattributes
+++ b/src/Symfony/Bundle/DebugBundle/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bundle/FrameworkBundle/.gitattributes
+++ b/src/Symfony/Bundle/FrameworkBundle/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bundle/SecurityBundle/.gitattributes
+++ b/src/Symfony/Bundle/SecurityBundle/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bundle/TwigBundle/.gitattributes
+++ b/src/Symfony/Bundle/TwigBundle/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
+++ b/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Bundle/WebServerBundle/.gitattributes
+++ b/src/Symfony/Bundle/WebServerBundle/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Asset/.gitattributes
+++ b/src/Symfony/Component/Asset/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/BrowserKit/.gitattributes
+++ b/src/Symfony/Component/BrowserKit/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Cache/.gitattributes
+++ b/src/Symfony/Component/Cache/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Config/.gitattributes
+++ b/src/Symfony/Component/Config/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Console/.gitattributes
+++ b/src/Symfony/Component/Console/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/CssSelector/.gitattributes
+++ b/src/Symfony/Component/CssSelector/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Debug/.gitattributes
+++ b/src/Symfony/Component/Debug/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/DependencyInjection/.gitattributes
+++ b/src/Symfony/Component/DependencyInjection/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/DomCrawler/.gitattributes
+++ b/src/Symfony/Component/DomCrawler/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Dotenv/.gitattributes
+++ b/src/Symfony/Component/Dotenv/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/EventDispatcher/.gitattributes
+++ b/src/Symfony/Component/EventDispatcher/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/ExpressionLanguage/.gitattributes
+++ b/src/Symfony/Component/ExpressionLanguage/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Filesystem/.gitattributes
+++ b/src/Symfony/Component/Filesystem/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Finder/.gitattributes
+++ b/src/Symfony/Component/Finder/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Form/.gitattributes
+++ b/src/Symfony/Component/Form/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/HttpFoundation/.gitattributes
+++ b/src/Symfony/Component/HttpFoundation/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/HttpKernel/.gitattributes
+++ b/src/Symfony/Component/HttpKernel/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Inflector/.gitattributes
+++ b/src/Symfony/Component/Inflector/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Intl/.gitattributes
+++ b/src/Symfony/Component/Intl/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Ldap/.gitattributes
+++ b/src/Symfony/Component/Ldap/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Lock/.gitattributes
+++ b/src/Symfony/Component/Lock/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/OptionsResolver/.gitattributes
+++ b/src/Symfony/Component/OptionsResolver/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Process/.gitattributes
+++ b/src/Symfony/Component/Process/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/PropertyAccess/.gitattributes
+++ b/src/Symfony/Component/PropertyAccess/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/PropertyInfo/.gitattributes
+++ b/src/Symfony/Component/PropertyInfo/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Routing/.gitattributes
+++ b/src/Symfony/Component/Routing/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Security/.gitattributes
+++ b/src/Symfony/Component/Security/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Security/Core/.gitattributes
+++ b/src/Symfony/Component/Security/Core/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Security/Csrf/.gitattributes
+++ b/src/Symfony/Component/Security/Csrf/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Security/Guard/.gitattributes
+++ b/src/Symfony/Component/Security/Guard/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Security/Http/.gitattributes
+++ b/src/Symfony/Component/Security/Http/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Serializer/.gitattributes
+++ b/src/Symfony/Component/Serializer/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Stopwatch/.gitattributes
+++ b/src/Symfony/Component/Stopwatch/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Templating/.gitattributes
+++ b/src/Symfony/Component/Templating/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Translation/.gitattributes
+++ b/src/Symfony/Component/Translation/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Validator/.gitattributes
+++ b/src/Symfony/Component/Validator/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/VarDumper/.gitattributes
+++ b/src/Symfony/Component/VarDumper/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/WebLink/.gitattributes
+++ b/src/Symfony/Component/WebLink/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Workflow/.gitattributes
+++ b/src/Symfony/Component/Workflow/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore

--- a/src/Symfony/Component/Yaml/.gitattributes
+++ b/src/Symfony/Component/Yaml/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+Tests export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When installing a Symfony package by composer all the tests for the package are downloaded as well. This is a problem because all the test classes are needlessly suggested by IDE. These files can be excluded from the download using export-ignore in .gitattributes files. Of course it only works for tagged releases as long as `--prefer-source` is not used.

This will of course exclude tests from ZIP downloads here on GitHub as well. I don't see a problem with that though.

I can rebase to 3.4 if you want.

Failed test seems unrelated.