### PR TITLE
[WebProfilerBundle] Render file links for twig templates (Fix #24355)

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -202,6 +202,10 @@ class CodeExtension extends AbstractExtension
      */
     public function getFileLink($file, $line)
     {
+        //If on Windows, we must escape $file if it contains backslash char
+        if('\\' === DIRECTORY_SEPARATOR && FALSE !== strpos($file, '\\')) {
+            $file = addslashes($file);
+        }
         if ($fmt = $this->fileLinkFormat) {
             return is_string($fmt) ? strtr($fmt, array('%f' => $file, '%l' => $line)) : $fmt->format($file, $line);
         }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -85,7 +85,7 @@
             <tbody>
             {% for template, count in collector.templates %}
                 <tr>
-                    {%- set file = collector.templatePaths[template]|default(false)|e('js') -%}
+                    {%- set file = collector.templatePaths[template]|default(false) -%}
                     {%- set link = file ? file|file_link(1) : false -%}
                     <td>{% if link %}<a href="{{ link }}" title="{{ file }}">{{ template }}</a>{% else %}{{ template }}{% endif %}</td>
                     <td class="font-normal">{{ count }}</td>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -85,7 +85,7 @@
             <tbody>
             {% for template, count in collector.templates %}
                 <tr>
-                    {%- set file = collector.templatePaths[template]|default(false) -%}
+                    {%- set file = collector.templatePaths[template]|default(false)|e('js') -%}
                     {%- set link = file ? file|file_link(1) : false -%}
                     <td>{% if link %}<a href="{{ link }}" title="{{ file }}">{{ template }}</a>{% else %}{{ template }}{% endif %}</td>
                     <td class="font-normal">{{ count }}</td>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Fixed tickets | #24355 and #24218
| License       | MIT

PR #24236 introduced a bug for Windows machines and this PR attempts to fix it.
See related discussions in tickets #24355 and #24218 (and starting from comment https://github.com/symfony/symfony/pull/24236#issuecomment-332780218)


//Edit
I'm not sure why so many commits are attached here, this is the commit I wanted to PR:

https://github.com/pquerner/symfony/commit/2aeed1f8bff716607db796d625bd2d25af3c722f