### PR TITLE
[Validator] Clarify UUID validator behavior

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UuidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UuidValidator.php
@@ -18,13 +18,19 @@ use Symfony\Component\Validator\Constraints\Deprecated\UuidValidator as Deprecat
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
- * Validates whether the value is a valid UUID per RFC 4122.
+ * Validates whether the value is a valid UUID (also known as GUID).
+ *
+ * Strict validation will allow a variant 1 UUID as described per RFC 4122.
+ * Loose validation will allow any type of UUID.
+ *
+ * For better compatibility, both loose and strict, you should consider using a specialized UUID library like "ramsey/uuid" instead.
  *
  * @author Colin O'Dell <colinodell@gmail.com>
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see http://tools.ietf.org/html/rfc4122
  * @see https://en.wikipedia.org/wiki/Universally_unique_identifier
+ * @see https://github.com/ramsey/uuid
  */
 class UuidValidator extends ConstraintValidator
 {

--- a/src/Symfony/Component/Validator/Constraints/UuidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UuidValidator.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * Validates whether the value is a valid UUID (also known as GUID).
  *
- * Strict validation will allow a variant 1 UUID as described per RFC 4122.
+ * Strict validation will allow a UUID as specified per RFC 4122.
  * Loose validation will allow any type of UUID.
  *
  * For better compatibility, both loose and strict, you should consider using a specialized UUID library like "ramsey/uuid" instead.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24209
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

TLDR; after some investigation this is now a doc update.

This fixes the variant detection of a UUID, in strict validation, as described by https://tools.ietf.org/html/rfc4122#section-4.1.1

Tested variant UUID's taken from [ramsey/uuid](https://github.com/ramsey/uuid/blob/master/tests/UuidTest.php#L506). I cannot produce an invalid variant UUID anymore, as i believe by now anything would be variant 3 (future reserved).

/cc @backbone87