### PR TITLE
Allow wrap a HTTP exceptions

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
@@ -30,4 +30,15 @@ class AccessDeniedHttpException extends HttpException
     {
         parent::__construct(403, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return AccessDeniedHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
@@ -29,4 +29,15 @@ class BadRequestHttpException extends HttpException
     {
         parent::__construct(400, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return BadRequestHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
@@ -29,4 +29,15 @@ class ConflictHttpException extends HttpException
     {
         parent::__construct(409, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return ConflictHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
@@ -29,4 +29,15 @@ class GoneHttpException extends HttpException
     {
         parent::__construct(410, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return GoneHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
@@ -29,4 +29,15 @@ class LengthRequiredHttpException extends HttpException
     {
         parent::__construct(411, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return LengthRequiredHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
@@ -34,13 +34,14 @@ class MethodNotAllowedHttpException extends HttpException
     }
 
     /**
+     * @param array      $allow    An array of allowed methods
      * @param \Exception $previous The previous exception
      * @param int        $code     The internal exception code
      *
      * @return MethodNotAllowedHttpException
      */
-    public static function wrap(\Exception $previous, $code = 0)
+    public static function wrap(array $allow, \Exception $previous, $code = 0)
     {
-        return new static($previous->getMessage(), $previous, $code);
+        return new static($allow, $previous->getMessage(), $previous, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
@@ -32,4 +32,15 @@ class MethodNotAllowedHttpException extends HttpException
 
         parent::__construct(405, $message, $previous, $headers, $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return MethodNotAllowedHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
@@ -29,4 +29,15 @@ class NotAcceptableHttpException extends HttpException
     {
         parent::__construct(406, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return NotAcceptableHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
@@ -29,4 +29,15 @@ class NotFoundHttpException extends HttpException
     {
         parent::__construct(404, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return NotFoundHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
@@ -29,4 +29,15 @@ class PreconditionFailedHttpException extends HttpException
     {
         parent::__construct(412, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return PreconditionFailedHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
@@ -31,4 +31,15 @@ class PreconditionRequiredHttpException extends HttpException
     {
         parent::__construct(428, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return PreconditionRequiredHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
@@ -35,4 +35,15 @@ class ServiceUnavailableHttpException extends HttpException
 
         parent::__construct(503, $message, $previous, $headers, $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return ServiceUnavailableHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
@@ -37,13 +37,14 @@ class ServiceUnavailableHttpException extends HttpException
     }
 
     /**
-     * @param \Exception $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param int|string $retryAfter The number of seconds or HTTP-date after which the request may be retried
+     * @param \Exception $previous   The previous exception
+     * @param int        $code       The internal exception code
      *
      * @return ServiceUnavailableHttpException
      */
-    public static function wrap(\Exception $previous, $code = 0)
+    public static function wrap($retryAfter = null, \Exception $previous, $code = 0)
     {
-        return new static($previous->getMessage(), $previous, $code);
+        return new static($retryAfter, $previous->getMessage(), $previous, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
@@ -37,4 +37,15 @@ class TooManyRequestsHttpException extends HttpException
 
         parent::__construct(429, $message, $previous, $headers, $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return TooManyRequestsHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
@@ -39,13 +39,14 @@ class TooManyRequestsHttpException extends HttpException
     }
 
     /**
-     * @param \Exception $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param int|string $retryAfter The number of seconds or HTTP-date after which the request may be retried
+     * @param \Exception $previous   The previous exception
+     * @param int        $code       The internal exception code
      *
      * @return TooManyRequestsHttpException
      */
-    public static function wrap(\Exception $previous, $code = 0)
+    public static function wrap($retryAfter = null, \Exception $previous, $code = 0)
     {
-        return new static($previous->getMessage(), $previous, $code);
+        return new static($retryAfter, $previous->getMessage(), $previous, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
@@ -32,4 +32,16 @@ class UnauthorizedHttpException extends HttpException
 
         parent::__construct(401, $message, $previous, $headers, $code);
     }
+
+    /**
+     * @param string     $challenge WWW-Authenticate challenge string
+     * @param \Exception $previous  The previous exception
+     * @param int        $code      The internal exception code
+     *
+     * @return UnauthorizedHttpException
+     */
+    public static function wrap($challenge, \Exception $previous, $code = 0)
+    {
+        return new static($challenge, $previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
@@ -29,4 +29,15 @@ class UnprocessableEntityHttpException extends HttpException
     {
         parent::__construct(422, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return UnprocessableEntityHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
@@ -29,4 +29,15 @@ class UnsupportedMediaTypeHttpException extends HttpException
     {
         parent::__construct(415, $message, $previous, array(), $code);
     }
+
+    /**
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     *
+     * @return UnsupportedMediaTypeHttpException
+     */
+    public static function wrap(\Exception $previous, $code = 0)
+    {
+        return new static($previous->getMessage(), $previous, $code);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
<!--| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

*I will update `CHANGELOG.md` and add the tests a little later.*

This improvement is necessary in order to facilitate the wrapping of wrapping exceptions.

Use case:

```php
class GameController extends Controller
{
    public function showAction($id, GameRepository $repository)
    {
        try {
            $game = $repository->get($id);
        } catch (GameNotFoundException $e) { // this is a domain exception
            // throw $this->createNotFoundException($e->getMessage(), $e); // before
            throw NotFoundHttpException::warp($e); // after
        }

        // ...
    }
}
```

This record looks simpler, shorter and clearer.

Perhaps this is not necessary improvement.
I propose to discuss its meaningfulness.