### PR TITLE
[Routing] Add the possibility to define a prefix for all routes of a controller

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
+ * Added the possibility to define a prefix for all routes of a controller via @Route(name="prefix_")
  * Added support for prioritized routing loaders.
  * Add matched and default parameters to redirect responses
  * Added support for a `controller` keyword for configuring route controllers in YAML and XML configurations.

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -129,6 +129,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
 
         if (0 === $collection->count() && $class->hasMethod('__invoke') && $annot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass)) {
             $globals['path'] = '';
+            $globals['name'] = '';
             $this->addRoute($collection, $annot, $globals, $class, $class->getMethod('__invoke'));
         }
 
@@ -141,6 +142,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
         if (null === $name) {
             $name = $this->getDefaultRouteName($class, $method);
         }
+        $name = $globals['name'].$name;
 
         $defaults = array_replace($globals['defaults'], $annot->getDefaults());
         foreach ($method->getParameters() as $param) {
@@ -222,9 +224,14 @@ abstract class AnnotationClassLoader implements LoaderInterface
             'methods' => array(),
             'host' => '',
             'condition' => '',
+            'name' => '',
         );
 
         if ($annot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass)) {
+            if (null !== $annot->getName()) {
+                $globals['name'] = $annot->getName();
+            }
+
             if (null !== $annot->getPath()) {
                 $globals['path'] = $annot->getPath();
             }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -149,6 +149,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     public function testClassRouteLoad()
     {
         $classRouteData = array(
+            'name' => 'prefix_',
             'path' => '/prefix',
             'schemes' => array('https'),
             'methods' => array('GET'),
@@ -173,7 +174,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         ;
 
         $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass');
-        $route = $routeCollection->get($methodRouteData['name']);
+        $route = $routeCollection->get($classRouteData['name'].$methodRouteData['name']);
 
         $this->assertSame($classRouteData['path'].$methodRouteData['path'], $route->getPath(), '->load concatenates class and method route path');
         $this->assertEquals(array_merge($classRouteData['schemes'], $methodRouteData['schemes']), $route->getSchemes(), '->load merges class and method route schemes');
@@ -240,7 +241,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 
         $this->assertNull($route, '->load ignores class route');
 
-        $route = $routeCollection->get($methodRouteData['name']);
+        $route = $routeCollection->get($classRouteData['name'].$methodRouteData['name']);
 
         $this->assertSame($classRouteData['path'].$methodRouteData['path'], $route->getPath(), '->load concatenates class and method route path');
         $this->assertEquals(array_merge($classRouteData['schemes'], $methodRouteData['schemes']), $route->getSchemes(), '->load merges class and method route schemes');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | sensiolabs/SensioFrameworkExtraBundle#283
| License       | MIT
| Doc PR        | not yet

This PR adds the possibility to define a name on a `@Route` annotation set on a controller class. The name is then used as a prefix for all routes defined in the controller.
