### PR TITLE
[PropertyInfo] Add support for the iterable type

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/TypeTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/TypeTest.php
@@ -37,6 +37,12 @@ class TypeTest extends TestCase
         $this->assertEquals(Type::BUILTIN_TYPE_STRING, $collectionValueType->getBuiltinType());
     }
 
+    public function testIterable()
+    {
+        $type = new Type('iterable');
+        $this->assertSame('iterable', $type->getBuiltinType());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage "foo" is not a valid PHP type.

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -27,6 +27,7 @@ class Type
     const BUILTIN_TYPE_ARRAY = 'array';
     const BUILTIN_TYPE_NULL = 'null';
     const BUILTIN_TYPE_CALLABLE = 'callable';
+    const BUILTIN_TYPE_ITERABLE = 'iterable';
 
     /**
      * List of PHP builtin types.
@@ -43,6 +44,7 @@ class Type
         self::BUILTIN_TYPE_ARRAY,
         self::BUILTIN_TYPE_CALLABLE,
         self::BUILTIN_TYPE_NULL,
+        self::BUILTIN_TYPE_ITERABLE,
     );
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -104,7 +104,7 @@ class Type
     /**
      * Gets built-in type.
      *
-     * Can be bool, int, float, string, array, object, resource, null or callback.
+     * Can be bool, int, float, string, array, object, resource, null, callback or iterable.
      *
      * @return string
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | reported on Slack
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10319

Add support for the `iterable` pseudo-type introduced in PHP 7.1.
