### PR TITLE
[FrameworkBundle] add config option for resetting services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -60,6 +60,7 @@ CHANGELOG
  * Added `asset.request_context.base_path` and `asset.request_context.secure` parameters
    to provide a default request context in case the stack is empty (similar to `router.request_context.*` parameters)
  * Display environment variables managed by `Dotenv` in `AboutCommand`
+ * Added new `framework.reset_services_on_terminate` configuration option to enable resetting services tagged with `kernel.reset` on kernel termination
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -107,7 +107,7 @@ class Configuration implements ConfigurationInterface
                     ->beforeNormalization()->ifString()->then(function ($v) { return array($v); })->end()
                     ->prototype('scalar')->end()
                 ->end()
-                ->booleanNode('reset_services')->defaultFalse()->end()
+                ->booleanNode('reset_services_on_terminate')->defaultFalse()->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -107,6 +107,7 @@ class Configuration implements ConfigurationInterface
                     ->beforeNormalization()->ifString()->then(function ($v) { return array($v); })->end()
                     ->prototype('scalar')->end()
                 ->end()
+                ->booleanNode('reset_services')->defaultFalse()->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -318,8 +318,8 @@ class FrameworkExtension extends Extension
             $loader->load('web_link.xml');
         }
 
-        if (!$config['reset_services']) {
-            $container->removeDefinition(ServiceResetListener::class);
+        if ($config['reset_services_on_terminate']) {
+            $container->register(ServiceResetListener::class)->addTag('kernel.event_subscriber');
         }
 
         $this->addAnnotatedClassesToCompile(array(

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -56,6 +56,7 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\EventListener\ServiceResetListener;
 use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\LockInterface;
@@ -315,6 +316,10 @@ class FrameworkExtension extends Extension
             }
 
             $loader->load('web_link.xml');
+        }
+
+        if (!$config['reset_services']) {
+            $container->removeDefinition(ServiceResetListener::class);
         }
 
         $this->addAnnotatedClassesToCompile(array(

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -318,8 +318,8 @@ class FrameworkExtension extends Extension
             $loader->load('web_link.xml');
         }
 
-        if ($config['reset_services_on_terminate']) {
-            $container->register(ServiceResetListener::class)->addTag('kernel.event_subscriber')->setPublic(false);
+        if (!$config['reset_services_on_terminate']) {
+            $container->removeDefinition(ServiceResetListener::class);
         }
 
         $this->addAnnotatedClassesToCompile(array(

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -319,7 +319,7 @@ class FrameworkExtension extends Extension
         }
 
         if ($config['reset_services_on_terminate']) {
-            $container->register(ServiceResetListener::class)->addTag('kernel.event_subscriber');
+            $container->register(ServiceResetListener::class)->addTag('kernel.event_subscriber')->setPublic(false);
         }
 
         $this->addAnnotatedClassesToCompile(array(

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -38,6 +38,7 @@
         <xsd:attribute name="secret" type="xsd:string" />
         <xsd:attribute name="default-locale" type="xsd:string" />
         <xsd:attribute name="test" type="xsd:boolean" />
+        <xsd:attribute name="reset-services" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="form">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -38,7 +38,7 @@
         <xsd:attribute name="secret" type="xsd:string" />
         <xsd:attribute name="default-locale" type="xsd:string" />
         <xsd:attribute name="test" type="xsd:boolean" />
-        <xsd:attribute name="reset-services" type="xsd:boolean" />
+        <xsd:attribute name="reset-services-on-terminate" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="form">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -74,5 +74,11 @@
         <service id="Symfony\Component\Config\Resource\SelfCheckingResourceChecker">
             <tag name="config_cache.resource_checker" priority="-990" />
         </service>
+
+        <service id="Symfony\Component\HttpKernel\EventListener\ServiceResetListener">
+            <argument /> <!-- ResettableServicePass will inject an iterator of initialized services here ($serviceId => $serviceInstance) -->
+            <argument type="collection" /> <!-- ResettableServicePass will inject an array of reset methods here ($serviceId => $method) -->
+            <tag name="kernel.event_subscriber" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -74,11 +74,5 @@
         <service id="Symfony\Component\Config\Resource\SelfCheckingResourceChecker">
             <tag name="config_cache.resource_checker" priority="-990" />
         </service>
-
-        <service id="Symfony\Component\HttpKernel\EventListener\ServiceResetListener">
-            <argument /> <!-- ResettableServicePass will inject an iterator of initialized services here ($serviceId => $serviceInstance) -->
-            <argument type="collection" /> <!-- ResettableServicePass will inject an array of reset methods here ($serviceId => $method) -->
-            <tag name="kernel.event_subscriber" />
-        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -352,7 +352,7 @@ class ConfigurationTest extends TestCase
                     ),
                 ),
             ),
-            'reset_services' => false,
+            'reset_services_on_terminate' => false,
         );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -352,6 +352,7 @@ class ConfigurationTest extends TestCase
                     ),
                 ),
             ),
+            'reset_services' => false,
         );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/reset_services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/reset_services.php
@@ -1,0 +1,5 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'reset_services' => true,
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/reset_services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/reset_services.php
@@ -1,5 +1,5 @@
 <?php
 
 $container->loadFromExtension('framework', array(
-    'reset_services' => true,
+    'reset_services_on_terminate' => true,
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/reset_services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/reset_services.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config reset-services="true" />
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/reset_services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/reset_services.xml
@@ -6,5 +6,5 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
-    <framework:config reset-services="true" />
+    <framework:config reset-services-on-terminate="true" />
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/reset_services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/reset_services.yml
@@ -1,0 +1,2 @@
+framework:
+    reset_services: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/reset_services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/reset_services.yml
@@ -1,2 +1,2 @@
 framework:
-    reset_services: true
+    reset_services_on_terminate: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -999,19 +999,16 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.def', 'cache.app', 11);
     }
 
-    public function testDoesNotAddServiceResetListenerDefWhenOptionSetToFalse()
+    public function testRemovesServiceResetListenerDefWhenOptionSetToFalse()
     {
         $container = $this->createContainerFromFile('default_config');
         $this->assertFalse($container->hasDefinition(ServiceResetListener::class));
     }
 
-    public function testAddsServiceResetListenerDefWhenOptionSetToTrue()
+    public function testDoesNotRemoveServiceResetListenerDefWhenOptionSetToTrue()
     {
         $container = $this->createContainerFromFile('reset_services');
-        $this->assertEquals(
-            (new Definition(ServiceResetListener::class))->addTag('kernel.event_subscriber')->setPublic(false),
-            $container->getDefinition(ServiceResetListener::class)
-        );
+        $this->assertTrue($container->hasDefinition(ServiceResetListener::class));
     }
 
     protected function createContainer(array $data = array())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1008,7 +1008,10 @@ abstract class FrameworkExtensionTest extends TestCase
     public function testAddsServiceResetListenerDefWhenOptionSetToTrue()
     {
         $container = $this->createContainerFromFile('reset_services');
-        $this->assertEquals((new Definition(ServiceResetListener::class))->addTag('kernel.event_subscriber'), $container->getDefinition(ServiceResetListener::class));
+        $this->assertEquals(
+            (new Definition(ServiceResetListener::class))->addTag('kernel.event_subscriber')->setPublic(false),
+            $container->getDefinition(ServiceResetListener::class)
+        );
     }
 
     protected function createContainer(array $data = array())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -999,16 +999,16 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.def', 'cache.app', 11);
     }
 
-    public function testRemovesServiceResetListenerDefWhenOptionSetToFalse()
+    public function testDoesNotAddServiceResetListenerDefWhenOptionSetToFalse()
     {
         $container = $this->createContainerFromFile('default_config');
         $this->assertFalse($container->hasDefinition(ServiceResetListener::class));
     }
 
-    public function testDoesNotRemoveServiceResetListenerDefWhenOptionSetToTrue()
+    public function testAddsServiceResetListenerDefWhenOptionSetToTrue()
     {
         $container = $this->createContainerFromFile('reset_services');
-        $this->assertTrue($container->hasDefinition(ServiceResetListener::class));
+        $this->assertEquals((new Definition(ServiceResetListener::class))->addTag('kernel.event_subscriber'), $container->getDefinition(ServiceResetListener::class));
     }
 
     protected function createContainer(array $data = array())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\EventListener\ServiceResetListener;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
@@ -996,6 +997,18 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.baz', 'cache.adapter.filesystem', 7);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foobar', 'cache.adapter.psr6', 10);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.def', 'cache.app', 11);
+    }
+
+    public function testRemovesServiceResetListenerDefWhenOptionSetToFalse()
+    {
+        $container = $this->createContainerFromFile('default_config');
+        $this->assertFalse($container->hasDefinition(ServiceResetListener::class));
+    }
+
+    public function testDoesNotRemoveServiceResetListenerDefWhenOptionSetToTrue()
+    {
+        $container = $this->createContainerFromFile('reset_services');
+        $this->assertTrue($container->hasDefinition(ServiceResetListener::class));
     }
 
     protected function createContainer(array $data = array())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | https://github.com/symfony/symfony/issues/24552
| License       | MIT
| Doc PR        | todo

As mentioned in https://github.com/symfony/symfony/issues/24552 the new resettable services feature has some BC breaks when it comes to functional tests and accessing services from the client's container after performing a request.

This PR makes the feature opt-in so it can be enabled if its needed.

TODOs:

- [x] fix tests
- [x] add tests
- [x] update changelog
- [ ] update docs