### PR TITLE
getGenerator() must be declared with return type

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/LazyLoadingValueHolderFactoryV1.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/LazyLoadingValueHolderFactoryV1.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\ProxyManager\LazyProxy\Instantiator;
 
 use ProxyManager\Factory\LazyLoadingValueHolderFactory as BaseFactory;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\LazyLoadingValueHolderGenerator;
+use ProxyManager\ProxyGenerator\ProxyGeneratorInterface;
 
 /**
  * @internal
@@ -24,7 +25,7 @@ class LazyLoadingValueHolderFactoryV1 extends BaseFactory
     /**
      * {@inheritdoc}
      */
-    protected function getGenerator()
+    protected function getGenerator() : ProxyGeneratorInterface
     {
         return $this->generatorV1 ?: $this->generatorV1 = new LazyLoadingValueHolderGenerator();
     }

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/LazyLoadingValueHolderFactoryV1.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/LazyLoadingValueHolderFactoryV1.php
@@ -25,7 +25,7 @@ class LazyLoadingValueHolderFactoryV1 extends BaseFactory
     /**
      * {@inheritdoc}
      */
-    protected function getGenerator() : ProxyGeneratorInterface
+    protected function getGenerator(): ProxyGeneratorInterface
     {
         return $this->generatorV1 ?: $this->generatorV1 = new LazyLoadingValueHolderGenerator();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

As of ProxyManager 2.0, 

> All classes and interfaces now use return type declarations. If you extended or implemented anything from the ProxyManager\ namespace, you probably need to change that code to adapt it to the new signature.

https://github.com/Ocramius/ProxyManager/blob/master/UPGRADE.md#200

So I think `LazyLoadingValueHolderFactoryV1` class should follow the parent class.
