### PR TITLE
[Twig] added support for named args on form functions

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -76,14 +76,14 @@ class FormExtension extends AbstractExtension implements InitRuntimeInterface
     public function getFunctions()
     {
         return array(
-            new TwigFunction('form_widget', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
-            new TwigFunction('form_errors', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
-            new TwigFunction('form_label', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
-            new TwigFunction('form_row', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
-            new TwigFunction('form_rest', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
-            new TwigFunction('form', null, array('node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => array('html'))),
-            new TwigFunction('form_start', null, array('node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => array('html'))),
-            new TwigFunction('form_end', null, array('node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => array('html'))),
+            new TwigFunction('form_widget', array('Symfony\Component\Form\FormRenderer', 'searchAndRenderBlock'), array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new TwigFunction('form_errors', array('Symfony\Component\Form\FormRenderer', 'searchAndRenderBlock'), array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new TwigFunction('form_label', array('Symfony\Component\Form\FormRenderer', 'searchAndRenderBlock'), array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new TwigFunction('form_row', array('Symfony\Component\Form\FormRenderer', 'searchAndRenderBlock'), array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new TwigFunction('form_rest', array('Symfony\Component\Form\FormRenderer', 'searchAndRenderBlock'), array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new TwigFunction('form', array('Symfony\Component\Form\FormRenderer', 'renderBlock'), array('node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => array('html'))),
+            new TwigFunction('form_start', array('Symfony\Component\Form\FormRenderer', 'renderBlock'), array('node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => array('html'))),
+            new TwigFunction('form_end', array('Symfony\Component\Form\FormRenderer', 'renderBlock'), array('node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => array('html'))),
             new TwigFunction('csrf_token', array('Symfony\Component\Form\FormRenderer', 'renderCsrfToken')),
         );
     }

--- a/src/Symfony/Bridge/Twig/Node/RenderBlockNode.php
+++ b/src/Symfony/Bridge/Twig/Node/RenderBlockNode.php
@@ -12,13 +12,12 @@
 namespace Symfony\Bridge\Twig\Node;
 
 use Twig\Compiler;
+use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FunctionExpression;
+use Twig\Node\Node;
 
 /**
  * Compiles a call to {@link \Symfony\Component\Form\FormRendererInterface::renderBlock()}.
- *
- * The function name is used as block name. For example, if the function name
- * is "foo", the block "foo" will be rendered.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
@@ -27,19 +26,11 @@ class RenderBlockNode extends FunctionExpression
     public function compile(Compiler $compiler)
     {
         $compiler->addDebugInfo($this);
-        $arguments = iterator_to_array($this->getNode('arguments'));
-        $compiler->write('$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->renderBlock(');
+        $this->setNode('arguments', new Node(array_merge(
+            iterator_to_array($this->getNode('arguments')),
+            array('blockName' => new ConstantExpression($this->getAttribute('name'), $this->getNode('arguments')->getTemplateLine()))
+        )));
 
-        if (isset($arguments[0])) {
-            $compiler->subcompile($arguments[0]);
-            $compiler->raw(', \''.$this->getAttribute('name').'\'');
-
-            if (isset($arguments[1])) {
-                $compiler->raw(', ');
-                $compiler->subcompile($arguments[1]);
-            }
-        }
-
-        $compiler->raw(')');
+        parent::compile($compiler);
     }
 }

--- a/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
+++ b/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
@@ -13,8 +13,12 @@ namespace Symfony\Bridge\Twig\Node;
 
 use Twig\Compiler;
 use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\ConditionalExpression;
 use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\FilterExpression;
+use Twig\Node\Expression\TestExpression;
 use Twig\Node\Expression\FunctionExpression;
+use Twig\Node\Node;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -24,88 +28,92 @@ class SearchAndRenderBlockNode extends FunctionExpression
     public function compile(Compiler $compiler)
     {
         $compiler->addDebugInfo($this);
-        $compiler->raw('$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(');
-
         preg_match('/_([^_]+)$/', $this->getAttribute('name'), $matches);
-
         $label = null;
-        $arguments = iterator_to_array($this->getNode('arguments'));
         $blockNameSuffix = $matches[1];
 
-        if (isset($arguments[0])) {
-            $compiler->subcompile($arguments[0]);
-            $compiler->raw(', \''.$blockNameSuffix.'\'');
-
+        $arguments = iterator_to_array($this->getNode('arguments'));
+        if ('label' === $blockNameSuffix) {
+            if (isset($arguments[2])) {
+                $arguments['variables'] = $arguments[2];
+                unset($arguments[2]);
+            }
+            $label = null;
             if (isset($arguments[1])) {
-                if ('label' === $blockNameSuffix) {
-                    // The "label" function expects the label in the second and
-                    // the variables in the third argument
-                    $label = $arguments[1];
-                    $variables = isset($arguments[2]) ? $arguments[2] : null;
-                    $lineno = $label->getTemplateLine();
+                $label = $arguments[1];
+                unset($arguments[1]);
+            } elseif (isset($arguments[1])) {
+                $label = $arguments['label'];
+                unset($arguments['label']);
+            }
 
-                    if ($label instanceof ConstantExpression) {
-                        // If the label argument is given as a constant, we can either
-                        // strip it away if it is empty, or integrate it into the array
-                        // of variables at compile time.
-                        $labelIsExpression = false;
+            if (null !== $label) {
+                $lineno = $label->getTemplateLine();
+                if (!isset($arguments['variables'])) {
+                    $arguments['variables'] = new ArrayExpression(array(), $lineno);
+                }
+                if ($label instanceof ConstantExpression) {
+                    // If the label argument is given as a constant, we can either
+                    // strip it away if it is empty, or integrate it into the array
+                    // of variables at compile time.
 
-                        // Only insert the label into the array if it is not empty
-                        if (!twig_test_empty($label->getAttribute('value'))) {
-                            $originalVariables = $variables;
-                            $variables = new ArrayExpression(array(), $lineno);
-                            $labelKey = new ConstantExpression('label', $lineno);
+                    // Only insert the label into the array if it is not empty
+                    if (!twig_test_empty($label->getAttribute('value'))) {
+                        $variables = new ArrayExpression(array(), $lineno);
+                        $labelKey = new ConstantExpression('label', $lineno);
 
-                            if (null !== $originalVariables) {
-                                foreach ($originalVariables->getKeyValuePairs() as $pair) {
-                                    // Don't copy the original label attribute over if it exists
-                                    if ((string) $labelKey !== (string) $pair['key']) {
-                                        $variables->addElement($pair['value'], $pair['key']);
-                                    }
+                        if (null !== $arguments['variables']) {
+                            foreach ($arguments['variables']->getKeyValuePairs() as $pair) {
+                                // Don't copy the original label attribute over if it exists
+                                if ((string) $labelKey !== (string) $pair['key']) {
+                                    $variables->addElement($pair['value'], $pair['key']);
                                 }
                             }
-
-                            // Insert the label argument into the array
-                            $variables->addElement($label, $labelKey);
                         }
-                    } else {
-                        // The label argument is not a constant, but some kind of
-                        // expression. This expression needs to be evaluated at runtime.
-                        // Depending on the result (whether it is null or not), the
-                        // label in the arguments should take precedence over the label
-                        // in the attributes or not.
-                        $labelIsExpression = true;
+
+                        // Insert the label argument into the array
+                        $variables->addElement($label, $labelKey);
+                        $arguments['variables'] = $variables;
                     }
                 } else {
-                    // All other functions than "label" expect the variables
-                    // in the second argument
-                    $label = null;
-                    $variables = $arguments[1];
-                    $labelIsExpression = false;
-                }
+                    // The label argument is not a constant, but some kind of
+                    // expression. This expression needs to be evaluated at runtime.
+                    // Depending on the result (whether it is null or not), the
+                    // label in the arguments should take precedence over the label
+                    // in the attributes or not.
 
-                if (null !== $variables || $labelIsExpression) {
-                    $compiler->raw(', ');
+                    // Check at runtime whether the label is empty.
+                    // If not, add it to the array at runtime.
+                    $labelExpr = new ArrayExpression(array(new ConstantExpression('label', $lineno), $label), $lineno);
+                    $condition = new TestExpression($label, 'empty', new Node(), $lineno);
+                    $conditional = new ConditionalExpression($condition, new ArrayExpression(array(), $lineno), $labelExpr, $lineno);
 
-                    if (null !== $variables) {
-                        $compiler->subcompile($variables);
-                    }
-
-                    if ($labelIsExpression) {
-                        if (null !== $variables) {
-                            $compiler->raw(' + ');
-                        }
-
-                        // Check at runtime whether the label is empty.
-                        // If not, add it to the array at runtime.
-                        $compiler->raw('(twig_test_empty($_label_ = ');
-                        $compiler->subcompile($label);
-                        $compiler->raw(') ? array() : array("label" => $_label_))');
+                    if (count($arguments['variables'])) {
+                        $arguments['variables'] = new FilterExpression(
+                            new Node(array($conditional)),
+                            new ConstantExpression('merge', $lineno),
+                            $arguments['variables'],
+                            $lineno
+                        );
+                    } else {
+                        $arguments['variables'] = $conditional;
                     }
                 }
+
+                unset($arguments[1]);
+            }
+        } else {
+            if (isset($arguments[1])) {
+                $arguments['variables'] = $arguments[1];
+                unset($arguments[1]);
             }
         }
 
-        $compiler->raw(')');
+        $this->setNode('arguments', new Node(array_merge(
+            $arguments,
+            array('blockNameSuffix' => new \Twig_Node_Expression_Constant($blockNameSuffix, 0))
+        )));
+
+        parent::compile($compiler);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests\Node;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode;
 use Twig\Compiler;
 use Twig\Environment;
@@ -31,14 +32,12 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'widget\')',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "widget")',
                 $this->getVariableGetter('form')
              ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -54,14 +53,12 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'widget\', array("foo" => "bar"))',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "widget", array("foo" => "bar"))',
                 $this->getVariableGetter('form')
             ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -74,14 +71,12 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', array("label" => "my label"))',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "label", array("label" => "my label"))',
                 $this->getVariableGetter('form')
             ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -94,16 +89,14 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\')',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "label", array())',
                 $this->getVariableGetter('form')
             ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -116,16 +109,14 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\')',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "label", array())',
                 $this->getVariableGetter('form')
             ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -137,14 +128,12 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\')',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "label")',
                 $this->getVariableGetter('form')
             ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -161,17 +150,15 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
         // https://github.com/symfony/symfony/issues/5029
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', array("foo" => "bar"))',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "label", array("foo" => "bar"))',
                 $this->getVariableGetter('form')
             ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -190,14 +177,12 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', array("foo" => "bar", "label" => "value in argument"))',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "label", array("foo" => "bar", "label" => "value in argument"))',
                 $this->getVariableGetter('form')
             ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -218,17 +203,15 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
         // https://github.com/symfony/symfony/issues/5029
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', (twig_test_empty($_label_ = ((true) ? (null) : (null))) ? array() : array("label" => $_label_)))',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "label", ((twig_test_empty(((true) ? (null) : (null)))) ? (array()) : (array("label" => ((true) ? (null) : (null))))))',
                 $this->getVariableGetter('form')
             ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -255,17 +238,15 @@ class SearchAndRenderBlockNodeTest extends TestCase
 
         $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
 
-        $compiler = new Compiler(new Environment($this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock()));
-
         // "label" => null must not be included in the output!
         // Otherwise the default label is overwritten with null.
         // https://github.com/symfony/symfony/issues/5029
         $this->assertEquals(
             sprintf(
-                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, \'label\', array("foo" => "bar", "label" => "value in attributes") + (twig_test_empty($_label_ = ((true) ? (null) : (null))) ? array() : array("label" => $_label_)))',
+                '$this->env->getRuntime(\'Symfony\Component\Form\FormRenderer\')->searchAndRenderBlock(%s, "label", twig_array_merge(((twig_test_empty(((true) ? (null) : (null)))) ? (array()) : (array("label" => ((true) ? (null) : (null))))), "foo", "bar", "label", "value in attributes"))',
                 $this->getVariableGetter('form')
             ),
-            trim($compiler->compile($node)->getSource())
+            trim($this->getCompiler()->compile($node)->getSource())
         );
     }
 
@@ -276,5 +257,14 @@ class SearchAndRenderBlockNodeTest extends TestCase
         }
 
         return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
+    }
+
+    private function getCompiler()
+    {
+        $loader = $this->getMockBuilder('Twig\Loader\LoaderInterface')->getMock();
+        $environment = new Environment($loader, array('strict_variables' => false));
+        $environment->addExtension(new FormExtension());
+
+        return new Compiler($environment);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20188 #23059
| License       | MIT
| Doc PR        | n/a

Alternative to #23059. Instead of reimplementing Twig's logic to support named argument, I've refactored the Node code to let Twig do its job.
