### PR TITLE
Fix dump panel hidden when closing a dump

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -58,6 +58,16 @@
                         }
                     };
                 }
+
+                var dumpInfo = document.querySelector('.sf-toolbar-block-dump .sf-toolbar-info');
+                if (null !== dumpInfo) {
+                    Sfjs.addEventListener(dumpInfo, 'sfbeforedumpcollapse', function () {
+                        dumpInfo.style.minHeight = dumpInfo.getBoundingClientRect().height+'px';
+                    });
+                    Sfjs.addEventListener(dumpInfo, 'mouseleave', function () {
+                        dumpInfo.style.minHeight = '';
+                    });
+                }
             },
             function(xhr) {
                 if (xhr.status !== 0) {

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -142,6 +142,13 @@ function toggle(a, recursive) {
         return false;
     }
 
+    if (doc.createEvent && s.dispatchEvent) {
+        var event = doc.createEvent('Event');
+        event.initEvent('sf-dump-expanded' === newClass ? 'sfbeforedumpexpand' : 'sfbeforedumpcollapse', true, false);
+
+        s.dispatchEvent(event);
+    }
+
     a.lastChild.innerHTML = arrow;
     s.className = s.className.replace(/\bsf-dump-(compact|expanded)\b/, newClass);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes-ish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In the dump panel of the debug bar, when closing a dump the panel sometimes get hidden:

![before](https://user-images.githubusercontent.com/1736542/31867025-615e9c48-b788-11e7-8329-96716c211523.gif)

This is because when the size of the panel is reduced, if the mouse is not over it anymore, the `:hover` pseudo-class does not apply anymore.

I "fixed" it by setting a min-height on the panel when closing a dump. The min-height is removed when leaving the panel _on purpose_:

![after](https://user-images.githubusercontent.com/1736542/31867054-d01a01cc-b788-11e7-9ef7-8418ae2b3094.gif)

For now I only tested it on Firefox 56 on Arch Linux.
