### PR TITLE
Add a link script to ease debugging Flex apps

### DIFF
--- a/link
+++ b/link
@@ -1,0 +1,59 @@
+#!/usr/bin/env php
+<?php
+
+/*
+* This file is part of the Symfony package.
+*
+* (c) Fabien Potencier <fabien@symfony.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+require __DIR__.'/src/Symfony/Component/Filesystem/Exception/ExceptionInterface.php';
+require __DIR__.'/src/Symfony/Component/Filesystem/Exception/IOExceptionInterface.php';
+require __DIR__.'/src/Symfony/Component/Filesystem/Exception/IOException.php';
+require __DIR__.'/src/Symfony/Component/Filesystem/Filesystem.php';
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Links dependencies to components to a local clone of the main symfony/symfony GitHub repository.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+
+if (2 !== $argc) {
+    echo 'Link dependencies to components to a local clone of the main symfony/symfony GitHub repository.'.PHP_EOL.PHP_EOL;
+    echo "Usage: $argv[0] /path/to/the/project".PHP_EOL;
+    exit(1);
+}
+
+if (!is_dir("$argv[1]/vendor/symfony")) {
+    echo "The directory \"$argv[1]\" does not exist or the dependencies are not installed, did you forget to run \"composer install\" in your project?".PHP_EOL;
+    exit(1);
+}
+
+$sfPackages = array('symfony/symfony' => __DIR__);
+foreach (glob(__DIR__.'/src/Symfony/{Bundle,Bridge,Component,Component/Security}/*', GLOB_BRACE | GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
+    $sfPackages[json_decode(file_get_contents("$dir/composer.json"))->name] = $dir;
+}
+
+$filesystem = new Filesystem();
+foreach (glob("$argv[1]/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
+    $package = 'symfony/'.basename($dir);
+    if (is_link($dir)) {
+        echo "\"$package\" is already a symlink, skipping.".PHP_EOL;
+        continue;
+    }
+
+    if (!isset($sfPackages[$package])) {
+        continue;
+    }
+
+    $sfDir = '\\' === DIRECTORY_SEPARATOR ? $sfPackages[$package] : $filesystem->makePathRelative($sfPackages[$package], dirname(realpath($dir)));
+
+    $filesystem->remove($dir);
+    $filesystem->symlink($sfDir, $dir);
+    echo "\"$package\" has been linked to \"$sfPackages[$package]\".".PHP_EOL;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24708
| License       | MIT
| Doc PR        | symfony/symfony-docs#8730

(Reopened because of mishandling in the previous PR)

It's painful to debug and patch Flex apps because `symfony/symfony` isn't installed by default (only components are) but PRs must be opened against the monolithic repository.

This tiny tool, inspired by `npm link`, scan the `vendor/` directory of the project, and replace `symfony/` dependencies by symlinks to the local clone of the `symfony/symfony` repositories.

Usage:

```
git clone git@github.com:symfony/symfony.git
cd symfony
./link /path/to/the/project
```