### PR TITLE
Forward compatibility for the removal of bundle inheritance in 4.0

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -73,6 +73,11 @@ class ControllerNameParser
             throw new \InvalidArgumentException($message, 0, $e);
         }
 
+        if (!is_array($allBundles)) {
+            // happens when HttpKernel is version 4+
+            $allBundles = array($allBundles);
+        }
+
         foreach ($allBundles as $b) {
             $try = $b->getNamespace().'\\Controller\\'.$controller.'Controller';
             if (class_exists($try)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel;
 
 class TranslationDebugCommandTest extends TestCase
 {
@@ -141,14 +142,21 @@ class TranslationDebugCommandTest extends TestCase
             );
 
         if (null === $kernel) {
+            $returnValues = array(
+                array('foo', $this->getBundle($this->translationDir)),
+                array('test', $this->getBundle('test')),
+            );
+            if (HttpKernel\Kernel::VERSION_ID < 40000) {
+                $returnValues = array(
+                    array('foo', true, $this->getBundle($this->translationDir)),
+                    array('test', true, $this->getBundle('test')),
+                );
+            }
             $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
             $kernel
                 ->expects($this->any())
                 ->method('getBundle')
-                ->will($this->returnValueMap(array(
-                    array('foo', true, $this->getBundle($this->translationDir)),
-                    array('test', true, $this->getBundle('test')),
-                )));
+                ->will($this->returnValueMap($returnValues));
         }
 
         $kernel

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -120,14 +120,21 @@ class TranslationUpdateCommandTest extends TestCase
             );
 
         if (null === $kernel) {
+            $returnValues = array(
+                array('foo', $this->getBundle($this->translationDir)),
+                array('test', $this->getBundle('test')),
+            );
+            if (HttpKernel\Kernel::VERSION_ID < 40000) {
+                $returnValues = array(
+                    array('foo', true, $this->getBundle($this->translationDir)),
+                    array('test', true, $this->getBundle('test')),
+                );
+            }
             $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
             $kernel
                 ->expects($this->any())
                 ->method('getBundle')
-                ->will($this->returnValueMap(array(
-                    array('foo', true, $this->getBundle($this->translationDir)),
-                    array('test', true, $this->getBundle('test')),
-                )));
+                ->will($this->returnValueMap($returnValues));
         }
 
         $kernel

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 use Composer\Autoload\ClassLoader;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
+use Symfony\Component\HttpKernel\Kernel;
 
 class ControllerNameParserTest extends TestCase
 {
@@ -98,10 +99,17 @@ class ControllerNameParserTest extends TestCase
 
     public function getMissingControllersTest()
     {
-        return array(
-            array('FooBundle:Fake:index'),          // a normal bundle
-            array('SensioFooBundle:Fake:index'),    // a bundle with children
+        // a normal bundle
+        $bundles = array(
+            array('FooBundle:Fake:index'),
         );
+
+        // a bundle with children
+        if (Kernel::VERSION_ID < 40000) {
+            $bundles[] = array('SensioFooBundle:Fake:index');
+        }
+
+        return $bundles;
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -214,7 +214,7 @@ class TwigExtension extends Extension
             }
             $container->addResource(new FileExistenceResource($dir));
 
-            if (null === $bundle['parent']) {
+            if (!isset($bundle['parent']) || null === $bundle['parent']) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Compat layer so that 3.4 and master combinations of framework/twig bundles and http-kernel work together.
