### PR TITLE
[Form] Change datetime to datetime-local for HTML5 datetime input

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -34,17 +34,12 @@ class DateTimeType extends AbstractType
 
     /**
      * This is not quite the HTML5 format yet, because ICU lacks the
-     * capability of parsing and generating RFC 3339 dates, which
-     * are like the below pattern but with a timezone suffix. The
-     * timezone suffix is.
-     *
-     *  * "Z" for UTC
-     *  * "(-|+)HH:mm" for other timezones (note the colon!)
+     * capability of parsing and generating RFC 3339 dates.
      *
      * For more information see:
      *
      * http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
-     * http://www.w3.org/TR/html-markup/input.datetime.html
+     * https://www.w3.org/TR/html5/sec-forms.html#local-date-and-time-state-typedatetimelocal
      * http://tools.ietf.org/html/rfc3339
      *
      * An ICU ticket was created:
@@ -54,7 +49,7 @@ class DateTimeType extends AbstractType
      * yet. To temporarily circumvent this issue, DateTimeToRfc3339Transformer
      * is used when the format matches this constant.
      */
-    const HTML5_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZZZZ";
+    const HTML5_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
     private static $acceptedFormats = array(
         \IntlDateFormatter::FULL,
@@ -192,7 +187,7 @@ class DateTimeType extends AbstractType
         //  * the format matches the one expected by HTML5
         //  * the html5 is set to true
         if ($options['html5'] && 'single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
-            $view->vars['type'] = 'datetime';
+            $view->vars['type'] = 'datetime-local';
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -1525,7 +1525,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
-    [@type="datetime"]
+    [@type="datetime-local"]
     [@name="name"]
     [@class="my&class form-control"]
     [@value="2011-02-03T04:05:06Z"]
@@ -1546,7 +1546,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class')),
 '/input
-    [@type="datetime"]
+    [@type="datetime-local"]
     [@name="name"]
     [@class="my&class form-control"]
     [@value="2011-02-03T04:05:06Z"]

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1426,7 +1426,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
-    [@type="datetime"]
+    [@type="datetime-local"]
     [@name="name"]
     [@value="2011-02-03T04:05:06Z"]
 '
@@ -1446,7 +1446,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
-    [@type="datetime"]
+    [@type="datetime-local"]
     [@name="name"]
     [@value="2011-02-03T04:05:06Z"]
 '

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -283,7 +283,7 @@ class DateTimeTypeTest extends BaseTypeTest
         ))
             ->createView();
 
-        $this->assertEquals('datetime', $view->vars['type']);
+        $this->assertEquals('datetime-local', $view->vars['type']);
     }
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
@@ -433,7 +433,7 @@ class DateTimeTypeTest extends BaseTypeTest
         ))
             ->createView();
 
-        $this->assertSame('datetime', $view->vars['type']);
+        $this->assertSame('datetime-local', $view->vars['type']);
     }
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | Unknown
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24307
| License       | MIT
| Doc PR        | N/A

Change the input type from datetime to datetime-local for HTML5 date input (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime)