### PR TITLE
[Workflow] mark ClassInstanceSupportStrategy as internal

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -7,7 +7,8 @@ CHANGELOG
  * Added guard `is_valid()` method support.
  * Added support for `Event::getWorkflowName()` for "announce" events.
  * Added `workflow.completed` events which are fired after a transition is completed.
-
+ * `ClassIntanceSupportStrategy` is now internal
+ 
 3.3.0
 -----
 

--- a/src/Symfony/Component/Workflow/SupportStrategy/ClassInstanceSupportStrategy.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/ClassInstanceSupportStrategy.php
@@ -6,6 +6,8 @@ use Symfony\Component\Workflow\Workflow;
 
 /**
  * @author Andreas Kleemann <akleemann@inviqa.com>
+ *
+ * @internal
  */
 final class ClassInstanceSupportStrategy implements SupportStrategyInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

We are marking ClassInstanceSupportStrategy as internal since we want to introduce a new interface for the workflow component in 4.1 see #24751 