### PR TITLE
[Security] Add impersonation support for stateless authentication

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -316,6 +316,9 @@ SecurityBundle
 
  * Deprecated the HTTP digest authentication: `HttpDigestFactory` will be removed in 4.0.
    Use another authentication system like `http_basic` instead.
+   
+ * Deprecated setting the `switch_user.stateless` option to false when the firewall is `stateless`.
+   Setting it to false will have no effect in 4.0.
 
 Translation
 -----------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -693,6 +693,8 @@ SecurityBundle
 
  * Removed the HTTP digest authentication system. The `HttpDigestFactory` class
    has been removed. Use another authentication system like `http_basic` instead.
+   
+ * The `switch_user.stateless` option is now always true if the firewall is stateless.
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * deprecated command `acl:set` along with `SetAclCommand` class
  * deprecated command `init:acl` along with `InitAclCommand` class
  * Added support for the new Argon2i password encoder
+ * added `stateless` option to the `switch_user` listener
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -304,6 +304,7 @@ class MainConfiguration implements ConfigurationInterface
                     ->scalarNode('provider')->end()
                     ->scalarNode('parameter')->defaultValue('_switch_user')->end()
                     ->scalarNode('role')->defaultValue('ROLE_ALLOWED_TO_SWITCH')->end()
+                    ->booleanNode('stateless')->defaultValue(false)->end()
                 ->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -456,7 +456,7 @@ class SecurityExtension extends Extension
         // Switch user listener
         if (isset($firewall['switch_user'])) {
             $listenerKeys[] = 'switch_user';
-            $listeners[] = new Reference($this->createSwitchUserListener($container, $id, $firewall['switch_user'], $defaultProvider));
+            $listeners[] = new Reference($this->createSwitchUserListener($container, $id, $firewall['switch_user'], $defaultProvider, $firewall['stateless']));
         }
 
         // Access listener
@@ -699,9 +699,14 @@ class SecurityExtension extends Extension
         return $exceptionListenerId;
     }
 
-    private function createSwitchUserListener($container, $id, $config, $defaultProvider)
+    private function createSwitchUserListener($container, $id, $config, $defaultProvider, $stateless)
     {
         $userProvider = isset($config['provider']) ? $this->getUserProviderId($config['provider']) : $defaultProvider;
+
+        // in 4.0, ignore the `switch_user.stateless` key if $stateless is `true`
+        if ($stateless && false === $config['stateless']) {
+            @trigger_error(sprintf('Firewall "%s" is configured as "stateless" but the "switch_user.stateless" key is set to false. Both should have the same value, the firewall\'s "stateless" value will be used as default value for the "switch_user.stateless" key in 4.0.', $id), E_USER_DEPRECATED);
+        }
 
         $switchUserListenerId = 'security.authentication.switchuser_listener.'.$id;
         $listener = $container->setDefinition($switchUserListenerId, new ChildDefinition('security.authentication.switchuser_listener'));
@@ -710,6 +715,7 @@ class SecurityExtension extends Extension
         $listener->replaceArgument(3, $id);
         $listener->replaceArgument(6, $config['parameter']);
         $listener->replaceArgument(7, $config['role']);
+        $listener->replaceArgument(9, $config['stateless']);
 
         return $switchUserListenerId;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -241,6 +241,7 @@
             <argument>_switch_user</argument>
             <argument>ROLE_ALLOWED_TO_SWITCH</argument>
             <argument type="service" id="event_dispatcher" on-invalid="null"/>
+            <argument>false</argument> <!-- Stateless -->
         </service>
 
         <service id="security.access_listener" class="Symfony\Component\Security\Http\Firewall\AccessListener">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -130,6 +130,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 array(
                     'parameter' => '_switch_user',
                     'role' => 'ROLE_ALLOWED_TO_SWITCH',
+                    'stateless' => true,
                 ),
             ),
             array(
@@ -256,6 +257,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 array(
                     'parameter' => '_switch_user',
                     'role' => 'ROLE_ALLOWED_TO_SWITCH',
+                    'stateless' => true,
                 ),
             ),
             array(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -65,7 +65,7 @@ $container->loadFromExtension('security', array(
             'http_basic' => true,
             'form_login' => true,
             'anonymous' => true,
-            'switch_user' => true,
+            'switch_user' => array('stateless' => true),
             'x509' => true,
             'remote_user' => true,
             'logout' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1_with_acl.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1_with_acl.php
@@ -67,7 +67,7 @@ $container->loadFromExtension('security', array(
             'http_digest' => array('secret' => 'TheSecret'),
             'form_login' => true,
             'anonymous' => true,
-            'switch_user' => true,
+            'switch_user' => array('stateless' => true),
             'x509' => true,
             'remote_user' => true,
             'logout' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1_with_digest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1_with_digest.php
@@ -67,7 +67,7 @@ $container->loadFromExtension('security', array(
             'http_digest' => array('secret' => 'TheSecret'),
             'form_login' => true,
             'anonymous' => true,
-            'switch_user' => true,
+            'switch_user' => array('stateless' => true),
             'x509' => true,
             'remote_user' => true,
             'logout' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
@@ -17,7 +17,7 @@ $container->loadFromExtension('security', array(
             'http_basic' => true,
             'form_login' => true,
             'anonymous' => true,
-            'switch_user' => true,
+            'switch_user' => array('stateless' => true),
             'x509' => true,
             'remote_user' => true,
             'logout' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -49,7 +49,7 @@
             <http-basic />
             <form-login />
             <anonymous />
-            <switch-user />
+            <switch-user stateless="true" />
             <x509 />
             <remote-user />
             <user-checker />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1_with_acl.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1_with_acl.xml
@@ -51,7 +51,7 @@
             <http-digest secret="TheSecret" />
             <form-login />
             <anonymous />
-            <switch-user />
+            <switch-user stateless="true" />
             <x509 />
             <remote-user />
             <user-checker />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1_with_digest.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1_with_digest.xml
@@ -52,7 +52,7 @@
             <http-digest secret="TheSecret" />
             <form-login />
             <anonymous />
-            <switch-user />
+            <switch-user stateless="true" />
             <x509 />
             <remote-user />
             <user-checker />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
@@ -17,7 +17,7 @@
             <http-basic />
             <form-login />
             <anonymous />
-            <switch-user />
+            <switch-user stateless="true" />
             <x509 />
             <remote-user />
             <user-checker />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -47,7 +47,8 @@ security:
             http_basic: true
             form_login: true
             anonymous: true
-            switch_user: true
+            switch_user:
+                stateless: true
             x509: true
             remote_user: true
             logout: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1_with_acl.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1_with_acl.yml
@@ -50,7 +50,8 @@ security:
                 secret: TheSecret
             form_login: true
             anonymous: true
-            switch_user: true
+            switch_user:
+                stateless: true
             x509: true
             remote_user: true
             logout: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1_with_digest.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1_with_digest.yml
@@ -50,7 +50,8 @@ security:
                 secret: TheSecret
             form_login: true
             anonymous: true
-            switch_user: true
+            switch_user:
+                stateless: true
             x509: true
             remote_user: true
             logout: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
@@ -12,7 +12,8 @@ security:
             http_basic: true
             form_login: true
             anonymous: true
-            switch_user: true
+            switch_user:
+                stateless: true
             x509: true
             remote_user: true
             logout: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -148,6 +148,32 @@ class SecurityExtensionTest extends TestCase
         $container->compile();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Firewall "some_firewall" is configured as "stateless" but the "switch_user.stateless" key is set to false. Both should have the same value, the firewall's "stateless" value will be used as default value for the "switch_user.stateless" key in 4.0.
+     */
+    public function testSwitchUserNotStatelessOnStatelessFirewall()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', array(
+            'providers' => array(
+                'default' => array('id' => 'foo'),
+            ),
+
+            'firewalls' => array(
+                'some_firewall' => array(
+                    'stateless' => true,
+                    'http_basic' => null,
+                    'switch_user' => array('stateless' => false),
+                    'logout_on_user_change' => true,
+                ),
+            ),
+        ));
+
+        $container->compile();
+    }
+
     protected function getRawContainer()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 
 class SwitchUserTest extends WebTestCase
@@ -48,6 +49,18 @@ class SwitchUserTest extends WebTestCase
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertEquals('user_can_switch', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testSwitchUserStateless()
+    {
+        $client = $this->createClient(array('test_case' => 'JsonLogin', 'root_config' => 'switchuser_stateless.yml'));
+        $client->request('POST', '/chk', array('_switch_user' => 'dunglas'), array(), array('CONTENT_TYPE' => 'application/json'), '{"user": {"login": "user_can_switch", "password": "test"}}');
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(array('message' => 'Welcome @dunglas!'), json_decode($response->getContent(), true));
+        $this->assertSame('dunglas', $client->getProfile()->getCollector('security')->getUser());
     }
 
     public function getTestParameters()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: ./config.yml }
+
+security:
+    providers:
+        in_memory:
+            memory:
+                users:
+                    user_can_switch: { password: test, roles: [ROLE_USER, ROLE_ALLOWED_TO_SWITCH] }
+    firewalls:
+        main:
+            switch_user:
+                stateless: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/lafourchette/SwitchUserStatelessBundle/issues/10#issuecomment-330434589
| License       | MIT
| Doc PR        | n/a

The `switch_user` listener triggers a redirection in case of success and thus does not play well with stateless authentication which is common nowadays (as opposed to other listeners like the [exception one](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php#L187..#L189)). 
This adds a new `stateless` option to the `switch_user` listener, if set to true then no redirection is triggered during user switching. 

This will avoid the need for [lafourchette/SwitchUserStatelessBundle](https://github.com/lafourchette/SwitchUserStatelessBundle) which just duplicated the symfony SwitchUserListener (with config factory) at a given state to avoid the 2 LOC which are causing the redirection. 
The bundle is not actively maintained and the listener it provides is out of date due to the missing upstream additions and bug fixes (see https://github.com/lafourchette/SwitchUserStatelessBundle/issues/10).