### PR TITLE
Remove some sf2 references

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
@@ -24,7 +24,7 @@
 
         var noop = function() {};
 
-        var profilerStorageKey = 'sf2/profiler/';
+        var profilerStorageKey = 'symfony/profiler/';
 
         var request = function(url, onSuccess, onError, payload, options) {
             var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -24,7 +24,7 @@
 
         var noop = function() {};
 
-        var profilerStorageKey = 'sf2/profiler/';
+        var profilerStorageKey = 'symfony/profiler/';
 
         var request = function(url, onSuccess, onError, payload, options) {
             var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -597,7 +597,7 @@ class XmlFileLoader extends FileLoader
         foreach ($schemaLocations as $namespace => $location) {
             $parts = explode('/', $location);
             if (0 === stripos($location, 'phar://')) {
-                $tmpfile = tempnam(sys_get_temp_dir(), 'sf2');
+                $tmpfile = tempnam(sys_get_temp_dir(), 'symfony');
                 if ($tmpfile) {
                     copy($location, $tmpfile);
                     $tmpfiles[] = $tmpfile;

--- a/src/Symfony/Component/HttpFoundation/Session/Flash/AutoExpireFlashBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/AutoExpireFlashBag.php
@@ -39,7 +39,7 @@ class AutoExpireFlashBag implements FlashBagInterface
      *
      * @param string $storageKey The key used to store flashes in the session
      */
-    public function __construct($storageKey = '_sf2_flashes')
+    public function __construct($storageKey = '_symfony_flashes')
     {
         $this->storageKey = $storageKey;
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBag.php
@@ -39,7 +39,7 @@ class FlashBag implements FlashBagInterface
      *
      * @param string $storageKey The key used to store flashes in the session
      */
-    public function __construct($storageKey = '_sf2_flashes')
+    public function __construct($storageKey = '_symfony_flashes')
     {
         $this->storageKey = $storageKey;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
@@ -62,7 +62,7 @@ class AutoExpireFlashBagTest extends TestCase
 
     public function testGetStorageKey()
     {
-        $this->assertEquals('_sf2_flashes', $this->bag->getStorageKey());
+        $this->assertEquals('_symfony_flashes', $this->bag->getStorageKey());
         $attributeBag = new FlashBag('test');
         $this->assertEquals('test', $attributeBag->getStorageKey());
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -57,7 +57,7 @@ class FlashBagTest extends TestCase
 
     public function testGetStorageKey()
     {
-        $this->assertEquals('_sf2_flashes', $this->bag->getStorageKey());
+        $this->assertEquals('_symfony_flashes', $this->bag->getStorageKey());
         $attributeBag = new FlashBag('test');
         $this->assertEquals('test', $attributeBag->getStorageKey());
     }

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -222,7 +222,7 @@ class XliffFileLoader implements LoaderInterface
         $newPath = str_replace('\\', '/', __DIR__).'/schema/dic/xliff-core/xml.xsd';
         $parts = explode('/', $newPath);
         if (0 === stripos($newPath, 'phar://')) {
-            $tmpfile = tempnam(sys_get_temp_dir(), 'sf2');
+            $tmpfile = tempnam(sys_get_temp_dir(), 'symfony');
             if ($tmpfile) {
                 copy($newPath, $tmpfile);
                 $parts = explode('/', str_replace('\\', '/', $tmpfile));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Those `sf2` references can be safely remove and changed to `symfony` as there are internal or they don't break anything when upgrading Symfony's version:

* Flashes are ephemeral, so changing the key in the session is not a problem;
* Changing the local storage key for the profiler is not an issue as this is a dev tool.

