### PR TITLE
[HttpKernel] "controller.service_arguments" services should be public

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -50,6 +50,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds($this->controllerTag, true) as $id => $tags) {
             $def = $container->getDefinition($id);
+            $def->setPublic(true);
             $class = $def->getClass();
             $autowire = $def->isAutowired();
 

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -266,6 +266,21 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
         $this->assertEmpty(array_keys($locator));
     }
+
+    public function testControllersAreMadePublic()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service')->addArgument(array());
+
+        $container->register('foo', ArgumentWithoutTypeController::class)
+            ->setPublic(false)
+            ->addTag('controller.service_arguments');
+
+        $pass = new RegisterControllerArgumentLocatorsPass();
+        $pass->process($container);
+
+        $this->assertTrue($container->getDefinition('foo')->isPublic());
+    }
 }
 
 class RegisterTestController


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Controller-as-services need to be public if they have constructor arguments (they don't need to if they have no arguments but that's for arcane reasons.)
Since services tagged "controller.service_arguments" *are* controllers, they need to be public to enhance DX and remove some WTFs that some ppl reported to me.