### PR TITLE
[SecurityBundle] Fix the datacollector to properly support decision.object being null

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -264,7 +264,7 @@
                                 {{ profiler_dump(decision.attributes) }}
                             {% endif %}
                         </td>
-                        <td>{{ profiler_dump(decision.object) }}</td>
+                        <td>{{ profiler_dump(decision.seek('object')) }}</td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24804 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Similar to https://github.com/symfony/symfony/pull/23050, when accessing a `Data` clone property through `__get()` and the value is `null` for instance, you'll really get `null` instead of a `Data` instance. The solution is to use `seek` instead whenever we access and try to use `profiler_dump` on a `Data` property that can be a simple scalar like `null` or `false`. AFAIK, `decision.object` is the only one here.
