### PR TITLE
[Dotenv] Get env using $_SERVER to work with fastcgi_param and workaround thread safety issues

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -438,13 +438,13 @@ class Container implements ResettableContainerInterface
         if (isset($this->envCache[$name]) || array_key_exists($name, $this->envCache)) {
             return $this->envCache[$name];
         }
-        if (0 !== strpos($name, 'HTTP_') && isset($_SERVER[$name])) {
+        if (isset($_SERVER[$name]) && 0 !== strpos($name, 'HTTP_')) {
             return $this->envCache[$name] = $_SERVER[$name];
         }
         if (isset($_ENV[$name])) {
             return $this->envCache[$name] = $_ENV[$name];
         }
-        if (false !== $env = getenv($name)) {
+        if (false !== ($env = getenv($name)) && null !== $env) { // null is a possible value because of thread safety issues
             return $this->envCache[$name] = $env;
         }
         if (!$this->hasParameter("env($name)")) {

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -208,11 +208,24 @@ class DotenvTest extends TestCase
     public function testEnvVarIsNotOverriden()
     {
         putenv('TEST_ENV_VAR=original_value');
+        $_SERVER['TEST_ENV_VAR'] = 'original_value';
 
         $dotenv = new DotEnv();
         $dotenv->populate(array('TEST_ENV_VAR' => 'new_value'));
 
         $this->assertSame('original_value', getenv('TEST_ENV_VAR'));
+    }
+
+    public function testHttpVarIsPartiallyOverriden()
+    {
+        $_SERVER['HTTP_TEST_ENV_VAR'] = 'http_value';
+
+        $dotenv = new DotEnv();
+        $dotenv->populate(array('HTTP_TEST_ENV_VAR' => 'env_value'));
+
+        $this->assertSame('env_value', getenv('HTTP_TEST_ENV_VAR'));
+        $this->assertSame('env_value', $_ENV['HTTP_TEST_ENV_VAR']);
+        $this->assertSame('http_value', $_SERVER['HTTP_TEST_ENV_VAR']);
     }
 
     public function testMemorizingLoadedVarsNamesInSpecialVar()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23502
| License       | MIT
| Doc PR        | -

`getenv()` is not thread safe, and doesn't work with `fastcgi_param`, see links in linked issue.