### PR TITLE
Deprecated the web_profiler.position option

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -53,6 +53,8 @@ CHANGELOG
    `EventDispatcherDebugCommand`, `RouterDebugCommand`, `RouterMatchCommand`,
    `TranslationDebugCommand`, `TranslationUpdateCommand`, `XliffLintCommand`
     and `YamlLintCommand` classes have been marked as final
+ * Deprecated the `web_profiler.position` config option (in Symfony 4.0 the toolbar
+   will always be displayed at the bottom).
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -39,6 +39,12 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('toolbar')->defaultFalse()->end()
                 ->scalarNode('position')
                     ->defaultValue('bottom')
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) { return null !== $v; })
+                        ->then(function () {
+                            @trigger_error('The "web_profiler.position" configuration key has been deprecated in Symfony 3.4 and it will be removed in 4.0.', E_USER_DEPRECATED);
+                        })
+                    ->end()
                     ->validate()
                         ->ifNotInArray(array('bottom', 'top'))
                         ->thenInvalid('The CSS position %s is not supported')

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -39,12 +39,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('toolbar')->defaultFalse()->end()
                 ->scalarNode('position')
                     ->defaultValue('bottom')
-                    ->beforeNormalization()
-                        ->ifTrue(function ($v) { return null !== $v; })
-                        ->then(function () {
-                            @trigger_error('The "web_profiler.position" configuration key has been deprecated in Symfony 3.4 and it will be removed in 4.0.', E_USER_DEPRECATED);
-                        })
-                    ->end()
+                    ->setDeprecated('The "web_profiler.position" configuration key has been deprecated in Symfony 3.4 and it will be removed in 4.0.')
                     ->validate()
                         ->ifNotInArray(array('bottom', 'top'))
                         ->thenInvalid('The CSS position %s is not supported')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #23528
| License       | MIT
| Doc PR        | -

Related to #23728, which removes the feature for Symfony 4.0.