### PR TITLE
[DoctrineBridge] Deprecate dbal session handler

### DIFF
--- a/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandler.php
+++ b/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandler.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\Doctrine\HttpFoundation;
 
+@trigger_error(sprintf('The class %s is deprecated since version 3.4 and will be removed in 4.0. Use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler instead.', DbalSessionHandler::class), E_USER_DEPRECATED);
+
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\DriverException;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
@@ -25,6 +27,8 @@ use Doctrine\DBAL\Platforms\SQLServer2008Platform;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Tobias Schultze <http://tobion.de>
+ *
+ * @deprecated since version 3.4, to be removed in 4.0. Use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler instead.
  */
 class DbalSessionHandler implements \SessionHandlerInterface
 {

--- a/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandlerSchema.php
+++ b/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandlerSchema.php
@@ -11,12 +11,16 @@
 
 namespace Symfony\Bridge\Doctrine\HttpFoundation;
 
+@trigger_error(sprintf('The class %s is deprecated since version 3.4 and will be removed in 4.0. Use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler::createTable instead.', DbalSessionHandlerSchema::class), E_USER_DEPRECATED);
+
 use Doctrine\DBAL\Schema\Schema;
 
 /**
  * DBAL Session Storage Schema.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since version 3.4, to be removed in 4.0. Use Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler::createTable instead.
  */
 final class DbalSessionHandlerSchema extends Schema
 {

--- a/src/Symfony/Bridge/Doctrine/Tests/HttpFoundation/DbalSessionHandlerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/HttpFoundation/DbalSessionHandlerTest.php
@@ -18,6 +18,8 @@ use Symfony\Bridge\Doctrine\HttpFoundation\DbalSessionHandler;
  * Test class for DbalSessionHandler.
  *
  * @author Drak <drak@zikula.org>
+ *
+ * @group legacy
  */
 class DbalSessionHandlerTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #20501
| License       | MIT
| Doc PR        | 

The DbalSessionHandler misses all the improvements from the PdoSessionHandler (lock modes, delayed GC, configurable naming). The only advantage it had was the ability to work with non-pdo drivers. But since DBAL requires PDO now as well (https://github.com/doctrine/dbal/commit/36df6828b3b7139d30170969353df3e2bd97a9f8) even that is not really relevant anymore.

Stofs argument in https://github.com/symfony/symfony/issues/20501#issuecomment-260131521 sound like a new feature that can be implemented separately. Ref. #24267