### PR TITLE
Add extra autowiring aliases

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -85,6 +85,7 @@
         <service id="Symfony\Component\Routing\RouterInterface" alias="router" />
         <service id="Symfony\Component\Routing\Generator\UrlGeneratorInterface" alias="router" />
         <service id="Symfony\Component\Routing\Matcher\UrlMatcherInterface" alias="router" />
+        <service id="Symfony\Component\Routing\RequestContextAwareInterface" alias="router" />
 
         <service id="router.request_context" class="Symfony\Component\Routing\RequestContext">
             <argument>%router.request_context.base_url%</argument>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -52,6 +52,7 @@
                 <argument type="service" id="event_dispatcher" />
             </call>
         </service>
+        <service id="Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface" alias="security.authentication.manager" />
 
         <service id="security.authentication.trust_resolver" class="Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver">
             <argument>%security.authentication.trust_resolver.anonymous_class%</argument>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | not really
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This adds autowiring for RequestContextAwareInterface for the routing layer and for AuthenticationManagerInterface in the security layer.
