### PR TITLE
[HttpFoundation] Deprecate compatibility with PHP <5.4 sessions

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -205,6 +205,30 @@ FrameworkBundle
    `TranslationDebugCommand`, `TranslationUpdateCommand`, `XliffLintCommand`
     and `YamlLintCommand` classes have been marked as final
 
+HttpFoundation
+--------------
+
+ * The `Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler`
+   class has been deprecated and will be removed in 4.0. Use the `\SessionHandler` class instead.
+
+ * The `Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy` class has been
+   deprecated and will be removed in 4.0. Use the `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy`
+   class instead.
+
+ * The `Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy` class has been
+   deprecated and will be removed in 4.0. Use the `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy`
+   class instead.
+
+ * The `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy::isSessionHandlerInterface()`
+   method has been deprecated and will be removed in 4.0.
+
+ * The `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy::isWrapper()`
+   method has been deprecated and will be removed in 4.0. You can check explicitly if the proxy wraps
+   a `\SessionHandler` instance.
+
+ * `NativeSessionStorage::setSaveHandler()` now takes an instance of `\SessionHandlerInterface` as argument.
+   Not passing it is deprecated and will throw a `TypeError` in 4.0.
+
 HttpKernel
 ----------
 

--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -212,19 +212,13 @@ HttpFoundation
    class has been deprecated and will be removed in 4.0. Use the `\SessionHandler` class instead.
 
  * The `Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy` class has been
-   deprecated and will be removed in 4.0. Use the `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy`
-   class instead.
+   deprecated and will be removed in 4.0. Use your `\SessionHandlerInterface` implementation directly.
 
  * The `Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy` class has been
-   deprecated and will be removed in 4.0. Use the `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy`
-   class instead.
+   deprecated and will be removed in 4.0. Use your `\SessionHandlerInterface` implementation directly.
 
- * The `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy::isSessionHandlerInterface()`
-   method has been deprecated and will be removed in 4.0.
-
- * The `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy::isWrapper()`
-   method has been deprecated and will be removed in 4.0. You can check explicitly if the proxy wraps
-   a `\SessionHandler` instance.
+ * The `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy` class has been
+   deprecated and will be removed in 4.0. Use your `\SessionHandlerInterface` implementation directly.
 
  * `NativeSessionStorage::setSaveHandler()` now takes an instance of `\SessionHandlerInterface` as argument.
    Not passing it is deprecated and will throw a `TypeError` in 4.0.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -524,6 +524,15 @@ HttpFoundation
  * The ability to check only for cacheable HTTP methods using `Request::isMethodSafe()` is
    not supported anymore, use `Request::isMethodCacheable()` instead.
 
+ * The `Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler`, 
+   `Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy` and 
+   `Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy` classes have been removed.
+
+ * The `SessionHandlerProxy::isSessionHandlerInterface()` and `SessionHandlerProxy::isWrapper()`
+   methods have been removed.
+
+ * `NativeSessionStorage::setSaveHandler()` now requires an instance of `\SessionHandlerInterface` as argument.
+
 HttpKernel
 ----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -525,11 +525,9 @@ HttpFoundation
    not supported anymore, use `Request::isMethodCacheable()` instead.
 
  * The `Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler`, 
-   `Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy` and 
-   `Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy` classes have been removed.
-
- * The `SessionHandlerProxy::isSessionHandlerInterface()` and `SessionHandlerProxy::isWrapper()`
-   methods have been removed.
+   `Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy`,
+   `Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy` and 
+   `Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy` classes have been removed.
 
  * `NativeSessionStorage::setSaveHandler()` now requires an instance of `\SessionHandlerInterface` as argument.
 

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -47,8 +47,9 @@ class AppVariableTest extends TestCase
 
     public function testGetSession()
     {
+        $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
-        $request->method('getSession')->willReturn($session = new Session());
+        $request->method('getSession')->willReturn($session);
 
         $this->setRequestStack($request);
 
@@ -167,8 +168,9 @@ class AppVariableTest extends TestCase
 
     public function testGetFlashesWithNoSessionStarted()
     {
+        $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
-        $request->method('getSession')->willReturn(new Session());
+        $request->method('getSession')->willReturn($session);
 
         $this->setRequestStack($request);
 
@@ -257,7 +259,7 @@ class AppVariableTest extends TestCase
         $flashBag = new FlashBag();
         $flashBag->initialize($flashMessages);
 
-        $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')->getMock();
+        $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')->disableOriginalConstructor()->getMock();
         $session->method('isStarted')->willReturn(true);
         $session->method('getFlashBag')->willReturn($flashBag);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -376,7 +376,7 @@ abstract class ControllerTraitTest extends TestCase
     public function testAddFlash()
     {
         $flashBag = new FlashBag();
-        $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')->getMock();
+        $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')->disableOriginalConstructor()->getMock();
         $session->expects($this->once())->method('getFlashBag')->willReturn($flashBag);
 
         $container = new Container();

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * deprecated the `NativeSessionHandler` class,
+ * deprecated the `AbstractProxy` and `NativeProxy` classes in favor of `SessionHandlerProxy` class,
+ * deprecated the `SessionHandlerProxy::isSessionHandlerInterface()` and `SessionHandlerProxy::isWrapper()` methods,
+ * deprecated setting session save handlers that do not implement `\SessionHandlerInterface` in `NativeSessionStorage::setSaveHandler()`
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,8 +5,7 @@ CHANGELOG
 -----
 
  * deprecated the `NativeSessionHandler` class,
- * deprecated the `AbstractProxy` and `NativeProxy` classes in favor of `SessionHandlerProxy` class,
- * deprecated the `SessionHandlerProxy::isSessionHandlerInterface()` and `SessionHandlerProxy::isWrapper()` methods,
+ * deprecated the `AbstractProxy`, `NativeProxy` and `SessionHandlerProxy` classes,
  * deprecated setting session save handlers that do not implement `\SessionHandlerInterface` in `NativeSessionStorage::setSaveHandler()`
 
 3.3.0

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
 /**
- * MemcacheSessionHandler.
- *
  * @author Drak <drak@zikula.org>
  */
 class MemcacheSessionHandler implements \SessionHandlerInterface

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
 /**
- * MemcachedSessionHandler.
- *
  * Memcached based session storage handler based on the Memcached class
  * provided by the PHP memcached extension.
  *

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
 /**
- * MongoDB session handler.
- *
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  */
 class MongoDbSessionHandler implements \SessionHandlerInterface

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
 /**
- * NativeFileSessionHandler.
- *
  * Native session handler using PHP's built in file storage.
  *
  * @author Drak <drak@zikula.org>
@@ -21,8 +19,6 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 class NativeFileSessionHandler extends NativeSessionHandler
 {
     /**
-     * Constructor.
-     *
      * @param string $savePath Path of directory to save session files
      *                         Default null will leave setting as defined by PHP.
      *                         '/path', 'N;/path', or 'N;octal-mode;/path
@@ -30,6 +26,7 @@ class NativeFileSessionHandler extends NativeSessionHandler
      * @see http://php.net/session.configuration.php#ini.session.save-path for further details.
      *
      * @throws \InvalidArgumentException On invalid $savePath
+     * @throws \RuntimeException         When failing to create the save directory
      */
     public function __construct($savePath = null)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSessionHandler.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
+@trigger_error('The '.__NAMESPACE__.'\NativeSessionHandler class is deprecated since version 3.4 and will be removed in 4.0. Use the \SessionHandler class instead.', E_USER_DEPRECATED);
+
 /**
- * Adds SessionHandler functionality if available.
- *
+ * @deprecated since version 3.4, to be removed in 4.0. Use \SessionHandler instead.
  * @see http://php.net/sessionhandler
  */
 class NativeSessionHandler extends \SessionHandler

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NullSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NullSessionHandler.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
 /**
- * NullSessionHandler.
- *
  * Can be used in unit testing or in a situations where persisted sessions are not desired.
  *
  * @author Drak <drak@zikula.org>

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
@@ -54,8 +54,6 @@ class MetadataBag implements SessionBagInterface
     private $updateThreshold;
 
     /**
-     * Constructor.
-     *
      * @param string $storageKey      The key used to store bag in the session
      * @param int    $updateThreshold The time to wait between two UPDATED updates
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -63,8 +63,6 @@ class MockArraySessionStorage implements SessionStorageInterface
     protected $bags = array();
 
     /**
-     * Constructor.
-     *
      * @param string      $name    Session name
      * @param MetadataBag $metaBag MetadataBag instance
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
@@ -30,8 +30,6 @@ class MockFileSessionStorage extends MockArraySessionStorage
     private $savePath;
 
     /**
-     * Constructor.
-     *
      * @param string      $savePath Path of directory to save session files
      * @param string      $name     Session name
      * @param MetadataBag $metaBag  MetadataBag instance

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -39,7 +39,7 @@ class NativeSessionStorage implements SessionStorageInterface
     protected $closed = false;
 
     /**
-     * @var AbstractProxy
+     * @var AbstractProxy|\SessionHandlerInterface
      */
     protected $saveHandler;
 
@@ -92,9 +92,9 @@ class NativeSessionStorage implements SessionStorageInterface
      * trans_sid_hosts, $_SERVER['HTTP_HOST']
      * trans_sid_tags, "a=href,area=href,frame=src,form="
      *
-     * @param array                                       $options Session configuration options
-     * @param AbstractProxy|\SessionHandlerInterface|null $handler
-     * @param MetadataBag                                 $metaBag MetadataBag
+     * @param array                         $options Session configuration options
+     * @param \SessionHandlerInterface|null $handler
+     * @param MetadataBag                   $metaBag MetadataBag
      */
     public function __construct(array $options = array(), $handler = null, MetadataBag $metaBag = null)
     {
@@ -111,7 +111,7 @@ class NativeSessionStorage implements SessionStorageInterface
     /**
      * Gets the save handler instance.
      *
-     * @return AbstractProxy
+     * @return AbstractProxy|\SessionHandlerInterface
      */
     public function getSaveHandler()
     {
@@ -362,7 +362,7 @@ class NativeSessionStorage implements SessionStorageInterface
      * @see http://php.net/sessionhandler
      * @see http://github.com/drak/NativeSession
      *
-     * @param AbstractProxy|\SessionHandlerInterface|null $saveHandler
+     * @param \SessionHandlerInterface|null $saveHandler
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -24,8 +24,6 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 class NativeSessionStorage implements SessionStorageInterface
 {
     /**
-     * Array of SessionBagInterface.
-     *
      * @var SessionBagInterface[]
      */
     protected $bags;
@@ -51,8 +49,6 @@ class NativeSessionStorage implements SessionStorageInterface
     protected $metadataBag;
 
     /**
-     * Constructor.
-     *
      * Depending on how you want the storage driver to behave you probably
      * want to override this constructor entirely.
      *
@@ -378,6 +374,13 @@ class NativeSessionStorage implements SessionStorageInterface
             throw new \InvalidArgumentException('Must be instance of AbstractProxy; implement \SessionHandlerInterface; or be null.');
         }
 
+        if ($saveHandler instanceof AbstractProxy) {
+            @trigger_error(
+                'Using session save handlers that are instances of AbstractProxy is deprecated since version 3.4 and will be removed in 4.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
         // Wrap $saveHandler in proxy and prevent double wrapping of proxy
         if (!$saveHandler instanceof AbstractProxy && $saveHandler instanceof \SessionHandlerInterface) {
             $saveHandler = new SessionHandlerProxy($saveHandler);
@@ -388,8 +391,6 @@ class NativeSessionStorage implements SessionStorageInterface
 
         if ($this->saveHandler instanceof \SessionHandlerInterface) {
             session_set_save_handler($this->saveHandler, false);
-        } else {
-            @trigger_error('Using session save handlers that do not implement \SessionHandlerInterface is deprecated since version 3.4 and will be removed in 4.0.', E_USER_DEPRECATED);
         }
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage;
 
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler;
 
 /**
  * Allows session to be started by PHP and managed by Symfony.
@@ -24,8 +23,8 @@ class PhpBridgeSessionStorage extends NativeSessionStorage
     /**
      * Constructor.
      *
-     * @param AbstractProxy|NativeSessionHandler|\SessionHandlerInterface|null $handler
-     * @param MetadataBag                                                      $metaBag MetadataBag
+     * @param AbstractProxy|\SessionHandlerInterface|null $handler
+     * @param MetadataBag                                 $metaBag MetadataBag
      */
     public function __construct($handler = null, MetadataBag $metaBag = null)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage;
 
-use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
-
 /**
  * Allows session to be started by PHP and managed by Symfony.
  *
@@ -21,8 +19,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
 class PhpBridgeSessionStorage extends NativeSessionStorage
 {
     /**
-     * @param AbstractProxy|\SessionHandlerInterface|null $handler
-     * @param MetadataBag                                 $metaBag MetadataBag
+     * @param \SessionHandlerInterface|null $handler
+     * @param MetadataBag                   $metaBag MetadataBag
      */
     public function __construct($handler = null, MetadataBag $metaBag = null)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorage.php
@@ -21,8 +21,6 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
 class PhpBridgeSessionStorage extends NativeSessionStorage
 {
     /**
-     * Constructor.
-     *
      * @param AbstractProxy|\SessionHandlerInterface|null $handler
      * @param MetadataBag                                 $metaBag MetadataBag
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Proxy;
 
 /**
- * AbstractProxy.
+ * @deprecated since version 3.4, to be removed in 4.0. Use SessionHandlerProxy instead.
  *
  * @author Drak <drak@zikula.org>
  */
@@ -20,6 +20,8 @@ abstract class AbstractProxy
 {
     /**
      * Flag if handler wraps an internal PHP session handler (using \SessionHandler).
+     *
+     * @deprecated since version 3.4 and will be removed in 4.0.
      *
      * @var bool
      */
@@ -43,20 +45,28 @@ abstract class AbstractProxy
     /**
      * Is this proxy handler and instance of \SessionHandlerInterface.
      *
+     * @deprecated since version 3.4 and will be removed in 4.0.
+     *
      * @return bool
      */
     public function isSessionHandlerInterface()
     {
+        @trigger_error('isSessionHandlerInterface() is deprecated since version 3.4 and will be removed in 4.0. A session handler proxy should always implement \SessionHandlerInterface.', E_USER_DEPRECATED);
+
         return $this instanceof \SessionHandlerInterface;
     }
 
     /**
      * Returns true if this handler wraps an internal PHP session save handler using \SessionHandler.
      *
+     * @deprecated since version 3.4 and will be removed in 4.0.
+     *
      * @return bool
      */
     public function isWrapper()
     {
+        @trigger_error('isWrapper() is deprecated since version 3.4 and will be removed in 4.0. You should explicitly check if the handler proxy wraps a \SessionHandler instance.', E_USER_DEPRECATED);
+
         return $this->wrapper;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Proxy;
 
+@trigger_error('The '.__NAMESPACE__.'\AbstractProxy class is deprecated since version 3.4 and will be removed in 4.0. Use your session handler implementation directly.', E_USER_DEPRECATED);
+
 /**
- * @deprecated since version 3.4, to be removed in 4.0. Use SessionHandlerProxy instead.
+ * @deprecated since version 3.4, to be removed in 4.0. Use your session handler implementation directly.
  *
  * @author Drak <drak@zikula.org>
  */
@@ -20,8 +22,6 @@ abstract class AbstractProxy
 {
     /**
      * Flag if handler wraps an internal PHP session handler (using \SessionHandler).
-     *
-     * @deprecated since version 3.4 and will be removed in 4.0.
      *
      * @var bool
      */
@@ -45,28 +45,20 @@ abstract class AbstractProxy
     /**
      * Is this proxy handler and instance of \SessionHandlerInterface.
      *
-     * @deprecated since version 3.4 and will be removed in 4.0.
-     *
      * @return bool
      */
     public function isSessionHandlerInterface()
     {
-        @trigger_error('isSessionHandlerInterface() is deprecated since version 3.4 and will be removed in 4.0. A session handler proxy should always implement \SessionHandlerInterface.', E_USER_DEPRECATED);
-
         return $this instanceof \SessionHandlerInterface;
     }
 
     /**
      * Returns true if this handler wraps an internal PHP session save handler using \SessionHandler.
      *
-     * @deprecated since version 3.4 and will be removed in 4.0.
-     *
      * @return bool
      */
     public function isWrapper()
     {
-        @trigger_error('isWrapper() is deprecated since version 3.4 and will be removed in 4.0. You should explicitly check if the handler proxy wraps a \SessionHandler instance.', E_USER_DEPRECATED);
-
         return $this->wrapper;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/NativeProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/NativeProxy.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Proxy;
 
+@trigger_error('The '.__NAMESPACE__.'\NativeProxy class is deprecated since version 3.4 and will be removed in 4.0. Use the Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy class instead.', E_USER_DEPRECATED);
+
 /**
- * NativeProxy.
+ * This proxy is built-in session handlers in PHP 5.3.x.
  *
- * This proxy is built-in session handlers in PHP 5.3.x
+ * @deprecated since version 3.4, to be removed in 4.0. Use SessionHandlerProxy instead.
  *
  * @author Drak <drak@zikula.org>
  */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/NativeProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/NativeProxy.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Proxy;
 
-@trigger_error('The '.__NAMESPACE__.'\NativeProxy class is deprecated since version 3.4 and will be removed in 4.0. Use the Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy class instead.', E_USER_DEPRECATED);
+@trigger_error('The '.__NAMESPACE__.'\NativeProxy class is deprecated since version 3.4 and will be removed in 4.0. Use your session handler implementation directly.', E_USER_DEPRECATED);
 
 /**
  * This proxy is built-in session handlers in PHP 5.3.x.
  *
- * @deprecated since version 3.4, to be removed in 4.0. Use SessionHandlerProxy instead.
+ * @deprecated since version 3.4, to be removed in 4.0. Use your session handler implementation directly.
  *
  * @author Drak <drak@zikula.org>
  */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Proxy;
 
 /**
- * SessionHandler proxy.
- *
  * @author Drak <drak@zikula.org>
  */
 class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterface
@@ -23,11 +21,6 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
      */
     protected $handler;
 
-    /**
-     * Constructor.
-     *
-     * @param \SessionHandlerInterface $handler
-     */
     public function __construct(\SessionHandlerInterface $handler)
     {
         $this->handler = $handler;

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
@@ -11,7 +11,11 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Proxy;
 
+@trigger_error('The '.__NAMESPACE__.'\SessionHandlerProxy class is deprecated since version 3.4 and will be removed in 4.0. Use your session handler implementation directly.', E_USER_DEPRECATED);
+
 /**
+ * @deprecated since version 3.4, to be removed in 4.0. Use your session handler implementation directly.
+ *
  * @author Drak <drak@zikula.org>
  */
 class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterface

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeSessionHandlerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandle
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
+ * @group legacy
  */
 class NativeSessionHandlerTest extends TestCase
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -198,17 +198,17 @@ class NativeSessionStorageTest extends TestCase
         $this->iniSet('session.save_handler', 'files');
         $storage = $this->getStorage();
         $storage->setSaveHandler();
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
         $storage->setSaveHandler(null);
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
         $storage->setSaveHandler(new SessionHandlerProxy(new NativeSessionHandler()));
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
         $storage->setSaveHandler(new NativeSessionHandler());
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
         $storage->setSaveHandler(new SessionHandlerProxy(new NullSessionHandler()));
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
         $storage->setSaveHandler(new NullSessionHandler());
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -198,17 +198,17 @@ class NativeSessionStorageTest extends TestCase
         $this->iniSet('session.save_handler', 'files');
         $storage = $this->getStorage();
         $storage->setSaveHandler();
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
+        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
         $storage->setSaveHandler(null);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
+        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
         $storage->setSaveHandler(new SessionHandlerProxy(new NativeSessionHandler()));
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
+        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
         $storage->setSaveHandler(new NativeSessionHandler());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
+        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
         $storage->setSaveHandler(new SessionHandlerProxy(new NullSessionHandler()));
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
+        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
         $storage->setSaveHandler(new NullSessionHandler());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy', $storage->getSaveHandler());
+        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -13,42 +13,12 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Proxy;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\AbstractProxy;
-
-// Note until PHPUnit_Mock_Objects 1.2 is released you cannot mock abstracts due to
-// https://github.com/sebastianbergmann/phpunit-mock-objects/issues/73
-class ConcreteProxy extends AbstractProxy
-{
-}
-
-class ConcreteSessionHandlerInterfaceProxy extends AbstractProxy implements \SessionHandlerInterface
-{
-    public function open($savePath, $sessionName)
-    {
-    }
-
-    public function close()
-    {
-    }
-
-    public function read($id)
-    {
-    }
-
-    public function write($id, $data)
-    {
-    }
-
-    public function destroy($id)
-    {
-    }
-
-    public function gc($maxlifetime)
-    {
-    }
-}
+use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
 /**
  * Test class for AbstractProxy.
+ *
+ * @group legacy
  *
  * @author Drak <drak@zikula.org>
  */
@@ -61,7 +31,7 @@ class AbstractProxyTest extends TestCase
 
     protected function setUp()
     {
-        $this->proxy = new ConcreteProxy();
+        $this->proxy = $this->getMockForAbstractClass(AbstractProxy::class);
     }
 
     protected function tearDown()
@@ -74,19 +44,13 @@ class AbstractProxyTest extends TestCase
         $this->assertNull($this->proxy->getSaveHandlerName());
     }
 
-    /**
-     * @group legacy
-     */
     public function testIsSessionHandlerInterface()
     {
         $this->assertFalse($this->proxy->isSessionHandlerInterface());
-        $sh = new ConcreteSessionHandlerInterfaceProxy();
+        $sh = new SessionHandlerProxy(new \SessionHandler());
         $this->assertTrue($sh->isSessionHandlerInterface());
     }
 
-    /**
-     * @group legacy
-     */
     public function testIsWrapper()
     {
         $this->assertFalse($this->proxy->isWrapper());

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/AbstractProxyTest.php
@@ -74,6 +74,9 @@ class AbstractProxyTest extends TestCase
         $this->assertNull($this->proxy->getSaveHandlerName());
     }
 
+    /**
+     * @group legacy
+     */
     public function testIsSessionHandlerInterface()
     {
         $this->assertFalse($this->proxy->isSessionHandlerInterface());
@@ -81,6 +84,9 @@ class AbstractProxyTest extends TestCase
         $this->assertTrue($sh->isSessionHandlerInterface());
     }
 
+    /**
+     * @group legacy
+     */
     public function testIsWrapper()
     {
         $this->assertFalse($this->proxy->isWrapper());

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/NativeProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/NativeProxyTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\NativeProxy;
 /**
  * Test class for NativeProxy.
  *
+ * @group legacy
+ *
  * @author Drak <drak@zikula.org>
  */
 class NativeProxyTest extends TestCase

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
+ * @group legacy
  */
 class SessionHandlerProxyTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR removes functionality added in Symfony 2.1 as a compatibility layer with sessions from PHP <5.4.

- [x] Fix tests