### PR TITLE
[FrameworkBundle][Translations] Fix translation commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -113,7 +113,10 @@ EOF
         $kernel = $this->getContainer()->get('kernel');
 
         // Define Root Path to App folder
-        $transPaths = array($kernel->getRootDir().'/Resources/');
+        $transPaths = array(
+            $kernel->getRootDir().'/Resources/',
+            $kernel->getProjectDir().'/',
+        );
 
         // Override with provided Bundle info
         if (null !== $input->getArgument('bundle')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -105,7 +105,10 @@ EOF
         $kernel = $this->getContainer()->get('kernel');
 
         // Define Root Path to App folder
-        $transPaths = array($kernel->getRootDir().'/Resources/');
+        $transPaths = array(
+            $kernel->getRootDir().'/Resources/',
+            $kernel->getProjectDir().'/',
+        );
         $currentName = 'app folder';
 
         // Override with provided Bundle info

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -33,7 +33,7 @@
         </service>
 
         <service id="translation.loader.yml" class="Symfony\Component\Translation\Loader\YamlFileLoader" public="true">
-            <tag name="translation.loader" alias="yml" />
+            <tag name="translation.loader" alias="yaml" legacy-alias="yml" />
         </service>
 
         <service id="translation.loader.xliff" class="Symfony\Component\Translation\Loader\XliffFileLoader" public="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -65,7 +65,10 @@ class TranslationDebugCommandTest extends TestCase
 
     public function testDebugCustomDirectory()
     {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Kernel')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $kernel->expects($this->once())
             ->method('getBundle')
             ->with($this->equalTo($this->translationDir))
@@ -83,7 +86,10 @@ class TranslationDebugCommandTest extends TestCase
      */
     public function testDebugInvalidDirectory()
     {
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Kernel')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $kernel->expects($this->once())
             ->method('getBundle')
             ->with($this->equalTo('dir'))
@@ -152,7 +158,10 @@ class TranslationDebugCommandTest extends TestCase
             );
 
         if (null === $kernel) {
-            $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
+            $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Kernel')
+                ->disableOriginalConstructor()
+                ->getMock();
+
             $kernel
                 ->expects($this->any())
                 ->method('getBundle')
@@ -165,6 +174,10 @@ class TranslationDebugCommandTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getRootDir')
+            ->will($this->returnValue($this->translationDir));
+
+        $kernel
+            ->method('getProjectDir')
             ->will($this->returnValue($this->translationDir));
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -132,7 +132,9 @@ class TranslationUpdateCommandTest extends TestCase
             );
 
         if (null === $kernel) {
-            $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
+            $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Kernel')
+                ->disableOriginalConstructor()
+                ->getMock();
             $kernel
                 ->expects($this->any())
                 ->method('getBundle')
@@ -145,6 +147,10 @@ class TranslationUpdateCommandTest extends TestCase
         $kernel
             ->expects($this->any())
             ->method('getRootDir')
+            ->will($this->returnValue($this->translationDir));
+
+        $kernel
+            ->method('getProjectDir')
             ->will($this->returnValue($this->translationDir));
 
         $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();


### PR DESCRIPTION
Hi,

I'm not sure about the target branch, but this bug seems to be present since we have the new `translations` directory in the project root. 

This add the search for a `translations` directory in the project root, **and** enable to have translations with `.yaml` extension, for now only `.yml` is working.

| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Please tell me how can I test this.
