### PR TITLE
[Bridge][Twig] Decouple the SecurityExtension from its runtime

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Bridge\Twig\Extension;
 
+use Symfony\Component\Security\Acl\Voter\FieldVote;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -21,13 +24,43 @@ use Twig\TwigFunction;
  */
 class SecurityExtension extends AbstractExtension
 {
+    private $securityChecker;
+
+    public function __construct(AuthorizationCheckerInterface $securityChecker = null)
+    {
+        if (null !== $securityChecker) {
+            @trigger_error(sprintf('The $securityChecker parameter is deprecated since 3.4 and will be removed in 4.0. Use %s instead.', SecurityRuntime::class), E_USER_DEPRECATED);
+        }
+
+        $this->securityChecker = $securityChecker;
+    }
+
+    public function isGranted($role, $object = null, $field = null)
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 3.4 and will be removed in 4.0. Use the %s::%s() method instead.', __METHOD__, SecurityRuntime::class, __FUNCTION__), E_USER_DEPRECATED);
+
+        if (null === $this->securityChecker) {
+            return false;
+        }
+
+        if (null !== $field) {
+            $object = new FieldVote($object, $field);
+        }
+
+        try {
+            return $this->securityChecker->isGranted($role, $object);
+        } catch (AuthenticationCredentialsNotFoundException $e) {
+            return false;
+        }
+    }
+
     /**
      * {@inheritdoc}
      */
     public function getFunctions()
     {
         return array(
-            new TwigFunction('is_granted', array(SecurityRuntime::class, 'isGranted')),
+            new TwigFunction('is_granted', array($this->securityChecker ? $this : SecurityRuntime::class, 'isGranted')),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Bridge\Twig\Extension;
 
-use Symfony\Component\Security\Acl\Voter\FieldVote;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -24,37 +21,13 @@ use Twig\TwigFunction;
  */
 class SecurityExtension extends AbstractExtension
 {
-    private $securityChecker;
-
-    public function __construct(AuthorizationCheckerInterface $securityChecker = null)
-    {
-        $this->securityChecker = $securityChecker;
-    }
-
-    public function isGranted($role, $object = null, $field = null)
-    {
-        if (null === $this->securityChecker) {
-            return false;
-        }
-
-        if (null !== $field) {
-            $object = new FieldVote($object, $field);
-        }
-
-        try {
-            return $this->securityChecker->isGranted($role, $object);
-        } catch (AuthenticationCredentialsNotFoundException $e) {
-            return false;
-        }
-    }
-
     /**
      * {@inheritdoc}
      */
     public function getFunctions()
     {
         return array(
-            new TwigFunction('is_granted', array($this, 'isGranted')),
+            new TwigFunction('is_granted', array(SecurityRuntime::class, 'isGranted')),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/SecurityRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityRuntime.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Symfony\Component\Security\Acl\Voter\FieldVote;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+
+/**
+ * SecurityRuntime exposes security context features.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class SecurityRuntime
+{
+    private $securityChecker;
+
+    public function __construct(AuthorizationCheckerInterface $securityChecker = null)
+    {
+        $this->securityChecker = $securityChecker;
+    }
+
+    public function isGranted($role, $object = null, $field = null)
+    {
+        if (null === $this->securityChecker) {
+            return false;
+        }
+
+        if (null !== $field) {
+            $object = new FieldVote($object, $field);
+        }
+
+        try {
+            return $this->securityChecker->isGranted($role, $object);
+        } catch (AuthenticationCredentialsNotFoundException $e) {
+            return false;
+        }
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
@@ -14,6 +14,10 @@
 
         <service id="twig.extension.security" class="Symfony\Bridge\Twig\Extension\SecurityExtension">
             <tag name="twig.extension" />
+        </service>
+
+        <service id="twig.runtime.security" class="Symfony\Bridge\Twig\Extension\SecurityRuntime">
+            <tag name="twig.runtime" />
             <argument type="service" id="security.authorization_checker" on-invalid="ignore" />
         </service>
     </services>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This indirectly fixes two bugs in Silex regarding Security and Twig.

The first is if `twig` is loaded before `boot()` some services/parameters are not defined.
- `twig` asks for `security.authorization_checker`
- `security.authorization_checker` asks for `security.authentication_manager`
- `security.authentication_manager` asks for `security.authentication_providers`
- `security.authentication_providers` are not completely defined until `security.firewall_map` is loaded ([here](https://github.com/silexphp/Silex/blob/master/src/Silex/Provider/SecurityServiceProvider.php#L307)).

I fixed this locally by wrapping the `security.authorization_checker` service and loading the `security.firewall_map` before hand:

```php
// Load firewall map before this, because it defines a dependency needed.
$factory = $app->raw('security.authorization_checker');
$app['security.authorization_checker'] = function ($app) use ($factory) {
    $app['security.firewall_map'];

    return $factory($app);
};
```

This technically fixed the problem, but it wouldn't be needed if the service wasn't loaded until `boot()` where the firewall is loaded by default.

-----

The second problem is a circular dependency. I was implementing an AccessDeniedHandler that rendered a template.
- `security.firewall_map` asks for AccessDeniedHandler service
- AccessDeniedHandler service asks for `twig`
- `twig` asks for `security.firewall_map` ....:boom:

And again this wouldn't be a problem if `twig` didn't need the `SecurityRuntime` until it's `is_granted` is called. 

-----

I don't see this as a _feature_ since it only modifies private services. And I _do_ see this as a _bugfix_ even though it's for Silex and not Symfony. But I know it's a gray area. Twig Runtimes seem to be the way we are heading so I don't think this is a step in the wrong direction either.

I have a PR ready for Silex depending on the direction of this issue. Here's the [diff](https://github.com/silexphp/Silex/compare/master...CarsonF:bugfix/security-runtime).