### PR TITLE
[DI] Improve class named services with root namespce

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -53,7 +53,7 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
                          'The definition for "%s" has no class attribute, and appears to reference a '
                         .'class or interface in the global namespace. Leaving out the "class" attribute '
                         .'is only allowed for namespaced classes. Please specify the class attribute '
-                        .'explicitly to get rid of this error.',
+                        .'explicitly or change its service identifier to \\%1$s to get rid of this error.',
                         $id
                     ));
                 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
@@ -31,7 +31,7 @@ class ResolveClassPass implements CompilerPassInterface
             if ($definition->isSynthetic() || null !== $definition->getClass()) {
                 continue;
             }
-            if (preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++$/', $id)) {
+            if (preg_match('/^(?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)++|\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)$/', $id)) {
                 if ($definition instanceof ChildDefinition && !class_exists($id)) {
                     throw new InvalidArgumentException(sprintf('Service definition "%s" has a parent but no class, and its name looks like a FQCN. Either the class is missing or you want to inherit it from the parent service. To resolve this ambiguity, please rename this service to a non-FQCN (e.g. using dots), or create the missing class.', $id));
                 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1069,18 +1069,6 @@ class ContainerBuilderTest extends TestCase
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The definition for "\foo" has no class.
-     */
-    public function testNoClassFromNsSeparatorId()
-    {
-        $container = new ContainerBuilder();
-
-        $definition = $container->register('\\foo');
-        $container->compile();
-    }
-
     public function testServiceLocator()
     {
         $container = new ContainerBuilder();
@@ -1128,6 +1116,26 @@ class ContainerBuilderTest extends TestCase
         $container->compile();
 
         $container->get('bar');
+    }
+
+    public function testNamespacedClassServiceWithRootNs()
+    {
+        $container = new ContainerBuilder();
+        $definition = $container->register($expected = '\\My\\DateTime');
+
+        $container->compile();
+
+        $this->assertSame($expected, $definition->getClass());
+    }
+
+    public function testClassServiceWithRootNs()
+    {
+        $container = new ContainerBuilder();
+        $definition = $container->register($expected = '\\DateTime');
+
+        $container->compile();
+
+        $this->assertSame($expected, $definition->getClass());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes. IMHO.
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

A continuation of #23468

_Fixed_ error for both test cases is

```
The definition for "\DateTime | \My\DateTime" has no class attribute,
and appears to reference a class or interface in the global namespace.
Leaving out the "class" attribute is only allowed for namespaced classes.
Please specify the class attribute explicitly to get rid of this error.
```

IMHO both qualify  as namespaced, making the error look weird (hence bugfix 3.3)

Yes; i know it doesnt work with `get(\DateTime::class)`.. but that's not the point really :)