### PR TITLE
[Routing] Add PHP fluent DSL for configuring routes

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class CollectionConfigurator
+{
+    use Traits\AddTrait;
+    use Traits\RouteTrait;
+
+    private $parent;
+
+    public function __construct(RouteCollection $parent, $name)
+    {
+        $this->parent = $parent;
+        $this->name = $name;
+        $this->collection = new RouteCollection();
+        $this->route = new Route('');
+    }
+
+    public function __destruct()
+    {
+        $this->collection->addPrefix(rtrim($this->route->getPath(), '/'));
+        $this->parent->addCollection($this->collection);
+    }
+
+    /**
+     * Adds a route.
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return RouteConfigurator
+     */
+    final public function add($name, $path)
+    {
+        $this->collection->add($this->name.$name, $route = clone $this->route);
+
+        return new RouteConfigurator($this->collection, $route->setPath($path), $this->name);
+    }
+
+    /**
+     * Creates a sub-collection.
+     *
+     * @return self
+     */
+    final public function collection($name = '')
+    {
+        return new self($this->collection, $this->name.$name);
+    }
+
+    /**
+     * Sets the prefix to add to the path of all child routes.
+     *
+     * @param string $prefix
+     *
+     * @return $this
+     */
+    final public function prefix($prefix)
+    {
+        $this->route->setPath($prefix);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ImportConfigurator
+{
+    use Traits\RouteTrait;
+
+    private $parent;
+
+    public function __construct(RouteCollection $parent, RouteCollection $route)
+    {
+        $this->parent = $parent;
+        $this->route = $route;
+    }
+
+    public function __destruct()
+    {
+        $this->parent->addCollection($this->route);
+    }
+
+    /**
+     * Sets the prefix to add to the path of all child routes.
+     *
+     * @param string $prefix
+     *
+     * @return $this
+     */
+    final public function prefix($prefix)
+    {
+        $this->route->addPrefix($prefix);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class RouteConfigurator
+{
+    use Traits\AddTrait;
+    use Traits\RouteTrait;
+
+    public function __construct(RouteCollection $collection, Route $route, $name = '')
+    {
+        $this->collection = $collection;
+        $this->route = $route;
+        $this->name = $name;
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+use Symfony\Component\Routing\Loader\PhpFileLoader;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class RoutingConfigurator
+{
+    use Traits\AddTrait;
+
+    private $loader;
+    private $path;
+    private $file;
+
+    public function __construct(RouteCollection $collection, PhpFileLoader $loader, $path, $file)
+    {
+        $this->collection = $collection;
+        $this->loader = $loader;
+        $this->path = $path;
+        $this->file = $file;
+    }
+
+    /**
+     * @return ImportConfigurator
+     */
+    final public function import($resource, $type = null, $ignoreErrors = false)
+    {
+        $this->loader->setCurrentDir(dirname($this->path));
+        $subCollection = $this->loader->import($resource, $type, $ignoreErrors, $this->file);
+
+        return new ImportConfigurator($this->collection, $subCollection);
+    }
+
+    /**
+     * @return CollectionConfigurator
+     */
+    final public function collection($name = '')
+    {
+        return new CollectionConfigurator($this->collection, $name);
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/AddTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/AddTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\Configurator\Traits;
+
+use Symfony\Component\Routing\Loader\Configurator\RouteConfigurator;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+trait AddTrait
+{
+    /**
+     * @var RouteCollection
+     */
+    private $collection;
+
+    private $name = '';
+
+    /**
+     * Adds a route.
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return RouteConfigurator
+     */
+    final public function add($name, $path)
+    {
+        $this->collection->add($this->name.$name, $route = new Route($path));
+
+        return new RouteConfigurator($this->collection, $route);
+    }
+
+    /**
+     * Adds a route.
+     *
+     * @param string $name
+     * @param string $path
+     *
+     * @return RouteConfigurator
+     */
+    final public function __invoke($name, $path)
+    {
+        return $this->add($name, $path);
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\Configurator\Traits;
+
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+trait RouteTrait
+{
+    /**
+     * @var RouteCollection|Route
+     */
+    private $route;
+
+    /**
+     * Adds defaults.
+     *
+     * @param array $defaults
+     *
+     * @return $this
+     */
+    final public function defaults(array $defaults)
+    {
+        $this->route->addDefaults($defaults);
+
+        return $this;
+    }
+
+    /**
+     * Adds requirements.
+     *
+     * @param array $requirements
+     *
+     * @return $this
+     */
+    final public function requirements(array $requirements)
+    {
+        $this->route->addRequirements($requirements);
+
+        return $this;
+    }
+
+    /**
+     * Adds options.
+     *
+     * @param array $options
+     *
+     * @return $this
+     */
+    final public function options(array $options)
+    {
+        $this->route->addOptions($options);
+
+        return $this;
+    }
+
+    /**
+     * Sets the condition.
+     *
+     * @param string $condition
+     *
+     * @return $this
+     */
+    final public function condition($condition)
+    {
+        $this->route->setCondition($condition);
+
+        return $this;
+    }
+
+    /**
+     * Sets the pattern for the host.
+     *
+     * @param string $pattern
+     *
+     * @return $this
+     */
+    final public function host($pattern)
+    {
+        $this->route->setHost($pattern);
+
+        return $this;
+    }
+
+    /**
+     * Sets the schemes (e.g. 'https') this route is restricted to.
+     * So an empty array means that any scheme is allowed.
+     *
+     * @param array $schemes
+     *
+     * @return $this
+     */
+    final public function schemes(array $schemes)
+    {
+        $this->route->setSchemes($schemes);
+
+        return $this;
+    }
+
+    /**
+     * Sets the HTTP methods (e.g. 'POST') this route is restricted to.
+     * So an empty array means that any method is allowed.
+     *
+     * @param array $methods
+     *
+     * @return $this
+     */
+    final public function methods(array $methods)
+    {
+        $this->route->setMethods($methods);
+
+        return $this;
+    }
+
+    /**
+     * Adds the "_controller" entry to defaults.
+     *
+     * @param callable $controller a callable or parseable pseudo-callable
+     *
+     * @return $this
+     */
+    final public function controller($controller)
+    {
+        $this->route->addDefaults(array('_controller' => $controller));
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -37,7 +38,21 @@ class PhpFileLoader extends FileLoader
         $path = $this->locator->locate($file);
         $this->setCurrentDir(dirname($path));
 
-        $collection = self::includeFile($path, $this);
+        // the closure forbids access to the private scope in the included file
+        $loader = $this;
+        $load = \Closure::bind(function ($file) use ($loader) {
+            return include $file;
+        }, null, ProtectedPhpFileLoader::class);
+
+        $result = $load($path);
+
+        if ($result instanceof \Closure) {
+            $collection = new RouteCollection();
+            $result(new RoutingConfigurator($collection, $this, $path, $file), $this);
+        } else {
+            $collection = $result;
+        }
+
         $collection->addResource(new FileResource($path));
 
         return $collection;
@@ -50,17 +65,11 @@ class PhpFileLoader extends FileLoader
     {
         return is_string($resource) && 'php' === pathinfo($resource, PATHINFO_EXTENSION) && (!$type || 'php' === $type);
     }
+}
 
-    /**
-     * Safe include. Used for scope isolation.
-     *
-     * @param string        $file   File to include
-     * @param PhpFileLoader $loader the loader variable is exposed to the included file below
-     *
-     * @return RouteCollection
-     */
-    private static function includeFile($file, PhpFileLoader $loader)
-    {
-        return include $file;
-    }
+/**
+ * @internal
+ */
+final class ProtectedPhpFileLoader extends PhpFileLoader
+{
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes
+        ->add('foo', '/foo')
+            ->condition('abc')
+            ->options(array('utf8' => true))
+        ->add('buz', 'zub')
+            ->controller('foo:act');
+
+    $routes->import('php_dsl_sub.php')
+        ->prefix('/sub')
+        ->requirements(array('id' => '\d+'));
+
+    $routes->add('ouf', '/ouf')
+        ->schemes(array('https'))
+        ->methods(array('GET'))
+        ->defaults(array('id' => 0));
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_sub.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_sub.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $add = $routes->collection('c_')
+        ->prefix('pub');
+
+    $add('bar', '/bar');
+
+    $add->collection('pub_')
+        ->host('host')
+        ->add('buz', 'buz');
+};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

If we add a PHP DSL for DI config (#23834), we must have a similar one for routing. Here it is. See fixtures.

So, you always start with a `RoutingConfigurator $routes`, which allows you to:
```php
$routes->add($name, $path); // adds a route
$routes->import($resource, $type = null, $ignoreErrors = false); // imports routes
$routes->collection($name = ''); // starts a collection, all *names* might be prefixed
```

then
- for "import" and "collection", you can `->prefix($path)`;
- for "add" and "collection", you can fluently "add" several times;
- for "collection" you add sub"`->collection()`";
- and on all, you can configure the route(s) with:
```php
->defaults(array $defaults)
->requirements(array $requirements)
->options(array $options)
->condition($condition)
->host($pattern)
->schemes(array $schemes)
->methods(array $methods)
->controller($controller)
```