### PR TITLE
Adding the Form default theme files to be warmed up in Twig's cache

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -45,7 +45,14 @@ class ExtensionPass implements CompilerPassInterface
         if ($container->has('form.extension')) {
             $container->getDefinition('twig.extension.form')->addTag('twig.extension');
             $reflClass = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
-            $container->getDefinition('twig.loader.native_filesystem')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
+
+            $coreThemePath = dirname(dirname($reflClass->getFileName())).'/Resources/views/Form';
+            $container->getDefinition('twig.loader.native_filesystem')->addMethodCall('addPath', array($coreThemePath));
+
+            $paths = $container->getDefinition('twig.cache_warmer')->getArgument(2);
+            $paths[$coreThemePath] = null;
+            $container->getDefinition('twig.cache_warmer')->replaceArgument(2, $paths);
+            $container->getDefinition('twig.template_iterator')->replaceArgument(2, $paths);
         }
 
         if ($container->has('fragment.handler')) {

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -89,6 +89,7 @@ class TwigExtension extends Extension
             }
         }
 
+        // paths are modified in ExtensionPass if forms are enabled
         $container->getDefinition('twig.cache_warmer')->replaceArgument(2, $config['paths']);
         $container->getDefinition('twig.template_iterator')->replaceArgument(2, $config['paths']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

Hiya guys!

So..... during a Symfony Live workshop, we found out that the form theme Twig templates are *not* included in the Twig cache warmup process. This fixes that. I believe this is the only "weird" case where we use a Twig template that is not in a bundle and also not added to Twig as a proper namespaces. 

I tested this on a 2.8 project. Before the patch, the form theme templates were not warmed up. After, they are warmed up. Booya.

Cheers!