### PR TITLE
Fix deprecations regarding core commands registered as services

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -120,7 +120,52 @@ FrameworkBundle
    class has been deprecated and will be removed in 4.0. Use the
    `Symfony\Component\Translation\Reader\TranslationReader` class instead.
    
- * The `translation.loader` service has been deprecated and will be removed in 4.0. Use the `translation.reader` service instead.
+ * The `translation.loader` service has been deprecated and will be removed in 4.0.
+   Use the `translation.reader` service instead..
+
+ * `AssetsInstallCommand::__construct()` now takes an instance of
+   `Symfony\Component\Filesystem\Filesystem` as first argument.
+   Not passing it is deprecated and will throw a `TypeError` in 4.0.
+
+ * `CacheClearCommand::__construct()` now takes an instance of
+   `Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface` as
+    first argument. Not passing it is deprecated and will throw
+    a `TypeError` in 4.0.
+
+ * `CachePoolClearCommand::__construct()` now takes an instance of
+   `Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer` as
+    first argument. Not passing it is deprecated and will throw
+    a `TypeError` in 4.0.
+
+ * `EventDispatcherDebugCommand::__construct()` now takes an instance of
+   `Symfony\Component\EventDispatcher\EventDispatcherInterface` as
+    first argument. Not passing it is deprecated and will throw
+    a `TypeError` in 4.0.
+
+ * `RouterDebugCommand::__construct()` now takes an instance of
+   `Symfony\Component\Routing\RouterInteface` as
+    first argument. Not passing it is deprecated and will throw
+    a `TypeError` in 4.0.
+
+ * `RouterMatchCommand::__construct()` now takes an instance of
+   `Symfony\Component\Routing\RouterInteface` as
+    first argument. Not passing it is deprecated and will throw
+    a `TypeError` in 4.0.
+
+ * `TranslationDebugCommand::__construct()` now takes an instance of
+   `Symfony\Component\Translation\TranslatorInterface` as
+    first argument. Not passing it is deprecated and will throw
+    a `TypeError` in 4.0.
+
+ * `TranslationUpdateCommand::__construct()` now takes an instance of
+   `Symfony\Component\Translation\TranslatorInterface` as
+    first argument. Not passing it is deprecated and will throw
+    a `TypeError` in 4.0.
+
+ * `AssetsInstallCommand`, `CacheClearCommand`, `CachePoolClearCommand`,
+   `EventDispatcherDebugCommand`, `RouterDebugCommand`, `RouterMatchCommand`,
+   `TranslationDebugCommand`, `TranslationUpdateCommand`, `XliffLintCommand`
+    and `YamlLintCommand` classes have been marked as final
 
 HttpKernel
 ----------
@@ -167,6 +212,15 @@ SecurityBundle
    the `AccessDecisionManager` and this functionality will be removed in 4.0.
 
  * `FirewallContext::getListeners()` now returns `\Traversable|array`
+
+ * `InitAclCommand::__construct()` now takes an instance of
+   `Doctrine\DBAL\Connection`  as first argument. Not passing it is
+    deprecated and will throw a `TypeError` in 4.0.
+
+ * `SetAclCommand::__construct()` now takes an instance of
+   `Symfony\Component\Security\Acl\Model\MutableAclProviderInterfaceConnection`
+    as first argument. Not passing it is deprecated and will throw a `TypeError`
+    in 4.0.
 
 Translation
 -----------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -419,8 +419,40 @@ FrameworkBundle
    class has been deprecated and will be removed in 4.0. Use the
    `Symfony\Component\Translation\Reader\TranslationReader` class instead.
 
- * The `translation.loader` service has been deprecated and will be removed in 4.0. Use the `translation.reader` service instead.
+ * The `translation.loader` service has been removed.
+   Use the `translation.reader` service instead.
  
+ * `AssetsInstallCommand::__construct()` now requires an instance of
+   `Symfony\Component\Filesystem\Filesystem` as first argument.
+
+ * `CacheClearCommand::__construct()` now requires an instance of
+   `Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface` as
+    first argument.
+
+ * `CachePoolClearCommand::__construct()` now requires an instance of
+   `Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer` as
+    first argument.
+
+ * `EventDispatcherDebugCommand::__construct()` now requires an instance of
+   `Symfony\Component\EventDispatcher\EventDispatcherInterface` as
+    first argument.
+
+ * `RouterDebugCommand::__construct()` now requires an instance of
+   `Symfony\Component\Routing\RouterInteface` as
+    first argument.
+
+ * `RouterMatchCommand::__construct()` now requires an instance of
+   `Symfony\Component\Routing\RouterInteface` as
+    first argument.
+
+ * `TranslationDebugCommand::__construct()` now requires an instance of
+   `Symfony\Component\Translation\TranslatorInterface` as
+    first argument.
+
+ * `TranslationUpdateCommand::__construct()` now requires an instance of
+   `Symfony\Component\Translation\TranslatorInterface` as
+    first argument.
+
 HttpFoundation
 --------------
 
@@ -568,6 +600,13 @@ SecurityBundle
 
  * `UserPasswordEncoderCommand` does not extend `ContainerAwareCommand` nor implement `ContainerAwareInterface` anymore.
 
+ * `InitAclCommand::__construct()` now requires an instance of
+   `Doctrine\DBAL\Connection`  as first argument.
+
+ * `SetAclCommand::__construct()` now requires an instance of
+   `Symfony\Component\Security\Acl\Model\MutableAclProviderInterfaceConnection`
+    as first argument.
+
 Serializer
 ----------
 
@@ -642,11 +681,12 @@ TwigBridge
  * The `TwigRendererEngine::setEnvironment()` method has been removed.
    Pass the Twig Environment as second argument of the constructor instead.
 
- * Removed `Symfony\Bridge\Twig\Command\DebugCommand::set/getTwigEnvironment` and the ability
-   to pass a command name as first argument.
+ * Removed `DebugCommand::set/getTwigEnvironment`. Pass an instance of
+   `Twig\Environment` as first argument of the constructor instead.
 
- * Removed `Symfony\Bridge\Twig\Command\LintCommand::set/getTwigEnvironment` and the ability
-   to pass a command name as first argument.
+ * Removed `LintCommand::set/getTwigEnvironment`. Pass an instance of
+   `Twig\Environment` as first argument of the constructor instead.
+
 
 Validator
 ---------

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,8 +5,10 @@ CHANGELOG
 -----
 
  * deprecated `Symfony\Bridge\Twig\Form\TwigRenderer`
- * deprecated `Symfony\Bridge\Twig\Command\DebugCommand::set/getTwigEnvironment` and the ability to pass a command name as first argument
- * deprecated `Symfony\Bridge\Twig\Command\LintCommand::set/getTwigEnvironment` and the ability to pass a command name as first argument
+ * deprecated `DebugCommand::set/getTwigEnvironment`. Pass an instance of
+   `Twig\Environment` as first argument  of the constructor instead
+ * deprecated `LintCommand::set/getTwigEnvironment`. Pass an instance of
+   `Twig\Environment` as first argument of the constructor instead
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -26,6 +26,33 @@ CHANGELOG
  * Deprecated `Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader`, use 
    `Symfony\Component\Translation\Reader\TranslationReader` instead
  * Deprecated `translation.loader` service, use `translation.reader` instead
+ * `AssetsInstallCommand::__construct()` now takes an instance of
+   `Symfony\Component\Filesystem\Filesystem` as first argument
+ * `CacheClearCommand::__construct()` now takes an instance of
+   `Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface` as
+    first argument
+ * `CachePoolClearCommand::__construct()` now takes an instance of
+   `Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer` as
+    first argument
+ * `EventDispatcherDebugCommand::__construct()` now takes an instance of
+   `Symfony\Component\EventDispatcher\EventDispatcherInterface` as
+    first argument
+ * `RouterDebugCommand::__construct()` now takes an instance of
+   `Symfony\Component\Routing\RouterInteface` as
+    first argument
+ * `RouterMatchCommand::__construct()` now takes an instance of
+   `Symfony\Component\Routing\RouterInteface` as
+    first argument
+ * `TranslationDebugCommand::__construct()` now takes an instance of
+   `Symfony\Component\Translation\TranslatorInterface` as
+    first argument
+ * `TranslationUpdateCommand::__construct()` now takes an instance of
+   `Symfony\Component\Translation\TranslatorInterface` as
+    first argument
+ * `AssetsInstallCommand`, `CacheClearCommand`, `CachePoolClearCommand`,
+   `EventDispatcherDebugCommand`, `RouterDebugCommand`, `RouterMatchCommand`,
+   `TranslationDebugCommand`, `TranslationUpdateCommand`, `XliffLintCommand`
+    and `YamlLintCommand` classes have been marked as final
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -45,7 +45,7 @@ class AssetsInstallCommand extends ContainerAwareCommand
     public function __construct($filesystem = null)
     {
         if (!$filesystem instanceof Filesystem) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, Filesystem::class), E_USER_DEPRECATED);
 
             parent::__construct($filesystem);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -45,7 +45,7 @@ class CacheClearCommand extends ContainerAwareCommand
     public function __construct($cacheClearer = null, Filesystem $filesystem = null)
     {
         if (!$cacheClearer instanceof CacheClearerInterface) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, CacheClearerInterface::class), E_USER_DEPRECATED);
 
             parent::__construct($cacheClearer);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
@@ -35,7 +35,7 @@ final class CachePoolClearCommand extends ContainerAwareCommand
     public function __construct($poolClearer = null)
     {
         if (!$poolClearer instanceof Psr6CacheClearer) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, Psr6CacheClearer::class), E_USER_DEPRECATED);
 
             parent::__construct($poolClearer);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -37,7 +37,7 @@ class EventDispatcherDebugCommand extends ContainerAwareCommand
     public function __construct($dispatcher = null)
     {
         if (!$dispatcher instanceof EventDispatcherInterface) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, EventDispatcherInterface::class), E_USER_DEPRECATED);
 
             parent::__construct($dispatcher);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -41,7 +41,7 @@ class RouterDebugCommand extends ContainerAwareCommand
     public function __construct($router = null)
     {
         if (!$router instanceof RouterInterface) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, RouterInterface::class), E_USER_DEPRECATED);
 
             parent::__construct($router);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -39,7 +39,7 @@ class RouterMatchCommand extends ContainerAwareCommand
     public function __construct($router = null)
     {
         if (!$router instanceof RouterInterface) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, RouterInterface::class), E_USER_DEPRECATED);
 
             parent::__construct($router);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -54,7 +54,7 @@ class TranslationDebugCommand extends ContainerAwareCommand
     public function __construct($translator = null, TranslationReaderInterface $reader = null, ExtractorInterface $extractor = null)
     {
         if (!$translator instanceof TranslatorInterface) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, TranslatorInterface::class), E_USER_DEPRECATED);
 
             parent::__construct($translator);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -49,7 +49,7 @@ class TranslationUpdateCommand extends ContainerAwareCommand
     public function __construct($writer = null, TranslationReaderInterface $reader = null, ExtractorInterface $extractor = null, $defaultLocale = null)
     {
         if (!$writer instanceof TranslationWriterInterface) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, TranslationWriterInterface::class), E_USER_DEPRECATED);
 
             parent::__construct($writer);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -49,7 +49,7 @@ class RouterDebugCommandTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
+     * @expectedDeprecation Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand::__construct() expects an instance of "Symfony\Component\Routing\RouterInterface" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.
      */
     public function testLegacyDebugCommand()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -43,8 +43,8 @@ class RouterMatchCommandTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
-     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
+     * @expectedDeprecation Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand::__construct() expects an instance of "Symfony\Component\Routing\RouterInterface" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.
+     * @expectedDeprecation Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand::__construct() expects an instance of "Symfony\Component\Routing\RouterInterface" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.
      */
     public function testLegacyMatchCommand()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -176,7 +176,7 @@ class TranslationDebugCommandTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
+     * @expectedDeprecation Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand::__construct() expects an instance of "Symfony\Component\Translation\TranslatorInterface" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.
      */
     public function testLegacyDebugCommand()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -155,7 +155,7 @@ class TranslationUpdateCommandTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
+     * @expectedDeprecation Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand::__construct() expects an instance of "Symfony\Component\Translation\Writer\TranslationWriterInterface" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.
      */
     public function testLegacyUpdateCommand()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -77,7 +77,7 @@ class CachePoolClearCommandTest extends WebTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a command name as the first argument of "Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand::__construct" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.
+     * @expectedDeprecation Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand::__construct() expects an instance of "Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.
      */
     public function testLegacyClearCommand()
     {

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -8,6 +8,11 @@ CHANGELOG
    `VoterInterface` on the class is now deprecated and will be removed in 4.0.
  * [BC BREAK] `FirewallContext::getListeners()` now returns `\Traversable|array`
  * added info about called security listeners in profiler 
+ * `InitAclCommand::__construct()` now takes an instance of
+   `Doctrine\DBAL\Connection`  as first argument
+ * `SetAclCommand::__construct()` now takes an instance of
+   `Symfony\Component\Security\Acl\Model\MutableAclProviderInterfaceConnection`
+   as first argument
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -39,7 +39,7 @@ class InitAclCommand extends ContainerAwareCommand
     public function __construct($connection = null, Schema $schema = null)
     {
         if (!$connection instanceof Connection) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, Connection::class), E_USER_DEPRECATED);
 
             parent::__construct($connection);
 

--- a/src/Symfony/Bundle/SecurityBundle/Command/SetAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/SetAclCommand.php
@@ -42,7 +42,7 @@ class SetAclCommand extends ContainerAwareCommand
     public function __construct($provider = null)
     {
         if (!$provider instanceof MutableAclProviderInterface) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version 3.4 and will be removed in 4.0. If the command was registered by convention, make it a service instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('%s() expects an instance of "%s" as first argument since version 3.4. Not passing it is deprecated and will throw a TypeError in 4.0.', __METHOD__, MutableAclProviderInterface::class), E_USER_DEPRECATED);
 
             parent::__construct($provider);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/23624#discussion_r131979501
| License       | MIT
| Doc PR        | n/a

Current deprecation messages can be confusing (see fixed ticket), this improves them and adds a bunch of missing CHANGELOG/UPGRADE entries on the same topic