### PR TITLE
Add "doctrine/annotations" to top-level composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "symfony/yaml": "self.version"
     },
     "require-dev": {
+        "doctrine/annotations": "~1.0",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.4",
         "doctrine/orm": "~2.4,>=2.4.5",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Adding to top-level composer.json as require-dev since it is already dev-required by the following:

* `src/Symfony/Bundle/FrameworkBundle/composer.json`:        `"doctrine/annotations": "~1.0"`
* `src/Symfony/Bundle/TwigBundle/composer.json`:        `"doctrine/annotations": "~1.0"`
* `src/Symfony/Component/PropertyInfo/composer.json`:        `"doctrine/annotations": "~1.0"`
* `src/Symfony/Component/Routing/composer.json`:        `"doctrine/annotations": "~1.0",`
* `src/Symfony/Component/Serializer/composer.json`:        `"doctrine/annotations": "~1.0",`
* `src/Symfony/Component/Validator/composer.json`:        `"doctrine/annotations": "~1.0",`