### PR TITLE
Escape trailing \ in QuestionHelper autocompletion

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Helper;
 
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -303,7 +304,7 @@ class QuestionHelper extends Helper
                 // Save cursor position
                 $output->write("\0337");
                 // Write highlighted text
-                $output->write('<hl>'.substr($matches[$ofs], $i).'</hl>');
+                $output->write('<hl>'.OutputFormatter::escapeTrailingBackslash(substr($matches[$ofs], $i)).'</hl>');
                 // Restore cursor position
                 $output->write("\0338");
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24652 
| License       | MIT

Fixes symfony/symfony#24652
Trailing backslash, being unescaped, used to escape closing formatting
tag and, thus, formatting tag appeared in autocompletion

Output of the added test without the fix:
```
./phpunit --filter testAutocompleteWithTrailingBackslash src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
#!/usr/bin/env php
PHPUnit 6.0.13 by Sebastian Bergmann and contributors.

Testing Symfony\Component\Console\Tests\Helper\QuestionHelperTest
F                                                                   1 / 1 (100%)

Time: 4.28 seconds, Memory: 6.00MB

There was 1 failure:

1) Symfony\Component\Console\Tests\Helper\QuestionHelperTest::testAutocompleteWithTrailingBackslash
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'ExampleNamespace\'
+'ExampleNamespace</hl>'
```

`OutputFormatter::escapeTrailingBackslash` is marked as `@internal`; however, this seems to be a valid use without exposing outside of the component. `OutputFormatter::escape`, which is not internal, doesn't fit here because escaping tags in autocompletion options is a deeper topic: there might be a valid use for tags in autocompletion and even if not, taking out the possibility to use them might be considered a BC break (even though it hasn't been advertised anywhere).