### PR TITLE
Improved how links are displayed in exception messages

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
@@ -84,8 +84,8 @@ header .container { display: flex; justify-content: space-between; }
 .exception-message { flex-grow: 1; }
 .exception-message, .exception-message a { color: #FFF; font-size: 21px; font-weight: 400; margin: 0; }
 .exception-message.long { font-size: 18px; }
-.exception-message a { text-decoration: none; }
-.exception-message a:hover { text-decoration: underline; }
+.exception-message a { border-bottom: 1px solid rgba(255, 255, 255, 0.5); font-size: inherit; text-decoration: none; }
+.exception-message a:hover { border-bottom-color: #ffffff; }
 
 .exception-illustration { flex-basis: 111px; flex-shrink: 0; height: 66px; margin-left: 15px; opacity: .7; }
 

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -310,8 +310,8 @@ EOF;
             .exception-message { flex-grow: 1; padding: 30px 0; }
             .exception-message, .exception-message a { color: #FFF; font-size: 21px; font-weight: 400; margin: 0; }
             .exception-message.long { font-size: 18px; }
-            .exception-message a { text-decoration: none; }
-            .exception-message a:hover { text-decoration: underline; }
+            .exception-message a { border-bottom: 1px solid rgba(255, 255, 255, 0.5); font-size: inherit; text-decoration: none; }
+            .exception-message a:hover { border-bottom-color: #ffffff; }
 
             .exception-illustration { flex-basis: 111px; flex-shrink: 0; height: 66px; margin-left: 15px; opacity: .7; }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

If the error message is long, we reduce the font size, but I forgot to do that for links. Besides, I propose to add a subtle bottom border to make links look like what they really are.

### Before

![before](https://user-images.githubusercontent.com/73419/29971763-c8e3805e-8f29-11e7-8bab-5f709f81074b.png)

### After

![after](https://user-images.githubusercontent.com/73419/29971766-ca9029b6-8f29-11e7-9ac1-70d9b82bb893.png)
