### PR TITLE
streamed response should return $this

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -109,6 +109,7 @@ class StreamedResponse extends Response
         }
 
         call_user_func($this->callback);
+
         return $this;
     }
 

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -83,12 +83,12 @@ class StreamedResponse extends Response
     public function sendHeaders()
     {
         if ($this->headersSent) {
-            return;
+            return $this;
         }
 
         $this->headersSent = true;
 
-        parent::sendHeaders();
+        return parent::sendHeaders();
     }
 
     /**
@@ -99,7 +99,7 @@ class StreamedResponse extends Response
     public function sendContent()
     {
         if ($this->streamed) {
-            return;
+            return $this;
         }
 
         $this->streamed = true;
@@ -109,6 +109,7 @@ class StreamedResponse extends Response
         }
 
         call_user_func($this->callback);
+        return $this;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -121,4 +121,15 @@ class StreamedResponseTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response);
         $this->assertEquals(204, $response->getStatusCode());
     }
+
+    public function testReturnThis()
+    {
+        $response = new StreamedResponse(function () {});
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response->sendContent());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response->sendContent());
+
+        $response = new StreamedResponse(function () {});
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response->sendHeaders());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response->sendHeaders());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | may be yes?
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

---



`sendHeaders()` and `sendContent()` should return $this,  as in the parent class.

related PRs:
https://github.com/symfony/symfony/pull/2935
https://github.com/symfony/symfony/pull/20289