### PR TITLE
[Form] Nullable FormInterface::getPropertyPath()

### DIFF
--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -171,7 +171,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the property path that the form is mapped to.
      *
-     * @return \Symfony\Component\PropertyAccess\PropertyPathInterface The property path
+     * @return \Symfony\Component\PropertyAccess\PropertyPathInterface|null The property path
      */
     public function getPropertyPath();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24560
| License       | MIT
| Doc PR        | 

`Symfony\Component\Form\Form::getPropertyPath()` returns `null` when the form has an empty name. It allows for unprefixed children.

```php
<?php

namespace App\Controller;

use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\Form\Extension\Core\Type\TextType;

class IndexController extends AbstractController
{
    /**
     * @Route(name="index")
     * @Template()
     */
    public function indexAction()
    {
        $form = $this->get('form.factory')
            ->createNamedBuilder('')
            ->add('text', TextType::class)
            ->getForm();

        return [
            'form' => $form->createView(),
        ];
    }
}
```

```html
<!DOCTYPE html>
<html>
    <head>
        <meta charset="UTF-8">
        <title>Welcome!</title>
    </head>
    <body>
        <form name="" method="post">
            <label for="text">Text</label>
            <input type="text" id="text" name="text">
        </form>
    </body>
</html>
```

But the return type of the `Symfony\Component\Form\FormInterface::getPropertyPath()` is not nullable.

We cannot change the behaviour, obviously. At least it's useful in API controllers.

So I decided to change the doc block of the interface.