### PR TITLE
[DI] Fix decorated service merge in ResolveInstanceofConditionalsPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -119,6 +119,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
             $abstract
                 ->setArguments(array())
                 ->setMethodCalls(array())
+                ->setDecoratedService(null)
                 ->setTags(array())
                 ->setAbstract(true);
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -224,4 +224,30 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
 
         (new ResolveInstanceofConditionalsPass())->process($container);
     }
+
+    public function testMergeReset()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('bar', self::class)
+            ->addArgument('a')
+            ->addMethodCall('setB')
+            ->setDecoratedService('foo')
+            ->addTag('t')
+            ->setInstanceofConditionals(array(
+                parent::class => (new ChildDefinition(''))->addTag('bar'),
+            ))
+        ;
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $abstract = $container->getDefinition('abstract.instanceof.bar');
+
+        $this->assertEmpty($abstract->getArguments());
+        $this->assertEmpty($abstract->getMethodCalls());
+        $this->assertNull($abstract->getDecoratedService());
+        $this->assertEmpty($abstract->getTags());
+        $this->assertTrue($abstract->isAbstract());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | api-platform/api-platform#414, symfony/symfony#24229
| License       | MIT
| Doc PR        | n/a

Follows #24229. It's [the patch](https://github.com/symfony/symfony/pull/24229#issuecomment-329972812) proposed by @nicolas-grekas + a test.