### PR TITLE
[VarDumper] Fix segfault in period caster

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -85,7 +85,7 @@ class DateCaster
 
     public static function castPeriod(\DatePeriod $p, array $a, Stub $stub, $isNested, $filter)
     {
-        if (defined('HHVM_VERSION_ID') || \PHP_VERSION_ID < 50605) {
+        if (defined('HHVM_VERSION_ID') || \PHP_VERSION_ID < 50620 || (\PHP_VERSION_ID >= 70000 && \PHP_VERSION_ID < 70005)) { // see https://bugs.php.net/bug.php?id=71635
             return $a;
         }
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -334,7 +334,7 @@ EODUMP;
      */
     public function testCastPeriod($start, $interval, $end, $options, $xPeriod, $xDates)
     {
-        if (defined('HHVM_VERSION_ID') || \PHP_VERSION_ID < 50605) {
+        if (defined('HHVM_VERSION_ID') || \PHP_VERSION_ID < 50620 || (\PHP_VERSION_ID >= 70000 && \PHP_VERSION_ID < 70005)) {
             $this->markTestSkipped();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/23668#issuecomment-325685087
| License       | MIT
| Doc PR        | /

[This segfault](https://bugs.php.net/bug.php?id=71635) was fixed in [5.6.20](http://www.php.net/ChangeLog-5.php#5.6.20) and in [7.0.5](http://www.php.net/ChangeLog-7.php#7.0.5).

Issue in action here: https://3v4l.org/DhOdT#v565