### PR TITLE
[Console] Require PHP 7 for ApplicationTest

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1040,6 +1040,9 @@ class ApplicationTest extends TestCase
         $this->assertContains('before.error.after.', $tester->getDisplay());
     }
 
+    /**
+     * @requires PHP 7
+     */
     public function testRunWithError()
     {
         $application = new Application();
@@ -1160,6 +1163,7 @@ class ApplicationTest extends TestCase
     }
 
     /**
+     * @requires PHP 7
      * @expectedException        \LogicException
      * @expectedExceptionMessage error
      */
@@ -1181,6 +1185,9 @@ class ApplicationTest extends TestCase
         $this->assertContains('before.dym.error.after.', $tester->getDisplay(), 'The PHP Error did not dispached events');
     }
 
+    /**
+     * @requires PHP 7
+     */
     public function testRunDispatchesAllEventsWithError()
     {
         $application = new Application();
@@ -1198,6 +1205,9 @@ class ApplicationTest extends TestCase
         $this->assertContains('before.dym.error.after.', $tester->getDisplay(), 'The PHP Error did not dispached events');
     }
 
+    /**
+     * @requires PHP 7
+     */
     public function testRunWithErrorFailingStatusCode()
     {
         $application = new Application();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!--highly recommended for new features-->

Since [ApplicationTest](https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Console/Tests/ApplicationTest.php) uses the `Error` class, this component should require-dev `symfony/polyfill-php70`
