### PR TITLE
[PhpUnitBridge] Make CoverageListenerTest more robust when xdebug is not available

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -8,12 +8,17 @@ class CoverageListenerTest extends TestCase
 {
     public function test()
     {
-        if ("\n" !== PHP_EOL) {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('This test cannot be run on Windows.');
         }
 
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('This test cannot be run on HHVM.');
+        }
+
+        exec('php --ri xdebug -d zend_extension=xdebug.so 2> /dev/null', $output, $returnCode);
+        if (0 !== $returnCode) {
+            $this->markTestSkipped('Xdebug is required to run this test.');
         }
 
         $dir = __DIR__.'/../Tests/Fixtures/coverage';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |