### PR TITLE
[FrameworkBundle][Routing] Use a PSR-11 container in FrameworkBundle Router

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
  * Added a new `parameter_bag` service with related autowiring aliases to access parameters as-a-service
+ * Allowed the `Router` to work with any PSR-11 container
 
 4.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -618,6 +618,13 @@ class FrameworkExtension extends Extension
 
         $loader->load('routing.xml');
 
+        if (!interface_exists(ContainerBagInterface::class)) {
+            $container->getDefinition('router.default')
+                ->replaceArgument(0, new Reference('service_container'))
+                ->clearTag('container.service_subscriber')
+            ;
+        }
+
         $container->setParameter('router.resource', $config['resource']);
         $container->setParameter('router.cache_class_prefix', $container->getParameter('kernel.container_class'));
         $router = $container->findDefinition('router.default');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -52,7 +52,8 @@
 
         <service id="router.default" class="Symfony\Bundle\FrameworkBundle\Routing\Router">
             <tag name="monolog.logger" channel="router" />
-            <argument type="service" id="service_container" />
+            <tag name="container.service_subscriber" id="routing.loader" />
+            <argument type="service" id="Psr\Container\ContainerInterface" />
             <argument>%router.resource%</argument>
             <argument type="collection">
                 <argument key="cache_dir">%kernel.cache_dir%</argument>
@@ -67,6 +68,7 @@
                 <argument key="matcher_cache_class">%router.cache_class_prefix%UrlMatcher</argument>
             </argument>
             <argument type="service" id="router.request_context" on-invalid="ignore" />
+            <argument type="service" id="parameter_bag" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
             <call method="setConfigCacheFactory">
                 <argument type="service" id="config_cache_factory" />

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -11,13 +11,14 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Routing;
 
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 use Symfony\Component\Routing\Router as BaseRouter;
 use Symfony\Component\Routing\RequestContext;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
@@ -32,22 +33,31 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
 {
     private $container;
     private $collectedParameters = array();
+    private $paramFetcher;
 
     /**
-     * @param ContainerInterface   $container A ContainerInterface instance
-     * @param mixed                $resource  The main resource to load
-     * @param array                $options   An array of options
-     * @param RequestContext       $context   The context
-     * @param LoggerInterface|null $logger
+     * @param ContainerInterface      $container  A ContainerInterface instance
+     * @param mixed                   $resource   The main resource to load
+     * @param array                   $options    An array of options
+     * @param RequestContext          $context    The context
+     * @param ContainerInterface|null $parameters A ContainerInterface instance allowing to fetch parameters
+     * @param LoggerInterface|null    $logger
      */
-    public function __construct(ContainerInterface $container, $resource, array $options = array(), RequestContext $context = null, LoggerInterface $logger = null)
+    public function __construct(ContainerInterface $container, $resource, array $options = array(), RequestContext $context = null, ContainerInterface $parameters = null, LoggerInterface $logger = null)
     {
         $this->container = $container;
-
         $this->resource = $resource;
         $this->context = $context ?: new RequestContext();
         $this->logger = $logger;
         $this->setOptions($options);
+
+        if ($parameters) {
+            $this->paramFetcher = array($parameters, 'get');
+        } elseif ($container instanceof SymfonyContainerInterface) {
+            $this->paramFetcher = array($container, 'getParameter');
+        } else {
+            throw new \LogicException(sprintf('You should either pass a "%s" instance or provide the $parameters argument of the "%s" method.', SymfonyContainerInterface::class, __METHOD__));
+        }
     }
 
     /**
@@ -142,9 +152,7 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
             return $value;
         }
 
-        $container = $this->container;
-
-        $escapedValue = preg_replace_callback('/%%|%([^%\s]++)%/', function ($match) use ($container, $value) {
+        $escapedValue = preg_replace_callback('/%%|%([^%\s]++)%/', function ($match) use ($value) {
             // skip %%
             if (!isset($match[1])) {
                 return '%%';
@@ -154,7 +162,7 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
                 throw new RuntimeException(sprintf('Using "%%%s%%" is not allowed in routing configuration.', $match[1]));
             }
 
-            $resolved = $container->getParameter($match[1]);
+            $resolved = ($this->paramFetcher)($match[1]);
 
             if (is_string($resolved) || is_numeric($resolved)) {
                 $this->collectedParameters[$match[1]] = $resolved;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -12,14 +12,52 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Routing;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class RouterTest extends TestCase
 {
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage You should either pass a "Symfony\Component\DependencyInjection\ContainerInterface" instance or provide the $parameters argument of the "Symfony\Bundle\FrameworkBundle\Routing\Router::__construct" method
+     */
+    public function testConstructThrowsOnNonSymfonyNorPsr11Container()
+    {
+        new Router($this->getMockBuilder(ContainerInterface::class)->getMock(), 'foo');
+    }
+
     public function testGenerateWithServiceParam()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route(
+            ' /{_locale}',
+            array(
+                '_locale' => '%locale%',
+            ),
+            array(
+                '_locale' => 'en|es',
+            ), array(), '', array(), array(), '"%foo%" == "bar"'
+        ));
+
+        $sc = $this->getPsr11ServiceContainer($routes);
+        $parameters = $this->getParameterBag(array(
+            'locale' => 'es',
+            'foo' => 'bar',
+        ));
+
+        $router = new Router($sc, 'foo', array(), null, $parameters);
+
+        $this->assertSame('/en', $router->generate('foo', array('_locale' => 'en')));
+        $this->assertSame('/', $router->generate('foo', array('_locale' => 'es')));
+        $this->assertSame('"bar" == "bar"', $router->getRouteCollection()->get('foo')->getCondition());
+    }
+
+    public function testGenerateWithServiceParamWithSfContainer()
     {
         $routes = new RouteCollection();
 
@@ -45,6 +83,47 @@ class RouterTest extends TestCase
     }
 
     public function testDefaultsPlaceholders()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route(
+            '/foo',
+            array(
+                'foo' => 'before_%parameter.foo%',
+                'bar' => '%parameter.bar%_after',
+                'baz' => '%%escaped%%',
+                'boo' => array('%parameter%', '%%escaped_parameter%%', array('%bee_parameter%', 'bee')),
+                'bee' => array('bee', 'bee'),
+            ),
+            array(
+            )
+        ));
+
+        $sc = $this->getPsr11ServiceContainer($routes);
+
+        $parameters = $this->getParameterBag(array(
+            'parameter.foo' => 'foo',
+            'parameter.bar' => 'bar',
+            'parameter' => 'boo',
+            'bee_parameter' => 'foo_bee',
+        ));
+
+        $router = new Router($sc, 'foo', array(), null, $parameters);
+        $route = $router->getRouteCollection()->get('foo');
+
+        $this->assertEquals(
+            array(
+                'foo' => 'before_foo',
+                'bar' => 'bar_after',
+                'baz' => '%escaped%',
+                'boo' => array('boo', '%escaped_parameter%', array('foo_bee', 'bee')),
+                'bee' => array('bee', 'bee'),
+            ),
+            $route->getDefaults()
+        );
+    }
+
+    public function testDefaultsPlaceholdersWithSfContainer()
     {
         $routes = new RouteCollection();
 
@@ -98,6 +177,41 @@ class RouterTest extends TestCase
             )
         ));
 
+        $sc = $this->getPsr11ServiceContainer($routes);
+        $parameters = $this->getParameterBag(array(
+            'parameter.foo' => 'foo',
+            'parameter.bar' => 'bar',
+        ));
+
+        $router = new Router($sc, 'foo', array(), null, $parameters);
+
+        $route = $router->getRouteCollection()->get('foo');
+
+        $this->assertEquals(
+            array(
+                'foo' => 'before_foo',
+                'bar' => 'bar_after',
+                'baz' => '%escaped%',
+            ),
+            $route->getRequirements()
+        );
+    }
+
+    public function testRequirementsPlaceholdersWithSfContainer()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route(
+            '/foo',
+            array(
+            ),
+            array(
+                'foo' => 'before_%parameter.foo%',
+                'bar' => '%parameter.bar%_after',
+                'baz' => '%%escaped%%',
+            )
+        ));
+
         $sc = $this->getServiceContainer($routes);
         $sc->setParameter('parameter.foo', 'foo');
         $sc->setParameter('parameter.bar', 'bar');
@@ -116,6 +230,24 @@ class RouterTest extends TestCase
     }
 
     public function testPatternPlaceholders()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route('/before/%parameter.foo%/after/%%escaped%%'));
+
+        $sc = $this->getPsr11ServiceContainer($routes);
+        $parameters = $this->getParameterBag(array('parameter.foo' => 'foo'));
+
+        $router = new Router($sc, 'foo', array(), null, $parameters);
+        $route = $router->getRouteCollection()->get('foo');
+
+        $this->assertEquals(
+            '/before/foo/after/%escaped%',
+            $route->getPath()
+        );
+    }
+
+    public function testPatternPlaceholdersWithSfContainer()
     {
         $routes = new RouteCollection();
 
@@ -143,11 +275,46 @@ class RouterTest extends TestCase
 
         $routes->add('foo', new Route('/%env(FOO)%'));
 
+        $router = new Router($this->getPsr11ServiceContainer($routes), 'foo', array(), null, $this->getParameterBag());
+        $router->getRouteCollection();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage Using "%env(FOO)%" is not allowed in routing configuration.
+     */
+    public function testEnvPlaceholdersWithSfContainer()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route('/%env(FOO)%'));
+
         $router = new Router($this->getServiceContainer($routes), 'foo');
         $router->getRouteCollection();
     }
 
     public function testHostPlaceholders()
+    {
+        $routes = new RouteCollection();
+
+        $route = new Route('foo');
+        $route->setHost('/before/%parameter.foo%/after/%%escaped%%');
+
+        $routes->add('foo', $route);
+
+        $sc = $this->getPsr11ServiceContainer($routes);
+        $parameters = $this->getParameterBag(array('parameter.foo' => 'foo'));
+
+        $router = new Router($sc, 'foo', array(), null, $parameters);
+        $route = $router->getRouteCollection()->get('foo');
+
+        $this->assertEquals(
+            '/before/foo/after/%escaped%',
+            $route->getHost()
+        );
+    }
+
+    public function testHostPlaceholdersWithSfContainer()
     {
         $routes = new RouteCollection();
 
@@ -172,7 +339,7 @@ class RouterTest extends TestCase
      * @expectedException \Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException
      * @expectedExceptionMessage You have requested a non-existent parameter "nope".
      */
-    public function testExceptionOnNonExistentParameter()
+    public function testExceptionOnNonExistentParameterWithSfContainer()
     {
         $routes = new RouteCollection();
 
@@ -194,6 +361,23 @@ class RouterTest extends TestCase
 
         $routes->add('foo', new Route('/%object%'));
 
+        $sc = $this->getPsr11ServiceContainer($routes);
+        $parameters = $this->getParameterBag(array('object' => new \stdClass()));
+
+        $router = new Router($sc, 'foo', array(), null, $parameters);
+        $router->getRouteCollection()->get('foo');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage The container parameter "object", used in the route configuration value "/%object%", must be a string or numeric, but it is of type object.
+     */
+    public function testExceptionOnNonStringParameterWithSfContainer()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route('/%object%'));
+
         $sc = $this->getServiceContainer($routes);
         $sc->setParameter('object', new \stdClass());
 
@@ -209,6 +393,23 @@ class RouterTest extends TestCase
         $routes = new RouteCollection();
         $routes->add('foo', new Route('foo', array('foo' => $value), array('foo' => '\d+')));
 
+        $sc = $this->getPsr11ServiceContainer($routes);
+
+        $router = new Router($sc, 'foo', array(), null, $this->getParameterBag());
+
+        $route = $router->getRouteCollection()->get('foo');
+
+        $this->assertSame($value, $route->getDefault('foo'));
+    }
+
+    /**
+     * @dataProvider getNonStringValues
+     */
+    public function testDefaultValuesAsNonStringsWithSfContainer($value)
+    {
+        $routes = new RouteCollection();
+        $routes->add('foo', new Route('foo', array('foo' => $value), array('foo' => '\d+')));
+
         $sc = $this->getServiceContainer($routes);
 
         $router = new Router($sc, 'foo');
@@ -219,6 +420,20 @@ class RouterTest extends TestCase
     }
 
     public function testGetRouteCollectionAddsContainerParametersResource()
+    {
+        $routeCollection = $this->getMockBuilder(RouteCollection::class)->getMock();
+        $routeCollection->method('getIterator')->willReturn(new \ArrayIterator(array(new Route('/%locale%'))));
+        $routeCollection->expects($this->once())->method('addResource')->with(new ContainerParametersResource(array('locale' => 'en')));
+
+        $sc = $this->getPsr11ServiceContainer($routeCollection);
+        $parameters = $this->getParameterBag(array('locale' => 'en'));
+
+        $router = new Router($sc, 'foo', array(), null, $parameters);
+
+        $router->getRouteCollection();
+    }
+
+    public function testGetRouteCollectionAddsContainerParametersResourceWithSfContainer()
     {
         $routeCollection = $this->getMockBuilder(RouteCollection::class)->getMock();
         $routeCollection->method('getIterator')->willReturn(new \ArrayIterator(array(new Route('/%locale%'))));
@@ -259,5 +474,40 @@ class RouterTest extends TestCase
         ;
 
         return $sc;
+    }
+
+    private function getPsr11ServiceContainer(RouteCollection $routes): ContainerInterface
+    {
+        $loader = $this->getMockBuilder(LoaderInterface::class)->getMock();
+
+        $loader
+            ->expects($this->any())
+            ->method('load')
+            ->will($this->returnValue($routes))
+        ;
+
+        $sc = $this->getMockBuilder(ContainerInterface::class)->getMock();
+
+        $sc
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($loader))
+        ;
+
+        return $sc;
+    }
+
+    private function getParameterBag(array $params = array()): ContainerInterface
+    {
+        $bag = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $bag
+            ->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function ($key) use ($params) {
+                return isset($params[$key]) ? $params[$key] : null;
+            }))
+        ;
+
+        return $bag;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | not yet <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

~3.4 because~ it allows to make the `routing.loader` service private and add sense into implementing the `ServiceSubscriberInterface` in the `Router` by injecting a ServiceLocator instead of the DI container.

Should we deprecate passing a DI `ContainerInterface` instance without providing the `$paramFetcher` argument?
Move the whole `Router::resolve()` method into a dedicated `callable $paramResolver` ?