### PR TITLE
Adding a new RepositoryTrait to make service repos easy

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
+++ b/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Repository;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
@@ -163,9 +164,9 @@ trait RepositoryTrait
     /**
      * @see EntityRepository::matching()
      *
-     * @param \Doctrine\Common\Collections\Criteria $criteria
+     * @param Criteria $criteria
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function matching(Criteria $criteria)
     {

--- a/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
+++ b/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
@@ -26,15 +26,40 @@ use Doctrine\ORM\QueryBuilder;
  */
 trait RepositoryTrait
 {
-    /**
-     * @return EntityManagerInterface
-     */
-    abstract protected function getEntityManager();
+    private $em;
 
     /**
      * @return string the class name for your entity
      */
     abstract protected function getClassName();
+
+    /**
+     * Setter to inject the EntityManager.
+     *
+     * If you are using the DependencyInjection component
+     * and this service is autowired, this method will automatically
+     * be called thanks to the "@required" annotation.
+     *
+     * @required
+     *
+     * @param EntityManagerInterface $em
+     */
+    public function setEntityManager(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * @return EntityManagerInterface
+     */
+    protected function getEntityManager()
+    {
+        if (null === $this->em) {
+            throw new \RuntimeException(sprintf('The setEntityManager() method must be called on the "%s" class before calling getEntityManager().', get_class($this)));
+        }
+
+        return $this->em;
+    }
 
     /**
      * @see EntityRepository::createQueryBuilder()

--- a/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
+++ b/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
@@ -50,18 +50,6 @@ trait RepositoryTrait
     }
 
     /**
-     * @return EntityManagerInterface
-     */
-    protected function getEntityManager()
-    {
-        if (null === $this->em) {
-            throw new \RuntimeException(sprintf('The setEntityManager() method must be called on the "%s" class before calling getEntityManager().', get_class($this)));
-        }
-
-        return $this->em;
-    }
-
-    /**
      * @see EntityRepository::createQueryBuilder()
      *
      * @param string $alias
@@ -169,7 +157,7 @@ trait RepositoryTrait
      */
     public function findOneBy(array $criteria, array $orderBy = null)
     {
-        return $this->findBy($criteria, $orderBy);
+        return $this->getRepository()->findOneBy($criteria, $orderBy);
     }
 
     /**
@@ -185,9 +173,21 @@ trait RepositoryTrait
     }
 
     /**
+     * @return EntityManagerInterface
+     */
+    protected function getEntityManager()
+    {
+        if (null === $this->em) {
+            throw new \RuntimeException(sprintf('The setEntityManager() method must be called on the "%s" class before calling getEntityManager().', get_class($this)));
+        }
+
+        return $this->em;
+    }
+
+    /**
      * @return EntityRepository
      */
-    private function getRepository()
+    protected function getRepository()
     {
         return $this->getEntityManager()->getRepository($this->getClassName());
     }

--- a/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
+++ b/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
@@ -20,7 +20,7 @@ use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * A helpful trait when creating your own repository.
+ * An optional trait that gives your class all the same methods as Doctrine's EntityRepository.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */
@@ -175,7 +175,7 @@ trait RepositoryTrait
     /**
      * @return EntityManagerInterface
      */
-    protected function getEntityManager()
+    final protected function getEntityManager()
     {
         if (null === $this->em) {
             throw new \RuntimeException(sprintf('The setEntityManager() method must be called on the "%s" class before calling getEntityManager().', get_class($this)));
@@ -187,7 +187,7 @@ trait RepositoryTrait
     /**
      * @return EntityRepository
      */
-    protected function getRepository()
+    final protected function getRepository()
     {
         return $this->getEntityManager()->getRepository($this->getClassName());
     }

--- a/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
+++ b/src/Symfony/Bridge/Doctrine/Repository/RepositoryTrait.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Repository;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NativeQuery;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * A helpful trait when creating your own repository.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+trait RepositoryTrait
+{
+    /**
+     * @return EntityManagerInterface
+     */
+    abstract protected function getEntityManager();
+
+    /**
+     * @return string the class name for your entity
+     */
+    abstract protected function getClassName();
+
+    /**
+     * @see EntityRepository::createQueryBuilder()
+     *
+     * @param string $alias
+     * @param string $indexBy the index for the from
+     *
+     * @return QueryBuilder
+     */
+    public function createQueryBuilder($alias, $indexBy = null)
+    {
+        return $this->getRepository()->createQueryBuilder($alias, $indexBy);
+    }
+
+    /**
+     * @see EntityRepository::createResultSetMappingBuilder()
+     *
+     * @param string $alias
+     *
+     * @return ResultSetMappingBuilder
+     */
+    public function createResultSetMappingBuilder($alias)
+    {
+        return $this->getRepository()->createResultSetMappingBuilder($alias);
+    }
+
+    /**
+     * @see EntityRepository::createNamedQuery()
+     *
+     * @param string $queryName
+     *
+     * @return Query
+     */
+    public function createNamedQuery($queryName)
+    {
+        return $this->getRepository()->createNamedQuery($queryName);
+    }
+
+    /**
+     * @see EntityRepository::createNativeNamedQuery()
+     *
+     * @param string $queryName
+     *
+     * @return NativeQuery
+     */
+    public function createNativeNamedQuery($queryName)
+    {
+        return $this->getRepository()->createNativeNamedQuery($queryName);
+    }
+
+    /**
+     * @see EntityRepository::clear()
+     */
+    public function clear()
+    {
+        $this->getRepository()->clear();
+    }
+
+    /**
+     * @see EntityRepository::find()
+     *
+     * @param mixed    $id          the identifier
+     * @param int|null $lockMode    one of the \Doctrine\DBAL\LockMode::* constants
+     *                              or NULL if no specific lock mode should be used
+     *                              during the search
+     * @param int|null $lockVersion the lock version
+     *
+     * @return object|null the entity instance or NULL if the entity can not be found
+     */
+    public function find($id, $lockMode = null, $lockVersion = null)
+    {
+        return $this->getRepository()->find($id, $lockMode, $lockVersion);
+    }
+
+    /**
+     * @see EntityRepository::findAll()
+     *
+     * @return array the entities
+     */
+    public function findAll()
+    {
+        return $this->getRepository()->findAll();
+    }
+
+    /**
+     * @see EntityRepository::findBy()
+     *
+     * @param array      $criteria
+     * @param array|null $orderBy
+     * @param int|null   $limit
+     * @param int|null   $offset
+     *
+     * @return array the objects
+     */
+    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+    {
+        return $this->getRepository()->findBy($criteria, $orderBy, $limit, $offset);
+    }
+
+    /**
+     * @see EntityRepository::findOneBy()
+     *
+     * @param array      $criteria
+     * @param array|null $orderBy
+     *
+     * @return object|null the entity instance or NULL if the entity can not be found
+     */
+    public function findOneBy(array $criteria, array $orderBy = null)
+    {
+        return $this->findBy($criteria, $orderBy);
+    }
+
+    /**
+     * @see EntityRepository::matching()
+     *
+     * @param \Doctrine\Common\Collections\Criteria $criteria
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function matching(Criteria $criteria)
+    {
+        return $this->getRepository()->matching($criteria);
+    }
+
+    /**
+     * @return EntityRepository
+     */
+    private function getRepository()
+    {
+        return $this->getEntityManager()->getRepository($this->getClassName());
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Repository/RepositoryTraitTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Repository/RepositoryTraitTest.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\PropertyInfo\Tests;
+
+use Symfony\Bridge\Doctrine\Repository\RepositoryTrait;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+class RepositoryTraitTest extends TestCase
+{
+    public function testBasicTraitFunctionality()
+    {
+        $em = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
+        $repo = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
+
+        $em->expects($this->once())
+            ->method('getRepository')
+            ->with('App\Entity\CoolStuff')
+            ->will($this->returnValue($repo));
+
+        $qb = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
+        $repo->expects($this->once())
+            ->method('createQueryBuilder')
+            ->with('cs')
+            ->willReturn($qb);
+
+        $stubRepo = new StubRepository($em);
+        $this->assertSame($qb, $stubRepo->createQueryBuilder('cs'));
+    }
+}
+
+class StubRepository
+{
+    use RepositoryTrait;
+
+    private $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    protected function getEntityManager()
+    {
+        return $this->em;
+    }
+
+    protected function getClassName()
+    {
+        return 'App\Entity\CoolStuff';
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Repository/RepositoryTraitTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Repository/RepositoryTraitTest.php
@@ -34,26 +34,25 @@ class RepositoryTraitTest extends TestCase
             ->with('cs')
             ->willReturn($qb);
 
-        $stubRepo = new StubRepository($em);
+        $stubRepo = new StubRepository();
+        $stubRepo->setEntityManager($em);
         $this->assertSame($qb, $stubRepo->createQueryBuilder('cs'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The setEntityManager() method must be called on the "Symfony\Bridge\Doctrine\PropertyInfo\Tests\StubRepository" class before calling getEntityManager().
+     */
+    public function testExceptionWhenEmIsNotSet()
+    {
+        $stubRepo = new StubRepository();
+        $stubRepo->createQueryBuilder('cs');
     }
 }
 
 class StubRepository
 {
     use RepositoryTrait;
-
-    private $em;
-
-    public function __construct(EntityManagerInterface $em)
-    {
-        $this->em = $em;
-    }
-
-    protected function getEntityManager()
-    {
-        return $this->em;
-    }
 
     protected function getClassName()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | TODO

See https://github.com/doctrine/DoctrineBundle/pull/725#issuecomment-339421794

The goal is to allow people to autowire & autoregister their repositories. Instead of actually trying to make the true repositories into services in some automatic way (an approach which has failed due to some technical reasons), this proposal simplifies creating your own services.

The new`RepositoryTrait` makes creating a new service that decorates your repository is very easy. And the PR (as you can see) is about 50 times simpler :).

Usage:

* You are still allowed to map a `repositoryClass` on your entity, but generally, you will not (create a service instead).

* Create a repository service:

```php
<?php

namespace App\Repository;

use Doctrine\Bundle\DoctrineBundle\Repository\RepositoryTrait;
use Symfony\Bridge\Doctrine\RegistryInterface;
use App\Entity\CoolStuff;

class CoolStuffRepository
{
    use RepositoryTrait;

    protected function getClassName()
    {
        return CoolStuff::class;
    }

    // add custom methods here
    // you have access to `$this->getEntityManager()` and `$this->getRepository()` methods
    // (in addition to createQueryBuilder(), and all the other normal methods)
    // this works because of autowiring & the @required annotation above setEntityManager()
}
```

The `RepositoryTrait` gives you all the existing methods on `EntityRepository`, like `createQueryBuilder()` and `find**` (but no magic methods). If the user wants to make their class implement the `ObjectRepository` interface, that's totally up to them. You can also ignore our trait and create your services all on your own.

To use it, just DI your class like normal. 

For entities with NO custom repository, users can still use `$em->getRepository()`. But when they need custom methods, they would create a custom service and start using it.

Thanks!