### PR TITLE
[FrameworkBundle] allow forms without translations and validator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
@@ -12,7 +12,7 @@
             <argument type="service" id="security.csrf.token_manager" />
             <argument>%form.type_extension.csrf.enabled%</argument>
             <argument>%form.type_extension.csrf.field_name%</argument>
-            <argument type="service" id="translator" />
+            <argument type="service" id="translator" on-invalid="null" />
             <argument>%validator.translation_domain%</argument>
             <argument type="service" id="form.server_params" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | symfony/flex#26, symfony/recipes#191, symfony/recipes#193
| License       | MIT
| Doc PR        | 

The Form component is perfectly usable without the Translation and Validator components. We should allow the same when using the FrameworkBundle to improve the user experience in Symfony Flex applications (see the linked issue).