### PR TITLE
[FrameworkBundle] Add default mapping path for serializer component in bundle-less app

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1470,6 +1470,11 @@ class FrameworkExtension extends Extension
             }
         }
 
+        $projectDir = $container->getParameter('kernel.project_dir');
+        if ($container->fileExists($dir = $projectDir.'/config/serializer', '/^$/')) {
+            $this->registerMappingFilesFromDir($dir, $fileRecorder);
+        }
+
         $this->registerMappingFilesFromConfig($container, $config, $fileRecorder);
 
         $chainLoader->replaceArgument(0, $serializerLoaders);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | ToDo

> http://symfony.com/doc/current/serializer.html#using-serialization-groups-annotations:
> In addition to the @Groups annotation, the Serializer component also supports Yaml or XML files. These files are automatically loaded when being stored in one of the following locations:
>* The `serialization.yml` or `serialization.xml` file in the `Resources/config/` directory of a bundle;
>* All `*.yml` and `*.xml` files in the `Resources/config/serialization/` directory of a bundle.

Inspired by the second convention, this proposal adds one more but for bundle-less structure. Theoretically this is what it does for you:
```yaml
framework:
    serializer:
        mapping:
            paths:
                - '%kernel.project_dir%/config/serializer/'
```