### PR TITLE
Fix case sensitive typo in use class name

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Symfony\Component\DependencyInjection\Parameterbag\EnvPlaceholderParameterBag;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 
 /**
  * Merges extension configs into the container builder.


### PR DESCRIPTION
closes #24001

Change is simple typo: Parameterbag = ParameterBag





| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT


Fixes this:

`
  [RuntimeException]
  An error occurred when executing the "'cache:clear --no-warmup'" command:
  Fatal error: Uncaught RuntimeException: Case mismatch between loaded and declared class names: "Symfony\Component\DependencyInjection\Parameterbag\EnvPlaceholderParameterBag" v
  s "Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag". in /Users/phil/Sites/maintain.myjoomla.com/vendor/symfony/symfony/src/Symfony/Component/Debug
  /DebugClassLoader.php:165
`
