### PR TITLE
[TwigBridge] fix BC for FormExtension if renderer is FormRenderer

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -11,12 +11,10 @@
 
 namespace Symfony\Bridge\Twig\Extension;
 
-use Symfony\Bridge\Twig\Form\TwigRendererEngineInterface;
 use Symfony\Bridge\Twig\TokenParser\FormThemeTokenParser;
 use Symfony\Bridge\Twig\Form\TwigRendererInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
-use Symfony\Component\Form\FormRendererInterface;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\InitRuntimeInterface;
@@ -56,9 +54,7 @@ class FormExtension extends AbstractExtension implements InitRuntimeInterface
     {
         if ($this->renderer instanceof TwigRendererInterface) {
             $this->renderer->setEnvironment($environment);
-        } elseif ($this->renderer instanceof FormRendererInterface && $this->renderer->getEngine() instanceof TwigRendererEngineInterface) {
-            $this->renderer->getEngine()->setEnvironment($environment);
-        } elseif (null !== $this->renderer) {
+        } elseif (is_array($this->renderer)) {
             $this->renderer[2] = $environment;
         }
     }
@@ -122,12 +118,8 @@ class FormExtension extends AbstractExtension implements InitRuntimeInterface
 
             if (is_array($this->renderer)) {
                 $renderer = $this->renderer[0]->get($this->renderer[1]);
-                if (isset($this->renderer[2])) {
-                    if ($renderer instanceof TwigRendererInterface) {
-                        $renderer->setEnvironment($this->renderer[2]);
-                    } elseif ($renderer instanceof FormRendererInterface && $renderer->getEngine() instanceof TwigRendererEngineInterface) {
-                        $renderer->getEngine()->setEnvironment($this->renderer[2]);
-                    }
+                if (isset($this->renderer[2]) && $renderer instanceof TwigRendererInterface) {
+                    $renderer->setEnvironment($this->renderer[2]);
                 }
                 $this->renderer = $renderer;
             }

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Bridge\Twig\Extension;
 
+use Symfony\Bridge\Twig\Form\TwigRendererEngineInterface;
 use Symfony\Bridge\Twig\TokenParser\FormThemeTokenParser;
 use Symfony\Bridge\Twig\Form\TwigRendererInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\FormRendererInterface;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\InitRuntimeInterface;
@@ -54,6 +56,8 @@ class FormExtension extends AbstractExtension implements InitRuntimeInterface
     {
         if ($this->renderer instanceof TwigRendererInterface) {
             $this->renderer->setEnvironment($environment);
+        } elseif ($this->renderer instanceof FormRendererInterface && $this->renderer->getEngine() instanceof TwigRendererEngineInterface) {
+            $this->renderer->getEngine()->setEnvironment($environment);
         } elseif (null !== $this->renderer) {
             $this->renderer[2] = $environment;
         }
@@ -119,7 +123,11 @@ class FormExtension extends AbstractExtension implements InitRuntimeInterface
             if (is_array($this->renderer)) {
                 $renderer = $this->renderer[0]->get($this->renderer[1]);
                 if (isset($this->renderer[2])) {
-                    $renderer->setEnvironment($this->renderer[2]);
+                    if ($renderer instanceof TwigRendererInterface) {
+                        $renderer->setEnvironment($this->renderer[2]);
+                    } elseif ($renderer instanceof FormRendererInterface && $renderer->getEngine() instanceof TwigRendererEngineInterface) {
+                        $renderer->getEngine()->setEnvironment($this->renderer[2]);
+                    }
                 }
                 $this->renderer = $renderer;
             }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRendererInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\FormRendererInterface;
+use Twig\Environment;
+
+class FormExtensionTest extends TestCase
+{
+    /**
+     * @dataProvider rendererDataProvider
+     */
+    public function testInitRuntimeAndAccessRenderer($renderer)
+    {
+        $extension = new FormExtension($renderer);
+        $extension->initRuntime($this->createMock(Environment::class));
+        $extension->renderer;
+    }
+
+    /**
+     * @dataProvider rendererDataProvider
+     */
+    public function testAccessRendererAndInitRuntime($renderer)
+    {
+        $extension = new FormExtension($renderer);
+        $extension->renderer;
+        $extension->initRuntime($this->createMock(Environment::class));
+    }
+
+    public function rendererDataProvider()
+    {
+        $twigRenderer = $this->createMock(TwigRendererInterface::class);
+        $twigRenderer->expects($this->once())
+            ->method('setEnvironment');
+
+        yield array($twigRenderer);
+
+        $twigRenderer = $this->createMock(TwigRendererInterface::class);
+        $twigRenderer->expects($this->once())
+            ->method('setEnvironment');
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with('service_id')
+            ->willReturn($twigRenderer);
+
+        yield array(array($container, 'service_id'));
+
+        $formRenderer = $this->createMock(FormRendererInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())
+            ->method('get')
+            ->with('service_id')
+            ->willReturn($formRenderer);
+
+        yield array(array($container, 'service_id'));
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
@@ -26,7 +26,7 @@ class FormExtensionTest extends TestCase
     public function testInitRuntimeAndAccessRenderer($rendererConstructor, $expectedAccessedRenderer)
     {
         $extension = new FormExtension($rendererConstructor);
-        $extension->initRuntime($this->createMock(Environment::class));
+        $extension->initRuntime($this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock());
         $this->assertSame($expectedAccessedRenderer, $extension->renderer);
     }
 
@@ -37,22 +37,22 @@ class FormExtensionTest extends TestCase
     {
         $extension = new FormExtension($rendererConstructor);
         $this->assertSame($expectedAccessedRenderer, $extension->renderer);
-        $extension->initRuntime($this->createMock(Environment::class));
+        $extension->initRuntime($this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock());
     }
 
     public function rendererDataProvider()
     {
-        $twigRenderer = $this->createMock(TwigRendererInterface::class);
+        $twigRenderer = $this->getMockBuilder(TwigRendererInterface::class)->getMock();
         $twigRenderer->expects($this->once())
             ->method('setEnvironment');
 
         yield array($twigRenderer, $twigRenderer);
 
-        $twigRenderer = $this->createMock(TwigRendererInterface::class);
+        $twigRenderer = $this->getMockBuilder(TwigRendererInterface::class)->getMock();
         $twigRenderer->expects($this->once())
             ->method('setEnvironment');
 
-        $container = $this->createMock(ContainerInterface::class);
+        $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $container->expects($this->once())
             ->method('get')
             ->with('service_id')
@@ -60,9 +60,9 @@ class FormExtensionTest extends TestCase
 
         yield array(array($container, 'service_id'), $twigRenderer);
 
-        $formRenderer = $this->createMock(FormRendererInterface::class);
+        $formRenderer = $this->getMockBuilder(FormRendererInterface::class)->getMock();
 
-        $container = $this->createMock(ContainerInterface::class);
+        $container = $this->getMockBuilder(ContainerInterface::class)->getMock();
         $container->expects($this->once())
             ->method('get')
             ->with('service_id')

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\FormRendererInterface;
 use Twig\Environment;
 
+/**
+ * @group legacy
+ */
 class FormExtensionTest extends TestCase
 {
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
@@ -23,20 +23,20 @@ class FormExtensionTest extends TestCase
     /**
      * @dataProvider rendererDataProvider
      */
-    public function testInitRuntimeAndAccessRenderer($renderer)
+    public function testInitRuntimeAndAccessRenderer($rendererConstructor, $expectedAccessedRenderer)
     {
-        $extension = new FormExtension($renderer);
+        $extension = new FormExtension($rendererConstructor);
         $extension->initRuntime($this->createMock(Environment::class));
-        $extension->renderer;
+        $this->assertSame($expectedAccessedRenderer, $extension->renderer);
     }
 
     /**
      * @dataProvider rendererDataProvider
      */
-    public function testAccessRendererAndInitRuntime($renderer)
+    public function testAccessRendererAndInitRuntime($rendererConstructor, $expectedAccessedRenderer)
     {
-        $extension = new FormExtension($renderer);
-        $extension->renderer;
+        $extension = new FormExtension($rendererConstructor);
+        $this->assertSame($expectedAccessedRenderer, $extension->renderer);
         $extension->initRuntime($this->createMock(Environment::class));
     }
 
@@ -46,7 +46,7 @@ class FormExtensionTest extends TestCase
         $twigRenderer->expects($this->once())
             ->method('setEnvironment');
 
-        yield array($twigRenderer);
+        yield array($twigRenderer, $twigRenderer);
 
         $twigRenderer = $this->createMock(TwigRendererInterface::class);
         $twigRenderer->expects($this->once())
@@ -58,14 +58,16 @@ class FormExtensionTest extends TestCase
             ->with('service_id')
             ->willReturn($twigRenderer);
 
-        yield array(array($container, 'service_id'));
+        yield array(array($container, 'service_id'), $twigRenderer);
+
+        $formRenderer = $this->createMock(FormRendererInterface::class);
 
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
             ->with('service_id')
-            ->willReturn($this->createMock(FormRendererInterface::class));
+            ->willReturn($formRenderer);
 
-        yield array(array($container, 'service_id'));
+        yield array(array($container, 'service_id'), $formRenderer);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTest.php
@@ -60,13 +60,11 @@ class FormExtensionTest extends TestCase
 
         yield array(array($container, 'service_id'));
 
-        $formRenderer = $this->createMock(FormRendererInterface::class);
-
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())
             ->method('get')
             ->with('service_id')
-            ->willReturn($formRenderer);
+            ->willReturn($this->createMock(FormRendererInterface::class));
 
         yield array(array($container, 'service_id'));
     }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "fig/link-util": "^1.0",
         "symfony/asset": "~2.8|~3.0|~4.0",
+        "symfony/dependency-injection": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
         "symfony/form": "~3.4|~4.0",
         "symfony/http-foundation": "^3.3.11|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/24533
| License       | MIT
| Doc PR        | -

This fixes some issues within FormExtension since the renderer is now a `FormRenderer`.
