### PR TITLE
[Cache] Fix race condition in TagAwareAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -250,19 +250,12 @@ class TagAwareAdapter implements TagAwareAdapterInterface
 
             $f = $this->getTagsByKey;
             $tagsByKey = $f($items);
-            $deletedTags = $this->deferred = array();
+            $this->deferred = array();
             $tagVersions = $this->getTagVersions($tagsByKey);
             $f = $this->createCacheItem;
 
             foreach ($tagsByKey as $key => $tags) {
-                if ($tags) {
-                    $this->itemsAdapter->saveDeferred($f(static::TAGS_PREFIX.$key, array_intersect_key($tagVersions, $tags), $items[$key]));
-                } else {
-                    $deletedTags[] = static::TAGS_PREFIX.$key;
-                }
-            }
-            if ($deletedTags) {
-                $this->itemsAdapter->deleteItems($deletedTags);
+                $this->itemsAdapter->saveDeferred($f(static::TAGS_PREFIX.$key, array_intersect_key($tagVersions, $tags), $items[$key]));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24240
| License       | MIT
| Doc PR        | -

This code is not needed, and might create a race condition (see linked issue). Let's drop it.
When no tags are set on an item, this stores an empty tags array, instead of deleting the tags array entry at all.