### PR TITLE
[FrameworkBundle] Use env vars instead of router.request_context.* and asset.request_context.* parameters.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 4.0.0
 -----
 
+ * Removed `router.request_context.*` parameters, use `env(ROUTER_REQUEST_CONTEXT_*)` instead. 
+ * Removed `asset.request_context.*` parameters, use `env(ASSET_REQUEST_CONTEXT_*)` instead. 
  * The default `type` option of the `framework.workflows.*` configuration entries is `state_machine`
  * removed `AddConsoleCommandPass`, `AddConstraintValidatorsPass`,
    `AddValidatorInitializersPass`, `CompilerDebugDumpPass`,  `ConfigCachePass`,

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
@@ -5,8 +5,8 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="asset.request_context.base_path"></parameter>
-        <parameter key="asset.request_context.secure">false</parameter>
+        <parameter key="env(ASSET_REQUEST_CONTEXT_BASE_PATH)"></parameter>
+        <parameter key="env(ASSET_REQUEST_CONTEXT_SECURE)">false</parameter>
     </parameters>
 
     <services>
@@ -24,8 +24,8 @@
 
         <service id="assets.context" class="Symfony\Component\Asset\Context\RequestStackContext">
             <argument type="service" id="request_stack" />
-            <argument>%asset.request_context.base_path%</argument>
-            <argument>%asset.request_context.secure%</argument>
+            <argument>%env(ASSET_REQUEST_CONTEXT_BASE_PATH)%</argument>
+            <argument>%env(ASSET_REQUEST_CONTEXT_SECURE)%</argument>
         </service>
 
         <service id="assets.path_package" class="Symfony\Component\Asset\PathPackage" abstract="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -5,9 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="router.request_context.host">localhost</parameter>
-        <parameter key="router.request_context.scheme">http</parameter>
-        <parameter key="router.request_context.base_url"></parameter>
+        <parameter key="env(ROUTER_REQUEST_CONTEXT_HOST)">localhost</parameter>
+        <parameter key="env(ROUTER_REQUEST_CONTEXT_SCHEME)">http</parameter>
+        <parameter key="env(ROUTER_REQUEST_CONTEXT_BASE_URL)"></parameter>
     </parameters>
 
     <services>
@@ -80,10 +80,10 @@
         <service id="Symfony\Component\Routing\RequestContextAwareInterface" alias="router" />
 
         <service id="router.request_context" class="Symfony\Component\Routing\RequestContext">
-            <argument>%router.request_context.base_url%</argument>
+            <argument>%env(ROUTER_REQUEST_CONTEXT_BASE_URL)%</argument>
             <argument>GET</argument>
-            <argument>%router.request_context.host%</argument>
-            <argument>%router.request_context.scheme%</argument>
+            <argument>%env(ROUTER_REQUEST_CONTEXT_HOST)%</argument>
+            <argument>%env(ROUTER_REQUEST_CONTEXT_SCHEME)%</argument>
             <argument>%request_listener.http_port%</argument>
             <argument>%request_listener.https_port%</argument>
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hi,

This PR remove the usage of `router.request_context.*` in favor of `env(ROUTER_REQUEST_CONTEXT_*)`. Same for `asset.request_context.*`.

Because you cannot use env vars for these parameters.

What do you think of it ?

If it's ok, I'll update the doc.
