### PR TITLE
[FrameworkBundle] Get KERNEL_CLASS through $_ENV too for KernelTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -106,8 +106,9 @@ abstract class KernelTestCase extends TestCase
      */
     protected static function getKernelClass()
     {
-        if (isset($_SERVER['KERNEL_CLASS'])) {
-            if (!class_exists($class = $_SERVER['KERNEL_CLASS'])) {
+        if (isset($_SERVER['KERNEL_CLASS']) || isset($_ENV['KERNEL_CLASS'])) {
+            $class = isset($_SERVER['KERNEL_CLASS']) ? $_SERVER['KERNEL_CLASS'] : $_ENV['KERNEL_CLASS'];
+            if (!class_exists($class)) {
                 throw new \RuntimeException(sprintf('Class "%s" doesn\'t exist or cannot be autoloaded. Check that the KERNEL_CLASS value in phpunit.xml matches the fully-qualified class name of your Kernel or override the %s::createKernel() method.', $class, static::class));
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/recipes/pull/170/files#diff-793b024840ee04ebdff5e04c2cd44f8cR12
| License       | MIT
| Doc PR        | -

I guess the check could be simplied in `master` with php7+

/cc @nicolas-grekas 
