### PR TITLE
Adding a new RefreshableRolesTokenInterface to refresh security roles

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RefreshableRolesTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RefreshableRolesTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class RefreshableRolesTest extends WebTestCase
+{
+    public function testRolesAreRefreshed()
+    {
+        // log them in!
+        $client = $this->createAuthenticatedClient('cool_user');
+
+        // refresh the page, roles have not changed yet
+        $client->request('GET', '/profile');
+        $rolesData = $client->getProfile()->getCollector('security')->getRoles();
+        $this->assertCount(1, $rolesData);
+        $this->assertEquals('ROLE_ORIGINAL', $rolesData[0]);
+
+        // this will cause the refreshed user to have these new roles
+        $client->request('GET', '/profile?new_role=ROLE_NEW');
+        $rolesData = $client->getProfile()->getCollector('security')->getRoles();
+        $this->assertCount(1, $rolesData);
+        $this->assertEquals('ROLE_NEW', $rolesData[0]);
+
+        // the change should be persistent
+        $client->request('GET', '/profile');
+        $rolesData = $client->getProfile()->getCollector('security')->getRoles();
+        $this->assertCount(1, $rolesData);
+        $this->assertEquals('ROLE_NEW', $rolesData[0]);
+    }
+
+    private function createAuthenticatedClient($username)
+    {
+        $client = $this->createClient(array('test_case' => 'StandardFormLogin', 'root_config' => 'refreshable_roles.yml'));
+        $client->followRedirects(true);
+
+        $form = $client->request('GET', '/login')->selectButton('login')->form();
+        $form['_username'] = $username;
+        $form['_password'] = 'test';
+        $client->submit($form);
+
+        return $client;
+    }
+}
+
+class RefreshableRolesUserProvider implements UserProviderInterface
+{
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function loadUserByUsername($username)
+    {
+        return new RefreshableUser($username, array('ROLE_ORIGINAL'));
+    }
+
+    public function refreshUser(UserInterface $user)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        // a sneaky way of faking the stored user's roles being changed
+        if ($request->query->has('new_role')) {
+            $user->setRoles(array($request->query->get('new_role')));
+        }
+
+        return $user;
+    }
+
+    public function supportsClass($class)
+    {
+        return RefreshableUser::class === $class;
+    }
+}
+
+class RefreshableUser implements UserInterface
+{
+    private $username;
+    private $roles;
+
+    public function __construct($username, array $roles)
+    {
+        $this->username = $username;
+        $this->roles = $roles;
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+
+    public function setRoles($roles)
+    {
+        $this->roles = $roles;
+    }
+
+    public function getPassword()
+    {
+        return 'test';
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/refreshable_roles.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/refreshable_roles.yml
@@ -1,0 +1,29 @@
+imports:
+    - { resource: ./../config/default.yml }
+
+services:
+    refreshable_roles_user_provider:
+      class: Symfony\Bundle\SecurityBundle\Tests\Functional\RefreshableRolesUserProvider
+      arguments: ['@request_stack']
+
+security:
+    encoders:
+        Symfony\Bundle\SecurityBundle\Tests\Functional\RefreshableUser: plaintext
+
+    providers:
+        all_users:
+            id: refreshable_roles_user_provider
+
+    firewalls:
+        # This firewall doesn't make sense in combination with the rest of the
+        # configuration file, but it's here for testing purposes (do not use
+        # this file in a real world scenario though)
+        login_form:
+            pattern: ^/login$
+            security: false
+
+        default:
+            form_login:
+                check_path: /login_check
+                default_target_path: /profile
+            anonymous: ~

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -222,7 +222,7 @@ abstract class AbstractToken implements TokenInterface, RefreshableRolesTokenInt
      */
     public function updateRoles(array $roles)
     {
-        $this->roles = [];
+        $this->roles = array();
 
         foreach ($roles as $role) {
             if (is_string($role)) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\User\EquatableInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-abstract class AbstractToken implements TokenInterface
+abstract class AbstractToken implements TokenInterface, RefreshableRolesTokenInterface
 {
     private $user;
     private $roles = array();
@@ -39,15 +39,7 @@ abstract class AbstractToken implements TokenInterface
      */
     public function __construct(array $roles = array())
     {
-        foreach ($roles as $role) {
-            if (is_string($role)) {
-                $role = new Role($role);
-            } elseif (!$role instanceof RoleInterface) {
-                throw new \InvalidArgumentException(sprintf('$roles must be an array of strings, Role instances or RoleInterface instances, but got %s.', gettype($role)));
-            }
-
-            $this->roles[] = $role;
-        }
+        $this->updateRoles($roles);
     }
 
     /**
@@ -223,6 +215,24 @@ abstract class AbstractToken implements TokenInterface
     public function setAttribute($name, $value)
     {
         $this->attributes[$name] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateRoles(array $roles)
+    {
+        $this->roles = [];
+
+        foreach ($roles as $role) {
+            if (is_string($role)) {
+                $role = new Role($role);
+            } elseif (!$role instanceof RoleInterface) {
+                throw new \InvalidArgumentException(sprintf('$roles must be an array of strings, Role instances or RoleInterface instances, but got %s.', gettype($role)));
+            }
+
+            $this->roles[] = $role;
+        }
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -29,6 +29,7 @@ abstract class AbstractToken implements TokenInterface, RefreshableRolesTokenInt
     private $roles = array();
     private $authenticated = false;
     private $attributes = array();
+    private $shouldUpdateRoles = false;
 
     /**
      * Constructor.
@@ -238,6 +239,14 @@ abstract class AbstractToken implements TokenInterface, RefreshableRolesTokenInt
     /**
      * {@inheritdoc}
      */
+    public function shouldUpdateRoles()
+    {
+        return $this->shouldUpdateRoles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function __toString()
     {
         $class = get_class($this);
@@ -249,6 +258,18 @@ abstract class AbstractToken implements TokenInterface, RefreshableRolesTokenInt
         }
 
         return sprintf('%s(user="%s", authenticated=%s, roles="%s")', $class, $this->getUsername(), json_encode($this->authenticated), implode(', ', $roles));
+    }
+
+    /**
+     * Call this from a sub-class if you want the token's roles
+     * to be updated from UserInterface::getRoles() on each
+     * page refresh (when using session-based authentication).
+     *
+     * @param bool $shouldUpdateRoles
+     */
+    protected function setShouldUpdateRoles($shouldUpdateRoles)
+    {
+        $this->shouldUpdateRoles = $shouldUpdateRoles;
     }
 
     private function hasUserChanged(UserInterface $user)

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
 use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * AnonymousToken represents an anonymous token.
@@ -36,6 +37,8 @@ class AnonymousToken extends AbstractToken
         $this->secret = $secret;
         $this->setUser($user);
         $this->setAuthenticated(true);
+
+        $this->setShouldUpdateRoles($user instanceof UserInterface && $user->getRoles() === $roles);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
+use Symfony\Component\Security\Core\User\UserInterface;
+
 /**
  * PreAuthenticatedToken implements a pre-authenticated token.
  *
@@ -44,6 +46,8 @@ class PreAuthenticatedToken extends AbstractToken
         if ($roles) {
             $this->setAuthenticated(true);
         }
+
+        $this->setShouldUpdateRoles($user instanceof UserInterface && $user->getRoles() === $roles);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RefreshableRolesTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RefreshableRolesTokenInterface.php
@@ -22,4 +22,15 @@ interface RefreshableRolesTokenInterface
      * @param array $roles An array of roles
      */
     public function updateRoles(array $roles);
+
+    /**
+     * Returns whether or not roles *should* be updated on this token.
+     *
+     * This can be useful if your token is adding custom roles,
+     * and so you purposely do not want the roles in the token to
+     * be automatically reset.
+     *
+     * @return bool
+     */
+    public function shouldUpdateRoles();
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RefreshableRolesTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RefreshableRolesTokenInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * Allows the roles of a token to be updated when security is persisted across a session.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+interface RefreshableRolesTokenInterface
+{
+    /**
+     * @param array $roles An array of roles
+     */
+    public function updateRoles(array $roles);
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -49,6 +49,7 @@ class RememberMeToken extends AbstractToken
 
         $this->setUser($user);
         parent::setAuthenticated(true);
+        $this->setShouldUpdateRoles(true);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
+use Symfony\Component\Security\Core\User\UserInterface;
+
 /**
  * UsernamePasswordToken implements a username and password token.
  *
@@ -44,6 +46,8 @@ class UsernamePasswordToken extends AbstractToken
         $this->providerKey = $providerKey;
 
         parent::setAuthenticated(count($roles) > 0);
+
+        $this->setShouldUpdateRoles($user instanceof UserInterface && $user->getRoles() === $roles);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -56,7 +56,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
     {
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
         $user
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('getRoles')
             ->will($this->returnValue(array()))
         ;

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -159,7 +159,7 @@ class UserAuthenticationProviderTest extends TestCase
     public function testAuthenticate()
     {
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
-        $user->expects($this->once())
+        $user->expects($this->atLeastOnce())
              ->method('getRoles')
              ->will($this->returnValue(array('ROLE_FOO')))
         ;
@@ -193,7 +193,7 @@ class UserAuthenticationProviderTest extends TestCase
     public function testAuthenticateWithPreservingRoleSwitchUserRole()
     {
         $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
-        $user->expects($this->once())
+        $user->expects($this->atLeastOnce())
              ->method('getRoles')
              ->will($this->returnValue(array('ROLE_FOO')))
         ;

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -138,6 +138,13 @@ class AbstractTokenTest extends TestCase
         $this->assertEquals(array(new Role('ROLE_FOO'), new Role('ROLE_BAR')), $token->getRoles());
     }
 
+    public function testUpdateRoles()
+    {
+        $token = $this->getToken();
+        $token->updateRoles(array('ROLE_FOO'));
+        $this->assertEquals(array(new Role('ROLE_FOO')), $token->getRoles());
+    }
+
     public function testAuthenticatedFlag()
     {
         $token = $this->getToken();

--- a/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
@@ -48,6 +48,8 @@ class PostAuthenticationGuardToken extends AbstractToken implements GuardTokenIn
         // this token is meant to be used after authentication success, so it is always authenticated
         // you could set it as non authenticated later if you need to
         parent::setAuthenticated(true);
+
+        $this->setShouldUpdateRoles($user instanceof UserInterface && $user->getRoles() === $roles);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\RefreshableRolesTokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -117,6 +118,14 @@ class ContextListener implements ListenerInterface
             }
 
             $token = null;
+        }
+
+        if ($token instanceof RefreshableRolesTokenInterface && $token->getUser() instanceof UserInterface) {
+            if (null !== $this->logger) {
+                $this->logger->debug('Refreshing token roles from the User object');
+            }
+
+            $token->updateRoles($token->getUser()->getRoles());
         }
 
         $this->tokenStorage->setToken($token);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes, probably
| New feature?  | no
| BC breaks?    | minor behavior change: roles are refreshed!
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12025
| License       | MIT
| Doc PR        | not needed

This could also be considered a bug fix.

tl;dr; If your roles change in the database, then on next refresh, your security token's roles will now *also* change. The current behavior is that the token's roles do not change until logout. This PR changes that behavior.
