### PR TITLE
[Lock] Fix race condition in tests between cache and lock component

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -41,7 +41,6 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
 
     public static function tearDownAfterClass()
     {
-        self::$redis->flushDB();
         self::$redis = null;
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
@@ -21,7 +21,6 @@ class PredisClusterAdapterTest extends AbstractRedisAdapterTest
 
     public static function tearDownAfterClass()
     {
-        self::$redis->getConnection()->getConnectionByKey('foo')->executeCommand(self::$redis->createCommand('FLUSHDB'));
         self::$redis = null;
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
@@ -41,7 +41,6 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
 
     public static function tearDownAfterClass()
     {
-        self::$redis->flushDB();
         self::$redis = null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Currently trying to fix
* [x] php 5.5 in testSaveWithDifferentResources "Failed asserting that false is true"
* [x] php 5.5 in testSaveWithDifferentKeysOnSameResources "The store shouldn't save the second key"

Workflow:
* [x] find a reproducer
* [x] fix memcached tests => #23969
* [x] fix redis tests => this PR