### PR TITLE
Fixed deprecations in WebProfiler tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -53,8 +53,6 @@ CHANGELOG
    `EventDispatcherDebugCommand`, `RouterDebugCommand`, `RouterMatchCommand`,
    `TranslationDebugCommand`, `TranslationUpdateCommand`, `XliffLintCommand`
     and `YamlLintCommand` classes have been marked as final
- * Deprecated the `web_profiler.position` config option (in Symfony 4.0 the toolbar
-   will always be displayed at the bottom).
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * Deprecated the `web_profiler.position` config option (in 4.0 version the toolbar
+   will always be displayed at the bottom) and the `web_profiler.debug_toolbar.position`
+   container parameter.
+
 3.1.0
 -----
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -29,6 +29,20 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($results, $config);
     }
 
+    /**
+     * @dataProvider getPositionConfig
+     * @group legacy
+     * @expectedDeprecation The "web_profiler.position" configuration key has been deprecated in Symfony 3.4 and it will be removed in 4.0.
+     */
+    public function testPositionConfig($options, $results)
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $config = $processor->processConfiguration($configuration, array($options));
+
+        $this->assertEquals($results, $config);
+    }
+
     public function getDebugModes()
     {
         return array(
@@ -36,8 +50,15 @@ class ConfigurationTest extends TestCase
             array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
             array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
             array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('position' => 'top'), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'top', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
             array(array('excluded_ajax_paths' => 'test'), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => 'test')),
+        );
+    }
+
+    public function getPositionConfig()
+    {
+        return array(
+            array(array('position' => 'top'), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt', 'position' => 'top')),
+            array(array('position' => 'bottom'), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt', 'position' => 'bottom')),
         );
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -25,12 +25,13 @@
         "twig/twig": "~1.34|~2.4"
     },
     "require-dev": {
-        "symfony/config": "~2.8|~3.0|~4.0",
+        "symfony/config": "~3.4|~4.0",
         "symfony/console": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~3.3|~4.0",
         "symfony/stopwatch": "~2.8|~3.0|~4.0"
     },
     "conflict": {
+        "symfony/config": "<3.4",
         "symfony/dependency-injection": "<3.3",
         "symfony/event-dispatcher": "<3.3",
         "symfony/var-dumper": "<3.3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

To avoid this error in tests:

```
The "web_profiler.position" configuration key has been deprecated in Symfony 3.4 and it will be removed in 4.0: 1x
    1x in ConfigurationTest::testConfigTree from Symfony\Bundle\WebProfilerBundle\Tests\DependencyInjection
```

Can anybody propose a better solution to fix this issue? Thanks!