### PR TITLE
Expose tags as consts for PHP config autocompletion

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
+require_once __DIR__.'/../Resources/di/tags.php';
+
 use Doctrine\Common\Annotations\Reader;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/di/tags.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/di/tags.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag {
+    const AUTO_ALIAS = 'auto_alias';
+    const DATA_COLLECTOR = 'data_collector';
+}
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\config_cache {
+    const RESOURCE_CHECKER = 'config_cache.resource_checker';
+}
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\console {
+    const COMMAND = 'console.command';
+}
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\container {
+    const ENV_VAR_PROCESSOR = 'container.env_var_processor';
+    const SERVICE_SUBSCRIBER = 'container.service_subscriber';
+}
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\controller {
+    const ARGUMENT_VALUE_RESOLVER = 'controller.argument_value_resolver';
+    const SERVICE_ARGUMENTS = 'controller.service_arguments';
+}
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\form {
+    const TYPE = 'form.type';
+    const TYPE_GUESSER = 'form.type_guesser';
+}
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\kernel {
+    const CACHE_CLEARER = 'kernel.cache_clearer';
+    const CACHE_WARMER = 'kernel.cache_warmer';
+    const EVENT_SUBSCRIBER = 'kernel.event_subscriber';
+    const RESET = 'kernel.reset';
+}
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\property_info {
+    const ACCESS_EXTRACTOR = 'property_info.access_extractor';
+    const DESCRIPTION_EXTRACTOR = 'property_info.description_extractor';
+    const LIST_EXTRACTOR = 'property_info.list_extractor';
+    const TYPE_EXTRACTOR = 'property_info.type_extractor';
+}
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\serializer {
+    const ENCODER = 'serializer.encoder';
+    const NORMALIZER = 'serializer.normalizer';
+}
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\validator {
+    const CONSTRAINT_VALIDATOR = 'validator.constraint_validator';
+    const INITIALIZER = 'validator.initializer';
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
+require_once __DIR__.'/../Resources/di/tags.php';
+
 use Symfony\Bundle\SecurityBundle\Command\InitAclCommand;
 use Symfony\Bundle\SecurityBundle\Command\SetAclCommand;
 use Symfony\Bundle\SecurityBundle\Command\UserPasswordEncoderCommand;

--- a/src/Symfony/Bundle/SecurityBundle/Resources/di/tags.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/di/tags.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\security;
+
+const VOTER = 'security.voter';

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\TwigBundle\DependencyInjection;
 
+require_once __DIR__.'/../Resources/di/tags.php';
+
 use Symfony\Bridge\Twig\Extension\WebLinkExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileExistenceResource;

--- a/src/Symfony/Bundle/TwigBundle/Resources/di/tags.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/di/tags.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator\tag\twig;
+
+const EXTENSION = 'twig.extension';
+const LOADER = 'twig.loader';
+const RUNTIME = 'twig.runtime';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/projects/6#card-4488902 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Now that we have [PHP based-config](https://symfony.com/blog/new-in-symfony-php-based-configuration-for-services-and-routes), it'll make sense to have tags exposed as constants for autocompletion & discoverability.

Consts are are defined in the bundles for discoverability and because that's where passes are configured.