### PR TITLE
[DependencyInjection] Don't use return on Assert::markTestSkipped

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
@@ -51,7 +51,7 @@ class IniFileLoaderTest extends TestCase
     public function testTypeConversionsWithNativePhp($key, $value, $supported)
     {
         if (defined('HHVM_VERSION_ID')) {
-            return $this->markTestSkipped();
+            $this->markTestSkipped();
         }
 
         if (!$supported) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | N/A

Removed an unnecessary return statement. `Assert::markTestSkipped()` will always throw an exception, so there's no need for a return statement here. And even if that method had a return value: A unit test is not supposed to return anything.