### PR TITLE
[CS] Remove `protected_to_private` rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,6 +13,7 @@ return PhpCsFixer\Config::create()
         'braces' => array('allow_single_line_closure' => true),
         'heredoc_to_nowdoc' => false,
         'phpdoc_annotation_without_dot' => false,
+        'protected_to_private' => false,
     ))
     ->setRiskyAllowed(true)
     ->setFinder(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| License       | MIT

Following:
https://github.com/symfony/symfony/pull/24123#issuecomment-328031180

I picked 3.1 as target as the rule discussed; 

| branch | hits
| --------- | ---
| 2.7 | 0
| 2.8 | 0
| 3.0 | 0
| 3.1 | 1
| master |  1 hit (same file as on 3.1)