### PR TITLE
Try to use the APCIterator to clear the APC cache

### DIFF
--- a/src/Symfony/Component/Cache/Traits/ApcuTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ApcuTrait.php
@@ -71,9 +71,15 @@ trait ApcuTrait
      */
     protected function doClear($namespace)
     {
-        return isset($namespace[0]) && class_exists('APCuIterator', false) && ('cli' !== PHP_SAPI || ini_get('apc.enable_cli'))
-            ? apcu_delete(new \APCuIterator(sprintf('/^%s/', preg_quote($namespace, '/')), APC_ITER_KEY))
-            : apcu_clear_cache();
+        if (!isset($namespace[0]) || !('cli' !== PHP_SAPI || ini_get('apc.enable_cli'))) {
+            return apcu_clear_cache();
+        }
+
+        if (class_exists('APCuIterator', false)) {
+            return apcu_delete(new \APCuIterator(sprintf('/^%s/', preg_quote($namespace, '/')), APC_ITER_KEY));
+        }
+
+        return apcu_delete(new \APCIterator('user', sprintf('/^%s/', preg_quote($namespace, '/')), APC_ITER_KEY));
     }
 
     /**


### PR DESCRIPTION
## Follow up here : https://github.com/symfony/symfony/pull/24011

| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

**TL;DR: when APCuIterator is not available (i.e. PHP 5.6 + APCu 4.0.7), the APC cache handling is broken.**

When the app initializes one APC cache, it tries to retrieve its namespace flag key.
If the app can't retrieve its flag key, it clears its namespaced cache and adds its flag key back.
But when APCuIterator is not usable, the app flushes the whole cache each time, preventing the others APC caches to retrieve their flag key, resulting in a regular full APC cache flush.

## Deeper explanation:

During the cache warmup, `\Symfony\Component\Cache\Adapter\AbstractAdapter::createSystemCache()` is called multiple times with different namespaces, i.e:
```php
protected function getCache_SystemService()
{
    return $this->services['cache.system'] = \Symfony\Component\Cache\Adapter\AbstractAdapter::createSystemCache('42DFrsyAcq', 0, 'i6ox8pAXPv2yMq+00ATexQ', (__DIR__.'/pools'), ${($_ = isset($this->services['monolog.logger.cache']) ? $this->services['monolog.logger.cache'] : $this->get('monolog.logger.cache', ContainerInterface::NULL_ON_INVALID_REFERENCE)) && false ?: '_'});
}
```
```php
protected function getCache_AnnotationsService($lazyLoad = true)
{
    return $this->services['cache.annotations'] = \Symfony\Component\Cache\Adapter\AbstractAdapter::createSystemCache('ljDfqzQGel', 0, 'i6ox8pAXPv2yMq+00ATexQ', (__DIR__.'/pools'), ${($_ = isset($this->services['monolog.logger.cache']) ? $this->services['monolog.logger.cache'] : $this->get('monolog.logger.cache', ContainerInterface::NULL_ON_INVALID_REFERENCE)) && false ?: '_'});
}
```

but when the APCuIterator is not usable, AbstractAdapter does init the APC cache with this code:
```php
private function init($namespace, $defaultLifetime, $version)
<snip>
            if (!apcu_exists($version.'@'.$namespace)) {
                $this->doClear($namespace);
                apcu_add($version.'@'.$namespace, null);
            }
<snip>
}

protected function doClear($namespace)
{
    return isset($namespace[0]) && class_exists('APCuIterator', false) && ('cli' !== PHP_SAPI || ini_get('apc.enable_cli'))
        ? apcu_delete(new \APCuIterator(sprintf('/^%s/', preg_quote($namespace, '/')), APC_ITER_KEY))
        : apcu_clear_cache();
}
```
Here is the callstack:
```
getCache_SystemService()
- AbstractAdapter::createSystemCache('42DFrsyAcq', 0, 'i6ox8pAXPv2yMq+00ATexQ')
-- !apcu_exists('i6ox8pAXPv2yMq+00ATexQ@42DFrsyAcq')
--- apcu_clear_cache()
--- apcu_add('i6ox8pAXPv2yMq+00ATexQ@42DFrsyAcq', null);

APC cache contains :
'i6ox8pAXPv2yMq+00ATexQ@42DFrsyAcq' => null

getCache_AnnotationsService()
- AbstractAdapter::createSystemCache('ljDfqzQGel', 0, 'i6ox8pAXPv2yMq+00ATexQ')
-- !apcu_exists('i6ox8pAXPv2yMq+00ATexQ@ljDfqzQGel')
--- apcu_clear_cache()
--- apcu_add('i6ox8pAXPv2yMq+00ATexQ@ljDfqzQGel', null);

APC cache contains :
'i6ox8pAXPv2yMq+00ATexQ@ljDfqzQGel' => null
```

Resulting in a complete cache reset between the 2 calls, making every subsequent call to `apcu_exists($version.'@'.$namespace)` false, and so **making the whole APC cache completely useless**.
