### PR TITLE
Feature/doctrine type guesser simple json array support

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * deprecated injecting `ClassMetadataFactory` in `DoctrineExtractor`,
    an instance of `EntityManagerInterface` should be injected instead
+ * added support for `simple_array` type
 
 4.1.0
 -----

--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -53,6 +53,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
 
         switch ($metadata->getTypeOfField($property)) {
             case Type::TARRAY:
+            case Type::SIMPLE_ARRAY:
                 return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), Guess::MEDIUM_CONFIDENCE);
             case Type::BOOLEAN:
                 return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(), Guess::HIGH_CONFIDENCE);


### PR DESCRIPTION
Symfony currently supports doctrine/dbal ~2.4 which has support for both `simple_array` and `json_array`:

https://github.com/doctrine/dbal/commit/44cd77f0228784b61d1109e98512bfe61df07924
https://github.com/doctrine/dbal/commit/2d183acdf06596ade895d2de9a39e756bce3a5af

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

There's technically a small BC break since `simple_array` and `json_array` fields would've been displayed as simple text fields. Is this an acceptable BC break for Symfony 3.4?