### PR TITLE
[FrameworkBundle] Allow to pass a logger instance to the Router

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
+
 4.0.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -51,6 +51,7 @@
         </service>
 
         <service id="router.default" class="Symfony\Bundle\FrameworkBundle\Routing\Router">
+            <tag name="monolog.logger" channel="router" />
             <argument type="service" id="service_container" />
             <argument>%router.resource%</argument>
             <argument type="collection">
@@ -66,6 +67,7 @@
                 <argument key="matcher_cache_class">%router.cache_class_prefix%UrlMatcher</argument>
             </argument>
             <argument type="service" id="router.request_context" on-invalid="ignore" />
+            <argument type="service" id="logger" on-invalid="ignore" />
             <call method="setConfigCacheFactory">
                 <argument type="service" id="config_cache_factory" />
             </call>

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Routing;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
 use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
@@ -33,17 +34,19 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
     private $collectedParameters = array();
 
     /**
-     * @param ContainerInterface $container A ContainerInterface instance
-     * @param mixed              $resource  The main resource to load
-     * @param array              $options   An array of options
-     * @param RequestContext     $context   The context
+     * @param ContainerInterface   $container A ContainerInterface instance
+     * @param mixed                $resource  The main resource to load
+     * @param array                $options   An array of options
+     * @param RequestContext       $context   The context
+     * @param LoggerInterface|null $logger
      */
-    public function __construct(ContainerInterface $container, $resource, array $options = array(), RequestContext $context = null)
+    public function __construct(ContainerInterface $container, $resource, array $options = array(), RequestContext $context = null, LoggerInterface $logger = null)
     {
         $this->container = $container;
 
         $this->resource = $resource;
         $this->context = $context ?: new RequestContext();
+        $this->logger = $logger;
         $this->setOptions($options);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24739 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

As explained in #24739, this will allow the `UrlGenerator` to log invalid calls when `router.strict_requirements` is `false` (so instead of throwing):

<img width="1064" alt="screenshot 2017-10-29 a 09 57 31" src="https://user-images.githubusercontent.com/2211145/32142080-482bc64e-bc90-11e7-8382-b78b507bae48.PNG">

~~This PR must re-introduce the `logger` argument in the definition along with the `monolog.logger` tag removed for cleaning in #24739, once it's merged up into master.~~ Done