### PR TITLE
[DI] Fix tracking of bound arguments when using autoconfiguration

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -90,9 +90,11 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
         }
 
         if ($parent) {
+            $bindings = $definition->getBindings();
             $abstract = $container->setDefinition('abstract.instanceof.'.$id, $definition);
 
             // cast Definition to ChildDefinition
+            $definition->setBindings(array());
             $definition = serialize($definition);
             $definition = substr_replace($definition, '53', 2, 2);
             $definition = substr_replace($definition, 'Child', 44, 0);
@@ -117,6 +119,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
 
             // reset fields with "merge" behavior
             $abstract
+                ->setBindings($bindings)
                 ->setArguments(array())
                 ->setMethodCalls(array())
                 ->setTags(array())

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
@@ -38,6 +38,8 @@ trait ParentTrait
             $this->definition->setParent($parent);
         } elseif ($this->definition->isAutoconfigured()) {
             throw new InvalidArgumentException(sprintf('The service "%s" cannot have a "parent" and also have "autoconfigure". Try disabling autoconfiguration for the service.', $this->id));
+        } elseif ($this->definition->getBindings()) {
+            throw new InvalidArgumentException(sprintf('The service "%s" cannot have a "parent" and also "bind" arguments.', $this->id));
         } else {
             // cast Definition to ChildDefinition
             $definition = serialize($this->definition);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

An exception is currently thrown when using arguments bindings on an autoconfigured controller action.
This fixes the issue.