### PR TITLE
Implemented PruneableInterface on TagAwareAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -14,11 +14,12 @@ namespace Symfony\Component\Cache\Adapter;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\PruneableInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class TagAwareAdapter implements TagAwareAdapterInterface
+class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface
 {
     const TAGS_PREFIX = "\0tags\0";
 
@@ -333,5 +334,17 @@ class TagAwareAdapter implements TagAwareAdapterInterface
         }
 
         return $tagVersions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prune()
+    {
+        if ($this->itemsAdapter instanceof PruneableInterface) {
+            return $this->itemsAdapter->prune();
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * added PruneableInterface so PSR-6 or PSR-16 cache implementations can declare support for manual stale cache pruning
- * added prune logic to FilesystemTrait, PhpFilesTrait, PdoTrait, and ChainTrait
+ * added prune logic to FilesystemTrait, PhpFilesTrait, PdoTrait, TagAwareAdapter and ChainTrait
  * now FilesystemAdapter, PhpFilesAdapter, FilesystemCache, PhpFilesCache, PdoAdapter, PdoCache, ChainAdapter, and
    ChainCache implement PruneableInterface and support manual stale cache pruning
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
@@ -124,5 +125,61 @@ class TagAwareAdapterTest extends AdapterTestCase
 
         $i = $pool->getItem('k');
         $this->assertSame(array('foo' => 'foo'), $i->getPreviousTags());
+    }
+
+    public function testPrune()
+    {
+        $cache = new TagAwareAdapter($this->getPruneableMock());
+        $this->assertTrue($cache->prune());
+
+        $cache = new TagAwareAdapter($this->getNonPruneableMock());
+        $this->assertFalse($cache->prune());
+
+        $cache = new TagAwareAdapter($this->getFailingPruneableMock());
+        $this->assertFalse($cache->prune());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|PruneableCacheInterface
+     */
+    private function getPruneableMock()
+    {
+        $pruneable = $this
+            ->getMockBuilder(PruneableCacheInterface::class)
+            ->getMock();
+
+        $pruneable
+            ->expects($this->atLeastOnce())
+            ->method('prune')
+            ->will($this->returnValue(true));
+
+        return $pruneable;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|PruneableCacheInterface
+     */
+    private function getFailingPruneableMock()
+    {
+        $pruneable = $this
+            ->getMockBuilder(PruneableCacheInterface::class)
+            ->getMock();
+
+        $pruneable
+            ->expects($this->atLeastOnce())
+            ->method('prune')
+            ->will($this->returnValue(false));
+
+        return $pruneable;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|AdapterInterface
+     */
+    private function getNonPruneableMock()
+    {
+        return $this
+            ->getMockBuilder(AdapterInterface::class)
+            ->getMock();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | See comment on https://github.com/symfony/symfony/pull/23451
| License       | MIT
| Doc PR        | Added a comment on https://github.com/symfony/symfony-docs/pull/8209

The `ChainAdapter` already delegates the `prune()` calls. The `TagAwareAdapter` is a wrapping adapter too and should delegate the `prune()` calls just the same.
