### PR TITLE
Make as many services private as possible

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -333,6 +333,7 @@ abstract class AbstractDoctrineExtension extends Extension
                 $memcachePort = !empty($cacheDriver['port']) || (isset($cacheDriver['port']) && $cacheDriver['port'] === 0) ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.memcache_port').'%';
                 $cacheDef = new Definition($memcacheClass);
                 $memcacheInstance = new Definition($memcacheInstanceClass);
+                $memcacheInstance->setPrivate(true);
                 $memcacheInstance->addMethodCall('connect', array(
                     $memcacheHost, $memcachePort,
                 ));
@@ -346,6 +347,7 @@ abstract class AbstractDoctrineExtension extends Extension
                 $memcachedPort = !empty($cacheDriver['port']) ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.memcached_port').'%';
                 $cacheDef = new Definition($memcachedClass);
                 $memcachedInstance = new Definition($memcachedInstanceClass);
+                $memcachedInstance->setPrivate(true);
                 $memcachedInstance->addMethodCall('addServer', array(
                     $memcachedHost, $memcachedPort,
                 ));
@@ -359,6 +361,7 @@ abstract class AbstractDoctrineExtension extends Extension
                 $redisPort = !empty($cacheDriver['port']) ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.redis_port').'%';
                 $cacheDef = new Definition($redisClass);
                 $redisInstance = new Definition($redisInstanceClass);
+                $redisInstance->setPrivate(true);
                 $redisInstance->addMethodCall('connect', array(
                     $redisHost, $redisPort,
                 ));

--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/DebugExtension.php
@@ -35,6 +35,9 @@ class DebugExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
+        $container->getDefinition('debug.dump_listener')->setPrivate(true);
+        $container->getDefinition('var_dumper.cli_dumper')->setPrivate(true);
+
         $container->getDefinition('var_dumper.cloner')
             ->addMethodCall('setMaxItems', array($config['max_items']))
             ->addMethodCall('setMinDepth', array($config['min_depth']))

--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -22,14 +22,14 @@
             <argument>null</argument><!-- var_dumper.cli_dumper when debug.dump_destination is set -->
         </service>
 
-        <service id="debug.dump_listener" class="Symfony\Component\HttpKernel\EventListener\DumpListener" public="true">
+        <service id="debug.dump_listener" class="Symfony\Component\HttpKernel\EventListener\DumpListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="var_dumper.cloner" />
             <argument type="service" id="var_dumper.cli_dumper" />
         </service>
 
         <service id="var_dumper.cloner" class="Symfony\Component\VarDumper\Cloner\VarCloner" public="true" />
-        <service id="var_dumper.cli_dumper" class="Symfony\Component\VarDumper\Dumper\CliDumper" public="true">
+        <service id="var_dumper.cli_dumper" class="Symfony\Component\VarDumper\Dumper\CliDumper">
             <argument>null</argument><!-- debug.dump_destination -->
             <argument>%kernel.charset%</argument>
             <argument>0</argument> <!-- flags -->

--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -24,8 +24,11 @@
     },
     "require-dev": {
         "symfony/config": "~3.3|~4.0",
-        "symfony/dependency-injection": "~3.3|~4.0",
+        "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/web-profiler-bundle": "~2.8|~3.0|~4.0"
+    },
+    "conflict": {
+        "symfony/dependency-injection": "<3.4"
     },
     "suggest": {
         "symfony/config": "For service container configuration",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -115,6 +115,15 @@ class FrameworkExtension extends Extension
         $loader->load('web.xml');
         $loader->load('services.xml');
 
+        $container->getDefinition('kernel.class_cache.cache_warmer')->setPrivate(true);
+        $container->getDefinition('uri_signer')->setPrivate(true);
+        $container->getDefinition('config_cache_factory')->setPrivate(true);
+        $container->getDefinition('response_listener')->setPrivate(true);
+        $container->getDefinition('file_locator')->setPrivate(true);
+        $container->getDefinition('streamed_response_listener')->setPrivate(true);
+        $container->getDefinition('locale_listener')->setPrivate(true);
+        $container->getDefinition('validate_request_listener')->setPrivate(true);
+
         // forward compatibility with Symfony 4.0 where the ContainerAwareEventDispatcher class is removed
         if (!class_exists(ContainerAwareEventDispatcher::class)) {
             $definition = $container->getDefinition('event_dispatcher');
@@ -131,6 +140,12 @@ class FrameworkExtension extends Extension
 
         $loader->load('fragment_renderer.xml');
 
+        $container->getDefinition('fragment.handler')->setPrivate(true);
+        $container->getDefinition('fragment.renderer.inline')->setPrivate(true);
+        $container->getDefinition('fragment.renderer.hinclude')->setPrivate(true);
+        $container->getDefinition('fragment.renderer.esi')->setPrivate(true);
+        $container->getDefinition('fragment.renderer.ssi')->setPrivate(true);
+
         if (class_exists(Application::class)) {
             $loader->load('console.xml');
 
@@ -145,8 +160,19 @@ class FrameworkExtension extends Extension
         // Property access is used by both the Form and the Validator component
         $loader->load('property_access.xml');
 
+        $container->getDefinition('property_accessor')->setPrivate(true);
+
         // Load Cache configuration first as it is used by other components
         $loader->load('cache.xml');
+
+        $container->getDefinition('cache.adapter.system')->setPrivate(true);
+        $container->getDefinition('cache.adapter.apcu')->setPrivate(true);
+        $container->getDefinition('cache.adapter.doctrine')->setPrivate(true);
+        $container->getDefinition('cache.adapter.filesystem')->setPrivate(true);
+        $container->getDefinition('cache.adapter.psr6')->setPrivate(true);
+        $container->getDefinition('cache.adapter.redis')->setPrivate(true);
+        $container->getDefinition('cache.adapter.memcached')->setPrivate(true);
+        $container->getDefinition('cache.default_clearer')->setPrivate(true);
 
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
@@ -202,6 +228,10 @@ class FrameworkExtension extends Extension
 
         if (!empty($config['test'])) {
             $loader->load('test.xml');
+
+            $container->getDefinition('test.client.history')->setPrivate(true);
+            $container->getDefinition('test.client.cookiejar')->setPrivate(true);
+            $container->getDefinition('test.session.listener')->setPrivate(true);
         }
 
         if ($this->isConfigEnabled($container, $config['session'])) {
@@ -389,12 +419,28 @@ class FrameworkExtension extends Extension
     private function registerFormConfiguration($config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         $loader->load('form.xml');
+
+        $container->getDefinition('form.resolved_type_factory')->setPrivate(true);
+        $container->getDefinition('form.registry')->setPrivate(true);
+        $container->getDefinition('form.type_guesser.validator')->setPrivate(true);
+        $container->getDefinition('form.type.form')->setPrivate(true);
+        $container->getDefinition('form.type.choice')->setPrivate(true);
+        $container->getDefinition('form.type_extension.form.http_foundation')->setPrivate(true);
+        $container->getDefinition('form.type_extension.form.validator')->setPrivate(true);
+        $container->getDefinition('form.type_extension.repeated.validator')->setPrivate(true);
+        $container->getDefinition('form.type_extension.submit.validator')->setPrivate(true);
+        $container->getDefinition('form.type_extension.upload.validator')->setPrivate(true);
+        $container->getDefinition('deprecated.form.registry')->setPrivate(true);
+
         if (null === $config['form']['csrf_protection']['enabled']) {
             $config['form']['csrf_protection']['enabled'] = $config['csrf_protection']['enabled'];
         }
 
         if ($this->isConfigEnabled($container, $config['form']['csrf_protection'])) {
             $loader->load('form_csrf.xml');
+
+            $container->getDefinition('form.type_extension.csrf')->setPrivate(true);
+            $container->getDefinition('deprecated.form.registry.csrf')->setPrivate(true);
 
             $container->setParameter('form.type_extension.csrf.enabled', true);
             $container->setParameter('form.type_extension.csrf.field_name', $config['form']['csrf_protection']['field_name']);
@@ -419,6 +465,9 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('esi.xml');
+
+        $container->getDefinition('esi')->setPrivate(true);
+        $container->getDefinition('esi_listener')->setPrivate(true);
     }
 
     /**
@@ -437,6 +486,9 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('ssi.xml');
+
+        $container->getDefinition('ssi')->setPrivate(true);
+        $container->getDefinition('ssi_listener')->setPrivate(true);
     }
 
     /**
@@ -480,8 +532,16 @@ class FrameworkExtension extends Extension
         $loader->load('collectors.xml');
         $loader->load('cache_debug.xml');
 
+        $container->getDefinition('data_collector.request')->setPrivate(true);
+        $container->getDefinition('data_collector.router')->setPrivate(true);
+        $container->getDefinition('profiler_listener')->setPrivate(true);
+
         if ($this->formConfigEnabled) {
             $loader->load('form_debug.xml');
+
+            $container->getDefinition('form.resolved_type_factory')->setPrivate(true);
+            $container->getDefinition('data_collector.form.extractor')->setPrivate(true);
+            $container->getDefinition('data_collector.form')->setPrivate(true);
         }
 
         if ($this->validatorConfigEnabled) {
@@ -490,6 +550,9 @@ class FrameworkExtension extends Extension
 
         if ($this->translationConfigEnabled) {
             $loader->load('translation_debug.xml');
+
+            $container->getDefinition('data_collector.translation')->setPrivate(true);
+
             $container->getDefinition('translator.data_collector')->setDecoratedService('translator');
         }
 
@@ -506,7 +569,7 @@ class FrameworkExtension extends Extension
 
         if ($this->isConfigEnabled($container, $config['matcher'])) {
             if (isset($config['matcher']['service'])) {
-                $container->setAlias('profiler.request_matcher', $config['matcher']['service']);
+                $container->setAlias('profiler.request_matcher', $config['matcher']['service'])->setPrivate(true);
             } elseif (isset($config['matcher']['ip']) || isset($config['matcher']['path']) || isset($config['matcher']['ips'])) {
                 $definition = $container->register('profiler.request_matcher', 'Symfony\\Component\\HttpFoundation\\RequestMatcher');
                 $definition->setPublic(false);
@@ -552,6 +615,10 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('workflow.xml');
+
+        $container->getDefinition('workflow.marking_store.multiple_state')->setPrivate(true);
+        $container->getDefinition('workflow.marking_store.single_state')->setPrivate(true);
+        $container->getDefinition('workflow.registry')->setPrivate(true);
 
         $registryDefinition = $container->getDefinition('workflow.registry');
 
@@ -626,6 +693,7 @@ class FrameworkExtension extends Extension
             // Enable the AuditTrail
             if ($workflow['audit_trail']['enabled']) {
                 $listener = new Definition(Workflow\EventListener\AuditTrailListener::class);
+                $listener->setPrivate(true);
                 $listener->addTag('monolog.logger', array('channel' => 'workflow'));
                 $listener->addTag('kernel.event_listener', array('event' => sprintf('workflow.%s.leave', $name), 'method' => 'onLeave'));
                 $listener->addTag('kernel.event_listener', array('event' => sprintf('workflow.%s.transition', $name), 'method' => 'onTransition'));
@@ -636,6 +704,7 @@ class FrameworkExtension extends Extension
 
             // Add Guard Listener
             $guard = new Definition(Workflow\EventListener\GuardListener::class);
+            $guard->setPrivate(true);
             $configuration = array();
             foreach ($workflow['transitions'] as $transitionName => $config) {
                 if (!isset($config['guard'])) {
@@ -681,8 +750,10 @@ class FrameworkExtension extends Extension
     {
         $loader->load('debug_prod.xml');
 
+        $container->getDefinition('debug.debug_handlers_listener')->setPrivate(true);
+
         if (class_exists(Stopwatch::class)) {
-            $container->register('debug.stopwatch', Stopwatch::class)->addArgument(true);
+            $container->register('debug.stopwatch', Stopwatch::class)->addArgument(true)->setPrivate(true);
             $container->setAlias(Stopwatch::class, new Alias('debug.stopwatch', false));
         }
 
@@ -694,6 +765,9 @@ class FrameworkExtension extends Extension
 
         if ($debug && class_exists(Stopwatch::class)) {
             $loader->load('debug.xml');
+            $container->getDefinition('debug.event_dispatcher')->setPrivate(true);
+            $container->getDefinition('debug.controller_resolver')->setPrivate(true);
+            $container->getDefinition('debug.argument_resolver')->setPrivate(true);
         }
 
         $definition = $container->findDefinition('debug.debug_handlers_listener');
@@ -733,6 +807,8 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('routing.xml');
+
+        $container->getDefinition('router_listener')->setPrivate(true);
 
         $container->setParameter('router.resource', $config['resource']);
         $container->setParameter('router.cache_class_prefix', $container->getParameter('kernel.container_class'));
@@ -792,8 +868,14 @@ class FrameworkExtension extends Extension
     {
         $loader->load('session.xml');
 
+        $container->getDefinition('session.storage.native')->setPrivate(true);
+        $container->getDefinition('session.storage.php_bridge')->setPrivate(true);
+        $container->getDefinition('session_listener')->setPrivate(true);
+        $container->getDefinition('session.save_listener')->setPrivate(true);
+        $container->getAlias('session.storage.filesystem')->setPrivate(true);
+
         // session storage
-        $container->setAlias('session.storage', $config['storage_id']);
+        $container->setAlias('session.storage', $config['storage_id'])->setPrivate(true);
         $options = array();
         foreach (array('name', 'cookie_lifetime', 'cookie_path', 'cookie_domain', 'cookie_secure', 'cookie_httponly', 'use_cookies', 'gc_maxlifetime', 'gc_probability', 'gc_divisor', 'use_strict_mode') as $key) {
             if (isset($config[$key])) {
@@ -816,7 +898,7 @@ class FrameworkExtension extends Extension
                 $handlerId = 'session.handler.write_check';
             }
 
-            $container->setAlias('session.handler', $handlerId);
+            $container->setAlias('session.handler', $handlerId)->setPrivate(true);
         }
 
         $container->setParameter('session.save_path', $config['save_path']);
@@ -853,6 +935,9 @@ class FrameworkExtension extends Extension
     {
         if ($config['formats']) {
             $loader->load('request.xml');
+
+            $container->getDefinition('request.add_request_formats_listener')->setPrivate(true);
+
             $container
                 ->getDefinition('request.add_request_formats_listener')
                 ->replaceArgument(0, $config['formats'])
@@ -870,6 +955,9 @@ class FrameworkExtension extends Extension
     private function registerTemplatingConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         $loader->load('templating.xml');
+
+        $container->getDefinition('templating.name_parser')->setPrivate(true);
+        $container->getDefinition('templating.filename_parser')->setPrivate(true);
 
         $container->setParameter('fragment.renderer.hinclude.global_template', $config['hinclude_default_template']);
 
@@ -889,10 +977,10 @@ class FrameworkExtension extends Extension
 
             // Use a delegation unless only a single loader was registered
             if (1 === count($loaders)) {
-                $container->setAlias('templating.loader', (string) reset($loaders));
+                $container->setAlias('templating.loader', (string) reset($loaders))->setPrivate(true);
             } else {
                 $container->getDefinition('templating.loader.chain')->addArgument($loaders);
-                $container->setAlias('templating.loader', 'templating.loader.chain');
+                $container->setAlias('templating.loader', 'templating.loader.chain')->setPrivate(true);
             }
         }
 
@@ -937,13 +1025,25 @@ class FrameworkExtension extends Extension
         if (in_array('php', $config['engines'], true)) {
             $loader->load('templating_php.xml');
 
+            $container->getDefinition('templating.helper.slots')->setPrivate(true);
+            $container->getDefinition('templating.helper.request')->setPrivate(true);
+            $container->getDefinition('templating.helper.session')->setPrivate(true);
+            $container->getDefinition('templating.helper.router')->setPrivate(true);
+            $container->getDefinition('templating.helper.assets')->setPrivate(true);
+            $container->getDefinition('templating.helper.actions')->setPrivate(true);
+            $container->getDefinition('templating.helper.code')->setPrivate(true);
+            $container->getDefinition('templating.helper.translator')->setPrivate(true);
+            $container->getDefinition('templating.helper.form')->setPrivate(true);
+            $container->getDefinition('templating.helper.stopwatch')->setPrivate(true);
+            $container->getDefinition('templating.globals')->setPrivate(true);
+
             $container->setParameter('templating.helper.form.resources', $config['form']['resources']);
 
             if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
                 $loader->load('templating_debug.xml');
 
                 $container->setDefinition('templating.engine.php', $container->findDefinition('debug.templating.engine.php'));
-                $container->setAlias('debug.templating.engine.php', 'templating.engine.php');
+                $container->setAlias('debug.templating.engine.php', 'templating.engine.php')->setPrivate(true);
             }
 
             if (\PHP_VERSION_ID < 70000) {
@@ -976,6 +1076,12 @@ class FrameworkExtension extends Extension
     private function registerAssetsConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         $loader->load('assets.xml');
+
+        $container->getDefinition('assets.packages')->setPrivate(true);
+        $container->getDefinition('assets.context')->setPrivate(true);
+        $container->getDefinition('assets.path_package')->setPrivate(true);
+        $container->getDefinition('assets.url_package')->setPrivate(true);
+        $container->getDefinition('assets.static_version_strategy')->setPrivate(true);
 
         $defaultVersion = null;
 
@@ -1073,6 +1179,35 @@ class FrameworkExtension extends Extension
 
         $loader->load('translation.xml');
 
+        $container->getDefinition('translator.default')->setPrivate(true);
+        $container->getDefinition('translation.loader.php')->setPrivate(true);
+        $container->getDefinition('translation.loader.yml')->setPrivate(true);
+        $container->getDefinition('translation.loader.xliff')->setPrivate(true);
+        $container->getDefinition('translation.loader.po')->setPrivate(true);
+        $container->getDefinition('translation.loader.mo')->setPrivate(true);
+        $container->getDefinition('translation.loader.qt')->setPrivate(true);
+        $container->getDefinition('translation.loader.csv')->setPrivate(true);
+        $container->getDefinition('translation.loader.res')->setPrivate(true);
+        $container->getDefinition('translation.loader.dat')->setPrivate(true);
+        $container->getDefinition('translation.loader.ini')->setPrivate(true);
+        $container->getDefinition('translation.loader.json')->setPrivate(true);
+        $container->getDefinition('translation.dumper.php')->setPrivate(true);
+        $container->getDefinition('translation.dumper.xliff')->setPrivate(true);
+        $container->getDefinition('translation.dumper.po')->setPrivate(true);
+        $container->getDefinition('translation.dumper.mo')->setPrivate(true);
+        $container->getDefinition('translation.dumper.yml')->setPrivate(true);
+        $container->getDefinition('translation.dumper.qt')->setPrivate(true);
+        $container->getDefinition('translation.dumper.csv')->setPrivate(true);
+        $container->getDefinition('translation.dumper.ini')->setPrivate(true);
+        $container->getDefinition('translation.dumper.json')->setPrivate(true);
+        $container->getDefinition('translation.dumper.res')->setPrivate(true);
+        $container->getDefinition('translation.extractor.php')->setPrivate(true);
+        $container->getDefinition('translator_listener')->setPrivate(true);
+        $container->getDefinition('translation.loader')->setPrivate(true);
+        $container->getDefinition('translation.reader')->setPrivate(true);
+        $container->getDefinition('translation.extractor')->setPrivate(true);
+        $container->getDefinition('translation.writer')->setPrivate(true);
+
         // Use the "real" translator instead of the identity default
         $container->setAlias('translator', 'translator.default');
         $container->setAlias('translator.formatter', new Alias($config['formatter'], false));
@@ -1168,6 +1303,10 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('validator.xml');
+
+        $container->getDefinition('validator.builder')->setPrivate(true);
+        $container->getDefinition('validator.expression')->setPrivate(true);
+        $container->getDefinition('validator.email')->setPrivate(true);
 
         $validatorBuilder = $container->getDefinition('validator.builder');
 
@@ -1281,6 +1420,8 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('annotations.xml');
+
+        $container->getAlias('annotation_reader')->setPrivate(true);
 
         if ('none' !== $config['cache']) {
             if (!class_exists('Doctrine\Common\Cache\CacheProvider')) {
@@ -1408,6 +1549,9 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('serializer.xml');
+
+        $container->getDefinition('serializer.mapping.cache.symfony')->setPrivate(true);
+
         $chainLoader = $container->getDefinition('serializer.mapping.chain_loader');
 
         $serializerLoaders = array();
@@ -1498,8 +1642,11 @@ class FrameworkExtension extends Extension
     {
         $loader->load('property_info.xml');
 
+        $container->getDefinition('property_info')->setPrivate(true);
+
         if (interface_exists('phpDocumentor\Reflection\DocBlockFactoryInterface')) {
             $definition = $container->register('property_info.php_doc_extractor', 'Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor');
+            $definition->setPrivate(true);
             $definition->addTag('property_info.description_extractor', array('priority' => -1000));
             $definition->addTag('property_info.type_extractor', array('priority' => -1001));
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -49,7 +49,7 @@
             </argument>
         </service>
 
-        <service id="annotation_reader" alias="annotations.reader" public="true" />
+        <service id="annotation_reader" alias="annotations.reader" />
         <service id="Doctrine\Common\Annotations\Reader" alias="annotation_reader" />
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="assets.packages" class="Symfony\Component\Asset\Packages" public="true">
+        <service id="assets.packages" class="Symfony\Component\Asset\Packages">
             <argument type="service" id="assets.empty_package" /> <!-- default package -->
             <argument type="collection" /> <!-- named packages -->
         </service>
@@ -17,23 +17,23 @@
             <argument type="service" id="assets.empty_version_strategy" />
         </service>
 
-        <service id="assets.context" class="Symfony\Component\Asset\Context\RequestStackContext" public="true">
+        <service id="assets.context" class="Symfony\Component\Asset\Context\RequestStackContext">
             <argument type="service" id="request_stack" />
         </service>
 
-        <service id="assets.path_package" class="Symfony\Component\Asset\PathPackage" abstract="true" public="true">
+        <service id="assets.path_package" class="Symfony\Component\Asset\PathPackage" abstract="true">
             <argument /> <!-- base path -->
             <argument /> <!-- version strategy -->
             <argument type="service" id="assets.context" />
         </service>
 
-        <service id="assets.url_package" class="Symfony\Component\Asset\UrlPackage" abstract="true" public="true">
+        <service id="assets.url_package" class="Symfony\Component\Asset\UrlPackage" abstract="true">
             <argument /> <!-- base URLs -->
             <argument /> <!-- version strategy -->
             <argument type="service" id="assets.context" />
         </service>
 
-        <service id="assets.static_version_strategy" class="Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy" abstract="true" public="true">
+        <service id="assets.static_version_strategy" class="Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy" abstract="true">
             <argument /> <!-- version -->
             <argument /> <!-- format -->
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -27,7 +27,7 @@
             <tag name="cache.pool" />
         </service>
 
-        <service id="cache.adapter.system" class="Symfony\Component\Cache\Adapter\AdapterInterface" abstract="true" public="true">
+        <service id="cache.adapter.system" class="Symfony\Component\Cache\Adapter\AdapterInterface" abstract="true">
             <factory class="Symfony\Component\Cache\Adapter\AbstractAdapter" method="createSystemCache" />
             <tag name="cache.pool" clearer="cache.default_clearer" />
             <tag name="monolog.logger" channel="cache" />
@@ -38,7 +38,7 @@
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
-        <service id="cache.adapter.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" abstract="true" public="true">
+        <service id="cache.adapter.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" abstract="true">
             <tag name="cache.pool" clearer="cache.default_clearer" />
             <tag name="monolog.logger" channel="cache" />
             <argument /> <!-- namespace -->
@@ -49,7 +49,7 @@
             </call>
         </service>
 
-        <service id="cache.adapter.doctrine" class="Symfony\Component\Cache\Adapter\DoctrineAdapter" abstract="true" public="true">
+        <service id="cache.adapter.doctrine" class="Symfony\Component\Cache\Adapter\DoctrineAdapter" abstract="true">
             <tag name="cache.pool" provider="cache.default_doctrine_provider" clearer="cache.default_clearer" />
             <tag name="monolog.logger" channel="cache" />
             <argument /> <!-- Doctrine provider service -->
@@ -60,7 +60,7 @@
             </call>
         </service>
 
-        <service id="cache.adapter.filesystem" class="Symfony\Component\Cache\Adapter\FilesystemAdapter" abstract="true" public="true">
+        <service id="cache.adapter.filesystem" class="Symfony\Component\Cache\Adapter\FilesystemAdapter" abstract="true">
             <tag name="cache.pool" clearer="cache.default_clearer" />
             <tag name="monolog.logger" channel="cache" />
             <argument /> <!-- namespace -->
@@ -71,14 +71,14 @@
             </call>
         </service>
 
-        <service id="cache.adapter.psr6" class="Symfony\Component\Cache\Adapter\ProxyAdapter" abstract="true" public="true">
+        <service id="cache.adapter.psr6" class="Symfony\Component\Cache\Adapter\ProxyAdapter" abstract="true">
             <tag name="cache.pool" provider="cache.default_psr6_provider" clearer="cache.default_clearer" />
             <argument /> <!-- PSR-6 provider service -->
             <argument /> <!-- namespace -->
             <argument>0</argument> <!-- default lifetime -->
         </service>
 
-        <service id="cache.adapter.redis" class="Symfony\Component\Cache\Adapter\RedisAdapter" abstract="true" public="true">
+        <service id="cache.adapter.redis" class="Symfony\Component\Cache\Adapter\RedisAdapter" abstract="true">
             <tag name="cache.pool" provider="cache.default_redis_provider" clearer="cache.default_clearer" />
             <tag name="monolog.logger" channel="cache" />
             <argument /> <!-- Redis connection service -->
@@ -89,7 +89,7 @@
             </call>
         </service>
 
-        <service id="cache.adapter.memcached" class="Symfony\Component\Cache\Adapter\MemcachedAdapter" abstract="true" public="true">
+        <service id="cache.adapter.memcached" class="Symfony\Component\Cache\Adapter\MemcachedAdapter" abstract="true">
             <tag name="cache.pool" provider="cache.default_memcached_provider" clearer="cache.default_clearer" />
             <tag name="monolog.logger" channel="cache" />
             <argument /> <!-- Memcached connection service -->
@@ -100,7 +100,7 @@
             </call>
         </service>
 
-        <service id="cache.default_clearer" class="Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer" public="true">
+        <service id="cache.default_clearer" class="Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer">
             <tag name="kernel.cache_clearer" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -12,7 +12,7 @@
             <call method="setKernel"><argument type="service" id="kernel" on-invalid="ignore" /></call>
         </service>
 
-        <service id="data_collector.request" class="Symfony\Bundle\FrameworkBundle\DataCollector\RequestDataCollector" public="true">
+        <service id="data_collector.request" class="Symfony\Bundle\FrameworkBundle\DataCollector\RequestDataCollector">
             <tag name="kernel.event_subscriber" />
             <tag name="data_collector" template="@WebProfiler/Collector/request.html.twig" id="request" priority="335" />
         </service>
@@ -47,7 +47,7 @@
             <tag name="data_collector" template="@WebProfiler/Collector/memory.html.twig" id="memory" priority="325" />
         </service>
 
-        <service id="data_collector.router" class="Symfony\Bundle\FrameworkBundle\DataCollector\RouterDataCollector" public="true">
+        <service id="data_collector.router" class="Symfony\Bundle\FrameworkBundle\DataCollector\RouterDataCollector">
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
             <tag name="data_collector" template="@WebProfiler/Collector/router.html.twig" id="router" priority="285" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -7,20 +7,20 @@
     <services>
         <defaults public="false" />
 
-        <service id="debug.event_dispatcher" class="Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher" decorates="event_dispatcher" public="true">
+        <service id="debug.event_dispatcher" class="Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher" decorates="event_dispatcher">
             <tag name="monolog.logger" channel="event" />
             <argument type="service" id="debug.event_dispatcher.inner" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="debug.controller_resolver" decorates="controller_resolver" class="Symfony\Component\HttpKernel\Controller\TraceableControllerResolver" public="true">
+        <service id="debug.controller_resolver" decorates="controller_resolver" class="Symfony\Component\HttpKernel\Controller\TraceableControllerResolver">
             <argument type="service" id="debug.controller_resolver.inner" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="argument_resolver" />
         </service>
 
-        <service id="debug.argument_resolver" decorates="argument_resolver" class="Symfony\Component\HttpKernel\Controller\TraceableArgumentResolver" public="true">
+        <service id="debug.argument_resolver" decorates="argument_resolver" class="Symfony\Component\HttpKernel\Controller\TraceableArgumentResolver">
             <argument type="service" id="debug.argument_resolver.inner" />
             <argument type="service" id="debug.stopwatch" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -11,7 +11,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="debug.debug_handlers_listener" class="Symfony\Component\HttpKernel\EventListener\DebugHandlersListener" public="true">
+        <service id="debug.debug_handlers_listener" class="Symfony\Component\HttpKernel\EventListener\DebugHandlersListener">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="php" />
             <argument>null</argument><!-- Exception handler -->

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
@@ -7,9 +7,9 @@
     <services>
         <defaults public="false" />
 
-        <service id="esi" class="Symfony\Component\HttpKernel\HttpCache\Esi" public="true" />
+        <service id="esi" class="Symfony\Component\HttpKernel\HttpCache\Esi" />
 
-        <service id="esi_listener" class="Symfony\Component\HttpKernel\EventListener\SurrogateListener" public="true">
+        <service id="esi_listener" class="Symfony\Component\HttpKernel\EventListener\SurrogateListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="esi" on-invalid="ignore" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -8,11 +8,11 @@
         <defaults public="false" />
 
         <!-- ResolvedFormTypeFactory -->
-        <service id="form.resolved_type_factory" class="Symfony\Component\Form\ResolvedFormTypeFactory" public="true" />
+        <service id="form.resolved_type_factory" class="Symfony\Component\Form\ResolvedFormTypeFactory" />
         <service id="Symfony\Component\Form\ResolvedFormTypeFactoryInterface" alias="form.resolved_type_factory" />
 
         <!-- FormRegistry -->
-        <service id="form.registry" class="Symfony\Component\Form\FormRegistry" public="true">
+        <service id="form.registry" class="Symfony\Component\Form\FormRegistry">
             <argument type="collection">
                 <!--
                 We don't need to be able to add more extensions.
@@ -191,17 +191,8 @@
             <argument type="string">%validator.translation_domain%</argument>
         </service>
 
-        <service id="deprecated.form.registry" class="stdClass" public="true">
-            <property name="registry" type="collection">
-                <property type="service" id="form.type_guesser.validator" />
-                <property type="service" id="form.type.choice" />
-                <property type="service" id="form.type.form" />
-                <property type="service" id="form.type_extension.form.http_foundation" />
-                <property type="service" id="form.type_extension.form.validator" />
-                <property type="service" id="form.type_extension.repeated.validator" />
-                <property type="service" id="form.type_extension.submit.validator" />
-                <property type="service" id="form.type_extension.upload.validator" />
-            </property>
+        <service id="deprecated.form.registry" class="stdClass">
+            <property name="registry" type="collection" />
             <deprecated>The service "%service_id%" is internal and deprecated since Symfony 3.3 and will be removed in Symfony 4.0</deprecated>
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
@@ -17,10 +17,8 @@
             <argument type="service" id="form.server_params" />
         </service>
 
-        <service id="deprecated.form.registry.csrf" class="stdClass" public="true">
-            <property name="registry" type="collection">
-                <property type="service" id="form.type_extension.csrf" />
-            </property>
+        <service id="deprecated.form.registry.csrf" class="stdClass">
+            <property name="registry" type="collection" />
             <deprecated>The service "%service_id%" is internal and deprecated since Symfony 3.3 and will be removed in Symfony 4.0</deprecated>
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="form.resolved_type_factory" class="Symfony\Component\Form\Extension\DataCollector\Proxy\ResolvedTypeFactoryDataCollectorProxy" public="true">
+        <service id="form.resolved_type_factory" class="Symfony\Component\Form\Extension\DataCollector\Proxy\ResolvedTypeFactoryDataCollectorProxy">
             <argument type="service">
                 <service class="Symfony\Component\Form\ResolvedFormTypeFactory" />
             </argument>
@@ -21,9 +21,9 @@
         </service>
 
         <!-- DataCollector -->
-        <service id="data_collector.form.extractor" class="Symfony\Component\Form\Extension\DataCollector\FormDataExtractor" public="true" />
+        <service id="data_collector.form.extractor" class="Symfony\Component\Form\Extension\DataCollector\FormDataExtractor" />
 
-        <service id="data_collector.form" class="Symfony\Component\Form\Extension\DataCollector\FormDataCollector" public="true">
+        <service id="data_collector.form" class="Symfony\Component\Form\Extension\DataCollector\FormDataCollector">
             <tag name="data_collector" template="@WebProfiler/Collector/form.html.twig" id="form" priority="310" />
             <argument type="service" id="data_collector.form.extractor" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_listener.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_listener.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="fragment.listener" class="Symfony\Component\HttpKernel\EventListener\FragmentListener" public="true">
+        <service id="fragment.listener" class="Symfony\Component\HttpKernel\EventListener\FragmentListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="uri_signer" />
             <argument>%fragment.path%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
@@ -12,27 +12,27 @@
     <services>
         <defaults public="false" />
 
-        <service id="fragment.handler" class="Symfony\Component\HttpKernel\DependencyInjection\LazyLoadingFragmentHandler" public="true">
+        <service id="fragment.handler" class="Symfony\Component\HttpKernel\DependencyInjection\LazyLoadingFragmentHandler">
             <argument /> <!-- fragment renderer locator -->
             <argument type="service" id="request_stack" />
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="fragment.renderer.inline" class="Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer" public="true">
+        <service id="fragment.renderer.inline" class="Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer">
             <tag name="kernel.fragment_renderer" alias="inline" />
             <argument type="service" id="http_kernel" />
             <argument type="service" id="event_dispatcher" />
             <call method="setFragmentPath"><argument>%fragment.path%</argument></call>
         </service>
 
-        <service id="fragment.renderer.hinclude" class="Symfony\Component\HttpKernel\Fragment\HIncludeFragmentRenderer" public="true">
+        <service id="fragment.renderer.hinclude" class="Symfony\Component\HttpKernel\Fragment\HIncludeFragmentRenderer">
             <argument /> <!-- templating or Twig service -->
             <argument type="service" id="uri_signer" />
             <argument>%fragment.renderer.hinclude.global_template%</argument>
             <call method="setFragmentPath"><argument>%fragment.path%</argument></call>
         </service>
 
-        <service id="fragment.renderer.esi" class="Symfony\Component\HttpKernel\Fragment\EsiFragmentRenderer" public="true">
+        <service id="fragment.renderer.esi" class="Symfony\Component\HttpKernel\Fragment\EsiFragmentRenderer">
             <tag name="kernel.fragment_renderer" alias="esi" />
             <argument type="service" id="esi" on-invalid="null" />
             <argument type="service" id="fragment.renderer.inline" />
@@ -40,7 +40,7 @@
             <call method="setFragmentPath"><argument>%fragment.path%</argument></call>
         </service>
 
-        <service id="fragment.renderer.ssi" class="Symfony\Component\HttpKernel\Fragment\SsiFragmentRenderer" public="true">
+        <service id="fragment.renderer.ssi" class="Symfony\Component\HttpKernel\Fragment\SsiFragmentRenderer">
             <tag name="kernel.fragment_renderer" alias="ssi" />
             <argument type="service" id="ssi" on-invalid="null" />
             <argument type="service" id="fragment.renderer.inline" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
@@ -17,7 +17,7 @@
             <argument>%profiler.storage.dsn%</argument>
         </service>
 
-        <service id="profiler_listener" class="Symfony\Component\HttpKernel\EventListener\ProfilerListener" public="true">
+        <service id="profiler_listener" class="Symfony\Component\HttpKernel\EventListener\ProfilerListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="profiler" />
             <argument type="service" id="request_stack" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="property_accessor" class="Symfony\Component\PropertyAccess\PropertyAccessor" public="true">
+        <service id="property_accessor" class="Symfony\Component\PropertyAccess\PropertyAccessor">
             <argument /> <!-- magicCall, set by the extension -->
             <argument /> <!-- throwExceptionOnInvalidIndex, set by the extension -->
             <argument type="service" id="cache.property_access" on-invalid="ignore" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="property_info" class="Symfony\Component\PropertyInfo\PropertyInfoExtractor" public="true">
+        <service id="property_info" class="Symfony\Component\PropertyInfo\PropertyInfoExtractor">
             <argument type="collection" />
             <argument type="collection" />
             <argument type="collection" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/request.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/request.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="request.add_request_formats_listener" class="Symfony\Component\HttpKernel\EventListener\AddRequestFormatsListener" public="true">
+        <service id="request.add_request_formats_listener" class="Symfony\Component\HttpKernel\EventListener\AddRequestFormatsListener">
             <tag name="kernel.event_subscriber" />
             <argument/>
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -102,7 +102,7 @@
             <argument type="service" id="Psr\Container\ContainerInterface" />
         </service>
 
-        <service id="router_listener" class="Symfony\Component\HttpKernel\EventListener\RouterListener" public="true">
+        <service id="router_listener" class="Symfony\Component\HttpKernel\EventListener\RouterListener">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="router" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -60,7 +60,7 @@
             <tag name="kernel.cache_warmer" />
         </service>
 
-        <service id="serializer.mapping.cache.symfony" class="Symfony\Component\Cache\Adapter\PhpArrayAdapter" public="true">
+        <service id="serializer.mapping.cache.symfony" class="Symfony\Component\Cache\Adapter\PhpArrayAdapter">
             <factory class="Symfony\Component\Cache\Adapter\PhpArrayAdapter" method="create" />
             <argument>%serializer.mapping.cache.file%</argument>
             <argument type="service" id="cache.serializer" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -27,7 +27,7 @@
             <argument type="collection" />
         </service>
 
-        <service id="kernel.class_cache.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\ClassCacheCacheWarmer" public="true">
+        <service id="kernel.class_cache.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\ClassCacheCacheWarmer">
             <argument type="collection">
                 <argument>Symfony\Component\HttpFoundation\ParameterBag</argument>
                 <argument>Symfony\Component\HttpFoundation\HeaderBag</argument>
@@ -49,7 +49,7 @@
         <service id="filesystem" class="Symfony\Component\Filesystem\Filesystem" public="true" />
         <service id="Symfony\Component\Filesystem\Filesystem" alias="filesystem" />
 
-        <service id="file_locator" class="Symfony\Component\HttpKernel\Config\FileLocator" public="true">
+        <service id="file_locator" class="Symfony\Component\HttpKernel\Config\FileLocator">
             <argument type="service" id="kernel" />
             <argument>%kernel.root_dir%/Resources</argument>
             <argument type="collection">
@@ -58,11 +58,11 @@
         </service>
         <service id="Symfony\Component\HttpKernel\Config\FileLocator" alias="file_locator" />
 
-        <service id="uri_signer" class="Symfony\Component\HttpKernel\UriSigner" public="true">
+        <service id="uri_signer" class="Symfony\Component\HttpKernel\UriSigner">
             <argument>%kernel.secret%</argument>
         </service>
 
-        <service id="config_cache_factory" class="Symfony\Component\Config\ResourceCheckerConfigCacheFactory" public="true">
+        <service id="config_cache_factory" class="Symfony\Component\Config\ResourceCheckerConfigCacheFactory">
             <argument /> <!-- resource checkers -->
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -26,13 +26,13 @@
             <argument>%session.metadata.update_threshold%</argument>
         </service>
 
-        <service id="session.storage.native" class="Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage" public="true">
+        <service id="session.storage.native" class="Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage">
             <argument>%session.storage.options%</argument>
             <argument type="service" id="session.handler" />
             <argument type="service" id="session.storage.metadata_bag" />
         </service>
 
-        <service id="session.storage.php_bridge" class="Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage" public="true">
+        <service id="session.storage.php_bridge" class="Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage">
             <argument type="service" id="session.handler" />
             <argument type="service" id="session.storage.metadata_bag" />
         </service>
@@ -53,7 +53,7 @@
 
         <service id="session.handler.write_check" class="Symfony\Component\HttpFoundation\Session\Storage\Handler\WriteCheckSessionHandler" />
 
-        <service id="session_listener" class="Symfony\Component\HttpKernel\EventListener\SessionListener" public="true">
+        <service id="session_listener" class="Symfony\Component\HttpKernel\EventListener\SessionListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service">
                 <service class="Symfony\Component\DependencyInjection\ServiceLocator">
@@ -65,11 +65,11 @@
             </argument>
         </service>
 
-        <service id="session.save_listener" class="Symfony\Component\HttpKernel\EventListener\SaveSessionListener" public="true">
+        <service id="session.save_listener" class="Symfony\Component\HttpKernel\EventListener\SaveSessionListener">
             <tag name="kernel.event_subscriber" />
         </service>
 
         <!-- for BC -->
-        <service id="session.storage.filesystem" alias="session.storage.mock_file" public="true" />
+        <service id="session.storage.filesystem" alias="session.storage.mock_file" />
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/ssi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/ssi.xml
@@ -7,9 +7,9 @@
     <services>
         <defaults public="false" />
 
-        <service id="ssi" class="Symfony\Component\HttpKernel\HttpCache\Ssi" public="true" />
+        <service id="ssi" class="Symfony\Component\HttpKernel\HttpCache\Ssi" />
 
-        <service id="ssi_listener" class="Symfony\Component\HttpKernel\EventListener\SurrogateListener" public="true">
+        <service id="ssi_listener" class="Symfony\Component\HttpKernel\EventListener\SurrogateListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="ssi" on-invalid="ignore" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
@@ -12,11 +12,11 @@
             <argument type="collection" /> <!-- engines -->
         </service>
 
-        <service id="templating.name_parser" class="Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser" public="true">
+        <service id="templating.name_parser" class="Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser">
             <argument type="service" id="kernel" />
         </service>
 
-        <service id="templating.filename_parser" class="Symfony\Bundle\FrameworkBundle\Templating\TemplateFilenameParser" public="true" />
+        <service id="templating.filename_parser" class="Symfony\Bundle\FrameworkBundle\Templating\TemplateFilenameParser" />
 
         <service id="templating.locator" class="Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator">
             <argument type="service" id="file_locator" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -20,53 +20,53 @@
             <argument type="collection" />
         </service>
 
-        <service id="templating.helper.slots" class="Symfony\Component\Templating\Helper\SlotsHelper" public="true">
+        <service id="templating.helper.slots" class="Symfony\Component\Templating\Helper\SlotsHelper">
             <tag name="templating.helper" alias="slots" />
         </service>
 
-        <service id="templating.helper.request" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\RequestHelper" public="true">
+        <service id="templating.helper.request" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\RequestHelper">
             <tag name="templating.helper" alias="request" />
             <argument type="service" id="request_stack" />
         </service>
 
-        <service id="templating.helper.session" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\SessionHelper" public="true">
+        <service id="templating.helper.session" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\SessionHelper">
             <tag name="templating.helper" alias="session" />
             <argument type="service" id="request_stack" />
         </service>
 
-        <service id="templating.helper.router" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\RouterHelper" public="true">
+        <service id="templating.helper.router" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\RouterHelper">
             <tag name="templating.helper" alias="router" />
             <argument type="service" id="router" />
         </service>
 
-        <service id="templating.helper.assets" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper" public="true">
+        <service id="templating.helper.assets" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper">
             <tag name="templating.helper" alias="assets" />
             <argument /> <!-- packages -->
         </service>
 
-        <service id="templating.helper.actions" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper" public="true">
+        <service id="templating.helper.actions" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper">
             <tag name="templating.helper" alias="actions" />
             <argument type="service" id="fragment.handler" />
         </service>
 
-        <service id="templating.helper.code" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper" public="true">
+        <service id="templating.helper.code" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper">
             <tag name="templating.helper" alias="code" />
             <argument type="service" id="debug.file_link_formatter"></argument>
             <argument>%kernel.root_dir%</argument>
             <argument>%kernel.charset%</argument>
         </service>
 
-        <service id="templating.helper.translator" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper" public="true">
+        <service id="templating.helper.translator" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper">
             <tag name="templating.helper" alias="translator" />
             <argument type="service" id="translator" />
         </service>
 
-        <service id="templating.helper.form" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper" public="true">
+        <service id="templating.helper.form" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper">
             <tag name="templating.helper" alias="form" />
             <argument type="service" id="templating.form.renderer" />
         </service>
 
-        <service id="templating.helper.stopwatch" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\StopwatchHelper" public="true">
+        <service id="templating.helper.stopwatch" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\StopwatchHelper">
             <tag name="templating.helper" alias="stopwatch" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
         </service>
@@ -81,7 +81,7 @@
             <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
         </service>
 
-        <service id="templating.globals" class="Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables" public="true">
+        <service id="templating.globals" class="Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables">
             <argument type="service" id="service_container" />
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -18,11 +18,11 @@
             <argument type="service" id="test.client.cookiejar" />
         </service>
 
-        <service id="test.client.history" class="Symfony\Component\BrowserKit\History" shared="false" public="true" />
+        <service id="test.client.history" class="Symfony\Component\BrowserKit\History" shared="false" />
 
-        <service id="test.client.cookiejar" class="Symfony\Component\BrowserKit\CookieJar" shared="false" public="true" />
+        <service id="test.client.cookiejar" class="Symfony\Component\BrowserKit\CookieJar" shared="false" />
 
-        <service id="test.session.listener" class="Symfony\Component\HttpKernel\EventListener\TestSessionListener" public="true">
+        <service id="test.session.listener" class="Symfony\Component\HttpKernel\EventListener\TestSessionListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service">
                 <service class="Symfony\Component\DependencyInjection\ServiceLocator">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="translator.default" class="Symfony\Bundle\FrameworkBundle\Translation\Translator" public="true">
+        <service id="translator.default" class="Symfony\Bundle\FrameworkBundle\Translation\Translator">
             <argument /> <!-- translation loaders locator -->
             <argument type="service" id="translator.formatter" />
             <argument>%kernel.default_locale%</argument>
@@ -32,67 +32,67 @@
             <argument type="service" id="translator.selector" />
         </service>
 
-        <service id="translation.loader.php" class="Symfony\Component\Translation\Loader\PhpFileLoader" public="true">
+        <service id="translation.loader.php" class="Symfony\Component\Translation\Loader\PhpFileLoader">
             <tag name="translation.loader" alias="php" />
         </service>
 
-        <service id="translation.loader.yml" class="Symfony\Component\Translation\Loader\YamlFileLoader" public="true">
+        <service id="translation.loader.yml" class="Symfony\Component\Translation\Loader\YamlFileLoader">
             <tag name="translation.loader" alias="yaml" legacy-alias="yml" />
         </service>
 
-        <service id="translation.loader.xliff" class="Symfony\Component\Translation\Loader\XliffFileLoader" public="true">
+        <service id="translation.loader.xliff" class="Symfony\Component\Translation\Loader\XliffFileLoader">
             <tag name="translation.loader" alias="xlf" legacy-alias="xliff" />
         </service>
 
-        <service id="translation.loader.po" class="Symfony\Component\Translation\Loader\PoFileLoader" public="true">
+        <service id="translation.loader.po" class="Symfony\Component\Translation\Loader\PoFileLoader">
             <tag name="translation.loader" alias="po" />
         </service>
 
-        <service id="translation.loader.mo" class="Symfony\Component\Translation\Loader\MoFileLoader" public="true">
+        <service id="translation.loader.mo" class="Symfony\Component\Translation\Loader\MoFileLoader">
             <tag name="translation.loader" alias="mo" />
         </service>
 
-        <service id="translation.loader.qt" class="Symfony\Component\Translation\Loader\QtFileLoader" public="true">
+        <service id="translation.loader.qt" class="Symfony\Component\Translation\Loader\QtFileLoader">
             <tag name="translation.loader" alias="ts" />
         </service>
 
-        <service id="translation.loader.csv" class="Symfony\Component\Translation\Loader\CsvFileLoader" public="true">
+        <service id="translation.loader.csv" class="Symfony\Component\Translation\Loader\CsvFileLoader">
             <tag name="translation.loader" alias="csv" />
         </service>
 
-        <service id="translation.loader.res" class="Symfony\Component\Translation\Loader\IcuResFileLoader" public="true">
+        <service id="translation.loader.res" class="Symfony\Component\Translation\Loader\IcuResFileLoader">
             <tag name="translation.loader" alias="res" />
         </service>
 
-        <service id="translation.loader.dat" class="Symfony\Component\Translation\Loader\IcuDatFileLoader" public="true">
+        <service id="translation.loader.dat" class="Symfony\Component\Translation\Loader\IcuDatFileLoader">
             <tag name="translation.loader" alias="dat" />
         </service>
 
-        <service id="translation.loader.ini" class="Symfony\Component\Translation\Loader\IniFileLoader" public="true">
+        <service id="translation.loader.ini" class="Symfony\Component\Translation\Loader\IniFileLoader">
             <tag name="translation.loader" alias="ini" />
         </service>
 
-        <service id="translation.loader.json" class="Symfony\Component\Translation\Loader\JsonFileLoader" public="true">
+        <service id="translation.loader.json" class="Symfony\Component\Translation\Loader\JsonFileLoader">
             <tag name="translation.loader" alias="json" />
         </service>
 
-        <service id="translation.dumper.php" class="Symfony\Component\Translation\Dumper\PhpFileDumper" public="true">
+        <service id="translation.dumper.php" class="Symfony\Component\Translation\Dumper\PhpFileDumper">
             <tag name="translation.dumper" alias="php" />
         </service>
 
-        <service id="translation.dumper.xliff" class="Symfony\Component\Translation\Dumper\XliffFileDumper" public="true">
+        <service id="translation.dumper.xliff" class="Symfony\Component\Translation\Dumper\XliffFileDumper">
             <tag name="translation.dumper" alias="xlf" />
         </service>
 
-        <service id="translation.dumper.po" class="Symfony\Component\Translation\Dumper\PoFileDumper" public="true">
+        <service id="translation.dumper.po" class="Symfony\Component\Translation\Dumper\PoFileDumper">
             <tag name="translation.dumper" alias="po" />
         </service>
 
-        <service id="translation.dumper.mo" class="Symfony\Component\Translation\Dumper\MoFileDumper" public="true">
+        <service id="translation.dumper.mo" class="Symfony\Component\Translation\Dumper\MoFileDumper">
             <tag name="translation.dumper" alias="mo" />
         </service>
 
-        <service id="translation.dumper.yml" class="Symfony\Component\Translation\Dumper\YamlFileDumper" public="true">
+        <service id="translation.dumper.yml" class="Symfony\Component\Translation\Dumper\YamlFileDumper">
             <tag name="translation.dumper" alias="yml" />
         </service>
 
@@ -101,38 +101,38 @@
             <tag name="translation.dumper" alias="yaml" />
         </service>
 
-        <service id="translation.dumper.qt" class="Symfony\Component\Translation\Dumper\QtFileDumper" public="true">
+        <service id="translation.dumper.qt" class="Symfony\Component\Translation\Dumper\QtFileDumper">
             <tag name="translation.dumper" alias="ts" />
         </service>
 
-        <service id="translation.dumper.csv" class="Symfony\Component\Translation\Dumper\CsvFileDumper" public="true">
+        <service id="translation.dumper.csv" class="Symfony\Component\Translation\Dumper\CsvFileDumper">
             <tag name="translation.dumper" alias="csv" />
         </service>
 
-        <service id="translation.dumper.ini" class="Symfony\Component\Translation\Dumper\IniFileDumper" public="true">
+        <service id="translation.dumper.ini" class="Symfony\Component\Translation\Dumper\IniFileDumper">
             <tag name="translation.dumper" alias="ini" />
         </service>
 
-        <service id="translation.dumper.json" class="Symfony\Component\Translation\Dumper\JsonFileDumper" public="true">
+        <service id="translation.dumper.json" class="Symfony\Component\Translation\Dumper\JsonFileDumper">
             <tag name="translation.dumper" alias="json" />
         </service>
 
-        <service id="translation.dumper.res" class="Symfony\Component\Translation\Dumper\IcuResFileDumper" public="true">
+        <service id="translation.dumper.res" class="Symfony\Component\Translation\Dumper\IcuResFileDumper">
             <tag name="translation.dumper" alias="res" />
         </service>
 
-        <service id="translation.extractor.php" class="Symfony\Bundle\FrameworkBundle\Translation\PhpExtractor" public="true">
+        <service id="translation.extractor.php" class="Symfony\Bundle\FrameworkBundle\Translation\PhpExtractor">
             <tag name="translation.extractor" alias="php" />
         </service>
 
-        <service id="translation.loader" class="Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader" public="true">
+        <service id="translation.loader" class="Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader">
             <deprecated>The "%service_id%" service is deprecated since Symfony 3.4 and will be removed in 4.0. Use "translation.reader" instead.</deprecated>
         </service>
-        <service id="translation.reader" class="Symfony\Component\Translation\Reader\TranslationReader" public="true" />
+        <service id="translation.reader" class="Symfony\Component\Translation\Reader\TranslationReader" />
 
-        <service id="translation.extractor" class="Symfony\Component\Translation\Extractor\ChainExtractor" public="true" />
+        <service id="translation.extractor" class="Symfony\Component\Translation\Extractor\ChainExtractor" />
 
-        <service id="translation.writer" class="Symfony\Component\Translation\Writer\TranslationWriter" public="true" />
+        <service id="translation.writer" class="Symfony\Component\Translation\Writer\TranslationWriter" />
 
         <service id="translation.warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\TranslationsCacheWarmer">
             <tag name="container.service_subscriber" id="translator" />
@@ -140,7 +140,7 @@
             <argument type="service" id="Psr\Container\ContainerInterface" />
         </service>
 
-        <service id="translator_listener" class="Symfony\Component\HttpKernel\EventListener\TranslatorListener" public="true">
+        <service id="translator_listener" class="Symfony\Component\HttpKernel\EventListener\TranslatorListener">
             <argument type="service" id="translator" />
             <argument type="service" id="request_stack" />
             <tag name="kernel.event_subscriber" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_debug.xml
@@ -13,7 +13,7 @@
         </service>
 
         <!-- DataCollector -->
-        <service id="data_collector.translation" class="Symfony\Component\Translation\DataCollector\TranslationDataCollector" public="true">
+        <service id="data_collector.translation" class="Symfony\Component\Translation\DataCollector\TranslationDataCollector">
             <tag name="data_collector" template="@WebProfiler/Collector/translation.html.twig" id="translation" priority="275" />
             <argument type="service" id="translator.data_collector" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -17,7 +17,7 @@
         </service>
         <service id="Symfony\Component\Validator\Validator\ValidatorInterface" alias="validator" />
 
-        <service id="validator.builder" class="Symfony\Component\Validator\ValidatorBuilderInterface" public="true">
+        <service id="validator.builder" class="Symfony\Component\Validator\ValidatorBuilderInterface">
             <factory class="Symfony\Component\Validator\Validation" method="createValidatorBuilder" />
             <call method="setConstraintValidatorFactory">
                 <argument type="service" id="validator.validator_factory" />
@@ -64,11 +64,11 @@
             <argument /> <!-- Constraint validators locator -->
         </service>
 
-        <service id="validator.expression" class="Symfony\Component\Validator\Constraints\ExpressionValidator" public="true">
+        <service id="validator.expression" class="Symfony\Component\Validator\Constraints\ExpressionValidator">
             <tag name="validator.constraint_validator" alias="validator.expression" />
         </service>
 
-        <service id="validator.email" class="Symfony\Component\Validator\Constraints\EmailValidator" public="true">
+        <service id="validator.email" class="Symfony\Component\Validator\Constraints\EmailValidator">
             <argument></argument>
             <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\EmailValidator" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -51,23 +51,23 @@
             <tag name="controller.argument_value_resolver" priority="-150" />
         </service>
 
-        <service id="response_listener" class="Symfony\Component\HttpKernel\EventListener\ResponseListener" public="true">
+        <service id="response_listener" class="Symfony\Component\HttpKernel\EventListener\ResponseListener">
             <tag name="kernel.event_subscriber" />
             <argument>%kernel.charset%</argument>
         </service>
 
-        <service id="streamed_response_listener" class="Symfony\Component\HttpKernel\EventListener\StreamedResponseListener" public="true">
+        <service id="streamed_response_listener" class="Symfony\Component\HttpKernel\EventListener\StreamedResponseListener">
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="locale_listener" class="Symfony\Component\HttpKernel\EventListener\LocaleListener" public="true">
+        <service id="locale_listener" class="Symfony\Component\HttpKernel\EventListener\LocaleListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="request_stack" />
             <argument>%kernel.default_locale%</argument>
             <argument type="service" id="router" on-invalid="ignore" />
         </service>
 
-        <service id="validate_request_listener" class="Symfony\Component\HttpKernel\EventListener\ValidateRequestListener" public="true">
+        <service id="validate_request_listener" class="Symfony\Component\HttpKernel\EventListener\ValidateRequestListener">
             <tag name="kernel.event_subscriber" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.xml
@@ -20,10 +20,10 @@
             <argument /> <!-- name -->
         </service>
 
-        <service id="workflow.marking_store.multiple_state" class="Symfony\Component\Workflow\MarkingStore\MultipleStateMarkingStore" abstract="true" public="true" />
-        <service id="workflow.marking_store.single_state" class="Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore" abstract="true" public="true" />
+        <service id="workflow.marking_store.multiple_state" class="Symfony\Component\Workflow\MarkingStore\MultipleStateMarkingStore" abstract="true" />
+        <service id="workflow.marking_store.single_state" class="Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore" abstract="true" />
 
-        <service id="workflow.registry" class="Symfony\Component\Workflow\Registry" public="true" />
+        <service id="workflow.registry" class="Symfony\Component\Workflow\Registry" />
         <service id="Symfony\Component\Workflow\Registry" alias="workflow.registry" />
 
         <service id="workflow.security.expression_language" class="Symfony\Component\Workflow\EventListener\ExpressionLanguage" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -58,10 +58,10 @@ class CachePoolClearCommandTest extends WebTestCase
     public function testCallClearer()
     {
         $tester = $this->createCommandTester();
-        $tester->execute(array('pools' => array('cache.default_clearer')), array('decorated' => false));
+        $tester->execute(array('pools' => array('cache.app_clearer')), array('decorated' => false));
 
         $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:clear exits with 0 in case of success');
-        $this->assertContains('Calling cache clearer: cache.default_clearer', $tester->getDisplay());
+        $this->assertContains('Calling cache clearer: cache.app_clearer', $tester->getDisplay());
         $this->assertContains('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/PropertyInfoTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/PropertyInfoTest.php
@@ -20,7 +20,7 @@ class PropertyInfoTest extends WebTestCase
         static::bootKernel(array('test_case' => 'Serializer'));
         $container = static::$kernel->getContainer();
 
-        $this->assertEquals(array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_INT))), $container->get('property_info')->getTypes('Symfony\Bundle\FrameworkBundle\Tests\Functional\Dummy', 'codes'));
+        $this->assertEquals(array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_INT))), $container->get('test.property_info')->getTypes('Symfony\Bundle\FrameworkBundle\Tests\Functional\Dummy', 'codes'));
     }
 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: ../config/default.yml }
 
+services:
+    test.property_info: '@property_info'
+
 framework:
     serializer: { enabled: true }
     property_info: { enabled: true }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -73,8 +73,19 @@ class SecurityExtension extends Extension
         $loader->load('collectors.xml');
         $loader->load('guard.xml');
 
+        $container->getDefinition('security.authentication.guard_handler')->setPrivate(true);
+        $container->getDefinition('security.firewall')->setPrivate(true);
+        $container->getDefinition('security.firewall.context')->setPrivate(true);
+        $container->getDefinition('security.validator.user_password')->setPrivate(true);
+        $container->getDefinition('security.rememberme.response_listener')->setPrivate(true);
+        $container->getDefinition('templating.helper.logout_url')->setPrivate(true);
+        $container->getDefinition('templating.helper.security')->setPrivate(true);
+        $container->getAlias('security.encoder_factory')->setPrivate(true);
+
         if ($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug')) {
             $loader->load('security_debug.xml');
+
+            $container->getAlias('security.firewall')->setPrivate(true);
         }
 
         if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
@@ -88,7 +99,7 @@ class SecurityExtension extends Extension
         $container->setParameter('security.authentication.session_strategy.strategy', $config['session_fixation_strategy']);
 
         if (isset($config['access_decision_manager']['service'])) {
-            $container->setAlias('security.access.decision_manager', $config['access_decision_manager']['service']);
+            $container->setAlias('security.access.decision_manager', $config['access_decision_manager']['service'])->setPrivate(true);
         } else {
             $container
                 ->getDefinition('security.access.decision_manager')
@@ -151,13 +162,13 @@ class SecurityExtension extends Extension
         $loader->load('security_acl.xml');
 
         if (isset($config['cache']['id'])) {
-            $container->setAlias('security.acl.cache', $config['cache']['id']);
+            $container->setAlias('security.acl.cache', $config['cache']['id'])->setPrivate(true);
         }
         $container->getDefinition('security.acl.voter.basic_permissions')->addArgument($config['voter']['allow_if_object_identity_unavailable']);
 
         // custom ACL provider
         if (isset($config['provider'])) {
-            $container->setAlias('security.acl.provider', $config['provider']);
+            $container->setAlias('security.acl.provider', $config['provider'])->setPrivate(true);
 
             return;
         }
@@ -168,6 +179,10 @@ class SecurityExtension extends Extension
     private function configureDbalAclProvider(array $config, ContainerBuilder $container, $loader)
     {
         $loader->load('security_acl_dbal.xml');
+
+        $container->getDefinition('security.acl.dbal.schema')->setPrivate(true);
+        $container->getAlias('security.acl.dbal.connection')->setPrivate(true);
+        $container->getAlias('security.acl.provider')->setPrivate(true);
 
         if (null !== $config['connection']) {
             $container->setAlias('security.acl.dbal.connection', sprintf('doctrine.dbal.%s_connection', $config['connection']));

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
@@ -9,7 +9,6 @@
 
         <service id="security.authentication.guard_handler"
                  class="Symfony\Component\Security\Guard\GuardAuthenticatorHandler"
-                 public="true"
             >
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="event_dispatcher" on-invalid="null" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -51,7 +51,7 @@
             <argument type="collection" />
         </service>
 
-        <service id="security.encoder_factory" alias="security.encoder_factory.generic" public="true" />
+        <service id="security.encoder_factory" alias="security.encoder_factory.generic" />
         <service id="Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface" alias="security.encoder_factory" />
 
         <service id="security.user_password_encoder.generic" class="Symfony\Component\Security\Core\Encoder\UserPasswordEncoder">
@@ -105,7 +105,7 @@
 
 
         <!-- Firewall related services -->
-        <service id="security.firewall" class="Symfony\Bundle\SecurityBundle\EventListener\FirewallListener" public="true">
+        <service id="security.firewall" class="Symfony\Bundle\SecurityBundle\EventListener\FirewallListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="security.firewall.map" />
             <argument type="service" id="event_dispatcher" />
@@ -118,7 +118,7 @@
             <argument /> <!-- Request matchers -->
         </service>
 
-        <service id="security.firewall.context" class="Symfony\Bundle\SecurityBundle\Security\FirewallContext" abstract="true" public="true">
+        <service id="security.firewall.context" class="Symfony\Bundle\SecurityBundle\Security\FirewallContext" abstract="true">
             <argument type="collection" />
             <argument type="service" id="security.exception_listener" />
             <argument />  <!-- FirewallConfig -->
@@ -169,7 +169,7 @@
 
 
         <!-- Validator -->
-        <service id="security.validator.user_password" class="Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator" public="true">
+        <service id="security.validator.user_password" class="Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator">
             <tag name="validator.constraint_validator" alias="security.validator.user_password" />
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.encoder_factory" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="security.acl.dbal.connection" alias="database_connection" public="true" />
+        <service id="security.acl.dbal.connection" alias="database_connection" />
 
         <service id="security.acl.dbal.provider" class="Symfony\Component\Security\Acl\Dbal\MutableAclProvider">
             <argument type="service" id="security.acl.dbal.connection" />
@@ -22,7 +22,7 @@
             <argument type="service" id="security.acl.cache" on-invalid="null" />
         </service>
 
-        <service id="security.acl.dbal.schema" class="Symfony\Component\Security\Acl\Dbal\Schema" public="true">
+        <service id="security.acl.dbal.schema" class="Symfony\Component\Security\Acl\Dbal\Schema">
             <argument type="collection">
                 <argument key="class_table_name">%security.acl.dbal.class_table_name%</argument>
                 <argument key="entry_table_name">%security.acl.dbal.entry_table_name%</argument>
@@ -36,7 +36,7 @@
             <argument type="service" id="security.acl.dbal.schema" />
         </service>
 
-        <service id="security.acl.provider" alias="security.acl.dbal.provider" public="true" />
+        <service id="security.acl.provider" alias="security.acl.dbal.provider" />
         <service id="Symfony\Component\Security\Acl\Model\AclProviderInterface" alias="security.acl.provider" />
 
         <service id="security.acl.cache.doctrine" class="Symfony\Component\Security\Acl\Domain\DoctrineAclCache">

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_debug.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_debug.xml
@@ -18,6 +18,6 @@
             <argument type="service" id="security.logout_url_generator" />
         </service>
 
-        <service id="security.firewall" alias="debug.security.firewall" public="true" />
+        <service id="security.firewall" alias="debug.security.firewall" />
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
@@ -45,7 +45,7 @@
                  public="false"
                  abstract="true" />
 
-        <service id="security.rememberme.response_listener" class="Symfony\Component\Security\Http\RememberMe\ResponseListener" public="true">
+        <service id="security.rememberme.response_listener" class="Symfony\Component\Security\Http\RememberMe\ResponseListener">
             <tag name="kernel.event_subscriber" />
         </service>
     </services>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
@@ -7,12 +7,12 @@
     <services>
         <defaults public="false" />
 
-        <service id="templating.helper.logout_url" class="Symfony\Bundle\SecurityBundle\Templating\Helper\LogoutUrlHelper" public="true">
+        <service id="templating.helper.logout_url" class="Symfony\Bundle\SecurityBundle\Templating\Helper\LogoutUrlHelper">
             <tag name="templating.helper" alias="logout_url" />
             <argument type="service" id="security.logout_url_generator" />
         </service>
 
-        <service id="templating.helper.security" class="Symfony\Bundle\SecurityBundle\Templating\Helper\SecurityHelper" public="true">
+        <service id="templating.helper.security" class="Symfony\Bundle\SecurityBundle\Templating\Helper\SecurityHelper">
             <tag name="templating.helper" alias="security" />
             <argument type="service" id="security.authorization_checker" on-invalid="ignore" />
         </service>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SetAclCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SetAclCommandTest.php
@@ -67,7 +67,7 @@ class SetAclCommandTest extends WebTestCase
         $permissionMap = new BasicPermissionMap();
 
         /** @var \Symfony\Component\Security\Acl\Model\AclProviderInterface $aclProvider */
-        $aclProvider = $application->getKernel()->getContainer()->get('security.acl.provider');
+        $aclProvider = $application->getKernel()->getContainer()->get('test.security.acl.provider');
         $acl = $aclProvider->findAcl($objectIdentity, array($securityIdentity1));
 
         $this->assertTrue($acl->isGranted($permissionMap->getMasks($grantedPermission1, null), array($securityIdentity1)));
@@ -95,7 +95,7 @@ class SetAclCommandTest extends WebTestCase
         $role = 'ROLE_ADMIN';
 
         $application = $this->getApplication();
-        $application->add(new SetAclCommand($application->getKernel()->getContainer()->get('security.acl.provider')));
+        $application->add(new SetAclCommand($application->getKernel()->getContainer()->get('test.security.acl.provider')));
 
         $setAclCommand = $application->find('acl:set');
         $setAclCommandTester = new CommandTester($setAclCommand);
@@ -111,7 +111,7 @@ class SetAclCommandTest extends WebTestCase
         $permissionMap = new BasicPermissionMap();
 
         /** @var \Symfony\Component\Security\Acl\Model\AclProviderInterface $aclProvider */
-        $aclProvider = $application->getKernel()->getContainer()->get('security.acl.provider');
+        $aclProvider = $application->getKernel()->getContainer()->get('test.security.acl.provider');
         $acl = $aclProvider->findAcl($objectIdentity, array($roleSecurityIdentity, $userSecurityIdentity));
 
         $this->assertTrue($acl->isGranted($permissionMap->getMasks($grantedPermission, null), array($roleSecurityIdentity)));
@@ -137,7 +137,7 @@ class SetAclCommandTest extends WebTestCase
         $role = 'ROLE_USER';
 
         $application = $this->getApplication();
-        $application->add(new SetAclCommand($application->getKernel()->getContainer()->get('security.acl.provider')));
+        $application->add(new SetAclCommand($application->getKernel()->getContainer()->get('test.security.acl.provider')));
 
         $setAclCommand = $application->find('acl:set');
         $setAclCommandTester = new CommandTester($setAclCommand);
@@ -154,7 +154,7 @@ class SetAclCommandTest extends WebTestCase
         $permissionMap = new BasicPermissionMap();
 
         /** @var \Symfony\Component\Security\Acl\Model\AclProviderInterface $aclProvider */
-        $aclProvider = $application->getKernel()->getContainer()->get('security.acl.provider');
+        $aclProvider = $application->getKernel()->getContainer()->get('test.security.acl.provider');
 
         $acl1 = $aclProvider->findAcl($objectIdentity1, array($roleSecurityIdentity));
         $this->assertTrue($acl1->isGranted($permissionMap->getMasks($grantedPermission, null), array($roleSecurityIdentity)));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Acl/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Acl/config.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: ./../config/framework.yml }
 
+services:
+    test.security.acl.provider: '@security.acl.provider'
+
 doctrine:
     dbal:
         driver:   pdo_sqlite

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -31,7 +31,7 @@
         "symfony/dom-crawler": "~2.8|~3.0|~4.0",
         "symfony/event-dispatcher": "^3.3.1|~4.0",
         "symfony/form": "^2.8.18|^3.2.5|~4.0",
-        "symfony/framework-bundle": "^3.2.8|~4.0",
+        "symfony/framework-bundle": "^3.4|~4.0",
         "symfony/http-foundation": "~2.8|~3.0|~4.0",
         "symfony/security-acl": "~2.8|~3.0",
         "symfony/translation": "~2.8|~3.0|~4.0",
@@ -48,6 +48,7 @@
     "conflict": {
         "symfony/var-dumper": "<3.3",
         "symfony/event-dispatcher": "<3.3.1",
+        "symfony/framework-bundle": "<3.4",
         "symfony/console": "<3.4"
     },
     "suggest": {

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -43,7 +44,7 @@ class TwigLoaderPass implements CompilerPassInterface
         }
 
         if (1 === $found) {
-            $container->setAlias('twig.loader', $id);
+            $container->setAlias('twig.loader', $id)->setPrivate(true);
         } else {
             $chainLoader = $container->getDefinition('twig.loader.chain');
             krsort($prioritizedLoaders);
@@ -54,7 +55,7 @@ class TwigLoaderPass implements CompilerPassInterface
                 }
             }
 
-            $container->setAlias('twig.loader', 'twig.loader.chain');
+            $container->setAlias('twig.loader', 'twig.loader.chain')->setPrivate(true);
         }
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -43,8 +43,15 @@ class TwigExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('twig.xml');
 
+        $container->getDefinition('twig.profile')->setPrivate(true);
+        $container->getDefinition('twig.runtime.httpkernel')->setPrivate(true);
+        $container->getDefinition('twig.translation.extractor')->setPrivate(true);
+        $container->getDefinition('workflow.twig_extension')->setPrivate(true);
+        $container->getDefinition('twig.exception_listener')->setPrivate(true);
+
         if (class_exists('Symfony\Component\Form\Form')) {
             $loader->load('form.xml');
+            $container->getDefinition('twig.form.renderer')->setPrivate(true);
         }
 
         if (interface_exists('Symfony\Component\Templating\EngineInterface')) {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/form.xml
@@ -18,7 +18,7 @@
             <argument type="service" id="twig" />
         </service>
 
-        <service id="twig.form.renderer" class="Symfony\Component\Form\FormRenderer" public="true">
+        <service id="twig.form.renderer" class="Symfony\Component\Form\FormRenderer">
             <argument type="service" id="twig.form.engine" />
             <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
             <tag name="twig.runtime" />

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -63,7 +63,7 @@
             <argument type="service" id="debug.stopwatch" on-invalid="null" />
         </service>
 
-        <service id="twig.profile" class="Twig\Profiler\Profile" public="true" />
+        <service id="twig.profile" class="Twig\Profiler\Profile" />
 
         <service id="data_collector.twig" class="Symfony\Bridge\Twig\DataCollector\TwigDataCollector">
             <tag name="data_collector" template="@WebProfiler/Collector/twig.html.twig" id="twig" priority="257" />
@@ -100,7 +100,7 @@
 
         <service id="twig.extension.httpkernel" class="Symfony\Bridge\Twig\Extension\HttpKernelExtension" />
 
-        <service id="twig.runtime.httpkernel" class="Symfony\Bridge\Twig\Extension\HttpKernelRuntime" public="true">
+        <service id="twig.runtime.httpkernel" class="Symfony\Bridge\Twig\Extension\HttpKernelRuntime">
             <argument type="service" id="fragment.handler" />
             <tag name="twig.runtime" />
         </service>
@@ -112,16 +112,16 @@
 
         <service id="twig.extension.debug" class="Twig\Extension\DebugExtension" />
 
-        <service id="twig.translation.extractor" class="Symfony\Bridge\Twig\Translation\TwigExtractor" public="true">
+        <service id="twig.translation.extractor" class="Symfony\Bridge\Twig\Translation\TwigExtractor">
             <argument type="service" id="twig" />
             <tag name="translation.extractor" alias="twig" />
         </service>
 
-        <service id="workflow.twig_extension" class="Symfony\Bridge\Twig\Extension\WorkflowExtension" public="true">
+        <service id="workflow.twig_extension" class="Symfony\Bridge\Twig\Extension\WorkflowExtension">
             <argument type="service" id="workflow.registry" />
         </service>
 
-        <service id="twig.exception_listener" class="Symfony\Component\HttpKernel\EventListener\ExceptionListener" public="true">
+        <service id="twig.exception_listener" class="Symfony\Component\HttpKernel\EventListener\ExceptionListener">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
             <argument>%twig.exception_listener.controller%</argument>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\TwigBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigLoaderPass;
 
@@ -55,7 +56,8 @@ class TwigLoaderPassTest extends TestCase
             ->will($this->returnValue($serviceIds));
         $this->builder->expects($this->once())
             ->method('setAlias')
-            ->with('twig.loader', 'test_loader_1');
+            ->with('twig.loader', 'test_loader_1')
+            ->will($this->returnValue(new Alias('test_loader_1')));
 
         $this->pass->process($this->builder);
     }
@@ -85,7 +87,8 @@ class TwigLoaderPassTest extends TestCase
             ->will($this->returnValue($this->chainLoader));
         $this->builder->expects($this->once())
             ->method('setAlias')
-            ->with('twig.loader', 'twig.loader.chain');
+            ->with('twig.loader', 'twig.loader.chain')
+            ->will($this->returnValue(new Alias('twig.loader.chain')));
 
         $this->pass->process($this->builder);
         $calls = $this->chainLoader->getMethodCalls();
@@ -121,7 +124,8 @@ class TwigLoaderPassTest extends TestCase
             ->will($this->returnValue($this->chainLoader));
         $this->builder->expects($this->once())
             ->method('setAlias')
-            ->with('twig.loader', 'twig.loader.chain');
+            ->with('twig.loader', 'twig.loader.chain')
+            ->will($this->returnValue(new Alias('twig.loader.chain')));
 
         $this->pass->process($this->builder);
         $calls = $this->chainLoader->getMethodCalls();

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -26,20 +26,21 @@
     "require-dev": {
         "symfony/asset": "~2.8|~3.0|~4.0",
         "symfony/stopwatch": "~2.8|~3.0|~4.0",
-        "symfony/dependency-injection": "~3.3|~4.0",
+        "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/expression-language": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
         "symfony/form": "~2.8|~3.0|~4.0",
         "symfony/routing": "~2.8|~3.0|~4.0",
         "symfony/templating": "~2.8|~3.0|~4.0",
         "symfony/yaml": "~2.8|~3.0|~4.0",
-        "symfony/framework-bundle": "^3.2.8|~4.0",
+        "symfony/framework-bundle": "^3.3|~4.0",
         "symfony/web-link": "~3.3|~4.0",
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0"
     },
     "conflict": {
-        "symfony/dependency-injection": "<3.3"
+        "symfony/dependency-injection": "<3.4",
+        "symfony/event-dispatcher": "<3.3.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\TwigBundle\\": "" },

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -48,6 +48,7 @@ class WebProfilerExtension extends Extension
 
         if ($config['toolbar'] || $config['intercept_redirects']) {
             $loader->load('toolbar.xml');
+            $container->getDefinition('web_profiler.debug_toolbar')->setPrivate(true);
             $container->getDefinition('web_profiler.debug_toolbar')->replaceArgument(5, $config['excluded_ajax_paths']);
             $container->setParameter('web_profiler.debug_toolbar.intercept_redirects', $config['intercept_redirects']);
             $container->setParameter('web_profiler.debug_toolbar.mode', $config['toolbar'] ? WebDebugToolbarListener::ENABLED : WebDebugToolbarListener::DISABLED);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="web_profiler.debug_toolbar" class="Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener" public="true">
+        <service id="web_profiler.debug_toolbar" class="Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="twig" />
             <argument>%web_profiler.debug_toolbar.intercept_redirects%</argument>

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -27,13 +27,13 @@
     "require-dev": {
         "symfony/config": "~3.4|~4.0",
         "symfony/console": "~2.8|~3.0|~4.0",
-        "symfony/dependency-injection": "~3.3|~4.0",
+        "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/stopwatch": "~2.8|~3.0|~4.0"
     },
     "conflict": {
         "symfony/config": "<3.4",
-        "symfony/dependency-injection": "<3.3",
-        "symfony/event-dispatcher": "<3.3",
+        "symfony/dependency-injection": "<3.4",
+        "symfony/event-dispatcher": "<3.3.1",
         "symfony/var-dumper": "<3.3"
     },
     "autoload": {

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -15,6 +15,7 @@ class Alias
 {
     private $id;
     private $public;
+    private $private = false;
 
     /**
      * @param string $id     Alias identifier
@@ -40,10 +41,43 @@ class Alias
      * Sets if this Alias is public.
      *
      * @param bool $boolean If this Alias should be public
+     *
+     * @return $this
      */
     public function setPublic($boolean)
     {
         $this->public = (bool) $boolean;
+
+        return $this;
+    }
+
+    /**
+     * Sets if this Alias is private.
+     *
+     * When set, the "private" state has a higher precedence than "public".
+     * In version 3.4, a "private" alias always remains publicly accessible,
+     * but triggers a deprecation notice when accessed from the container,
+     * so that the alias can be made really private in 4.0.
+     *
+     * @param bool $boolean
+     *
+     * @return $this
+     */
+    public function setPrivate($boolean)
+    {
+        $this->private = (bool) $boolean;
+
+        return $this;
+    }
+
+    /**
+     * Whether this alias is private.
+     *
+     * @return bool
+     */
+    public function isPrivate()
+    {
+        return $this->private;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -39,7 +39,7 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
     {
         foreach ($container->getDefinitions() as $id => $definition) {
             // synthetic service is public
-            if ($definition->isSynthetic() && !$definition->isPublic()) {
+            if ($definition->isSynthetic() && (!$definition->isPublic() || $definition->isPrivate())) {
                 throw new RuntimeException(sprintf('A synthetic service ("%s") must be public.', $id));
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -49,6 +49,7 @@ class DecoratorServicePass implements CompilerPassInterface
             if ($container->hasAlias($inner)) {
                 $alias = $container->getAlias($inner);
                 $public = $alias->isPublic();
+                $private = $alias->isPrivate();
                 $container->setAlias($renamedId, new Alias((string) $alias, false));
             } else {
                 $decoratedDefinition = $container->getDefinition($inner);
@@ -57,6 +58,7 @@ class DecoratorServicePass implements CompilerPassInterface
                     $definition->setAutowiringTypes($types);
                 }
                 $public = $decoratedDefinition->isPublic();
+                $private = $decoratedDefinition->isPrivate();
                 $decoratedDefinition->setPublic(false);
                 $decoratedDefinition->setTags(array());
                 if ($decoratedDefinition->getAutowiringTypes(false)) {
@@ -65,7 +67,7 @@ class DecoratorServicePass implements CompilerPassInterface
                 $container->setDefinition($renamedId, $decoratedDefinition);
             }
 
-            $container->setAlias($inner, new Alias($id, $public));
+            $container->setAlias($inner, $id)->setPublic($public && !$private)->setPrivate($private);
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -82,7 +82,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
             return true;
         }
 
-        if ($definition->isDeprecated() || $definition->isPublic() || $definition->isLazy()) {
+        if ($definition->isDeprecated() || $definition->isPublic() || $definition->isPrivate() || $definition->isLazy()) {
             return false;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/RemovePrivateAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemovePrivateAliasesPass.php
@@ -30,7 +30,7 @@ class RemovePrivateAliasesPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         foreach ($container->getAliases() as $id => $alias) {
-            if ($alias->isPublic()) {
+            if ($alias->isPublic() || $alias->isPrivate()) {
                 continue;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
@@ -41,7 +41,7 @@ class RemoveUnusedDefinitionsPass implements RepeatablePassInterface
 
         $hasChanged = false;
         foreach ($container->getDefinitions() as $id => $definition) {
-            if ($definition->isPublic()) {
+            if ($definition->isPublic() || $definition->isPrivate()) {
                 continue;
             }
 
@@ -68,7 +68,8 @@ class RemoveUnusedDefinitionsPass implements RepeatablePassInterface
 
             if (1 === count($referencingAliases) && false === $isReferenced) {
                 $container->setDefinition((string) reset($referencingAliases), $definition);
-                $definition->setPublic(true);
+                $definition->setPrivate(reset($referencingAliases)->isPrivate());
+                $definition->setPublic(!$definition->isPrivate());
                 $container->removeDefinition($id);
                 $container->log($this, sprintf('Removed service "%s"; reason: replaces alias %s.', $id, reset($referencingAliases)));
             } elseif (0 === count($referencingAliases) && false === $isReferenced) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -58,11 +58,12 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
             } catch (InvalidArgumentException $e) {
                 throw new InvalidArgumentException(sprintf('Unable to replace alias "%s" with actual definition "%s".', $definitionId, $targetId), null, $e);
             }
-            if ($definition->isPublic()) {
+            if ($definition->isPublic() || $definition->isPrivate()) {
                 continue;
             }
             // Remove private definition and schedule for replacement
-            $definition->setPublic(true);
+            $definition->setPublic(!$target->isPrivate());
+            $definition->setPrivate($target->isPrivate());
             $container->setDefinition($definitionId, $definition);
             $container->removeDefinition($targetId);
             $replacements[$targetId] = $definitionId;

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\ExceptionInterface;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
@@ -25,6 +26,26 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
  */
 class ResolveChildDefinitionsPass extends AbstractRecursivePass
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        parent::process($container);
+
+        foreach ($container->getDefinitions() as $definition) {
+            if ($definition->isPrivate()) {
+                $definition->setPublic(false);
+            }
+        }
+
+        foreach ($container->getAliases() as $alias) {
+            if ($alias->isPrivate()) {
+                $alias->setPublic(false);
+            }
+        }
+    }
+
     protected function processValue($value, $isRoot = false)
     {
         if (!$value instanceof Definition) {
@@ -121,6 +142,8 @@ class ResolveChildDefinitionsPass extends AbstractRecursivePass
         }
         if (isset($changes['public'])) {
             $def->setPublic($definition->isPublic());
+        } else {
+            $def->setPrivate($definition->isPrivate() || $parentDef->isPrivate());
         }
         if (isset($changes['lazy'])) {
             $def->setLazy($definition->isLazy());

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -51,7 +51,7 @@ class ResolveReferencesToAliasesPass implements CompilerPassInterface
         foreach ($container->getAliases() as $id => $alias) {
             $aliasId = (string) $alias;
             if ($aliasId !== $defId = $this->getDefinitionId($aliasId)) {
-                $container->setAlias($id, new Alias($defId, $alias->isPublic()));
+                $container->setAlias($id, $defId)->setPublic($alias->isPublic() && !$alias->isPrivate())->setPrivate($alias->isPrivate());
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -806,6 +806,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @param string       $alias The alias to create
      * @param string|Alias $id    The service to alias
      *
+     * @return Alias
+     *
      * @throws InvalidArgumentException if the id is not a string or an Alias
      * @throws InvalidArgumentException if the alias is for itself
      */
@@ -825,7 +827,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
         unset($this->definitions[$alias]);
 
-        $this->aliasDefinitions[$alias] = $id;
+        return $this->aliasDefinitions[$alias] = $id;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -35,6 +35,7 @@ class Definition
     private $configurator;
     private $tags = array();
     private $public = true;
+    private $private = false;
     private $synthetic = false;
     private $abstract = false;
     private $lazy = false;
@@ -614,6 +615,35 @@ class Definition
     public function isPublic()
     {
         return $this->public;
+    }
+
+    /**
+     * Sets if this service is private.
+     *
+     * When set, the "private" state has a higher precedence than "public".
+     * In version 3.4, a "private" service always remains publicly accessible,
+     * but triggers a deprecation notice when accessed from the container,
+     * so that the service can be made really private in 4.0.
+     *
+     * @param bool $boolean
+     *
+     * @return $this
+     */
+    public function setPrivate($boolean)
+    {
+        $this->private = (bool) $boolean;
+
+        return $this;
+    }
+
+    /**
+     * Whether this service is private.
+     *
+     * @return bool
+     */
+    public function isPrivate()
+    {
+        return $this->private;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1040,11 +1040,17 @@ EOF;
      */
     private function addPrivateServices()
     {
-        if (!$definitions = $this->container->getDefinitions()) {
-            return '';
+        $code = '';
+
+        $aliases = $this->container->getAliases();
+        ksort($aliases);
+        foreach ($aliases as $id => $alias) {
+            if ($alias->isPrivate()) {
+                $code .= '            '.$this->export($id)." => true,\n";
+            }
         }
 
-        $code = '';
+        $definitions = $this->container->getDefinitions();
         ksort($definitions);
         foreach ($definitions as $id => $definition) {
             if (!$definition->isPublic()) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -397,6 +397,26 @@ class ResolveChildDefinitionsPassTest extends TestCase
         $this->assertFalse($container->getDefinition('child1')->isAutoconfigured());
     }
 
+    public function testPrivateHasHigherPrecedenceThanPublic()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', 'stdClass')
+            ->setPrivate(true)
+            ->setPublic(true)
+        ;
+
+        $container->setAlias('bar', 'foo')
+            ->setPrivate(false)
+            ->setPublic(false)
+        ;
+
+        $this->process($container);
+
+        $this->assertFalse($container->getDefinition('foo')->isPublic());
+        $this->assertFalse($container->getAlias('bar')->isPublic());
+    }
+
     /**
      * @group legacy
      */

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -779,6 +779,52 @@ class PhpDumperTest extends TestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation Requesting the "private" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedDeprecation Requesting the "private_alias" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedDeprecation Requesting the "decorated_private" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedDeprecation Requesting the "decorated_private_alias" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedDeprecation Requesting the "private_not_inlined" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedDeprecation Requesting the "private_not_removed" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedDeprecation Requesting the "private_child" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     * @expectedDeprecation Requesting the "private_parent" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
+     */
+    public function testLegacyPrivateServices()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_legacy_privates.yml');
+
+        $container->getDefinition('private')->setPrivate(true);
+        $container->getDefinition('private_not_inlined')->setPrivate(true);
+        $container->getDefinition('private_not_removed')->setPrivate(true);
+        $container->getDefinition('decorated_private')->setPrivate(true);
+        $container->getDefinition('private_child')->setPrivate(true);
+        $container->getAlias('decorated_private_alias')->setPrivate(true);
+        $container->getAlias('private_alias')->setPrivate(true);
+
+        $container->compile();
+        $dumper = new PhpDumper($container);
+
+        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_legacy_privates.php', $dumper->dump(array('class' => 'Symfony_DI_PhpDumper_Test_Legacy_Privates', 'file' => self::$fixturesPath.'/php/services_legacy_privates.php')));
+
+        require self::$fixturesPath.'/php/services_legacy_privates.php';
+
+        $container = new \Symfony_DI_PhpDumper_Test_Legacy_Privates();
+
+        $container->get('private');
+        $container->get('private_alias');
+        $container->get('alias_to_private');
+        $container->get('decorated_private');
+        $container->get('decorated_private_alias');
+        $container->get('private_not_inlined');
+        $container->get('private_not_removed');
+        $container->get('private_child');
+        $container->get('private_parent');
+        $container->get('public_child');
+    }
+
+    /**
      * This test checks the trigger of a deprecation note and should not be removed in major releases.
      *
      * @group legacy

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_legacy_privates.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_legacy_privates.php
@@ -1,0 +1,200 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * Symfony_DI_PhpDumper_Test_Legacy_Privates.
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final since Symfony 3.3
+ */
+class Symfony_DI_PhpDumper_Test_Legacy_Privates extends Container
+{
+    private $parameters;
+    private $targetDirs = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $dir = __DIR__;
+        for ($i = 1; $i <= 5; ++$i) {
+            $this->targetDirs[$i] = $dir = dirname($dir);
+        }
+        $this->services = array();
+        $this->methodMap = array(
+            'bar' => 'getBarService',
+            'private' => 'getPrivateService',
+            'private_alias' => 'getPrivateAliasService',
+            'private_alias_decorator' => 'getPrivateAliasDecoratorService',
+            'private_child' => 'getPrivateChildService',
+            'private_decorator' => 'getPrivateDecoratorService',
+            'private_decorator.inner' => 'getPrivateDecorator_InnerService',
+            'private_not_inlined' => 'getPrivateNotInlinedService',
+            'private_not_removed' => 'getPrivateNotRemovedService',
+            'private_parent' => 'getPrivateParentService',
+            'public_child' => 'getPublicChildService',
+        );
+        $this->privates = array(
+            'decorated_private' => true,
+            'decorated_private_alias' => true,
+            'private' => true,
+            'private_alias' => true,
+            'private_child' => true,
+            'private_decorator.inner' => true,
+            'private_not_inlined' => true,
+            'private_not_removed' => true,
+            'private_parent' => true,
+        );
+        $this->aliases = array(
+            'alias_to_private' => 'private',
+            'decorated_private' => 'private_decorator',
+            'decorated_private_alias' => 'private_alias_decorator',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped container that was already compiled.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCompiled()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFrozen()
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 3.3 and will be removed in 4.0. Use the isCompiled() method instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return true;
+    }
+
+    /**
+     * Gets the public 'bar' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getBarService()
+    {
+        return $this->services['bar'] = new \stdClass(${($_ = isset($this->services['private_not_inlined']) ? $this->services['private_not_inlined'] : $this->services['private_not_inlined'] = new \stdClass()) && false ?: '_'});
+    }
+
+    /**
+     * Gets the public 'private_alias_decorator' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPrivateAliasDecoratorService()
+    {
+        return $this->services['private_alias_decorator'] = new \stdClass();
+    }
+
+    /**
+     * Gets the public 'private_decorator' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPrivateDecoratorService()
+    {
+        return $this->services['private_decorator'] = new \stdClass();
+    }
+
+    /**
+     * Gets the public 'public_child' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPublicChildService()
+    {
+        return $this->services['public_child'] = new \stdClass();
+    }
+
+    /**
+     * Gets the private 'private' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPrivateService()
+    {
+        return $this->services['private'] = new \stdClass();
+    }
+
+    /**
+     * Gets the private 'private_alias' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPrivateAliasService()
+    {
+        return $this->services['private_alias'] = new \stdClass();
+    }
+
+    /**
+     * Gets the private 'private_child' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPrivateChildService()
+    {
+        return $this->services['private_child'] = new \stdClass();
+    }
+
+    /**
+     * Gets the private 'private_decorator.inner' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPrivateDecorator_InnerService()
+    {
+        return $this->services['private_decorator.inner'] = new \stdClass();
+    }
+
+    /**
+     * Gets the private 'private_not_inlined' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPrivateNotInlinedService()
+    {
+        return $this->services['private_not_inlined'] = new \stdClass();
+    }
+
+    /**
+     * Gets the private 'private_not_removed' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPrivateNotRemovedService()
+    {
+        return $this->services['private_not_removed'] = new \stdClass();
+    }
+
+    /**
+     * Gets the private 'private_parent' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getPrivateParentService()
+    {
+        return $this->services['private_parent'] = new \stdClass();
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_legacy_privates.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_legacy_privates.yml
@@ -1,0 +1,28 @@
+services:
+
+    foo: {class: stdClass, public: false}
+
+    bar:
+        class: stdClass
+        arguments: [ '@private_not_inlined' ]
+
+    private: {class: stdClass, public: false}
+    decorated_private: {class: stdClass}
+    decorated_private_alias: '@foo'
+    alias_to_private: '@private'
+    private_alias: {alias: foo, public: false}
+
+    private_decorator:
+        class: stdClass
+        decorates: 'decorated_private'
+
+    private_alias_decorator:
+        class: stdClass
+        decorates: 'decorated_private_alias'
+
+    private_not_inlined: {class: stdClass, public: false}
+    private_not_removed: {class: stdClass, public: false}
+
+    private_child: {parent: foo}
+    private_parent: {parent: private}
+    public_child: {parent: private, public: true}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | not yet
| Fixed tickets | #23822
| License       | MIT
| Doc PR        | -

- [x] review the list of currently public services and validate which one should be turned private (noted as such with the `container.private` tag in this PR)
- [x] rebase on top of #24103
- [x] implement the behavior described in https://github.com/symfony/symfony/issues/23822#issuecomment-327208485
- [x] add tests

List of services that will be kept public:

### Remaining public aliases

cache.app_clearer <- for the cache:pool:clear command to clear app pools
$commandId <- for non-lazy commands which are get() at runtime
router <- for the base controller
templating <- for the base controller

### Remaining public services

test.client <- for WebTestCase
security.password_encoder <- for use in ContainerAware classes
security.authentication_utils <- for use in ContainerAware classes
filesystem <- for use in ContainerAware classes
kernel <- for use in ContainerAware classes
translator <- for use in ContainerAware classes
validator <- for use in ContainerAware classes
cache_clearer <- for the cache:clear command
cache_warmer <- required to bootstrap the kernel
cache.app <- for userland only
cache.global_clearer <- for the cache:pool:clear command to clear all pools
cache.system <- for userland only
data_collector.dump <- required to have dump() work very early when booting the kernel
event_dispatcher <- required to wire console apps
form.factory <- for the base controller
http_kernel <- required to bootstrap the kernel
profiler <- used in tests
request_stack <- for the base controller
routing.loader <- used by routing
security.authorization_checker <- for the base controller
security.csrf.token_manager <- for the base controller
security.token_storage <- for the base controller
serializer <- for the base controller
session <- for the base controller
state_machine.abstract <- userland state machines
workflow.abstract <- userland workflows
twig <- for the base controller
twig.controller.exception <- controllers referenced by routing
twig.controller.preview_error <- controllers referenced by routing
var_dumper.cloner <- required to have dump() work very early when booting the kernel
web_profiler.controller.exception <- controllers referenced by routing
web_profiler.controller.profiler <- controllers referenced by routing
web_profiler.controller.router <- controllers referenced by routing