### PR TITLE
Fix defined services overridden by PSR-4 discovery

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -41,6 +41,7 @@ class Definition
     private $autowired = false;
     private $autowiringTypes = array();
     private $changes = array();
+    private $registeredViaServiceDiscovery = false;
 
     protected $arguments = array();
 
@@ -891,5 +892,25 @@ class Definition
         @trigger_error(sprintf('Autowiring-types are deprecated since Symfony 3.3 and will be removed in 4.0. Use aliases instead for "%s".', $type), E_USER_DEPRECATED);
 
         return isset($this->autowiringTypes[$type]);
+    }
+
+    /**
+     * Returns whether the definition was created by a service discovery mechanism.
+     *
+     * @return bool
+     */
+    public function isRegisteredViaServiceDiscovery()
+    {
+        return $this->registeredViaServiceDiscovery;
+    }
+
+    /**
+     * Marks the definition as created by a service discovery mechanism.
+     *
+     * @param bool $registeredViaServiceDiscovery
+     */
+    public function setRegisteredViaServiceDiscovery($registeredViaServiceDiscovery)
+    {
+        $this->registeredViaServiceDiscovery = $registeredViaServiceDiscovery;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -60,10 +60,13 @@ abstract class FileLoader extends BaseFileLoader
 
         $classes = $this->findClasses($namespace, $resource, $exclude);
         // prepare for deep cloning
+        $prototype->setRegisteredViaServiceDiscovery(true);
         $prototype = serialize($prototype);
 
         foreach ($classes as $class) {
-            $this->setDefinition($class, unserialize($prototype));
+            if (!$this->container->hasDefinition($class) || $this->container->getDefinition($class)->isRegisteredViaServiceDiscovery()) {
+                $this->setDefinition($class, unserialize($prototype));
+            }
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -387,4 +387,16 @@ class DefinitionTest extends TestCase
         $def->setAutoconfigured(true);
         $this->assertTrue($def->isAutoconfigured());
     }
+
+    public function testRegisteredViaServiceDiscovery()
+    {
+        $def = new Definition('stdClass');
+        $this->assertFalse($def->isRegisteredViaServiceDiscovery());
+
+        $def->setRegisteredViaServiceDiscovery(true);
+        $this->assertTrue($def->isRegisteredViaServiceDiscovery());
+
+        $def->setRegisteredViaServiceDiscovery(false);
+        $this->assertFalse($def->isRegisteredViaServiceDiscovery());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_multiple.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_multiple.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*" />
+      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\" resource="../Prototype/OtherDir/*" public="true">
+          <tag name="foo" />
+      </prototype>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_with_already_defined_service.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_with_already_defined_service.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar">
+            <argument type="string">foo</argument>
+            <argument type="string">bar</argument>
+            <tag name="baz" />
+        </service>
+        <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*" exclude="../Prototype/{OtherDir}" />
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_multiple.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_multiple.yml
@@ -1,0 +1,8 @@
+services:
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\:
+        resource: ../Prototype
+
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\:
+        resource: ../Prototype/OtherDir
+        public: true
+        tags: [foo]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_with_already_defined_service.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype_with_already_defined_service.yml
@@ -1,0 +1,8 @@
+services:
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
+        arguments: [foo, bar]
+        tags: [baz]
+
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\:
+        resource: ../Prototype
+        exclude: '../Prototype/{OtherDir}'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -91,6 +91,8 @@ class FileLoaderTest extends TestCase
             array('service_container', Bar::class),
             array_keys($container->getDefinitions())
         );
+
+        $this->assertTrue($container->getDefinition(Bar::class)->isRegisteredViaServiceDiscovery());
     }
 
     public function testRegisterClassesWithExclude()
@@ -111,6 +113,9 @@ class FileLoaderTest extends TestCase
         $this->assertTrue($container->has(Baz::class));
         $this->assertFalse($container->has(Foo::class));
         $this->assertFalse($container->has(DeeperBaz::class));
+
+        $this->assertTrue($container->getDefinition(Bar::class)->isRegisteredViaServiceDiscovery());
+        $this->assertTrue($container->getDefinition(Baz::class)->isRegisteredViaServiceDiscovery());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -617,6 +617,54 @@ class XmlFileLoaderTest extends TestCase
         $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
     }
 
+    public function testPrototypeWithAlreadyDefinedService()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_prototype_with_already_defined_service.xml');
+
+        $ids = array_keys($container->getDefinitions());
+        sort($ids);
+        $this->assertSame(array(Prototype\Foo::class, Prototype\Sub\Bar::class, 'service_container'), $ids);
+
+        $definition = $container->getDefinition(Prototype\Sub\Bar::class);
+        $this->assertSame(array('foo', 'bar'), $definition->getArguments());
+        $this->assertSame(array('baz' => array(array())), $definition->getTags());
+
+        $resources = $container->getResources();
+
+        $fixturesDir = dirname(__DIR__).DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR;
+        $this->assertTrue(false !== array_search(new FileResource($fixturesDir.'xml'.DIRECTORY_SEPARATOR.'services_prototype_with_already_defined_service.xml'), $resources));
+        $this->assertTrue(false !== array_search(new GlobResource($fixturesDir.'Prototype', '/*', true), $resources));
+        $resources = array_map('strval', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
+    }
+
+    public function testPrototypeMultiple()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_prototype_multiple.xml');
+
+        $ids = array_keys($container->getDefinitions());
+        sort($ids);
+        $this->assertSame(array(Prototype\Foo::class, Prototype\OtherDir\AnotherSub\DeeperBaz::class, Prototype\OtherDir\Baz::class, Prototype\Sub\Bar::class, 'service_container'), $ids);
+
+        $definition = $container->getDefinition(Prototype\OtherDir\AnotherSub\DeeperBaz::class);
+        $this->assertTrue($definition->isPublic());
+        $this->assertSame(array('foo' => array(array())), $definition->getTags());
+
+        $resources = $container->getResources();
+
+        $fixturesDir = dirname(__DIR__).DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR;
+        $this->assertTrue(false !== array_search(new FileResource($fixturesDir.'xml'.DIRECTORY_SEPARATOR.'services_prototype_multiple.xml'), $resources));
+        $this->assertTrue(false !== array_search(new GlobResource($fixturesDir.'Prototype', '/*', true), $resources));
+        $resources = array_map('strval', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
+    }
+
     /**
      * @group legacy
      * @expectedDeprecation Using the attribute "class" is deprecated for the service "bar" which is defined as an alias %s.

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -388,6 +388,54 @@ class YamlFileLoaderTest extends TestCase
         $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
     }
 
+    public function testPrototypeWithAlreadyDefinedService()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_prototype_with_already_defined_service.yml');
+
+        $ids = array_keys($container->getDefinitions());
+        sort($ids);
+        $this->assertSame(array(Prototype\Foo::class, Prototype\Sub\Bar::class, 'service_container'), $ids);
+
+        $definition = $container->getDefinition(Prototype\Sub\Bar::class);
+        $this->assertSame(array('foo', 'bar'), $definition->getArguments());
+        $this->assertSame(array('baz' => array(array())), $definition->getTags());
+
+        $resources = $container->getResources();
+
+        $fixturesDir = dirname(__DIR__).DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR;
+        $this->assertTrue(false !== array_search(new FileResource($fixturesDir.'yaml'.DIRECTORY_SEPARATOR.'services_prototype_with_already_defined_service.yml'), $resources));
+        $this->assertTrue(false !== array_search(new GlobResource($fixturesDir.'Prototype', '', true), $resources));
+        $resources = array_map('strval', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
+    }
+
+    public function testPrototypeMultiple()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_prototype_multiple.yml');
+
+        $ids = array_keys($container->getDefinitions());
+        sort($ids);
+        $this->assertSame(array(Prototype\Foo::class, Prototype\OtherDir\AnotherSub\DeeperBaz::class, Prototype\OtherDir\Baz::class, Prototype\Sub\Bar::class, 'service_container'), $ids);
+
+        $definition = $container->getDefinition(Prototype\OtherDir\AnotherSub\DeeperBaz::class);
+        $this->assertTrue($definition->isPublic());
+        $this->assertSame(array('foo' => array(array())), $definition->getTags());
+
+        $resources = $container->getResources();
+
+        $fixturesDir = dirname(__DIR__).DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR;
+        $this->assertTrue(false !== array_search(new FileResource($fixturesDir.'yaml'.DIRECTORY_SEPARATOR.'services_prototype_multiple.yml'), $resources));
+        $this->assertTrue(false !== array_search(new GlobResource($fixturesDir.'Prototype', '', true), $resources));
+        $resources = array_map('strval', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
+    }
+
     public function testDefaults()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The PSR-4 service discovery sets service definitions for all the classes it finds, including classes that are already defined as services. If these initial definitions have a different configuration, they are overridden with the one applied by the PSR-4 discovery, which might be unexpected.