### PR TITLE
[DomCrawler] Fix conversion to int on GetPhpFiles

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -172,6 +172,18 @@ class Form extends Link implements \ArrayAccess
             if (!empty($qs)) {
                 parse_str($qs, $expandedValue);
                 $varName = substr($name, 0, strlen(key($expandedValue)));
+
+                array_walk_recursive(
+                    $expandedValue,
+                    function (&$value, $key) {
+                        if (ctype_digit($value) && ('size' === $key || 'error' === $key)) {
+                            $value = (int) $value;
+                        }
+                    }
+                );
+
+                reset($expandedValue);
+
                 $values = array_replace_recursive($values, array($varName => current($expandedValue)));
             }
         }

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -456,6 +456,15 @@ class FormTest extends TestCase
 
         $form = $this->createForm('<form method="post"><input type="file" name="f.o o[bar][ba.z]" /><input type="file" name="f.o o[bar][]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');
         $this->assertEquals(array('f.o o' => array('bar' => array('ba.z' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0), array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0)))), $form->getPhpFiles(), '->getPhpFiles() preserves periods and spaces in names recursively');
+
+        $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');
+        $files = $form->getPhpFiles();
+
+        $this->assertSame(0, $files['foo']['bar']['size'], '->getPhpFiles() converts size to int');
+        $this->assertSame(4, $files['foo']['bar']['error'], '->getPhpFiles() converts error to int');
+
+        $form = $this->createForm('<form method="post"><input type="file" name="size[error]" /><input type="text" name="error" value="error" /><input type="submit" /></form>');
+        $this->assertEquals(array('size' => array('error' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0))), $form->getPhpFiles(), '->getPhpFiles() int conversion does not collide with file names');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |


We've encountered that when using the DomCrawler with the UploadedFile, everything gets converted into strings. We've addressed the issue, and made sure that the attributes in the UploadedFile respects their type.

The code below demonstrates the problem.

```<?php
require 'vendor/autoload.php';
require 'app/AppKernel.php';
$crawler = new \Symfony\Component\DomCrawler\Crawler(
    '<form method="post"><input type="file" name="image"/></form>',
    'http://www.example.com'
);
$form = $crawler->filter('form')->form();
$form['image'] = new \Symfony\Component\HttpFoundation\File\UploadedFile(
    'path/to/file',
    'foo',
    'text/plain',
    100
);

$client = new \Symfony\Bundle\FrameworkBundle\Client(new AppKernel('test', true));
$crawler = $client->submit($form);

var_dump($client->getRequest()->files->get('image')->getClientSize());  //returns string, not int
echo 'Done.' . PHP_EOL;