### PR TITLE
[DI][DX] Allow exclude to be an array of patterns

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -40,10 +40,10 @@ abstract class FileLoader extends BaseFileLoader
     /**
      * Registers a set of classes as services using PSR-4 for discovery.
      *
-     * @param Definition $prototype A definition to use as template
-     * @param string     $namespace The namespace prefix of classes in the scanned directory
-     * @param string     $resource  The directory to look for classes, glob-patterns allowed
-     * @param string     $exclude   A globed path of files to exclude
+     * @param Definition      $prototype A definition to use as template
+     * @param string          $namespace The namespace prefix of classes in the scanned directory
+     * @param string          $resource  The directory to look for classes, glob-patterns allowed
+     * @param string|string[] $exclude   A globed path of files to exclude or an array of globed paths of files to exclude
      */
     public function registerClasses(Definition $prototype, $namespace, $resource, $exclude = null)
     {
@@ -54,7 +54,7 @@ abstract class FileLoader extends BaseFileLoader
             throw new InvalidArgumentException(sprintf('Namespace is not a valid PSR-4 prefix: %s.', $namespace));
         }
 
-        $classes = $this->findClasses($namespace, $resource, $exclude);
+        $classes = $this->findClasses($namespace, $resource, (array) $exclude);
         // prepare for deep cloning
         $serializedPrototype = serialize($prototype);
         $interfaces = array();
@@ -101,21 +101,22 @@ abstract class FileLoader extends BaseFileLoader
         }
     }
 
-    private function findClasses($namespace, $pattern, $excludePattern)
+    private function findClasses($namespace, $pattern, array $excludePatterns)
     {
         $parameterBag = $this->container->getParameterBag();
 
         $excludePaths = array();
         $excludePrefix = null;
-        if ($excludePattern) {
-            $excludePattern = $parameterBag->unescapeValue($parameterBag->resolveValue($excludePattern));
-            foreach ($this->glob($excludePattern, true, $resource) as $path => $info) {
-                if (null === $excludePrefix) {
-                    $excludePrefix = $resource->getPrefix();
+        if ($excludePatterns) {
+            $excludePatterns = $parameterBag->unescapeValue($parameterBag->resolveValue($excludePatterns));
+            foreach ($excludePatterns as $excludePattern) {
+                foreach ($this->glob($excludePattern, true, $resource) as $path => $info) {
+                    if (null === $excludePrefix) {
+                        $excludePrefix = $resource->getPrefix();
+                    }
+                    // normalize Windows slashes
+                    $excludePaths[str_replace('\\', '/', $path)] = true;
                 }
-
-                // normalize Windows slashes
-                $excludePaths[str_replace('\\', '/', $path)] = true;
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -184,6 +184,27 @@ class FileLoaderTest extends TestCase
         );
     }
 
+    public function testRegisterClassesWithExcludeAsArray()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('sub_dir', 'Sub');
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        $loader->registerClasses(
+            new Definition(),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\\',
+            'Prototype/*', array(
+                'Prototype/%sub_dir%',
+                'Prototype/OtherDir/AnotherSub/DeeperBaz.php',
+            )
+        );
+
+        $this->assertTrue($container->has(Foo::class));
+        $this->assertTrue($container->has(Baz::class));
+        $this->assertFalse($container->has(Bar::class));
+        $this->assertFalse($container->has(DeeperBaz::class));
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @expectedExceptionMessageRegExp /Expected to find class "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\Prototype\\Bar" in file ".+" while importing services from resource "Prototype\/Sub\/\*", but it was not found\! Check the namespace prefix used with the resource/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23956 
| License       | MIT
| Doc PR        | not provided yet

Before:
```yaml
AppBundle\:
  resource: '../../src/AppBundle/*'
  exclude: '../../src/AppBundle/{Entity,Payload,Repository}'
```
After:
```yaml
AppBundle\:
  resource: '../../src/AppBundle/*'
  exclude:
    - '../../src/AppBundle/{Entity,Payload,Repository}'
    - '../../src/AppBundle/Event/*Event.php'
```
