### PR TITLE
[BrowserKit] add a way to switch to ajax for one request

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -150,6 +150,16 @@ abstract class Client
         return isset($this->server[$key]) ? $this->server[$key] : $default;
     }
 
+    public function switchToXHR()
+    {
+        $this->setServerParameter('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');
+    }
+
+    public function removeXHR()
+    {
+        unset($this->server['HTTP_X_REQUESTED_WITH']);
+    }
+
     /**
      * Returns the History instance.
      *

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -94,6 +94,16 @@ class ClientTest extends TestCase
         $this->assertEquals('http://example.com/', $client->getRequest()->getUri(), '->getCrawler() returns the Request of the last request');
     }
 
+    public function testGetRequestWithXHR()
+    {
+        $client = new TestClient();
+        $client->switchToXHR();
+        $client->request('GET', 'http://example.com/', array(), array(), array(), null, true, true);
+        $this->assertEquals($client->getRequest()->getServer()['HTTP_X_REQUESTED_WITH'], 'XMLHttpRequest');
+        $client->removeXHR();
+        $this->assertFalse($client->getServerParameter('HTTP_X_REQUESTED_WITH', false));
+    }
+
     public function testGetRequestWithIpAsHttpHost()
     {
         $client = new TestClient();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #20306 
| License       | MIT
| Doc PR        | will do

Follow the work on #20306.

/cc @fabpot is it the right implementation ?