### PR TITLE
fix PHP 7.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
-        "phpdocumentor/type-resolver": "<0.2.0",
+        "phpdocumentor/type-resolver": "<0.2.1",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
     },
     "provide": {

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -61,7 +61,7 @@
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0",
-        "phpdocumentor/type-resolver": "<0.2.0",
+        "phpdocumentor/type-resolver": "<0.2.1",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
         "symfony/asset": "<3.3",
         "symfony/console": "<3.3",

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -35,7 +35,7 @@
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
-        "phpdocumentor/type-resolver": "<0.2.0",
+        "phpdocumentor/type-resolver": "<0.2.1",
         "symfony/dependency-injection": "<3.3"
     },
     "suggest": {

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -31,6 +31,7 @@
         "phpdocumentor/reflection-docblock": "^3.0|^4.0"
     },
     "conflict": {
+        "phpdocumentor/type-resolver": "<0.2.1",
         "symfony/dependency-injection": "<3.2",
         "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
         "symfony/property-info": "<3.1",

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -261,11 +261,13 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
 
         if (is_object($objectOrClass)) {
             $object = $objectOrClass;
+            $class = get_class($object);
             $cacheKey = spl_object_hash($objectOrClass);
             $propertyPath = PropertyPath::append($this->defaultPropertyPath, $propertyName);
         } else {
             // $objectOrClass contains a class name
             $object = null;
+            $class = $objectOrClass;
             $cacheKey = null;
             $propertyPath = $this->defaultPropertyPath;
         }
@@ -280,7 +282,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             $this->validateGenericNode(
                 $value,
                 $object,
-                $cacheKey.':'.get_class($object).':'.$propertyName,
+                $cacheKey.':'.$class.':'.$propertyName,
                 $propertyMetadata,
                 $propertyPath,
                 $groups,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

* the `phpdocumentor/type-resolver` package was not PHP 7.2 compatible
  before release 0.2.1 (see see phpDocumentor/TypeResolver@e224fb2)
* the validator must not call `get_class()` if no object but a class
  name was passed to the `validatePropertyValue()` method