### PR TITLE
[Cache] Use zend.detect_unicode instead of zend.multibyte

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -38,7 +38,7 @@ class PhpArrayAdapter implements AdapterInterface
     {
         $this->file = $file;
         $this->fallbackPool = $fallbackPool;
-        $this->zendMultiByte = ini_get('zend.multibyte');
+        $this->zendDetectUnicode = ini_get('zend.detect_unicode');
         $this->createCacheItem = \Closure::bind(
             function ($key, $value, $isHit) {
                 $item = new CacheItem();

--- a/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
@@ -35,6 +35,6 @@ class PhpFilesAdapter extends AbstractAdapter
 
         $e = new \Exception();
         $this->includeHandler = function () use ($e) { throw $e; };
-        $this->zendMultiByte = ini_get('zend.multibyte');
+        $this->zendDetectUnicode = ini_get('zend.detect_unicode');
     }
 }

--- a/src/Symfony/Component/Cache/Simple/PhpArrayCache.php
+++ b/src/Symfony/Component/Cache/Simple/PhpArrayCache.php
@@ -34,7 +34,7 @@ class PhpArrayCache implements CacheInterface
     {
         $this->file = $file;
         $this->fallbackPool = $fallbackPool;
-        $this->zendMultiByte = ini_get('zend.multibyte');
+        $this->zendDetectUnicode = ini_get('zend.detect_unicode');
     }
 
     /**

--- a/src/Symfony/Component/Cache/Simple/PhpFilesCache.php
+++ b/src/Symfony/Component/Cache/Simple/PhpFilesCache.php
@@ -35,6 +35,6 @@ class PhpFilesCache extends AbstractCache
 
         $e = new \Exception();
         $this->includeHandler = function () use ($e) { throw $e; };
-        $this->zendMultiByte = ini_get('zend.multibyte');
+        $this->zendDetectUnicode = ini_get('zend.detect_unicode');
     }
 }

--- a/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
@@ -25,7 +25,7 @@ trait PhpArrayTrait
     private $file;
     private $values;
     private $fallbackPool;
-    private $zendMultiByte;
+    private $zendDetectUnicode;
 
     /**
      * Store an array of cached values.
@@ -127,14 +127,14 @@ EOF;
      */
     private function initialize()
     {
-        if ($this->zendMultiByte) {
-            $zmb = ini_set('zend.multibyte', 0);
+        if ($this->zendDetectUnicode) {
+            $zmb = ini_set('zend.detect_unicode', 0);
         }
         try {
             $this->values = file_exists($this->file) ? (include $this->file ?: array()) : array();
         } finally {
-            if ($this->zendMultiByte) {
-                ini_set('zend.multibyte', $zmb);
+            if ($this->zendDetectUnicode) {
+                ini_set('zend.detect_unicode', $zmb);
             }
         }
     }

--- a/src/Symfony/Component/Cache/Traits/PhpFilesTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PhpFilesTrait.php
@@ -25,7 +25,7 @@ trait PhpFilesTrait
     use FilesystemCommonTrait;
 
     private $includeHandler;
-    private $zendMultiByte;
+    private $zendDetectUnicode;
 
     public static function isSupported()
     {
@@ -40,8 +40,8 @@ trait PhpFilesTrait
         $values = array();
         $now = time();
 
-        if ($this->zendMultiByte) {
-            $zmb = ini_set('zend.multibyte', 0);
+        if ($this->zendDetectUnicode) {
+            $zmb = ini_set('zend.detect_unicode', 0);
         }
         set_error_handler($this->includeHandler);
         try {
@@ -58,8 +58,8 @@ trait PhpFilesTrait
             }
         } finally {
             restore_error_handler();
-            if ($this->zendMultiByte) {
-                ini_set('zend.multibyte', $zmb);
+            if ($this->zendDetectUnicode) {
+                ini_set('zend.detect_unicode', $zmb);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22972, #23985
| License       | MIT
| Doc PR        | -

Verified.