### PR TITLE
[Security] add impersonator_user to "User was reloaded" log message

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -173,19 +173,16 @@ class ContextListener implements ListenerInterface
                 $token->setUser($refreshedUser);
 
                 if (null !== $this->logger) {
-                    $impersonatorUsername = null;
+                    $context = array('provider' => get_class($provider), 'username' => $refreshedUser->getUsername());
+
                     foreach ($token->getRoles() as $role) {
                         if ($role instanceof SwitchUserRole) {
-                            $impersonatorUsername = $role->getSource()->getUsername();
+                            $context['impersonator_username'] = $role->getSource()->getUsername();
                             break;
                         }
                     }
 
-                    $this->logger->debug('User was reloaded from a user provider.', array(
-                        'provider' => get_class($provider),
-                        'username' => $refreshedUser->getUsername(),
-                        'impersonator_username' => $impersonatorUsername,
-                    ));
+                    $this->logger->debug('User was reloaded from a user provider.', $context);
                 }
 
                 return $token;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

My main concern is this: I use the swift monolog handler to get emails for exceptions.
I would like to see the impersonator in these mails.

But I'm not sure, if this is a good place for the log message.

