### PR TITLE
[Form] Fix precision of MoneyToLocalizedStringTransformer's divisions and multiplications

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -54,12 +54,11 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
      */
     public function transform($value)
     {
-        if (null !== $value) {
+        if (null !== $value && 1 !== $this->divisor) {
             if (!is_numeric($value)) {
                 throw new TransformationFailedException('Expected a numeric.');
             }
-
-            $value /= $this->divisor;
+            $value = (string) ($value / $this->divisor);
         }
 
         return parent::transform($value);
@@ -78,9 +77,8 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
     public function reverseTransform($value)
     {
         $value = parent::reverseTransform($value);
-
-        if (null !== $value) {
-            $value *= $this->divisor;
+        if (null !== $value && 1 !== $this->divisor) {
+            $value = (float) (string) ($value * $this->divisor);
         }
 
         return $value;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -72,4 +72,12 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
 
         $this->assertNull($transformer->reverseTransform(''));
     }
+
+    public function testFloatToIntConversionMismatchOnReversTransform()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, null, 100);
+        IntlTestHelper::requireFullIntl($this, false);
+        \Locale::setDefault('de_AT');
+        $this->assertSame(3655, (int) $transformer->reverseTransform('36,55'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | no
| License       | MIT

There is a [PHP Bug](https://bugs.php.net/bug.php?id=75004) with the accuracy of divisions and multiplications when `/=` and `*=` are used.
Here is the proof: https://3v4l.org/u1DkX
It would be better to use `bcmul()` and `bcdiv()` in the `MoneyToLocalizedStringTransformer.php` to prevent this bug.