### PR TITLE
[Validator] Fix TraceableValidator is reset on data collector instantiation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator_debug.xml
@@ -9,6 +9,7 @@
 
         <service id="debug.validator" decorates="validator" decoration-priority="255" class="Symfony\Component\Validator\Validator\TraceableValidator">
             <argument type="service" id="debug.validator.inner" />
+            <tag name="kernel.reset" method="reset" />
         </service>
 
         <!-- DataCollector -->

--- a/src/Symfony/Component/Validator/DataCollector/ValidatorDataCollector.php
+++ b/src/Symfony/Component/Validator/DataCollector/ValidatorDataCollector.php
@@ -45,7 +45,6 @@ class ValidatorDataCollector extends DataCollector implements LateDataCollectorI
 
     public function reset()
     {
-        $this->validator->reset();
         $this->data = array(
             'calls' => $this->cloneVar(array()),
             'violations_count' => 0,

--- a/src/Symfony/Component/Validator/Tests/DataCollector/ValidatorDataCollectorTest.php
+++ b/src/Symfony/Component/Validator/Tests/DataCollector/ValidatorDataCollectorTest.php
@@ -70,11 +70,6 @@ class ValidatorDataCollectorTest extends TestCase
 
         $this->assertCount(0, $collector->getCalls());
         $this->assertSame(0, $collector->getViolationsCount());
-
-        $collector->lateCollect();
-
-        $this->assertCount(0, $collector->getCalls());
-        $this->assertSame(0, $collector->getViolationsCount());
     }
 
     protected function createMock($classname)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Calling reset from the constructor is wrong in this case as it'll reset the `TraceableValidator`, which means you'll never get collected data on the first request as the collector is instantiated after (on kernel response).

Another option would be to tag the `debug.validator` service with `kernel.reset` and remove the reset call from the collector.