### PR TITLE
[FrameworkBundle][Config] fix: do not add resource checkers for no-debug

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -361,6 +361,11 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(ObjectInitializerInterface::class)
             ->addTag('validator.initializer');
 
+        if (!$container->getParameter('kernel.debug')) {
+            // remove tagged iterator argument for resource checkers
+            $container->getDefinition('config_cache_factory')->setArguments(array());
+        }
+
         if (\PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(
                 'Symfony\\Component\\Config\\ConfigCache',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -988,6 +988,17 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.def', 'cache.app', 11);
     }
 
+    public function testRemovesResourceCheckerConfigCacheFactoryArgumentOnlyIfNoDebug()
+    {
+        $container = $this->createContainer(array('kernel.debug' => true));
+        (new FrameworkExtension())->load(array(), $container);
+        $this->assertCount(1, $container->getDefinition('config_cache_factory')->getArguments());
+
+        $container = $this->createContainer(array('kernel.debug' => false));
+        (new FrameworkExtension())->load(array(), $container);
+        $this->assertEmpty($container->getDefinition('config_cache_factory')->getArguments());
+    }
+
     protected function createContainer(array $data = array())
     {
         return new ContainerBuilder(new ParameterBag(array_merge(array(

--- a/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
+++ b/src/Symfony/Component/Config/ResourceCheckerConfigCache.php
@@ -68,7 +68,11 @@ class ResourceCheckerConfigCache implements ConfigCacheInterface
             return false;
         }
 
-        if (!$this->resourceCheckers) {
+        if ($this->resourceCheckers instanceof \Traversable && !$this->resourceCheckers instanceof \Countable) {
+            $this->resourceCheckers = iterator_to_array($this->resourceCheckers);
+        }
+
+        if (!count($this->resourceCheckers)) {
             return true; // shortcut - if we don't have any checkers we don't need to bother with the meta file at all
         }
 

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -57,11 +57,17 @@ class ResourceCheckerConfigCacheTest extends TestCase
         $this->assertFalse($cache->isFresh());
     }
 
-    public function testCacheIsFreshIfNocheckerProvided()
+    public function testCacheIsFreshIfNoCheckerProvided()
     {
         /* For example in prod mode, you may choose not to run any checkers
            at all. In that case, the cache should always be considered fresh. */
         $cache = new ResourceCheckerConfigCache($this->cacheFile);
+        $this->assertTrue($cache->isFresh());
+    }
+
+    public function testCacheIsFreshIfEmptyCheckerIteratorProvided()
+    {
+        $cache = new ResourceCheckerConfigCache($this->cacheFile, new \ArrayIterator(array()));
         $this->assertTrue($cache->isFresh());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24808
| License       | MIT
| Doc PR        | -

As mentioned within #24808 replacing the `ConfigCachePass` here https://github.com/symfony/symfony/compare/537c496dfee1d04aab832f8441f8b6cfe7dc2af5...a442e378e18d399e942bcffe0c2e960fcdc0b53f#diff-687bdbb38a4dc672ca2a79f23e764892L127 with a tagged iterator argument resulted in resource checkers being added even if debug=false.

This resulted in a performance drop as on every request all the checkers have been checked.

This restores the previous behavior and does not add any checkers if debug=false.