### PR TITLE
[PhpUnitBridge] do not require an error context

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -303,7 +303,7 @@ class SymfonyTestsListenerTrait
         }
     }
 
-    public function handleError($type, $msg, $file, $line, $context)
+    public function handleError($type, $msg, $file, $line, $context = array())
     {
         if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
             $h = $this->previousErrorHandler;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The error context argument of an error handler is deprecated as of PHP
7.2. Requiring it in the error handler of the SymfonyTestsListenerTrait
will make error handlers fail that are executed when running PHPUnit
tests and forward the error handling to the previously registered error
handler.