### PR TITLE
[FrameworkBundle] Register a NullLogger from test kernels

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command\CacheClearCommand\Fixture;
 
+use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class TestAppKernel extends Kernel
@@ -32,5 +34,10 @@ class TestAppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load(__DIR__.DIRECTORY_SEPARATOR.'config.yml');
+    }
+
+    protected function build(ContainerBuilder $container)
+    {
+        $container->register('logger', NullLogger::class);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\app;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -70,6 +72,11 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load($this->rootConfig);
+    }
+
+    protected function build(ContainerBuilder $container)
+    {
+        $container->register('logger', NullLogger::class);
     }
 
     public function serialize()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Kernel;
 
+use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -77,6 +78,7 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
     {
+        $c->register('logger', NullLogger::class);
         $c->loadFromExtension('framework', array(
             'secret' => '$ecret',
         ));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Relates to #24300 

This will avoid unnecessary output on Travis or when running FrameworkBundle tests locally:
- before: https://travis-ci.org/symfony/symfony/jobs/281624658#L3594-L3635
- after: https://travis-ci.org/symfony/symfony/jobs/281643868#L3599-L3617

but also needed for anyone running functional tests on their project and using the default logger, in order to not get garbage output.

Do we need to find a more generic solution (like exposing a `framework.default_logger` option so users can set it to false for test)? Or just documenting this?