### PR TITLE
[VarDumper] Make `dump()` a little bit more easier to use

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -22,7 +22,7 @@ if (!function_exists('dump')) {
         foreach ($moreVars as $var) {
             VarDumper::dump($var);
         }
-        
+
         return $var;
     }
 }

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -23,6 +23,10 @@ if (!function_exists('dump')) {
             VarDumper::dump($var);
         }
 
+        if ($moreVars) {
+            return func_get_args();
+        }
+
         return $var;
     }
 }

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -22,5 +22,7 @@ if (!function_exists('dump')) {
         foreach ($moreVars as $var) {
             VarDumper::dump($var);
         }
+        
+        return $var;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Imagine you have this code:

```php
$object->method();
```

If you want to dump the object, this is currently the way to do that:

```php
dump($object);

$object->method();
```

This PR makes adding (and removing) the `dump` function easier. When using one argument is used, that argument is returned.

```php
dump($object)->method();
```

When dumping multiple things, they all get returned. So you can to this:

```php
$object->someMethod(...dump($arg1, $arg2, $arg3));
```