### PR TITLE
[DI] Throw when a service name or an alias contains dynamic values (prevent an infinite loop)

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\EnvParameterException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
@@ -78,14 +79,14 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
 
             $resolvedId = $container->resolveEnvPlaceholders($id, null, $usedEnvs);
             if (null !== $usedEnvs) {
-                throw new RuntimeException(sprintf('A service name ("%s") cannot contain dynamic values.', $resolvedId));
+                throw new EnvParameterException(array($resolvedId), null, 'A service name ("%s") cannot contain dynamic values.');
             }
         }
 
         foreach ($container->getAliases() as $id => $alias) {
             $resolvedId = $container->resolveEnvPlaceholders($id, null, $usedEnvs);
             if (null !== $usedEnvs) {
-                throw new RuntimeException(sprintf('An alias name ("%s") cannot contain dynamic values.', $resolvedId));
+                throw new EnvParameterException(array($resolvedId), null, 'An alias name ("%s") cannot contain dynamic values.');
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -75,6 +75,18 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
                     }
                 }
             }
+
+            $resolvedId = $container->resolveEnvPlaceholders($id, null, $usedEnvs);
+            if (null !== $usedEnvs) {
+                throw new RuntimeException(sprintf('A service name ("%s") cannot contain dynamic values.', $resolvedId));
+            }
+        }
+
+        foreach ($container->getAliases() as $id => $alias) {
+            $resolvedId = $container->resolveEnvPlaceholders($id, null, $usedEnvs);
+            if (null !== $usedEnvs) {
+                throw new RuntimeException(sprintf('An alias name ("%s") cannot contain dynamic values.', $resolvedId));
+            }
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -76,6 +76,30 @@ class CheckDefinitionValidityPassTest extends TestCase
         $this->process($container);
     }
 
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     */
+    public function testDynamicServiceName()
+    {
+        $container = new ContainerBuilder();
+        $env = $container->getParameterBag()->get('env(BAR)');
+        $container->register("foo.$env", 'class');
+
+        $this->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     */
+    public function testDynamicAliasName()
+    {
+        $container = new ContainerBuilder();
+        $env = $container->getParameterBag()->get('env(BAR)');
+        $container->setAlias("foo.$env", 'class');
+
+        $this->process($container);
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new CheckDefinitionValidityPass();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -77,7 +77,7 @@ class CheckDefinitionValidityPassTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvParameterException
      */
     public function testDynamicServiceName()
     {
@@ -89,7 +89,7 @@ class CheckDefinitionValidityPassTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvParameterException
      */
     public function testDynamicAliasName()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

If an environment variable is used to build a service name (like in [this snippet](https://github.com/api-platform/core/blame/4b3d1abfe595d507c9064ef86fd8ef6881b7e5b5/src/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php#L471)), an infinite loop occurs.

It's common to build dynamic service names (in a compiler pass), if the dynamic part comes from a parameter, this bug can occurs.
