### PR TITLE
[TwigBundle] register an identity translator as fallback

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -32,7 +32,7 @@ class TranslationExtension extends AbstractExtension
     private $translator;
     private $translationNodeVisitor;
 
-    public function __construct(TranslatorInterface $translator, NodeVisitorInterface $translationNodeVisitor = null)
+    public function __construct(TranslatorInterface $translator = null, NodeVisitorInterface $translationNodeVisitor = null)
     {
         if (!$translationNodeVisitor) {
             $translationNodeVisitor = new TranslationNodeVisitor();
@@ -94,11 +94,19 @@ class TranslationExtension extends AbstractExtension
 
     public function trans($message, array $arguments = array(), $domain = null, $locale = null)
     {
+        if (null === $this->translator) {
+            return $message;
+        }
+
         return $this->translator->trans($message, $arguments, $domain, $locale);
     }
 
     public function transchoice($message, $count, array $arguments = array(), $domain = null, $locale = null)
     {
+        if (null === $this->translator) {
+            return $message;
+        }
+
         return $this->translator->transChoice($message, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);
     }
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -35,9 +35,6 @@ class ExtensionPass implements CompilerPassInterface
         if (!interface_exists('Symfony\Component\Routing\Generator\UrlGeneratorInterface')) {
             $container->removeDefinition('twig.extension.routing');
         }
-        if (!interface_exists('Symfony\Component\Translation\TranslatorInterface')) {
-            $container->removeDefinition('twig.extension.trans');
-        }
 
         if (!class_exists('Symfony\Component\Yaml\Yaml')) {
             $container->removeDefinition('twig.extension.yaml');
@@ -47,10 +44,6 @@ class ExtensionPass implements CompilerPassInterface
             $container->getDefinition('twig.extension.form')->addTag('twig.extension');
             $reflClass = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
             $container->getDefinition('twig.loader.native_filesystem')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
-        }
-
-        if ($container->has('translator')) {
-            $container->getDefinition('twig.extension.trans')->addTag('twig.extension');
         }
 
         if ($container->has('router')) {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -72,7 +72,8 @@
         </service>
 
         <service id="twig.extension.trans" class="Symfony\Bridge\Twig\Extension\TranslationExtension">
-            <argument type="service" id="translator" />
+            <argument type="service" id="translator" on-invalid="null" />
+            <tag name="twig.extension" />
         </service>
 
         <service id="twig.extension.assets" class="Symfony\Bridge\Twig\Extension\AssetExtension">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/24303#issuecomment-331864529
| License       | MIT
| Doc PR        | 

The Form component can be used without the Translation component.
However, to be able to use the default form themes provided by the
TwigBridge you need to have the `trans` filter to be available.

This change ensures that there will always be a `trans` filter which as
a fallback will just return the message key if no translator is present.