### PR TITLE
[PHPUnitBridge] don't remove when set to  empty string

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -60,7 +60,8 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
     $zip->extractTo(getcwd());
     $zip->close();
     chdir("phpunit-$PHPUNIT_VERSION");
-    passthru("$COMPOSER remove --no-update ".(getenv('SYMFONY_PHPUNIT_REMOVE') ?: 'phpspec/prophecy symfony/yaml'));
+    $SYMFONY_PHPUNIT_REMOVE = getenv('SYMFONY_PHPUNIT_REMOVE');
+    passthru("$COMPOSER remove --no-update ".('' === $SYMFONY_PHPUNIT_REMOVE ?: 'phpspec/prophecy symfony/yaml'));
     if (5.1 <= $PHPUNIT_VERSION && $PHPUNIT_VERSION < 5.4) {
         passthru("$COMPOSER require --no-update phpunit/phpunit-mock-objects \"~3.1.0\"");
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |3.3
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23955 
| License       | MIT
| Doc PR        |


Fix a bug when passing empty string symfony/yaml and phpspec/prophecy