### PR TITLE
[Lock] Fix some tests that require pcntl_sigwaitinfo() function

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
@@ -31,6 +31,7 @@ trait BlockingStoreTestTrait
      * This test is time sensible: the $clockDelay could be adjust.
      *
      * @requires extension pcntl
+     * @requires function pcntl_sigwaitinfo
      */
     public function testBlockingLocks()
     {
@@ -39,13 +40,6 @@ trait BlockingStoreTestTrait
 
         if (\PHP_VERSION_ID < 50600 || defined('HHVM_VERSION_ID')) {
             $this->markTestSkipped('The PHP engine does not keep resource in child forks');
-
-            return;
-        }
-
-        // this function is not available in macOS. See https://bugs.php.net/bug.php?id=70708
-        if (!function_exists('pcntl_sigwaitinfo')) {
-            $this->markTestSkipped('pcntl_sigwaitinfo() PHP function is required.');
 
             return;
         }

--- a/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
@@ -43,6 +43,13 @@ trait BlockingStoreTestTrait
             return;
         }
 
+        // this function is not available in macOS. See https://bugs.php.net/bug.php?id=70708
+        if (!function_exists('pcntl_sigwaitinfo')) {
+            $this->markTestSkipped('pcntl_sigwaitinfo() PHP function is required.');
+
+            return;
+        }
+
         /** @var StoreInterface $store */
         $store = $this->getStore();
         $key = new Key(uniqid(__METHOD__, true));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23993
| License       | MIT
| Doc PR        | -
