### PR TITLE
[SecurityBundle] Remove auto picking the first provider

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * removed command `acl:set` along with `SetAclCommand` class
  * removed command `init:acl` along with `InitAclCommand` class
  * removed `acl` configuration key and related services, use symfony/acl-bundle instead
+ * removed auto picking the first registered provider when no configured provider on a firewall and ambiguous
 
 3.4.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -261,6 +261,10 @@ class SecurityExtension extends Extension
             }
             $defaultProvider = $providerIds[$normalizedName];
         } else {
+            if (count($providerIds) > 1) {
+                throw new InvalidConfigurationException(sprintf('Not configuring explicitly the provider on "%s" firewall is ambiguous as there is more than one registered provider.', $id));
+            }
+
             $defaultProvider = reset($providerIds);
 
             if (count($providerIds) > 1) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -175,8 +175,8 @@ class SecurityExtensionTest extends TestCase
     }
 
     /**
-     * @group legacy
-     * @expectedDeprecation Firewall "default" has no "provider" set but multiple providers exist. Using the first configured provider (first) is deprecated since 3.4 and will throw an exception in 4.0, set the "provider" key on the firewall instead.
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Not configuring explicitly the provider on "default" firewall is ambiguous as there is more than one registered provider.
      */
     public function testDeprecationForAmbiguousProvider()
     {


### PR DESCRIPTION
when no provider is explicitly configured on a firewall

| Q             | A
| ------------- | ---
| Branch?       | master <!-- see comment below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | yes
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24378 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

After #24378