### PR TITLE
[DebugBundle] Fix the var-dumper requirement in composer.json

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "symfony/http-kernel": "~2.8|~3.0|~4.0",
         "symfony/twig-bridge": "~2.8|~3.0|~4.0",
-        "symfony/var-dumper": "~2.8|~3.0|~4.0"
+        "symfony/var-dumper": "~3.4|~4.0"
     },
     "require-dev": {
         "symfony/config": "~3.3|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The v3.4 of the debug bundle calls `VarCloner::setMinDepth()` and thus requires v3.4+ of the var-dumper component. However, the composer file has not been updated in 30cd70d.

I upped the var-dumper requirement to `~3.4|~4.0`.