### PR TITLE
[DependencyInjection] Prevent service:method factory notation in PHP config

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator\Traits;
 
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
 trait FactoryTrait
 {
     /**
@@ -22,6 +24,12 @@ trait FactoryTrait
      */
     final public function factory($factory)
     {
+        if (is_string($factory) && 1 === substr_count($factory, ':')) {
+            $factoryParts = explode(':', $factory);
+
+            throw new InvalidArgumentException(sprintf('Invalid factory "%s": the `service:method` notation is not available when using PHP-based DI configuration. Use "[ref(\'%s\'), \'%s\']" instead.', $factory, $factoryParts[0], $factoryParts[1]));
+        }
+
         $this->definition->setFactory(static::processValue($factory, true));
 
         return $this;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/factory_short_notation.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/factory_short_notation.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $c) {
+    $c->services()
+        ->set('service', \stdClass::class)
+        ->factory('factory:method');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -89,4 +89,17 @@ class PhpFileLoaderTest extends TestCase
         $loader->load($fixtures.'/config/services_autoconfigure_with_parent.php');
         $container->compile();
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid factory "factory:method": the `service:method` notation is not available when using PHP-based DI configuration. Use "[ref('factory'), 'method']" instead.
+     */
+    public function testFactoryShortNotationNotAllowed()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator());
+        $loader->load($fixtures.'/config/factory_short_notation.php');
+        $container->compile();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24704 
| License       | MIT
| Doc PR        | 

Started working on fixing #24704.

@nicolas-grekas, am I on the right way? If yes I will look at the tests and try to add this case.