### PR TITLE
Fix frozen parameter bags with camelCased keys

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
@@ -30,9 +30,7 @@ class FrozenParameterBag extends ParameterBag
      */
     public function __construct(array $parameters = array())
     {
-        foreach ($parameters as $key => $value) {
-            $this->parameters[strtolower($key)] = $value;
-        }
+        $this->parameters = array_change_key_case($parameters);
         $this->resolved = true;
     }
 

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
@@ -30,7 +30,9 @@ class FrozenParameterBag extends ParameterBag
      */
     public function __construct(array $parameters = array())
     {
-        $this->parameters = $parameters;
+        foreach ($parameters as $key => $value) {
+            $this->parameters[strtolower($key)] = $value;
+        }
         $this->resolved = true;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
@@ -21,9 +21,18 @@ class FrozenParameterBagTest extends TestCase
         $parameters = array(
             'foo' => 'foo',
             'bar' => 'bar',
+            'fooBar' => 'fooBar',
         );
         $bag = new FrozenParameterBag($parameters);
-        $this->assertEquals($parameters, $bag->all(), '__construct() takes an array of parameters as its first argument');
+        $this->assertEquals(
+            array(
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'foobar' => 'fooBar',
+            ),
+            $bag->all(),
+            '__construct() takes an array of parameters as its first argument and lowercase it keys'
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | >=2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | not sure
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

The frozen parameter bags can't use the `add` function of the ParametersBag so the `key` don't get lowercased but will be accessed as lowercase by the `get` function and throw an error. So we also need to lowercase the parameters key in the constructor of the frozenparameter bag.

Not sure if I should create instead an `protected` function in the ParameterBag instead and use always this. But don't know how to name that function.

# Example

```php
$bag = new FrozenParameterBag(['fooBar' => 'fooBar']);
$bag->get('fooBar'); // will throw an error currently
```