### PR TITLE
[Security] Call logout handlers even if token is null

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -94,10 +94,9 @@ class LogoutListener implements ListenerInterface
         }
 
         // handle multiple logout attempts gracefully
-        if ($token = $this->tokenStorage->getToken()) {
-            foreach ($this->handlers as $handler) {
-                $handler->logout($request, $response, $token);
-            }
+        $token = $this->tokenStorage->getToken();
+        foreach ($this->handlers as $handler) {
+            $handler->logout($request, $response, $token);
         }
 
         $this->tokenStorage->setToken(null);

--- a/src/Symfony/Component/Security/Http/Logout/CookieClearingLogoutHandler.php
+++ b/src/Symfony/Component/Security/Http/Logout/CookieClearingLogoutHandler.php
@@ -35,7 +35,7 @@ class CookieClearingLogoutHandler implements LogoutHandlerInterface
     /**
      * Implementation for the LogoutHandlerInterface. Deletes all requested cookies.
      */
-    public function logout(Request $request, Response $response, TokenInterface $token)
+    public function logout(Request $request, Response $response, TokenInterface $token = null)
     {
         foreach ($this->cookies as $cookieName => $cookieData) {
             $response->headers->clearCookie($cookieName, $cookieData['path'], $cookieData['domain']);

--- a/src/Symfony/Component/Security/Http/Logout/LogoutHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutHandlerInterface.php
@@ -27,5 +27,5 @@ interface LogoutHandlerInterface
      * to be logged out. Usually, you would unset session variables, or remove
      * cookies, etc.
      */
-    public function logout(Request $request, Response $response, TokenInterface $token);
+    public function logout(Request $request, Response $response, TokenInterface $token = null);
 }

--- a/src/Symfony/Component/Security/Http/Logout/SessionLogoutHandler.php
+++ b/src/Symfony/Component/Security/Http/Logout/SessionLogoutHandler.php
@@ -25,7 +25,7 @@ class SessionLogoutHandler implements LogoutHandlerInterface
     /**
      * Invalidate the current session.
      */
-    public function logout(Request $request, Response $response, TokenInterface $token)
+    public function logout(Request $request, Response $response, TokenInterface $token = null)
     {
         $request->getSession()->invalidate();
     }

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -155,7 +155,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
     /**
      * Implementation for LogoutHandlerInterface. Deletes the cookie.
      */
-    public function logout(Request $request, Response $response, TokenInterface $token)
+    public function logout(Request $request, Response $response, TokenInterface $token = null)
     {
         $this->cancelCookie($request);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #7104 
| License       | MIT

[My previous attempt](https://github.com/symfony/symfony/pull/24489) to fix #7104 without any BC break was quite ugly so here we are.

As said before the logout handlers are currently not invoked if the security token is null. Problem is, the firewall listeners registration order only allows `ContextListener` to set a token before `LogoutListener`. This means any stateless firewall cannot benefit from the `logout` option, which is quite ironic as we have a `CookieClearingLogoutHandler`.

None of the Symfony logout handlers use `logout`'s `$token` parameter so I thought about removing it but in the meantime I just allowed it to be `null` in order to mitigate possible BC breaks.

I really would like this to be fixed with Symfony 4!