### PR TITLE
[DX][FrameworkBundle] Clarify where to find exceptions for non-registered commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -190,7 +190,7 @@ class Application extends BaseApplication
             $output = $output->getErrorOutput();
         }
 
-        (new SymfonyStyle($input, $output))->warning('Some commands could not be registered.');
+        (new SymfonyStyle($input, $output))->warning('Some commands could not be registered:');
 
         foreach ($this->registrationErrors as $error) {
             $this->doRenderException($error, $output);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -160,7 +160,7 @@ class ApplicationTest extends TestCase
         $output = $tester->getDisplay();
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertContains('Some commands could not be registered.', $output);
+        $this->assertContains('Some commands could not be registered:', $output);
         $this->assertContains('throwing', $output);
         $this->assertContains('fine', $output);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

As a developer, when I saw "Some commands could not be registered." displayed on my console... it wasn't clear ether the next displayed exception was related to this or not. Just adding a reference to the "following errors" would help.