### PR TITLE
Force MergeCollectionListener to keep data order

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -73,6 +73,26 @@ class MergeCollectionListener implements EventSubscriberInterface
             throw new UnexpectedTypeException($dataToMergeInto, 'array or (\Traversable and \ArrayAccess)');
         }
 
+        // Reorder $dataToMergeInto as $data is
+        $itemsToCheck = is_object($data) ? clone $data : $data;
+        $orderedItems = array();
+        $itemsLeft = array();
+
+        foreach ($dataToMergeInto as $beforeKey => $beforeItem) {
+            foreach ($itemsToCheck as $afterKey => $afterItem) {
+                if ($afterItem === $beforeItem) {
+                    // Item found, assign it to the final position
+                    $orderedItems[$afterKey] = $beforeItem;
+                    unset($itemsToCheck[$afterKey]);
+                    continue 2;
+                }
+            }
+
+            // Item not found. Will be added at the end of the ordered items
+            $itemsLeft[] = $beforeItem;
+        }
+
+        $dataToMergeInto = $orderedItems + $itemsLeft;
         // If we are not allowed to change anything, return immediately
         if ((!$this->allowAdd && !$this->allowDelete) || $data === $dataToMergeInto) {
             $event->setData($dataToMergeInto);


### PR DESCRIPTION
Reorder elements in `$dataToMergeInto` so they match `$data` order.
This prevent issues when using sortable libraries for ChoiceType forms

| Q             | A
| ------------- | ---
| Branch?       | 2.7, 2.8 or 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - #... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
