### PR TITLE
[Cache] Fix >30 days expirations with Memcached

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -45,6 +45,26 @@ abstract class AdapterTestCase extends CachePoolTest
         $this->assertFalse($item->isHit());
     }
 
+    public function testExpiration()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $cache = $this->createCachePool();
+        $cache->save($cache->getItem('k1')->set('v1')->expiresAfter(2));
+        $cache->save($cache->getItem('k2')->set('v2')->expiresAfter(366 * 86400));
+
+        sleep(3);
+        $item = $cache->getItem('k1');
+        $this->assertFalse($item->isHit());
+        $this->assertNull($item->get(), "Item's value must be null when isHit() is false.");
+
+        $item = $cache->getItem('k2');
+        $this->assertTrue($item->isHit());
+        $this->assertSame('v2', $item->get());
+    }
+
     public function testNotUnserializable()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 class MemcachedAdapterTest extends AdapterTestCase
 {
     protected $skippedTests = array(
-        'testExpiration' => 'Testing expiration slows down the test suite',
         'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
     );

--- a/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
+++ b/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
@@ -187,6 +187,10 @@ trait MemcachedTrait
      */
     protected function doSave(array $values, $lifetime)
     {
+        if ($lifetime && $lifetime > 30 * 86400) {
+            $lifetime += time();
+        }
+
         return $this->checkResultCode($this->client->setMulti($values, $lifetime));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As documented in https://github.com/memcached/memcached/wiki/Programming#expiration, expiration times > 30 days are considered as unix timestamps by Memcached.