### PR TITLE
[Serializer] Getter for extra attributes in ExtraAttributesException

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added `AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT` context option
    to disable throwing an `UnexpectedValueException` on a type mismatch
  * added support for serializing `DateInterval` objects
+ * added getter for extra attributes in `ExtraAttributesException`
 
 3.3.0
 -----

--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
@@ -18,10 +18,32 @@ namespace Symfony\Component\Serializer\Exception;
  */
 class ExtraAttributesException extends RuntimeException
 {
+    /**
+     * Extra attributes
+     * @var array
+     */
+    private $extraAttributes;
+    
+    /**
+     * {@inheritDoc}
+     * @param array $extraAttributes Extra attributes that are not allowed
+     * @param \Exception $previous Previous exception
+     */
     public function __construct(array $extraAttributes, \Exception $previous = null)
     {
         $msg = sprintf('Extra attributes are not allowed ("%s" are unknown).', implode('", "', $extraAttributes));
+        
+        $this->extraAttributes = $extraAttributes;
 
         parent::__construct($msg, 0, $previous);
+    }
+    
+    /**
+     * Get the extra attributes that are not allowed
+     * @return array
+     */
+    public function getExtraAttributes()
+    {
+        return $this->extraAttributes;
     }
 }

--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
@@ -19,27 +19,30 @@ namespace Symfony\Component\Serializer\Exception;
 class ExtraAttributesException extends RuntimeException
 {
     /**
-     * Extra attributes
+     * Extra attributes.
+     *
      * @var array
      */
     private $extraAttributes;
-    
+
     /**
-     * {@inheritDoc}
-     * @param array $extraAttributes Extra attributes that are not allowed
-     * @param \Exception $previous Previous exception
+     * {@inheritdoc}
+     *
+     * @param array      $extraAttributes Extra attributes that are not allowed
+     * @param \Exception $previous        Previous exception
      */
     public function __construct(array $extraAttributes, \Exception $previous = null)
     {
         $msg = sprintf('Extra attributes are not allowed ("%s" are unknown).', implode('", "', $extraAttributes));
-        
+
         $this->extraAttributes = $extraAttributes;
 
         parent::__construct($msg, 0, $previous);
     }
-    
+
     /**
-     * Get the extra attributes that are not allowed
+     * Get the extra attributes that are not allowed.
+     *
      * @return array
      */
     public function getExtraAttributes()

--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
@@ -18,19 +18,8 @@ namespace Symfony\Component\Serializer\Exception;
  */
 class ExtraAttributesException extends RuntimeException
 {
-    /**
-     * Extra attributes.
-     *
-     * @var array
-     */
     private $extraAttributes;
 
-    /**
-     * {@inheritdoc}
-     *
-     * @param array      $extraAttributes Extra attributes that are not allowed
-     * @param \Exception $previous        Previous exception
-     */
     public function __construct(array $extraAttributes, \Exception $previous = null)
     {
         $msg = sprintf('Extra attributes are not allowed ("%s" are unknown).', implode('", "', $extraAttributes));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (failure unrelated)
| Fixed tickets | 
| License       | MIT

This PR adds a public getter for the extra attributes in `ExtraAttributesException` and makes it easier to create custom exception messages (e.g. JSON formatted).