### PR TITLE
 CS: Removed unused variable, removed space from progressCharacter.

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -656,7 +656,7 @@ class ProgressBarTest extends TestCase
         putenv('COLUMNS=156');
 
         $bar = new ProgressBar($output = $this->getOutputStream(), 15);
-        ProgressBar::setPlaceholderFormatterDefinition('memory', function (ProgressBar $bar) {
+        ProgressBar::setPlaceholderFormatterDefinition('memory', function () {
             static $i = 0;
             $mem = 100000 * $i;
             $colors = $i++ ? '41;37' : '44;37';
@@ -666,7 +666,7 @@ class ProgressBarTest extends TestCase
         $bar->setFormat(" \033[44;37m %title:-37s% \033[0m\n %current%/%max% %bar% %percent:3s%%\n 🏁  %remaining:-10s% %memory:37s%");
         $bar->setBarCharacter($done = "\033[32m●\033[0m");
         $bar->setEmptyBarCharacter($empty = "\033[31m●\033[0m");
-        $bar->setProgressCharacter($progress = "\033[32m➤ \033[0m");
+        $bar->setProgressCharacter($progress = "\033[32m➤\033[0m");
 
         $bar->setMessage('Starting the demo... fingers crossed', 'title');
         $bar->start();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | /no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Symfony/Component/Console/Tests/Helper/ProgressBarTest

`$bar->setProgressCharacter($progress = "\033[32m➤ \033[0m");`

The space between ➤ and backslash lead to this ex:
`[Symfony\Component\Debug\Exception\ContextErrorException]`
Warning: str_repeat(): Second argument has to be greater than or equal to 0.
