### PR TITLE
add DOMElement as return type in Crawler::getIterator to support foreach support in ide

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1071,7 +1071,7 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * @return \ArrayIterator
+     * @return \ArrayIterator|\DOMElement[]
      */
     public function getIterator()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

In `Crawler::getIterator` return type is missing so ide (PhpStorm) is not able to provide completion inside foreach statements. This PR adds `DOMElement[]` to it

```php
$crawler = new Crawler('foobar');
foreach($crawler->filter('a') as $link) {
   # support completion
   $link->...
}
```
