### PR TITLE
[Translation] Adding ReplaceOperation

### DIFF
--- a/src/Symfony/Component/Translation/Catalogue/ReplaceOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/ReplaceOperation.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Catalogue;
+
+use Symfony\Component\Translation\MetadataAwareInterface;
+
+/**
+ * This will merge and replace all values in $target with values from $source.
+ * It is the equivalent of running array_merge($target, $source). When in conflict,
+ * always take values from $source.
+ *
+ * This operation is metadata aware. It will do the same recursive merge on metadata.
+ *
+ * all = source ∪ target = {x: x ∈ source ∨ x ∈ target}
+ * new = all ∖ target = {x: x ∈ source ∧ x ∉ target}
+ * obsolete = target ∖ all = {x: x ∈ target ∧ x ∉ source}
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class ReplaceOperation extends AbstractOperation
+{
+    protected function processDomain($domain)
+    {
+        $this->messages[$domain] = array(
+            'all' => array(),
+            'new' => array(),
+            'obsolete' => array(),
+        );
+        $sourceMessages = $this->source->all($domain);
+
+        foreach ($this->target->all($domain) as $id => $message) {
+            $this->messages[$domain]['all'][$id] = $message;
+
+            // If $id is NOT defined in source.
+            if (!array_key_exists($id, $sourceMessages)) {
+                $this->messages[$domain]['obsolete'][$id] = $message;
+            }
+        }
+
+        foreach ($sourceMessages as $id => $message) {
+            if (!empty($message)) {
+                $this->messages[$domain]['all'][$id] = $message;
+            }
+
+            if (!$this->target->has($id, $domain)) {
+                $this->messages[$domain]['new'][$id] = $message;
+
+                // Make sure to add it to the source if even if empty($message)
+                $this->messages[$domain]['all'][$id] = $message;
+            }
+        }
+
+        $this->result->add($this->messages[$domain]['all'], $domain);
+
+        $targetMetadata = $this->target instanceof MetadataAwareInterface ? $this->target->getMetadata('', $domain) : array();
+        $sourceMetadata = $this->source instanceof MetadataAwareInterface ? $this->source->getMetadata('', $domain) : array();
+        $resultMetadata = $this->mergeMetaData($sourceMetadata, $targetMetadata);
+
+        // Write back metadata
+        foreach ($resultMetadata as $id => $data) {
+            $this->result->setMetadata($id, $data, $domain);
+        }
+    }
+
+    /**
+     * @param array|null $source
+     * @param array|null $target
+     *
+     * @return array
+     */
+    private function mergeMetadata($source, $target)
+    {
+        if (empty($source) && empty($target)) {
+            return array();
+        }
+
+        if (empty($source)) {
+            return $target;
+        }
+
+        if (empty($target)) {
+            return $source;
+        }
+
+        if (!is_array($source) || !is_array($target)) {
+            return $source;
+        }
+
+        $result = $this->doMergeMetadata($source, $target);
+
+        return $result;
+    }
+
+    private function doMergeMetadata(array $source, array $target)
+    {
+        $isTargetArrayAssociative = $this->isArrayAssociative($target);
+        foreach ($target as $key => $value) {
+            if ($isTargetArrayAssociative) {
+                if (isset($source[$key]) && $source[$key] !== $value) {
+                    if (is_array($source[$key]) && is_array($value)) {
+                        // If both arrays, do recursive call
+                        $source[$key] = $this->doMergeMetadata($source[$key], $value);
+                    }
+                    // Else, use value form $source
+                } else {
+                    // Add new value
+                    $source[$key] = $value;
+                }
+                // if sequential
+            } elseif (!in_array($value, $source)) {
+                $source[] = $value;
+            }
+        }
+
+        return $source;
+    }
+
+    public function isArrayAssociative(array $arr)
+    {
+        if (array() === $arr) {
+            return false;
+        }
+
+        return array_keys($arr) !== range(0, count($arr) - 1);
+    }
+}

--- a/src/Symfony/Component/Translation/Catalogue/ReplaceOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/ReplaceOperation.php
@@ -54,7 +54,7 @@ final class ReplaceOperation extends AbstractOperation
             if (!$this->target->has($id, $domain)) {
                 $this->messages[$domain]['new'][$id] = $message;
 
-                // Make sure to add it to the source if even if empty($message)
+                // Make sure to add it to the source even if empty($message)
                 $this->messages[$domain]['all'][$id] = $message;
             }
         }
@@ -77,7 +77,7 @@ final class ReplaceOperation extends AbstractOperation
      *
      * @return array
      */
-    private function mergeMetadata($source, $target)
+    private function mergeMetadata(array $source = null, array $target = null)
     {
         if (empty($source) && empty($target)) {
             return array();

--- a/src/Symfony/Component/Translation/Catalogue/ReplaceOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/ReplaceOperation.php
@@ -22,7 +22,7 @@ use Symfony\Component\Translation\MetadataAwareInterface;
  *
  * all = source ∪ target = {x: x ∈ source ∨ x ∈ target}
  * new = all ∖ target = {x: x ∈ source ∧ x ∉ target}
- * obsolete = target ∖ all = {x: x ∈ target ∧ x ∉ source}
+ * obsolete = all ∖ source = {x: x ∈ target ∧ x ∉ source}
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */

--- a/src/Symfony/Component/Translation/Tests/Catalogue/ReplaceOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/ReplaceOperationTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Translation\Catalogue\ReplaceOperation;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 
-class ReplaceOperationTest extends MergeOperationTest
+class ReplaceOperationTest extends AbstractOperationTest
 {
     public function testGetMessagesFromSingleDomain()
     {

--- a/src/Symfony/Component/Translation/Tests/Catalogue/ReplaceOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/ReplaceOperationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Catalogue;
+
+use Symfony\Component\Translation\Catalogue\ReplaceOperation;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+class ReplaceOperationTest extends MergeOperationTest
+{
+    public function testGetMessagesFromSingleDomain()
+    {
+        $operation = $this->createOperation(
+            new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'c' => 'new_c'))),
+            new MessageCatalogue('en', array('messages' => array('a' => 'old_a', 'b' => 'old_b')))
+        );
+
+        $this->assertEquals(
+            array('a' => 'new_a', 'b' => 'old_b', 'c' => 'new_c'),
+            $operation->getMessages('messages')
+        );
+
+        $this->assertEquals(
+            array('c' => 'new_c'),
+            $operation->getNewMessages('messages')
+        );
+
+        $this->assertEquals(
+            array('b' => 'old_b'),
+            $operation->getObsoleteMessages('messages')
+        );
+    }
+
+    public function testGetResultFromSingleDomain()
+    {
+        $this->assertEquals(
+            new MessageCatalogue('en', array(
+                'messages' => array('a' => 'new_a', 'b' => 'old_b', 'c' => 'new_c'),
+            )),
+            $this->createOperation(
+                new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'c' => 'new_c'))),
+                new MessageCatalogue('en', array('messages' => array('a' => 'old_a', 'b' => 'old_b')))
+            )->getResult()
+        );
+    }
+
+    public function testGetResultWithMetadata()
+    {
+        $leftCatalogue = new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'b' => 'new_b')));
+        $leftCatalogue->setMetadata('a', 'foo', 'messages');
+        $leftCatalogue->setMetadata('b', 'bar', 'messages');
+        $rightCatalogue = new MessageCatalogue('en', array('messages' => array('b' => 'old_b', 'c' => 'old_c')));
+        $rightCatalogue->setMetadata('b', 'baz', 'messages');
+        $rightCatalogue->setMetadata('c', 'qux', 'messages');
+
+        $mergedCatalogue = new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'b' => 'new_b', 'c' => 'old_c')));
+        $mergedCatalogue->setMetadata('a', 'foo', 'messages');
+        $mergedCatalogue->setMetadata('b', 'bar', 'messages');
+        $mergedCatalogue->setMetadata('c', 'qux', 'messages');
+
+        $this->assertEquals(
+            $mergedCatalogue,
+            $this->createOperation($leftCatalogue, $rightCatalogue)->getResult()
+        );
+    }
+
+    public function testGetResultWithArrayMetadata()
+    {
+        $leftCatalogue = new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'b' => 'new_b')));
+        $notes = array(
+            array('category' => 'note1', 'content' => 'a'),
+            array('category' => 'note2', 'content' => 'b'),
+        );
+        $leftCatalogue->setMetadata('a', array('notes' => array('test')), 'messages');
+        $leftCatalogue->setMetadata('b', array('notes' => $notes, 'meta0' => 'zz', 'meta1' => 'yy'), 'messages');
+
+        $rightCatalogue = new MessageCatalogue('en', array('messages' => array('b' => 'old_b', 'c' => 'old_c')));
+        $notes = array(
+            array('category' => 'note2', 'content' => 'b'),
+            array('category' => 'note2', 'content' => 'c'),
+        );
+        $rightCatalogue->setMetadata('b', array('notes' => $notes, 'meta0' => 'aa', 'meta2' => 'xx'), 'messages');
+        $rightCatalogue->setMetadata('c', 'qux', 'messages');
+
+        $mergedCatalogue = new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'b' => 'new_b', 'c' => 'old_c')));
+        $mergedNotes = array(
+            array('category' => 'note1', 'content' => 'a'),
+            array('category' => 'note2', 'content' => 'b'),
+            array('category' => 'note2', 'content' => 'c'),
+        );
+        $mergedCatalogue->setMetadata('a', array('notes' => array('test')), 'messages');
+        $mergedCatalogue->setMetadata('b', array('notes' => $mergedNotes, 'meta0' => 'zz',  'meta1' => 'yy', 'meta2' => 'xx'), 'messages');
+        $mergedCatalogue->setMetadata('c', 'qux', 'messages');
+
+        $resultCatalogue = $this->createOperation($leftCatalogue, $rightCatalogue)->getResult();
+
+        $this->assertEquals(array('notes' => array('test')), $resultCatalogue->getMetadata('a'));
+        $this->assertEquals('qux', $resultCatalogue->getMetadata('c'));
+
+        $bMeta = $resultCatalogue->getMetadata('b');
+        $this->assertCount(4, $bMeta);
+        $this->assertEquals('zz', $bMeta['meta0']);
+        $this->assertEquals('yy', $bMeta['meta1']);
+        $this->assertEquals('xx', $bMeta['meta2']);
+        $this->assertCount(3, $bMeta['notes']);
+        foreach ($mergedNotes as $note) {
+            $this->assertContains($note, $bMeta['notes']);
+        }
+    }
+
+    public function testGetResultWithOneCatalogeWithoutMetadata()
+    {
+        $a = new MessageCatalogue('en', array('messages' => array('foo' => 'foo_a')));
+        $notes = array(
+            array('category' => 'note1', 'content' => 'a'),
+        );
+        // Only $a has metadata
+        $a->setMetadata('foo', array('notes' => $notes), 'messages');
+
+        $b = new MessageCatalogue('en', array('messages' => array('foo' => 'foo_b')));
+
+        $mergedCatalogue = new MessageCatalogue('en', array('messages' => array('foo' => 'foo_a')));
+        $mergedCatalogue->setMetadata('foo', array('notes' => $notes), 'messages');
+
+        $resultCatalogue = $this->createOperation($a, $b)->getResult();
+        $this->assertEquals($mergedCatalogue, $resultCatalogue);
+
+        // Reverse the operation
+        $mergedCatalogue = new MessageCatalogue('en', array('messages' => array('foo' => 'foo_b')));
+        $mergedCatalogue->setMetadata('foo', array('notes' => $notes), 'messages');
+
+        $resultCatalogue = $this->createOperation($b, $a)->getResult();
+        $this->assertEquals($mergedCatalogue, $resultCatalogue);
+    }
+
+    protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target)
+    {
+        return new ReplaceOperation($source, $target);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I've been looking quite a while on the MergeOperation to try to figure out the intentions and how to use it. We use it in our `TranslationUpdate` command as `new MergeOperation($currentCatalogue, $extractedCatalogue)`.

The all Operation does things with a `$source` and `$target` catalogue. The doc block for the `MergeOperation` class looks like: 

```php
/**
 * Merge operation between two catalogues as follows:
 * all = source ∪ target = {x: x ∈ source ∨ x ∈ target}
 * new = all ∖ source = {x: x ∈ target ∧ x ∉ source}
 * obsolete = source ∖ all = {x: x ∈ source ∧ x ∉ source ∧ x ∉ target} = ∅
 * Basically, the result contains messages from both catalogues.
 */
```

So a "new" key is something that exists in `$target` but not in `$source`. 
I have all my messages in `$source` and then I want to merge in just a few ones that I've stored in `$target`. (Just like we do in `TranslationUpdate` command)

```php
$source = [
  'key0'=>'trans0',
  'key1'=>'trans1',
  // ...
];

$target = [
  'key0'=>'new_trans0', // <-- Does also exist in $source
  'new_key1'=>'new_trans1',
];
```
When doing the following I get 1 new translation which is fine. 
```php
$result = (new MergeOperation($source, $target))->getNewMessages($domain);
```

However, the metadata from `$source::key0` is removed iff (math for: if and only if) `$target::key0` has metadata. That means that you cannot store data like "approved" or "state" in the metadata since they will be (randomly) deleted when running `TranslationUpdate`. 

In PHP-translation organization we have the same problem. I introduced the `ReplaceOperation`. (The name could be discussed.) See the doc block for description: 

```php
/**
 * This will merge and replace all values in $target with values from $source.
 * It is the equivalent of running array_merge($target, $source). When in conflict,
 * always take values from $source.
 *
 * This operation is metadata aware. It will do the same recursive merge on metadata.
 *
 * all = source ∪ target = {x: x ∈ source ∨ x ∈ target}
 * new = all ∖ target = {x: x ∈ source ∧ x ∉ target}
 * obsolete = all ∖ source = {x: x ∈ target ∧ x ∉ source}
 */
```


This operation will do a "metadata aware" merge. Running the `TranslationUpdate` command with 
`new ReplaceOperation($extractedCatalogue, $currentCatalogue)` you would get a new catalogue with recursive merged metadata. It will also mark some some translations as obsolete. Ie the once that exists in `$currentCatalogue` but not in `$extractedCatalogue`.

I have been investigating to simply improve the `MergeOperation` but I found no way of doing a BC way of doing it. 


FYI @jfsimon
