### PR TITLE
[Intl] Allow passing null as a locale fallback

### DIFF
--- a/src/Symfony/Component/Intl/Locale.php
+++ b/src/Symfony/Component/Intl/Locale.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\Intl;
 final class Locale extends \Locale
 {
     /**
-     * @var string
+     * @var string|null
      */
     private static $defaultFallback = 'en';
 
@@ -31,11 +31,11 @@ final class Locale extends \Locale
      * The default fallback locale is used as fallback for locales that have no
      * fallback otherwise.
      *
-     * @param string $locale The default fallback locale
+     * @param string|null $locale The default fallback locale
      *
      * @see getFallback()
      */
-    public static function setDefaultFallback(string $locale)
+    public static function setDefaultFallback(?string $locale)
     {
         self::$defaultFallback = $locale;
     }
@@ -43,12 +43,12 @@ final class Locale extends \Locale
     /**
      * Returns the default fallback locale.
      *
-     * @return string The default fallback locale
+     * @return string|null The default fallback locale
      *
      * @see setDefaultFallback()
      * @see getFallback()
      */
-    public static function getDefaultFallback(): string
+    public static function getDefaultFallback(): ?string
     {
         return self::$defaultFallback;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

[`Null` is passed in `update-data.php`](https://github.com/symfony/symfony/blob/e2b4a35a720b85173d15055d0554f86602d43593/src/Symfony/Component/Intl/Resources/bin/update-data.php#L209) to prevent falling back to English locale during icu data import. It's been always possible, but since it hasn't been documented in the docblock it was missed while merging #23262.
