### PR TITLE
[FrameworkBundle] Bugfix, make sure index is related to the argument

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
@@ -65,10 +65,10 @@ class CachePoolPass implements CompilerPassInterface
             if (isset($tags[0]['provider'])) {
                 $tags[0]['provider'] = new Reference(static::getServiceProvider($container, $tags[0]['provider']));
             }
-            $i = 0;
-            foreach ($attributes as $attr) {
+
+            foreach ($attributes as $i => $attr) {
                 if (isset($tags[0][$attr])) {
-                    $pool->replaceArgument($i++, $tags[0][$attr]);
+                    $pool->replaceArgument($i, $tags[0][$attr]);
                 }
                 unset($tags[0][$attr]);
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
@@ -65,6 +65,28 @@ class CachePoolPassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(3, $cachePool->getArgument(2));
     }
 
+
+    public function testArgsOrder()
+    {
+        $container = new ContainerBuilder();
+        $cachePool = new Definition();
+        $cachePool->addTag('cache.pool', array(
+            'default_lifetime' => 3,
+            'namespace' => 'foo'
+        ));
+        // This cache pool has 3 arguments: Provider, Namespace and DefaultLifetime
+        $cachePool->addArgument(null);
+        $cachePool->addArgument(null);
+        $cachePool->addArgument(null);
+        $container->setDefinition('app.cache_pool', $cachePool);
+
+        $this->cachePoolPass->process($container);
+
+        $this->assertNull($cachePool->getArgument(0));
+        $this->assertSame('foo', $cachePool->getArgument(1));
+        $this->assertSame(3, $cachePool->getArgument(2));
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Invalid "cache.pool" tag for service "app.cache_pool": accepted attributes are


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When one is using a custom service and tagging it with "cache.pool" but not using the "provider". Then the "namespace" will replace the "provider" argument. 
