### PR TITLE
[Debug] Fix same vendor detection in class loader

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -203,18 +203,11 @@ class DebugClassLoader
             } elseif (preg_match('#\n \* @deprecated (.*?)\r?\n \*(?: @|/$)#s', $refl->getDocComment(), $notice)) {
                 self::$deprecated[$name] = preg_replace('#\s*\r?\n \* +#', ' ', $notice[1]);
             } else {
-                if (2 > $len = 1 + (strpos($name, '\\', 1 + strpos($name, '\\')) ?: strpos($name, '_'))) {
+                if (2 > $len = 1 + (strpos($name, '\\') ?: strpos($name, '_'))) {
                     $len = 0;
                     $ns = '';
                 } else {
-                    switch ($ns = substr($name, 0, $len)) {
-                        case 'Symfony\Bridge\\':
-                        case 'Symfony\Bundle\\':
-                        case 'Symfony\Component\\':
-                            $ns = 'Symfony\\';
-                            $len = strlen($ns);
-                            break;
-                    }
+                    $ns = substr($name, 0, $len);
                 }
                 $parent = get_parent_class($class);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Fix about same vendor detection in ClassLoader. Actually, detected namespace for `Doctrine\ORM\Configuration` is `Doctrine\ORM` instead of `Doctrine\`. So deprecations are triggered for classes in same namespace.