### PR TITLE
[Console] Add OutputAwareInterface

### DIFF
--- a/src/Symfony/Component/Console/Output/OutputAwareInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputAwareInterface.php
@@ -19,10 +19,9 @@ namespace Symfony\Component\Console\Output;
 interface OutputAwareInterface
 {
     /**
-     * Set the console output
+     * Set the console output.
      *
      * @param OutputInterface $output
-     * @return void
      */
     public function setOutput(OutputInterface $output);
 }

--- a/src/Symfony/Component/Console/Output/OutputAwareInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputAwareInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Output;
+
+/**
+ * OutputAwareInterface should be implemented by classes that depends on the console output.
+ *
+ * @author Adam Sentner <adam@adamsentner.com>
+ */
+interface OutputAwareInterface
+{
+    /**
+     * Set the console output
+     *
+     * @param OutputInterface $output
+     * @return void
+     */
+    public function setOutput(OutputInterface $output);
+}


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug report?      | no
| Feature request? | yes
| BC Break report? | no
| RFC?             | no
| Symfony version  | 3.4 & 4.0

Please add OutputAwareInterface to the Symfony\Component\Console\Output namespace. This is similar to the existing Symfony\Component\Console\Input\InputAwareInterface. In my application, I am currently using the OutputAwareInterface for any classes that depend on the console output. I'd like to see this as part of the Symfony 3.4 and 4.0 framework.