### PR TITLE
declare Cookie[]

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -30,7 +30,7 @@ class ResponseHeaderBag extends HeaderBag
     protected $computedCacheControl = array();
 
     /**
-     * @var array
+     * @var Cookie[]
      */
     protected $cookies = array();
 
@@ -229,7 +229,7 @@ class ResponseHeaderBag extends HeaderBag
      *
      * @param string $format
      *
-     * @return array
+     * @return Cookie[] An array of cookies
      *
      * @throws \InvalidArgumentException When the $format is invalid
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

`Cookie[]` instead of `array` would be more verbose.