### PR TITLE
enable PHP 7.2 on Travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - php: 7.1.3
         - php: 7.1
           env: deps=high
-        - php: 7.1
+        - php: 7.2
           env: deps=low
     fast_finish: true
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Travis CI now uses RC5. Tests *should* be green with PHP 7.2 too.