### PR TITLE
[DebugBundle] fix dep issue

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 /**
  * DebugExtension.
@@ -37,8 +38,11 @@ class DebugExtension extends Extension
 
         $container->getDefinition('var_dumper.cloner')
             ->addMethodCall('setMaxItems', array($config['max_items']))
-            ->addMethodCall('setMinDepth', array($config['min_depth']))
             ->addMethodCall('setMaxString', array($config['max_string_length']));
+
+        if (method_exists(VarCloner::class, 'setMinDepth')) {
+            $container->getDefinition('var_dumper.cloner')->addMethodCall('setMinDepth', array($config['min_depth']));
+        }
 
         if (null !== $config['dump_destination']) {
             $container->getDefinition('var_dumper.cli_dumper')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

`VarCloner::setMinDepth` has been added in 3.4 but `DebugBundle` is compatible with all versions back to 2.8. Feature detection allows to keep deps as is.
