### PR TITLE
[Lock] Make SemaphoreStore::isSupported() internal

### DIFF
--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -30,6 +30,8 @@ class SemaphoreStore implements StoreInterface
      * @param bool|null $blocking When not null, checked again the blocking mode.
      *
      * @return bool
+     *
+     * @internal
      */
     public static function isSupported($blocking = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/24053#discussion_r136391875
| License       | MIT
| Doc PR        | /