### PR TITLE
[SecurityBundle] fix allow_if expression service compilation to support custom functions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
@@ -36,10 +36,10 @@ class AddExpressionLanguageProvidersPass implements CompilerPassInterface
         }
 
         // security
-        if ($container->has('security.access.expression_voter')) {
-            $definition = $container->findDefinition('security.access.expression_voter');
+        if ($container->has('security.expression_language')) {
+            $definition = $container->findDefinition('security.expression_language');
             foreach ($container->findTaggedServiceIds('security.expression_language_provider') as $id => $attributes) {
-                $definition->addMethodCall('addExpressionLanguageProvider', array(new Reference($id)));
+                $definition->addMethodCall('registerProvider', array(new Reference($id)));
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ParseSecurityExpressionsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ParseSecurityExpressionsPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Parses expressions used in the security access_control configuration to make sure they are dumped as SerializedParsedExpression
+ * This compiler pass must be registered after AddExpressionLanguageProvidersPass so custom functions can also be parsed.
+ *
+ * @author David Maicher <mail@dmaicher.de>
+ */
+class ParseSecurityExpressionsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('security.expression_language')) {
+            return;
+        }
+
+        $expressionLanguage = $container->get('security.expression_language');
+
+        foreach ($container->findTaggedServiceIds('security.expression.unparsed') as $id => $attributes) {
+            $defition = $container->getDefinition($id);
+            $defition
+                ->setClass('Symfony\Component\ExpressionLanguage\SerializedParsedExpression')
+                ->addArgument(serialize($expressionLanguage->parse($defition->getArgument(0), array('token', 'user', 'object', 'roles', 'request', 'trust_resolver'))->getNodes()))
+                ->setTags(array());
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ParseSecurityExpressionsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ParseSecurityExpressionsPass.php
@@ -31,10 +31,10 @@ class ParseSecurityExpressionsPass implements CompilerPassInterface
         $expressionLanguage = $container->get('security.expression_language');
 
         foreach ($container->findTaggedServiceIds('security.expression') as $id => $attributes) {
-            $defition = $container->getDefinition($id);
-            $defition
+            $definition = $container->getDefinition($id);
+            $definition
                 ->setClass('Symfony\Component\ExpressionLanguage\SerializedParsedExpression')
-                ->addArgument(serialize($expressionLanguage->parse($defition->getArgument(0), array('token', 'user', 'object', 'roles', 'request', 'trust_resolver'))->getNodes()))
+                ->addArgument(serialize($expressionLanguage->parse($definition->getArgument(0), array('token', 'user', 'object', 'roles', 'request', 'trust_resolver'))->getNodes()))
                 ->setTags(array());
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ParseSecurityExpressionsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ParseSecurityExpressionsPass.php
@@ -30,7 +30,7 @@ class ParseSecurityExpressionsPass implements CompilerPassInterface
 
         $expressionLanguage = $container->get('security.expression_language');
 
-        foreach ($container->findTaggedServiceIds('security.expression.unparsed') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('security.expression') as $id => $attributes) {
             $defition = $container->getDefinition($id);
             $defition
                 ->setClass('Symfony\Component\ExpressionLanguage\SerializedParsedExpression')

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddValidatorInit
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConsoleCommandPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DataCollectorTranslatorPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ParseSecurityExpressionsPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TemplatingPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RoutingResolverPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
@@ -85,6 +86,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new AddCacheWarmerPass());
         $container->addCompilerPass(new AddCacheClearerPass());
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
+        $container->addCompilerPass(new ParseSecurityExpressionsPass()); // must be registered after AddExpressionLanguageProvidersPass
         $container->addCompilerPass(new TranslationExtractorPass());
         $container->addCompilerPass(new TranslationDumperPass());
         $container->addCompilerPass(new FragmentRendererPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
@@ -24,7 +24,7 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition = new Definition('\stdClass');
         $definition->addTag('routing.expression_language_provider');
         $container->setDefinition('some_routing_provider', $definition);
 
@@ -43,7 +43,7 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition = new Definition('\stdClass');
         $definition->addTag('routing.expression_language_provider');
         $container->setDefinition('some_routing_provider', $definition);
 
@@ -63,17 +63,16 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition = new Definition('\stdClass');
         $definition->addTag('security.expression_language_provider');
         $container->setDefinition('some_security_provider', $definition);
 
-        $container->register('security.access.expression_voter', '\stdClass');
+        $container->register('security.expression_language', '\stdClass');
         $container->compile();
 
-        $router = $container->getDefinition('security.access.expression_voter');
-        $calls = $router->getMethodCalls();
+        $calls = $container->getDefinition('security.expression_language')->getMethodCalls();
         $this->assertCount(1, $calls);
-        $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);
+        $this->assertEquals('registerProvider', $calls[0][0]);
         $this->assertEquals(new Reference('some_security_provider'), $calls[0][1][0]);
     }
 
@@ -82,22 +81,17 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition = new Definition('\stdClass');
         $definition->addTag('security.expression_language_provider');
         $container->setDefinition('some_security_provider', $definition);
 
-        $container->register('my_security.access.expression_voter', '\stdClass');
-        $container->setAlias('security.access.expression_voter', 'my_security.access.expression_voter');
+        $container->register('my.security.expression_language', '\stdClass');
+        $container->setAlias('security.expression_language', 'my.security.expression_language');
         $container->compile();
 
-        $router = $container->getDefinition('my_security.access.expression_voter');
-        $calls = $router->getMethodCalls();
+        $calls = $container->getDefinition('my.security.expression_language')->getMethodCalls();
         $this->assertCount(1, $calls);
-        $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);
+        $this->assertEquals('registerProvider', $calls[0][0]);
         $this->assertEquals(new Reference('some_security_provider'), $calls[0][1][0]);
     }
-}
-
-class TestProvider
-{
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ParseSecurityExpressionsPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ParseSecurityExpressionsPassTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ParseSecurityExpressionsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ParseSecurityExpressionsPassTest extends TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new ParseSecurityExpressionsPass());
+        $container->register('security.expression_language', 'Symfony\Component\Security\Core\Authorization\ExpressionLanguage');
+
+        $container->register('security.expression.one', 'Symfony\Component\ExpressionLanguage\Expression')
+            ->addArgument('true or false')
+            ->addTag('security.expression.unparsed');
+
+        $container->register('security.expression.two', 'Symfony\Component\ExpressionLanguage\Expression')
+            ->addArgument('false or true')
+            ->addTag('security.expression.unparsed');
+
+        $container->compile();
+
+        $expressionOne = $container->getDefinition('security.expression.one');
+        $this->assertSame('Symfony\Component\ExpressionLanguage\SerializedParsedExpression', $expressionOne->getClass());
+        $this->assertInstanceOf('Symfony\Component\ExpressionLanguage\Node\BinaryNode', unserialize($expressionOne->getArgument(1)));
+
+        $expressionTwo = $container->getDefinition('security.expression.one');
+        $this->assertSame('Symfony\Component\ExpressionLanguage\SerializedParsedExpression', $expressionTwo->getClass());
+        $this->assertInstanceOf('Symfony\Component\ExpressionLanguage\Node\BinaryNode', unserialize($expressionTwo->getArgument(1)));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ParseSecurityExpressionsPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ParseSecurityExpressionsPassTest.php
@@ -25,11 +25,11 @@ class ParseSecurityExpressionsPassTest extends TestCase
 
         $container->register('security.expression.one', 'Symfony\Component\ExpressionLanguage\Expression')
             ->addArgument('true or false')
-            ->addTag('security.expression.unparsed');
+            ->addTag('security.expression');
 
         $container->register('security.expression.two', 'Symfony\Component\ExpressionLanguage\Expression')
             ->addArgument('false or true')
-            ->addTag('security.expression.unparsed');
+            ->addTag('security.expression');
 
         $container->compile();
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -590,7 +590,7 @@ class SecurityExtension extends Extension
             ->register($id, 'Symfony\Component\ExpressionLanguage\Expression')
             ->setPublic(false)
             ->addArgument($expression)
-            ->addTag('security.expression.unparsed')
+            ->addTag('security.expression')
         ;
 
         return $this->expressions[$id] = new Reference($id);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23208
| License       | MIT
| Doc PR        | -

I would like to discuss possibilities to fix https://github.com/symfony/symfony/issues/23208 (also see closed duplicate https://github.com/symfony/symfony/issues/24306).

~~The proposed solution in this PR is to simply not dump the parsed expression but simply the "raw" expressions~~

~~**Question: Will this have a big negative performance impact?** As far as I understand the `ExpressionLanguage` should have a cache anyway for parsed expressions? Or not?~~

~~Idea: maybe we can add an additional `CacheWarmer` that warms the cache for all those expressions?~~

~~Or is there a way to perform the compilation into parsed expressions at the very end of the container compilation when we could instantiate the actual `ExpressionLanguage` service with all its custom extensions?~~

Edit: the new approach is to still dump the parsed expressions but we do it using the "real" expression language service with all custom extensions.
