### PR TITLE
[WebProfilerBundle] Show the kernel class in the profiler instead of the kernel name

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -50,10 +50,10 @@
                 </span>
             </div>
 
-            {% if 'n/a' is not same as(collector.appname) %}
+            {% if 'n/a' is not same as(collector.kernelclass) %}
                 <div class="sf-toolbar-info-piece">
-                    <b>Kernel name</b>
-                    <span>{{ collector.appname }}</span>
+                    <b>Kernel class</b>
+                    <span>{{ collector.kernelclass }}</span>
                 </div>
             {% endif %}
 
@@ -161,10 +161,10 @@
                 <span class="label">Symfony version</span>
             </div>
 
-            {% if 'n/a' != collector.appname %}
+            {% if 'n/a' != collector.kernelclass %}
                 <div class="metric">
-                    <span class="value">{{ collector.appname }}</span>
-                    <span class="label">Application name</span>
+                    <span class="value">{{ collector.kernelclass }}</span>
+                    <span class="label">Kernel class</span>
                 </div>
             {% endif %}
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -60,7 +60,7 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
             'token' => $response->headers->get('X-Debug-Token'),
             'symfony_version' => Kernel::VERSION,
             'symfony_state' => 'unknown',
-            'name' => isset($this->kernel) ? $this->kernel->getName() : 'n/a',
+            'kernel_class' => isset($this->kernel) ? get_class($this->kernel) : 'n/a',
             'env' => isset($this->kernel) ? $this->kernel->getEnvironment() : 'n/a',
             'debug' => isset($this->kernel) ? $this->kernel->isDebug() : 'n/a',
             'php_version' => PHP_VERSION,
@@ -114,6 +114,11 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
     public function getApplicationVersion()
     {
         return $this->data['app_version'];
+    }
+
+    public function getKernelClass()
+    {
+        return $this->data['kernel_class'];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In my opinion, displaying the "kernel FQCN" is more useful than the "kernel name" for modern Symfony versions. This PR tries to do that and it'd look as follows:

![kernel-class-1](https://user-images.githubusercontent.com/73419/32133359-9197f98e-bbd6-11e7-8967-7a0766f8668f.png)

![kernel-class-2](https://user-images.githubusercontent.com/73419/32133360-9283e0b0-bbd6-11e7-8992-b16359e74a5f.png)
