### PR TITLE
[Yaml] initialize inline line numbers

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -20,7 +20,7 @@ class InlineTest extends TestCase
 {
     protected function setUp()
     {
-        Inline::initialize(0);
+        Inline::initialize(0, 0);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Without this change, tests from `InlineTest` cannot be executed
standalone as the parsed line number would never be initialized.