### PR TITLE
[DI] Improve PSR4-based service discovery

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir1/NotAClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir1/NotAClass.php
@@ -1,0 +1,5 @@
+<?php
+
+function foo() {
+    return 'bar';
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir1/Service1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir1/Service1.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir1;
+
+class Service1
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir2/Service2.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir2/Service2.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir2;
+
+class Service2
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir3/Service3.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir3/Service3.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir3;
+
+class Service3
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component2/Dir1/Service4.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component2/Dir1/Service4.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component2\Dir1;
+
+class Service4
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component2/Dir2/Service5.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component2/Dir2/Service5.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component2\Dir2;
+
+class Service5
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_glob.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_glob.yml
@@ -1,0 +1,8 @@
+services:
+    dir1:
+        resource: ../Prototype/OtherDir/*/Dir1
+        tags: [foo]
+
+    dir2:
+        resource: ../Prototype/OtherDir/*/Dir2
+        tags: [bar]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -114,19 +114,6 @@ class FileLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Expected to find class "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\Prototype\\Bar" in file ".+" while importing services from resource "Prototype\/Sub\/\*", but it was not found\! Check the namespace prefix used with the resource/
-     */
-    public function testRegisterClassesWithBadPrefix()
-    {
-        $container = new ContainerBuilder();
-        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
-
-        // the Sub is missing from namespace prefix
-        $loader->registerClasses(new Definition(), 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\\', 'Prototype/Sub/*');
-    }
-
-    /**
      * @dataProvider getIncompatibleExcludeTests
      */
     public function testRegisterClassesWithIncompatibleExclude($resourcePattern, $excludePattern)

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -359,6 +359,34 @@ class YamlFileLoaderTest extends TestCase
         $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
     }
 
+    public function testPrototypeWithGlob()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_prototype_glob.yml');
+
+        $ids = array_keys($container->getDefinitions());
+        sort($ids);
+
+        $this->assertSame(array(
+            Prototype\OtherDir\Component1\Dir1\Service1::class,
+            Prototype\OtherDir\Component1\Dir2\Service2::class,
+            Prototype\OtherDir\Component2\Dir1\Service4::class,
+            Prototype\OtherDir\Component2\Dir2\Service5::class,
+            'service_container',
+        ), $ids);
+
+        $this->assertTrue($container->getDefinition(Prototype\OtherDir\Component1\Dir1\Service1::class)->hasTag('foo'));
+        $this->assertTrue($container->getDefinition(Prototype\OtherDir\Component2\Dir1\Service4::class)->hasTag('foo'));
+        $this->assertFalse($container->getDefinition(Prototype\OtherDir\Component1\Dir1\Service1::class)->hasTag('bar'));
+        $this->assertFalse($container->getDefinition(Prototype\OtherDir\Component2\Dir1\Service4::class)->hasTag('bar'));
+
+        $this->assertTrue($container->getDefinition(Prototype\OtherDir\Component1\Dir2\Service2::class)->hasTag('bar'));
+        $this->assertTrue($container->getDefinition(Prototype\OtherDir\Component2\Dir2\Service5::class)->hasTag('bar'));
+        $this->assertFalse($container->getDefinition(Prototype\OtherDir\Component1\Dir2\Service2::class)->hasTag('foo'));
+        $this->assertFalse($container->getDefinition(Prototype\OtherDir\Component2\Dir2\Service5::class)->hasTag('foo'));
+    }
+
     public function testDefaults()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no (?)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22397 
| License       | MIT
| Doc PR        | todo

This is an attempt to add the feature described here: https://github.com/symfony/symfony/issues/22397#issuecomment-318658235. A side effect of my implementation is the namespace is no longer required as the service id - it can be anything now... I am unsure if this is desired or could cause a BC break but all the tests pass (except one testing for an invalid namespace).

With this feature, you can now define services like this:

```yaml
services:
    command_handlers:
        resource: ../../src/Domain/*/CommandHandler
        tags: [command_handler]

    event_subscribers:
        resource: ../../src/Domain/*/EventSubscriber
        tags: [event_subscriber]
```

Let me know if you have alternative suggestions for how to implement this.

(ping @nicolas-grekas)