### PR TITLE
[Form] Fix 5.5 compatibility for ResizeFormListener

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -149,12 +149,12 @@ class ResizeFormListener implements EventSubscriberInterface
             throw new UnexpectedTypeException($data, 'array or (\Traversable and \ArrayAccess)');
         }
 
-        if ($entryFilter = $this->deleteEmpty) {
+        if ($this->deleteEmpty) {
             $previousData = $form->getData();
             /** @var FormInterface $child */
             foreach ($form as $name => $child) {
                 $isNew = !isset($previousData[$name]);
-                $isEmpty = is_callable($entryFilter) ? $entryFilter($child->getData()) : $child->isEmpty();
+                $isEmpty = is_callable($this->deleteEmpty) ? call_user_func($this->deleteEmpty, $child->getData()) : $child->isEmpty();
 
                 // $isNew can only be true if allowAdd is true, so we don't
                 // need to check allowAdd again

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -314,17 +314,12 @@ class ResizeFormListenerTest extends TestCase
             $this->form->get($child)->setData($dat);
         }
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', array(), false, true, self::class.'::deleteEmptyCallback');
+        $callback = function ($data) {
+            return '' === $data['name'];
+        };
+        $listener = new ResizeFormListener('text', array(), false, true, $callback);
         $listener->onSubmit($event);
 
         $this->assertEquals(array('0' => array('name' => 'John')), $event->getData());
-    }
-
-    /**
-     * JUST FOR 5.6 FAILURE PURPOSE (REMOVED IN THE SECOND COMMIT)
-     */
-    public static function deleteEmptyCallback($data)
-    {
-        return '' === $data['name'];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -275,4 +275,56 @@ class ResizeFormListenerTest extends TestCase
         $this->assertArrayNotHasKey(0, $event->getData());
         $this->assertArrayNotHasKey(2, $event->getData());
     }
+
+    public function testOnSubmitDeleteEmptyNotCompoundEntriesIfAllowDelete()
+    {
+        $this->form->setData(array('0' => 'first', '1' => 'second'));
+        $this->form->add($this->getForm('0'));
+        $this->form->add($this->getForm('1'));
+
+        $data = array(0 => 'first', 1 => '');
+        foreach ($data as $child => $dat) {
+            $this->form->get($child)->setData($dat);
+        }
+        $event = new FormEvent($this->form, $data);
+        $listener = new ResizeFormListener('text', array(), false, true, true);
+        $listener->onSubmit($event);
+
+        $this->assertEquals(array(0 => 'first'), $event->getData());
+    }
+
+    public function testOnSubmitDeleteEmptyCompoundEntriesIfAllowDelete()
+    {
+        $this->form->setData(array('0' => array('name' => 'John'), '1' => array('name' => 'Jane')));
+        $form1 = $this->getBuilder('0')
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->getForm();
+        $form1->add($this->getForm('name'));
+        $form2 = $this->getBuilder('1')
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->getForm();
+        $form2->add($this->getForm('name'));
+        $this->form->add($form1);
+        $this->form->add($form2);
+
+        $data = array('0' => array('name' => 'John'), '1' => array('name' => ''));
+        foreach ($data as $child => $dat) {
+            $this->form->get($child)->setData($dat);
+        }
+        $event = new FormEvent($this->form, $data);
+        $listener = new ResizeFormListener('text', array(), false, true, self::class.'::deleteEmptyCallback');
+        $listener->onSubmit($event);
+
+        $this->assertEquals(array('0' => array('name' => 'John')), $event->getData());
+    }
+
+    /**
+     * JUST FOR 5.6 FAILURE PURPOSE (REMOVED IN THE SECOND COMMIT)
+     */
+    public static function deleteEmptyCallback($data)
+    {
+        return '' === $data['name'];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/blob/531b294b218920f551b28314d1b102e0b0b0ce63/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php#L152-L157

Issue description: http://php.net/manual/en/language.types.callable.php#117260 (https://3v4l.org/oOoAV)
