### PR TITLE
Drop support for PHPUnit 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
         "phpdocumentor/type-resolver": "<0.2.1",
-        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+        "phpunit/phpunit": "<5.4.3"
     },
     "provide": {
         "psr/cache-implementation": "1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

You can no longer mock Symfony > 4.0 components, because they now use nullable type hints. PHPUnit 4 requires 2.* for phpunit-mock-objects, which don't support that. For example, it's no longer possible to mock ContainerBuilder with PHPUnit 4. This will save time debugging this issue for bundles still using PHPUnit 4. I have discovered this problem when patching KnpPaginatorBundle for Symfony 4.0.