### PR TITLE
[HttpFoundation] optimize files for distribution

### DIFF
--- a/src/Symfony/Component/HttpFoundation/.gitattributes
+++ b/src/Symfony/Component/HttpFoundation/.gitattributes
@@ -1,0 +1,4 @@
+Tests/           export-ignore
+phpunit.xml.dist export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Currently every production installation will pull in all of the tests into the vendor directory. This is unnecessary file bloat on the server and network bandwidth. By adding a `.gitattributes` file with filenames listed to be excluded during export, this will speed up installations and facilitate better stewardship of server resources.

This is my 1st PR, so I hope I understood the contributing guidelines and submitted to the correct repository and branch, so please kindly advise if otherwise. If acceptable in principle, then I'd be happy to duplicate the efforts in additional commits for the other components. I chose the HttpFoundation subtree because it came to my attention as it was used in a project when a lint failed on a php 5.6 server only because of php 7 language used in one of the tests.

Thanks!