### PR TITLE
[4.0][HttpKernel] Remove composer require-dev "symfony/class-loader"

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -24,7 +24,6 @@
     },
     "require-dev": {
         "symfony/browser-kit": "~3.4|~4.0",
-        "symfony/class-loader": "~3.4|~4.0",
         "symfony/config": "~3.4|~4.0",
         "symfony/console": "~3.4|~4.0",
         "symfony/css-selector": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

ClassLoader component is removed in version 4.  This pull request removes HttpKernel's `composer.json` 's `require-dev` of the `symfony/class-loader` package.