### PR TITLE
[Console] Modify console output and print multiple modifyable sections

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added option to run suggested command if command is not found and only 1 alternative is available
+ * added option to modify console output and print multiple modifyable sections
 
 4.0.0
 -----

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * added option to run suggested command if command is not found and only 1 alternative is available
- * added option to modify console output and print multiple modifyable sections
+ * added option to modify console output and print multiple modifiable sections
 
 4.0.0
 -----

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Helper;
 
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Terminal;
@@ -375,15 +376,20 @@ final class ProgressBar
     {
         if ($this->overwrite) {
             if (!$this->firstRun) {
-                // Move the cursor to the beginning of the line
-                $this->output->write("\x0D");
+                if ($this->output instanceof ConsoleSectionOutput) {
+                    $lines = floor(Helper::strlen($message) / $this->terminal->getWidth()) + $this->formatLineCount + 1;
+                    $this->output->clear($lines);
+                } else {
+                    // Move the cursor to the beginning of the line
+                    $this->output->write("\x0D");
 
-                // Erase the line
-                $this->output->write("\x1B[2K");
+                    // Erase the line
+                    $this->output->write("\x1B[2K");
 
-                // Erase previous lines
-                if ($this->formatLineCount > 0) {
-                    $this->output->write(str_repeat("\x1B[1A\x1B[2K", $this->formatLineCount));
+                    // Erase previous lines
+                    if ($this->formatLineCount > 0) {
+                        $this->output->write(str_repeat("\x1B[1A\x1B[2K", $this->formatLineCount));
+                    }
                 }
             }
         } elseif ($this->step > 0) {

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Console\Helper;
 
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\RuntimeException;
 
 /**
  * Provides helpers to display a table.
@@ -69,6 +71,8 @@ class Table
     private $columnWidths = array();
 
     private static $styles;
+
+    private $rendered = false;
 
     public function __construct(OutputInterface $output)
     {
@@ -252,6 +256,25 @@ class Table
         return $this;
     }
 
+    /**
+     * Add a row to the table, and re-render the table.
+     */
+    public function appendRow($row): self
+    {
+        if (!$this->output instanceof ConsoleSectionOutput) {
+            throw new RuntimeException(sprintf('Output should be an instance of "%s" when calling "%s".', ConsoleSectionOutput::class, __METHOD__));
+        }
+
+        if ($this->rendered) {
+            $this->output->clear($this->calculateRowCount());
+        }
+
+        $this->addRow($row);
+        $this->render();
+
+        return $this;
+    }
+
     public function setRow($column, array $row)
     {
         $this->rows[$column] = $row;
@@ -311,6 +334,7 @@ class Table
         $this->renderRowSeparator();
 
         $this->cleanup();
+        $this->rendered = true;
     }
 
     /**
@@ -443,6 +467,19 @@ class Table
                 }
             }
         });
+    }
+
+    private function calculateRowCount(): int
+    {
+        $numberOfRows = count(iterator_to_array($this->buildTableRows(array_merge($this->headers, array(new TableSeparator()), $this->rows))));
+
+        if ($this->headers) {
+            ++$numberOfRows; // Add row for header separator
+        }
+
+        ++$numberOfRows; // Add row for footer separator
+
+        return $numberOfRows;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -257,7 +257,7 @@ class Table
     }
 
     /**
-     * Add a row to the table, and re-render the table.
+     * Adds a row to the table, and re-renders the table.
      */
     public function appendRow($row): self
     {

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -30,6 +30,7 @@ use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
 {
     private $stderr;
+    private $consoleSectionOutputs = array();
 
     /**
      * @param int                           $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
@@ -46,6 +47,14 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
         if (null === $decorated) {
             $this->setDecorated($actualDecorated && $this->stderr->isDecorated());
         }
+    }
+
+    /**
+     * Creates a new output section.
+     */
+    public function section(): ConsoleSectionOutput
+    {
+        return new ConsoleSectionOutput($this->getStream(), $this->consoleSectionOutputs, $this->getVerbosity(), $this->isDecorated(), $this->getFormatter());
     }
 
     /**

--- a/src/Symfony/Component/Console/Output/ConsoleOutputInterface.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutputInterface.php
@@ -13,9 +13,11 @@ namespace Symfony\Component\Console\Output;
 
 /**
  * ConsoleOutputInterface is the interface implemented by ConsoleOutput class.
- * This adds information about stderr output stream.
+ * This adds information about stderr and section output stream.
  *
  * @author Dariusz Górecki <darek.krk@gmail.com>
+ *
+ * @method ConsoleSectionOutput section() Creates a new output section
  */
 interface ConsoleOutputInterface extends OutputInterface
 {

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Output;
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Terminal;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ * @author Gabriel Ostrolucký <gabriel.ostrolucky@gmail.com>
+ */
+class ConsoleSectionOutput extends StreamOutput
+{
+    private $content = array();
+    private $lines = 0;
+    private $sections;
+    private $terminal;
+
+    /**
+     * @param resource               $stream
+     * @param ConsoleSectionOutput[] $sections
+     */
+    public function __construct($stream, array &$sections, int $verbosity, bool $decorated, OutputFormatterInterface $formatter)
+    {
+        parent::__construct($stream, $verbosity, $decorated, $formatter);
+        array_unshift($sections, $this);
+        $this->sections = &$sections;
+        $this->terminal = new Terminal();
+    }
+
+    /**
+     * Clears previous output for this section.
+     *
+     * @param int $lines Number of lines to clear. If null, then the entire output of this section is cleared
+     */
+    public function clear(int $lines = null)
+    {
+        if (empty($this->content) || !$this->isDecorated()) {
+            return;
+        }
+
+        if ($lines) {
+            \array_splice($this->content, -($lines * 2)); // Multiply lines by 2 to cater for each new line added between content
+        } else {
+            $lines = $this->lines;
+            $this->content = array();
+        }
+
+        $this->lines -= $lines;
+
+        parent::doWrite($this->popStreamContentUntilCurrentSection($lines), false);
+    }
+
+    /**
+     * Overwrites the previous output with a new message.
+     *
+     * @param array|string $message
+     */
+    public function overwrite($message)
+    {
+        $this->clear();
+        $this->writeln($message);
+    }
+
+    public function getContent(): string
+    {
+        return implode('', $this->content);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doWrite($message, $newline)
+    {
+        if (!$this->isDecorated()) {
+            return parent::doWrite($message, $newline);
+        }
+
+        $erasedContent = $this->popStreamContentUntilCurrentSection();
+
+        foreach (explode(PHP_EOL, $message) as $lineContent) {
+            $this->lines += ceil($this->getDisplayLength($lineContent) / $this->terminal->getWidth()) ?: 1;
+            $this->content[] = $lineContent;
+            $this->content[] = PHP_EOL;
+        }
+
+        parent::doWrite($message, true);
+        parent::doWrite($erasedContent, false);
+    }
+
+    /**
+     * At initial stage, cursor is at the end of stream output. This method makes cursor crawl upwards until it hits
+     * current section. Then it erases content it crawled through. Optionally, it erases part of current section too.
+     */
+    private function popStreamContentUntilCurrentSection(int $numberOfLinesToClearFromCurrentSection = 0): string
+    {
+        $numberOfLinesToClear = $numberOfLinesToClearFromCurrentSection;
+        $erasedContent = array();
+
+        foreach ($this->sections as $section) {
+            if ($section === $this) {
+                break;
+            }
+
+            $numberOfLinesToClear += $section->lines;
+            $erasedContent[] = $section->getContent();
+        }
+
+        if ($numberOfLinesToClear > 0) {
+            // Move cursor up n lines
+            parent::doWrite(sprintf("\x1b[%dA", $numberOfLinesToClear), false);
+            // erase to end of screen
+            parent::doWrite("\x1b[0J", false);
+        }
+
+        return implode('', array_reverse($erasedContent));
+    }
+
+    private function getDisplayLength(string $text): string
+    {
+        return Helper::strlenWithoutDecoration($this->getFormatter(), str_replace("\t", '        ', $text));
+    }
+}

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -117,7 +117,7 @@ class ConsoleSectionOutput extends StreamOutput
         }
 
         if ($numberOfLinesToClear > 0) {
-            // Move cursor up n lines
+            // move cursor up n lines
             parent::doWrite(sprintf("\x1b[%dA", $numberOfLinesToClear), false);
             // erase to end of screen
             parent::doWrite("\x1b[0J", false);

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -12,10 +12,12 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableStyle;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\StreamOutput;
 
 class TableTest extends TestCase
@@ -819,6 +821,115 @@ TABLE;
 TABLE;
 
         $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    public function testSectionOutput()
+    {
+        $sections = array();
+        $stream = $this->getOutputStream(true);
+        $output = new ConsoleSectionOutput($stream->getStream(), $sections, $stream->getVerbosity(), $stream->isDecorated(), new OutputFormatter());
+        $table = new Table($output);
+        $table
+            ->setHeaders(array('ISBN', 'Title', 'Author', 'Price'))
+            ->setRows(array(
+                array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'),
+            ));
+
+        $table->render();
+
+        $table->appendRow(array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'));
+
+        $expected =
+            <<<TABLE
++---------------+---------------+-----------------+-------+
+|\033[32m ISBN          \033[39m|\033[32m Title         \033[39m|\033[32m Author          \033[39m|\033[32m Price \033[39m|
++---------------+---------------+-----------------+-------+
+| 99921-58-10-7 | Divine Comedy | Dante Alighieri | 9.95  |
++---------------+---------------+-----------------+-------+
+\x1b[5A\x1b[0J+---------------+----------------------+-----------------+--------+
+|\033[32m ISBN          \033[39m|\033[32m Title                \033[39m|\033[32m Author          \033[39m|\033[32m Price  \033[39m|
++---------------+----------------------+-----------------+--------+
+| 99921-58-10-7 | Divine Comedy        | Dante Alighieri | 9.95   |
+| 9971-5-0210-0 | A Tale of Two Cities | Charles Dickens | 139.25 |
++---------------+----------------------+-----------------+--------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    public function testSectionOutputDoesntClearIfTableIsntRendered()
+    {
+        $sections = array();
+        $stream = $this->getOutputStream(true);
+        $output = new ConsoleSectionOutput($stream->getStream(), $sections, $stream->getVerbosity(), $stream->isDecorated(), new OutputFormatter());
+        $table = new Table($output);
+        $table
+            ->setHeaders(array('ISBN', 'Title', 'Author', 'Price'))
+            ->setRows(array(
+                array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'),
+            ));
+
+        $table->appendRow(array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'));
+
+        $expected =
+            <<<TABLE
++---------------+----------------------+-----------------+--------+
+|\033[32m ISBN          \033[39m|\033[32m Title                \033[39m|\033[32m Author          \033[39m|\033[32m Price  \033[39m|
++---------------+----------------------+-----------------+--------+
+| 99921-58-10-7 | Divine Comedy        | Dante Alighieri | 9.95   |
+| 9971-5-0210-0 | A Tale of Two Cities | Charles Dickens | 139.25 |
++---------------+----------------------+-----------------+--------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    public function testSectionOutputWithoutDecoration()
+    {
+        $sections = array();
+        $stream = $this->getOutputStream();
+        $output = new ConsoleSectionOutput($stream->getStream(), $sections, $stream->getVerbosity(), $stream->isDecorated(), new OutputFormatter());
+        $table = new Table($output);
+        $table
+            ->setHeaders(array('ISBN', 'Title', 'Author', 'Price'))
+            ->setRows(array(
+                array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'),
+            ));
+
+        $table->render();
+
+        $table->appendRow(array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'));
+
+        $expected =
+            <<<TABLE
++---------------+---------------+-----------------+-------+
+| ISBN          | Title         | Author          | Price |
++---------------+---------------+-----------------+-------+
+| 99921-58-10-7 | Divine Comedy | Dante Alighieri | 9.95  |
++---------------+---------------+-----------------+-------+
++---------------+----------------------+-----------------+--------+
+| ISBN          | Title                | Author          | Price  |
++---------------+----------------------+-----------------+--------+
+| 99921-58-10-7 | Divine Comedy        | Dante Alighieri | 9.95   |
+| 9971-5-0210-0 | A Tale of Two Cities | Charles Dickens | 139.25 |
++---------------+----------------------+-----------------+--------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
+     * @expectedExceptionMessage Output should be an instance of "Symfony\Component\Console\Output\ConsoleSectionOutput" when calling "Symfony\Component\Console\Helper\Table::appendRow".
+     */
+    public function testAppendRowWithoutSectionOutput()
+    {
+        $table = new Table($this->getOutputStream());
+
+        $table->appendRow(array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'));
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Output;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class ConsoleSectionOutputTest extends TestCase
+{
+    private $stream;
+
+    protected function setUp()
+    {
+        $this->stream = fopen('php://memory', 'r+', false);
+    }
+
+    protected function tearDown()
+    {
+        $this->stream = null;
+    }
+
+    public function testClearAll()
+    {
+        $sections = array();
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->writeln('Foo'.PHP_EOL.'Bar');
+        $output->clear();
+
+        rewind($output->getStream());
+        $this->assertEquals('Foo'.PHP_EOL.'Bar'.PHP_EOL.sprintf("\x1b[%dA", 2)."\x1b[0J", stream_get_contents($output->getStream()));
+    }
+
+    public function testClearNumberOfLines()
+    {
+        $sections = array();
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->writeln("Foo\nBar\nBaz\nFooBar");
+        $output->clear(2);
+
+        rewind($output->getStream());
+        $this->assertEquals("Foo\nBar\nBaz\nFooBar".PHP_EOL.sprintf("\x1b[%dA", 2)."\x1b[0J", stream_get_contents($output->getStream()));
+    }
+
+    public function testClearNumberOfLinesWithMultipleSections()
+    {
+        $output = new StreamOutput($this->stream);
+        $sections = array();
+        $output1 = new ConsoleSectionOutput($output->getStream(), $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $output2 = new ConsoleSectionOutput($output->getStream(), $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output2->writeln('Foo');
+        $output2->writeln('Bar');
+        $output2->clear(1);
+        $output1->writeln('Baz');
+
+        rewind($output->getStream());
+
+        $this->assertEquals('Foo'.PHP_EOL.'Bar'.PHP_EOL."\x1b[1A\x1b[0J\e[1A\e[0J".'Baz'.PHP_EOL.'Foo'.PHP_EOL, stream_get_contents($output->getStream()));
+    }
+
+    public function testClearPreservingEmptyLines()
+    {
+        $output = new StreamOutput($this->stream);
+        $sections = array();
+        $output1 = new ConsoleSectionOutput($output->getStream(), $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $output2 = new ConsoleSectionOutput($output->getStream(), $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output2->writeln(PHP_EOL.'foo');
+        $output2->clear(1);
+        $output1->writeln('bar');
+
+        rewind($output->getStream());
+
+        $this->assertEquals(PHP_EOL.'foo'.PHP_EOL."\x1b[1A\x1b[0J\x1b[1A\x1b[0J".'bar'.PHP_EOL.PHP_EOL, stream_get_contents($output->getStream()));
+    }
+
+    public function testOverwrite()
+    {
+        $sections = array();
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->writeln('Foo');
+        $output->overwrite('Bar');
+
+        rewind($output->getStream());
+        $this->assertEquals('Foo'.PHP_EOL."\x1b[1A\x1b[0JBar".PHP_EOL, stream_get_contents($output->getStream()));
+    }
+
+    public function testOverwriteMultipleLines()
+    {
+        $sections = array();
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->writeln('Foo'.PHP_EOL.'Bar'.PHP_EOL.'Baz');
+        $output->overwrite('Bar');
+
+        rewind($output->getStream());
+        $this->assertEquals('Foo'.PHP_EOL.'Bar'.PHP_EOL.'Baz'.PHP_EOL.sprintf("\x1b[%dA", 3)."\x1b[0J".'Bar'.PHP_EOL, stream_get_contents($output->getStream()));
+    }
+
+    public function testAddingMultipleSections()
+    {
+        $sections = array();
+        $output1 = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $output2 = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $this->assertCount(2, $sections);
+    }
+
+    public function testMultipleSectionsOutput()
+    {
+        $output = new StreamOutput($this->stream);
+        $sections = array();
+        $output1 = new ConsoleSectionOutput($output->getStream(), $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+        $output2 = new ConsoleSectionOutput($output->getStream(), $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output1->writeln('Foo');
+        $output2->writeln('Bar');
+
+        $output1->overwrite('Baz');
+        $output2->overwrite('Foobar');
+
+        rewind($output->getStream());
+        $this->assertEquals('Foo'.PHP_EOL.'Bar'.PHP_EOL."\x1b[2A\x1b[0JBar".PHP_EOL."\x1b[1A\x1b[0JBaz".PHP_EOL.'Bar'.PHP_EOL."\x1b[1A\x1b[0JFoobar".PHP_EOL, stream_get_contents($output->getStream()));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | TBD
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#9304

Add support to create different output sections for the console output.
Each section is it's own 'stream' of output, where the output can be modified (even if there are other output after it). This allows you to modify previous output in the console, either by appending new lines, modifying previous lines or clearing the output. Modifying a sections output doesn't affect the output after that or in other sections.

Some examples of what can be done:

**Overwriting content in a previous section:**

Code:

```php
$section1 = $output->section();
$section2 = $output->section();

$section1->writeln("<comment>Doing something</comment>\n");
usleep(500000);
$section2->writeln('<info>Result of first operation</info>');
usleep(500000);

$section1->overwrite("<comment>Doing something else</comment>\n");
usleep(500000);
$section2->writeln('<info>Result of second operation</info>');
usleep(500000);

$section1->overwrite("<comment>Finishing</comment>\n");
usleep(500000);
$section2->writeln('<info>Last Result</info>');
```

Result:
![overwrite-append](https://user-images.githubusercontent.com/144858/30975030-769f2c46-a471-11e7-819f-c3698b43f0af.gif)

**Multiple Progress Bars:**

Code:

```php
$section1 = $output->section();
$section2 = $output->section();

$progress = new ProgressBar($section1);
$progress2 = new ProgressBar($section2);

$progress->start(100);
$progress2->start(100);

$c = 0;
while (++$c < 100) {
    $progress->advance();

    if ($c % 2 === 0) {
        $progress2->advance(4);
    }

    usleep(500000);
}
```

Result:
![multiple-progress](https://user-images.githubusercontent.com/144858/30975119-b63222be-a471-11e7-89aa-a555cdf3d2e0.gif)

**Modifying content of a table & updating a progress bar:**

Code:

```php
$section1 = $output->section();
$section2 = $output->section();

$progress = new ProgressBar($section1);
$table = new Table($section2);

$table->addRow(['Row 1']);
$table->render();

$progress->start(5);

$c = 0;
while (++$c < 5) {
    $table->appendRow(['Row '.($c + 1)]);

    $progress->advance();

    usleep(500000);
}

$progress->finish();
$section1->clear();
```

Result:
![progress-table](https://user-images.githubusercontent.com/144858/30975176-e332499c-a471-11e7-9d4f-f58b464a53c2.gif)

**Example with Symfony Installer:***

Before:
![sf-installer-old](https://user-images.githubusercontent.com/144858/30975291-40f22106-a472-11e7-8836-bc39139c2d30.gif)

After:
![sf-installer](https://user-images.githubusercontent.com/144858/30975302-4a00acf4-a472-11e7-83ba-88ea9d0f0f3f.gif)

TODO:
- [x] Add unit tests