### PR TITLE
[Dotenv] Fix check if environment variables need to be set

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -71,16 +71,27 @@ final class Dotenv
 
         foreach ($values as $name => $value) {
             $notHttpName = 0 !== strpos($name, 'HTTP_');
+            $isSetEnv = false;
+            $isSetServer = false;
+
             // don't check existence with getenv() because of thread safety issues
-            if (!isset($loadedVars[$name]) && (isset($_ENV[$name]) || (isset($_SERVER[$name]) && $notHttpName))) {
+            if (isset($loadedVars[$name]) || !isset($_ENV[$name])) {
+                $_ENV[$name] = $value;
+                $isSetEnv = true;
+            }
+
+            if (isset($loadedVars[$name]) || !isset($_SERVER[$name])) {
+                if ($notHttpName) {
+                    $_SERVER[$name] = $value;
+                    $isSetServer = true;
+                }
+            }
+
+            if (!isset($loadedVars[$name]) && (!$isSetEnv || !$isSetServer)) {
                 continue;
             }
 
             putenv("$name=$value");
-            $_ENV[$name] = $value;
-            if ($notHttpName) {
-                $_SERVER[$name] = $value;
-            }
 
             $loadedVars[$name] = true;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no (working on it)
| Fixed tickets | #24332
| License       | MIT

Check each of `$_ENV` and `$_SERVER` before setting new variables from the `.env` file. This will fix variables being skipped if they are only set in one of the arrays, but not in both. See example in #24332.