### PR TITLE
[FrameworkBundle] Reset stopwatch between requests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -753,7 +753,10 @@ class FrameworkExtension extends Extension
         $container->getDefinition('debug.debug_handlers_listener')->setPrivate(true);
 
         if (class_exists(Stopwatch::class)) {
-            $container->register('debug.stopwatch', Stopwatch::class)->addArgument(true)->setPrivate(true);
+            $container->register('debug.stopwatch', Stopwatch::class)
+                ->addArgument(true)
+                ->setPrivate(true)
+                ->addTag('kernel.reset', array('method' => 'reset'));
             $container->setAlias(Stopwatch::class, new Alias('debug.stopwatch', false));
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -46,7 +46,7 @@
         "symfony/security-core": "~3.2|~4.0",
         "symfony/security-csrf": "~2.8|~3.0|~4.0",
         "symfony/serializer": "~3.3|~4.0",
-        "symfony/stopwatch": "~2.8|~3.0|~4.0",
+        "symfony/stopwatch": "~3.4|~4.0",
         "symfony/translation": "~3.4|~4.0",
         "symfony/templating": "~2.8|~3.0|~4.0",
         "symfony/validator": "~3.4|~4.0",
@@ -68,6 +68,7 @@
         "symfony/form": "<3.4",
         "symfony/property-info": "<3.3",
         "symfony/serializer": "<3.3",
+        "symfony/stopwatch": "<3.4",
         "symfony/translation": "<3.4",
         "symfony/validator": "<3.4",
         "symfony/workflow": "<3.3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23984
| License       | MIT
| Doc PR        | N/A

Follow-up to #24155. This PR ensures that the stopwatch is reset between requests.