### PR TITLE
[DependencyInjection] Don't autoconfigure decorators

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 
@@ -432,6 +433,10 @@ class Definition
      */
     public function setAutoconfigured($autoconfigured)
     {
+        if (null !== $this->decoratedService && $autoconfigured) {
+            throw new BadMethodCallException('A decorator cannot be autoconfigured.');
+        }
+
         $this->changes['autoconfigured'] = true;
 
         $this->autoconfigured = $autoconfigured;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | api-platform/api-platform#414
| License       | MIT
| Doc PR        | n/a

Autoconfiguring decorators create strange problems like this one api-platform/api-platform#414.
As autoconfiguring is on by default when using Symfony SE 3.3, it's better to give an explicit error to the end user.

 TODO:

* [ ] Add tests
