### PR TITLE
[Routing] Fix resource miss

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -311,6 +311,9 @@ class RouteCollectionBuilder
                 $subCollection->addPrefix($this->prefix);
 
                 $routeCollection->addCollection($subCollection);
+                foreach ($route->resources as $resource) {
+                    $routeCollection->addResource($resource);
+                }
             }
 
             foreach ($this->resources as $resource) {

--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -311,14 +311,11 @@ class RouteCollectionBuilder
                 $subCollection->addPrefix($this->prefix);
 
                 $routeCollection->addCollection($subCollection);
-                foreach ($route->resources as $resource) {
-                    $routeCollection->addResource($resource);
-                }
             }
+        }
 
-            foreach ($this->resources as $resource) {
-                $routeCollection->addResource($resource);
-            }
+        foreach ($this->resources as $resource) {
+            $routeCollection->addResource($resource);
         }
 
         return $routeCollection;

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\Routing\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Loader\YamlFileLoader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouteCollectionBuilder;
@@ -59,7 +61,18 @@ class RouteCollectionBuilderTest extends TestCase
         $this->assertCount(1, $addedCollection->getResources());
 
         // make sure the routes were imported into the top-level builder
+        $routeCollection = $routes->build();
         $this->assertCount(1, $routes->build());
+        $this->assertCount(1, $routeCollection->getResources());
+    }
+
+    public function testImportAddResources()
+    {
+        $routeCollectionBuilder = new RouteCollectionBuilder(new YamlFileLoader(new FileLocator(array(__DIR__.'/Fixtures/'))));
+        $routeCollectionBuilder->import('file_resource.yml');
+        $routeCollection = $routeCollectionBuilder->build();
+
+        $this->assertCount(1, $routeCollection->getResources());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Some routing resources are not watched. To reproduce:

1. Install Symfony 4
2. Change something in `config/routes.yaml`

The change is not taken into account.

This PR fixes this bug.