### PR TITLE
[FrameworkBundle] Expose dotenv in bin/console about

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -59,6 +59,7 @@ CHANGELOG
     and `YamlLintCommand` classes have been marked as final
  * Added `asset.request_context.base_path` and `asset.request_context.secure` parameters
    to provide a default request context in case the stack is empty (similar to `router.request_context.*` parameters)
+ * Display environment variables managed by `Dotenv` in `AboutCommand`
 
 3.3.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

For completeness in CLI, shown in web under "Server parameters".

```php
(new Dotenv())->populate(['APP_ENV' => 'prod', 'APP_DEBUG' => '1']);
```

![image](https://user-images.githubusercontent.com/1047696/30293203-fe360d0a-9738-11e7-80ed-94901cea8898.png)
