### PR TITLE
Throwing exception if redis and predis unavailable

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -108,6 +108,9 @@ trait RedisTrait
             $params += $query;
         }
         $params += $options + self::$defaultConnectionOptions;
+        if ($params['class'] === null && !extension_loaded('redis') && !class_exists(\Predis\Client::class)) {
+            throw new \RuntimeException(sprintf("Cannot find the redis extension, and predis/predis is not installed: %s", $dsn));
+        }
         $class = null === $params['class'] ? (extension_loaded('redis') ? \Redis::class : \Predis\Client::class) : $params['class'];
 
         if (is_a($class, \Redis::class, true)) {

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -108,8 +108,8 @@ trait RedisTrait
             $params += $query;
         }
         $params += $options + self::$defaultConnectionOptions;
-        if ($params['class'] === null && !extension_loaded('redis') && !class_exists(\Predis\Client::class)) {
-            throw new \RuntimeException(sprintf("Cannot find the redis extension, and predis/predis is not installed: %s", $dsn));
+        if (null === $params['class'] && !extension_loaded('redis') && !class_exists(\Predis\Client::class)) {
+            throw new \RuntimeException(sprintf('Cannot find the "redis" extension, and "predis/predis" is not installed: %s', $dsn));
         }
         $class = null === $params['class'] ? (extension_loaded('redis') ? \Redis::class : \Predis\Client::class) : $params['class'];
 

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -16,6 +16,7 @@ use Predis\Connection\Aggregate\ClusterInterface;
 use Predis\Connection\Aggregate\PredisCluster;
 use Predis\Connection\Aggregate\RedisCluster;
 use Predis\Response\Status;
+use Symfony\Component\Cache\Exception\CacheException;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
 /**
@@ -109,7 +110,7 @@ trait RedisTrait
         }
         $params += $options + self::$defaultConnectionOptions;
         if (null === $params['class'] && !extension_loaded('redis') && !class_exists(\Predis\Client::class)) {
-            throw new \RuntimeException(sprintf('Cannot find the "redis" extension, and "predis/predis" is not installed: %s', $dsn));
+            throw new CacheException(sprintf('Cannot find the "redis" extension, and "predis/predis" is not installed: %s', $dsn));
         }
         $class = null === $params['class'] ? (extension_loaded('redis') ? \Redis::class : \Predis\Client::class) : $params['class'];
 


### PR DESCRIPTION
If the redis extension and predis are unavailable, line 137 throws an exception stating that \Predis\Client is not a class.

| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

If the redis extension and predis are unavailable, the new line 137 throws an exception stating that \Predis\Client is not a class.