### PR TITLE
[Console] Escape command usage

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -143,7 +143,7 @@ class TextDescriptor extends Descriptor
         $this->writeText('<comment>Usage:</comment>', $options);
         foreach (array_merge(array($command->getSynopsis(true)), $command->getAliases(), $command->getUsages()) as $usage) {
             $this->writeText("\n");
-            $this->writeText('  '.$usage, $options);
+            $this->writeText('  '.OutputFormatter::escape($usage), $options);
         }
         $this->writeText("\n");
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
@@ -1,7 +1,7 @@
 <comment>Usage:</comment>
-  descriptor:command2 [options] [--] <argument_name>
-  descriptor:command2 -o|--option_name <argument_name>
-  descriptor:command2 <argument_name>
+  descriptor:command2 [options] [--] \<argument_name>
+  descriptor:command2 -o|--option_name \<argument_name>
+  descriptor:command2 \<argument_name>
 
 <comment>Arguments:</comment>
   <info>argument_name</info>      

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
@@ -1,7 +1,7 @@
 <comment>Usage:</comment>
-  descriptor:åèä [options] [--] <argument_åèä>
-  descriptor:åèä -o|--option_name <argument_name>
-  descriptor:åèä <argument_name>
+  descriptor:åèä [options] [--] \<argument_åèä>
+  descriptor:åèä -o|--option_name \<argument_name>
+  descriptor:åèä \<argument_name>
 
 <comment>Arguments:</comment>
   <info>argument_åèä</info>   


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24225
| License       | MIT
| Doc PR        | ø

Escape the console usage to prevent arguments named `info` or similar to be formatted. 