### PR TITLE
TwigBundle exception/deprecation tweaks

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
@@ -54,14 +54,15 @@
             </div>
         </div>
 
-        <div class="tab {{ logger is empty ? 'disabled' }}">
+        {% if logger %}
+        <div class="tab {{ logger.logs is empty ? 'disabled' }}">
             <h3 class="tab-title">
                 Logs
                 {% if logger.counterrors ?? false %}<span class="badge status-error">{{ logger.counterrors }}</span>{% endif %}
             </h3>
 
             <div class="tab-content">
-                {% if logger %}
+                {% if logger.logs %}
                     {{ include('@Twig/Exception/logs.html.twig', { logs: logger.logs }, with_context = false)  }}
                 {% else %}
                     <div class="empty">
@@ -70,6 +71,7 @@
                 {% endif %}
             </div>
         </div>
+        {% endif %}
 
         <div class="tab">
             <h3 class="tab-title">

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/logs.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/logs.html.twig
@@ -11,7 +11,15 @@
 
     <tbody>
     {% for log in logs %}
-        <tr class="status-{{ log.priority >= 400 ? 'error' : log.priority >= 300 ? 'warning' : 'normal' }}">
+        {% if log.priority >= 400 %}
+            {% set status = 'error' %}
+        {% elseif log.priority >= 300 %}
+            {% set status = 'warning' %}
+        {% else %}
+            {% set severity = log.context.exception.severity|default(false) %}
+            {% set status = severity is constant('E_DEPRECATED') or severity is constant('E_USER_DEPRECATED') ? 'warning' : 'normal' %}
+        {% endif %}
+        <tr class="status-{{ status }}">
             <td class="text-small" nowrap>
                 <span class="colored text-bold">{{ log.priorityName }}</span>
                 <span class="text-muted newline">{{ log.timestamp|date('H:i:s') }}</span>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
@@ -525,7 +525,7 @@
         };
     })();
 
-    Sfjs.addEventListener(window, 'load', function() {
+    Sfjs.addEventListener(document, 'DOMContentLoaded', function() {
         Sfjs.createTabs();
         Sfjs.createToggles();
     });

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -525,7 +525,7 @@
         };
     })();
 
-    Sfjs.addEventListener(window, 'load', function() {
+    Sfjs.addEventListener(document, 'DOMContentLoaded', function() {
         Sfjs.createTabs();
         Sfjs.createToggles();
     });

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -832,6 +832,8 @@ tr.status-warning td {
 .tab-navigation li .badge.status-warning { background: {{ colors.warning|raw }}; color: #FFF; }
 .tab-navigation li .badge.status-error { background: {{ colors.error|raw }}; color: #FFF; }
 
+.sf-tabs .tab:not(:first-child) { display: none; }
+
 {# Toggles
    ========================================================================= #}
 .sf-toggle-content {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->


- 1st commit) if you view a exception in the profiler, there is no logger available. Making the tab useless, disabled state is now triggered at zero log messages. There's a specialized panel here.
- 2nd commit) when an exception occurs this highlights deprecations in the log table outside the profiler with a warning status. This follows the same signal colors in the profiler.
- 3rd commit) hide the default inactive tabs from CSS to avoid scrollbar flickering.
- 4th commit) favors document.DOMContentLoaded over window.load, we dont want to wait for images to be loaded

Further out-of-scope improvements could be;

- From https://github.com/symfony/symfony/pull/24191; i think the logs table should show a direct `View file` link for every error/deprecation/red or yellow line in here. Traversing with `Show context` is tedious.
  - links to file.php for your trigger_error() calls
  - links to config.yml for trigger_error() calls by SF
- From #24151; having the same tooling on both sides is nice
- Events/Translations logs is noise, we have specialized panels for those. To further reduce the overall page size container logs can be moved away too, linked from Configuration and/or Logs. Also see #23247