### PR TITLE
Improved the deprecation about logout_on_user_change

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -248,7 +248,6 @@ class MainConfiguration implements ConfigurationInterface
             ->booleanNode('stateless')->defaultFalse()->end()
             ->scalarNode('context')->cannotBeEmpty()->end()
             ->booleanNode('logout_on_user_change')
-                ->defaultFalse()
                 ->info('When true, it will trigger a logout for the user if something has changed. This will be the default behavior as of Syfmony 4.0.')
             ->end()
             ->arrayNode('logout')
@@ -338,17 +337,6 @@ class MainConfiguration implements ConfigurationInterface
                     }
 
                     return $firewall;
-                })
-            ->end()
-            ->validate()
-                ->ifTrue(function ($v) {
-                    return (isset($v['stateless']) && true === $v['stateless']) || (isset($v['security']) && false === $v['security']);
-                })
-                ->then(function ($v) {
-                    // this option doesn't change behavior when true when stateless, so prevent deprecations
-                    $v['logout_on_user_change'] = true;
-
-                    return $v;
                 })
             ->end()
         ;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -282,7 +282,9 @@ class SecurityExtension extends Extension
                 $customUserChecker = true;
             }
 
-            if (!isset($firewall['logout_on_user_change']) || !$firewall['logout_on_user_change']) {
+            if (!isset($firewall['logout_on_user_change'])) {
+                $firewall['logout_on_user_change'] = false;
+            } elseif (false === $firewall['logout_on_user_change']) {
                 @trigger_error('Setting logout_on_user_change to false is deprecated as of 3.4 and will always be true in 4.0. Set logout_on_user_change to true in your firewall configuration.', E_USER_DEPRECATED);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I've updated several Symfony apps to 3.4 beta and I'm always getting this annoying deprecation message:

![deprecation-message](https://user-images.githubusercontent.com/73419/32135142-647d7ab8-bbfa-11e7-8d60-513f0e4b95cc.png)

It's annoying because I've never configured this option in my `security.yml`, so it's strange to add `logout_on_user_change: true` to my firewalls in order to remove this deprecation. Could we avoid this deprecation when the option is not configured explicitly?