### PR TITLE
[TwigBundle] Added priority to twig extensions

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 4.1.0
 -----
+
  * added priority to Twig extensions 
 
 4.0.0

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,11 +1,14 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+ * added priority to twig extensions 
+
 4.0.0
 -----
 
  * removed `ContainerAwareRuntimeLoader`
- * added priority to twig extensions 
 
 3.4.0
 -----

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 4.1.0
 -----
- * added priority to twig extensions 
+ * added priority to Twig extensions 
 
 4.0.0
 -----

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * removed `ContainerAwareRuntimeLoader`
+ * added priority to twig extensions 
 
 3.4.0
 -----

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\TwigBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
@@ -40,7 +40,7 @@ class TwigEnvironmentPass implements CompilerPassInterface
         $calls = $definition->getMethodCalls();
         $definition->setMethodCalls(array());
         foreach ($this->findAndSortTaggedServices('twig.extension', $container) as $extension) {
-            $definition->addMethodCall('addExtension', array(new Reference($extension)));
+            $definition->addMethodCall('addExtension', array($extension));
         }
         $definition->setMethodCalls(array_merge($definition->getMethodCalls(), $calls));
     }

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigEnvironmentPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigEnvironmentPassTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigEnvironmentPass;
+use Symfony\Component\DependencyInjection\Definition;
+
+class TwigEnvironmentPassTest extends TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $builder;
+    /**
+     * @var Definition
+     */
+    private $definition;
+    /**
+     * @var TwigEnvironmentPass
+     */
+    private $pass;
+
+    protected function setUp()
+    {
+        $this->builder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->setMethods(array('hasDefinition', 'findTaggedServiceIds', 'setAlias', 'getDefinition'))->getMock();
+        $this->definition = new Definition('twig');
+        $this->pass = new TwigEnvironmentPass();
+    }
+
+    public function testPassWithTwoExtensionsWithPriority()
+    {
+        $serviceIds = array(
+            'test_extension_1' => array(
+                array('priority' => 100),
+            ),
+            'test_extension_2' => array(
+                array('priority' => 200),
+            ),
+        );
+
+        $this->builder->expects($this->once())
+            ->method('hasDefinition')
+            ->with('twig')
+            ->will($this->returnValue(true));
+        $this->builder->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('twig.extension')
+            ->will($this->returnValue($serviceIds));
+        $this->builder->expects($this->once())
+            ->method('getDefinition')
+            ->with('twig')
+            ->will($this->returnValue($this->definition));
+
+        $this->pass->process($this->builder);
+        $calls = $this->definition->getMethodCalls();
+        $this->assertCount(2, $calls);
+        $this->assertEquals('addExtension', $calls[0][0]);
+        $this->assertEquals('addExtension', $calls[1][0]);
+        $this->assertEquals('test_extension_2', (string) $calls[0][1][0]);
+        $this->assertEquals('test_extension_1', (string) $calls[1][1][0]);
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigEnvironmentPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigEnvironmentPassTest.php
@@ -18,41 +18,25 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class TwigEnvironmentPassTest extends TestCase
 {
-    /**
-     * @var ContainerBuilder
-     */
-    private $builder;
-    /**
-     * @var Definition
-     */
-    private $definition;
-    /**
-     * @var TwigEnvironmentPass
-     */
-    private $pass;
-
-    protected function setUp()
-    {
-        $this->builder = new ContainerBuilder();
-        $this->definition = new Definition('twig');
-        $this->definition->setPublic(true);
-        $this->builder->setDefinition('twig', $this->definition);
-
-        $this->pass = new TwigEnvironmentPass();
-    }
 
     public function testPassWithTwoExtensionsWithPriority()
     {
+        $twigDefinition = new Definition('twig');
+        $twigDefinition->setPublic(true);
+        $builder = new ContainerBuilder();
+        $builder->setDefinition('twig', $twigDefinition);
+        $pass = new TwigEnvironmentPass();
+
         $definition = new Definition('test_extension_1');
         $definition->addTag('twig.extension', array('priority' => 100));
-        $this->builder->setDefinition('test_extension_1', $definition);
+        $builder->setDefinition('test_extension_1', $definition);
 
         $definition = new Definition('test_extension_2');
         $definition->addTag('twig.extension', array('priority' => 200));
-        $this->builder->setDefinition('test_extension_2', $definition);
+        $builder->setDefinition('test_extension_2', $definition);
 
-        $this->pass->process($this->builder);
-        $calls = $this->definition->getMethodCalls();
+        $pass->process($builder);
+        $calls = $twigDefinition->getMethodCalls();
         $this->assertCount(2, $calls);
         $this->assertEquals('addExtension', $calls[0][0]);
         $this->assertEquals('addExtension', $calls[1][0]);

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigEnvironmentPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigEnvironmentPassTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class TwigEnvironmentPassTest extends TestCase
 {
-
     public function testPassWithTwoExtensionsWithPriority()
     {
         $twigDefinition = new Definition('twig');

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigEnvironmentPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigEnvironmentPassTest.php
@@ -33,7 +33,7 @@ class TwigEnvironmentPassTest extends TestCase
 
     protected function setUp()
     {
-        $this->builder = new ContainerBuilder;
+        $this->builder = new ContainerBuilder();
         $this->definition = new Definition('twig');
         $this->definition->setPublic(true);
         $this->builder->setDefinition('twig', $this->definition);
@@ -44,11 +44,11 @@ class TwigEnvironmentPassTest extends TestCase
     public function testPassWithTwoExtensionsWithPriority()
     {
         $definition = new Definition('test_extension_1');
-        $definition->addTag('twig.extension', ['priority' => 100]);
+        $definition->addTag('twig.extension', array('priority' => 100));
         $this->builder->setDefinition('test_extension_1', $definition);
 
         $definition = new Definition('test_extension_2');
-        $definition->addTag('twig.extension', ['priority' => 200]);
+        $definition->addTag('twig.extension', array('priority' => 200));
         $this->builder->setDefinition('test_extension_2', $definition);
 
         $this->pass->process($this->builder);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | Don't merge before the docs

Added priority to twig extensions in the `TwigEnvironmentPass` to control the order in which they're registered, similar to the `TwigLoaderPass`

Though, unsure on what priority to use as a default, and will PR docs when finalised.