### PR TITLE
[FrameworkBundle] Improve the DX of TemplateController when using SF 4

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -67,4 +67,9 @@ class TemplateController
 
         return $response;
     }
+
+    public function __invoke(string $template, int $maxAge = null, int $sharedAge = null, bool $private = null): Response
+    {
+        return $this->templateAction($template, $maxAge, $sharedAge, $private);
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -23,21 +23,23 @@ class TemplateControllerTest extends TestCase
     public function testTwig()
     {
         $twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
-        $twig->expects($this->once())->method('render')->willReturn('bar');
+        $twig->expects($this->exactly(2))->method('render')->willReturn('bar');
 
         $controller = new TemplateController($twig);
 
         $this->assertEquals('bar', $controller->templateAction('mytemplate')->getContent());
+        $this->assertEquals('bar', $controller('mytemplate')->getContent());
     }
 
     public function testTemplating()
     {
         $templating = $this->getMockBuilder(EngineInterface::class)->getMock();
-        $templating->expects($this->once())->method('render')->willReturn('bar');
+        $templating->expects($this->exactly(2))->method('render')->willReturn('bar');
 
         $controller = new TemplateController(null, $templating);
 
         $this->assertEquals('bar', $controller->templateAction('mytemplate')->getContent());
+        $this->assertEquals('bar', $controller('mytemplate')->getContent());
     }
 
     /**
@@ -49,5 +51,6 @@ class TemplateControllerTest extends TestCase
         $controller = new TemplateController();
 
         $controller->templateAction('mytemplate')->getContent();
+        $controller('mytemplate')->getContent();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10320

Tiny DX improvement when using modern Symfony.

Allow to write:

```yaml
# config/routes.yaml
index:
    path: /
    defaults:
      _controller: 'Symfony\Bundle\FrameworkBundle\Controller\TemplateController'
      template: 'homepage.html.twig'
```

Instead of:

```yaml
index:
    path: /
    defaults:
      _controller: 'Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction'
      template: 'homepage.html.twig'
```
I was thinking about doing the same for `RedirectController`, but it's not that easy because it contains two methods.