### PR TITLE
[HttpKernel] Always require the dependency injection component

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/event-dispatcher": "~3.4|~4.0",
         "symfony/http-foundation": "~3.4|~4.0",
         "symfony/debug": "~3.4|~4.0",
@@ -27,7 +28,6 @@
         "symfony/config": "~3.4|~4.0",
         "symfony/console": "~3.4|~4.0",
         "symfony/css-selector": "~3.4|~4.0",
-        "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/dom-crawler": "~3.4|~4.0",
         "symfony/expression-language": "~3.4|~4.0",
         "symfony/finder": "~3.4|~4.0",
@@ -52,7 +52,6 @@
         "symfony/browser-kit": "",
         "symfony/config": "",
         "symfony/console": "",
-        "symfony/dependency-injection": "",
         "symfony/var-dumper": ""
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24798
| License       | MIT
| Doc PR        | —

As described in the ticket, the HttpKernel component currently only has a suggestion / dev requirement on the DI component. But as the `Bundle` uses the `ContainerAwareTrait` (which is provided by the DI component) this is a hard requirement.