### PR TITLE
[PhpUnitBridge] Fixed fatal error in CoverageListener when something goes wrong in Test::setUpBeforeClass

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\PhpUnit\Legacy;
 
 use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Warning;
 
 /**
@@ -36,6 +37,10 @@ class CoverageListenerTrait
 
     public function startTest($test)
     {
+        if (!$test instanceof TestCase) {
+            return;
+        }
+
         $annotations = $test->getAnnotations();
 
         $ignoredAnnotations = array('covers', 'coversDefaultClass', 'coversNothing');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |