### PR TITLE
[HttpFoundation] Fix file upload multiple with no files

### DIFF
--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -69,7 +69,7 @@ class FileBag extends ParameterBag
      *
      * @param array|UploadedFile $file A (multi-dimensional) array of uploaded file information
      *
-     * @return UploadedFile|UploadedFile[] A (multi-dimensional) array of UploadedFile instances
+     * @return UploadedFile[]|UploadedFile|null A (multi-dimensional) array of UploadedFile instances
      */
     protected function convertFileInformation($file)
     {
@@ -89,7 +89,7 @@ class FileBag extends ParameterBag
                     $file = new UploadedFile($file['tmp_name'], $file['name'], $file['type'], $file['size'], $file['error']);
                 }
             } else {
-                $file = array_map(array($this, 'convertFileInformation'), $file);
+                $file = array_filter(array_map(array($this, 'convertFileInformation'), $file));
             }
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -60,6 +60,19 @@ class FileBagTest extends TestCase
         $this->assertNull($bag->get('file'));
     }
 
+    public function testShouldRemoveEmptyUploadedFilesForMultiUpload()
+    {
+        $bag = new FileBag(array('file' => array(
+            'name' => array(''),
+            'type' => array(''),
+            'tmp_name' => array(''),
+            'error' => array(UPLOAD_ERR_NO_FILE),
+            'size' => array(0),
+        )));
+
+        $this->assertSame(array(), $bag->get('file'));
+    }
+
     public function testShouldConvertUploadedFilesWithPhpBug()
     {
         $tmpFile = $this->createTempFile();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

```php
<form method="post" enctype="multipart/form-data">
<input type="file" multiple name="img[]">
<input type="submit">
</form>

<?php

$loader = require __DIR__ . '/../app/autoload.php';

if ($_SERVER['REQUEST_METHOD'] === 'POST') {
    $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
    var_export($request->files->all()['img']);
}
```

Expected result when I send the form without any files:

```
array ()
```

Actual result:

```
array ( 0 => NULL, )
```

This causes a problem later when using FileType with multiple option - if no files are sent the form data are `[0 => '']` instead of `[]`.

Of course I need to add a test for this.