### PR TITLE
[HttpKernel] Deprecate auto-discovery in Kernel::getName()

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -21,7 +21,7 @@ class NoTemplatingEntryTest extends TestCase
 {
     public function test()
     {
-        $kernel = new NoTemplatingEntryKernel('dev', true);
+        $kernel = new NoTemplatingEntryKernel('dev', true, 'app');
         $kernel->boot();
 
         $container = $kernel->getContainer();

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/config": "~3.2|~4.0",
         "symfony/twig-bridge": "^3.4|~4.0",
         "symfony/http-foundation": "~2.8|~3.0|~4.0",
-        "symfony/http-kernel": "^3.3|~4.0",
+        "symfony/http-kernel": "^3.4|~4.0",
         "twig/twig": "~1.34|~2.4"
     },
     "require-dev": {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -78,15 +78,23 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     /**
      * Constructor.
      *
-     * @param string $environment The environment
-     * @param bool   $debug       Whether to enable debugging or not
+     * @param string      $environment The environment
+     * @param bool        $debug       Whether to enable debugging or not
+     * @param string|null $name        The application name
      */
-    public function __construct($environment, $debug)
+    public function __construct($environment, $debug, $name = null)
     {
         $this->environment = $environment;
         $this->debug = (bool) $debug;
         $this->rootDir = $this->getRootDir();
-        $this->name = $this->getName();
+
+        if (null === $name) {
+            $this->name = $this->getName();
+        } elseif (preg_match('~^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$~', $name)) {
+            $this->name = $name;
+        } else {
+            throw new \InvalidArgumentException(sprintf('"%s" is not a valid kernel name.', $name));
+        }
 
         if ($this->debug) {
             $this->startTime = microtime(true);
@@ -296,6 +304,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             $this->name = preg_replace('/[^a-zA-Z0-9_]+/', '', basename($this->rootDir));
             if (ctype_digit($this->name[0])) {
                 $this->name = '_'.$this->name;
+            }
+
+            if ('app' !== $this->name) {
+                @trigger_error(sprintf('Auto-discovery of the kernel name is deprecated since Symfony 3.4 and won\'t be supported in 4.0.'), E_USER_DEPRECATED);
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
@@ -16,6 +16,11 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 
 class KernelForTest extends Kernel
 {
+    public function __construct($environment, $debug, $name = 'app')
+    {
+        parent::__construct($environment, $debug, $name);
+    }
+
     public function getBundleMap()
     {
         return $this->bundleMap;

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelWithoutBundles.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelWithoutBundles.php
@@ -17,6 +17,11 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class KernelWithoutBundles extends Kernel
 {
+    public function __construct($environment, $debug, $name = 'app')
+    {
+        parent::__construct($environment, $debug, $name);
+    }
+
     public function registerBundles()
     {
         return array();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | almost
| Fixed tickets | https://github.com/symfony/recipes/pull/186
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

The auto-discovery of kernel name doesnt work well with new structure. You probably want to override it.

@fabpot suggested to get rid of getName(), however; this is an important feature actually. It enables multi-kernel approach. See https://github.com/yceruto/symfony-skeleton-vkernel for example, but also things like  `ApiKernel`, `AppKernel` live today. 

In core it's crucial for `Kernel::getContainerClass()` and  `%kernel.name%` might being used a lot today. So the concept of a kernel name should not be deprecated to me.

This PR suggests the default kernel name will be `"app"` in 4.0, but any other can be specified as constructor arg. I.e. set it from APP_NAME env.

cc @yceruto 