### PR TITLE
[Serializer] Fix extra attributes when no group specified

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -31,6 +31,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
     const OBJECT_TO_POPULATE = 'object_to_populate';
     const GROUPS = 'groups';
     const ATTRIBUTES = 'attributes';
+    const ALLOW_EXTRA_ATTRIBUTES = 'allow_extra_attributes';
 
     /**
      * @var int
@@ -201,7 +202,14 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      */
     protected function getAllowedAttributes($classOrObject, array $context, $attributesAsString = false)
     {
-        if (!$this->classMetadataFactory || !isset($context[static::GROUPS]) || !is_array($context[static::GROUPS])) {
+        if (!$this->classMetadataFactory) {
+            return false;
+        }
+
+        $groups = false;
+        if (isset($context[static::GROUPS]) && is_array($context[static::GROUPS])) {
+            $groups = $context[static::GROUPS];
+        } elseif (!isset($context[static::ALLOW_EXTRA_ATTRIBUTES]) || $context[static::ALLOW_EXTRA_ATTRIBUTES]) {
             return false;
         }
 
@@ -210,7 +218,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
             $name = $attributeMetadata->getName();
 
             if (
-                count(array_intersect($attributeMetadata->getGroups(), $context[static::GROUPS])) &&
+                (false === $groups || count(array_intersect($attributeMetadata->getGroups(), $groups))) &&
                 $this->isAllowedAttribute($classOrObject, $name, null, $context)
             ) {
                 $allowedAttributes[] = $attributesAsString ? $name : $attributeMetadata;

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -31,7 +31,6 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 {
     const ENABLE_MAX_DEPTH = 'enable_max_depth';
     const DEPTH_KEY_PATTERN = 'depth_%s::%s';
-    const ALLOW_EXTRA_ATTRIBUTES = 'allow_extra_attributes';
 
     private $propertyTypeExtractor;
     private $attributesCache = array();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 class AbstractObjectNormalizerTest extends TestCase
@@ -51,6 +54,21 @@ class AbstractObjectNormalizerTest extends TestCase
             array('allow_extra_attributes' => false)
         );
     }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\ExtraAttributesException
+     * @expectedExceptionMessage Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).
+     */
+    public function testDenormalizeWithExtraAttributesAndNoGroupsWithMetadataFactory()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+        $normalizer->denormalize(
+            array('fooFoo' => 'foo', 'fooBar' => 'bar', 'bar' => 'bar'),
+            Dummy::class,
+            'any',
+            array('allow_extra_attributes' => false)
+        );
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
@@ -84,4 +102,25 @@ class Dummy
     public $foo;
     public $bar;
     public $baz;
+}
+
+class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
+{
+    public function __construct()
+    {
+        parent::__construct(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())));
+    }
+
+    protected function extractAttributes($object, $format = null, array $context = array())
+    {
+    }
+
+    protected function getAttributeValue($object, $attribute, $format = null, array $context = array())
+    {
+    }
+
+    protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = array())
+    {
+        $object->$attribute = $value;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24783 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

~~Two commits, for two possible solutions, but I think the last one is probably the most efficient one, as the first one will also impact normalization and systematically try to intersect allowedAttributes and extractedAttributes.~~