### PR TITLE
[Config] Fix dumped files invalidation by OPCache

### DIFF
--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -149,6 +149,10 @@ class ConfigCache implements ConfigCacheInterface
                 // discard chmod failure (some filesystem may not support it)
             }
         }
+
+        if (\function_exists('opcache_invalidate') && ini_get('opcache.enable')) {
+            @opcache_invalidate($this->file, true);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

While demoing Flex, I've noticed that container invalidation takes a few seconds on my setup.
I've debugged that down to OPcache, which serves the legacy container while it's been overridden.
Let's invalidate the file explicitly when it changes.