### PR TITLE
Remove BC Break label from `NullDumper` class in upgrade instructions

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -84,7 +84,7 @@ DependencyInjection
 
  * Autowiring services based on the types they implement is deprecated and won't be supported in version 4.0. Rename (or alias) your services to their FQCN id to make them autowirable.
 
- * [BC BREAK] The `NullDumper` class has been made final
+ * The `NullDumper` class has been made final
 
  * [BC BREAK] `_defaults` and `_instanceof` are now reserved service names in Yaml configurations. Please rename any services with that names.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe?
| Deprecations? | no
| Tests pass?   | yes
|Fixed tickets|
|License| MIT
|Doc PR|

https://github.com/symfony/dependency-injection/commit/7f34aa2643519f3400a6f66415a8cf9bf7147e81

This is the commit where the class has been made "final", but it has only been made final via php doc, not via code, so this shouldn't be a BC break in my opinion.