### PR TITLE
Add a link.sh script to ease debugging Flex apps

### DIFF
--- a/link.sh
+++ b/link.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# Link dependencies to components to a local clone of the monolithic Symfony repository
-# author: Kévin Dunglas
+# Author: Kévin Dunglas
 
 if [ $# -eq 0 ]
 then

--- a/link.sh
+++ b/link.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Link dependencies to components to a local clone of the monolithic Symfony repository
+# author: Kévin Dunglas
+
+if [ $# -eq 0 ]
+then
+    echo "Link dependencies to components to a local clone of the monolithic Symfony repository"
+    echo ""
+    echo "Usage: ./link.sh /path/to/the/project"
+    exit
+fi
+
+# Can't use maps because Mac OS doesn't ship Bash 4 by default...
+declare -a dirs names
+
+for dir in $(find $(pwd)/src/Symfony/{Bundle,Bridge,Component} -type d -maxdepth 1 -mindepth 1)
+do
+    dirs+=($dir)
+    names+=($(cat $dir/composer.json | egrep -o '"name": "symfony/[a-zA-Z0-9-]+"' | egrep -o 'symfony/[a-zA-Z0-9-]+'))
+done
+
+for vendor in $(find $1/vendor/symfony -type d -maxdepth 1 -mindepth 1)
+do
+    vendorName=$(echo $vendor | rev | cut -sd / -f -2 | rev)
+    for i in "${!names[@]}"
+    do
+        name=${names[$i]}
+
+        if [ "$name" = "$vendorName" ]
+        then
+            mv $vendor $vendor.back
+            ln -s ${dirs[$i]} $vendor
+            echo "$vendorName linked to ${dirs[$i]}"
+        fi
+    done
+done

--- a/link.sh
+++ b/link.sh
@@ -31,6 +31,7 @@ do
             mv $vendor $vendor.back
             ln -s ${dirs[$i]} $vendor
             echo "$vendorName linked to ${dirs[$i]}"
+            continue
         fi
     done
 done


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

It's painful to debug and patch Flex apps because `symfony/symfony` isn't installed by default (only components are) but PRs must be opened against the monolithic repository.

This tiny tool, inspired by `npm link`, scan the `vendor/` directory of the project, and replace `symfony/` dependencies by symlinks to the local clone of the `symfony/symfony` repositories.

Usage:

```
git clone git@github.com:symfony/symfony.git
cd symfony
./link.sh /path/to/the/project
```