### PR TITLE
Improving annotation loader message

### DIFF
--- a/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
@@ -64,7 +64,7 @@ class FileLoaderLoadException extends \Exception
         } elseif (null !== $type) {
             // maybe there is no loader for this specific type
             if ('annotation' === $type) {
-                $message .= ' Make sure annotations are enabled.';
+                $message .= ' Make sure annotations are installed and enabled.';
             } else {
                 $message .= sprintf(' Make sure there is a loader supporting the "%s" type.', $type);
             }

--- a/src/Symfony/Component/Config/Tests/Exception/FileLoaderLoadExceptionTest.php
+++ b/src/Symfony/Component/Config/Tests/Exception/FileLoaderLoadExceptionTest.php
@@ -31,7 +31,7 @@ class FileLoaderLoadExceptionTest extends TestCase
     public function testMessageCannotLoadResourceWithAnnotationType()
     {
         $exception = new FileLoaderLoadException('resource', null, null, null, 'annotation');
-        $this->assertEquals('Cannot load resource "resource". Make sure annotations are enabled.', $exception->getMessage());
+        $this->assertEquals('Cannot load resource "resource". Make sure annotations are installed and enabled.', $exception->getMessage());
     }
 
     public function testMessageCannotImportResourceFromSource()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

This is the error that happens with Flex when you try to load annotation routes, but you don't have annotations installed/enabled yet. Fabien created this error message to help with this exact situation. For Flex users, the real solution is to run `composer require annotation`. This at least *somewhat* hints that even better.