### PR TITLE
.php_cs.dist - simplify config

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,9 +9,6 @@ return PhpCsFixer\Config::create()
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'array_syntax' => array('syntax' => 'long'),
-        'no_unreachable_default_argument_value' => false,
-        'braces' => array('allow_single_line_closure' => true),
-        'heredoc_to_nowdoc' => false,
     ))
     ->setRiskyAllowed(true)
     ->setFinder(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

dropped configuration is already part of `@Symfony` ruleset