### PR TITLE
Adding a new debug:autowiring command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * A console command for autowiring information.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ *
+ * @internal
+ */
+class DebugAutowiringCommand extends ContainerDebugCommand
+{
+    protected static $defaultName = 'debug:autowiring';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setDefinition(array(
+                new InputArgument('search', InputArgument::OPTIONAL, 'A search filter'),
+            ))
+            ->setDescription('Lists classes/interfaces you can use for autowiring')
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> command displays all classes and interfaces that
+you can use as type-hints for autowiring:
+
+  <info>php %command.full_name%</info>
+
+You can also pass a search term to filter the list:
+
+  <info>php %command.full_name% log</info>
+
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $errorIo = $io->getErrorStyle();
+
+        $builder = $this->getContainerBuilder();
+        $serviceIds = $builder->getServiceIds();
+        $serviceIds = array_filter($serviceIds, array($this, 'filterToServiceTypes'));
+
+        if ($search = $input->getArgument('search')) {
+            $serviceIds = array_filter($serviceIds, function ($serviceId) use ($search) {
+                return false !== stripos($serviceId, $search);
+            });
+
+            if (empty($serviceIds)) {
+                $errorIo->error(sprintf('No autowirable classes or interfaces found matching "%s"', $search));
+
+                return 1;
+            }
+        }
+
+        asort($serviceIds);
+
+        $io->title('Autowirable Services');
+        $io->text('The following classes & interfaces can be used as type-hints when autowiring:');
+        if ($search) {
+            $io->text(sprintf('(only showing classes/interfaces matching <comment>%s</comment>)', $search));
+        }
+        $io->newLine();
+        $tableRows = array();
+        foreach ($serviceIds as $serviceId) {
+            $tableRows[] = array(sprintf('<fg=cyan>%s</fg=cyan>', $serviceId));
+            if ($builder->hasAlias($serviceId)) {
+                $tableRows[] = array(sprintf('    alias to %s', $builder->getAlias($serviceId)));
+            }
+        }
+
+        $io->table(array(), $tableRows);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -55,6 +55,10 @@
             <tag name="console.command" command="debug:container" />
         </service>
 
+        <service id="Symfony\Bundle\FrameworkBundle\Command\DebugAutowiringCommand">
+            <tag name="console.command" command="debug:autowiring" />
+        </service>
+
         <service id="Symfony\Bundle\FrameworkBundle\Command\EventDispatcherDebugCommand">
             <argument type="service" id="event_dispatcher" />
             <tag name="console.command" command="debug:event-dispatcher" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+/**
+ * @group functional
+ */
+class DebugAutowiringCommandTest extends WebTestCase
+{
+    public function testBasicFunctionality()
+    {
+        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'debug:autowiring'));
+
+        $this->assertContains('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
+        $this->assertContains('alias to http_kernel', $tester->getDisplay());
+    }
+
+    public function testSearchArgument()
+    {
+        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'debug:autowiring', 'search' => 'kern'));
+
+        $this->assertContains('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
+        $this->assertNotContains('Symfony\Component\Routing\RouterInterface', $tester->getDisplay());
+    }
+
+    public function testSearchNoResults()
+    {
+        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'debug:autowiring', 'search' => 'foo_fake'), array('capture_stderr_separately' => true));
+
+        $this->assertContains('No autowirable classes or interfaces found matching "foo_fake"', $tester->getErrorOutput());
+        $this->assertEquals(1, $tester->getStatusCode());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 (if I can make my case, otherwise 4.1)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21222 and #24562 partially
| License       | MIT
| Doc PR        | TODO

Very simply, this adds a proper `debug:autowiring`, which is much shorter / nicer than `debug:container --types` and much prettier.

Before (`debug:container --types`):

<img width="1280" alt="screen shot 2017-10-16 at 8 28 05 pm" src="https://user-images.githubusercontent.com/121003/31641112-931c84ca-b2b0-11e7-9432-136ecf47ed0f.png">
<img width="1280" alt="screen shot 2017-10-16 at 8 28 18 pm" src="https://user-images.githubusercontent.com/121003/31641113-932ac1fc-b2b0-11e7-8a65-34199c9933c1.png">

After (`debug:autowiring`)

<img width="1131" alt="screen shot 2017-10-16 at 7 58 06 pm" src="https://user-images.githubusercontent.com/121003/31641124-a3288a6c-b2b0-11e7-8255-a8e676a26aba.png">
<img width="1101" alt="screen shot 2017-10-16 at 7 58 16 pm" src="https://user-images.githubusercontent.com/121003/31641125-a334c354-b2b0-11e7-8ee3-3bbad5678a1a.png">

The command is purposely simple: no special powers, no magic (other than a `search` argument), just a clean list and nice output.

I would love to sneak this in for 3.4, but I understand either way.