### PR TITLE
[FrameworkBundle] Do not load property_access.xml if the component isn't installed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -63,9 +63,6 @@ class FrameworkExtension extends Extension
         // will be used and everything will still work as expected.
         $loader->load('translation.xml');
 
-        // Property access is used by both the Form and the Validator component
-        $loader->load('property_access.xml');
-
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
@@ -129,7 +126,7 @@ class FrameworkExtension extends Extension
         }
 
         $this->registerAnnotationsConfiguration($config['annotations'], $container, $loader);
-        $this->registerPropertyAccessConfiguration($config['property_access'], $container);
+        $this->registerPropertyAccessConfiguration($config['property_access'], $container, $loader);
 
         if (isset($config['serializer'])) {
             $this->registerSerializerConfiguration($config['serializer'], $container, $loader);
@@ -852,8 +849,14 @@ class FrameworkExtension extends Extension
         }
     }
 
-    private function registerPropertyAccessConfiguration(array $config, ContainerBuilder $container)
+    private function registerPropertyAccessConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
+        if (!class_exists('Symfony\Component\PropertyAccess\PropertyAccessor')) {
+            return;
+        }
+
+        $loader->load('property_access.xml');
+
         $container
             ->getDefinition('property_accessor')
             ->replaceArgument(0, $config['magic_call'])

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -903,6 +903,11 @@ class FrameworkExtension extends Extension
         $loader->load('serializer.xml');
         $chainLoader = $container->getDefinition('serializer.mapping.chain_loader');
 
+        if (!class_exists('Symfony\Component\PropertyAccess\PropertyAccessor')) {
+            $container->removeAlias('serializer.property_accessor');
+            $container->removeDefinition('serializer.normalizer.object');
+        }
+
         $serializerLoaders = array();
         if (isset($config['enable_annotations']) && $config['enable_annotations']) {
             $annotationLoader = new Definition(

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -23,7 +23,7 @@
         <service id="serializer.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument>null</argument>
-            <argument type="service" id="serializer.property_accessor" on-invalid="ignore" />
+            <argument type="service" id="serializer.property_accessor" />
 
             <!-- Run after all custom serializers -->
             <tag name="serializer.normalizer" priority="-1000" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -23,7 +23,7 @@
         <service id="serializer.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument>null</argument>
-            <argument type="service" id="serializer.property_accessor" />
+            <argument type="service" id="serializer.property_accessor" on-invalid="ignore" />
 
             <!-- Run after all custom serializers -->
             <tag name="serializer.normalizer" priority="-1000" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/24563#issuecomment-337549147 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This PR actually aims to fix https://github.com/symfony/symfony/pull/24563#issuecomment-337549147 as the exception introduced in the PR can't be reached anyway when using the FrameworkBundle without the property access component as you'll get:

> Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "PropertyAccessor" from namespace "Symfony\Component\PropertyAccess".

With this fix, you properly get:

> The ObjectNormalizer class requires the "PropertyAccess" component. Install "symfony/property-access" to use it.

Not sure this change really belongs to a patch release, but the original PR was accepted in the 2.7 branch.

Also, I'd rather remove the ObjectNormalizer definition if the component isn't available, as suggested by @xabbuh (https://github.com/symfony/symfony/pull/24563#issuecomment-336795644). But in 2.7, this is the only normalizer registered by default and the [`SerializerPass` throws an exception if no normalizer is registered.](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SerializerPass.php#L46)

To sum up, either:

1. we completly prevent using the FrameworkBundle and the serializer without the property access component, even if you don't really care about the ObjectNormalizer because you only use your owns specific ones. (and you'll get the exception hinting to install the property access component)
2. we allow using the FrameworkBundle and the serializer without the property access component, so we remove the ObjectNormalizer definition, but the user'll get a `You must tag at least one service as "serializer.normalizer" to use the Serializer service` exception until he configures a normalizer (and we don't get the hint about installing the property access component to enable the ObjectNormalizer. We already have a suggest entry in the composer.json file, though).

To me option 2 looks better. WDYT?