### PR TITLE
[Serializer] Change visibility of getNormalizer and getDenormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -225,7 +225,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
      *
      * @return NormalizerInterface|null
      */
-    private function getNormalizer($data, $format, array $context)
+    protected function getNormalizer($data, $format, array $context)
     {
         foreach ($this->normalizers as $normalizer) {
             if ($normalizer instanceof NormalizerInterface && $normalizer->supportsNormalization($data, $format, $context)) {
@@ -244,7 +244,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
      *
      * @return DenormalizerInterface|null
      */
-    private function getDenormalizer($data, $class, $format, array $context)
+    protected function getDenormalizer($data, $class, $format, array $context)
     {
         foreach ($this->normalizers as $normalizer) {
             if ($normalizer instanceof DenormalizerInterface && $normalizer->supportsDenormalization($data, $class, $format, $context)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I'm currently working on a projet that have many normalizers. Enough to get almost 20sec in `getDenormalizer` method:

![capture d ecran 2017-09-14 a 15 04 35](https://user-images.githubusercontent.com/773875/30441844-dd81d924-997a-11e7-9d8e-210fb423653c.png)

I would like to write my own Serializer, and I figure out that `getNormalizer` and `getDenormalizer` methods are private.

Here what I would like to do:

```php
<?php

class ChainSerializer extends Serializer
{
    public function __construct(array $normalizers = [], array $encoders = [])
    {
        $indexedNormalizers = [];

        foreach ($normalizers as $normalizer) {
            /* Little workaround to get clean indices */
            $normalizerClassName = get_class($normalizer);
            $modelClassName = str_replace('Normalizer', '', $normalizerClassName);
            $modelClassName = str_replace('\\\\', '\\Model\\', $modelClassName);
            $indexedNormalizers[$modelClassName] = $normalizer;
        }

        parent::__construct($indexedNormalizers, $encoders);
    }

    protected function getNormalizer($data, $format, array $context)
    {
        return $this->normalizers[get_class($data)];
    }

    protected function getDenormalizer($data, $class, $format, array $context)
    {
        return $this->normalizers[$class];
    }
}
```

I figure out too these `$normalizers` are `protected` which enforce me to submit this PR.


Ping @dunglas @lyrixx