### PR TITLE
Fixed mistake in exception expectation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -165,12 +165,11 @@ class ConfigurationTest extends TestCase
      */
     public function testInvalidAssetsConfiguration(array $assetConfig, $expectedMessage)
     {
-        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
-            InvalidConfigurationException::class,
-            $expectedMessage
-        );
-        if (method_exists($this, 'expectExceptionMessage')) {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(InvalidConfigurationException::class);
             $this->expectExceptionMessage($expectedMessage);
+        } else {
+            $this->setExpectedException(InvalidConfigurationException::class, $expectedMessage);
         }
 
         $processor = new Processor();

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\ButtonBuilder;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
 
 /**
  * @author Alexander Cheprasov <cheprasov.84@ya.ru>
@@ -53,10 +54,12 @@ class ButtonBuilderTest extends TestCase
      */
     public function testInvalidNames($name)
     {
-        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
-            '\Symfony\Component\Form\Exception\InvalidArgumentException',
-            'Buttons cannot have empty names.'
-        );
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage('Buttons cannot have empty names.');
+        } else {
+            $this->setExpectedException(InvalidArgumentException::class, 'Buttons cannot have empty names.');
+        }
         new ButtonBuilder($name);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateIntervalToArrayTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateIntervalToArrayTransformerTest.php
@@ -181,7 +181,12 @@ class DateIntervalToArrayTransformerTest extends DateIntervalTestCase
             'minutes' => '',
             'seconds' => '6',
         );
-        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(TransformationFailedException::class, 'This amount of "minutes" is invalid');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(TransformationFailedException::class);
+            $this->expectExceptionMessage('This amount of "minutes" is invalid');
+        } else {
+            $this->setExpectedException(TransformationFailedException::class, 'This amount of "minutes" is invalid');
+        }
         $transformer->reverseTransform($input);
     }
 
@@ -191,7 +196,12 @@ class DateIntervalToArrayTransformerTest extends DateIntervalTestCase
         $input = array(
             'invert' => '1',
         );
-        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(TransformationFailedException::class, 'The value of "invert" must be boolean');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(TransformationFailedException::class);
+            $this->expectExceptionMessage('The value of "invert" must be boolean');
+        } else {
+            $this->setExpectedException(TransformationFailedException::class, 'The value of "invert" must be boolean');
+        }
         $transformer->reverseTransform($input);
     }
 

--- a/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessFailedExceptionTest.php
@@ -29,10 +29,12 @@ class ProcessFailedExceptionTest extends TestCase
             ->method('isSuccessful')
             ->will($this->returnValue(true));
 
-        $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}(
-            '\InvalidArgumentException',
-            'Expected a failed process, but the given process was successful.'
-        );
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Expected a failed process, but the given process was successful.');
+        } else {
+            $this->setExpectedException(\InvalidArgumentException::class, 'Expected a failed process, but the given process was successful.');
+        }
 
         new ProcessFailedException($process);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In some cases, (5 to be exact), the `expectException` is misused while attempting to provide compatibility with the older `setExpectedException` by making use of a non-existent parameter.
Firstly, this makes the tests inconsistent (old PHPUnit version test exception message, while newer one doesn't). Secondly, if PHPUnit interface suddenly starts making use of a 2nd parameter in `expectException`, the existing code might break or cause unexpected side-effects.

Original report: https://github.com/symfony/process/commit/87bb7267122867c80b2c192be985252030b62c19#commitcomment-24848315