### PR TITLE
[Console] Fix #21789 : CLI Windows autcompletion for ChoiceQuestion function

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -129,16 +129,17 @@ abstract class Helper implements HelperInterface
 
     /**
      * GET Os Terminal to define CLI's behavior
-     * Used especially for autocompletion
+     * Used especially for autocompletion.
+     *
      * @return string
      */
     public function getOSTerminal()
     {
-        switch (true){
+        switch (true) {
             case stristr(PHP_OS, 'DAR'): return self::OS_OSX;
             case stristr(PHP_OS, 'WIN'): return self::OS_WIN;
             case stristr(PHP_OS, 'LINUX'): return self::OS_LINUX;
-            default : return self::OS_UNKNOWN;
+            default: return self::OS_UNKNOWN;
         }
     }
 }

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -22,6 +22,11 @@ abstract class Helper implements HelperInterface
 {
     protected $helperSet = null;
 
+    const OS_UNKNOWN = 1;
+    const OS_WIN = 2;
+    const OS_LINUX = 3;
+    const OS_OSX = 4;
+
     /**
      * {@inheritdoc}
      */
@@ -120,5 +125,20 @@ abstract class Helper implements HelperInterface
         $formatter->setDecorated($isDecorated);
 
         return $string;
+    }
+
+    /**
+     * GET Os Terminal to define CLI's behavior
+     * Used especially for autocompletion
+     * @return string
+     */
+    public function getOSTerminal()
+    {
+        switch (true){
+            case stristr(PHP_OS, 'DAR'): return self::OS_OSX;
+            case stristr(PHP_OS, 'WIN'): return self::OS_WIN;
+            case stristr(PHP_OS, 'LINUX'): return self::OS_LINUX;
+            default : return self::OS_UNKNOWN;
+        }
     }
 }

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -114,7 +114,7 @@ class QuestionHelper extends Helper
         $inputStream = $this->inputStream ?: STDIN;
         $autocomplete = $question->getAutocompleterValues();
 
-        if (null === $autocomplete || !$this->hasSttyAvailable()) {
+        if ((null === $autocomplete || self::OS_WIN == $this->getOSTerminal()) || !$this->hasSttyAvailable()) {
             $ret = false;
             if ($question->isHidden()) {
                 try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21789 
| License       | MIT
| Doc PR        |  no

[Console] fixed ChoiceQuestion behavior for Win CLI

WIP : 
[ ] Unit test break 

This PR change CLI Windows behavior for autocompletion in Console->ChoiceQuestion. 

In Win CLI you can't see autocompletion so your results can be false if in your choices you've one first symbol (letter or number) equals to your array_keys. 
This is described in bug topic. 

In this PR, I've just removed autocompletion for Win CLI. 
