### PR TITLE
[Console] Fix BC break in console.command.ids parameter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -173,8 +173,9 @@ class Application extends BaseApplication
         }
 
         if ($container->hasParameter('console.command.ids')) {
+            $lazyCommandIds = $container->hasParameter('console.lazy_command.ids') ? $container->getParameter('console.lazy_command.ids') : array();
             foreach ($container->getParameter('console.command.ids') as $id) {
-                if (false !== $id) {
+                if (!isset($lazyCommandIds[$id])) {
                     try {
                         $this->add($container->get($id));
                     } catch (\Exception $e) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -183,16 +183,16 @@ class ApplicationTest extends TestCase
         }
 
         $container
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('hasParameter')
-            ->with($this->equalTo('console.command.ids'))
-            ->will($this->returnValue(true))
+            ->withConsecutive(array('console.command.ids'), array('console.lazy_command.ids'))
+            ->willReturnOnConsecutiveCalls(true, true)
         ;
         $container
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getParameter')
-            ->with($this->equalTo('console.command.ids'))
-            ->will($this->returnValue(array()))
+            ->withConsecutive(array('console.lazy_command.ids'), array('console.command.ids'))
+            ->willReturnOnConsecutiveCalls(array(), array())
         ;
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -41,6 +41,7 @@ class AddConsoleCommandPass implements CompilerPassInterface
         $lazyCommandMap = array();
         $lazyCommandRefs = array();
         $serviceIds = array();
+        $lazyServiceIds = array();
 
         foreach ($commandServices as $id => $tags) {
             $definition = $container->getDefinition($id);
@@ -73,7 +74,8 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 continue;
             }
 
-            $serviceIds[$commandId] = false;
+            $serviceIds[$commandId] = $id;
+            $lazyServiceIds[$id] = true;
             unset($tags[0]);
             $lazyCommandMap[$commandName] = $id;
             $lazyCommandRefs[$id] = new TypedReference($id, $class);
@@ -98,5 +100,6 @@ class AddConsoleCommandPass implements CompilerPassInterface
             ->setArguments(array(ServiceLocatorTagPass::register($container, $lazyCommandRefs), $lazyCommandMap));
 
         $container->setParameter('console.command.ids', $serviceIds);
+        $container->setParameter('console.lazy_command.ids', $lazyServiceIds);
     }
 }

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -73,7 +73,8 @@ class AddConsoleCommandPassTest extends TestCase
         $this->assertSame(ContainerCommandLoader::class, $commandLoader->getClass());
         $this->assertSame(array('my:command' => 'my-command', 'my:alias' => 'my-command'), $commandLoader->getArgument(1));
         $this->assertEquals(array(array('my-command' => new ServiceClosureArgument(new TypedReference('my-command', MyCommand::class)))), $commandLocator->getArguments());
-        $this->assertSame(array('console.command.symfony_component_console_tests_dependencyinjection_mycommand' => false), $container->getParameter('console.command.ids'));
+        $this->assertSame(array('console.command.symfony_component_console_tests_dependencyinjection_mycommand' => 'my-command'), $container->getParameter('console.command.ids'));
+        $this->assertSame(array('my-command' => true), $container->getParameter('console.lazy_command.ids'));
         $this->assertSame(array(array('setName', array('my:command')), array('setAliases', array(array('my:alias')))), $command->getMethodCalls());
     }
 
@@ -95,7 +96,8 @@ class AddConsoleCommandPassTest extends TestCase
         $this->assertSame(ContainerCommandLoader::class, $commandLoader->getClass());
         $this->assertSame(array('default' => 'with-default-name'), $commandLoader->getArgument(1));
         $this->assertEquals(array(array('with-default-name' => new ServiceClosureArgument(new TypedReference('with-default-name', NamedCommand::class)))), $commandLocator->getArguments());
-        $this->assertSame(array('console.command.symfony_component_console_tests_dependencyinjection_namedcommand' => false), $container->getParameter('console.command.ids'));
+        $this->assertSame(array('console.command.symfony_component_console_tests_dependencyinjection_namedcommand' => 'with-default-name'), $container->getParameter('console.command.ids'));
+        $this->assertSame(array('with-default-name' => true), $container->getParameter('console.lazy_command.ids'));
 
         $container = new ContainerBuilder();
         $container


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/flex/issues/142#issuecomment-326029873
| License       | MIT
| Doc PR        | n/a

To make command services lazy loaded when their name is known, we need to exclude them from [runtime registration of other (non lazy-loadable) command services](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Console/Application.php#L176). 
We also need to have them in the `console.command.ids` parameter in order to [not register them by convention](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/HttpKernel/Bundle/Bundle.php#L188). 
It is managed using `false` as values instead of ids for the parameter, [excluding false values from runtime registration](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Console/Application.php#L177). Problem is that it makes FrameworkBundle's 3.3 Application incompatible with Console 3.4+ given the check for `false` is missing. 

This PR fixes it using another parameter referencing ids of command services which can be lazy loaded. 
I would be happy to not add the parameter if someone has a suggestion that allows to do so.