### PR TITLE
[Validator] [Twig] added magic method __isset()  to File Constraint class

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
    the `Url::CHECK_DNS_TYPE_*` constants values and will throw an exception in Symfony 4.0
  * added min/max amount of pixels check to `Image` constraint via `minPixels` and `maxPixels`
  * added a new "propertyPath" option to comparison constraints in order to get the value to compare from an array or object
+ * added magic method `__isset()` to `File` constraint class
 
 3.3.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -88,6 +88,15 @@ class File extends Constraint
         return parent::__get($option);
     }
 
+    public function __isset($option)
+    {
+        if ('maxSize' === $option) {
+            return true;
+        }
+
+        return parent::__isset($option);
+    }
+
     private function normalizeBinaryFormat($maxSize)
     {
         $factors = array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master / 2.7, 2.8 or 3.3 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24512  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

In my project I get assert constraints from one of my entity and I use this value in my front end via Twig.
I faced a problem with the property $maxSize of the File Constraint.

As this property is protected I cannot access it via Twig because the magic method __isset is missing, as I read in twig documentation.
<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
