### PR TITLE
debug:container --types: Fix bug with non-existent classes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -238,7 +238,18 @@ EOF
             return false;
         }
 
-        // see if the class exists (only need to trigger autoload once)
-        return class_exists($serviceId) || interface_exists($serviceId, false);
+        // if the id has a \, assume it is a class
+        if (false !== strpos($serviceId, '\\')) {
+            return true;
+        }
+
+        try {
+            $r = new \ReflectionClass($serviceId);
+
+            return true;
+        } catch (\ReflectionException $e) {
+            // the service id is not a valid class/interface
+            return false;
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24639
| License       | MIT
| Doc PR        | n/a

I've just tested manually that this *does* fix the issue I described in #24639. 

Oddly enough, in a "stock" Flex project, after this patch, there is one *additional* "type" that's reported:

> Symfony\Component\PropertyAccess\PropertyAccessorInterface   alias for "property_accessor"

That is a valid type... for some reason `interface_exists()` return false for this (??? maybe a quirk of my machine). Anyways, this is also "fixed" with this new approach.