### PR TITLE
Removes \n or space when $context/$extra are empty

### DIFF
--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -108,12 +108,12 @@ class ConsoleFormatter implements FormatterInterface
 
         $context = $this->dumpData($record['context']);
         if ($context) {
-            $context = $separator . $context;
+            $context = $separator.$context;
         }
 
         $extra = $this->dumpData($record['extra']);
         if ($extra) {
-            $extra = $separator . $extra;
+            $extra = $separator.$extra;
         }
 
         $formatted = strtr($this->options['format'], array(

--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -101,12 +101,20 @@ class ConsoleFormatter implements FormatterInterface
         $levelColor = self::$levelColorMap[$record['level']];
 
         if ($this->options['multiline']) {
-            $context = $extra = "\n";
+            $separator = "\n";
         } else {
-            $context = $extra = ' ';
+            $separator = ' ';
         }
-        $context .= $this->dumpData($record['context']);
-        $extra .= $this->dumpData($record['extra']);
+
+        $context = $this->dumpData($record['context']);
+        if ($context) {
+            $context .= $separator;
+        }
+
+        $extra = $this->dumpData($record['extra']);
+        if ($extra) {
+            $extra .= $separator;
+        }
 
         $formatted = strtr($this->options['format'], array(
             '%datetime%' => $record['datetime']->format($this->options['date_format']),

--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -108,12 +108,12 @@ class ConsoleFormatter implements FormatterInterface
 
         $context = $this->dumpData($record['context']);
         if ($context) {
-            $context .= $separator;
+            $context = $separator . $context;
         }
 
         $extra = $this->dumpData($record['extra']);
         if ($extra) {
-            $extra .= $separator;
+            $extra = $separator . $extra;
         }
 
         $formatted = strtr($this->options['format'], array(


### PR DESCRIPTION
Simple log messages cause extra spaces or newlines when using the default format and $context or $extra are empty, resulting in output like this:

```
23:24:41 DEBUG     [test] debug


23:24:41 INFO      [test] info


23:24:41 NOTICE    [test] notice


23:24:41 WARNING   [test] warning


23:24:41 ERROR     [test] error


```

This makes reviewing command history difficult. 

In the instance where $context or $extra is empty, it should not get appended with a space or newline.

| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT

