### PR TITLE
Doc doesn't match authenticate() implementations

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationManagerInterface.php
@@ -27,7 +27,7 @@ interface AuthenticationManagerInterface
      *
      * @param TokenInterface $token The TokenInterface instance to authenticate
      *
-     * @return TokenInterface An authenticated TokenInterface instance, never null
+     * @return TokenInterface|null An authenticated TokenInterface instance, or null if the token is not supported
      *
      * @throws AuthenticationException if the authentication fails
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 and up
| Bug fix?      | no (doc fix)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no (I ran no tests, doc change only)
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The `AuthenticationManagerInterface::authenticate()` docblock was changed [way back when](https://github.com/symfony/symfony/commit/3d976388130e359750ccbe8a88819d8df0278784) to say it will never return null. But existing implementations then and now [do](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php#L43) [return](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Security/Core/Authentication/Provider/AnonymousAuthenticationProvider.php#L41) [null](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php#L59). So it seems the doc is wrong, not the implementations.

Closed, see alternative approach: https://github.com/symfony/symfony/pull/24644