### PR TITLE
[Console] Sync ConsoleLogger::interpolate with the one in HttpKernel

### DIFF
--- a/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
+++ b/src/Symfony/Component/Console/Tests/Logger/ConsoleLoggerTest.php
@@ -166,9 +166,7 @@ class ConsoleLoggerTest extends TestCase
         } else {
             $dummy = $this->getMock('Symfony\Component\Console\Tests\Logger\DummyTest', array('__toString'));
         }
-        $dummy->expects($this->once())
-            ->method('__toString')
-            ->will($this->returnValue('DUMMY'));
+        $dummy->method('__toString')->will($this->returnValue('DUMMY'));
 
         $this->getLogger()->warning($dummy);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Adapted from: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Log/Logger.php#L92

Better performance and datetime support (maybe should it be merged in a newer version, but I've targeted 2.7 to prevent future merge conflicts).