### PR TITLE
[TwigBridge] Bootstrap 4 form theme fixes

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -73,8 +73,9 @@
     {%- if expanded is defined and expanded -%}
         {%- set element = 'legend' -%}
         {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' col-form-legend')|trim}) -%}
+    {%- else -%}
+        {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' form-control-label')|trim}) -%}
     {%- endif -%}
-    {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' form-control-label')|trim}) -%}
     {{- parent() -}}
 {%- endblock form_label %}
 

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -70,7 +70,7 @@
 {# Labels #}
 
 {% block form_label -%}
-    {%- if expanded is defined and expanded -%}
+    {%- if compound is defined and compound -%}
         {%- set element = 'legend' -%}
         {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' col-form-legend')|trim}) -%}
     {%- else -%}
@@ -108,7 +108,7 @@
 {# Rows #}
 
 {% block form_row -%}
-    {%- if expanded is defined and expanded -%}
+    {%- if compound is defined and compound -%}
         {%- set element = 'fieldset' -%}
     {%- endif -%}
     <{{ element|default('div') }} class="form-group">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 and higher
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Some fixes for compound forms and their labels.

1. Do not add `.form-control-label` and `.col-form-legend` at the same time. It's enough to have only one of them.
1. Use legends instead of labels for compound fields. I think it makes more sense to have nested `fieldsets` than `labels` without `for` in a compound form. An example of nested fieldsets is given at the bottom of [this page](https://dev.w3.org/html5/spec-preview/the-fieldset-element.html).