### PR TITLE
[DI] Turn services and aliases private by default, with BC layer

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -4,6 +4,9 @@ UPGRADE FROM 3.3 to 3.4
 DependencyInjection
 -------------------
 
+ * Definitions and aliases will be made private by default in 4.0. You should either use service injection
+   or explicitly define your services as public if you really need to inject the container.
+
  * Relying on service auto-registration while autowiring is deprecated and won't be supported
    in Symfony 4.0. Explicitly inject your dependencies or create services
    whose ids are their fully-qualified class name.
@@ -154,7 +157,7 @@ FrameworkBundle
  * The `Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader`
    class has been deprecated and will be removed in 4.0. Use the
    `Symfony\Component\Translation\Reader\TranslationReader` class instead.
-   
+
  * The `translation.loader` service has been deprecated and will be removed in 4.0.
    Use the `translation.reader` service instead..
 
@@ -269,9 +272,9 @@ SecurityBundle
 Translation
 -----------
 
- * `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations` has been deprecated 
-   and will be removed in 4.0, use `Symfony\Component\Translation\Writer\TranslationWriter::write` 
-   instead. 
+ * `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations` has been deprecated
+   and will be removed in 4.0, use `Symfony\Component\Translation\Writer\TranslationWriter::write`
+   instead.
 
  * Passing a `Symfony\Component\Translation\MessageSelector` to `Translator` has been
    deprecated. You should pass a message formatter instead

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -77,6 +77,9 @@ Debug
 DependencyInjection
 -------------------
 
+ * Definitions and aliases are now private by default in 4.0. You should either use service injection
+   or explicitly define your services as public if you really need to inject the container.
+
  * Relying on service auto-registration while autowiring is not supported anymore.
    Explicitly inject your dependencies or create services whose ids are
    their fully-qualified class name.
@@ -449,14 +452,14 @@ FrameworkBundle
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslatorPass`
    class has been removed. Use the
    `Symfony\Component\Translation\DependencyInjection\TranslatorPass` class instead.
- 
+
  * The `Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader`
    class has been deprecated and will be removed in 4.0. Use the
    `Symfony\Component\Translation\Reader\TranslationReader` class instead.
 
  * The `translation.loader` service has been removed.
    Use the `translation.reader` service instead.
- 
+
  * `AssetsInstallCommand::__construct()` now requires an instance of
    `Symfony\Component\Filesystem\Filesystem` as first argument.
 
@@ -673,11 +676,11 @@ Translation
 -----------
 
  * Removed the backup feature from the file dumper classes.
- 
+
  * The default value of the `$readerServiceId` argument of `TranslatorPass::__construct()` has been changed to `"translation.reader"`.
- 
- * Removed `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations`, 
-   use `Symfony\Component\Translation\Writer\TranslationWriter::write` instead. 
+
+ * Removed `Symfony\Component\Translation\Writer\TranslationWriter::writeTranslations`,
+   use `Symfony\Component\Translation\Writer\TranslationWriter::write` instead.
 
  * Removed support for passing `Symfony\Component\Translation\MessageSelector` as a second argument to the
    `Translator::__construct()`. You should pass an instance of `Symfony\Component\Translation\Formatter\MessageFormatterInterface` instead.

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Dumper/PhpDumperTest.php
@@ -61,7 +61,7 @@ class PhpDumperTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('foo', 'stdClass');
+        $container->register('foo', 'stdClass')->setPublic(true);
         $container->getDefinition('foo')->setLazy(true);
         $container->compile();
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1012,12 +1012,12 @@ class FrameworkExtension extends Extension
 
         // Use a delegation unless only a single engine was registered
         if (1 === count($engines)) {
-            $container->setAlias('templating', (string) reset($engines));
+            $container->setAlias('templating', (string) reset($engines))->setPublic(true);
         } else {
             foreach ($engines as $engine) {
                 $container->getDefinition('templating.engine.delegating')->addMethodCall('addEngine', array($engine));
             }
-            $container->setAlias('templating', 'templating.engine.delegating');
+            $container->setAlias('templating', 'templating.engine.delegating')->setPublic(true);
         }
 
         $container->getDefinition('fragment.renderer.hinclude')
@@ -1213,7 +1213,7 @@ class FrameworkExtension extends Extension
         $container->getDefinition('translation.writer')->setPrivate(true);
 
         // Use the "real" translator instead of the identity default
-        $container->setAlias('translator', 'translator.default');
+        $container->setAlias('translator', 'translator.default')->setPublic(true);
         $container->setAlias('translator.formatter', new Alias($config['formatter'], false));
         $translator = $container->findDefinition('translator.default');
         $translator->addMethodCall('setFallbackLocales', array($config['fallbacks']));

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -72,6 +72,7 @@ trait MicroKernelTrait
             if ($this instanceof EventSubscriberInterface) {
                 $container->register('kernel', static::class)
                     ->setSynthetic(true)
+                    ->setPublic(true)
                     ->addTag('kernel.event_subscriber')
                 ;
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ../config/default.yml }
 
 services:
+    _defaults: { public: true }
     test.autowiring_types.autowired_services:
         class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\AutowiringTypes\AutowiredServices
         autowire: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ../config/default.yml }
 
 services:
+    _defaults: { public: true }
     public:
         class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\DeclaredClass
     private_alias:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ../config/default.yml }
 
 services:
+    _defaults: { public: true }
     test.property_info: '@property_info'
 
 framework:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -82,7 +82,7 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
         ));
 
         $c->setParameter('halloween', 'Have a great day!');
-        $c->register('halloween', 'stdClass');
+        $c->register('halloween', 'stdClass')->setPublic(true);
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -185,7 +185,7 @@ class SecurityExtension extends Extension
         $container->getAlias('security.acl.provider')->setPrivate(true);
 
         if (null !== $config['connection']) {
-            $container->setAlias('security.acl.dbal.connection', sprintf('doctrine.dbal.%s_connection', $config['connection']));
+            $container->setAlias('security.acl.dbal.connection', sprintf('doctrine.dbal.%s_connection', $config['connection']))->setPrivate(true);
         }
 
         $container

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Acl/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Acl/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 services:
+    _defaults: { public: true }
     test.security.acl.provider: '@security.acl.provider'
 
 doctrine:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ../config/framework.yml }
 
 services:
+    _defaults: { public: true }
     test.autowiring_types.autowired_services:
         class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AutowiringBundle\AutowiredServices
         autowire: true

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -65,8 +65,8 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 if (isset($serviceIds[$commandId]) || $container->hasAlias($commandId)) {
                     $commandId = $commandId.'_'.$id;
                 }
-                if (!$definition->isPublic()) {
-                    $container->setAlias($commandId, $id);
+                if (!$definition->isPublic() || $definition->isPrivate()) {
+                    $container->setAlias($commandId, $id)->setPublic(true);
                     $id = $commandId;
                 }
                 $serviceIds[$commandId] = $id;
@@ -97,6 +97,7 @@ class AddConsoleCommandPass implements CompilerPassInterface
 
         $container
             ->register($this->commandLoaderServiceId, ContainerCommandLoader::class)
+            ->setPublic(true)
             ->setArguments(array(ServiceLocatorTagPass::register($container, $lazyCommandRefs), $lazyCommandMap));
 
         $container->setParameter('console.command.ids', $serviceIds);

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "symfony/config": "~3.3|~4.0",
         "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-        "symfony/dependency-injection": "~3.3|~4.0",
+        "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/lock": "~3.4|~4.0",
         "symfony/process": "~3.3|~4.0",
         "psr/log": "~1.0"
@@ -35,7 +35,7 @@
         "psr/log": "For using the console logger"
     },
     "conflict": {
-        "symfony/dependency-injection": "<3.3",
+        "symfony/dependency-injection": "<3.4",
         "symfony/process": "<3.3"
     },
     "autoload": {

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -15,7 +15,7 @@ class Alias
 {
     private $id;
     private $public;
-    private $private = false;
+    private $private;
 
     /**
      * @param string $id     Alias identifier
@@ -25,6 +25,7 @@ class Alias
     {
         $this->id = (string) $id;
         $this->public = $public;
+        $this->private = 2 > func_num_args();
     }
 
     /**
@@ -47,6 +48,7 @@ class Alias
     public function setPublic($boolean)
     {
         $this->public = (bool) $boolean;
+        $this->private = false;
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.4.0
 -----
 
+ * deprecated "public-by-default" definitions and aliases, the new default will be "private" in 4.0
  * added `EnvVarProcessorInterface` and corresponding "container.env_var_processor" tag for processing env vars
  * added support for ignore-on-uninitialized references
  * deprecated service auto-registration while autowiring

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutoAliasServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutoAliasServicePass.php
@@ -33,7 +33,7 @@ class AutoAliasServicePass implements CompilerPassInterface
 
                 $aliasId = $container->getParameterBag()->resolveValue($tag['format']);
                 if ($container->hasDefinition($aliasId) || $container->hasAlias($aliasId)) {
-                    $container->setAlias($serviceId, new Alias($aliasId));
+                    $container->setAlias($serviceId, new Alias($aliasId, true));
                 }
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -39,7 +39,7 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
     {
         foreach ($container->getDefinitions() as $id => $definition) {
             // synthetic service is public
-            if ($definition->isSynthetic() && (!$definition->isPublic() || $definition->isPrivate())) {
+            if ($definition->isSynthetic() && !($definition->isPublic() || $definition->isPrivate())) {
                 throw new RuntimeException(sprintf('A synthetic service ("%s") must be public.', $id));
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -67,7 +67,7 @@ class DecoratorServicePass implements CompilerPassInterface
                 $container->setDefinition($renamedId, $decoratedDefinition);
             }
 
-            $container->setAlias($inner, $id)->setPublic($public && !$private)->setPrivate($private);
+            $container->setAlias($inner, $id)->setPublic($public)->setPrivate($private);
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
@@ -52,6 +52,7 @@ class RegisterEnvVarProcessorsPass implements CompilerPassInterface
                 $bag->setProvidedTypes($types);
             }
             $container->register('container.env_var_processors_locator', ServiceLocator::class)
+                ->setPublic(true)
                 ->setArguments(array($processors))
             ;
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -45,7 +45,7 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
             }
             // Check if target needs to be replaces
             if (isset($replacements[$targetId])) {
-                $container->setAlias($definitionId, $replacements[$targetId]);
+                $container->setAlias($definitionId, $replacements[$targetId])->setPublic($target->isPublic())->setPrivate($target->isPrivate());
             }
             // No need to process the same target twice
             if (isset($seenAliasTargets[$targetId])) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
@@ -36,12 +36,14 @@ class ResolveChildDefinitionsPass extends AbstractRecursivePass
         foreach ($container->getDefinitions() as $definition) {
             if ($definition->isPrivate()) {
                 $definition->setPublic(false);
+                $definition->setPrivate(true);
             }
         }
 
         foreach ($container->getAliases() as $alias) {
             if ($alias->isPrivate()) {
                 $alias->setPublic(false);
+                $alias->setPrivate(true);
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -32,7 +32,7 @@ class ResolveReferencesToAliasesPass extends AbstractRecursivePass
         foreach ($container->getAliases() as $id => $alias) {
             $aliasId = (string) $alias;
             if ($aliasId !== $defId = $this->getDefinitionId($aliasId, $container)) {
-                $container->setAlias($id, $defId)->setPublic($alias->isPublic() && !$alias->isPrivate())->setPrivate($alias->isPrivate());
+                $container->setAlias($id, $defId)->setPublic($alias->isPublic())->setPrivate($alias->isPrivate());
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -35,7 +35,7 @@ class Definition
     private $configurator;
     private $tags = array();
     private $public = true;
-    private $private = false;
+    private $private = true;
     private $synthetic = false;
     private $abstract = false;
     private $lazy = false;
@@ -603,6 +603,7 @@ class Definition
         $this->changes['public'] = true;
 
         $this->public = (bool) $boolean;
+        $this->private = false;
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -122,8 +122,8 @@ class XmlDumper extends Dumper
         if (!$definition->isShared()) {
             $service->setAttribute('shared', 'false');
         }
-        if (!$definition->isPublic()) {
-            $service->setAttribute('public', 'false');
+        if (!$definition->isPrivate()) {
+            $service->setAttribute('public', $definition->isPublic() ? 'true' : 'false');
         }
         if ($definition->isSynthetic()) {
             $service->setAttribute('synthetic', 'true');
@@ -242,8 +242,8 @@ class XmlDumper extends Dumper
         $service = $this->document->createElement('service');
         $service->setAttribute('id', $alias);
         $service->setAttribute('alias', $id);
-        if (!$id->isPublic()) {
-            $service->setAttribute('public', 'false');
+        if (!$id->isPrivate()) {
+            $service->setAttribute('public', $id->isPublic() ? 'true' : 'false');
         }
         $parent->appendChild($service);
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -74,8 +74,8 @@ class YamlDumper extends Dumper
             $code .= sprintf("        class: %s\n", $this->dumper->dump($class));
         }
 
-        if (!$definition->isPublic()) {
-            $code .= "        public: false\n";
+        if (!$definition->isPrivate()) {
+            $code .= sprintf("        public: %s\n", $definition->isPublic() ? 'true' : 'false');
         }
 
         $tagsCode = '';
@@ -178,11 +178,11 @@ class YamlDumper extends Dumper
      */
     private function addServiceAlias($alias, $id)
     {
-        if ($id->isPublic()) {
+        if ($id->isPrivate()) {
             return sprintf("    %s: '@%s'\n", $alias, $id);
         }
 
-        return sprintf("    %s:\n        alias: %s\n        public: false\n", $alias, $id);
+        return sprintf("    %s:\n        alias: %s\n        public: %s\n", $alias, $id, $id->isPublic() ? 'true' : 'false');
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -203,13 +203,12 @@ class XmlFileLoader extends FileLoader
         if ($alias = $service->getAttribute('alias')) {
             $this->validateAlias($service, $file);
 
-            $public = true;
+            $this->container->setAlias((string) $service->getAttribute('id'), $alias = new Alias($alias));
             if ($publicAttr = $service->getAttribute('public')) {
-                $public = XmlUtils::phpize($publicAttr);
+                $alias->setPublic(XmlUtils::phpize($publicAttr));
             } elseif (isset($defaults['public'])) {
-                $public = $defaults['public'];
+                $alias->setPublic($defaults['public']);
             }
-            $this->container->setAlias((string) $service->getAttribute('id'), new Alias($alias, $public));
 
             return;
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -336,8 +336,10 @@ class YamlFileLoader extends FileLoader
             @trigger_error(sprintf('Service names that start with an underscore are deprecated since Symfony 3.3 and will be reserved in 4.0. Rename the "%s" service or define it in XML instead.', $id), E_USER_DEPRECATED);
         }
         if (is_string($service) && 0 === strpos($service, '@')) {
-            $public = isset($defaults['public']) ? $defaults['public'] : true;
-            $this->container->setAlias($id, new Alias(substr($service, 1), $public));
+            $this->container->setAlias($id, $alias = new Alias(substr($service, 1)));
+            if (isset($defaults['public'])) {
+                $alias->setPublic($defaults['public']);
+            }
 
             return;
         }
@@ -357,8 +359,12 @@ class YamlFileLoader extends FileLoader
         $this->checkDefinition($id, $service, $file);
 
         if (isset($service['alias'])) {
-            $public = array_key_exists('public', $service) ? (bool) $service['public'] : (isset($defaults['public']) ? $defaults['public'] : true);
-            $this->container->setAlias($id, new Alias($service['alias'], $public));
+            $this->container->setAlias($id, $alias = new Alias($service['alias']));
+            if (array_key_exists('public', $service)) {
+                $alias->setPublic($service['public']);
+            } elseif (isset($defaults['public'])) {
+                $alias->setPublic($defaults['public']);
+            }
 
             foreach ($service as $key => $value) {
                 if (!in_array($key, array('alias', 'public'))) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -402,13 +402,13 @@ class ResolveChildDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register('foo', 'stdClass')
-            ->setPrivate(true)
             ->setPublic(true)
+            ->setPrivate(true)
         ;
 
         $container->setAlias('bar', 'foo')
-            ->setPrivate(false)
             ->setPublic(false)
+            ->setPrivate(false)
         ;
 
         $this->process($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -57,7 +57,7 @@ class XmlDumperTest extends TestCase
         $this->assertEquals(str_replace('%path%', self::$fixturesPath.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR, file_get_contents(self::$fixturesPath.'/xml/services9.xml')), $dumper->dump(), '->dump() dumps services');
 
         $dumper = new XmlDumper($container = new ContainerBuilder());
-        $container->register('foo', 'FooClass')->addArgument(new \stdClass());
+        $container->register('foo', 'FooClass')->addArgument(new \stdClass())->setPublic(true);
         try {
             $dumper->dump();
             $this->fail('->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
@@ -75,7 +75,7 @@ class XmlDumperTest extends TestCase
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
-    <service id="foo" class="FooClass">
+    <service id="foo" class="FooClass" public="true">
       <argument type="service">
         <service class="BarClass">
           <argument type="service">
@@ -99,7 +99,7 @@ class XmlDumperTest extends TestCase
 <container xmlns=\"http://symfony.com/schema/dic/services\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd\">
   <services>
     <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" synthetic=\"true\"/>
-    <service id=\"foo\" class=\"FooClass\Foo\">
+    <service id=\"foo\" class=\"FooClass\Foo\" public=\"true\">
       <tag name=\"foo&quot;bar\bar\" foo=\"foo&quot;barřž€\"/>
       <argument>foo&lt;&gt;&amp;bar</argument>
     </service>
@@ -128,7 +128,7 @@ class XmlDumperTest extends TestCase
 <container xmlns=\"http://symfony.com/schema/dic/services\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd\">
   <services>
     <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" synthetic=\"true\"/>
-    <service id=\"foo\" class=\"FooClass\Foo\" decorates=\"bar\" decoration-inner-name=\"bar.woozy\"/>
+    <service id=\"foo\" class=\"FooClass\Foo\" public=\"true\" decorates=\"bar\" decoration-inner-name=\"bar.woozy\"/>
     <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
     <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
   </services>
@@ -138,7 +138,7 @@ class XmlDumperTest extends TestCase
 <container xmlns=\"http://symfony.com/schema/dic/services\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd\">
   <services>
     <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" synthetic=\"true\"/>
-    <service id=\"foo\" class=\"FooClass\Foo\" decorates=\"bar\"/>
+    <service id=\"foo\" class=\"FooClass\Foo\" public=\"true\" decorates=\"bar\"/>
     <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
     <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -52,7 +52,7 @@ class YamlDumperTest extends TestCase
         $this->assertEqualYamlStructure(str_replace('%path%', self::$fixturesPath.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR, file_get_contents(self::$fixturesPath.'/yaml/services9.yml')), $dumper->dump(), '->dump() dumps services');
 
         $dumper = new YamlDumper($container = new ContainerBuilder());
-        $container->register('foo', 'FooClass')->addArgument(new \stdClass());
+        $container->register('foo', 'FooClass')->addArgument(new \stdClass())->setPublic(true);
         try {
             $dumper->dump();
             $this->fail('->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
@@ -85,6 +85,7 @@ class YamlDumperTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container->register('foo', 'Class1')
+            ->setPublic(true)
             ->addArgument((new Definition('Class2'))
                 ->addArgument(new Definition('Class2'))
             )

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container10.php
@@ -9,6 +9,7 @@ $container = new ContainerBuilder();
 $container->
     register('foo', 'FooClass')->
     addArgument(new Reference('bar'))
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container11.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container11.php
@@ -7,6 +7,7 @@ $container = new ContainerBuilder();
 $container->
     register('foo', 'FooClass')->
     addArgument(new Definition('BarClass', array(new Definition('BazClass'))))
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container12.php
@@ -7,6 +7,7 @@ $container->
     register('foo', 'FooClass\\Foo')->
     addArgument('foo<>&bar')->
     addTag('foo"bar\\bar', array('foo' => 'foo"barřž€'))
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container13.php
@@ -7,9 +7,11 @@ $container = new ContainerBuilder();
 $container->
     register('foo', 'FooClass')->
     addArgument(new Reference('bar'))
+    ->setPublic(true)
 ;
 $container->
     register('bar', 'BarClass')
+    ->setPublic(true)
 ;
 $container->compile();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container15.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container15.php
@@ -6,6 +6,7 @@ $container = new ContainerBuilder();
 $container
     ->register('foo', 'FooClass\\Foo')
     ->setDecoratedService('bar', 'bar.woozy')
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container16.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container16.php
@@ -6,6 +6,7 @@ $container = new ContainerBuilder();
 $container
     ->register('foo', 'FooClass\\Foo')
     ->setDecoratedService('bar')
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container17.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container17.php
@@ -5,6 +5,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 $container = new ContainerBuilder();
 $container
     ->register('foo', '%foo.class%')
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container19.php
@@ -10,6 +10,7 @@ $container = new ContainerBuilder();
 $container
     ->register('service_from_anonymous_factory', 'Bar\FooClass')
     ->setFactory(array(new Definition('Bar\FooClass'), 'getInstance'))
+    ->setPublic(true)
 ;
 
 $anonymousServiceWithFactory = new Definition('Bar\FooClass');
@@ -17,6 +18,7 @@ $anonymousServiceWithFactory->setFactory('Bar\FooClass::getInstance');
 $container
     ->register('service_with_method_call_and_factory', 'Bar\FooClass')
     ->addMethodCall('setBar', array($anonymousServiceWithFactory))
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container21.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container21.php
@@ -15,6 +15,7 @@ $container
     ->register('foo', 'Foo')
     ->setFactory(array($fooFactory, 'createFoo'))
     ->setConfigurator(array($bar, 'configureFoo'))
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container24.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container24.php
@@ -7,6 +7,7 @@ $container = new ContainerBuilder();
 $container
     ->register('foo', 'Foo')
     ->setAutowired(true)
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container33.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container33.php
@@ -6,7 +6,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 $container = new ContainerBuilder();
 
-$container->register(\Foo\Foo::class);
-$container->register(\Bar\Foo::class);
+$container->register(\Foo\Foo::class)->setPublic(true);
+$container->register(\Bar\Foo::class)->setPublic(true);
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -21,21 +21,25 @@ $container
     ->addMethodCall('setBar', array(new Reference('bar')))
     ->addMethodCall('initialize')
     ->setConfigurator('sc_configure')
+    ->setPublic(true)
 ;
 $container
     ->register('foo.baz', '%baz_class%')
     ->setFactory(array('%baz_class%', 'getInstance'))
     ->setConfigurator(array('%baz_class%', 'configureStatic1'))
+    ->setPublic(true)
 ;
 $container
     ->register('bar', 'Bar\FooClass')
     ->setArguments(array('foo', new Reference('foo.baz'), new Parameter('foo_bar')))
     ->setConfigurator(array(new Reference('foo.baz'), 'configure'))
+    ->setPublic(true)
 ;
 $container
     ->register('foo_bar', '%foo_class%')
     ->addArgument(new Reference('deprecated_service'))
     ->setShared(false)
+    ->setPublic(true)
 ;
 $container->getParameterBag()->clear();
 $container->getParameterBag()->add(array(
@@ -43,8 +47,8 @@ $container->getParameterBag()->add(array(
     'foo_class' => 'Bar\FooClass',
     'foo' => 'bar',
 ));
-$container->setAlias('alias_for_foo', 'foo');
-$container->setAlias('alias_for_alias', 'alias_for_foo');
+$container->setAlias('alias_for_foo', 'foo')->setPublic(true);
+$container->setAlias('alias_for_alias', 'alias_for_foo')->setPublic(true);
 $container
     ->register('method_call1', 'Bar\FooClass')
     ->setFile(realpath(__DIR__.'/../includes/foo.php'))
@@ -53,10 +57,12 @@ $container
     ->addMethodCall('setBar', array(new Reference('foo3', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))
     ->addMethodCall('setBar', array(new Reference('foobaz', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))
     ->addMethodCall('setBar', array(new Expression('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")')))
+    ->setPublic(true)
 ;
 $container
     ->register('foo_with_inline', 'Foo')
     ->addMethodCall('setBar', array(new Reference('inlined')))
+    ->setPublic(true)
 ;
 $container
     ->register('inlined', 'Bar')
@@ -67,10 +73,12 @@ $container
 $container
     ->register('baz', 'Baz')
     ->addMethodCall('setFoo', array(new Reference('foo_with_inline')))
+    ->setPublic(true)
 ;
 $container
     ->register('request', 'Request')
     ->setSynthetic(true)
+    ->setPublic(true)
 ;
 $container
     ->register('configurator_service', 'ConfClass')
@@ -80,6 +88,7 @@ $container
 $container
     ->register('configured_service', 'stdClass')
     ->setConfigurator(array(new Reference('configurator_service'), 'configureStdClass'))
+    ->setPublic(true)
 ;
 $container
     ->register('configurator_service_simple', 'ConfClass')
@@ -89,21 +98,26 @@ $container
 $container
     ->register('configured_service_simple', 'stdClass')
     ->setConfigurator(array(new Reference('configurator_service_simple'), 'configureStdClass'))
+    ->setPublic(true)
 ;
 $container
     ->register('decorated', 'stdClass')
+    ->setPublic(true)
 ;
 $container
     ->register('decorator_service', 'stdClass')
     ->setDecoratedService('decorated')
+    ->setPublic(true)
 ;
 $container
     ->register('decorator_service_with_name', 'stdClass')
     ->setDecoratedService('decorated', 'decorated.pif-pouf')
+    ->setPublic(true)
 ;
 $container
     ->register('deprecated_service', 'stdClass')
     ->setDeprecated(true)
+    ->setPublic(true)
 ;
 $container
     ->register('new_factory', 'FactoryClass')
@@ -113,15 +127,18 @@ $container
 $container
     ->register('factory_service', 'Bar')
     ->setFactory(array(new Reference('foo.baz'), 'getInstance'))
+    ->setPublic(true)
 ;
 $container
     ->register('new_factory_service', 'FooBarBaz')
     ->setProperty('foo', 'bar')
     ->setFactory(array(new Reference('new_factory'), 'getInstance'))
+    ->setPublic(true)
 ;
 $container
     ->register('service_from_static_method', 'Bar\FooClass')
     ->setFactory(array('Bar\FooClass', 'getInstance'))
+    ->setPublic(true)
 ;
 $container
     ->register('factory_simple', 'SimpleFactoryClass')
@@ -132,14 +149,17 @@ $container
 $container
     ->register('factory_service_simple', 'Bar')
     ->setFactory(array(new Reference('factory_simple'), 'getInstance'))
+    ->setPublic(true)
 ;
 $container
     ->register('lazy_context', 'LazyContext')
     ->setArguments(array(new IteratorArgument(array('k1' => new Reference('foo.baz'), 'k2' => new Reference('service_container'))), new IteratorArgument(array())))
+    ->setPublic(true)
 ;
 $container
     ->register('lazy_context_ignore_invalid_ref', 'LazyContext')
     ->setArguments(array(new IteratorArgument(array(new Reference('foo.baz'), new Reference('invalid', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))), new IteratorArgument(array())))
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_abstract.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_abstract.php
@@ -7,6 +7,7 @@ $container = new ContainerBuilder();
 $container
     ->register('foo', 'Foo')
     ->setAbstract(true)
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_uninitialized_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_uninitialized_ref.php
@@ -9,6 +9,7 @@ $container = new ContainerBuilder();
 
 $container
     ->register('foo1', 'stdClass')
+    ->setPublic(true)
 ;
 
 $container
@@ -24,6 +25,7 @@ $container
 $container
     ->register('baz', 'stdClass')
     ->setProperty('foo3', new Reference('foo3'))
+    ->setPublic(true)
 ;
 
 $container
@@ -41,6 +43,7 @@ $container
         'foo2' => new Reference('foo2', $container::IGNORE_ON_UNINITIALIZED_REFERENCE),
         'foo3' => new Reference('foo3', $container::IGNORE_ON_UNINITIALIZED_REFERENCE),
     )))
+    ->setPublic(true)
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-1.php
@@ -29,6 +29,9 @@ class Container extends AbstractContainer
     public function __construct()
     {
         $this->services = array();
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1.php
@@ -27,6 +27,9 @@ class ProjectServiceContainer extends Container
     public function __construct()
     {
         $this->services = array();
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -32,6 +32,9 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'test' => 'getTestService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -36,6 +36,9 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'test' => 'getTestService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -30,6 +30,9 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'bar' => 'getBarService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -31,6 +31,9 @@ class ProjectServiceContainer extends Container
             'service_from_anonymous_factory' => 'getServiceFromAnonymousFactoryService',
             'service_with_method_call_and_factory' => 'getServiceWithMethodCallAndFactoryService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services24.php
@@ -30,6 +30,9 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'foo' => 'getFooService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
@@ -36,6 +36,9 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
         $this->methodMap = array(
             'test' => 'getTestService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services33.php
@@ -35,6 +35,9 @@ class ProjectServiceContainer extends Container
             'Bar\\Foo' => 'getFooService',
             'Foo\\Foo' => 'getFoo2Service',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -29,6 +29,9 @@ class ProjectServiceContainer extends Container
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = array();
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -295,6 +295,7 @@ class Container%s extends Container
         );
         $this->privates = array(
             'factory_simple' => true,
+            'service_container' => true,
         );
         $this->aliases = array(
             'alias_for_alias' => 'foo',

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -52,6 +52,7 @@ class ProjectServiceContainer extends Container
         );
         $this->privates = array(
             'factory_simple' => true,
+            'service_container' => true,
         );
         $this->aliases = array(
             'alias_for_alias' => 'foo',

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -36,6 +36,9 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'bar' => 'getBarService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
@@ -29,6 +29,9 @@ class Symfony_DI_PhpDumper_Test_Base64Parameters extends Container
         $this->parameters = $this->getDefaultParameters();
 
         $this->services = array();
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_legacy_privates.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_legacy_privates.php
@@ -38,7 +38,6 @@ class Symfony_DI_PhpDumper_Test_Legacy_Privates extends Container
             'private_alias_decorator' => 'getPrivateAliasDecoratorService',
             'private_child' => 'getPrivateChildService',
             'private_decorator' => 'getPrivateDecoratorService',
-            'private_decorator.inner' => 'getPrivateDecorator_InnerService',
             'private_not_inlined' => 'getPrivateNotInlinedService',
             'private_not_removed' => 'getPrivateNotRemovedService',
             'private_parent' => 'getPrivateParentService',
@@ -50,10 +49,10 @@ class Symfony_DI_PhpDumper_Test_Legacy_Privates extends Container
             'private' => true,
             'private_alias' => true,
             'private_child' => true,
-            'private_decorator.inner' => true,
             'private_not_inlined' => true,
             'private_not_removed' => true,
             'private_parent' => true,
+            'service_container' => true,
         );
         $this->aliases = array(
             'alias_to_private' => 'private',
@@ -156,16 +155,6 @@ class Symfony_DI_PhpDumper_Test_Legacy_Privates extends Container
     protected function getPrivateChildService()
     {
         return $this->services['private_child'] = new \stdClass();
-    }
-
-    /**
-     * Gets the private 'private_decorator.inner' shared service.
-     *
-     * @return \stdClass
-     */
-    protected function getPrivateDecorator_InnerService()
-    {
-        return $this->services['private_decorator.inner'] = new \stdClass();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -40,6 +40,7 @@ class ProjectServiceContainer extends Container
         );
         $this->privates = array(
             'baz_service' => true,
+            'service_container' => true,
         );
 
         $this->aliases = array();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_frozen.php
@@ -34,6 +34,7 @@ class ProjectServiceContainer extends Container
         );
         $this->privates = array(
             'baz_service' => true,
+            'service_container' => true,
         );
 
         $this->aliases = array();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_in_expression.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_private_in_expression.php
@@ -33,6 +33,7 @@ class ProjectServiceContainer extends Container
         );
         $this->privates = array(
             'private_foo' => true,
+            'service_container' => true,
         );
 
         $this->aliases = array();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -36,6 +36,9 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
             'Symfony\\Component\\DependencyInjection\\Tests\\Dumper\\Rot13EnvVarProcessor' => 'getRot13EnvVarProcessorService',
             'container.env_var_processors_locator' => 'getContainer_EnvVarProcessorsLocatorService',
         );
+        $this->privates = array(
+            'service_container' => true,
+        );
 
         $this->aliases = array();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -38,6 +38,7 @@ class ProjectServiceContainer extends Container
         );
         $this->privates = array(
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => true,
+            'service_container' => true,
         );
 
         $this->aliases = array();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
@@ -35,6 +35,7 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
         );
         $this->privates = array(
             'foo3' => true,
+            'service_container' => true,
         );
 
         $this->aliases = array();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
-    <service id="foo" class="Foo">
+    <service id="foo" class="Foo" public="true">
       <factory method="createFoo">
         <service class="FooFactory">
           <factory method="createFooFactory">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
-    <service id="foo" class="Foo" autowire="true"/>
+    <service id="foo" class="Foo" public="true" autowire="true"/>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -7,7 +7,7 @@
   </parameters>
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
-    <service id="foo" class="Bar\FooClass">
+    <service id="foo" class="Bar\FooClass" public="true">
       <tag name="foo" foo="foo"/>
       <tag name="foo" bar="bar" baz="baz"/>
       <argument>foo</argument>
@@ -31,20 +31,20 @@
       <factory class="Bar\FooClass" method="getInstance"/>
       <configurator function="sc_configure"/>
     </service>
-    <service id="foo.baz" class="%baz_class%">
+    <service id="foo.baz" class="%baz_class%" public="true">
       <factory class="%baz_class%" method="getInstance"/>
       <configurator class="%baz_class%" method="configureStatic1"/>
     </service>
-    <service id="bar" class="Bar\FooClass">
+    <service id="bar" class="Bar\FooClass" public="true">
       <argument>foo</argument>
       <argument type="service" id="foo.baz"/>
       <argument>%foo_bar%</argument>
       <configurator service="foo.baz" method="configure"/>
     </service>
-    <service id="foo_bar" class="%foo_class%" shared="false">
+    <service id="foo_bar" class="%foo_class%" shared="false" public="true">
       <argument type="service" id="deprecated_service"/>
     </service>
-    <service id="method_call1" class="Bar\FooClass">
+    <service id="method_call1" class="Bar\FooClass" public="true">
       <file>%path%foo.php</file>
       <call method="setBar">
         <argument type="service" id="foo"/>
@@ -62,7 +62,7 @@
         <argument type="expression">service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")</argument>
       </call>
     </service>
-    <service id="foo_with_inline" class="Foo">
+    <service id="foo_with_inline" class="Foo" public="true">
       <call method="setBar">
         <argument type="service" id="inlined"/>
       </call>
@@ -73,60 +73,60 @@
         <argument type="service" id="baz"/>
       </call>
     </service>
-    <service id="baz" class="Baz">
+    <service id="baz" class="Baz" public="true">
       <call method="setFoo">
         <argument type="service" id="foo_with_inline"/>
       </call>
     </service>
-    <service id="request" class="Request" synthetic="true"/>
+    <service id="request" class="Request" public="true" synthetic="true"/>
     <service id="configurator_service" class="ConfClass" public="false">
       <call method="setFoo">
         <argument type="service" id="baz"/>
       </call>
     </service>
-    <service id="configured_service" class="stdClass">
+    <service id="configured_service" class="stdClass" public="true">
       <configurator service="configurator_service" method="configureStdClass"/>
     </service>
     <service id="configurator_service_simple" class="ConfClass" public="false">
       <argument>bar</argument>
     </service>
-    <service id="configured_service_simple" class="stdClass">
+    <service id="configured_service_simple" class="stdClass" public="true">
       <configurator service="configurator_service_simple" method="configureStdClass"/>
     </service>
-    <service id="decorated" class="stdClass"/>
-    <service id="decorator_service" class="stdClass" decorates="decorated"/>
-    <service id="decorator_service_with_name" class="stdClass" decorates="decorated" decoration-inner-name="decorated.pif-pouf"/>
-    <service id="deprecated_service" class="stdClass">
+    <service id="decorated" class="stdClass" public="true"/>
+    <service id="decorator_service" class="stdClass" public="true" decorates="decorated"/>
+    <service id="decorator_service_with_name" class="stdClass" public="true" decorates="decorated" decoration-inner-name="decorated.pif-pouf"/>
+    <service id="deprecated_service" class="stdClass" public="true">
       <deprecated>The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.</deprecated>
     </service>
     <service id="new_factory" class="FactoryClass" public="false">
       <property name="foo">bar</property>
     </service>
-    <service id="factory_service" class="Bar">
+    <service id="factory_service" class="Bar" public="true">
       <factory service="foo.baz" method="getInstance"/>
     </service>
-    <service id="new_factory_service" class="FooBarBaz">
+    <service id="new_factory_service" class="FooBarBaz" public="true">
       <property name="foo">bar</property>
       <factory service="new_factory" method="getInstance"/>
     </service>
-    <service id="service_from_static_method" class="Bar\FooClass">
+    <service id="service_from_static_method" class="Bar\FooClass" public="true">
       <factory class="Bar\FooClass" method="getInstance"/>
     </service>
     <service id="factory_simple" class="SimpleFactoryClass" public="false">
       <argument>foo</argument>
       <deprecated>The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.</deprecated>
     </service>
-    <service id="factory_service_simple" class="Bar">
+    <service id="factory_service_simple" class="Bar" public="true">
       <factory service="factory_simple" method="getInstance"/>
     </service>
-    <service id="lazy_context" class="LazyContext">
+    <service id="lazy_context" class="LazyContext" public="true">
       <argument type="iterator">
         <argument key="k1" type="service" id="foo.baz"/>
         <argument key="k2" type="service" id="service_container"/>
       </argument>
       <argument type="iterator"/>
     </service>
-    <service id="lazy_context_ignore_invalid_ref" class="LazyContext">
+    <service id="lazy_context_ignore_invalid_ref" class="LazyContext" public="true">
       <argument type="iterator">
         <argument type="service" id="foo.baz"/>
         <argument type="service" id="invalid" on-invalid="ignore"/>
@@ -135,7 +135,7 @@
     </service>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
-    <service id="alias_for_foo" alias="foo"/>
-    <service id="alias_for_alias" alias="foo"/>
+    <service id="alias_for_foo" alias="foo" public="true"/>
+    <service id="alias_for_alias" alias="foo" public="true"/>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_abstract.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_abstract.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" synthetic="true"/>
-    <service id="foo" class="Foo" abstract="true"/>
+    <service id="foo" class="Foo" public="true" abstract="true"/>
     <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
     <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_without_id.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_without_id.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
+    <defaults public="true" />
     <service class="FooClass"/>
     <service id="FooClass">
       <argument type="service">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
@@ -5,6 +5,7 @@ services:
         synthetic: true
     foo:
         class: Foo
+        public: true
         autowire: true
     Psr\Container\ContainerInterface:
         alias: service_container

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services26.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services26.yml
@@ -9,6 +9,7 @@ parameters:
 
 services:
     test:
+        public: true
         class: '%env(FOO)%'
         arguments:
             - '%env(Bar)%'

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -20,18 +20,22 @@ services:
 
         factory: [Bar\FooClass, getInstance]
         configurator: sc_configure
+        public: true
     foo.baz:
         class: '%baz_class%'
         factory: ['%baz_class%', getInstance]
         configurator: ['%baz_class%', configureStatic1]
+        public: true
     bar:
         class: Bar\FooClass
         arguments: [foo, '@foo.baz', '%foo_bar%']
         configurator: ['@foo.baz', configure]
+        public: true
     foo_bar:
         class: '%foo_class%'
         shared: false
         arguments: ['@deprecated_service']
+        public: true
     method_call1:
         class: Bar\FooClass
         file: '%path%foo.php'
@@ -41,11 +45,13 @@ services:
             - [setBar, ['@?foo3']]
             - [setBar, ['@?foobaz']]
             - [setBar, ['@=service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")']]
+        public: true
 
     foo_with_inline:
         class: Foo
         calls:
             - [setBar, ['@inlined']]
+        public: true
 
     inlined:
         class: Bar
@@ -58,10 +64,12 @@ services:
         class: Baz
         calls:
             - [setFoo, ['@foo_with_inline']]
+        public: true
 
     request:
         class: Request
         synthetic: true
+        public: true
     configurator_service:
         class: ConfClass
         public: false
@@ -71,6 +79,7 @@ services:
     configured_service:
         class: stdClass
         configurator: ['@configurator_service', configureStdClass]
+        public: true
     configurator_service_simple:
         class: ConfClass
         public: false
@@ -78,18 +87,23 @@ services:
     configured_service_simple:
         class: stdClass
         configurator: ['@configurator_service_simple', configureStdClass]
+        public: true
     decorated:
         class: stdClass
+        public: true
     decorator_service:
         class: stdClass
         decorates: decorated
+        public: true
     decorator_service_with_name:
         class: stdClass
         decorates: decorated
         decoration_inner_name: decorated.pif-pouf
+        public: true
     deprecated_service:
         class: stdClass
         deprecated: The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.
+        public: true
     new_factory:
         class: FactoryClass
         public: false
@@ -97,13 +111,16 @@ services:
     factory_service:
         class: Bar
         factory: ['@foo.baz', getInstance]
+        public: true
     new_factory_service:
         class: FooBarBaz
         properties: { foo: bar }
         factory: ['@new_factory', getInstance]
+        public: true
     service_from_static_method:
         class: Bar\FooClass
         factory: [Bar\FooClass, getInstance]
+        public: true
     factory_simple:
         class: SimpleFactoryClass
         deprecated: The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.
@@ -112,14 +129,21 @@ services:
     factory_service_simple:
         class: Bar
         factory: ['@factory_simple', getInstance]
+        public: true
     lazy_context:
         class: LazyContext
         arguments: [!iterator {'k1': '@foo.baz', 'k2': '@service_container'}, !iterator []]
+        public: true
     lazy_context_ignore_invalid_ref:
         class: LazyContext
         arguments: [!iterator ['@foo.baz', '@?invalid'], !iterator []]
-    alias_for_foo: '@foo'
-    alias_for_alias: '@foo'
+        public: true
+    alias_for_foo:
+        alias: 'foo'
+        public: true
+    alias_for_alias:
+        alias: 'foo'
+        public: true
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_inline.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_inline.yml
@@ -5,6 +5,7 @@ services:
         synthetic: true
     foo:
         class: Class1
+        public: true
         arguments: [!service { class: Class2, arguments: [!service { class: Class2 }] }]
     Psr\Container\ContainerInterface:
         alias: service_container

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_legacy_privates.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_legacy_privates.yml
@@ -1,4 +1,5 @@
 services:
+    _defaults: {public: true}
 
     foo: {class: stdClass, public: false}
 
@@ -23,6 +24,4 @@ services:
     private_not_inlined: {class: stdClass, public: false}
     private_not_removed: {class: stdClass, public: false}
 
-    private_child: {parent: foo}
-    private_parent: {parent: private}
     public_child: {parent: private, public: true}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -234,7 +234,7 @@ class XmlFileLoaderTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Top-level anonymous services are deprecated since Symfony 3.4, the "id" attribute will be required in version 4.0 in %sservices_without_id.xml at line 4.
+     * @expectedDeprecation Top-level anonymous services are deprecated since Symfony 3.4, the "id" attribute will be required in version 4.0 in %sservices_without_id.xml at line 5.
      */
     public function testLoadAnonymousServicesWithoutId()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #20048
| License       | MIT
| Doc PR        | -

With this PR, all services and aliases are made private by default.
This is done in a BC way, thanks to the layer introduced in #24104.

We will require bundles to explicitly opt-in for "public", either using "defaults", or stating `public="true"` explicitly. Same in DI extension, where calling `->setPublic(true)` will be required in 4.0.
