### PR TITLE
[Form] Use for=ID on radio/checkbox label.

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -148,10 +148,14 @@
 {% endblock %}
 
 {% block checkbox_label -%}
+    {%- set label_attr = label_attr|merge({'for': id}) -%}
+
     {{- block('checkbox_radio_label') -}}
 {%- endblock checkbox_label %}
 
 {% block radio_label -%}
+    {%- set label_attr = label_attr|merge({'for': id}) -%}
+
     {{- block('checkbox_radio_label') -}}
 {%- endblock radio_label %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I recently let Europe's leading accessibility experts (Funkanu.se) review a site of mine, they gave me (among other) this feedback.

> Putting the checkbox/radio input inside the label is great, but the label still needs the "for=ID". Screen readers like Jaws does not work properly without this attribute. 
