### PR TITLE
[HttpFoundation] add just in time url resolution to the RedirectResponse with a callable

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -33,7 +33,7 @@ class RedirectResponse extends Response
      *
      * @see http://tools.ietf.org/html/rfc2616#section-10.3
      */
-    public function __construct(?string $url, int $status = 302, array $headers = array())
+    public function __construct($url, int $status = 302, array $headers = array())
     {
         parent::__construct('', $status, $headers);
 

--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -18,15 +18,16 @@ namespace Symfony\Component\HttpFoundation;
  */
 class RedirectResponse extends Response
 {
+    protected $callable;
     protected $targetUrl;
 
     /**
      * Creates a redirect response so that it conforms to the rules defined for a redirect status code.
      *
-     * @param string $url     The URL to redirect to. The URL should be a full URL, with schema etc.,
-     *                        but practically every browser redirects on paths only as well
-     * @param int    $status  The status code (302 by default)
-     * @param array  $headers The headers (Location is always set to the given URL)
+     * @param string|callable $url     The URL to redirect to. The URL should be a full URL, with schema etc.,
+     *                                 but practically every browser redirects on paths only as well
+     * @param int             $status  The status code (302 by default)
+     * @param array           $headers The headers (Location is always set to the given URL)
      *
      * @throws \InvalidArgumentException
      *
@@ -36,7 +37,11 @@ class RedirectResponse extends Response
     {
         parent::__construct('', $status, $headers);
 
-        $this->setTargetUrl($url);
+        if (!is_callable($url)) {
+            $this->setTargetUrl($url);
+        } else {
+            $this->callable = $url;
+        }
 
         if (!$this->isRedirect()) {
             throw new \InvalidArgumentException(sprintf('The HTTP status code is not a redirect ("%s" given).', $status));
@@ -103,6 +108,20 @@ class RedirectResponse extends Response
 </html>', htmlspecialchars($url, ENT_QUOTES, 'UTF-8')));
 
         $this->headers->set('Location', $url);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendHeaders()
+    {
+        if (!$this->targetUrl && $this->callable) {
+            $this->setTargetUrl(call_user_func($this->callable, $this));
+        }
+
+        parent::sendHeaders();
 
         return $this;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -65,6 +65,17 @@ class RedirectResponseTest extends TestCase
         $this->assertEquals('baz.beep', $response->getTargetUrl());
     }
 
+    public function testSetTargetUrlWithCallback()
+    {
+        $response = new RedirectResponse(function () {
+            return 'foo.bar';
+        });
+
+        $response->sendHeaders();
+
+        $this->assertEquals('foo.bar', $response->getTargetUrl());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */
@@ -72,6 +83,18 @@ class RedirectResponseTest extends TestCase
     {
         $response = new RedirectResponse('foo.bar');
         $response->setTargetUrl(null);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetTargetUrlNullWithCallback()
+    {
+        $response = new RedirectResponse(function () {
+            return null;
+        });
+
+        $response->sendHeaders();
     }
 
     public function testCreate()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| License       | MIT

Gives the ability to redirect response to resolve url juste in time (before sending headers).

This can be useful when dealing with a global transaction driven by kernel event.
For exemple when em->flush is execute after the controller action and new created entity id are no known and is needed for routing.
