### PR TITLE
[FrameworkBundle] fix CachePoolPrunerPass to use correct command service id

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPrunerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPrunerPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+use Symfony\Bundle\FrameworkBundle\Command\CachePoolPruneCommand;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -26,7 +27,7 @@ class CachePoolPrunerPass implements CompilerPassInterface
     private $cacheCommandServiceId;
     private $cachePoolTag;
 
-    public function __construct($cacheCommandServiceId = 'cache.command.pool_pruner', $cachePoolTag = 'cache.pool')
+    public function __construct($cacheCommandServiceId = CachePoolPruneCommand::class, $cachePoolTag = 'cache.pool')
     {
         $this->cacheCommandServiceId = $cacheCommandServiceId;
         $this->cachePoolTag = $cachePoolTag;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPrunerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPrunerPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\CachePoolPruneCommand;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolPrunerPass;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
@@ -24,7 +25,7 @@ class CachePoolPrunerPassTest extends TestCase
     public function testCompilerPassReplacesCommandArgument()
     {
         $container = new ContainerBuilder();
-        $container->register('cache.command.pool_pruner')->addArgument(array());
+        $container->register(CachePoolPruneCommand::class)->addArgument(array());
         $container->register('pool.foo', FilesystemAdapter::class)->addTag('cache.pool');
         $container->register('pool.bar', PhpFilesAdapter::class)->addTag('cache.pool');
 
@@ -35,7 +36,7 @@ class CachePoolPrunerPassTest extends TestCase
             'pool.foo' => new Reference('pool.foo'),
             'pool.bar' => new Reference('pool.bar'),
         );
-        $argument = $container->getDefinition('cache.command.pool_pruner')->getArgument(0);
+        $argument = $container->getDefinition(CachePoolPruneCommand::class)->getArgument(0);
 
         $this->assertInstanceOf(IteratorArgument::class, $argument);
         $this->assertEquals($expected, $argument->getValues());
@@ -51,7 +52,7 @@ class CachePoolPrunerPassTest extends TestCase
         $container
             ->expects($this->atLeastOnce())
             ->method('hasDefinition')
-            ->with('cache.command.pool_pruner')
+            ->with(CachePoolPruneCommand::class)
             ->will($this->returnValue(false));
 
         $container
@@ -73,7 +74,7 @@ class CachePoolPrunerPassTest extends TestCase
     public function testCompilerPassThrowsOnInvalidDefinitionClass()
     {
         $container = new ContainerBuilder();
-        $container->register('cache.command.pool_pruner')->addArgument(array());
+        $container->register(CachePoolPruneCommand::class)->addArgument(array());
         $container->register('pool.not-found', NotFound::class)->addTag('cache.pool');
 
         $pass = new CachePoolPrunerPass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/23451#discussion_r147509615
| License       | MIT
| Doc PR        | n/a

https://github.com/symfony/symfony/pull/23624 broke https://github.com/symfony/symfony/pull/23451.