### PR TITLE
adding AdapterInterface alias for cache.app

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -111,5 +111,6 @@
         <service id="cache.global_clearer" parent="cache.default_clearer" public="true" />
         <service id="cache.app_clearer" alias="cache.default_clearer" public="true" />
         <service id="Psr\Cache\CacheItemPoolInterface" alias="cache.app" />
+        <service id="Symfony\Component\Cache\Adapter\AdapterInterface" alias="cache.app" />
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no-ish
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | TODO

I'd like to add this alias for autowiring. If only `CacheItemPoolInterface` is available, then it's a bit weird to use the extra Symfony cache features (e.g. tagging), as I'm calling methods on the `CacheItemPoolInterface` that don't exist. I'd rather type-hint `AdapterInterface` and confidently call those (+ get auto-complete).