### PR TITLE
[Console] ProgressBar displays incorrectly after clear.

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -424,6 +424,7 @@ final class ProgressBar
             $this->setRealFormat($this->internalFormat ?: $this->determineBestFormat());
         }
 
+        $this->output->write(str_repeat("\n", $this->formatLineCount));
         $this->overwrite('');
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -433,6 +433,27 @@ class ProgressBarTest extends TestCase
         );
     }
 
+    public function testClearWithReDisplay()
+    {
+        $memory = fopen('php://memory', 'r+', false);
+        fwrite($memory, $this->generateOutput('1')."\n".
+            $this->generateOutput('2')."\n".
+            $this->generateOutput('3')."\n");
+        $progressBar = new ProgressBar($output = new StreamOutput($memory), 100);
+        $progressBar->setFormat($this->generateOutput('hello')."\n".$this->generateOutput('world')."\n");
+        $progressBar->display();
+        $progressBar->clear();
+        $progressBar->display();
+        rewind($output->getStream());
+
+        $this->assertEquals($this->generateOutput('1')."\n".
+            $this->generateOutput('2')."\n".
+            $this->generateOutput('3')."\n".
+            $this->generateOutput('hello')."\n".$this->generateOutput('world')."\n".
+            $this->generateOutput('hello')."\n".$this->generateOutput('world')."\n", stream_get_contents($output->getStream()));
+        fclose($memory);
+    }
+
     public function testPercentNotHundredBeforeComplete()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 200);
@@ -645,6 +666,7 @@ class ProgressBarTest extends TestCase
         $this->assertEquals(
             ">---------------------------\nfoobar".
             $this->generateOutput("=========>------------------\nfoobar").
+            "\n".
             "\x0D\x1B[2K\x1B[1A\x1B[2K".
             $this->generateOutput("============================\nfoobar"),
             stream_get_contents($output->getStream())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | yesish ?
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24224
| License       | MIT
| Doc PR        | has to be done to explains this behaviour.

I'm adding `reset` to change that behaviour and to have the right output.

I'm not changing the clear method, because if the output changes (which will be the case), it should considered as a BC Break.
