### PR TITLE
[Security] Look at headers for switch_user username

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
@@ -54,7 +54,7 @@ class SwitchUserTest extends WebTestCase
     public function testSwitchUserStateless()
     {
         $client = $this->createClient(array('test_case' => 'JsonLogin', 'root_config' => 'switchuser_stateless.yml'));
-        $client->request('POST', '/chk', array('_switch_user' => 'dunglas'), array(), array('CONTENT_TYPE' => 'application/json'), '{"user": {"login": "user_can_switch", "password": "test"}}');
+        $client->request('POST', '/chk', array(), array(), array('HTTP_X_SWITCH_USER' => 'dunglas', 'CONTENT_TYPE' => 'application/json'), '{"user": {"login": "user_can_switch", "password": "test"}}');
         $response = $client->getResponse();
 
         $this->assertInstanceOf(JsonResponse::class, $response);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
@@ -10,4 +10,5 @@ security:
     firewalls:
         main:
             switch_user:
+                parameter: X-Switch-User
                 stateless: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24260
| License       | MIT
| Doc PR        | n/a

Allowing `switch_user.parameter` config node to be a header name.
It's supported by SwitchUserStatelessBundle and I think it makes sense.
Forgotten in #24260 so targets 3.4 but not a blocker.