### PR TITLE
[SecurityBundle] Stop delete_cookies keys from being normalized

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -264,6 +264,7 @@ class MainConfiguration implements ConfigurationInterface
                 ->fixXmlConfig('delete_cookie')
                 ->children()
                     ->arrayNode('delete_cookies')
+                        ->normalizeKeys(false)
                         ->beforeNormalization()
                             ->ifTrue(function ($v) { return is_array($v) && is_int(key($v)); })
                             ->then(function ($v) { return array_map(function ($v) { return array('name' => $v); }, $v); })

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -238,6 +238,12 @@ abstract class CompleteConfigurationTest extends TestCase
         $this->assertFalse($service->getArgument(5));
     }
 
+    public function testCookieClearingName()
+    {
+        $container = $this->getContainer('container1');
+        $this->assertArrayHasKey('cookie-name', $container->getDefinition('security.logout.handler.cookie_clearing.secure')->getArgument(0));
+    }
+
     protected function getContainer($file)
     {
         $file = $file.'.'.$this->getFileExtension();

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -70,7 +70,9 @@ $container->loadFromExtension('security', array(
             'switch_user' => true,
             'x509' => true,
             'remote_user' => true,
-            'logout' => true,
+            'logout' => array(
+                'delete_cookies' => array('cookie-name' => true),
+            ),
             'remember_me' => array('key' => 'TheKey'),
         ),
         'host' => array(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -55,7 +55,11 @@
             <switch-user />
             <x509 />
             <remote-user />
-            <logout />
+            <logout>
+                <delete-cookies>
+                    <cookie-name/>
+                </delete-cookies>
+            </logout>
             <remember-me key="TheyKey"/>
         </firewall>
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -53,7 +53,9 @@ security:
             switch_user: true
             x509: true
             remote_user: true
-            logout: true
+            logout:
+                delete_cookies:
+                    cookie-name: ~
             remember_me:
                 key: TheKey
         host:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Currently the cookie names inside `delete_cookies` are normalized, so using YAML a cookie with the name 'foo-bar' becomes 'foo_bar', and so isn't deleted.