### PR TITLE
[Form] Hide label button when its setted to false

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -176,7 +176,7 @@
 {%- endblock email_widget -%}
 
 {%- block button_widget -%}
-    {%- if label is empty -%}
+    {%- if label is not same as(false) and label is empty -%}
         {%- if label_format is not empty -%}
             {% set label = label_format|replace({
                 '%name%': name,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Added same behaviour in buttons like in other form components when label is setted to false, don't show it. 
It's very useful with buttons with icon and without text.