### PR TITLE
[Serializer] Throws when passing an xml and allow_extra_attributes to false

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -175,6 +175,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         $allowedAttributes = $this->getAllowedAttributes($class, $context, true);
+        if ('xml' === $format) {
+            $data = $this->parseXmlIntoArray($data);
+        }
         $normalizedData = $this->prepareForDenormalization($data);
         $extraAttributes = array();
 
@@ -361,5 +364,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             // The context cannot be serialized, skip the cache
             return false;
         }
+    }
+
+    private function parseXmlIntoArray($data)
+    {
+        return json_decode(json_encode(new \SimpleXMLElement($data)), true);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -51,6 +51,27 @@ class AbstractObjectNormalizerTest extends TestCase
             array('allow_extra_attributes' => false)
         );
     }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\ExtraAttributesException
+     * @expectedExceptionMessage Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).
+     */
+    public function testDenormalizeWithExtraAttributesWithXml()
+    {
+        $normalizer = new AbstractObjectNormalizerDummy();
+        $data = <<<EOF
+<dummy>
+    <fooFoo>foo</fooFoo>
+    <fooBar>99</fooBar>
+</dummy>
+EOF;
+        $normalizer->denormalize(
+            $data,
+            __NAMESPACE__.'\Dummy',
+            'xml',
+            array('allow_extra_attributes' => false)
+        );
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24783 
| License       | MIT
| Doc PR        | already existing

I'm not sure about the implementation of this one, But the bug is when you pass an xml, it does not try to transform it really to an array, changing the `AbstractNormalizer::prepareForDenormalization` method would be a BC break. 

It may occurs too when passing anything else than a php array.

cc @dunglas @nicolas-grekas if you have something better to propose, i'll be glad to implement it.
