### PR TITLE
[Bridge\Doctrine][FrameworkBundle] Deprecate some remaining uses of ContainerAwareTrait

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
+++ b/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
@@ -12,9 +12,10 @@
 namespace Symfony\Bridge\Doctrine;
 
 use ProxyManager\Proxy\LazyLoadingInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Doctrine\Common\Persistence\AbstractManagerRegistry;
 
 /**
@@ -24,7 +25,21 @@ use Doctrine\Common\Persistence\AbstractManagerRegistry;
  */
 abstract class ManagerRegistry extends AbstractManagerRegistry implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @deprecated since version 3.4, to be removed in 4.0 alongside with the ContainerAwareInterface type.
+     * @final since version 3.4
+     */
+    public function setContainer(SymfonyContainerInterface $container = null)
+    {
+        @trigger_error(sprintf('The "%s()" method is deprecated since version 3.4 and will be removed in 4.0. Inject a PSR-11 container using the constructor instead.', __METHOD__), E_USER_DEPRECATED);
+
+        $this->container = $container;
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
@@ -31,7 +31,7 @@ class ManagerRegistryTest extends TestCase
         $container = new \LazyServiceProjectServiceContainer();
 
         $registry = new TestManagerRegistry('name', array(), array('defaultManager' => 'foo'), 'defaultConnection', 'defaultManager', 'proxyInterfaceName');
-        $registry->setContainer($container);
+        $registry->setTestContainer($container);
 
         $foo = $container->get('foo');
         $foo->bar = 123;
@@ -46,6 +46,11 @@ class ManagerRegistryTest extends TestCase
 
 class TestManagerRegistry extends ManagerRegistry
 {
+    public function setTestContainer($container)
+    {
+        $this->container = $container;
+    }
+
     public function getAliasNamespace($alias)
     {
         return 'Foo';

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -48,13 +48,7 @@ class ControllerResolver extends ContainerControllerResolver
         $resolvedController = parent::createController($controller);
 
         if (1 === substr_count($controller, ':') && is_array($resolvedController)) {
-            if ($resolvedController[0] instanceof ContainerAwareInterface) {
-                $resolvedController[0]->setContainer($this->container);
-            }
-
-            if ($resolvedController[0] instanceof AbstractController && null !== $previousContainer = $resolvedController[0]->setContainer($this->container)) {
-                $resolvedController[0]->setContainer($previousContainer);
-            }
+            $resolvedController[0] = $this->configureController($resolvedController[0]);
         }
 
         return $resolvedController;
@@ -65,9 +59,19 @@ class ControllerResolver extends ContainerControllerResolver
      */
     protected function instantiateController($class)
     {
-        $controller = parent::instantiateController($class);
+        return $this->configureController(parent::instantiateController($class));
+    }
 
+    private function configureController($controller)
+    {
         if ($controller instanceof ContainerAwareInterface) {
+            // @deprecated switch, to be removed in 4.0 where these classes
+            // won't implement ContainerAwareInterface anymore
+            switch (\get_class($controller)) {
+                case RedirectController::class:
+                case TemplateController::class:
+                    return $controller;
+            }
             $controller->setContainer($this->container);
         }
         if ($controller instanceof AbstractController && null !== $previousContainer = $controller->setContainer($this->container)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Controller;
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,10 +23,37 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * Redirects a request to another URL.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since version 3.4
  */
 class RedirectController implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
+    /**
+     * @deprecated since version 3.4, to be removed in 4.0
+     */
+    protected $container;
+
+    private $router;
+    private $httpPort;
+    private $httpsPort;
+
+    public function __construct(UrlGeneratorInterface $router = null, $httpPort = null, $httpsPort = null)
+    {
+        $this->router = $router;
+        $this->httpPort = $httpPort;
+        $this->httpsPort = $httpsPort;
+    }
+
+    /**
+     * @deprecated since version 3.4, to be removed in 4.0 alongside with the ContainerAwareInterface type.
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        @trigger_error(sprintf('The "%s()" method is deprecated since version 3.4 and will be removed in 4.0. Inject an UrlGeneratorInterface using the constructor instead.', __METHOD__), E_USER_DEPRECATED);
+
+        $this->container = $container;
+        $this->router = $container->get('router');
+    }
 
     /**
      * Redirects to another route with the given name.
@@ -61,7 +88,7 @@ class RedirectController implements ContainerAwareInterface
             }
         }
 
-        return new RedirectResponse($this->container->get('router')->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL), $permanent ? 301 : 302);
+        return new RedirectResponse($this->router->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL), $permanent ? 301 : 302);
     }
 
     /**
@@ -115,8 +142,11 @@ class RedirectController implements ContainerAwareInterface
             if (null === $httpPort) {
                 if ('http' === $request->getScheme()) {
                     $httpPort = $request->getPort();
-                } elseif ($this->container->hasParameter('request_listener.http_port')) {
+                } elseif ($this->container && $this->container->hasParameter('request_listener.http_port')) {
+                    @trigger_error(sprintf('Passing the http port as a container parameter is deprecated since Symfony 3.4 and won\'t be possible in 4.0. Pass it to the constructor of the "%s" class instead.', __CLASS__), E_USER_DEPRECATED);
                     $httpPort = $this->container->getParameter('request_listener.http_port');
+                } else {
+                    $httpPort = $this->httpPort;
                 }
             }
 
@@ -127,8 +157,11 @@ class RedirectController implements ContainerAwareInterface
             if (null === $httpsPort) {
                 if ('https' === $request->getScheme()) {
                     $httpsPort = $request->getPort();
-                } elseif ($this->container->hasParameter('request_listener.https_port')) {
+                } elseif ($this->container && $this->container->hasParameter('request_listener.https_port')) {
+                    @trigger_error(sprintf('Passing the https port as a container parameter is deprecated since Symfony 3.4 and won\'t be possible in 4.0. Pass it to the constructor of the "%s" class instead.', __CLASS__), E_USER_DEPRECATED);
                     $httpsPort = $this->container->getParameter('request_listener.https_port');
+                } else {
+                    $httpsPort = $this->httpsPort;
                 }
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -110,5 +110,16 @@
             <argument type="service" id="router.request_context" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
+
+        <service id="Symfony\Bundle\FrameworkBundle\Controller\RedirectController" public="true">
+            <argument type="service" id="router" />
+            <argument>%request_listener.http_port%</argument>
+            <argument>%request_listener.https_port%</argument>
+        </service>
+
+        <service id="Symfony\Bundle\FrameworkBundle\Controller\TemplateController" public="true">
+            <argument type="service" id="twig" on-invalid="ignore" />
+            <argument type="service" id="templating" on-invalid="ignore" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -21,6 +21,29 @@ use Symfony\Component\HttpFoundation\Response;
 class TemplateControllerTest extends TestCase
 {
     public function testTwig()
+    {
+        $twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
+        $twig->expects($this->once())->method('render')->willReturn('bar');
+
+        $controller = new TemplateController($twig);
+
+        $this->assertEquals('bar', $controller->templateAction('mytemplate')->getContent());
+    }
+
+    public function testTemplating()
+    {
+        $templating = $this->getMockBuilder(EngineInterface::class)->getMock();
+        $templating->expects($this->once())->method('render')->willReturn('bar');
+
+        $controller = new TemplateController(null, $templating);
+
+        $this->assertEquals('bar', $controller->templateAction('mytemplate')->getContent());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyTwig()
     {
         $twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
         $twig->expects($this->once())->method('render')->willReturn('bar');
@@ -36,10 +59,13 @@ class TemplateControllerTest extends TestCase
         $this->assertEquals('bar', $controller->templateAction('mytemplate')->getContent());
     }
 
-    public function testTemplating()
+    /**
+     * @group legacy
+     */
+    public function testLegacyTemplating()
     {
         $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface')->getMock();
-        $templating->expects($this->once())->method('renderResponse')->willReturn(new Response('bar'));
+        $templating->expects($this->once())->method('render')->willReturn('bar');
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $container->expects($this->at(0))->method('has')->willReturn(true);
@@ -57,12 +83,7 @@ class TemplateControllerTest extends TestCase
      */
     public function testNoTwigNorTemplating()
     {
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $container->expects($this->at(0))->method('has')->willReturn(false);
-        $container->expects($this->at(1))->method('has')->willReturn(false);
-
         $controller = new TemplateController();
-        $controller->setContainer($container);
 
         $controller->templateAction('mytemplate')->getContent();
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandl
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  * @group time-sensitive
+ * @group legacy
  */
 class MongoDbSessionHandlerTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

With this PR, the last two remaining uses of ContainerAwareTrait will be `Symfony\Component\HttpKernel\Bundle\Bundle` and `Symfony\Bundle\FrameworkBundle\Controller\Controller`.
For Bundle, I think it's legitimate, for Controller, I think it's not, but that we should wait for 4.1 before considering its deprecation, alongside with `ContainerAwareCommand` (maybe).