### PR TITLE
[Validator] MethodMapping as last MetaDataFactory Loader

### DIFF
--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -304,7 +304,6 @@ class ValidatorBuilder implements ValidatorBuilderInterface
             $loaders[] = new StaticMethodLoader($methodName);
         }
 
-
         return $loaders;
     }
 

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -295,14 +295,15 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         foreach ($this->yamlMappings as $yamlMappings) {
             $loaders[] = new YamlFileLoader($yamlMappings);
         }
-
-        foreach ($this->methodMappings as $methodName) {
-            $loaders[] = new StaticMethodLoader($methodName);
-        }
-
+        
         if ($this->annotationReader) {
             $loaders[] = new AnnotationLoader($this->annotationReader);
         }
+        
+        foreach ($this->methodMappings as $methodName) {
+            $loaders[] = new StaticMethodLoader($methodName);
+        }
+        
 
         return $loaders;
     }

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -295,15 +295,15 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         foreach ($this->yamlMappings as $yamlMappings) {
             $loaders[] = new YamlFileLoader($yamlMappings);
         }
-        
+
         if ($this->annotationReader) {
             $loaders[] = new AnnotationLoader($this->annotationReader);
         }
-        
+
         foreach ($this->methodMappings as $methodName) {
             $loaders[] = new StaticMethodLoader($methodName);
         }
-        
+
 
         return $loaders;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| BC breaks?    | no
| Deprecations? |no 
| Fixed tickets | #24299
| License       | MIT

I wanted to achieve that my Serializer Groups are set to the Validation Constraint, so i don´t have  add lot of same lines in my annotations. 

Currently the MethodMappings call in the ValidationBuilder is  before the AnnotationLoader, so if i pass the metaData into my Class to validate, its empty (i´m  just using annotation validation).
By moving it as last addition to the loader array, it is now possible to handle the metaData dynamically. 

e.g.

    public static function loadValidatorMetadata(ClassMetadata $metaData){
        $props = self::getSerializerProperties(self::class);
        if(count($props) > 0){
           foreach($metaData->properties as $propertyMetadata){
               if($props->available($propertyMetadata->getName(), "groups")){
                   foreach ($propertyMetadata->constraints as $constraint){
                       $constraint->groups = $props->get($propertyMetadata->getName(), "groups")
                   }
               }
           }
        }
    }
