### PR TITLE
[HttpKernel] Dont store response cookies with HttpCache

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -216,7 +216,7 @@ class Store implements StoreInterface
         }
 
         $headers = $this->persistResponse($response);
-        unset($headers['age']);
+        unset($headers['age'], $headers['set-cookie']);
 
         array_unshift($entries, array($storedEnv, $headers));
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpCache\Store;
@@ -261,6 +262,19 @@ class StoreTest extends TestCase
         $this->assertTrue($this->store->purge('http://example.com/foo'));
         $this->assertEmpty($this->getStoreMetadata($requestHttp));
         $this->assertEmpty($this->getStoreMetadata($requestHttps));
+    }
+
+    public function testNoResponseCookiesAreStored()
+    {
+        $request = Request::create('/foo');
+        $response = new Response('foo');
+        $response->headers->set('set-cookie', 'foo=bar');
+        $response->headers->setCookie(new Cookie('bar', 'foo'));
+        $this->store->write($request, $response);
+
+        $newResponse = $this->store->lookup($request);
+        $this->assertEmpty($newResponse->headers->getCookies());
+        $this->assertNull($newResponse->headers->get('set-cookie'));
     }
 
     protected function storeSimpleEntry($path = null, $headers = array())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Before #20569 response cookies, created using the _object_ API, were not preserved in `ResponseHeaderBag::all()`, thus not stored with `HttpCache`. Yet, cookies created with the string API did.

That difference is now eliminated, but because of it we now always include all cookies :sweat_smile:  Causing side effects here (mentioned on slack today). Sorry, i did not anticipated _that_.

I think the preferred behavior is to not store any cookies, as i tend to believe object api is used a lot more.

So this is a hotfix, whereas 3.4 might further discuss features about cookie policy.

Reporter notified, lets wait for confirmation a bit. But i think this should do.