### PR TITLE
[FrameworkBundle] Add soft conflict rule of "cache:clear" + HttpKernel 3.4

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Finder\Finder;
 
@@ -55,6 +56,10 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);
+
+        if (Kernel::VERSION_ID >= 30400) {
+            throw new \LogicException('The "cache:clear" command in Symfony 3.3 is incompatible with HttpKernel 3.4, please upgrade "symfony/framework-bundle" or downgrade "symfony/http-kernel".');
+        }
 
         $realCacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
         // the old cache dir name must not be longer than the real one to avoid exceeding

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\Kernel;
 
 class CacheClearCommandTest extends TestCase
 {
@@ -48,6 +49,17 @@ class CacheClearCommandTest extends TestCase
         $input = new ArrayInput(array('cache:clear'));
         $application = new Application($this->kernel);
         $application->setCatchExceptions(false);
+
+        if (Kernel::VERSION_ID >= 30400) {
+            $expectedMsg = 'The "cache:clear" command in Symfony 3.3 is incompatible with HttpKernel 3.4, please upgrade "symfony/framework-bundle" or downgrade "symfony/http-kernel".';
+
+            if (method_exists($this, 'expectException')) {
+                $this->expectException(\LogicException::class);
+                $this->expectExceptionMessage($expectedMsg);
+            } else {
+                $this->setExpectedException(\LogicException::class, $expectedMsg);
+            }
+        }
 
         $application->doRun($input, new NullOutput());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Current tests on branch 3.3 fail because the "cache:clear" command relies on internal details that did change in HttpKernel 3.4.
I propose to add this soft conflict logic to warn users about it.
I prefer doing so than adding a real conflict in composer.json because that would prevent us from testing other features across versions.