### PR TITLE
bug #24037 Limit the console application exit code to 254

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -146,8 +146,8 @@ class Application
         }
 
         if ($this->autoExit) {
-            if ($exitCode > 255) {
-                $exitCode = 255;
+            if ($exitCode > 254) {
+                $exitCode = 254;
             }
 
             exit($exitCode);


### PR DESCRIPTION
The exit code 255 is reserved by PHP

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24037 
| License       | MIT
| Doc PR        | -
