### PR TITLE
[DI] rename ResolveDefinitionTemplatesPass to ResolveChildDefinitionsPass

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -52,6 +52,9 @@ DependencyInjection
 
  * Case insensitivity of parameter names is deprecated and will be removed in 4.0.
 
+ * The `ResolveDefinitionTemplatesPass` class is deprecated and will be removed in 4.0.
+   Use the `ResolveChildDefinitionsPass` class instead.
+
 Debug
 -----
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -159,6 +159,9 @@ DependencyInjection
  * The `DefinitionDecorator` class has been removed. Use the `ChildDefinition`
    class instead.
 
+ * The `ResolveDefinitionTemplatesPass` class has been removed.
+   Use the `ResolveChildDefinitionsPass` class instead.
+
  * Using unsupported configuration keys in YAML configuration files raises an
    exception.
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * deprecated the ability to check for the initialization of a private service with the `Container::initialized()` method
  * deprecated support for top-level anonymous services in XML
  * deprecated case insensitivity of parameter names
+ * deprecated the `ResolveDefinitionTemplatesPass` class in favor of `ResolveChildDefinitionsPass`
 
 3.3.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -48,7 +48,7 @@ class PassConfig
 
         $this->optimizationPasses = array(array(
             new ExtensionCompilerPass(),
-            new ResolveDefinitionTemplatesPass(),
+            new ResolveChildDefinitionsPass(),
             new ServiceLocatorTagPass(),
             new DecoratorServicePass(),
             new ResolveParameterPlaceHoldersPass(false),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\ExceptionInterface;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+
+/**
+ * This replaces all ChildDefinition instances with their equivalent fully
+ * merged Definition instance.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ResolveChildDefinitionsPass extends AbstractRecursivePass
+{
+    protected function processValue($value, $isRoot = false)
+    {
+        if (!$value instanceof Definition) {
+            return parent::processValue($value, $isRoot);
+        }
+        if ($isRoot) {
+            // yes, we are specifically fetching the definition from the
+            // container to ensure we are not operating on stale data
+            $value = $this->container->getDefinition($this->currentId);
+        }
+        if ($value instanceof ChildDefinition) {
+            $value = $this->resolveDefinition($value);
+            if ($isRoot) {
+                $this->container->setDefinition($this->currentId, $value);
+            }
+        }
+
+        return parent::processValue($value, $isRoot);
+    }
+
+    /**
+     * Resolves the definition.
+     *
+     * @return Definition
+     *
+     * @throws RuntimeException When the definition is invalid
+     */
+    private function resolveDefinition(ChildDefinition $definition)
+    {
+        try {
+            return $this->doResolveDefinition($definition);
+        } catch (ExceptionInterface $e) {
+            $r = new \ReflectionProperty($e, 'message');
+            $r->setAccessible(true);
+            $r->setValue($e, sprintf('Service "%s": %s', $this->currentId, $e->getMessage()));
+
+            throw $e;
+        }
+    }
+
+    private function doResolveDefinition(ChildDefinition $definition)
+    {
+        if (!$this->container->has($parent = $definition->getParent())) {
+            throw new RuntimeException(sprintf('Parent definition "%s" does not exist.', $parent));
+        }
+
+        $parentDef = $this->container->findDefinition($parent);
+        if ($parentDef instanceof ChildDefinition) {
+            $id = $this->currentId;
+            $this->currentId = $parent;
+            $parentDef = $this->resolveDefinition($parentDef);
+            $this->container->setDefinition($parent, $parentDef);
+            $this->currentId = $id;
+        }
+
+        $this->container->log($this, sprintf('Resolving inheritance for "%s" (parent: %s).', $this->currentId, $parent));
+        $def = new Definition();
+
+        // merge in parent definition
+        // purposely ignored attributes: abstract, shared, tags, autoconfigured
+        $def->setClass($parentDef->getClass());
+        $def->setArguments($parentDef->getArguments());
+        $def->setMethodCalls($parentDef->getMethodCalls());
+        $def->setProperties($parentDef->getProperties());
+        if ($parentDef->getAutowiringTypes(false)) {
+            $def->setAutowiringTypes($parentDef->getAutowiringTypes(false));
+        }
+        if ($parentDef->isDeprecated()) {
+            $def->setDeprecated(true, $parentDef->getDeprecationMessage('%service_id%'));
+        }
+        $def->setFactory($parentDef->getFactory());
+        $def->setConfigurator($parentDef->getConfigurator());
+        $def->setFile($parentDef->getFile());
+        $def->setPublic($parentDef->isPublic());
+        $def->setLazy($parentDef->isLazy());
+        $def->setAutowired($parentDef->isAutowired());
+        $def->setChanges($parentDef->getChanges());
+
+        $def->setBindings($parentDef->getBindings());
+
+        // overwrite with values specified in the decorator
+        $changes = $definition->getChanges();
+        if (isset($changes['class'])) {
+            $def->setClass($definition->getClass());
+        }
+        if (isset($changes['factory'])) {
+            $def->setFactory($definition->getFactory());
+        }
+        if (isset($changes['configurator'])) {
+            $def->setConfigurator($definition->getConfigurator());
+        }
+        if (isset($changes['file'])) {
+            $def->setFile($definition->getFile());
+        }
+        if (isset($changes['public'])) {
+            $def->setPublic($definition->isPublic());
+        }
+        if (isset($changes['lazy'])) {
+            $def->setLazy($definition->isLazy());
+        }
+        if (isset($changes['deprecated'])) {
+            $def->setDeprecated($definition->isDeprecated(), $definition->getDeprecationMessage('%service_id%'));
+        }
+        if (isset($changes['autowired'])) {
+            $def->setAutowired($definition->isAutowired());
+        }
+        if (isset($changes['shared'])) {
+            $def->setShared($definition->isShared());
+        }
+        if (isset($changes['decorated_service'])) {
+            $decoratedService = $definition->getDecoratedService();
+            if (null === $decoratedService) {
+                $def->setDecoratedService($decoratedService);
+            } else {
+                $def->setDecoratedService($decoratedService[0], $decoratedService[1], $decoratedService[2]);
+            }
+        }
+
+        // merge arguments
+        foreach ($definition->getArguments() as $k => $v) {
+            if (is_numeric($k)) {
+                $def->addArgument($v);
+            } elseif (0 === strpos($k, 'index_')) {
+                $def->replaceArgument((int) substr($k, strlen('index_')), $v);
+            } else {
+                $def->setArgument($k, $v);
+            }
+        }
+
+        // merge properties
+        foreach ($definition->getProperties() as $k => $v) {
+            $def->setProperty($k, $v);
+        }
+
+        // append method calls
+        if ($calls = $definition->getMethodCalls()) {
+            $def->setMethodCalls(array_merge($def->getMethodCalls(), $calls));
+        }
+
+        // merge autowiring types
+        foreach ($definition->getAutowiringTypes(false) as $autowiringType) {
+            $def->addAutowiringType($autowiringType);
+        }
+
+        // these attributes are always taken from the child
+        $def->setAbstract($definition->isAbstract());
+        $def->setTags($definition->getTags());
+        // autoconfigure is never taken from parent (on purpose)
+        // and it's not legal on an instanceof
+        $def->setAutoconfigured($definition->isAutoconfigured());
+
+        return $def;
+    }
+}
+
+class_alias(ResolveChildDefinitionsPass::class, ResolveDefinitionTemplatesPass::class);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -11,171 +11,19 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ChildDefinition;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Exception\ExceptionInterface;
-use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+@trigger_error('The '.__NAMESPACE__.'\ResolveDefinitionTemplatesPass class is deprecated since version 3.4 and will be removed in 4.0. Use the ResolveChildDefinitionsPass class instead.', E_USER_DEPRECATED);
 
-/**
- * This replaces all ChildDefinition instances with their equivalent fully
- * merged Definition instance.
- *
- * @author Johannes M. Schmitt <schmittjoh@gmail.com>
- * @author Nicolas Grekas <p@tchwork.com>
- */
-class ResolveDefinitionTemplatesPass extends AbstractRecursivePass
-{
-    protected function processValue($value, $isRoot = false)
-    {
-        if (!$value instanceof Definition) {
-            return parent::processValue($value, $isRoot);
-        }
-        if ($isRoot) {
-            // yes, we are specifically fetching the definition from the
-            // container to ensure we are not operating on stale data
-            $value = $this->container->getDefinition($this->currentId);
-        }
-        if ($value instanceof ChildDefinition) {
-            $value = $this->resolveDefinition($value);
-            if ($isRoot) {
-                $this->container->setDefinition($this->currentId, $value);
-            }
-        }
+class_exists(ResolveChildDefinitionsPass::class);
 
-        return parent::processValue($value, $isRoot);
-    }
-
+if (false) {
     /**
-     * Resolves the definition.
+     * This definition decorates another definition.
      *
-     * @return Definition
+     * @author Johannes M. Schmitt <schmittjoh@gmail.com>
      *
-     * @throws RuntimeException When the definition is invalid
+     * @deprecated The ResolveDefinitionTemplatesPass class is deprecated since version 3.4 and will be removed in 4.0. Use the ResolveChildDefinitionsPass class instead.
      */
-    private function resolveDefinition(ChildDefinition $definition)
+    class ResolveDefinitionTemplatesPass extends AbstractRecursivePass
     {
-        try {
-            return $this->doResolveDefinition($definition);
-        } catch (ExceptionInterface $e) {
-            $r = new \ReflectionProperty($e, 'message');
-            $r->setAccessible(true);
-            $r->setValue($e, sprintf('Service "%s": %s', $this->currentId, $e->getMessage()));
-
-            throw $e;
-        }
-    }
-
-    private function doResolveDefinition(ChildDefinition $definition)
-    {
-        if (!$this->container->has($parent = $definition->getParent())) {
-            throw new RuntimeException(sprintf('Parent definition "%s" does not exist.', $parent));
-        }
-
-        $parentDef = $this->container->findDefinition($parent);
-        if ($parentDef instanceof ChildDefinition) {
-            $id = $this->currentId;
-            $this->currentId = $parent;
-            $parentDef = $this->resolveDefinition($parentDef);
-            $this->container->setDefinition($parent, $parentDef);
-            $this->currentId = $id;
-        }
-
-        $this->container->log($this, sprintf('Resolving inheritance for "%s" (parent: %s).', $this->currentId, $parent));
-        $def = new Definition();
-
-        // merge in parent definition
-        // purposely ignored attributes: abstract, shared, tags, autoconfigured
-        $def->setClass($parentDef->getClass());
-        $def->setArguments($parentDef->getArguments());
-        $def->setMethodCalls($parentDef->getMethodCalls());
-        $def->setProperties($parentDef->getProperties());
-        if ($parentDef->getAutowiringTypes(false)) {
-            $def->setAutowiringTypes($parentDef->getAutowiringTypes(false));
-        }
-        if ($parentDef->isDeprecated()) {
-            $def->setDeprecated(true, $parentDef->getDeprecationMessage('%service_id%'));
-        }
-        $def->setFactory($parentDef->getFactory());
-        $def->setConfigurator($parentDef->getConfigurator());
-        $def->setFile($parentDef->getFile());
-        $def->setPublic($parentDef->isPublic());
-        $def->setLazy($parentDef->isLazy());
-        $def->setAutowired($parentDef->isAutowired());
-        $def->setChanges($parentDef->getChanges());
-
-        $def->setBindings($parentDef->getBindings());
-
-        // overwrite with values specified in the decorator
-        $changes = $definition->getChanges();
-        if (isset($changes['class'])) {
-            $def->setClass($definition->getClass());
-        }
-        if (isset($changes['factory'])) {
-            $def->setFactory($definition->getFactory());
-        }
-        if (isset($changes['configurator'])) {
-            $def->setConfigurator($definition->getConfigurator());
-        }
-        if (isset($changes['file'])) {
-            $def->setFile($definition->getFile());
-        }
-        if (isset($changes['public'])) {
-            $def->setPublic($definition->isPublic());
-        }
-        if (isset($changes['lazy'])) {
-            $def->setLazy($definition->isLazy());
-        }
-        if (isset($changes['deprecated'])) {
-            $def->setDeprecated($definition->isDeprecated(), $definition->getDeprecationMessage('%service_id%'));
-        }
-        if (isset($changes['autowired'])) {
-            $def->setAutowired($definition->isAutowired());
-        }
-        if (isset($changes['shared'])) {
-            $def->setShared($definition->isShared());
-        }
-        if (isset($changes['decorated_service'])) {
-            $decoratedService = $definition->getDecoratedService();
-            if (null === $decoratedService) {
-                $def->setDecoratedService($decoratedService);
-            } else {
-                $def->setDecoratedService($decoratedService[0], $decoratedService[1], $decoratedService[2]);
-            }
-        }
-
-        // merge arguments
-        foreach ($definition->getArguments() as $k => $v) {
-            if (is_numeric($k)) {
-                $def->addArgument($v);
-            } elseif (0 === strpos($k, 'index_')) {
-                $def->replaceArgument((int) substr($k, strlen('index_')), $v);
-            } else {
-                $def->setArgument($k, $v);
-            }
-        }
-
-        // merge properties
-        foreach ($definition->getProperties() as $k => $v) {
-            $def->setProperty($k, $v);
-        }
-
-        // append method calls
-        if ($calls = $definition->getMethodCalls()) {
-            $def->setMethodCalls(array_merge($def->getMethodCalls(), $calls));
-        }
-
-        // merge autowiring types
-        foreach ($definition->getAutowiringTypes(false) as $autowiringType) {
-            $def->addAutowiringType($autowiringType);
-        }
-
-        // these attributes are always taken from the child
-        $def->setAbstract($definition->isAbstract());
-        $def->setTags($definition->getTags());
-        // autoconfigure is never taken from parent (on purpose)
-        // and it's not legal on an instanceof
-        $def->setAutoconfigured($definition->isAutoconfigured());
-
-        return $def;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -13,13 +13,11 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * @group legacy
- */
-class ResolveDefinitionTemplatesPassTest extends TestCase
+class ResolveChildDefinitionsPassTest extends TestCase
 {
     public function testProcess()
     {
@@ -399,9 +397,17 @@ class ResolveDefinitionTemplatesPassTest extends TestCase
         $this->assertFalse($container->getDefinition('child1')->isAutoconfigured());
     }
 
+    /**
+     * @group legacy
+     */
+    public function testAliasExistsForBackwardsCompatibility()
+    {
+        $this->assertInstanceOf(ResolveChildDefinitionsPass::class, new ResolveDefinitionTemplatesPass());
+    }
+
     protected function process(ContainerBuilder $container)
     {
-        $pass = new ResolveDefinitionTemplatesPass();
+        $pass = new ResolveChildDefinitionsPass();
         $pass->process($container);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
-use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ResolveInstanceofConditionalsPassTest extends TestCase
@@ -57,7 +57,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $container->setDefinition('child', $def);
 
         (new ResolveInstanceofConditionalsPass())->process($container);
-        (new ResolveDefinitionTemplatesPass())->process($container);
+        (new ResolveChildDefinitionsPass())->process($container);
 
         $expected = array(
             array('foo', array('bar')),
@@ -95,7 +95,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         ));
 
         (new ResolveInstanceofConditionalsPass())->process($container);
-        (new ResolveDefinitionTemplatesPass())->process($container);
+        (new ResolveChildDefinitionsPass())->process($container);
 
         $def = $container->getDefinition('foo');
         $this->assertTrue($def->isAutowired());
@@ -119,7 +119,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
             ->setFactory('autoconfigured_factory');
 
         (new ResolveInstanceofConditionalsPass())->process($container);
-        (new ResolveDefinitionTemplatesPass())->process($container);
+        (new ResolveChildDefinitionsPass())->process($container);
 
         $def = $container->getDefinition('normal_service');
         // autowired thanks to the autoconfigured instanceof
@@ -147,7 +147,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         ;
 
         (new ResolveInstanceofConditionalsPass())->process($container);
-        (new ResolveDefinitionTemplatesPass())->process($container);
+        (new ResolveChildDefinitionsPass())->process($container);
 
         $def = $container->getDefinition('normal_service');
         $this->assertSame(array('duplicated_tag' => array(array(), array('and_attributes' => 1))), $def->getTags());
@@ -165,7 +165,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
             ->setAutowired(true);
 
         (new ResolveInstanceofConditionalsPass())->process($container);
-        (new ResolveDefinitionTemplatesPass())->process($container);
+        (new ResolveChildDefinitionsPass())->process($container);
 
         $def = $container->getDefinition('normal_service');
         $this->assertFalse($def->isAutowired());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Because that name makes things harder to understand now.
This uses exactly the same BC layer logic as the one we have for the renaming of DefinitionDecorator to ChildDefinition.