### PR TITLE
[Form] Add ability to define form theme file from form type classes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -84,5 +84,11 @@
         <service id="templating.globals" class="Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables">
             <argument type="service" id="service_container" />
         </service>
+
+        <service id="templating.form_extension.theme" class="Symfony\Component\Form\Extension\Templating\Type\FormTypeThemeExtension">
+            <argument type="service" id="templating.form.engine" />
+            <argument>.html.php</argument>
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/templating.xml
@@ -18,5 +18,11 @@
             <argument type="service" id="templating.name_parser" />
             <argument type="service" id="templating.locator" />
         </service>
+
+        <service id="templating.form_extension.twig" class="Symfony\Component\Form\Extension\Templating\Type\FormTypeThemeExtension">
+            <argument type="service" id="twig.form.engine" />
+            <argument>.html.twig</argument>
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Component/Form/Extension/Templating/TemplatingExtension.php
+++ b/src/Symfony/Component/Form/Extension/Templating/TemplatingExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Templating;
 
 use Symfony\Component\Form\AbstractExtension;
+use Symfony\Component\Form\Extension\Templating\Type\FormTypeThemeExtension;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Templating\PhpEngine;
@@ -24,10 +25,23 @@ use Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper;
  */
 class TemplatingExtension extends AbstractExtension
 {
+    /**
+     * @var TemplatingRendererEngine
+     */
+    private $templatingRendererEngine;
+
     public function __construct(PhpEngine $engine, CsrfTokenManagerInterface $csrfTokenManager = null, array $defaultThemes = array())
     {
+        $this->templatingRendererEngine = new TemplatingRendererEngine($engine, $defaultThemes);
         $engine->addHelpers(array(
-            new FormHelper(new FormRenderer(new TemplatingRendererEngine($engine, $defaultThemes), $csrfTokenManager)),
+            new FormHelper(new FormRenderer($this->templatingRendererEngine, $csrfTokenManager)),
         ));
+    }
+
+    public function getTypeExtensions($name)
+    {
+        return array(
+            new FormTypeThemeExtension($this->templatingRendererEngine, '.html.php'),
+        );
     }
 }

--- a/src/Symfony/Component/Form/Extension/Templating/Type/FormTypeThemeExtension.php
+++ b/src/Symfony/Component/Form/Extension/Templating/Type/FormTypeThemeExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Templating\Type;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormRendererEngineInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Allows to define from theme as form type option
+ * The form them is passed to rendering engine when Form::createView() is called.
+ *
+ * @author Damian Wróblewski <damianwroblewski75@gmail.com>
+ */
+class FormTypeThemeExtension extends AbstractTypeExtension
+{
+    /**
+     * @var FormRendererEngineInterface
+     */
+    private $rendererEngine;
+
+    /**
+     * @var string
+     */
+    private $extension;
+
+    public function __construct(FormRendererEngineInterface $rendererEngine, $extension)
+    {
+        $this->extension = $extension;
+        $this->rendererEngine = $rendererEngine;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefault('theme', null)
+            ->setDefault('theme_auto_extension', false);
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        if ($options['theme']) {
+            $theme = $options['theme'];
+            if ($options['theme_auto_extension']) {
+                $theme .= $this->extension;
+            }
+            $this->rendererEngine->setTheme($view, $theme);
+        }
+    }
+
+    public function getExtendedType()
+    {
+        return FormType::class;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Templating/Type/FormTypeThemeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Templating/Type/FormTypeThemeExtensionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Symfony\Component\Form\Tests\Extension\Templating\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Templating\Type\FormTypeThemeExtension;
+use Symfony\Component\Form\FormRendererEngineInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+/**
+ * @author Damian Wróblewski <damianwroblewski75@gmail.com>
+ */
+class FormTypeThemeExtensionTest extends TypeTestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|FormRendererEngineInterface
+     */
+    private $formRendererEngine;
+
+    /**
+     * @var string
+     */
+    private $extension;
+
+    protected function setUp()
+    {
+        $this->formRendererEngine = $this->getMockBuilder(FormRendererEngineInterface::class)->getMock();
+        $this->extension = '.html.twig';
+        parent::setUp();
+    }
+
+    public function testNoTheme()
+    {
+        $form = $this->factory->create(FormType::class);
+        $this->assertNull($form->getConfig()->getOption('theme'));
+    }
+
+    public function testWithTheme()
+    {
+        $setThemeView = null; // to make sure that setTheme receives the right form view
+        $theme = '/path/to/theme';
+        $this->formRendererEngine->expects($this->once())->method('setTheme')
+            ->with($this->isInstanceOf(FormView::class), $theme)
+            ->willReturnCallback(function ($view) use (&$setThemeView) {
+                $setThemeView = $view;
+            });
+        $form = $this->factory->create(FormType::class, null, array('theme' => $theme));
+
+        $this->assertEquals($theme, $form->getConfig()->getOption('theme'));
+
+        $view = $form->createView();
+
+        $this->assertEquals($view, $setThemeView);
+    }
+
+    public function testWithAutoExtension()
+    {
+        $setThemeView = null; // to make sure that setTheme receives the right form view
+        $theme = '/path/to/theme';
+        $this->formRendererEngine->expects($this->once())->method('setTheme')
+            ->with($this->isInstanceOf(FormView::class), $theme.$this->extension)
+            ->willReturnCallback(function ($view) use (&$setThemeView) {
+                $setThemeView = $view;
+            });
+        $form = $this->factory->create(FormType::class, null, array('theme' => $theme, 'theme_auto_extension' => true));
+
+        $this->assertEquals($theme, $form->getConfig()->getOption('theme'));
+
+        $view = $form->createView();
+
+        $this->assertEquals($view, $setThemeView);
+    }
+
+    protected function getTypeExtensions()
+    {
+        return array(new FormTypeThemeExtension($this->formRendererEngine, $this->extension));
+    }
+}


### PR DESCRIPTION
Enables ability to call:
```
public function configureOptions(OptionsResolver $resolver)
    {
      $resolver
          ->setDefault('theme', 'path/to/theme');
    }
```
on FormType class which will be equivalent to` {% form_theme form 'path/to/theme.{extension}'` where extension is `.html.twig` or `.html.php` depending on rendering engine.

Why?
1. Simplyfy definning views for specific form types.
2. Simplyfy defining form themes in case of re-usable bundles. Currently if your bundle has form types and views related to it you will have to use compiller pass to add your form theme to default themes list or leave note in docs saying to include the template somehow. By using form theme option this can be automated.

Original issue: #23070

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | will add if this feature gets accepted