### PR TITLE
[DI] Dont use JSON_BIGINT_AS_STRING

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -119,7 +119,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         }
 
         if ('json' === $prefix) {
-            $env = json_decode($env, true, JSON_BIGINT_AS_STRING);
+            $env = json_decode($env, true);
 
             if (JSON_ERROR_NONE !== json_last_error()) {
                 throw new RuntimeException(sprintf('Invalid JSON in env var "%s": '.json_last_error_msg(), $name));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ye
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Because it's incompatible with stringy keys, for unknown reason, see https://3v4l.org/IHSqv