### PR TITLE
[Filesystem] improved errors for invalid dump targets

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -525,13 +525,21 @@ class Filesystem
      * @param null|int $mode     The file mode (octal). If null, file permissions are not modified
      *                           Deprecated since version 2.3.12, to be removed in 3.0.
      *
-     * @throws IOException If the file cannot be written to.
+     * @throws IOException if the file cannot be written to
      */
     public function dumpFile($filename, $content, $mode = 0666)
     {
         $dir = dirname($filename);
 
         if (!is_dir($dir)) {
+            if (is_file($dir)) {
+                throw new IOException(sprintf('The parent path of "%s" is a file.', $dir));
+            }
+
+            if (is_link($dir)) {
+                throw new IOException(sprintf('The parent path of "%s" is a symlink to a nonexistent directory.', $dir));
+            }
+
             $this->mkdir($dir);
         }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1102,6 +1102,37 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFilePermissions(745, $filename);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
+     * @expectedExceptionMessageRegExp /^The parent path of ".*" is a file\.$/
+     */
+    public function testDumpFailsIfParentDirectoryIsAnExistingFile()
+    {
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'foo';
+        $target = $file.DIRECTORY_SEPARATOR.'bar';
+        touch($file);
+
+        $this->filesystem->dumpFile($target, 'baz');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
+     * @expectedExceptionMessageRegExp /^The parent path of ".*" is a symlink to a nonexistent directory\.$/
+     */
+    public function testDumpFailsIfTargetIsSymlinkAndSymlinkTargetDoesNotExist()
+    {
+        $this->markAsSkippedIfSymlinkIsMissing();
+
+        $dir = $this->workspace.DIRECTORY_SEPARATOR.'foo';
+        mkdir($dir);
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'bar';
+        symlink($dir, $link);
+        rmdir($dir);
+        $target = $link.DIRECTORY_SEPARATOR.'baz';
+
+        $this->filesystem->dumpFile($target, 'baz');
+    }
+
     public function testCopyShouldKeepExecutionPermission()
     {
         $this->markAsSkippedIfChmodIsMissing();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24097
| License       | MIT
| Doc PR        | 