### PR TITLE
[3.3][travis] update to trusty, move LDAP to appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: precise
+dist: trusty
 sudo: false
 
 git:
@@ -20,10 +20,8 @@ env:
 
 matrix:
     include:
-        # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
         - php: hhvm-3.18
           sudo: required
-          dist: trusty
           group: edge
         - php: 5.5
         - php: 5.6
@@ -104,7 +102,6 @@ before_install:
       echo opcache.enable_cli = 1 >> $INI
       echo hhvm.jit = 0 >> $INI
       echo apc.enable_cli = 1 >> $INI
-      echo extension = ldap.so >> $INI
       echo extension = redis.so >> $INI
       echo extension = memcached.so >> $INI
       [[ $PHP = 5.* ]] && echo extension = memcache.so >> $INI
@@ -131,6 +128,9 @@ before_install:
 
     - |
       # Install extra PHP extensions
+      wget https://github.com/symfony/binary-utils/releases/download/v0.1/php-extensions.tar.bz2
+      tar -xjf php-extensions.tar.bz2
+      echo extension = $(pwd)/$PHP/ldap.so >> $INI
       if [[ ! $skip && $PHP = 5.* ]]; then
           ([[ $deps ]] || tfold ext.symfony_debug 'cd src/Symfony/Component/Debug/Resources/ext && phpize && ./configure && make && echo extension = $(pwd)/modules/symfony_debug.so >> '"$INI") &&
           tfold ext.apcu4 'echo yes | pecl install -f apcu-4.0.11'

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -151,7 +151,7 @@ class JsonResponse extends Response
                 // Fortunately, PHP 5.5 and up do not trigger any warning anymore.
                 $data = json_encode($data, $this->encodingOptions);
             } catch (\Exception $e) {
-                if ('Exception' === get_class($e) && 0 === strpos($e->getMessage(), 'Failed calling ')) {
+                if (interface_exists('JsonSerializable') && 'Exception' === get_class($e) && 0 === strpos($e->getMessage(), 'Failed calling ')) {
                     throw $e->getPrevious() ?: $e;
                 }
                 throw $e;

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -228,6 +228,10 @@ class JsonResponseTest extends TestCase
      */
     public function testSetContentJsonSerializeError()
     {
+        if (!interface_exists('JsonSerializable')) {
+            $this->markTestSkipped('JsonSerializable is required.');
+        }
+
         $serializable = new JsonSerializableObject();
 
         JsonResponse::create($serializable);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

That's #24108 on 3.3.
ldap.so in not available on Travis (see https://github.com/travis-ci/travis-ci/issues/7067) so let's move those tests to appveyor.