### PR TITLE
added ability to handle parent classes for PropertyNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -163,22 +163,15 @@ class PropertyNormalizer extends AbstractObjectNormalizer
      */
     private function getReflectionProperty($classOrObject, $attribute)
     {
-        $class = is_string($classOrObject) ? $classOrObject : get_class($classOrObject);
-
-        try {
-            return new \ReflectionProperty($class, $attribute);
-        } catch (\ReflectionException $e) {
-            $class = new \ReflectionClass($class);
-
-            while ($parent = $class->getParentClass()) {
-                try {
-                    return new \ReflectionProperty($parent->getName(), $attribute);
-                } catch (\ReflectionException $e) {
-                    $class = $parent;
+        $reflectionClass = new \ReflectionClass($classOrObject);
+        while (true) {
+            try {
+                return $reflectionClass->getProperty($attribute);
+            } catch (\ReflectionException $e) {
+                if (!$reflectionClass = $reflectionClass->getParentClass()) {
+                    throw $e;
                 }
             }
-
-            throw $e;
         }
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummyChild.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummyChild.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class GroupDummyChild extends GroupDummy
+{
+    private $baz;
+
+    /**
+     * @return mixed
+     */
+    public function getBaz()
+    {
+        return $this->baz;
+    }
+
+    /**
+     * @param mixed $baz
+     */
+    public function setBaz($baz)
+    {
+        $this->baz = $baz;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -65,6 +65,33 @@ class PropertyNormalizerTest extends TestCase
         $this->assertEquals('bar', $obj->getBar());
     }
 
+    public function testNormalizeWithParentClass()
+    {
+        $group = new GroupDummy();
+        $group->setFoo('foo');
+        $group->setBar('bar');
+        $group->setKevin('Kevin');
+        $group->setCoopTilleuls('coop');
+        $this->assertEquals(
+            array('foo' => 'foo', 'bar' => 'bar', 'kevin' => 'Kevin',
+                  'coopTilleuls' => 'coop', 'fooBar' => null, 'symfony' => null, ),
+            $this->normalizer->normalize($group, 'any')
+        );
+    }
+
+    public function testDenormalizeWithParentClass()
+    {
+        $obj = $this->normalizer->denormalize(
+            array('foo' => 'foo', 'bar' => 'bar', 'kevin' => 'Kevin'),
+            GroupDummy::class,
+            'any'
+        );
+        $this->assertEquals('foo', $obj->getFoo());
+        $this->assertEquals('bar', $obj->getBar());
+        $this->assertEquals('Kevin', $obj->getKevin());
+        $this->assertNull($obj->getSymfony());
+    }
+
     public function testConstructorDenormalize()
     {
         $obj = $this->normalizer->denormalize(
@@ -147,12 +174,14 @@ class PropertyNormalizerTest extends TestCase
             'bar' => 'bar',
         ), $this->normalizer->normalize($obj, null, array(PropertyNormalizer::GROUPS => array('c'))));
 
-        // The PropertyNormalizer is not able to hydrate properties from parent classes
+        // The PropertyNormalizer is also able to hydrate properties from parent classes
         $this->assertEquals(array(
             'symfony' => 'symfony',
             'foo' => 'foo',
             'fooBar' => 'fooBar',
             'bar' => 'bar',
+            'kevin' => 'kevin',
+            'coopTilleuls' => 'coopTilleuls',
         ), $this->normalizer->normalize($obj, null, array(PropertyNormalizer::GROUPS => array('a', 'c'))));
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\GroupDummyChild;
 use Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\PropertyCircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\PropertySiblingHolder;
@@ -67,14 +68,15 @@ class PropertyNormalizerTest extends TestCase
 
     public function testNormalizeWithParentClass()
     {
-        $group = new GroupDummy();
+        $group = new GroupDummyChild();
+        $group->setBaz('baz');
         $group->setFoo('foo');
         $group->setBar('bar');
         $group->setKevin('Kevin');
         $group->setCoopTilleuls('coop');
         $this->assertEquals(
             array('foo' => 'foo', 'bar' => 'bar', 'kevin' => 'Kevin',
-                  'coopTilleuls' => 'coop', 'fooBar' => null, 'symfony' => null, ),
+                  'coopTilleuls' => 'coop', 'fooBar' => null, 'symfony' => null, 'baz' => 'baz', ),
             $this->normalizer->normalize($group, 'any')
         );
     }
@@ -82,13 +84,14 @@ class PropertyNormalizerTest extends TestCase
     public function testDenormalizeWithParentClass()
     {
         $obj = $this->normalizer->denormalize(
-            array('foo' => 'foo', 'bar' => 'bar', 'kevin' => 'Kevin'),
-            GroupDummy::class,
+            array('foo' => 'foo', 'bar' => 'bar', 'kevin' => 'Kevin', 'baz' => 'baz'),
+            GroupDummyChild::class,
             'any'
         );
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
         $this->assertEquals('Kevin', $obj->getKevin());
+        $this->assertEquals('baz', $obj->getBaz());
         $this->assertNull($obj->getSymfony());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24152 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

This adds the ability for PropertyNormalizer to normalize/denormalize properties from parent classes.