### PR TITLE
[FrameworkBundle] Fix Di config to allow for more private services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TemplatingPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TemplatingPass.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface as FrameworkBundle
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Templating\EngineInterface as ComponentEngineInterface;
 
 class TemplatingPass implements CompilerPassInterface
@@ -31,16 +32,22 @@ class TemplatingPass implements CompilerPassInterface
         }
 
         if ($container->hasDefinition('templating.engine.php')) {
+            $refs = array();
             $helpers = array();
             foreach ($container->findTaggedServiceIds('templating.helper', true) as $id => $attributes) {
                 if (isset($attributes[0]['alias'])) {
                     $helpers[$attributes[0]['alias']] = $id;
+                    $refs[$id] = new Reference($id);
                 }
             }
 
             if (count($helpers) > 0) {
                 $definition = $container->getDefinition('templating.engine.php');
                 $definition->addMethodCall('setHelpers', array($helpers));
+
+                if ($container->hasDefinition('templating.engine.php.helpers_locator')) {
+                    $container->getDefinition('templating.engine.php.helpers_locator')->replaceArgument(0, $refs);
+                }
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class UnusedTagsPass implements CompilerPassInterface
 {
     private $whitelist = array(
+        'cache.pool.clearer',
         'console.command',
         'container.service_locator',
         'container.service_subscriber',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -597,15 +597,15 @@ class FrameworkExtension extends Extension
             }
 
             // Create Workflow
+            $workflowId = sprintf('%s.%s', $type, $name);
             $workflowDefinition = new ChildDefinition(sprintf('%s.abstract', $type));
-            $workflowDefinition->replaceArgument(0, $definitionDefinition);
+            $workflowDefinition->replaceArgument(0, new Reference(sprintf('%s.definition', $workflowId)));
             if (isset($markingStoreDefinition)) {
                 $workflowDefinition->replaceArgument(1, $markingStoreDefinition);
             }
             $workflowDefinition->replaceArgument(3, $name);
 
             // Store to container
-            $workflowId = sprintf('%s.%s', $type, $name);
             $container->setDefinition($workflowId, $workflowDefinition);
             $container->setDefinition(sprintf('%s.definition', $workflowId), $definitionDefinition);
 
@@ -680,7 +680,7 @@ class FrameworkExtension extends Extension
 
         if (class_exists(Stopwatch::class)) {
             $container->register('debug.stopwatch', Stopwatch::class)->addArgument(true);
-            $container->setAlias(Stopwatch::class, 'debug.stopwatch');
+            $container->setAlias(Stopwatch::class, new Alias('debug.stopwatch', false));
         }
 
         $debug = $container->getParameter('kernel.debug');

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -106,7 +106,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
         $this->addCompilerPassIfExists($container, TranslationExtractorPass::class);
         $this->addCompilerPassIfExists($container, TranslationDumperPass::class);
-        $container->addCompilerPass(new FragmentRendererPass(), PassConfig::TYPE_AFTER_REMOVING);
+        $container->addCompilerPass(new FragmentRendererPass());
         $this->addCompilerPassIfExists($container, SerializerPass::class);
         $this->addCompilerPassIfExists($container, PropertyInfoPass::class);
         $container->addCompilerPass(new DataCollectorTranslatorPass());

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_debug.xml
@@ -9,7 +9,7 @@
 
         <service id="debug.templating.engine.php" class="Symfony\Bundle\FrameworkBundle\Templating\TimedPhpEngine">
             <argument type="service" id="templating.name_parser" />
-            <argument type="service" id="service_container" />
+            <argument type="service" id="templating.engine.php.helpers_locator" />
             <argument type="service" id="templating.loader" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="templating.globals" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -9,10 +9,15 @@
 
         <service id="templating.engine.php" class="Symfony\Bundle\FrameworkBundle\Templating\PhpEngine">
             <argument type="service" id="templating.name_parser" />
-            <argument type="service" id="service_container" />
+            <argument type="service" id="templating.engine.php.helpers_locator" />
             <argument type="service" id="templating.loader" />
             <argument type="service" id="templating.globals" />
             <call method="setCharset"><argument>%kernel.charset%</argument></call>
+        </service>
+
+        <service id="templating.engine.php.helpers_locator">
+            <tag name="container.service_locator" />
+            <argument type="collection" />
         </service>
 
         <service id="templating.helper.slots" class="Symfony\Component\Templating\Helper\SlotsHelper" public="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -226,7 +226,7 @@ class FormHelper extends Helper
      * Check the token in your action using the same CSRF token id.
      *
      * <code>
-     * $csrfProvider = $this->get('security.csrf.token_generator');
+     * // $csrfProvider being an instance of Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface
      * if (!$csrfProvider->isCsrfTokenValid('rm_user_'.$user->getId(), $token)) {
      *     throw new \RuntimeException('CSRF attack detected.');
      * }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SubRequestController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SubRequestController.php
@@ -21,10 +21,8 @@ class SubRequestController implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 
-    public function indexAction()
+    public function indexAction($handler)
     {
-        $handler = $this->container->get('fragment.handler');
-
         $errorUrl = $this->generateUrl('subrequest_fragment_error', array('_locale' => 'fr', '_format' => 'json'));
         $altUrl = $this->generateUrl('subrequest_fragment', array('_locale' => 'fr', '_format' => 'json'));
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Session/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Session/config.yml
@@ -1,2 +1,7 @@
 imports:
     - { resource: ./../config/default.yml }
+
+services:
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SubRequestController:
+        tags:
+            - { name: controller.service_arguments, action: indexAction, argument: handler, id: fragment.handler }

--- a/src/Symfony/Component/Form/FormRendererInterface.php
+++ b/src/Symfony/Component/Form/FormRendererInterface.php
@@ -76,7 +76,7 @@ interface FormRendererInterface
      * Check the token in your action using the same token ID.
      *
      * <code>
-     * $csrfProvider = $this->get('security.csrf.token_generator');
+     * // $csrfProvider being an instance of Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface
      * if (!$csrfProvider->isCsrfTokenValid('rm_user_'.$user->getId(), $token)) {
      *     throw new \RuntimeException('CSRF attack detected.');
      * }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR is a prelude to #23822:
- allow cache pool clearers to be private by using IGNORE_ON_UNINITIALIZED_REFERENCE, allowing much more sane logic in the related passes
- allow templating helpers to be private by using a service locator
- replace an inline def by a reference in workflow's config (ping @lyrixx @Nyholm)
- fix the Stopwatch alias, which is public in 3.4, but private in 3.3
- remove direct access to `->get('fragment.handler')` in tests so that the service could be made private