### PR TITLE
[Security] remove invalid deprecation notice on AbstractGuardAuthenticator::supports()

### DIFF
--- a/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
@@ -24,8 +24,6 @@ abstract class AbstractGuardAuthenticator implements AuthenticatorInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @deprecated since version 3.4, to be removed in 4.0
      */
     public function supports(Request $request)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/16835#issuecomment-339097374
| License       | MIT
| Doc PR        | n/a

This deprecation flag causes a false positive.
