### PR TITLE
[Debug] Remove false-positive check in DebugClassLoader

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -26,6 +26,7 @@ class DebugClassLoader
 {
     private $classLoader;
     private $isFinder;
+    private $loaded = array();
     private $wasFinder;
     private static $caseCheck;
     private static $deprecated = array();
@@ -164,9 +165,10 @@ class DebugClassLoader
         ErrorHandler::stackErrors();
 
         try {
-            if ($this->isFinder) {
+            if ($this->isFinder && !isset($this->loaded[$class])) {
+                $this->loaded[$class] = true;
                 if ($file = $this->classLoader[0]->findFile($class)) {
-                    require_once $file;
+                    require $file;
                 }
             } else {
                 call_user_func($this->classLoader, $class);

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -59,6 +59,23 @@ class DebugClassLoaderTest extends TestCase
         $this->fail('DebugClassLoader did not register');
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage boo
+     */
+    public function testThrowingClass()
+    {
+        try {
+            class_exists(__NAMESPACE__.'\Fixtures\Throwing');
+            $this->fail('Exception expected');
+        } catch (\Exception $e) {
+            $this->assertSame('boo', $e->getMessage());
+        }
+
+        // the second call also should throw
+        class_exists(__NAMESPACE__.'\Fixtures\Throwing');
+    }
+
     public function testUnsilencing()
     {
         if (\PHP_VERSION_ID >= 70000) {
@@ -128,6 +145,7 @@ class DebugClassLoaderTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionMessage Case mismatch between loaded and declared class names
      */
     public function testNameCaseMismatch()
     {
@@ -149,6 +167,7 @@ class DebugClassLoaderTest extends TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionMessage Case mismatch between loaded and declared class names
      */
     public function testPsr4CaseMismatch()
     {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/Throwing.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/Throwing.php
@@ -1,0 +1,3 @@
+<?php
+
+throw new \Exception('boo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23977
| License       | MIT
| Doc PR        | -

In some edge case situations, DebugClassLoader generates false-positives (see linked issue, ping @gharlan).