### PR TITLE
[TwigBundle] require twig-bridge ~3.4

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.5.9|>=7.0.8",
         "symfony/config": "~3.2|~4.0",
-        "symfony/twig-bridge": "^3.3|~4.0",
+        "symfony/twig-bridge": "^3.4|~4.0",
         "symfony/http-foundation": "~2.8|~3.0|~4.0",
         "symfony/http-kernel": "^3.3|~4.0",
         "twig/twig": "~1.34|~2.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Injecting "twig" as first arg of the DebugCommand works only in ^3.4 - as of #23519.