### PR TITLE
[FrameworkBundle] Don't clear app pools on cache:clear

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -113,6 +113,10 @@ Form
 FrameworkBundle
 ---------------
 
+ * The `cache:clear` command doesn't clear "app" PSR-6 cache pools anymore,
+   but still clears "system" ones.
+   Use the `cache:pool:clear` command to clear "app" pools instead.
+
  * The `doctrine/cache` dependency has been removed; require it via `composer
    require doctrine/cache` if you are using Doctrine cache in your project.
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.4.0
 -----
 
+ * Made the `cache:clear` command to *not* clear "app" PSR-6 cache pools anymore,
+   but to still clear "system" ones; use the `cache:pool:clear` command to clear "app" pools instead
  * Always register a minimalist logger that writes in `stderr`
  * Deprecated `profiler.matcher` option
  * Added support for `EventSubscriberInterface` on `MicroKernelTrait`

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
@@ -106,7 +106,7 @@ class CachePoolPass implements CompilerPassInterface
 
         foreach ($clearers as $id => $pools) {
             $clearer = $container->getDefinition($id);
-            if ($clearer instanceof ChilDefinition) {
+            if ($clearer instanceof ChildDefinition) {
                 $clearer->replaceArgument(0, $pools);
             } else {
                 $clearer->setArgument(0, $pools);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1802,7 +1802,7 @@ class FrameworkExtension extends Extension
             if (!$container->getParameter('kernel.debug')) {
                 $propertyAccessDefinition->setFactory(array(PropertyAccessor::class, 'createCache'));
                 $propertyAccessDefinition->setArguments(array(null, null, $version, new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)));
-                $propertyAccessDefinition->addTag('cache.pool', array('clearer' => 'cache.default_clearer'));
+                $propertyAccessDefinition->addTag('cache.pool', array('clearer' => 'cache.system_clearer'));
                 $propertyAccessDefinition->addTag('monolog.logger', array('channel' => 'cache'));
             } else {
                 $propertyAccessDefinition->setClass(ArrayAdapter::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -29,7 +29,7 @@
 
         <service id="cache.adapter.system" class="Symfony\Component\Cache\Adapter\AdapterInterface" abstract="true">
             <factory class="Symfony\Component\Cache\Adapter\AbstractAdapter" method="createSystemCache" />
-            <tag name="cache.pool" clearer="cache.default_clearer" />
+            <tag name="cache.pool" clearer="cache.system_clearer" />
             <tag name="monolog.logger" channel="cache" />
             <argument /> <!-- namespace -->
             <argument>0</argument> <!-- default lifetime -->
@@ -101,6 +101,10 @@
         </service>
 
         <service id="cache.default_clearer" class="Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer">
+            <argument type="collection" />
+        </service>
+
+        <service id="cache.system_clearer" parent="cache.default_clearer" public="true">
             <tag name="kernel.cache_clearer" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
@@ -19,7 +19,7 @@ class CachePoolsTest extends WebTestCase
 {
     public function testCachePools()
     {
-        $this->doTestCachePools(array(), FilesystemAdapter::class);
+        $this->doTestCachePools(array(), AdapterInterface::class);
     }
 
     /**
@@ -67,7 +67,7 @@ class CachePoolsTest extends WebTestCase
         }
     }
 
-    public function doTestCachePools($options, $adapterClass)
+    private function doTestCachePools($options, $adapterClass)
     {
         static::bootKernel($options);
         $container = static::$kernel->getContainer();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/config.yml
@@ -6,6 +6,7 @@ framework:
         pools:
             cache.pool1:
                 public: true
+                adapter: cache.system
             cache.pool2:
                 public: true
                 adapter: cache.pool3

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_config.yml
@@ -11,6 +11,7 @@ framework:
         pools:
             cache.pool1:
                 public: true
+                clearer: cache.system_clearer
             cache.pool2:
                 public: true
                 clearer: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_custom_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_custom_config.yml
@@ -22,6 +22,7 @@ framework:
         pools:
             cache.pool1:
                 public: true
+                clearer: cache.system_clearer
             cache.pool2:
                 public: true
                 clearer: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no, but behavior change
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23685
| License       | MIT
| Doc PR        | -

The cache:clear command currently clears all cache pools by default.
This is not expected and is a bad default behavior (as explained in linked issue).
If we don't want to have that behavior forever, I see no other option than just doing the change, as done here, targeting 3.4.