### PR TITLE
added interruptible trait for command

### DIFF
--- a/src/Symfony/Component/Console/Command/InterruptibleTrait.php
+++ b/src/Symfony/Component/Console/Command/InterruptibleTrait.php
@@ -1,16 +1,22 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Console\Command;
 
 use Symfony\Component\Console\Exception\RuntimeException;
 
 /**
- * Trait InterruptibleTrait
- *
- * This trait adds ability to interrupt safely long-running or endless commands in case "^C" is pressed or "$ kill -2"
+ * This trait adds ability to interrupt safely long-running or endless commands in case "^C" is pressed or "$ kill -2".
  *
  * @author Maksym Slesarenko <maks.slesarenko@gmail.com>
- * @package Symfony\Component\Console\Command
  *
  * @example
  * protected function execute(InputInterface $input, OutputInterface $output)
@@ -41,10 +47,12 @@ trait InterruptibleTrait
     }
 
     /**
-     * Check if command is interrupted
+     * Check if command is interrupted.
      *
      * @throws RuntimeException
+     *
      * @param bool $throwException
+     *
      * @return bool
      */
     public function isInterrupted($throwException = false)
@@ -54,6 +62,7 @@ trait InterruptibleTrait
         if ($this->isInterrupted && $throwException) {
             throw new RuntimeException('Command execution was interrupted');
         }
+
         return $this->isInterrupted;
     }
 }

--- a/src/Symfony/Component/Console/Command/InterruptibleTrait.php
+++ b/src/Symfony/Component/Console/Command/InterruptibleTrait.php
@@ -40,7 +40,13 @@ trait InterruptibleTrait
 
     public function __construct($name = null)
     {
+        pcntl_signal(\SIGHUP, function () {
+            $this->isInterrupted = true;
+        });
         pcntl_signal(\SIGINT, function () {
+            $this->isInterrupted = true;
+        });
+        pcntl_signal(\SIGTERM, function () {
             $this->isInterrupted = true;
         });
         parent::__construct($name);

--- a/src/Symfony/Component/Console/Command/InterruptibleTrait.php
+++ b/src/Symfony/Component/Console/Command/InterruptibleTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Symfony\Component\Console\Command;
+
+use Symfony\Component\Console\Exception\RuntimeException;
+
+/**
+ * Trait InterruptibleTrait
+ *
+ * This trait adds ability to interrupt safely long-running or endless commands in case "^C" is pressed or "$ kill -2"
+ *
+ * @author Maksym Slesarenko <maks.slesarenko@gmail.com>
+ * @package Symfony\Component\Console\Command
+ *
+ * @example
+ * protected function execute(InputInterface $input, OutputInterface $output)
+ * {
+ *     while (true) {
+ *         $this->isInterrupted(true);
+ *
+ *         //doSomething
+ *         sleep(100);
+ *    }
+ *    // or
+ *    while (!$this->isInterrupted()) {
+ *         //doSomething
+ *         sleep(100);
+ *    }
+ * }
+ */
+trait InterruptibleTrait
+{
+    private $isInterrupted = false;
+
+    public function __construct($name = null)
+    {
+        pcntl_signal(\SIGINT, function () {
+            $this->isInterrupted = true;
+        });
+        parent::__construct($name);
+    }
+
+    /**
+     * Check if command is interrupted
+     *
+     * @throws RuntimeException
+     * @param bool $throwException
+     * @return bool
+     */
+    public function isInterrupted($throwException = false)
+    {
+        pcntl_signal_dispatch();
+
+        if ($this->isInterrupted && $throwException) {
+            throw new RuntimeException('Command execution was interrupted');
+        }
+        return $this->isInterrupted;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Many times there is a need to stop running command safely without data corruption. By using this trait you can modify your commands and add checks between iterations that will allow command to complete processing a portion of data that it has already started and then exit safely.