### PR TITLE
Preventing token data self-linking

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -271,16 +271,16 @@ class FileProfilerStorage implements ProfilerStorageInterface
         $profile->setTime($data['time']);
         $profile->setCollectors($data['data']);
 
-        if (!$parent && $data['parent']) {
+        if (!$parent && $data['parent'] && $data['parent'] !== $token) {
             $parent = $this->read($data['parent']);
         }
 
-        if ($parent) {
+        if ($parent && $parent->getToken() !== $token) {
             $profile->setParent($parent);
         }
 
         foreach ($data['children'] as $token) {
-            if (!$token || !file_exists($file = $this->getFilename($token))) {
+            if (!$token || !file_exists($file = $this->getFilename($token)) || $token === $data['token']) {
                 continue;
             }
 


### PR DESCRIPTION
Preventing unconditional looping on child token equals current token.
Fixes maximum nesting level reached fatal or memory exhausted fatal.

| Q             | A
| ------------- | ---
| Branch?       | from 2.8 to master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

<!--
Preventing unconditional looping on child token equals current token
by skipping children tokens connections on equality.
-->

