### PR TITLE
Fix phpdoc and unnecessary sprintf

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -40,7 +40,7 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
     final public function tag($name, array $attributes = array())
     {
         if (!is_string($name) || '' === $name) {
-            throw new InvalidArgumentException(sprintf('The tag name in "_defaults" must be a non-empty string.'));
+            throw new InvalidArgumentException('The tag name in "_defaults" must be a non-empty string.');
         }
 
         foreach ($attributes as $attribute => $value) {

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -42,7 +42,7 @@ class CollectionConfigurator
      * Adds a route.
      *
      * @param string $name
-     * @param string $value
+     * @param string $path
      *
      * @return RouteConfigurator
      */


### PR DESCRIPTION
(detected by static analysis)

`%1$::`: is not a format string, it should be `%1$s::`
Simplify no-op sprintf.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | 
| Fixed tickets | 
| License       | MIT
| Doc PR        |