### PR TITLE
[Cache] Use options from Memcached DSN

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
+ * added using options from Memcached DSN
  * added PruneableInterface so PSR-6 or PSR-16 cache implementations can declare support for manual stale cache pruning
  * added FilesystemTrait::prune() and PhpFilesTrait::prune() implementations
  * now FilesystemAdapter, PhpFilesAdapter, FilesystemCache, and PhpFilesCache implement PruneableInterface and support

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -162,4 +162,34 @@ class MemcachedAdapterTest extends AdapterTestCase
             );
         }
     }
+
+    /**
+     * @dataProvider provideDsnWithOptions
+     */
+    public function testDsnWithOptions($dsn, array $options, array $expectedOptions)
+    {
+        $client = MemcachedAdapter::createConnection($dsn, $options);
+
+        foreach ($expectedOptions as $option => $expect) {
+            $this->assertSame($expect, $client->getOption($option));
+        }
+    }
+
+    public function provideDsnWithOptions()
+    {
+        if (!class_exists('\Memcached')) {
+            self::markTestSkipped('Extension memcached required.');
+        }
+
+        yield array(
+            'memcached://localhost:11222?retry_timeout=10',
+            array(\Memcached::OPT_RETRY_TIMEOUT => 8),
+            array(\Memcached::OPT_RETRY_TIMEOUT => 10),
+        );
+        yield array(
+            'memcached://localhost:11222?socket_recv_size=1&socket_send_size=2',
+            array(\Memcached::OPT_RETRY_TIMEOUT => 8),
+            array(\Memcached::OPT_SOCKET_RECV_SIZE => 1, \Memcached::OPT_SOCKET_SEND_SIZE => 2, \Memcached::OPT_RETRY_TIMEOUT => 8),
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23962 
| License       | MIT
| Doc PR        | -

This PR allows to pass options in cache config.
Example:
```yaml
framework:
    cache:
        app: cache.adapter.memcached
        default_memcached_provider: 'memcached://%env(MEMCACHE_HOST)%?socket_recv_size=1&socket_send_size=2'
```