### PR TITLE
[HttpFoundation] Fix RedirectResponse factory method phpdoc

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -44,7 +44,13 @@ class RedirectResponse extends Response
     }
 
     /**
-     * {@inheritdoc}
+     * Factory method for chainability.
+     *
+     * @param string $url     The url to redirect to
+     * @param int    $status  The response status code
+     * @param array  $headers An array of response headers
+     *
+     * @return static
      */
     public static function create($url = '', $status = 302, $headers = array())
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| License       | MIT

Fix the phpdoc of the factory method on the RedirectResponse (signatures are different between Response and RedirectResponse).