### PR TITLE
deprecated profiler.matcher configuration

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -210,6 +210,11 @@ Process
  * The `Symfony\Component\Process\ProcessBuilder` class has been deprecated,
    use the `Symfony\Component\Process\Process` class directly instead.
 
+Profiler
+--------
+
+ * The `profiler.matcher` option has been deprecated.
+
 SecurityBundle
 --------------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -583,6 +583,11 @@ Process
 
  * The `getEnhanceWindowsCompatibility()` and `setEnhanceWindowsCompatibility()` methods of the `Process` class have been removed.
 
+Profiler
+--------
+
+ * The `profiler.matcher` option has been removed.
+
 ProxyManager
 ------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
+ * Deprecated `profiler.matcher` option
  * Added support for `EventSubscriberInterface` on `MicroKernelTrait`
  * Removed `doctrine/cache` from the list of required dependencies in `composer.json`
  * Deprecated `validator.mapping.cache.doctrine.apc` service

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -253,7 +253,7 @@ class Configuration implements ConfigurationInterface
                                 $workflows = $v;
                                 unset($workflows['enabled']);
 
-                                if (count($workflows) === 1 && isset($workflows[0]['enabled'])) {
+                                if (1 === count($workflows) && isset($workflows[0]['enabled'])) {
                                     $workflows = array();
                                 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -219,6 +219,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('only_master_requests')->defaultFalse()->end()
                         ->scalarNode('dsn')->defaultValue('file:%kernel.cache_dir%/profiler')->end()
                         ->arrayNode('matcher')
+                            ->setDeprecated('The "profiler.matcher" configuration key has been deprecated in Symfony 3.4 and it will be removed in 4.0.')
                             ->canBeEnabled()
                             ->performNoDeepMerging()
                             ->fixXmlConfig('ip')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | closes #24077, would also close #21944, #22484
| License       | MIT
| Doc PR        | not yet

The profiler matcher configuration was added at a time where we thought that having the profiler in production could make sense (and so being able to enable it conditionally made sense). That's not the case anymore. Nobody should ever enable it in production.

With that in mind, I propose to deprecate this setting in 3.4 and remove it in 4.0.
