### PR TITLE
Catching deprecations in isolated tests always adds to the Legacy group

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -112,7 +112,11 @@ class DeprecationErrorHandler
 
             $i = count($trace);
             while (1 < $i && (!isset($trace[--$i]['class']) || ('ReflectionMethod' === $trace[$i]['class'] || 0 === strpos($trace[$i]['class'], 'PHPUnit_') || 0 === strpos($trace[$i]['class'], 'PHPUnit\\')))) {
-                // No-op
+                // If the test is run isolation we don't have the actual test class therefore break on the test case
+                // class because that will have test object.
+                if (isset($trace[$i]['class']) && ($trace[$i]['class'] === 'PHPUnit_Framework_TestCase' || $trace[$i]['class'] === 'PHPUnit\Framework\TestCase')) {
+                    break;
+                }
             }
 
             if (isset($trace[$i]['object']) || isset($trace[$i]['class'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24567
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
