### PR TITLE
[Cache] Always require symfony/polyfill-apcu to provide APCuIterator everywhere

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "psr/link": "^1.0",
         "psr/log": "~1.0",
         "psr/simple-cache": "^1.0",
+        "symfony/polyfill-apcu": "~1.1",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php56": "~1.0",
@@ -96,7 +97,6 @@
         "predis/predis": "~1.0",
         "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
         "symfony/phpunit-bridge": "~3.2",
-        "symfony/polyfill-apcu": "~1.1",
         "symfony/security-acl": "~2.8|~3.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0",
         "sensio/framework-extra-bundle": "^3.0.2"

--- a/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
@@ -77,6 +77,31 @@ class ApcuAdapterTest extends AdapterTestCase
         $this->assertNull($item->get());
     }
 
+    public function testNamespace()
+    {
+        $namespace = str_replace('\\', '.', get_class($this));
+
+        $pool1 = new ApcuAdapter($namespace.'_1', 0, 'p1');
+
+        $item = $pool1->getItem('foo');
+        $this->assertFalse($item->isHit());
+        $this->assertTrue($pool1->save($item->set('bar')));
+
+        $item = $pool1->getItem('foo');
+        $this->assertTrue($item->isHit());
+        $this->assertSame('bar', $item->get());
+
+        $pool2 = new ApcuAdapter($namespace.'_2', 0, 'p1');
+
+        $item = $pool2->getItem('foo');
+        $this->assertFalse($item->isHit());
+        $this->assertNull($item->get());
+
+        $item = $pool1->getItem('foo');
+        $this->assertTrue($item->isHit());
+        $this->assertSame('bar', $item->get());
+    }
+
     public function testWithCliSapi()
     {
         try {

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -23,7 +23,8 @@
         "php": "^5.5.9|>=7.0.8",
         "psr/cache": "~1.0",
         "psr/log": "~1.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0",
+        "symfony/polyfill-apcu": "~1.1"
     },
     "require-dev": {
         "cache/integration-tests": "dev-master",
@@ -33,9 +34,6 @@
     },
     "conflict": {
         "symfony/var-dumper": "<3.3"
-    },
-    "suggest": {
-        "symfony/polyfill-apcu": "For using ApcuAdapter on HHVM"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Cache\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

**TL;DR: when APCuIterator is not available (i.e. PHP 5.6 + APCu 4.0.7), the APC cache handling is broken.**

When [the app initializes](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml#L31) one of [the APC caches](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml#L14-L28), it tries to [retrieve its namespace flag key](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Cache/Traits/ApcuTrait.php#L42). If it can't, [it clears its namespaced cache](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Cache/Traits/ApcuTrait.php#L43) and [adds its flag key back](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Cache/Traits/ApcuTrait.php#L44).
But [when APCuIterator is not usable](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Cache/Traits/ApcuTrait.php#L74), **the app [flushes the whole cache each time](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Cache/Traits/ApcuTrait.php#L76)**, preventing all the APC caches to retrieve their own flag key, resulting in a **perpetual full APC cache flush**.


TODO:
- [x] add test => https://travis-ci.org/symfony/symfony/jobs/269383629#L3334

See https://github.com/symfony/symfony/pull/24008