### PR TITLE
[FrameworkBundle] Use PhpExtractor from Translation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -121,7 +121,7 @@
             <tag name="translation.dumper" alias="res" />
         </service>
 
-        <service id="translation.extractor.php" class="Symfony\Bundle\FrameworkBundle\Translation\PhpExtractor">
+        <service id="translation.extractor.php" class="Symfony\Component\Translation\Extractor\PhpExtractor">
             <tag name="translation.extractor" alias="php" />
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The FrameworkBundle's one is legacy, so triggers a deprecation notice.