### PR TITLE
[DI] Improve psr4-based service discovery (alternative implementation)

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir1/Service1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir1/Service1.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir1;
+
+class Service1
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir2/Service2.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir2/Service2.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir2;
+
+class Service2
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir3/Service3.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component1/Dir3/Service3.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir3;
+
+class Service3
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component2/Dir1/Service4.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component2/Dir1/Service4.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component2\Dir1;
+
+class Service4
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component2/Dir2/Service5.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/OtherDir/Component2/Dir2/Service5.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component2\Dir2;
+
+class Service5
+{
+
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_namespace.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_namespace.yml
@@ -1,0 +1,10 @@
+services:
+    dir1:
+        namespace: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\
+        resource: ../Prototype/OtherDir/*/Dir1
+        tags: [foo]
+
+    dir2:
+        namespace: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\
+        resource: ../Prototype/OtherDir/*/Dir2
+        tags: [bar]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_namespace_without_resource.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_namespace_without_resource.yml
@@ -1,0 +1,4 @@
+services:
+    dir1:
+        namespace: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\
+        tags: [foo]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -390,6 +390,45 @@ class YamlFileLoaderTest extends TestCase
         $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
     }
 
+    public function testPrototypeWithNamespace()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_prototype_namespace.yml');
+
+        $ids = array_keys($container->getDefinitions());
+        sort($ids);
+
+        $this->assertSame(array(
+            Prototype\OtherDir\Component1\Dir1\Service1::class,
+            Prototype\OtherDir\Component1\Dir2\Service2::class,
+            Prototype\OtherDir\Component2\Dir1\Service4::class,
+            Prototype\OtherDir\Component2\Dir2\Service5::class,
+            'service_container',
+        ), $ids);
+
+        $this->assertTrue($container->getDefinition(Prototype\OtherDir\Component1\Dir1\Service1::class)->hasTag('foo'));
+        $this->assertTrue($container->getDefinition(Prototype\OtherDir\Component2\Dir1\Service4::class)->hasTag('foo'));
+        $this->assertFalse($container->getDefinition(Prototype\OtherDir\Component1\Dir1\Service1::class)->hasTag('bar'));
+        $this->assertFalse($container->getDefinition(Prototype\OtherDir\Component2\Dir1\Service4::class)->hasTag('bar'));
+
+        $this->assertTrue($container->getDefinition(Prototype\OtherDir\Component1\Dir2\Service2::class)->hasTag('bar'));
+        $this->assertTrue($container->getDefinition(Prototype\OtherDir\Component2\Dir2\Service5::class)->hasTag('bar'));
+        $this->assertFalse($container->getDefinition(Prototype\OtherDir\Component1\Dir2\Service2::class)->hasTag('foo'));
+        $this->assertFalse($container->getDefinition(Prototype\OtherDir\Component2\Dir2\Service5::class)->hasTag('foo'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp /A "resource" attribute must be set when the "namespace" attribute is set for service ".+" in .+/
+     */
+    public function testPrototypeWithNamespaceAndNoResource()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_prototype_namespace_without_resource.yml');
+    }
+
     public function testDefaults()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22397 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/8310

This is an alternative to #23986. It is simpler and doesn't require a second glob in the service id. This adds a `namespace` option. It is optional and if it isn't used, then it falls back to using the service id (current behaviour).

As stof mentions in https://github.com/symfony/symfony/issues/22397#issuecomment-324972955, it is consistent with the xml loader.

With this feature, you can define your services like this:

```yaml
services:
    command_handlers:
        namespace: App\Domain\
        resource: ../../src/Domain/*/CommandHandler
        tags: [command_handler]

    event_subscribers:
        namespace: App\Domain\
        resource: ../../src/Domain/*/EventSubscriber
        tags: [event_subscriber]
```

ping @stof, @nicolas-grekas 