### PR TITLE
Display orphaned events in profiler

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 4.0 to 4.1
 =======================
 
+Event Dispatcher
+----------------
+
+ * The `TraceableEventDispatcherInterface` has been deprecated and will be removed in 5.0.
+
 HttpFoundation
 --------------
 

--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -1,8 +1,8 @@
 UPGRADE FROM 4.0 to 4.1
 =======================
 
-Event Dispatcher
-----------------
+EventDispatcher
+---------------
 
  * The `TraceableEventDispatcherInterface` has been deprecated and will be removed in 5.0.
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,8 +1,8 @@
 UPGRADE FROM 4.x to 5.0
 =======================
 
-Event Dispatcher
-----------------
+EventDispatcher
+---------------
 
  * The `TraceableEventDispatcherInterface` has been removed.
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 4.x to 5.0
 =======================
 
+Event Dispatcher
+----------------
+
+ * The `TraceableEventDispatcherInterface` has been removed.
+
 HttpFoundation
 --------------
 

--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.0.0
 -----
 
+ * added information about orphaned events
  * removed the `WebProfilerExtension::dumpValue()` method
  * removed the `getTemplates()` method of the `TemplateManager` class in favor of the ``getNames()`` method
  * removed the `web_profiler.position` config option and the

--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,10 +1,14 @@
 CHANGELOG
 =========
 
-4.0.0
+4.1.0
 -----
 
  * added information about orphaned events
+
+4.0.0
+-----
+
  * removed the `WebProfilerExtension::dumpValue()` method
  * removed the `getTemplates()` method of the `TemplateManager` class in favor of the ``getNames()`` method
  * removed the `web_profiler.position` config option and the

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
@@ -45,6 +45,26 @@
                     {% endif %}
                 </div>
             </div>
+
+            <div class="tab">
+                <h3 class="tab-title">Orphaned events <span class="badge">{{ collector.orphanedEvents|length }}</span></h3>
+                <div class="tab-content">
+                    {% if collector.orphanedEvents is empty %}
+                        <div class="empty">
+                            <p>
+                                <strong>There are no orphaned events</strong>.
+                            </p>
+                            <p>
+                                All dispatched events were handled or an error occurred
+                                when trying to collect orphaned events (in which case check the
+                                logs to get more information).
+                            </p>
+                        </div>
+                    {% else %}
+                        {{ helper.render_table(collector.orphanedEvents) }}
+                    {% endif %}
+                </div>
+            </div>
         </div>
     {% endif %}
 {% endblock %}

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 4.1.0
 -----
 
- * The method `TraceableEventDispatcher::getOrphanedEvents()` has been added.
+ * The `TraceableEventDispatcher::getOrphanedEvents()` method has been added.
+ * The `TraceableEventDispatcherInterface` has been deprecated and will be removed in 5.0.
 
 4.0.0
 -----

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,10 +1,14 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * The method `TraceableEventDispatcher::getOrphanedEvents()` has been added.
+
 4.0.0
 -----
 
-  * The method `EventDispatcherInterface::getOrphanedEvents()` has been added.
  * removed the `ContainerAwareEventDispatcher` class
  * added the `reset()` method to the `TraceableEventDispatcherInterface`
 

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.0.0
 -----
 
+  * The method `EventDispatcherInterface::getOrphanedEvents()` has been added.
  * removed the `ContainerAwareEventDispatcher` class
  * added the `reset()` method to the `TraceableEventDispatcherInterface`
 

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -32,6 +32,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     private $called;
     private $dispatcher;
     private $wrappedListeners;
+    private $orphanedEvents;
 
     public function __construct(EventDispatcherInterface $dispatcher, Stopwatch $stopwatch, LoggerInterface $logger = null)
     {
@@ -40,6 +41,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         $this->logger = $logger;
         $this->called = array();
         $this->wrappedListeners = array();
+        $this->orphanedEvents = array();
     }
 
     /**
@@ -247,6 +249,10 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
 
     private function preProcess($eventName)
     {
+        if (false === $this->dispatcher->hasListeners($eventName)) {
+            $this->orphanedEvents[] = $eventName;
+        }
+
         foreach ($this->dispatcher->getListeners($eventName) as $listener) {
             $priority = $this->getListenerPriority($eventName, $listener);
             $wrappedListener = new WrappedListener($listener, null, $this->stopwatch, $this);
@@ -318,5 +324,15 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         }
 
         return 1;
+    }
+
+    /**
+     * Gets the orphaned events.
+     *
+     * @return array An array of orphaned events
+     */
+    public function getOrphanedEvents()
+    {
+        return $this->orphanedEvents;
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -209,6 +209,16 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         return $notCalled;
     }
 
+    /**
+     * Gets the orphaned events.
+     *
+     * @return array An array of orphaned events
+     */
+    public function getOrphanedEvents()
+    {
+        return $this->orphanedEvents;
+    }
+
     public function reset()
     {
         $this->called = array();
@@ -249,8 +259,10 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
 
     private function preProcess($eventName)
     {
-        if (false === $this->dispatcher->hasListeners($eventName)) {
+        if (!$this->dispatcher->hasListeners($eventName)) {
             $this->orphanedEvents[] = $eventName;
+
+            return;
         }
 
         foreach ($this->dispatcher->getListeners($eventName) as $listener) {
@@ -324,15 +336,5 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         }
 
         return 1;
-    }
-
-    /**
-     * Gets the orphaned events.
-     *
-     * @return array An array of orphaned events
-     */
-    public function getOrphanedEvents()
-    {
-        return $this->orphanedEvents;
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\EventDispatcher\Debug;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
+ * @deprecated since version 4.1, will be removed in 5.0.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 interface TraceableEventDispatcherInterface extends EventDispatcherInterface
@@ -36,11 +38,4 @@ interface TraceableEventDispatcherInterface extends EventDispatcherInterface
      * Resets the trace.
      */
     public function reset();
-
-    /**
-     * Gets the orphaned events.
-     *
-     * @return array An array of orphaned events
-     */
-    public function getOrphanedEvents();
 }

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
@@ -36,4 +36,11 @@ interface TraceableEventDispatcherInterface extends EventDispatcherInterface
      * Resets the trace.
      */
     public function reset();
+
+    /**
+     * Gets the orphaned events.
+     *
+     * @return array An array of orphaned events
+     */
+    public function getOrphanedEvents();
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -153,6 +153,40 @@ class TraceableEventDispatcherTest extends TestCase
         $this->assertCount(2, $dispatcher->getCalledListeners());
     }
 
+    public function testItReturnsNoOrphanedEventsWhenCreated()
+    {
+        // GIVEN
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        // WHEN
+        $events = $tdispatcher->getOrphanedEvents();
+        // THEN
+        $this->assertEmpty($events);
+    }
+
+    public function testItReturnsOrphanedEventsAfterDispatch()
+    {
+        // GIVEN
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->dispatch('foo');
+        // WHEN
+        $events = $tdispatcher->getOrphanedEvents();
+        // THEN
+        $this->assertCount(1, $events);
+        $this->assertEquals(array('foo'), $events);
+    }
+
+    public function testItDoesNotReturnHandledEvents()
+    {
+        // GIVEN
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->addListener('foo', function () {});
+        $tdispatcher->dispatch('foo');
+        // WHEN
+        $events = $tdispatcher->getOrphanedEvents();
+        // THEN
+        $this->assertEmpty($events);
+    }
+
     public function testLogger()
     {
         $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 4.0.0
 -----
 
+ * added orphaned events support to `EventDataCollector`
  * removed the `DataCollector::varToString()` method, use `DataCollector::cloneVar()`
    instead
  * using the `DataCollector::cloneVar()` method requires the VarDumper component

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.1.0
 -----
 
+ * added orphaned events support to `EventDataCollector`
  * `ExceptionListener` now logs and collects exceptions at priority `2048` (previously logged at `-128` and collected at `0`)
 
 4.0.0
@@ -33,7 +34,6 @@ CHANGELOG
 3.4.0
 -----
 
- * added orphaned events support to `EventDataCollector`
  * added a minimalist PSR-3 `Logger` class that writes in `stderr`
  * made kernels implementing `CompilerPassInterface` able to process the container
  * deprecated bundle inheritance

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -9,7 +9,6 @@ CHANGELOG
 4.0.0
 -----
 
- * added orphaned events support to `EventDataCollector`
  * removed the `DataCollector::varToString()` method, use `DataCollector::cloneVar()`
    instead
  * using the `DataCollector::cloneVar()` method requires the VarDumper component
@@ -34,6 +33,7 @@ CHANGELOG
 3.4.0
 -----
 
+ * added orphaned events support to `EventDataCollector`
  * added a minimalist PSR-3 `Logger` class that writes in `stderr`
  * made kernels implementing `CompilerPassInterface` able to process the container
  * deprecated bundle inheritance

--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\HttpKernel\DataCollector;
 
+use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface;
 
 /**
  * EventDataCollector.
@@ -53,7 +53,7 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
 
     public function lateCollect()
     {
-        if ($this->dispatcher instanceof TraceableEventDispatcherInterface) {
+        if ($this->dispatcher instanceof TraceableEventDispatcher) {
             $this->setCalledListeners($this->dispatcher->getCalledListeners());
             $this->setNotCalledListeners($this->dispatcher->getNotCalledListeners());
             $this->setOrphanedEvents($this->dispatcher->getOrphanedEvents());
@@ -66,7 +66,7 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
      *
      * @param array $listeners An array of called listeners
      *
-     * @see TraceableEventDispatcherInterface
+     * @see TraceableEventDispatcher
      */
     public function setCalledListeners(array $listeners)
     {
@@ -74,23 +74,11 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
     }
 
     /**
-     * Gets the called listeners.
-     *
-     * @return array An array of called listeners
-     *
-     * @see TraceableEventDispatcherInterface
-     */
-    public function getCalledListeners()
-    {
-        return $this->data['called_listeners'];
-    }
-
-    /**
      * Sets the not called listeners.
      *
      * @param array $listeners An array of not called listeners
      *
-     * @see TraceableEventDispatcherInterface
+     * @see TraceableEventDispatcher
      */
     public function setNotCalledListeners(array $listeners)
     {
@@ -98,23 +86,11 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
     }
 
     /**
-     * Gets the not called listeners.
-     *
-     * @return array An array of not called listeners
-     *
-     * @see TraceableEventDispatcherInterface
-     */
-    public function getNotCalledListeners()
-    {
-        return $this->data['not_called_listeners'];
-    }
-
-    /**
      * Sets the orphaned events.
      *
      * @param array $events An array of orphaned events
      *
-     * @see TraceableEventDispatcherInterface
+     * @see TraceableEventDispatcher
      */
     public function setOrphanedEvents(array $events)
     {
@@ -122,11 +98,35 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
     }
 
     /**
+     * Gets the called listeners.
+     *
+     * @return array An array of called listeners
+     *
+     * @see TraceableEventDispatcher
+     */
+    public function getCalledListeners()
+    {
+        return $this->data['called_listeners'];
+    }
+
+    /**
+     * Gets the not called listeners.
+     *
+     * @return array An array of not called listeners
+     *
+     * @see TraceableEventDispatcher
+     */
+    public function getNotCalledListeners()
+    {
+        return $this->data['not_called_listeners'];
+    }
+
+    /**
      * Gets the orphaned events.
      *
      * @return array An array of orphaned events
      *
-     * @see TraceableEventDispatcherInterface
+     * @see TraceableEventDispatcher
      */
     public function getOrphanedEvents()
     {

--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\DataCollector;
 
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
+use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -53,11 +54,15 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
 
     public function lateCollect()
     {
-        if ($this->dispatcher instanceof TraceableEventDispatcher) {
+        if ($this->dispatcher instanceof TraceableEventDispatcherInterface) {
             $this->setCalledListeners($this->dispatcher->getCalledListeners());
             $this->setNotCalledListeners($this->dispatcher->getNotCalledListeners());
+        }
+
+        if ($this->dispatcher instanceof TraceableEventDispatcher) {
             $this->setOrphanedEvents($this->dispatcher->getOrphanedEvents());
         }
+
         $this->data = $this->cloneVar($this->data);
     }
 
@@ -74,30 +79,6 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
     }
 
     /**
-     * Sets the not called listeners.
-     *
-     * @param array $listeners An array of not called listeners
-     *
-     * @see TraceableEventDispatcher
-     */
-    public function setNotCalledListeners(array $listeners)
-    {
-        $this->data['not_called_listeners'] = $listeners;
-    }
-
-    /**
-     * Sets the orphaned events.
-     *
-     * @param array $events An array of orphaned events
-     *
-     * @see TraceableEventDispatcher
-     */
-    public function setOrphanedEvents(array $events)
-    {
-        $this->data['orphaned_events'] = $events;
-    }
-
-    /**
      * Gets the called listeners.
      *
      * @return array An array of called listeners
@@ -110,15 +91,39 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
     }
 
     /**
+     * Sets the not called listeners.
+     *
+     * @param array $listeners
+     *
+     * @see TraceableEventDispatcher
+     */
+    public function setNotCalledListeners(array $listeners)
+    {
+        $this->data['not_called_listeners'] = $listeners;
+    }
+
+    /**
      * Gets the not called listeners.
      *
-     * @return array An array of not called listeners
+     * @return array
      *
      * @see TraceableEventDispatcher
      */
     public function getNotCalledListeners()
     {
         return $this->data['not_called_listeners'];
+    }
+
+    /**
+     * Sets the orphaned events.
+     *
+     * @param array $events An array of orphaned events
+     *
+     * @see TraceableEventDispatcher
+     */
+    public function setOrphanedEvents(array $events)
+    {
+        $this->data['orphaned_events'] = $events;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -38,6 +38,7 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
         $this->data = array(
             'called_listeners' => array(),
             'not_called_listeners' => array(),
+            'orphaned_events' => array(),
         );
     }
 
@@ -55,6 +56,7 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
         if ($this->dispatcher instanceof TraceableEventDispatcherInterface) {
             $this->setCalledListeners($this->dispatcher->getCalledListeners());
             $this->setNotCalledListeners($this->dispatcher->getNotCalledListeners());
+            $this->setOrphanedEvents($this->dispatcher->getOrphanedEvents());
         }
         $this->data = $this->cloneVar($this->data);
     }
@@ -105,6 +107,30 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
     public function getNotCalledListeners()
     {
         return $this->data['not_called_listeners'];
+    }
+
+    /**
+     * Sets the orphaned events.
+     *
+     * @param array $events An array of orphaned events
+     *
+     * @see TraceableEventDispatcherInterface
+     */
+    public function setOrphanedEvents(array $events)
+    {
+        $this->data['orphaned_events'] = $events;
+    }
+
+    /**
+     * Gets the orphaned events.
+     *
+     * @return array An array of orphaned events
+     *
+     * @see TraceableEventDispatcherInterface
+     */
+    public function getOrphanedEvents()
+    {
+        return $this->data['orphaned_events'];
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/TestEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/TestEventDispatcher.php
@@ -11,10 +11,9 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Fixtures;
 
-use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
 
-class TestEventDispatcher extends EventDispatcher implements TraceableEventDispatcherInterface
+class TestEventDispatcher extends TraceableEventDispatcher
 {
     public function getCalledListeners()
     {

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/TestEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/TestEventDispatcher.php
@@ -29,4 +29,9 @@ class TestEventDispatcher extends EventDispatcher implements TraceableEventDispa
     public function reset()
     {
     }
+
+    public function getOrphanedEvents()
+    {
+        return array();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #24347
| License       | MIT

Implements #24347.

Deprecating `TraceableEventDispatcherInterface`.
