### PR TITLE
[Validator] Traverse traversables

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Fixtures/Timer.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Timer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class Timer
+{
+    private $duration;
+
+    public function __construct($duration)
+    {
+        $this->duration = $duration;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/TimerCollection.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/TimerCollection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class TimerCollection implements \IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    private $timers;
+
+    /**
+     * @param Timer[] $timers
+     */
+    public function __construct(array $timers)
+    {
+        $this->timers = $timers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->timers);
+    }
+}

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -748,9 +748,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         // See validateClassNode()
         $cascadedGroups = null !== $cascadedGroups && count($cascadedGroups) > 0 ? $cascadedGroups : $groups;
 
+//        if (is_array($value) || $value instanceof \IteratorAggregate) {
         if (is_array($value)) {
-            // Arrays are always traversed, independent of the specified
-            // traversal strategy
+            // Arrays and instance of IteratorAggregate are always traversed, independent of the
+            // specified traversal strategy
             // (BC with Symfony < 2.5)
             $this->validateEachObjectIn(
                 $value,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Instances such as Doctrine's collections are not traversed because the condition is `is_array()`. This PR checks for `\Traversable` too.

I was trying to validate the following:

```
HelloFresh\RecipeService\Domain\Recipe\Serving:
  properties:
    number:
      - NotBlank: ~

HelloFresh\RecipeService\Domain\Recipe\Recipe:
  properties:
    servings:
      - Valid:
          traverse: true
      - NotBlank: ~
```

But it kept failing because `servings` is a `ArrayCollection`, not an `array`.

I'm targeting v2.8 but this goes all the way to master. I'm using v3.4.