### PR TITLE
Added check for ext-dom to XmlUtil::loadFile

### DIFF
--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -37,9 +37,14 @@ class XmlUtils
      * @return \DOMDocument
      *
      * @throws \InvalidArgumentException When loading of XML file returns error
+     * @throws \RuntimeException         When DOM extension is missing
      */
     public static function loadFile($file, $schemaOrCallable = null)
     {
+        if (!extension_loaded('dom')) {
+            throw new \RuntimeException('Extension DOM is required.');
+        }
+
         $content = @file_get_contents($file);
         if ('' === trim($content)) {
             throw new \InvalidArgumentException(sprintf('File %s does not contain valid XML, it is empty.', $file));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no, minor enhancement to gracefully suggest to install `ext-dom` if missing when trying to use `XmlUtil::loadFile`
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | #24046
| License       | MIT