### PR TITLE
[Form] Add $useDefaultThemes flag to the interfaces

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -326,6 +326,8 @@ Form
    }
    ```
 
+ * `FormRendererInterface::setTheme` and `FormRendererEngineInterface::setTheme` have a new optional argument `$useDefaultThemes` with a default value set to `true`.
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/Form/AbstractRendererEngine.php
+++ b/src/Symfony/Component/Form/AbstractRendererEngine.php
@@ -62,15 +62,13 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
     /**
      * {@inheritdoc}
      */
-    public function setTheme(FormView $view, $themes /*, $useDefaultThemes = true */)
+    public function setTheme(FormView $view, $themes, $useDefaultThemes = true)
     {
         $cacheKey = $view->vars[self::CACHE_KEY_VAR];
 
         // Do not cast, as casting turns objects into arrays of properties
         $this->themes[$cacheKey] = is_array($themes) ? $themes : array($themes);
-
-        $args = func_get_args();
-        $this->useDefaultThemes[$cacheKey] = isset($args[2]) ? (bool) $args[2] : true;
+        $this->useDefaultThemes[$cacheKey] = (bool) $useDefaultThemes;
 
         // Unset instead of resetting to an empty array, in order to allow
         // implementations (like TwigRendererEngine) to check whether $cacheKey

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -70,10 +70,9 @@ class FormRenderer implements FormRendererInterface
     /**
      * {@inheritdoc}
      */
-    public function setTheme(FormView $view, $themes /*, $useDefaultThemes = true */)
+    public function setTheme(FormView $view, $themes, $useDefaultThemes = true)
     {
-        $args = func_get_args();
-        $this->engine->setTheme($view, $themes, isset($args[2]) ? (bool) $args[2] : true);
+        $this->engine->setTheme($view, $themes, $useDefaultThemes);
     }
 
     /**

--- a/src/Symfony/Component/Form/FormRendererEngineInterface.php
+++ b/src/Symfony/Component/Form/FormRendererEngineInterface.php
@@ -25,9 +25,9 @@ interface FormRendererEngineInterface
      * @param mixed    $themes           The theme(s). The type of these themes
      *                                   is open to the implementation.
      * @param bool     $useDefaultThemes If true, will use default themes specified
-     *                                   in the engine, will be added to the interface in 4.0
+     *                                   in the engine
      */
-    public function setTheme(FormView $view, $themes /*, $useDefaultThemes = true */);
+    public function setTheme(FormView $view, $themes, $useDefaultThemes = true);
 
     /**
      * Returns the resource for a block name.

--- a/src/Symfony/Component/Form/FormRendererInterface.php
+++ b/src/Symfony/Component/Form/FormRendererInterface.php
@@ -32,9 +32,9 @@ interface FormRendererInterface
      * @param mixed    $themes           The theme(s). The type of these themes
      *                                   is open to the implementation.
      * @param bool     $useDefaultThemes If true, will use default themes specified
-     *                                   in the renderer, will be added to the interface in 4.0
+     *                                   in the renderer
      */
-    public function setTheme(FormView $view, $themes /*, $useDefaultThemes = true */);
+    public function setTheme(FormView $view, $themes, $useDefaultThemes = true);
 
     /**
      * Renders a named block of the form theme.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Followup to #22610 to add `$useDefaultThemes` to the interfaces as discussed in the issue.
