### PR TITLE
[Console] Do not display short exception trace for common console exceptions

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -761,7 +761,9 @@ class Application
             }
 
             $messages = array();
-            $messages[] = sprintf('<comment>%s</comment>', OutputFormatter::escape(sprintf('In %s line %s:', basename($e->getFile()) ?: 'n/a', $e->getLine() ?: 'n/a')));
+            if (!$e instanceof ExceptionInterface || OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
+                $messages[] = sprintf('<comment>%s</comment>', OutputFormatter::escape(sprintf('In %s line %s:', basename($e->getFile()) ?: 'n/a', $e->getLine() ?: 'n/a')));
+            }
             $messages[] = $emptyLine = sprintf('<error>%s</error>', str_repeat(' ', $len));
             if ('' === $message || OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
                 $messages[] = sprintf('<error>%s%s</error>', $title, str_repeat(' ', max(0, $len - Helper::strlen($title))));

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception1.txt
@@ -1,5 +1,4 @@
 
-In Application.php line 615:
                                  
   Command "foo" is not defined.  
                                  

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception2.txt
@@ -1,5 +1,4 @@
 
-In ArrayInput.php line 178:
                                       
   The "--foo" option does not exist.  
                                       

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception4.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception4.txt
@@ -1,5 +1,4 @@
 
-In Application.php line 615:
                                
   Command "foo" is not define  
   d.                           


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

![console_before](https://user-images.githubusercontent.com/2028198/30173516-edb9e42c-93c5-11e7-882e-f8b0335387b3.png)

I'd like reconsider [the new error output][1] with short exception trace always displayed at top, IMHO it's annoying for common exceptions (there is not real debugging reason, the message is clear enough) such as `Symfony\Component\Console\Exception\*` which have an impact into current CLI applications.

However, I'm proposing display it for unexpected exceptions or if verbosity is enabled:

![console](https://user-images.githubusercontent.com/2028198/30173085-94322636-93c4-11e7-81a6-bba807910e62.png)

Note @nicolas-grekas's https://github.com/symfony/symfony/pull/21414#issuecomment-326013025 is still covered.

 [1]: https://github.com/symfony/symfony/pull/21414
