### PR TITLE
[Console] Fix CommandTester::setInputs() docblock

### DIFF
--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -132,8 +132,8 @@ class CommandTester
     /**
      * Sets the user inputs.
      *
-     * @param array an array of strings representing each input
-     *              passed to the command input stream
+     * @param array $inputs An array of strings representing each input
+     *                      passed to the command input stream
      *
      * @return CommandTester
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A