### PR TITLE
HttpCache does not consider ESI resources in HEAD requests

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -5,6 +5,15 @@
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
  * This code is partially based on the Rack-Cache library by Ryan Tomayko,
  * which is released under the MIT license.
  * (based on commit 02d2b48d75bcb63cf1c0c7149c077ad256542801)

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -5,15 +5,6 @@
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
  * This code is partially based on the Rack-Cache library by Ryan Tomayko,
  * which is released under the MIT license.
  * (based on commit 02d2b48d75bcb63cf1c0c7149c077ad256542801)

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -1133,7 +1133,7 @@ class HttpCacheTest extends HttpCacheTestCase
             array(
                 'status' => 200,
                 'body' => 'Hello World!',
-                'headers' => array('Cache-Control' => 's-maxage=300'),
+                'headers' => array('Cache-Control' => 's-maxage=200'),
             ),
             array(
                 'status' => 200,
@@ -1147,8 +1147,33 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->request('GET', '/', array(), array(), true);
         $this->assertEquals('Hello World! My name is Bobby.', $this->response->getContent());
 
-        // check for 100 or 99 as the test can be executed after a second change
-        $this->assertTrue(in_array($this->response->getTtl(), array(99, 100)));
+        $this->assertEquals(100, $this->response->getTtl());
+    }
+
+    public function testEsiCacheSendsTheLowestTtlForHeadRequests()
+    {
+        $responses = array(
+            array(
+                'status' => 200,
+                'body' => 'I am a long-lived master response, but I embed a short-lived resource: <esi:include src="/foo" />',
+                'headers' => array(
+                    'Cache-Control' => 's-maxage=300',
+                    'Surrogate-Control' => 'content="ESI/1.0"',
+                ),
+            ),
+            array(
+                'status' => 200,
+                'body' => 'I am a short-lived resource',
+                'headers' => array('Cache-Control' => 's-maxage=100'),
+            ),
+        );
+
+        $this->setNextResponses($responses);
+
+        $this->request('HEAD', '/', array(), array(), true);
+
+        $this->assertEmpty($this->response->getContent());
+        $this->assertEquals(100, $this->response->getTtl());
     }
 
     public function testEsiCacheForceValidation()
@@ -1184,6 +1209,37 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertTrue($this->response->headers->hasCacheControlDirective('no-cache'));
     }
 
+    public function testEsiCacheForceValidationForHeadRequests()
+    {
+        $responses = array(
+            array(
+                'status' => 200,
+                'body' => 'I am the master response and use expiration caching, but I embed another resource: <esi:include src="/foo" />',
+                'headers' => array(
+                    'Cache-Control' => 's-maxage=300',
+                    'Surrogate-Control' => 'content="ESI/1.0"',
+                ),
+            ),
+            array(
+                'status' => 200,
+                'body' => 'I am the embedded resource and use validation caching',
+                'headers' => array('ETag' => 'foobar'),
+            ),
+        );
+
+        $this->setNextResponses($responses);
+
+        $this->request('HEAD', '/', array(), array(), true);
+
+        // The response has been assembled from expiration and validation based resources
+        // This can neither be cached nor revalidated, so it should be private/no cache
+        $this->assertEmpty($this->response->getContent());
+        $this->assertNull($this->response->getTtl());
+        $this->assertTrue($this->response->mustRevalidate());
+        $this->assertTrue($this->response->headers->hasCacheControlDirective('private'));
+        $this->assertTrue($this->response->headers->hasCacheControlDirective('no-cache'));
+    }
+
     public function testEsiRecalculateContentLengthHeader()
     {
         $responses = array(
@@ -1192,7 +1248,6 @@ class HttpCacheTest extends HttpCacheTestCase
                 'body' => '<esi:include src="/foo" />',
                 'headers' => array(
                     'Content-Length' => 26,
-                    'Cache-Control' => 's-maxage=300',
                     'Surrogate-Control' => 'content="ESI/1.0"',
                 ),
             ),
@@ -1207,6 +1262,37 @@ class HttpCacheTest extends HttpCacheTestCase
 
         $this->request('GET', '/', array(), array(), true);
         $this->assertEquals('Hello World!', $this->response->getContent());
+        $this->assertEquals(12, $this->response->headers->get('Content-Length'));
+    }
+
+    public function testEsiRecalculateContentLengthHeaderForHeadRequest()
+    {
+        $responses = array(
+            array(
+                'status' => 200,
+                'body' => '<esi:include src="/foo" />',
+                'headers' => array(
+                    'Content-Length' => 26,
+                    'Surrogate-Control' => 'content="ESI/1.0"',
+                ),
+            ),
+            array(
+                'status' => 200,
+                'body' => 'Hello World!',
+                'headers' => array(),
+            ),
+        );
+
+        $this->setNextResponses($responses);
+
+        $this->request('HEAD', '/', array(), array(), true);
+
+        // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
+        // "The Content-Length entity-header field indicates the size of the entity-body,
+        // in decimal number of OCTETs, sent to the recipient or, in the case of the HEAD
+        // method, the size of the entity-body that would have been sent had the request
+        // been a GET."
+        $this->assertEmpty($this->response->getContent());
         $this->assertEquals(12, $this->response->headers->get('Content-Length'));
     }
 
@@ -1297,6 +1383,35 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->setNextResponses($responses);
 
         $this->request('GET', '/', array(), array(), true);
+        $this->assertNull($this->response->getETag());
+        $this->assertNull($this->response->getLastModified());
+    }
+
+    public function testEsiCacheRemoveValidationHeadersIfEmbeddedResponsesAndHeadRequest()
+    {
+        $time = \DateTime::createFromFormat('U', time());
+
+        $responses = array(
+            array(
+                'status' => 200,
+                'body' => '<esi:include src="/hey" />',
+                'headers' => array(
+                    'Surrogate-Control' => 'content="ESI/1.0"',
+                    'ETag' => 'hey',
+                    'Last-Modified' => $time->format(DATE_RFC2822),
+                ),
+            ),
+            array(
+                'status' => 200,
+                'body' => 'Hey!',
+                'headers' => array(),
+            ),
+        );
+
+        $this->setNextResponses($responses);
+
+        $this->request('HEAD', '/', array(), array(), true);
+        $this->assertEmpty($this->response->getContent());
         $this->assertNull($this->response->getETag());
         $this->assertNull($this->response->getLastModified());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Due to this shortcut:
https://github.com/symfony/symfony/blob/3b42d8859ea98fdd17012e21f774f55d33cccc3f/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php#L634-L642
... the `HttpCache` never looks at the response body for `HEAD` requests. This makes it completely miss ESI-related tweaks like computing the correct TTL, removing validation headers or updating the `Content-Length`.

From RFC2616 (https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4):

> The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response. The metainformation contained in the HTTP headers in response to a HEAD request SHOULD be identical to the information sent in response to a GET request.

Although it says "SHOULD", I think it can be misleading at best when HEAD requests do, for example, return different (greater) `s-maxage` values than a corresponding GET request.