### PR TITLE
[Security] Fix missing BC layer for AbstractGuardAuthenticator::getCredentials()

### DIFF
--- a/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Guard\Firewall;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
 use Symfony\Component\Security\Guard\GuardAuthenticatorInterface;
 use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
@@ -124,7 +125,13 @@ class GuardAuthenticationListener implements ListenerInterface
                     return;
                 }
 
-                throw new \UnexpectedValueException(sprintf('The return value of "%s::getCredentials()" must not be null. Return false from "%s::supports()" instead.', get_class($guardAuthenticator), get_class($guardAuthenticator)));
+                if ($guardAuthenticator instanceof AbstractGuardAuthenticator) {
+                    @trigger_error(sprintf('Returning null from "%1$s::getCredentials()" is deprecated since version 3.4 and will throw an \UnexpectedValueException in 4.0. Return false from "%1$s::supports()" instead.', get_class($guardAuthenticator)), E_USER_DEPRECATED);
+
+                    return;
+                }
+
+                throw new \UnexpectedValueException(sprintf('The return value of "%1$s::getCredentials()" must not be null. Return false from "%1$s::supports()" instead.', get_class($guardAuthenticator)));
             }
 
             // create a token with the unique key, so that the provider knows which authenticator to use

--- a/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Component\Security\Guard\Firewall\GuardAuthenticationListener;
 use Symfony\Component\Security\Guard\GuardAuthenticatorInterface;
@@ -364,6 +365,37 @@ class GuardAuthenticationListenerTest extends TestCase
     public function testReturnNullFromGetCredentials()
     {
         $authenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
+        $providerKey = 'my_firewall4';
+
+        $authenticator
+            ->expects($this->once())
+            ->method('supports')
+            ->will($this->returnValue(true));
+
+        // this will raise exception
+        $authenticator
+            ->expects($this->once())
+            ->method('getCredentials')
+            ->will($this->returnValue(null));
+
+        $listener = new GuardAuthenticationListener(
+            $this->guardAuthenticatorHandler,
+            $this->authenticationManager,
+            $providerKey,
+            array($authenticator),
+            $this->logger
+        );
+
+        $listener->handle($this->event);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Returning null from "%s::getCredentials()" is deprecated since version 3.4 and will throw an \UnexpectedValueException in 4.0. Return false from "%s::supports()" instead.
+     */
+    public function testReturnNullFromGetCredentialsTriggersForAbstractGuardAuthenticatorInstances()
+    {
+        $authenticator = $this->getMockBuilder(AbstractGuardAuthenticator::class)->getMock();
         $providerKey = 'my_firewall4';
 
         $authenticator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

If a guard authenticator extends `AbstractGuardAuthenticator` and returns `null` from `getCredentials()`, an `\UnexpectedValueException` is thrown when upgrading to 3.4 because the abstract already implements the new interface.
This triggers a deprecation notice instead.