### PR TITLE
[HttpKernel] Remove obsolete PHPDoc from UriSigner

### DIFF
--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -55,10 +55,6 @@ class UriSigner
     /**
      * Checks that a URI contains the correct hash.
      *
-     * The _hash query string parameter must be the last one
-     * (as it is generated that way by the sign() method, it should
-     * never be a problem).
-     *
      * @param string $uri A signed URI
      *
      * @return bool True if the URI is signed correctly, false otherwise


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

`_hash` query param does not have to be at the end of the URL ever since https://github.com/symfony/symfony/pull/12574 so this PHPDoc is confusing. I've actually lost couple of hours of work rewriting my URLs to place it at the end before I realized that `UriSigner` doesn't really care.