### PR TITLE
[DI] Fix TypeHint of ParametersConfigurator::set()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
@@ -31,7 +31,7 @@ class ParametersConfigurator extends AbstractConfigurator
      * Creates a parameter.
      *
      * @param string $name
-     * @param string $value
+     * @param mixed  $value
      *
      * @return $this
      */
@@ -46,7 +46,7 @@ class ParametersConfigurator extends AbstractConfigurator
      * Creates a parameter.
      *
      * @param string $name
-     * @param string $value
+     * @param mixed  $value
      *
      * @return $this
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4  <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | <!--highly recommended for new features-->

Use TypeHint of `Symfony\Component\DependencyInjection\Loader\ConfiguratorAbstractConfigurator::processValue` instead of `string`
