### PR TITLE
[WebProfiler] Fix z-index for sticky ajax window

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -310,6 +310,9 @@
     position: relative;
     z-index: 10002;
 }
+.sf-toolbar-block-ajax.hover .sf-toolbar-info {
+    z-index: 10001;
+}
 .sf-toolbar-block:hover .sf-toolbar-info,
 .sf-toolbar-block.hover .sf-toolbar-info {
     display: block;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Forgotten in #23154

Before
![image](https://user-images.githubusercontent.com/1047696/30522978-f49c3c5c-9bd8-11e7-8bac-e7a690d5c34d.png)

After
![image](https://user-images.githubusercontent.com/1047696/30522965-d000e6fe-9bd8-11e7-92a8-52699c6619f8.png)

In case you hover the time panel.