### PR TITLE
Fix an invalid printf format string in symfony 4 test case

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -38,7 +38,7 @@ abstract class KernelTestCase extends TestCase
     protected static function getKernelClass()
     {
         if (!isset($_SERVER['KERNEL_CLASS']) && !isset($_ENV['KERNEL_CLASS'])) {
-            throw new \LogicException(sprintf('You must set the KERNEL_CLASS environment variable to the fully-qualified class name of your Kernel in phpunit.xml / phpunit.xml.dist or override the %1$::createKernel() or %1$::getKernelClass() method.', static::class));
+            throw new \LogicException(sprintf('You must set the KERNEL_CLASS environment variable to the fully-qualified class name of your Kernel in phpunit.xml / phpunit.xml.dist or override the %1$s::createKernel() or %1$s::getKernelClass() method.', static::class));
         }
 
         if (!class_exists($class = $_SERVER['KERNEL_CLASS'] ?? $_ENV['KERNEL_CLASS'])) {


### PR DESCRIPTION
`%1$::` should be `%1$s::`
(`1$` means the first parameter, `s` meaning string)

Detected by static analysis

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no (test)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets |
| License       | MIT
| Doc PR        | 