### PR TITLE
[Serializer] YamlEncoder: throw if the Yaml component isn't installed

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Encoder;
 
+use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Yaml\Dumper;
 use Symfony\Component\Yaml\Parser;
 
@@ -29,6 +30,10 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
 
     public function __construct(Dumper $dumper = null, Parser $parser = null, array $defaultContext = array())
     {
+        if (!class_exists(Dumper::class)) {
+            throw new RuntimeException('Unable to use YamlEncoder as the Symfony Yaml component is not installed.');
+        }
+
         $this->dumper = $dumper ?: new Dumper();
         $this->parser = $parser ?: new Parser();
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -31,7 +31,7 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
     public function __construct(Dumper $dumper = null, Parser $parser = null, array $defaultContext = array())
     {
         if (!class_exists(Dumper::class)) {
-            throw new RuntimeException('Unable to use YamlEncoder as the Symfony Yaml component is not installed.');
+            throw new RuntimeException('The YamlEncoder class requires the "Yaml" component. Install "symfony/yaml" to use it.');
         }
 
         $this->dumper = $dumper ?: new Dumper();

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -110,7 +110,7 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface
         $supportedTypes = array(
             \SplFileInfo::class => true,
             \SplFileObject::class => true,
-            'Symfony\Component\HttpFoundation\File\File' => true,
+            File::class => true,
         );
 
         return isset($supportedTypes[$type]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a

Similar to #24563 but for the Yaml encoder (not the same branch).