### PR TITLE
[HttpKernel] Don't bind scalar values to controller method arguments

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -135,6 +135,11 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         $binding = $bindings[$bindingName];
 
                         list($bindingValue, $bindingId) = $binding->getValues();
+
+                        if (!$bindingValue instanceof Reference) {
+                            continue;
+                        }
+
                         $binding->setValues(array($bindingValue, $bindingId, true));
                         $args[$p->name] = $bindingValue;
 

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -310,6 +310,22 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
     {
         return array(array(ControllerDummy::class), array('$bar'));
     }
+
+    public function testDoNotBindScalarValueToControllerArgument()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service')->addArgument(array());
+
+        $container->register('foo', ArgumentWithoutTypeController::class)
+            ->setBindings(array('$someArg' => '%foo%'))
+            ->addTag('controller.service_arguments');
+
+        $pass = new RegisterControllerArgumentLocatorsPass();
+        $pass->process($container);
+
+        $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
+        $this->assertEmpty($locator);
+    }
 }
 
 class RegisterTestController


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/24555#issuecomment-337071029
| License       | MIT
| Doc PR        | -

See linked issue.

Let's suppose we have this configuration:
```yaml
services:
    _defaults:
        # ...
        bind:
            $foo: '%foobar%'
```
`$foo` was successfully bound to any controller constructor, but in another controller I have this edit action (nothing to do with the intention of bind such a parameter, but it has the same name):
```php
/**
 * @Route("/{foo}/edit")
 */
public function editAction(string $foo) {}
```
triggering:
> Type error: Argument 1 passed to Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument::__construct() must be an instance of Symfony\Component\DependencyInjection\Reference, string given, called in /home/yceruto/github/symfony/symfony-demo/vendor/symfony/dependency-injection/Compiler/ServiceLocatorTagPass.php on line 81

or after https://github.com/symfony/symfony/pull/24582:
> Invalid service locator definition: only services can be referenced, "string" found for key "foo". Inject parameter values using constructors instead.