### PR TITLE
[TwigBridge] Fix template paths in profiler

### DIFF
--- a/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
+++ b/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
@@ -63,9 +63,18 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
         $this->data['template_paths'] = array();
 
         $templateFinder = function (Profile $profile) use (&$templateFinder) {
-            if ($profile->isTemplate() && $template = $this->twig->load($profile->getName())->getSourceContext()->getPath()) {
-                $this->data['template_paths'][$profile->getName()] = $template;
+            if ($profile->isTemplate()) {
+                try {
+                    $template = $this->twig->load($name = $profile->getName());
+                } catch (\Twig_Error_Loader $e) {
+                    $template = null;
+                }
+
+                if (null !== $template && '' !== $path = $template->getSourceContext()->getPath()) {
+                    $this->data['template_paths'][$name] = $path;
+                }
             }
+
             foreach ($profile as $p) {
                 $templateFinder($p);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #24540
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Fixes the profiler being unavailable with non filesystem templates.

![image](https://user-images.githubusercontent.com/1047696/32117680-87866354-bb4f-11e7-9cb9-428ad6751a1e.png)
