### PR TITLE
[TwigBundle] Break long lines in exceptions

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/trace.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/trace.html.twig
@@ -1,4 +1,4 @@
-<div class="trace-line-header {{ trace.file|default(false) ? 'sf-toggle' }}" data-toggle-selector="#trace-html-{{ prefix }}-{{ i }}" data-toggle-initial="{{ _display_code_snippet ? 'display' }}">
+<div class="trace-line-header break-long-words {{ trace.file|default(false) ? 'sf-toggle' }}" data-toggle-selector="#trace-html-{{ prefix }}-{{ i }}" data-toggle-initial="{{ _display_code_snippet ? 'display' }}">
     {% if trace.file|default(false) %}
         <span class="icon icon-close">{{ include('@Twig/images/icon-minus-square.svg') }}</span>
         <span class="icon icon-open">{{ include('@Twig/images/icon-plus-square.svg') }}</span>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
@@ -105,7 +105,7 @@ header .container { display: flex; justify-content: space-between; }
 .trace-line a { color: #222; }
 .trace-line .icon { opacity: .4; position: absolute; left: 10px; top: 11px; }
 .trace-line .icon svg { height: 16px; width: 16px; }
-.trace-line-header { padding-left: 36px; }
+.trace-line-header { padding-left: 36px; padding-right: 10px; }
 
 .trace-file-path, .trace-file-path a { color: #222; font-size: 13px; }
 .trace-class { color: #B0413E; }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Break long lines in exception to stay in screen

Before:
![exception_before](https://user-images.githubusercontent.com/2345927/30586794-63b35b44-9d31-11e7-90ce-507af56934d0.png)

After:
![exception_after](https://user-images.githubusercontent.com/2345927/30586801-691c2548-9d31-11e7-9af4-54c01b4cc400.png)
