### PR TITLE
Remove the array long syntax requirement

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,7 +8,6 @@ return PhpCsFixer\Config::create()
     ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        'array_syntax' => array('syntax' => 'long'),
         'protected_to_private' => false,
     ))
     ->setRiskyAllowed(true)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

Remove the long-array-syntax rule in the PHP-CS rules to allow usage of short-syntax PHP array for new PRs going to 4.1.