### PR TITLE
[ExpressionLanguage] throws an exception on calling uncallable method

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -77,8 +77,11 @@ class GetAttrNode extends Node
                 if (!is_object($obj)) {
                     throw new \RuntimeException('Unable to get a property on a non-object.');
                 }
+                if (!is_callable($toCall = array($obj, $this->nodes['attribute']->attributes['value']))) {
+                    throw new \RuntimeException(sprintf('Unable to call method "%s" of object "%s".', $this->nodes['attribute']->attributes['value'], get_class($obj)));
+                }
 
-                return call_user_func_array(array($obj, $this->nodes['attribute']->attributes['value']), $this->nodes['arguments']->evaluate($functions, $values));
+                return call_user_func_array($toCall, $this->nodes['arguments']->evaluate($functions, $values));
 
             case self::ARRAY_CALL:
                 $array = $this->nodes['node']->evaluate($functions, $values);

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -164,6 +164,16 @@ class ExpressionLanguageTest extends TestCase
     }
 
     /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp  /Unable to call method "\w+" of object "\w+"./
+     */
+    public function testCallBadCallable()
+    {
+        $el = new ExpressionLanguage();
+        $el->evaluate('foo.myfunction()', array('foo' => new \stdClass()));
+    }
+
+    /**
      * @dataProvider getRegisterCallbacks
      * @expectedException \LogicException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When we evaluate an expression, if a callable is incorrect (not exists or not accessible) a warning is printed.
This PR handles this case and throws a \RuntimeException when `is_callable()` returns `false` : 

```php
$el = new ExpressionLanguage();
$el->evaluate('foo.myfunction()', array('foo' => new \stdClass()));
```

**Before:**
`Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'stdClass' does not have a method 'myfunction' in /home/.../src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php on line 84`

**After:**
`Fatal error: Uncaught RuntimeException: Unable to call method "myfunction" of object "stdClass". in /home/.../src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php:81`