### PR TITLE
[Yaml] mark some classes as final

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -203,6 +203,8 @@ Validator
 Yaml
 ----
 
+ * the `Dumper`, `Parser`, and `Yaml` classes are marked as final
+
  * using the `!php/object:` tag is deprecated and won't be supported in 4.0. Use
    the `!php/object` tag (without the colon) instead.
 

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.4.0
 -----
 
+ * the `Dumper`, `Parser`, and `Yaml` classes are marked as final
+
  * Deprecated the `!php/object:` tag which will be replaced by the
    `!php/object` tag (without the colon) in 4.0.
 

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Yaml;
  * Dumper dumps PHP variables to YAML strings.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since version 3.4
  */
 class Dumper
 {

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -18,6 +18,8 @@ use Symfony\Component\Yaml\Tag\TaggedValue;
  * Parser parses YAML strings to convert them to PHP arrays.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since version 3.4
  */
 class Parser
 {

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -17,6 +17,8 @@ use Symfony\Component\Yaml\Exception\ParseException;
  * Yaml offers convenience methods to load and dump YAML.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since version 3.4
  */
 class Yaml
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Making these classes final unlocks more scalar type hint possibilities on top of the changes proposed in #23262.