### PR TITLE
[Form] Fix FormEvents::* constant and value matching

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -226,8 +226,9 @@ Finder
 Form
 ----
 
- * The constant values of `FormEvents::*` have been renamed to match with its name.
-   May break rare cases where the event name is used rather than the constant.
+* The values of the `FormEvents::*` constants have been updated to match the
+  constant names. You should only update your application if you relied on the
+  constant values instead of their names.
 
  * The `choices_as_values` option of the `ChoiceType` has been removed.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -226,6 +226,9 @@ Finder
 Form
 ----
 
+ * The constant values of `FormEvents::*` have been renamed to match with its name.
+   May break rare cases where the event name is used rather than the constant.
+
  * The `choices_as_values` option of the `ChoiceType` has been removed.
 
  * Support for data objects that implements both `Traversable` and

--- a/src/Symfony/Component/Form/FormEvents.php
+++ b/src/Symfony/Component/Form/FormEvents.php
@@ -31,7 +31,7 @@ final class FormEvents
      *
      * @Event("Symfony\Component\Form\FormEvent")
      */
-    const PRE_SUBMIT = 'form.pre_bind';
+    const PRE_SUBMIT = 'form.pre_submit';
 
     /**
      * The SUBMIT event is dispatched just before the Form::submit() method
@@ -41,7 +41,7 @@ final class FormEvents
      *
      * @Event("Symfony\Component\Form\FormEvent")
      */
-    const SUBMIT = 'form.bind';
+    const SUBMIT = 'form.submit';
 
     /**
      * The FormEvents::POST_SUBMIT event is dispatched after the Form::submit()
@@ -51,7 +51,7 @@ final class FormEvents
      *
      * @Event("Symfony\Component\Form\FormEvent")
      */
-    const POST_SUBMIT = 'form.post_bind';
+    const POST_SUBMIT = 'form.post_submit';
 
     /**
      * The FormEvents::PRE_SET_DATA event is dispatched at the beginning of the Form::setData() method.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes (ppl relying on const value directly, very weird)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/24615
| License       | MIT
| Doc PR        | -

> https://github.com/symfony/symfony/issues/24615#issuecomment-337945875 by @stof:
Yeah, I think we could change this in 4.0 without a big impact (btw, I think our BC policy even allows it for this case).
There is one case where people will use the event name rather than the constant: the kernel.event_listener tag (and recent versions can even use the constant in YAML files). But this won't be the case for this event, as form events are not dispatched in the main dispatcher anyway.
