### PR TITLE
[TwigBridge] Show Twig's loader paths on debug:twig command

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\Twig\Command;
 
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -153,11 +152,16 @@ EOF
 
         $rows = array();
         foreach ($this->getLoaderPaths() as $namespace => $paths) {
+            if (count($paths) > 1) {
+                $rows[] = array('', '');
+            }
             foreach ($paths as $path) {
-                $rows[] = array($namespace, '* '.$path);
+                $rows[] = array($namespace, '- '.$path);
                 $namespace = '';
             }
-            $rows[] = new TableSeparator();
+            if (count($paths) > 1) {
+                $rows[] = array('', '');
+            }
         }
         array_pop($rows);
         $io->section('Loader Paths');

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/console.xml
@@ -9,6 +9,7 @@
 
         <service id="Symfony\Bridge\Twig\Command\DebugCommand">
             <argument type="service" id="twig" />
+            <argument>%kernel.project_dir%</argument>
             <tag name="console.command" command="debug:twig" />
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

`bin/console debug:twig`:
![twig-loader-paths](https://user-images.githubusercontent.com/2028198/29986784-ee5a4094-8f32-11e7-86c8-c78183630221.png
)

This information is not displayed anywhere ATM and it should be important to know:
 * The Twig's namespaces availables
 * The Twig's paths availables
 * The order that templates will be loaded ( regarding its namespace -> LOAD PRIORITY ! )

So it should help us to debug any issue related to circular templates reference, invalid namespaces, unsuccessful attempt to override a template, etc.

WDYT?

