### PR TITLE
Ensure DeprecationErrorHandler::collectDeprecations() is triggered

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -262,7 +262,7 @@ class SymfonyTestsListenerTrait
         if ($this->runsInSeparateProcess) {
             $deprecations = file_get_contents($this->runsInSeparateProcess);
             unlink($this->runsInSeparateProcess);
-            putenv('SYMFONY_DEPRECATIONS_SERIALIZE=');
+            putenv('SYMFONY_DEPRECATIONS_SERIALIZE');
             foreach ($deprecations ? unserialize($deprecations) : array() as $deprecation) {
                 if ($deprecation[0]) {
                     trigger_error(serialize(array('deprecation' => $deprecation[1], 'class' => $className, 'method' => $test->getName(false))), E_USER_DEPRECATED);

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -262,6 +262,7 @@ class SymfonyTestsListenerTrait
         if ($this->runsInSeparateProcess) {
             $deprecations = file_get_contents($this->runsInSeparateProcess);
             unlink($this->runsInSeparateProcess);
+            putenv('SYMFONY_DEPRECATIONS_SERIALIZE=');
             foreach ($deprecations ? unserialize($deprecations) : array() as $deprecation) {
                 if ($deprecation[0]) {
                     trigger_error(serialize(array('deprecation' => $deprecation[1], 'class' => $className, 'method' => $test->getName(false))), E_USER_DEPRECATED);

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -12,12 +12,15 @@
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
+// Detect if we need to serialize deprecations to a file.
+if ($file = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
+    DeprecationErrorHandler::collectDeprecations($file);
+
+    return;
+}
+
 // Detect if we're loaded by an actual run of phpunit
 if (!defined('PHPUNIT_COMPOSER_INSTALL') && !class_exists('PHPUnit_TextUI_Command', false) && !class_exists('PHPUnit\TextUI\Command', false)) {
-    if ($ser = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
-        DeprecationErrorHandler::collectDeprecations($ser);
-    }
-
     return;
 }
 


### PR DESCRIPTION
Ensure DeprecationErrorHandler::collectDeprecations() is triggered if SYMFONY_DEPRECATIONS_SERIALIZE is set

| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes 
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

Drupal doesn't use src/Symfony/Bridge/PhpUnit/bin/simple-phpunit but would like to use the deprecation collection features of src/Symfony/Bridge/PhpUnit. The checks in src/Symfony/Bridge/PhpUnit/bootstrap.php mean that this is difficult because they rely on simple-phpunit - but I'm not sure that that is necessary.

The problem is even in isolated tests we have PHPUNIT_COMPOSER_INSTALL set because we use a custom phpunit config file.