### PR TITLE
[DependencyInjection] Anonymous services in PHP DSL

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -31,6 +31,7 @@ class ContainerConfigurator extends AbstractConfigurator
     private $instanceof;
     private $path;
     private $file;
+    private $anonymousCount = 0;
 
     public function __construct(ContainerBuilder $container, PhpFileLoader $loader, array &$instanceof, string $path, string $file)
     {
@@ -70,7 +71,7 @@ class ContainerConfigurator extends AbstractConfigurator
 
     final public function services(): ServicesConfigurator
     {
-        return new ServicesConfigurator($this->container, $this->loader, $this->instanceof);
+        return new ServicesConfigurator($this->container, $this->loader, $this->instanceof, $this->path, $this->anonymousCount);
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StdClassDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/StdClassDecorator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+final class StdClassDecorator
+{
+    public function __construct(\stdClass $foo)
+    {
+        $this->foo = $foo;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
@@ -1,0 +1,19 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    listener_aggregator:
+        class: Bar\FooClass
+        public: true
+        arguments: [!tagged listener]
+    2_stdClass~%s:
+        class: stdClass
+        public: false
+        tags:
+            - { name: listener }
+    decorated:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\StdClassDecorator
+        public: true
+        arguments: [!service { class: stdClass, public: false }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Bar\FooClass;
+use stdClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\StdClassDecorator;
+
+return function (ContainerConfigurator $c) {
+    $s = $c->services();
+
+    $s->set('decorated', stdClass::class);
+
+    $s->set(null, StdClassDecorator::class)
+        ->decorate('decorated', 'decorator42')
+        ->args(array(ref('decorator42')));
+
+    $s->set('listener_aggregator', FooClass::class)->public()->args(array(tagged('listener')));
+
+    $s->set(null, stdClass::class)->tag('listener');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -61,7 +61,7 @@ class PhpFileLoaderTest extends TestCase
         $container->compile();
 
         $dumper = new YamlDumper($container);
-        $this->assertStringEqualsFile($fixtures.'/config/'.$file.'.expected.yml', $dumper->dump());
+        $this->assertStringMatchesFormatFile($fixtures.'/config/'.$file.'.expected.yml', $dumper->dump());
     }
 
     public function provideConfig()
@@ -72,6 +72,7 @@ class PhpFileLoaderTest extends TestCase
         yield array('prototype');
         yield array('child');
         yield array('php7');
+        yield array('anonymous');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | enhancement for fluent PHP configs
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24493
| License       | MIT
| Doc PR        | not yet

See #24493:
```php
$s->anonymous(SendEmailForRegisteredUser::class)->tag('listener');
```
  