### PR TITLE
[Security] Reject remember-me token if UserCheckerInterface::checkPostAuth() fails

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
@@ -49,6 +49,7 @@ class RememberMeAuthenticationProvider implements AuthenticationProviderInterfac
 
         $user = $token->getUser();
         $this->userChecker->checkPreAuth($user);
+        $this->userChecker->checkPostAuth($user);
 
         $authenticatedToken = new RememberMeToken($user, $this->providerKey, $this->key);
         $authenticatedToken->setAttributes($token->getAttributes());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24525 
| License       | MIT
| Doc PR        | -

I think this is a security hole - a user can remain logged in with a remember me cookie even though they can no longer pass `UserCheckInterface::checkPostAuth()` (could be disabled).

This is a small BC break but shouldn't be an issue as I think it is a bug. I don't think this requires a BC layer but if so, I can add.