### PR TITLE
[Intl] Change number PHPDoc type to int|float

### DIFF
--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -355,9 +355,9 @@ class NumberFormatter
     /**
      * Format a number.
      *
-     * @param number $value The value to format
-     * @param int    $type  Type of the formatting, one of the format type constants
-     *                      Only type NumberFormatter::TYPE_DEFAULT is currently supported.
+     * @param int|float $value The value to format
+     * @param int       $type  Type of the formatting, one of the format type constants
+     *                         Only type NumberFormatter::TYPE_DEFAULT is currently supported.
      *
      * @return bool|string The formatted value or false on error
      *


### PR DESCRIPTION
While number is a valid type inside PHP internally, it's not a part of the PHPDoc standard. This causes IDEs and static analysers to raise errors on this function. The internal PHP type `number` is the same as `int|float`, this changes the type to that.

https://php.net/manual/en/language.pseudo-types.php#language.types.number
https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#keyword

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

