### PR TITLE
[Translation] Adding the ability do load <notes> in xliff2.0

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -11,7 +11,7 @@ CHANGELOG
  * Improved Xliff 2.0 loader to load <notes> section.
  * Added `TranslationWriterInterface`
  * Deprecated `TranslationWriter::writeTranslations` in favor of `TranslationWriter::write`
- 
+
 3.2.0
 -----
 

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -8,9 +8,10 @@ CHANGELOG
  * Added `TranslationExtractorPass`
  * Added `TranslatorPass`
  * Added <notes> section to the Xliff 2.0 dumper.
+ * Improved Xliff 2.0 loader to load <notes> section.
  * Added `TranslationWriterInterface`
  * Deprecated `TranslationWriter::writeTranslations` in favor of `TranslationWriter::write`
-
+ 
 3.2.0
 -----
 

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -146,16 +146,16 @@ class XliffFileLoader implements LoaderInterface
             }
 
             if (isset($unit->notes)) {
-                $metadata['notes'] = [];
+                $metadata['notes'] = array();
                 foreach ($unit->notes->note as $noteNode) {
-                    $note = [];
+                    $note = array();
                     foreach ($noteNode->attributes() as $key => $value) {
                         $note[$key] = (string) $value;
                     }
                     $note['content'] = (string) $noteNode;
                     $metadata['notes'][] = $note;
                 }
-             }
+            }
 
             $catalogue->setMetadata((string) $source, $metadata, $domain);
         }

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -127,7 +127,8 @@ class XliffFileLoader implements LoaderInterface
 
         $xml->registerXPathNamespace('xliff', 'urn:oasis:names:tc:xliff:document:2.0');
 
-        foreach ($xml->xpath('//xliff:unit/xliff:segment') as $segment) {
+        foreach ($xml->xpath('//xliff:unit') as $unit) {
+            $segment = $unit->segment;
             $source = $segment->source;
 
             // If the xlf file has another encoding specified, try to convert it because
@@ -143,6 +144,18 @@ class XliffFileLoader implements LoaderInterface
                     $metadata['target-attributes'][$key] = (string) $value;
                 }
             }
+
+            if (isset($unit->notes)) {
+                $metadata['notes'] = [];
+                foreach ($unit->notes->note as $noteNode) {
+                    $note = [];
+                    foreach ($noteNode->attributes() as $key => $value) {
+                        $note[$key] = (string) $value;
+                    }
+                    $note['content'] = (string) $noteNode;
+                    $metadata['notes'][] = $note;
+                }
+             }
 
             $catalogue->setMetadata((string) $source, $metadata, $domain);
         }

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -93,11 +93,16 @@ class XliffFileDumperTest extends TestCase
         $catalogue = new MessageCatalogue('en_US');
         $catalogue->add(array(
             'foo' => 'bar',
+            'baz' => 'biz',
         ));
         $catalogue->setMetadata('foo', array('notes' => array(
             array('category' => 'state', 'content' => 'new'),
             array('category' => 'approved', 'content' => 'true'),
             array('category' => 'section', 'content' => 'user login', 'priority' => '1'),
+        )));
+        $catalogue->setMetadata('baz', array('notes' => array(
+            array('id' => 'x', 'content' => 'x_content'),
+            array('appliesTo' => 'target', 'category'=>'quality', 'content' => 'Fuzzy'),
         )));
 
         $dumper = new XliffFileDumper();

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -102,7 +102,7 @@ class XliffFileDumperTest extends TestCase
         )));
         $catalogue->setMetadata('baz', array('notes' => array(
             array('id' => 'x', 'content' => 'x_content'),
-            array('appliesTo' => 'target', 'category'=>'quality', 'content' => 'Fuzzy'),
+            array('appliesTo' => 'target', 'category' => 'quality', 'content' => 'Fuzzy'),
         )));
 
         $dumper = new XliffFileDumper();

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -188,4 +188,30 @@ class XliffFileLoaderTest extends TestCase
         // target attributes
         $this->assertEquals(array('target-attributes' => array('order' => 1)), $catalogue->getMetadata('bar', 'domain1'));
     }
+
+    public function testLoadVersion2WithNoteMeta()
+    {
+        $loader = new XliffFileLoader();
+        $resource =  __DIR__.'/../fixtures/resources-notes-meta.xlf';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals('en', $catalogue->getLocale());
+        $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
+        $this->assertSame(array(), libxml_get_errors());
+
+        $this->assertTrue($catalogue->defines('foo'));
+        $metadata = $catalogue->getMetadata('foo');
+        $this->assertNotEmpty($metadata);
+        $this->assertCount(3, $metadata['notes']);
+
+        $this->assertEquals('state', $metadata['notes'][0]['category']);
+        $this->assertEquals('new', $metadata['notes'][0]['content']);
+
+        $this->assertEquals('approved', $metadata['notes'][1]['category']);
+        $this->assertEquals('true', $metadata['notes'][1]['content']);
+
+        $this->assertEquals('section', $metadata['notes'][2]['category']);
+        $this->assertEquals('1', $metadata['notes'][2]['priority']);
+        $this->assertEquals('user login', $metadata['notes'][2]['content']);
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -192,15 +192,16 @@ class XliffFileLoaderTest extends TestCase
     public function testLoadVersion2WithNoteMeta()
     {
         $loader = new XliffFileLoader();
-        $resource =  __DIR__.'/../fixtures/resources-notes-meta.xlf';
+        $resource = __DIR__.'/../fixtures/resources-notes-meta.xlf';
         $catalogue = $loader->load($resource, 'en', 'domain1');
 
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
         $this->assertSame(array(), libxml_get_errors());
 
-        $this->assertTrue($catalogue->defines('foo'));
-        $metadata = $catalogue->getMetadata('foo');
+        // test for "foo" metadata
+        $this->assertTrue($catalogue->defines('foo', 'domain1'));
+        $metadata = $catalogue->getMetadata('foo', 'domain1');
         $this->assertNotEmpty($metadata);
         $this->assertCount(3, $metadata['notes']);
 
@@ -213,5 +214,18 @@ class XliffFileLoaderTest extends TestCase
         $this->assertEquals('section', $metadata['notes'][2]['category']);
         $this->assertEquals('1', $metadata['notes'][2]['priority']);
         $this->assertEquals('user login', $metadata['notes'][2]['content']);
+
+        // test for "baz" metadata
+        $this->assertTrue($catalogue->defines('baz', 'domain1'));
+        $metadata = $catalogue->getMetadata('baz', 'domain1');
+        $this->assertNotEmpty($metadata);
+        $this->assertCount(2, $metadata['notes']);
+
+        $this->assertEquals('x', $metadata['notes'][0]['id']);
+        $this->assertEquals('x_content', $metadata['notes'][0]['content']);
+
+        $this->assertEquals('target', $metadata['notes'][1]['appliesTo']);
+        $this->assertEquals('quality', $metadata['notes'][1]['category']);
+        $this->assertEquals('Fuzzy', $metadata['notes'][1]['content']);
     }
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources-notes-meta.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources-notes-meta.xlf
@@ -12,5 +12,15 @@
         <target>bar</target>
       </segment>
     </unit>
+    <unit id="uqWglk0">
+      <notes>
+        <note id="x">x_content</note>
+        <note appliesTo="target" category="quality">Fuzzy</note>
+      </notes>
+      <segment>
+        <source>baz</source>
+        <target>biz</target>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | ~~~~yes~~~ no (sorry)
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Since #23890 we can dump `<notes>`. We should also have the ability to load them back. 