### PR TITLE
[Security] Proposal for making Symfony anonymous user an object.

### DIFF
--- a/src/Symfony/Component/Security/Core/User/AnonymousUser.php
+++ b/src/Symfony/Component/Security/Core/User/AnonymousUser.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Symfony\Component\Security\Core\User;

--- a/src/Symfony/Component/Security/Core/User/AnonymousUser.php
+++ b/src/Symfony/Component/Security/Core/User/AnonymousUser.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\User;
+
+/**
+ * Class AnonymousUser represents an anonymous (not authenticated) user.
+ *
+ * @author Ole Rößner <ole@roessner.it>
+ */
+final class AnonymousUser implements AnonymousUserInterface
+{
+    /** {@inheritdoc} */
+    public function getRoles(): array
+    {
+        return array();
+    }
+
+    /** {@inheritdoc} */
+    public function getPassword(): string
+    {
+        return '';
+    }
+
+    /** {@inheritdoc} */
+    public function getSalt(): ?string
+    {
+        return null;
+    }
+
+    /** {@inheritdoc} */
+    public function getUsername(): string
+    {
+        return 'anon.';
+    }
+
+    /** {@inheritdoc} */
+    public function eraseCredentials(): void
+    {
+    }
+
+    /**
+     * Returns the username.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->getUsername();
+    }
+}

--- a/src/Symfony/Component/Security/Core/User/AnonymousUserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/AnonymousUserInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Security\Core\User;
+
+/**
+ * Class AnonymousUserInterface.
+ */
+interface AnonymousUserInterface extends UserInterface
+{
+}

--- a/src/Symfony/Component/Security/Core/User/AnonymousUserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/AnonymousUserInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Symfony\Component\Security\Core\User;

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\User\AnonymousUser;
 
 /**
  * AnonymousAuthenticationListener automatically adds a Token if none is
@@ -51,7 +52,7 @@ class AnonymousAuthenticationListener implements ListenerInterface
         }
 
         try {
-            $token = new AnonymousToken($this->secret, 'anon.', array());
+            $token = new AnonymousToken($this->secret, new AnonymousUser(), array());
             if (null !== $this->authenticationManager) {
                 $token = $this->authenticationManager->authenticate($token);
             }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\User\AnonymousUser;
 use Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener;
 
 class AnonymousAuthenticationListenerTest extends TestCase
@@ -49,7 +50,7 @@ class AnonymousAuthenticationListenerTest extends TestCase
             ->will($this->returnValue(null))
         ;
 
-        $anonymousToken = new AnonymousToken('TheSecret', 'anon.', array());
+        $anonymousToken = new AnonymousToken('TheSecret', new AnonymousUser(), array());
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
         $authenticationManager


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | no
| License       | MIT

I've read some pretty old issues (#10168 and #3697) about this topic and use a similar solution in my current project which works out pretty well. Maybe 4.0 is a good starting point to change the behaviour of returning a mixed type from TokenInterface::getUser().

What do you think?
