### PR TITLE
Fix $_ENV/$_SERVER precedence in test framework

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -107,7 +107,7 @@ abstract class KernelTestCase extends TestCase
     protected static function getKernelClass()
     {
         if (isset($_SERVER['KERNEL_CLASS']) || isset($_ENV['KERNEL_CLASS'])) {
-            $class = isset($_SERVER['KERNEL_CLASS']) ? $_SERVER['KERNEL_CLASS'] : $_ENV['KERNEL_CLASS'];
+            $class = isset($_ENV['KERNEL_CLASS']) ? $_ENV['KERNEL_CLASS'] : $_SERVER['KERNEL_CLASS'];
             if (!class_exists($class)) {
                 throw new \RuntimeException(sprintf('Class "%s" doesn\'t exist or cannot be autoloaded. Check that the KERNEL_CLASS value in phpunit.xml matches the fully-qualified class name of your Kernel or override the %s::createKernel() method.', $class, static::class));
             }
@@ -116,7 +116,7 @@ abstract class KernelTestCase extends TestCase
         }
 
         if (isset($_SERVER['KERNEL_DIR']) || isset($_ENV['KERNEL_DIR'])) {
-            $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : $_ENV['KERNEL_DIR'];
+            $dir = isset($_ENV['KERNEL_DIR']) ? $_ENV['KERNEL_DIR'] : $_SERVER['KERNEL_DIR'];
 
             if (!is_dir($dir)) {
                 $phpUnitDir = static::getPhpUnitXmlDir();
@@ -176,20 +176,20 @@ abstract class KernelTestCase extends TestCase
 
         if (isset($options['environment'])) {
             $env = $options['environment'];
-        } elseif (isset($_SERVER['APP_ENV'])) {
-            $env = $_SERVER['APP_ENV'];
         } elseif (isset($_ENV['APP_ENV'])) {
             $env = $_ENV['APP_ENV'];
+        } elseif (isset($_SERVER['APP_ENV'])) {
+            $env = $_SERVER['APP_ENV'];
         } else {
             $env = 'test';
         }
 
         if (isset($options['debug'])) {
             $debug = $options['debug'];
-        } elseif (isset($_SERVER['APP_DEBUG'])) {
-            $debug = $_SERVER['APP_DEBUG'];
         } elseif (isset($_ENV['APP_DEBUG'])) {
             $debug = $_ENV['APP_DEBUG'];
+        } elseif (isset($_SERVER['APP_DEBUG'])) {
+            $debug = $_SERVER['APP_DEBUG'];
         } else {
             $debug = true;
         }

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -432,11 +432,11 @@ class Container implements ResettableContainerInterface
         if (isset($this->envCache[$name]) || array_key_exists($name, $this->envCache)) {
             return $this->envCache[$name];
         }
-        if (isset($_SERVER[$name]) && 0 !== strpos($name, 'HTTP_')) {
-            return $this->envCache[$name] = $_SERVER[$name];
-        }
         if (isset($_ENV[$name])) {
             return $this->envCache[$name] = $_ENV[$name];
+        }
+        if (isset($_SERVER[$name]) && 0 !== strpos($name, 'HTTP_')) {
+            return $this->envCache[$name] = $_SERVER[$name];
         }
         if (false !== ($env = getenv($name)) && null !== $env) { // null is a possible value because of thread safety issues
             return $this->envCache[$name] = $env;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When defining env vars values in `phpunit.xml.dist`, we are using `<env ...>`. PHPUnit registers those env vars in `$_ENV`, but not in `$_SERVER`. This means that those values might not be used by Symfony if env vars defined in `.env` are automatically registered (which is my case).

In any case, I think it makes sense to make `$_ENV` take precedence as this is how we register them in `phpunit.xml.dist`.

