### PR TITLE
[Validator] support protocolless urls validation

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -104,6 +104,7 @@ class Url extends Constraint
      * @deprecated since Symfony 4.1, to be removed in 5.0
      */
     public $checkDNS = self::CHECK_DNS_TYPE_NONE;
+    public $relativeProtocol = false;
 
     public function __construct($options = null)
     {

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -61,7 +61,8 @@ class UrlValidator extends ConstraintValidator
             return;
         }
 
-        $pattern = sprintf(static::PATTERN, implode('|', $constraint->protocols));
+        $pattern = $constraint->relativeProtocol ? str_replace('(%s):', '(?:(%s):)?', static::PATTERN) : static::PATTERN;
+        $pattern = sprintf($pattern, implode('|', $constraint->protocols));
 
         if (!preg_match($pattern, $value)) {
             $this->context->buildViolation($constraint->message)

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -65,6 +65,30 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @dataProvider getValidRelativeUrls
+     * @dataProvider getValidUrls
+     */
+    public function testValidRelativeUrl($url)
+    {
+        $constraint = new Url(array(
+            'relativeProtocol' => true,
+        ));
+
+        $this->validator->validate($url, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidRelativeUrls()
+    {
+        return array(
+            array('//google.com'),
+            array('//symfony.fake/blog/'),
+            array('//symfony.com/search?type=&q=url+validator'),
+        );
+    }
+
     public function getValidUrls()
     {
         return array(
@@ -145,6 +169,46 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ value }}', '"'.$url.'"')
             ->setCode(Url::INVALID_URL_ERROR)
             ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getInvalidRelativeUrls
+     * @dataProvider getInvalidUrls
+     */
+    public function testInvalidRelativeUrl($url)
+    {
+        $constraint = new Url(array(
+            'message' => 'myMessage',
+            'relativeProtocol' => true,
+        ));
+
+        $this->validator->validate($url, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$url.'"')
+            ->setCode(Url::INVALID_URL_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidRelativeUrls()
+    {
+        return array(
+            array('/google.com'),
+            array('//goog_le.com'),
+            array('//google.com::aa'),
+            array('//google.com:aa'),
+            array('//127.0.0.1:aa/'),
+            array('//[::1'),
+            array('//hello.☎/'),
+            array('//:password@symfony.com'),
+            array('//:password@@symfony.com'),
+            array('//username:passwordsymfony.com'),
+            array('//usern@me:password@symfony.com'),
+            array('//example.com/exploit.html?<script>alert(1);</script>'),
+            array('//example.com/exploit.html?hel lo'),
+            array('//example.com/exploit.html?not_a%hex'),
+            array('//'),
+        );
     }
 
     public function getInvalidUrls()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24287 
| License       | MIT

As specified in issue #24287 URL's starting with no protocol but with just `//` are valid URL's and should be accepted by the validator. This pull request fixes the regex used to validate URL's. 