### PR TITLE
[Form] Fix FormInterface::submit() annotation

### DIFF
--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -269,10 +269,9 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Submits data to the form, transforms and validates it.
      *
-     * @param null|string|array $submittedData The submitted data
-     * @param bool              $clearMissing  whether to set fields to NULL
-     *                                         when they are missing in the
-     *                                         submitted data
+     * @param mixed $submittedData The submitted data
+     * @param bool  $clearMissing  whether to set fields to NULL when they
+     *                             are missing in the submitted data
      *
      * @return $this
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

`null|string|array` does not cover all possible values. For example for UploadType it is an instance of UploadedFile.