### PR TITLE
[Validator] Add common double dot email typo

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -411,6 +411,8 @@ Validator
  * Not setting the `strict` option of the `Choice` constraint to `true` is
    deprecated and will throw an exception in Symfony 4.0.
 
+ * The pattern for used by the `Email` validator will use the html5 email input pattern in Symfony 4.0.
+
 Yaml
 ----
 

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -23,6 +23,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class EmailValidator extends ConstraintValidator
 {
+    const PATTERN_LOOSE = '/^.+\@\S+\.\S+$/';
+    const PATTERN_HTML5 = '/^[a-zA-Z0-9.!#$%&\'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/';
+
     /**
      * @var bool
      */
@@ -78,7 +81,11 @@ class EmailValidator extends ConstraintValidator
 
                 return;
             }
-        } elseif (!preg_match('/^.+\@\S+\.\S+$/', $value)) {
+        } elseif (!preg_match(self::PATTERN_LOOSE, $value)) {
+            if (!preg_match(self::PATTERN_HTML5, $value)) {
+                @trigger_error('The loose email pattern is deprecated since version 3.4 and will be switched to the html5 email elements pattern in 4.0');
+            }
+
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Email::INVALID_FORMAT_ERROR)

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -68,6 +68,16 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
+     */
+    public function testLegacyPattern()
+    {
+        $this->validator->validate('example@example.co..uk', new Email());
+
+        $this->assertNoViolation();
+    }
+
+    /**
      * @dataProvider getInvalidEmails
      */
     public function testInvalidEmails($email)


### PR DESCRIPTION
The most common email typo that we see in our logs is the "double dot".
This is where a user types "username@example..com", rather than
"username@example.com". This particular common user typo isn't a
possible email address and, wasn't previously covered by the validator.

Why is this added here and not strict? Strict allows some addresses like
"username@example", which, while technically valid (you could use this
case to address a machine with the hostname "example") are undesirable
for nearly all applications.

Note: This specific case is already covered under strict validations.

| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
