### PR TITLE
[Validator] ExpressionValidator should use OBJECT_TO_STRING 

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -78,11 +78,11 @@ class ExpressionValidator extends ConstraintValidator
         if (!$this->getExpressionLanguage()->evaluate($constraint->expression, $variables)) {
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING))
                     ->addViolation();
             } else {
                 $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING))
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Validator\Constraints\Expression;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
 use Symfony\Component\Validator\Tests\Fixtures\Entity;
+use Symfony\Component\Validator\Tests\Fixtures\ToString;
 use Symfony\Component\Validator\Validation;
 
 class ExpressionValidatorTest extends AbstractConstraintValidatorTest
@@ -87,6 +88,39 @@ class ExpressionValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'object')
+            ->assertRaised();
+    }
+
+    public function testSucceedingExpressionAtObjectLevelWithToString()
+    {
+        $constraint = new Expression('this.data == 1');
+
+        $object = new ToString();
+        $object->data = '1';
+
+        $this->setObject($object);
+
+        $this->validator->validate($object, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testFailingExpressionAtObjectLevelWithToString()
+    {
+        $constraint = new Expression(array(
+            'expression' => 'this.data == 1',
+            'message' => 'myMessage',
+        ));
+
+        $object = new ToString();
+        $object->data = '2';
+
+        $this->setObject($object);
+
+        $this->validator->validate($object, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'toString')
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ToString.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ToString.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class ToString
+{
+    public $data;
+
+    public function __toString()
+    {
+        return 'toString';
+    }
+}


### PR DESCRIPTION
…value in message

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24595 
| License       | MIT
| Doc PR        | Will do.

