### PR TITLE
[HttpKernel] Fix loading legacy 3.3 containers in 3.4 context

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -598,9 +598,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                 }
             }
 
-            if ($oldContainer = file_exists($cache->getPath()) ? @include $cache->getPath() : false) {
-                $oldContainer = new \ReflectionClass($oldContainer);
-            }
+            $oldContainer = file_exists($cache->getPath()) && is_object($oldContainer = @include $cache->getPath()) ? new \ReflectionClass($oldContainer) : false;
 
             $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When moving from 3.3 to 3.4, if a dumped container exists, an exception is triggered because "include" returns "1".
ping @umpirsky