### PR TITLE
[Form] Display general forms information on debug:form

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -100,6 +100,9 @@
         <service id="Symfony\Component\Form\Command\DebugCommand">
             <argument type="service" id="form.registry" />
             <argument type="collection" /> <!-- All form types namespaces are stored here by FormPass -->
+            <argument type="collection" /> <!-- All services form types are stored here by FormPass -->
+            <argument type="collection" /> <!-- All type extensions are stored here by FormPass -->
+            <argument type="collection" /> <!-- All type guessers are stored here by FormPass -->
             <tag name="console.command" command="debug:form" />
         </service>
     </services>

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * added `DebugCommand`
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/JsonDescriptor.php
@@ -20,6 +20,16 @@ use Symfony\Component\Form\ResolvedFormTypeInterface;
  */
 class JsonDescriptor extends Descriptor
 {
+    protected function describeDefaults(array $options = array())
+    {
+        $data['builtin_form_types'] = $this->getCoreTypes();
+        $data['service_form_types'] = array_values(array_diff($options['types'], $data['builtin_form_types']));
+        $data['type_extensions'] = $options['extensions'];
+        $data['type_guessers'] = $options['guessers'];
+
+        $this->writeData($data, $options);
+    }
+
     protected function describeResolvedFormType(ResolvedFormTypeInterface $resolvedFormType, array $options = array())
     {
         $this->collectOptions($resolvedFormType);

--- a/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
@@ -21,6 +21,26 @@ use Symfony\Component\Form\ResolvedFormTypeInterface;
  */
 class TextDescriptor extends Descriptor
 {
+    protected function describeDefaults(array $options = array())
+    {
+        $coreTypes = $this->getCoreTypes();
+
+        $this->output->section('Built-in form types (Symfony\Component\Form\Extension\Core\Type)');
+        $shortClassNames = array_map(function ($fqcn) { return array_slice(explode('\\', $fqcn), -1)[0]; }, $coreTypes);
+        for ($i = 0; $i * 5 < count($shortClassNames); ++$i) {
+            $this->output->writeln(' '.implode(', ', array_slice($shortClassNames, $i * 5, 5)));
+        }
+
+        $this->output->section('Service form types');
+        $this->output->listing(array_diff($options['types'], $coreTypes));
+
+        $this->output->section('Type extensions');
+        $this->output->listing($options['extensions']);
+
+        $this->output->section('Type guessers');
+        $this->output->listing($options['guessers']);
+    }
+
     protected function describeResolvedFormType(ResolvedFormTypeInterface $resolvedFormType, array $options = array())
     {
         $this->collectOptions($resolvedFormType);

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -21,6 +21,15 @@ use Symfony\Component\Form\ResolvedFormTypeInterface;
 
 class DebugCommandTest extends TestCase
 {
+    public function testDebugDefaults()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(array(), array('decorated' => false));
+
+        $this->assertEquals(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains('Built-in form types', $tester->getDisplay());
+    }
+
     public function testDebugSingleFormType()
     {
         $tester = $this->createCommandTester();

--- a/src/Symfony/Component/Form/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Component/Form/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -24,6 +24,19 @@ use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
 abstract class AbstractDescriptorTest extends TestCase
 {
+    /** @dataProvider getDescribeDefaultsTestData */
+    public function testDescribeDefaults($object, array $options, $fixtureName)
+    {
+        $expectedDescription = $this->getExpectedDescription($fixtureName);
+        $describedObject = $this->getObjectDescription($object, $options);
+
+        if ('json' === $this->getFormat()) {
+            $this->assertEquals(json_encode(json_decode($expectedDescription), JSON_PRETTY_PRINT), json_encode(json_decode($describedObject), JSON_PRETTY_PRINT));
+        } else {
+            $this->assertEquals(trim($expectedDescription), trim(str_replace(PHP_EOL, "\n", $describedObject)));
+        }
+    }
+
     /** @dataProvider getDescribeResolvedFormTypeTestData */
     public function testDescribeResolvedFormType(ResolvedFormTypeInterface $type, array $options, $fixtureName)
     {
@@ -35,6 +48,15 @@ abstract class AbstractDescriptorTest extends TestCase
         } else {
             $this->assertEquals(trim($expectedDescription), trim(str_replace(PHP_EOL, "\n", $describedObject)));
         }
+    }
+
+    public function getDescribeDefaultsTestData()
+    {
+        $options['types'] = array('Symfony\Bridge\Doctrine\Form\Type\EntityType');
+        $options['extensions'] = array('Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension');
+        $options['guessers'] = array('Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser');
+
+        yield array(null, $options, 'defaults_1');
     }
 
     public function getDescribeResolvedFormTypeTestData()

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/defaults_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/defaults_1.json
@@ -1,0 +1,45 @@
+{
+    "builtin_form_types": [
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\BirthdayType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\ButtonType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\CheckboxType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\ChoiceType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\CountryType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\CurrencyType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\DateIntervalType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\DateType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\EmailType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\HiddenType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\IntegerType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\LanguageType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\LocaleType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\MoneyType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\NumberType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\PasswordType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\PercentType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\RangeType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\RepeatedType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\ResetType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\SearchType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\SubmitType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\TextType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\TextareaType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\TimeType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\TimezoneType",
+        "Symfony\\Component\\Form\\Extension\\Core\\Type\\UrlType"
+    ],
+    "service_form_types": [
+        "Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType"
+    ],
+    "type_extensions": [
+        "Symfony\\Component\\Form\\Extension\\Csrf\\Type\\FormTypeCsrfExtension"
+    ],
+    "type_guessers": [
+        "Symfony\\Component\\Form\\Extension\\Validator\\ValidatorTypeGuesser"
+    ]
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/defaults_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/defaults_1.txt
@@ -1,0 +1,27 @@
+
+[33mBuilt-in form types (Symfony\Component\Form\Extension\Core\Type)[39m
+[33m----------------------------------------------------------------[39m
+
+ BirthdayType, ButtonType, CheckboxType, ChoiceType, CollectionType
+ CountryType, CurrencyType, DateIntervalType, DateTimeType, DateType
+ EmailType, FileType, FormType, HiddenType, IntegerType
+ LanguageType, LocaleType, MoneyType, NumberType, PasswordType
+ PercentType, RadioType, RangeType, RepeatedType, ResetType
+ SearchType, SubmitType, TextType, TextareaType, TimeType
+ TimezoneType, UrlType
+
+[33mService form types[39m
+[33m------------------[39m
+
+ * Symfony\Bridge\Doctrine\Form\Type\EntityType
+
+[33mType extensions[39m
+[33m---------------[39m
+
+ * Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension
+
+[33mType guessers[39m
+[33m-------------[39m
+
+ * Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

![debug-form-defaults](https://user-images.githubusercontent.com/2028198/30436620-998103ca-993a-11e7-9873-31f042327374.png)

When we run `bin/console debug:form` (without argument) all possible Form Component information is displayed.

