### PR TITLE
Config: mark builder property deprecated

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 3.3 to 3.4
 =======================
 
+Config
+------
+
+ * Using protected builder property of TreeBuilder is deprecated and property will be removed in 4.0.
+
 DependencyInjection
 -------------------
 

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -22,6 +22,10 @@ class TreeBuilder implements NodeParentInterface
 {
     protected $tree;
     protected $root;
+
+    /**
+     * @deprecates since 3.4. To be removed in 4.0
+     */
     protected $builder;
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -24,7 +24,7 @@ class TreeBuilder implements NodeParentInterface
     protected $root;
 
     /**
-     * @deprecates since 3.4. To be removed in 4.0
+     * @deprecated since 3.4. To be removed in 4.0
      */
     protected $builder;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | 

`builder` protected property is not used at all in class. Mark as deprecated to enable removing asap. This is to avoid keeping dead code up to symfony `5.0` and still having this dead code in the `4.4` LTS version