### PR TITLE
[Process] Continue writing input stream if the stream is not empty

### DIFF
--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -164,6 +164,9 @@ abstract class AbstractPipes implements PipesInterface
             unset($this->pipes[0]);
         } elseif (!$w) {
             return array($this->pipes[0]);
+        } elseif ($this->input instanceof \Iterator ? $this->input->valid() : !feof($this->input)) {
+            // If input iterator is not yet empty, continue writing
+            return $this->write();
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24500
| License       | MIT
| Doc PR        | N/A

When using an iterator as a data source for the process stdin, currently the streams writes one iteration of the data, then hits the line [UnixPipes.php#L105](https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Process/Pipes/UnixPipes.php#L105) which blocks for 200000 micro seconds before continuing writing the data. This causes very slow performance in writing data.
The goal of this PR is to continue writing all the data of the iterator (or resource stream if a resource is used) until it reaches the end before continuing.
I'm not sure if this is the best way to solve this issue, but just opening this for discussion in case some else has a better idea