### PR TITLE
Updated console error font color

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -69,7 +69,7 @@ class OutputFormatter implements OutputFormatterInterface
     {
         $this->decorated = (bool) $decorated;
 
-        $this->setStyle('error', new OutputFormatterStyle('white', 'red'));
+        $this->setStyle('error', new OutputFormatterStyle('black', 'red'));
         $this->setStyle('info', new OutputFormatterStyle('green'));
         $this->setStyle('comment', new OutputFormatterStyle('yellow'));
         $this->setStyle('question', new OutputFormatterStyle('black', 'cyan'));


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The previous white on red(ANSI) was hard to read.
Black on red is much more pleasant to read.

**Before / After comparison**

![before-after-console-color](https://user-images.githubusercontent.com/1721611/30161592-43f0e4aa-93e2-11e7-9331-8a9aaaca9a2c.jpg)
