### PR TITLE
Make AbstractTrait::getId and $namespace protected.

### DIFF
--- a/src/Symfony/Component/Cache/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractTrait.php
@@ -23,7 +23,7 @@ trait AbstractTrait
 {
     use LoggerAwareTrait;
 
-    private $namespace;
+    protected $namespace;
     private $deferred = array();
 
     /**
@@ -185,7 +185,7 @@ trait AbstractTrait
         }
     }
 
-    private function getId($key)
+    protected function getId($key)
     {
         CacheItem::validateKey($key);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR allows to extend the getId-method of the caching classes.

Use case: Incrementing the namespace upon a clear()-call instead of flushing all cache instances with all namespaces (e.g. with Memcached).