### PR TITLE
Fix merge 3.3 -> 3.4

### DIFF
--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
@@ -16,8 +16,8 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (choice_translation_domain
   Allowed values   -                  %s 
  ---------------- --------------------%s 
   Normalizer       Closure {          %s 
-                     parameters: 2,   %s 
-                     file: "%s%eExtension%eCore%eType%eChoiceType.php",  
+                     parameters: 2    %s 
+                     file: "%s%eExtension%eCore%eType%eChoiceType.php"  
                      line: "%s to %s" %s 
                    }                  %s 
  ---------------- --------------------%s 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
@@ -9,13 +9,13 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (empty_data)
                                         %s 
                    Closure(s): [        %s 
                      Closure {          %s 
-                       parameters: 1,   %s 
-                       file: "%s%eExtension%eCore%eType%eFormType.php",                     
+                       parameters: 1   %s 
+                       file: "%s%eExtension%eCore%eType%eFormType.php"                     
                        line: "%s to %s" %s 
                      },                 %s 
                      Closure {          %s 
-                       parameters: 2,   %s 
-                       file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php",  
+                       parameters: 2   %s 
+                       file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"  
                        line: "%s to %s" %s 
                      }                  %s 
                    ]                    %s 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
@@ -17,8 +17,8 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (foo)
                    ]                  %s 
  ---------------- --------------------%s 
   Normalizer       Closure {          %s 
-                     parameters: 2,   %s 
-                     file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php",  
+                     parameters: 2   %s 
+                     file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"  
                      line: "%s to %s" %s 
                    }                  %s 
  ---------------- --------------------%s 

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -41,7 +41,8 @@
         "symfony/doctrine-bridge": "<2.7",
         "symfony/framework-bundle": "<3.4",
         "symfony/http-kernel": "<3.3.5",
-        "symfony/twig-bridge": "<3.4"
+        "symfony/twig-bridge": "<3.4",
+        "symfony/var-dumper": "<3.3.11"
     },
     "suggest": {
         "symfony/validator": "For form validation.",

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -147,10 +147,10 @@ RuntimeException {
   #file: "%ACliDumperTest.php"
   #line: %d
   trace: {
-    %ACliDumperTest.php:%d: {
-      : 
-      : $ex = new \RuntimeException('foo');
-      : 
+    %ACliDumperTest.php:%d {
+      › 
+      › $ex = new \RuntimeException('foo');
+      › 
     }
     %A
   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes (failing on deps=high because `symfony/var-dumper:dev-master#1a0a790` was used instead of `symfony/var-dumper:dev-master#88dbf40`
| Fixed tickets | N/A (merge commit 73982760f7c386e7e662addba822a37588f7de5f) <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A