### PR TITLE
return null explicitly

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1288,6 +1288,8 @@ class Request
                 return $format;
             }
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

`getFormat()` is declared as `@return string|null`.
So IMHO returning `null` at the end of method explicitly would be more consistent.
