### PR TITLE
CsvEncoder handling variable structures and custom header order

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * added `AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT` context option
    to disable throwing an `UnexpectedValueException` on a type mismatch
  * added support for serializing `DateInterval` objects
+ * improved `CsvEncoder` to handle variable nested structures
+ * CSV headers can be passed to the `CsvEncoder` via the `csv_headers` serialization context variable 
 
 3.3.0
 -----

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -135,12 +135,22 @@ CSV
         $this->assertEquals("\n\n", $this->encoder->encode(array(array()), 'csv'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     */
-    public function testEncodeNonFlattenableStructure()
+    public function testEncodeVariableStructure()
     {
-        $this->encoder->encode(array(array('a' => array('foo', 'bar')), array('a' => array())), 'csv');
+        $value = array(
+            array('a' => array('foo', 'bar')),
+            array('a' => array(), 'b' => 'baz'),
+            array('a' => array('bar', 'foo'), 'c' => 'pong'),
+        );
+        $csv = <<<CSV
+a.0,a.1,c,b
+foo,bar,,
+,,,baz
+bar,foo,pong,
+
+CSV;
+
+        $this->assertEquals($csv, $this->encoder->encode($value, 'csv'));
     }
 
     public function testSupportsDecoding()

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -153,6 +153,26 @@ CSV;
         $this->assertEquals($csv, $this->encoder->encode($value, 'csv'));
     }
 
+    public function testEncodeCustomHeaders()
+    {
+        $context = array(
+            CsvEncoder::HEADERS_KEY => array(
+                'b',
+                'c',
+            ),
+        );
+        $value = array(
+            array('a' => 'foo', 'b' => 'bar'),
+        );
+        $csv = <<<CSV
+b,c,a
+bar,,foo
+
+CSV;
+
+        $this->assertEquals($csv, $this->encoder->encode($value, 'csv', $context));
+    }
+
     public function testSupportsDecoding()
     {
         $this->assertTrue($this->encoder->supportsDecoding('csv'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23278
| License       | MIT
| Doc PR        | TBD

This PR improves the CsvEncoder to handle variable nesting structures and adds a context option that allows custom csv header order.
