### PR TITLE
[BrowserKit][Bridge\PhpUnit] Handle deprecations triggered in separate processes

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -238,6 +238,20 @@ class DeprecationErrorHandler
         }
     }
 
+    public static function collectDeprecations($outputFile)
+    {
+        $deprecations = array();
+        $previousErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = array()) use (&$deprecations, &$previousErrorHandler) {
+            if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
+                return $previousErrorHandler ? $previousErrorHandler($type, $msg, $file, $line, $context) : false;
+            }
+            $deprecations[] = array(error_reporting(), $msg);
+        });
+        register_shutdown_function(function () use ($outputFile, &$deprecations) {
+            file_put_contents($outputFile, serialize($deprecations));
+        });
+    }
+
     private static function hasColorSupport()
     {
         if ('\\' === DIRECTORY_SEPARATOR) {

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -39,6 +39,7 @@ class SymfonyTestsListenerTrait
     private $testsWithWarnings;
     private $reportUselessTests;
     private $error;
+    private $runsInSeparateProcess = false;
 
     /**
      * @param array $mockedNamespaces List of namespaces, indexed by mocked features (time-sensitive or dns-sensitive)
@@ -183,6 +184,12 @@ class SymfonyTestsListenerTrait
                 $this->reportUselessTests = $test->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything();
             }
 
+            // This event is triggered before the test is re-run in isolation
+            if ($this->willBeIsolated($test)) {
+                $this->runsInSeparateProcess = tempnam(sys_get_temp_dir(), 'deprec');
+                putenv('SYMFONY_DEPRECATIONS_SERIALIZE='.$this->runsInSeparateProcess);
+            }
+
             if (class_exists('PHPUnit_Util_Blacklist', false)) {
                 $Test = 'PHPUnit_Util_Test';
                 $AssertionFailedError = 'PHPUnit_Framework_AssertionFailedError';
@@ -192,12 +199,14 @@ class SymfonyTestsListenerTrait
             }
             $groups = $Test::getGroups(get_class($test), $test->getName(false));
 
-            if (in_array('time-sensitive', $groups, true)) {
-                ClockMock::register(get_class($test));
-                ClockMock::withClockMock(true);
-            }
-            if (in_array('dns-sensitive', $groups, true)) {
-                DnsMock::register(get_class($test));
+            if (!$this->runsInSeparateProcess) {
+                if (in_array('time-sensitive', $groups, true)) {
+                    ClockMock::register(get_class($test));
+                    ClockMock::withClockMock(true);
+                }
+                if (in_array('dns-sensitive', $groups, true)) {
+                    DnsMock::register(get_class($test));
+                }
             }
 
             $annotations = $Test::parseTestMethodAnnotations(get_class($test), $test->getName(false));
@@ -245,15 +254,20 @@ class SymfonyTestsListenerTrait
             $this->reportUselessTests = null;
         }
 
-        $errored = false;
-
-        if (null !== $this->error) {
-            if ($BaseTestRunner::STATUS_PASSED === $test->getStatus()) {
-                $test->getTestResultObject()->addError($test, $this->error, 0);
-                $errored = true;
-            }
-
+        if ($errored = null !== $this->error) {
+            $test->getTestResultObject()->addError($test, $this->error, 0);
             $this->error = null;
+        }
+
+        if ($this->runsInSeparateProcess) {
+            foreach (unserialize(file_get_contents($this->runsInSeparateProcess)) as $deprecation) {
+                if ($deprecation[0]) {
+                    trigger_error($deprecation[1], E_USER_DEPRECATED);
+                } else {
+                    @trigger_error($deprecation[1], E_USER_DEPRECATED);
+                }
+            }
+            $this->runsInSeparateProcess = false;
         }
 
         if ($this->expectedDeprecations) {
@@ -277,7 +291,7 @@ class SymfonyTestsListenerTrait
             $this->expectedDeprecations = $this->gatheredDeprecations = array();
             $this->previousErrorHandler = null;
         }
-        if (-2 < $this->state && ($test instanceof \PHPUnit_Framework_TestCase || $test instanceof TestCase)) {
+        if (!$this->runsInSeparateProcess && -2 < $this->state && ($test instanceof \PHPUnit_Framework_TestCase || $test instanceof TestCase)) {
             if (in_array('time-sensitive', $groups, true)) {
                 ClockMock::withClockMock(false);
             }
@@ -314,5 +328,22 @@ class SymfonyTestsListenerTrait
             $msg = 'Unsilenced deprecation: '.$msg;
         }
         $this->gatheredDeprecations[] = $msg;
+    }
+
+    /**
+     * @param Test $test
+     *
+     * @return bool
+     */
+    private function willBeIsolated($test)
+    {
+        if ($test->isInIsolation()) {
+            return false;
+        }
+
+        $r = new \ReflectionProperty($test, 'runTestInSeparateProcess');
+        $r->setAccessible(true);
+
+        return $r->getValue($test);
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Tests/ProcessIsolationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ProcessIsolationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Bridge\PhpUnit\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Don't remove this test case, it tests the legacy group.
+ *
+ * @group legacy
+ *
+ * @runTestsInSeparateProcesses
+ */
+class ProcessIsolationTest extends TestCase
+{
+    /**
+     * @expectedDeprecation Test abc
+     */
+    public function testIsolation()
+    {
+        @trigger_error('Test abc', E_USER_DEPRECATED);
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -14,6 +14,10 @@ use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
 // Detect if we're loaded by an actual run of phpunit
 if (!defined('PHPUNIT_COMPOSER_INSTALL') && !class_exists('PHPUnit_TextUI_Command', false) && !class_exists('PHPUnit\TextUI\Command', false)) {
+    if ($ser = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
+        DeprecationErrorHandler::collectDeprecations($ser);
+    }
+
     return;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23003, #16726
| License       | MIT
| Doc PR        | -

As reported in #23003, deprecations triggered in process-isolated test cases are not gathered.
This caught us already: HttpFoundation is still using deprecated code paths, but we missed them because of that issue with the bridge.

Here is the fixed output:
![capture du 2017-10-13 13-45-12](https://user-images.githubusercontent.com/243674/31544827-fe7ffee0-b01c-11e7-8020-4001735ce7a3.png)

Credits to @paul-m for working on the issue first.