### PR TITLE
[Session] remove lazy_write polyfill for php < 7.0

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -88,9 +88,6 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
 
         $data = $this->doRead($sessionId);
         $this->newSessionId = '' === $data ? $sessionId : null;
-        if (\PHP_VERSION_ID < 70000) {
-            $this->prefetchData = $data;
-        }
 
         return $data;
     }
@@ -100,14 +97,6 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
      */
     public function write($sessionId, $data)
     {
-        if (\PHP_VERSION_ID < 70000 && $this->prefetchData) {
-            $readData = $this->prefetchData;
-            $this->prefetchData = null;
-
-            if ($readData === $data) {
-                return $this->updateTimestamp($sessionId, $data);
-            }
-        }
         if (null === $this->igbinaryEmptyData) {
             // see https://github.com/igbinary/igbinary/issues/146
             $this->igbinaryEmptyData = \function_exists('igbinary_serialize') ? igbinary_serialize(array()) : '';
@@ -125,9 +114,6 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
      */
     public function destroy($sessionId)
     {
-        if (\PHP_VERSION_ID < 70000) {
-            $this->prefetchData = null;
-        }
         if (!headers_sent() && ini_get('session.use_cookies')) {
             if (!$this->sessionName) {
                 throw new \LogicException(sprintf('Session name cannot be empty, did you forget to call "parent::open()" in "%s"?.', get_class($this)));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
@@ -13,9 +13,6 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @requires PHP 7.0
- */
 class AbstractSessionHandlerTest extends TestCase
 {
     private static $server;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    |no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Remove the session.lazy_write fallback implementation for php < 7 introduced in #24523 as we don't need it in sf 4
