### PR TITLE
[VarDumper] fix trailling comma when dumping an exception

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Dumper;
 
 use Symfony\Component\VarDumper\Cloner\Cursor;
+use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
  * CliDumper dumps variables for command line output.
@@ -494,10 +495,12 @@ class CliDumper extends AbstractDumper
 
     protected function endValue(Cursor $cursor)
     {
-        if (self::DUMP_TRAILING_COMMA & $this->flags && 0 < $cursor->depth) {
-            $this->line .= ',';
-        } elseif (self::DUMP_COMMA_SEPARATOR & $this->flags && 1 < $cursor->hashLength - $cursor->hashIndex) {
-            $this->line .= ',';
+        if (Stub::ARRAY_INDEXED === $cursor->hashType || Stub::ARRAY_ASSOC === $cursor->hashType) {
+            if (self::DUMP_TRAILING_COMMA & $this->flags && 0 < $cursor->depth) {
+                $this->line .= ',';
+            } elseif (self::DUMP_COMMA_SEPARATOR & $this->flags && 1 < $cursor->hashLength - $cursor->hashIndex) {
+                $this->line .= ',';
+            }
         }
 
         $this->dumpLine($cursor->depth, true);

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -130,6 +130,36 @@ EOTXT
         $this->assertSame($expected, $dump);
     }
 
+    public function testDumpWithCommaFlagsAndExceptionCodeExcerpt()
+    {
+        $dumper = new CliDumper(null, null, CliDumper::DUMP_TRAILING_COMMA);
+        $dumper->setColors(false);
+        $cloner = new VarCloner();
+
+        $ex = new \RuntimeException('foo');
+
+        $dump = $dumper->dump($cloner->cloneVar($ex)->withRefHandles(false), true);
+
+        $this->assertStringMatchesFormat(<<<'EOTXT'
+RuntimeException {
+  #message: "foo"
+  #code: 0
+  #file: "%ACliDumperTest.php"
+  #line: %d
+  trace: {
+    %ACliDumperTest.php:%d: {
+      : 
+      : $ex = new \RuntimeException('foo');
+      : 
+    }
+    %A
+  }
+}
+
+EOTXT
+            , $dump);
+    }
+
     public function provideDumpWithCommaFlagTests()
     {
         $expected = <<<'EOTXT'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yesish
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #24581 
| License       | MIT
| Doc PR        |  O

This PR is fixing a behaviour when a exception got every single line with a comma.
