### PR TITLE
[Filesystem] check permissions if dump target dir is missing

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -532,6 +532,16 @@ class Filesystem
         $dir = dirname($filename);
 
         if (!is_dir($dir)) {
+            $oldCwd = getcwd();
+
+            if (!@chdir(dirname($dir))) {
+                // When the parent directory misses the executable permission bit, we are unable to enter it and thus
+                // cannot check if the target directory exists.
+                throw new IOException(sprintf('Unable to detect if the target directory "%s" exists.', $dir));
+            }
+
+            chdir($oldCwd);
+
             $this->mkdir($dir);
         }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1102,6 +1102,22 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFilePermissions(745, $filename);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
+     * @expectedExceptionMessageRegExp /^Unable to detect if the target directory ".*" exists\.$/
+     */
+    public function testDumpFailsWithExceptionIfExecutablePermissionsForTheParentDirectoryAreMissing()
+    {
+        $this->markAsSkippedIfChmodIsMissing();
+
+        $target = $this->workspace.DIRECTORY_SEPARATOR.'foo';
+        $file = $target.DIRECTORY_SEPARATOR.'foobar';
+        mkdir($target);
+        chmod($this->workspace, 0666);
+
+        $this->filesystem->dumpFile($file, 'baz');
+    }
+
     public function testCopyShouldKeepExecutionPermission()
     {
         $this->markAsSkippedIfChmodIsMissing();

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -61,6 +61,7 @@ class FilesystemTestCase extends TestCase
             $this->longPathNamesWindows = array();
         }
 
+        chmod($this->workspace, 0777);
         $this->filesystem->remove($this->workspace);
         umask($this->umask);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24097
| License       | MIT
| Doc PR        | 

`is_dir()` returns `false` if the parent directory misses the executable
bit even when the directory itself is present.