### PR TITLE
symfony/form auto-enables symfony/validator, even when not present

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -241,9 +241,10 @@ class FrameworkExtension extends Extension
         if ($this->isConfigEnabled($container, $config['form'])) {
             $this->formConfigEnabled = true;
             $this->registerFormConfiguration($config, $container, $loader);
-            $config['validation']['enabled'] = true;
 
-            if (!class_exists('Symfony\Component\Validator\Validation')) {
+            if (class_exists('Symfony\Component\Validator\Validation')) {
+                $config['validation']['enabled'] = true;
+            } else {
                 $container->setParameter('validator.translation_domain', 'validators');
 
                 $container->removeDefinition('form.type_extension.form.validator');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 or master / 2.7, 2.8 or 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | not needed

In #24303, we allowed form to be used without the validator component. But, there is a small problem with the logic: the validation system is set to enabled, even if it is not present. If you install form but NOT validator, you see the error:

> Validation support cannot be enabled as the Validator component is not installed.

Assuming the form system really is usable without validation, this should be an easy merge.
