### PR TITLE
[Security] Call logout handlers even if token is null

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/DummyToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/DummyToken.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * DummyToken allows fixing #7104 without introducing any BC break.
+ *
+ * @author Mathieu Lechat <math.lechat@gmail.com>
+ *
+ * @internal
+ */
+class DummyToken extends AbstractToken
+{
+    public function __construct()
+    {
+        parent::__construct(array());
+
+        $this->setUser('dummy');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCredentials()
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\Authentication\Token\DummyToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
@@ -109,10 +110,12 @@ class LogoutListener implements ListenerInterface
         }
 
         // handle multiple logout attempts gracefully
-        if ($token = $this->tokenStorage->getToken()) {
-            foreach ($this->handlers as $handler) {
-                $handler->logout($request, $response, $token);
-            }
+        $token = $this->tokenStorage->getToken();
+        if (null === $token) {
+            $token = new DummyToken();
+        }
+        foreach ($this->handlers as $handler) {
+            $handler->logout($request, $response, $token);
         }
 
         $this->tokenStorage->setToken(null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7104 
| License       | MIT

When listeners are registered in `SecurityExtension` first ones always are `ChannelListener`, `ContextListener` (if stateful) and `LogoutListener`. This means only `ContextListener` can set a token to trigger the logout handlers. This means the `LogoutListener` is useless

- if we don't have any token in the session
- if the firewall is stateless

As said in https://github.com/symfony/symfony/issues/7104#issuecomment-278625482 we cannot  register the `LogoutListener` last so a quick solution is to call the logout handlers wether a token is present or not in which case I pass a `DummyToken` instead (see https://github.com/symfony/symfony/pull/24489#discussion_r143459000).