### PR TITLE
[Security] Preserve URI fragment in HttpUtils::generateUri()

### DIFF
--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -41,7 +41,7 @@ class HttpUtils
     public function __construct(UrlGeneratorInterface $urlGenerator = null, $urlMatcher = null)
     {
         $this->urlGenerator = $urlGenerator;
-        if ($urlMatcher !== null && !$urlMatcher instanceof UrlMatcherInterface && !$urlMatcher instanceof RequestMatcherInterface) {
+        if (null !== $urlMatcher && !$urlMatcher instanceof UrlMatcherInterface && !$urlMatcher instanceof RequestMatcherInterface) {
             throw new \InvalidArgumentException('Matcher must either implement UrlMatcherInterface or RequestMatcherInterface.');
         }
         $this->urlMatcher = $urlMatcher;
@@ -150,7 +150,12 @@ class HttpUtils
         // fortunately, they all are, so we have to remove entire query string
         $position = strpos($url, '?');
         if (false !== $position) {
+            $fragment = parse_url($url, PHP_URL_FRAGMENT);
             $url = substr($url, 0, $position);
+            // fragment must be preserved
+            if ($fragment) {
+                $url .= "#$fragment";
+            }
         }
 
         return $url;

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -252,6 +252,15 @@ class HttpUtilsTest extends TestCase
         $this->assertEquals('/foo/bar', $utils->generateUri(new Request(), 'route_name'));
     }
 
+    public function testGenerateUriPreservesFragment()
+    {
+        $utils = new HttpUtils($this->getUrlGenerator('/foo/bar?param=value#fragment'));
+        $this->assertEquals('/foo/bar#fragment', $utils->generateUri(new Request(), 'route_name'));
+
+        $utils = new HttpUtils($this->getUrlGenerator('/foo/bar#fragment'));
+        $this->assertEquals('/foo/bar#fragment', $utils->generateUri(new Request(), 'route_name'));
+    }
+
     /**
      * @expectedException \LogicException
      * @expectedExceptionMessage You must provide a UrlGeneratorInterface instance to be able to use routes.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/23675
| License       | MIT
| Doc PR        | n/a