### PR TITLE
[Translation] Fix InvalidArgumentException when using untranslated plural forms from .po files

### DIFF
--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -50,7 +50,7 @@ class MessageSelector
     public function choose($message, $number, $locale)
     {
         $parts = array();
-        if (preg_match('/^\|+$/', $message)) {
+        if (preg_match('/^\|++$/', $message)) {
             $parts = explode('|', $message);
         } elseif (preg_match_all('/(?:\|\||[^\|])++/', $message, $matches)) {
             $parts = $matches[0];

--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -49,10 +49,16 @@ class MessageSelector
      */
     public function choose($message, $number, $locale)
     {
-        preg_match_all('/(?:\|\||[^\|])++/', $message, $parts);
+        $parts = array();
+        if (preg_match('/^\|+$/', $message)) {
+            $parts = explode('|', $message);
+        } elseif (preg_match_all('/(?:\|\||[^\|])++/', $message, $matches)) {
+            $parts = $matches[0];
+        }
+
         $explicitRules = array();
         $standardRules = array();
-        foreach ($parts[0] as $part) {
+        foreach ($parts as $part) {
             $part = trim(str_replace('||', '|', $part));
 
             if (preg_match('/^(?P<interval>'.Interval::getIntervalRegexp().')\s*(?P<message>.*?)$/xs', $part, $matches)) {
@@ -76,7 +82,7 @@ class MessageSelector
         if (!isset($standardRules[$position])) {
             // when there's exactly one rule given, and that rule is a standard
             // rule, use this rule
-            if (1 === count($parts[0]) && isset($standardRules[0])) {
+            if (1 === count($parts) && isset($standardRules[0])) {
                 return $standardRules[0];
             }
 

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -128,6 +128,10 @@ class MessageSelectorTest extends TestCase
             array("This is a text with a\nnew-line in it. Selector = 1.", "{0}This is a text with a\nnew-line in it. Selector = 0.|{1}This is a text with a\nnew-line in it. Selector = 1.|[1,Inf]This is a text with a\nnew-line in it. Selector > 1.", 1),
             // esacape pipe
             array('This is a text with | in it. Selector = 0.', '{0}This is a text with || in it. Selector = 0.|{1}This is a text with || in it. Selector = 1.', 0),
+            // Empty plural set (2 plural forms) from a .PO file
+            array('', '|', 1),
+            // Empty plural set (3 plural forms) from a .PO file
+            array('', '||', 1),
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24593
| License       | MIT

This PR fixes the bug in #24593. It's not the absolutely ideal way to address the issue, but I don't see how else to handle it without either dropping support for pips in translation strings, or rearchitecting the code that feeds translations to the MessageSelector as pipe separated in the first place. 