### PR TITLE
[Security] [Firewall] Fix support of multiple HTTP authentication methods

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\EntryPoint\BasicAuthenticationEntryPoint;
 
 /**
  * HttpBasicFactory creates services for HTTP basic authentication.
@@ -66,7 +67,7 @@ class HttpBasicFactory implements SecurityFactoryInterface
 
     protected function createEntryPoint($container, $id, $config, $defaultEntryPoint)
     {
-        if (null !== $defaultEntryPoint) {
+        if (null !== $defaultEntryPoint && $defaultEntryPoint instanceof BasicAuthenticationEntryPoint) {
             return $defaultEntryPoint;
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint;
 
 /**
  * HttpDigestFactory creates services for HTTP digest authentication.
@@ -68,7 +69,7 @@ class HttpDigestFactory implements SecurityFactoryInterface
 
     protected function createEntryPoint($container, $id, $config, $defaultEntryPoint)
     {
-        if (null !== $defaultEntryPoint) {
+        if (null !== $defaultEntryPoint && $defaultEntryPoint instanceof DigestAuthenticationEntryPoint) {
             return $defaultEntryPoint;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10035 

Configuring guard along with http_digest breaks, because the default entry point for the firewall is automatically the guard authenticator, which is not a BasicAuthenticationEntryPoint / DigestAuthenticationEntryPoint.
We do create the entry point if there is no default entry point configured, so we should keep creating it if the default one is not an instance of BasicAuthenticationEntryPoint / DigestAuthenticationEntryPoint.
Related to lexik/LexikJWTAuthenticationBundle#384.
