### PR TITLE
[WebProfilerBundle] Added missing link to profile token

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -274,7 +274,7 @@
                         <a href="{{ path('_profiler', { token: child.token }) }}">
                             {{ helper.set_handler(child.getcollector('request').controller) }}
                         </a>
-                        <small>(token = {{ child.token }})</small>
+                        <small>(token = <a href="{{ path('_profiler', { token: child.token }) }}">{{ child.token }}</a>)</small>
                     </h3>
 
                     {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: child.getcollector('request').requestattributes }, with_context = false) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes, it was on 3.3.6 (before merge https://github.com/symfony/symfony/pull/23676)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | - 
| License       | MIT
| Doc PR        | -

On v3.3.6 I can open profiles for sub-request on this link
![selection_188](https://user-images.githubusercontent.com/21358010/30518552-dc6a1f72-9b89-11e7-9d2f-d348846d7285.png)

But after 3.3.7 it was replaced by links to the controller. In this pull request was added missing link to the profile
![selection_186](https://user-images.githubusercontent.com/21358010/30518572-7a1420c4-9b8a-11e7-8514-098c4ec2c3d6.png)

