### PR TITLE
[FrameworkBundle][Routing] Remove unused logger argument

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -53,7 +53,6 @@
         </service>
 
         <service id="router.default" class="%router.class%" public="false">
-            <tag name="monolog.logger" channel="router" />
             <argument type="service" id="service_container" />
             <argument>%router.resource%</argument>
             <argument type="collection">
@@ -69,7 +68,6 @@
                 <argument key="matcher_cache_class">%router.options.matcher.cache_class%</argument>
             </argument>
             <argument type="service" id="router.request_context" on-invalid="ignore" />
-            <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
         <service id="router" alias="router.default" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This argument was never used as far as the FrameworkBundle Router was.
But actually don't we want to add the `$logger` argument to this class? It's used by the `UrlGenerator` when `router.strict_requirements` is `false` for instance:

<img width="1064" alt="screenshot 2017-10-29 a 09 57 31" src="https://user-images.githubusercontent.com/2211145/32142080-482bc64e-bc90-11e7-8382-b78b507bae48.PNG">
