### PR TITLE
[FrameworkBundle][HttpKernel] Reset profiler

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -63,6 +63,12 @@ Debug
 
  * Support for stacked errors in the `ErrorHandler` is deprecated and will be removed in Symfony 4.0.
 
+EventDispatcher
+---------------
+
+ * Implementing `TraceableEventDispatcherInterface` without the `reset()` method
+   is deprecated and will be unsupported in 4.0.
+
 Filesystem
 ----------
 
@@ -270,6 +276,10 @@ HttpKernel
 
  * The `Symfony\Component\HttpKernel\Config\EnvParametersResource` class has been deprecated and will be removed in 4.0.
 
+ * Implementing `DataCollectorInterface` without a `reset()` method has been deprecated and will be unsupported in 4.0.
+
+ * Implementing `DebugLoggerInterface` without a `clear()` method has been deprecated and will be unsupported in 4.0.
+
  * The `ChainCacheClearer::add()` method has been deprecated and will be removed in 4.0,
    inject the list of clearers as a constructor argument instead.
 
@@ -320,11 +330,11 @@ SecurityBundle
 
  * Deprecated the HTTP digest authentication: `HttpDigestFactory` will be removed in 4.0.
    Use another authentication system like `http_basic` instead.
-   
+
  * Deprecated setting the `switch_user.stateless` option to false when the firewall is `stateless`.
    Setting it to false will have no effect in 4.0.
 
- * Not configuring explicitly the provider on a firewall is ambiguous when there is more than one registered provider. 
+ * Not configuring explicitly the provider on a firewall is ambiguous when there is more than one registered provider.
    Using the first configured provider is deprecated since 3.4 and will throw an exception on 4.0.
    Explicitly configure the provider to use on your firewalls.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -192,6 +192,8 @@ EventDispatcher
  * The `ContainerAwareEventDispatcher` class has been removed.
    Use `EventDispatcher` with closure factories instead.
 
+ * The `reset()` method has been added to `TraceableEventDispatcherInterface`.
+
 ExpressionLanguage
 ------------------
 
@@ -611,6 +613,10 @@ HttpKernel
 
  * The `Symfony\Component\HttpKernel\Config\EnvParametersResource` class has been removed.
 
+ * The `reset()` method has been added to `Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface`.
+
+ * The `clear()` method has been added to `Symfony\Component\HttpKernel\Log\DebugLoggerInterface`.
+
  * The `ChainCacheClearer::add()` method has been removed,
    inject the list of clearers as a constructor argument instead.
 
@@ -693,10 +699,10 @@ SecurityBundle
 
  * Removed the HTTP digest authentication system. The `HttpDigestFactory` class
    has been removed. Use another authentication system like `http_basic` instead.
-   
+
  * The `switch_user.stateless` option is now always true if the firewall is stateless.
 
- * Not configuring explicitly the provider on a firewall is ambiguous when there is more than one registered provider. 
+ * Not configuring explicitly the provider on a firewall is ambiguous when there is more than one registered provider.
    The first configured provider is not used anymore and an exception is thrown instead.
    Explicitly configure the provider to use on your firewalls.
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "doctrine/common": "~2.4",
         "fig/link-util": "^1.0",
-        "twig/twig": "~1.34|~2.4",
+        "twig/twig": "^1.35|^2.4.4",
         "psr/cache": "~1.0",
         "psr/container": "^1.0",
         "psr/link": "^1.0",

--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -28,6 +28,10 @@ class DoctrineDataCollector extends DataCollector
     private $registry;
     private $connections;
     private $managers;
+
+    /**
+     * @var DebugStack[]
+     */
     private $loggers = array();
 
     public function __construct(ManagerRegistry $registry)
@@ -63,6 +67,16 @@ class DoctrineDataCollector extends DataCollector
             'connections' => $this->connections,
             'managers' => $this->managers,
         );
+    }
+
+    public function reset()
+    {
+        $this->data = array();
+
+        foreach ($this->loggers as $logger) {
+            $logger->queries = array();
+            $logger->currentQuery = 0;
+        }
     }
 
     public function getManagers()

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -101,6 +101,20 @@ class DoctrineDataCollectorTest extends TestCase
         $this->assertTrue($collectedQueries['default'][1]['explainable']);
     }
 
+    public function testReset()
+    {
+        $queries = array(
+            array('sql' => 'SELECT * FROM table1', 'params' => array(), 'types' => array(), 'executionMS' => 1),
+        );
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+
+        $c->reset();
+        $c->collect(new Request(), new Response());
+
+        $this->assertEquals(array('default' => array()), $c->getQueries());
+    }
+
     /**
      * @dataProvider paramProvider
      */

--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -46,6 +46,16 @@ class Logger extends BaseLogger implements DebugLoggerInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        if (($logger = $this->getDebugLogger()) && method_exists($logger, 'clear')) {
+            $logger->clear();
+        }
+    }
+
+    /**
      * Returns a DebugLoggerInterface instance if one is registered with this logger.
      *
      * @return DebugLoggerInterface|null A DebugLoggerInterface instance or null if none is registered

--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -55,4 +55,13 @@ class DebugProcessor implements DebugLoggerInterface
     {
         return $this->errorCount;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        $this->records = array();
+        $this->errorCount = 0;
+    }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -128,4 +128,17 @@ class LoggerTest extends TestCase
         $this->assertEquals('test', $record['message']);
         $this->assertEquals(Logger::INFO, $record['priority']);
     }
+
+    public function testClear()
+    {
+        $handler = new TestHandler();
+        $logger = new Logger('test', array($handler));
+        $logger->pushProcessor(new DebugProcessor());
+
+        $logger->addInfo('test');
+        $logger->clear();
+
+        $this->assertEmpty($logger->getLogs());
+        $this->assertSame(0, $logger->countErrors());
+    }
 }

--- a/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
+++ b/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
@@ -47,6 +47,16 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
     /**
      * {@inheritdoc}
      */
+    public function reset()
+    {
+        $this->profile->reset();
+        $this->computed = null;
+        $this->data = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function lateCollect()
     {
         $this->data['profile'] = serialize($this->profile);

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^5.5.9|>=7.0.8",
-        "twig/twig": "~1.34|~2.4"
+        "twig/twig": "^1.35|^2.4.4"
     },
     "require-dev": {
         "fig/link-util": "^1.0",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -609,9 +609,9 @@ class FrameworkExtension extends Extension
             }
         }
 
-        if (!$config['collect']) {
-            $container->getDefinition('profiler')->addMethodCall('disable', array());
-        }
+        $container->getDefinition('profiler')
+            ->addArgument($config['collect'])
+            ->addTag('kernel.reset', array('method' => 'reset'));
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -203,6 +203,14 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = array();
+    }
+
     public function lateCollect()
     {
         $this->data = $this->cloneVar($this->data);

--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -53,6 +53,15 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
         $this->data['total']['statistics'] = $this->calculateTotalStatistics();
     }
 
+    public function reset()
+    {
+        $this->data = array();
+        foreach ($this->instances as $instance) {
+            // Calling getCalls() will clear the calls.
+            $instance->getCalls();
+        }
+    }
+
     public function lateCollect()
     {
         $this->data = $this->cloneVar($this->data);

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+  * Implementing `TraceableEventDispatcherInterface` without the `reset()` method has been deprecated.
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -212,6 +212,11 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         return $notCalled;
     }
 
+    public function reset()
+    {
+        $this->called = array();
+    }
+
     /**
      * Proxies all method calls to the original event dispatcher.
      *

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
@@ -15,6 +15,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method reset() Resets the trace.
  */
 interface TraceableEventDispatcherInterface extends EventDispatcherInterface
 {

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -124,6 +124,21 @@ class TraceableEventDispatcherTest extends TestCase
         $this->assertEquals(array(), $tdispatcher->getNotCalledListeners());
     }
 
+    public function testClearCalledListeners()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', function () {}, 5);
+
+        $tdispatcher->dispatch('foo');
+        $tdispatcher->reset();
+
+        $listeners = $tdispatcher->getNotCalledListeners();
+        $this->assertArrayHasKey('stub', $listeners['foo.closure']);
+        unset($listeners['foo.closure']['stub']);
+        $this->assertEquals(array(), $tdispatcher->getCalledListeners());
+        $this->assertEquals(array('foo.closure' => array('event' => 'foo', 'pretty' => 'closure', 'priority' => 5)), $listeners);
+    }
+
     public function testGetCalledListenersNested()
     {
         $tdispatcher = null;

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -72,12 +72,9 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
     public function __construct(FormDataExtractorInterface $dataExtractor)
     {
         $this->dataExtractor = $dataExtractor;
-        $this->data = array(
-            'forms' => array(),
-            'forms_by_hash' => array(),
-            'nb_errors' => 0,
-        );
         $this->hasVarDumper = class_exists(ClassStub::class);
+
+        $this->reset();
     }
 
     /**
@@ -85,6 +82,15 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
+    }
+
+    public function reset()
+    {
+        $this->data = array(
+            'forms' => array(),
+            'forms_by_hash' => array(),
+            'nb_errors' => 0,
+        );
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -695,6 +695,36 @@ class FormDataCollectorTest extends TestCase
         $this->assertFalse(isset($child21Data['has_children_error']), 'The leaf data does not contains "has_children_error" property.');
     }
 
+    public function testReset()
+    {
+        $form = $this->createForm('my_form');
+
+        $this->dataExtractor->expects($this->any())
+            ->method('extractConfiguration')
+            ->will($this->returnValue(array()));
+        $this->dataExtractor->expects($this->any())
+            ->method('extractDefaultData')
+            ->will($this->returnValue(array()));
+        $this->dataExtractor->expects($this->any())
+            ->method('extractSubmittedData')
+            ->with($form)
+            ->will($this->returnValue(array('errors' => array('baz'))));
+
+        $this->dataCollector->buildPreliminaryFormTree($form);
+        $this->dataCollector->collectSubmittedData($form);
+
+        $this->dataCollector->reset();
+
+        $this->assertSame(
+            array(
+                'forms' => array(),
+                'forms_by_hash' => array(),
+                'nb_errors' => 0,
+            ),
+            $this->dataCollector->getData()
+        );
+    }
+
     private function createForm($name)
     {
         $builder = new FormBuilder($name, null, $this->dispatcher, $this->factory);

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -14,7 +14,9 @@ CHANGELOG
  * deprecated the `ChainCacheClearer::add()` method
  * deprecated the `CacheaWarmerAggregate::add()` and `setWarmers()` methods
  * made `CacheWarmerAggregate` and `ChainCacheClearer` classes final
-
+ * added the possibility to reset the profiler to its initial state
+ * deprecated data collectors without a `reset()` method
+ * deprecated implementing `DebugLoggerInterface` without a `clear()` method
 
 3.3.0
 -----

--- a/src/Symfony/Component/HttpKernel/DataCollector/AjaxDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/AjaxDataCollector.php
@@ -26,6 +26,11 @@ class AjaxDataCollector extends DataCollector
         // all collecting is done client side
     }
 
+    public function reset()
+    {
+        // all collecting is done client side
+    }
+
     public function getName()
     {
         return 'ajax';

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -95,6 +95,14 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = array();
+    }
+
     public function lateCollect()
     {
         $this->data = $this->cloneVar($this->data);

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpFoundation\Response;
  * DataCollectorInterface.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method reset() Resets this data collector to its initial state.
  */
 interface DataCollectorInterface
 {

--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -27,6 +27,9 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
 
     public function __construct(EventDispatcherInterface $dispatcher = null)
     {
+        if ($dispatcher instanceof TraceableEventDispatcherInterface && !method_exists($dispatcher, 'reset')) {
+            @trigger_error(sprintf('Implementing "%s" without the "reset()" method is deprecated since version 3.4 and will be unsupported in 4.0 for class "%s".', TraceableEventDispatcherInterface::class, \get_class($dispatcher)), E_USER_DEPRECATED);
+        }
         $this->dispatcher = $dispatcher;
     }
 
@@ -39,6 +42,19 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
             'called_listeners' => array(),
             'not_called_listeners' => array(),
         );
+    }
+
+    public function reset()
+    {
+        $this->data = array();
+
+        if ($this->dispatcher instanceof TraceableEventDispatcherInterface) {
+            if (!method_exists($this->dispatcher, 'reset')) {
+                return; // @deprecated
+            }
+
+            $this->dispatcher->reset();
+        }
     }
 
     public function lateCollect()

--- a/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
@@ -35,6 +35,14 @@ class ExceptionDataCollector extends DataCollector
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = array();
+    }
+
+    /**
      * Checks if the exception is not null.
      *
      * @return bool true if the exception is not null, false otherwise

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -29,6 +29,10 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
     public function __construct($logger = null, $containerPathPrefix = null)
     {
         if (null !== $logger && $logger instanceof DebugLoggerInterface) {
+            if (!method_exists($logger, 'clear')) {
+                @trigger_error(sprintf('Implementing "%s" without the "clear()" method is deprecated since version 3.4 and will be unsupported in 4.0 for class "%s".', DebugLoggerInterface::class, \get_class($logger)), E_USER_DEPRECATED);
+            }
+
             $this->logger = $logger;
         }
 
@@ -41,6 +45,17 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         // everything is done as late as possible
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        if ($this->logger && method_exists($this->logger, 'clear')) {
+            $this->logger->clear();
+        }
+        $this->data = array();
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DataCollector/MemoryDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/MemoryDataCollector.php
@@ -23,10 +23,7 @@ class MemoryDataCollector extends DataCollector implements LateDataCollectorInte
 {
     public function __construct()
     {
-        $this->data = array(
-            'memory' => 0,
-            'memory_limit' => $this->convertToBytes(ini_get('memory_limit')),
-        );
+        $this->reset();
     }
 
     /**
@@ -35,6 +32,17 @@ class MemoryDataCollector extends DataCollector implements LateDataCollectorInte
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         $this->updateMemoryUsage();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = array(
+            'memory' => 0,
+            'memory_limit' => $this->convertToBytes(ini_get('memory_limit')),
+        );
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -156,6 +156,12 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         $this->data = $this->cloneVar($this->data);
     }
 
+    public function reset()
+    {
+        $this->data = array();
+        $this->controllers = new \SplObjectStorage();
+    }
+
     public function getMethod()
     {
         return $this->data['method'];

--- a/src/Symfony/Component/HttpKernel/DataCollector/RouterDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RouterDataCollector.php
@@ -23,17 +23,14 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
  */
 class RouterDataCollector extends DataCollector
 {
+    /**
+     * @var \SplObjectStorage
+     */
     protected $controllers;
 
     public function __construct()
     {
-        $this->controllers = new \SplObjectStorage();
-
-        $this->data = array(
-            'redirect' => false,
-            'url' => null,
-            'route' => null,
-        );
+        $this->reset();
     }
 
     /**
@@ -51,6 +48,17 @@ class RouterDataCollector extends DataCollector
         }
 
         unset($this->controllers[$request]);
+    }
+
+    public function reset()
+    {
+        $this->controllers = new \SplObjectStorage();
+
+        $this->data = array(
+            'redirect' => false,
+            'url' => null,
+            'route' => null,
+        );
     }
 
     protected function guessRoute(Request $request, $controller)

--- a/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
@@ -52,6 +52,14 @@ class TimeDataCollector extends DataCollector implements LateDataCollectorInterf
     /**
      * {@inheritdoc}
      */
+    public function reset()
+    {
+        $this->data = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function lateCollect()
     {
         if (null !== $this->stopwatch && isset($this->data['token'])) {

--- a/src/Symfony/Component/HttpKernel/Log/DebugLoggerInterface.php
+++ b/src/Symfony/Component/HttpKernel/Log/DebugLoggerInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\HttpKernel\Log;
  * DebugLoggerInterface.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method clear() Removes all log records.
  */
 interface DebugLoggerInterface
 {

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ExceptionDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ExceptionDataCollectorTest.php
@@ -37,4 +37,23 @@ class ExceptionDataCollectorTest extends TestCase
         $this->assertSame('exception', $c->getName());
         $this->assertSame($trace, $c->getTrace());
     }
+
+    public function testCollectWithoutException()
+    {
+        $c = new ExceptionDataCollector();
+        $c->collect(new Request(), new Response());
+
+        $this->assertFalse($c->hasException());
+    }
+
+    public function testReset()
+    {
+        $c = new ExceptionDataCollector();
+
+        $c->collect(new Request(), new Response(), new \Exception());
+        $c->reset();
+        $c->collect(new Request(), new Response());
+
+        $this->assertFalse($c->hasException());
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -19,7 +19,10 @@ class LoggerDataCollectorTest extends TestCase
 {
     public function testCollectWithUnexpectedFormat()
     {
-        $logger = $this->getMockBuilder('Symfony\Component\HttpKernel\Log\DebugLoggerInterface')->getMock();
+        $logger = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Log\DebugLoggerInterface')
+            ->setMethods(array('countErrors', 'getLogs', 'clear'))
+            ->getMock();
         $logger->expects($this->once())->method('countErrors')->will($this->returnValue('foo'));
         $logger->expects($this->exactly(2))->method('getLogs')->will($this->returnValue(array()));
 
@@ -43,7 +46,10 @@ class LoggerDataCollectorTest extends TestCase
      */
     public function testCollect($nb, $logs, $expectedLogs, $expectedDeprecationCount, $expectedScreamCount, $expectedPriorities = null)
     {
-        $logger = $this->getMockBuilder('Symfony\Component\HttpKernel\Log\DebugLoggerInterface')->getMock();
+        $logger = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Log\DebugLoggerInterface')
+            ->setMethods(array('countErrors', 'getLogs', 'clear'))
+            ->getMock();
         $logger->expects($this->once())->method('countErrors')->will($this->returnValue($nb));
         $logger->expects($this->exactly(2))->method('getLogs')->will($this->returnValue($logs));
 
@@ -68,6 +74,18 @@ class LoggerDataCollectorTest extends TestCase
         if (isset($expectedPriorities)) {
             $this->assertSame($expectedPriorities, $c->getPriorities()->getValue(true));
         }
+    }
+
+    public function testReset()
+    {
+        $logger = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Log\DebugLoggerInterface')
+            ->setMethods(array('countErrors', 'getLogs', 'clear'))
+            ->getMock();
+        $logger->expects($this->once())->method('clear');
+
+        $c = new LoggerDataCollector($logger);
+        $c->reset();
     }
 
     public function getCollectTestData()

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/CloneVarDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/CloneVarDataCollector.php
@@ -29,6 +29,11 @@ class CloneVarDataCollector extends DataCollector
         $this->data = $this->cloneVar($this->varToClone);
     }
 
+    public function reset()
+    {
+        $this->data = array();
+    }
+
     public function getData()
     {
         return $this->data;

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/TestEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/TestEventDispatcher.php
@@ -25,4 +25,8 @@ class TestEventDispatcher extends EventDispatcher implements TraceableEventDispa
     {
         return array('bar');
     }
+
+    public function reset()
+    {
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Profiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
@@ -38,6 +39,19 @@ class ProfilerTest extends TestCase
         $this->assertSame(204, $profile->getStatusCode());
         $this->assertSame('GET', $profile->getMethod());
         $this->assertSame('bar', $profile->getCollector('request')->getRequestQuery()->all()['foo']->getValue());
+    }
+
+    public function testReset()
+    {
+        $collector = $this->getMockBuilder(DataCollectorInterface::class)
+            ->setMethods(['collect', 'getName', 'reset'])
+            ->getMock();
+        $collector->expects($this->any())->method('getName')->willReturn('mock');
+        $collector->expects($this->once())->method('reset');
+
+        $profiler = new Profiler($this->storage);
+        $profiler->add($collector);
+        $profiler->reset();
     }
 
     public function testFindWorksWithDates()

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -59,6 +59,14 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = array();
+    }
+
+    /**
      * @return array
      */
     public function getMessages()

--- a/src/Symfony/Component/Validator/DataCollector/ValidatorDataCollector.php
+++ b/src/Symfony/Component/Validator/DataCollector/ValidatorDataCollector.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\Validator\Validator\TraceableValidator;
 use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Caster\ClassStub;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
@@ -31,10 +32,7 @@ class ValidatorDataCollector extends DataCollector implements LateDataCollectorI
     public function __construct(TraceableValidator $validator)
     {
         $this->validator = $validator;
-        $this->data = array(
-            'calls' => array(),
-            'violations_count' => 0,
-        );
+        $this->reset();
     }
 
     /**
@@ -45,6 +43,15 @@ class ValidatorDataCollector extends DataCollector implements LateDataCollectorI
         // Everything is collected once, on kernel terminate.
     }
 
+    public function reset()
+    {
+        $this->validator->reset();
+        $this->data = array(
+            'calls' => $this->cloneVar(array()),
+            'violations_count' => 0,
+        );
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -52,16 +59,22 @@ class ValidatorDataCollector extends DataCollector implements LateDataCollectorI
     {
         $collected = $this->validator->getCollectedData();
         $this->data['calls'] = $this->cloneVar($collected);
-        $this->data['violations_count'] += array_reduce($collected, function ($previous, $item) {
-            return $previous += count($item['violations']);
+        $this->data['violations_count'] = array_reduce($collected, function ($previous, $item) {
+            return $previous + count($item['violations']);
         }, 0);
     }
 
+    /**
+     * @return Data
+     */
     public function getCalls()
     {
         return $this->data['calls'];
     }
 
+    /**
+     * @return int
+     */
     public function getViolationsCount()
     {
         return $this->data['violations_count'];

--- a/src/Symfony/Component/Validator/Tests/DataCollector/ValidatorDataCollectorTest.php
+++ b/src/Symfony/Component/Validator/Tests/DataCollector/ValidatorDataCollectorTest.php
@@ -50,6 +50,33 @@ class ValidatorDataCollectorTest extends TestCase
         $this->assertCount(2, $call['violations']);
     }
 
+    public function testReset()
+    {
+        $originalValidator = $this->createMock(ValidatorInterface::class);
+        $validator = new TraceableValidator($originalValidator);
+
+        $collector = new ValidatorDataCollector($validator);
+
+        $violations = new ConstraintViolationList(array(
+            $this->createMock(ConstraintViolation::class),
+            $this->createMock(ConstraintViolation::class),
+        ));
+        $originalValidator->method('validate')->willReturn($violations);
+
+        $validator->validate(new \stdClass());
+
+        $collector->lateCollect();
+        $collector->reset();
+
+        $this->assertCount(0, $collector->getCalls());
+        $this->assertSame(0, $collector->getViolationsCount());
+
+        $collector->lateCollect();
+
+        $this->assertCount(0, $collector->getCalls());
+        $this->assertSame(0, $collector->getViolationsCount());
+    }
+
     protected function createMock($classname)
     {
         return $this->getMockBuilder($classname)->disableOriginalConstructor()->getMock();

--- a/src/Symfony/Component/Validator/Validator/TraceableValidator.php
+++ b/src/Symfony/Component/Validator/Validator/TraceableValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Validator;
 
-use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
@@ -30,11 +29,16 @@ class TraceableValidator implements ValidatorInterface
     }
 
     /**
-     * @return ConstraintViolationList[]
+     * @return array
      */
     public function getCollectedData()
     {
         return $this->collectedData;
+    }
+
+    public function reset()
+    {
+        $this->collectedData = array();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #18244
| License       | MIT
| Doc PR        | N/A

This PR adds the ability to reset the profiler between requests. Furthermore, the profiler service has been tagged with the new `kernel.reset` tag from #24155. For this, I had to readd the ability to define multiple reset methods for a service.

Note: This PR requires twigphp/Twig#2560.