### PR TITLE
[VarDumper] HtmlDumper: fix collapsing nodes with depth < maxDepth

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -383,8 +383,9 @@ return function (root, x) {
                 x += elt.parentNode.getAttribute('data-depth')/1;
             }
             elt.setAttribute('data-depth', x);
-            if (elt.className ? 'sf-dump-expanded' !== elt.className : (x > options.maxDepth)) {
-                elt.className = 'sf-dump-expanded';
+            var className = elt.className;
+            elt.className = 'sf-dump-expanded';
+            if (className ? 'sf-dump-expanded' !== className : (x > options.maxDepth)) {
                 toggle(a);
             }
         } else if (/\bsf-dump-ref\b/.test(elt.className) && (a = elt.getAttribute('href'))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes (failures unrelated)
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This error happens since #23967: 

> (index):3 Uncaught TypeError: Cannot read property 'substr' of null

https://github.com/symfony/symfony/blob/98dae3edb1ba8fa35c06a8c9a459e0ffb9105826/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php#L325

when trying to collapse the root node (or more precisely, the nodes with a depth <= maxDepth) because it misses one of the `sf-dump-expanded`/`sf-dump-compact` classes which are necessary for the toggling to work.