### PR TITLE
[TwigBridge] [Bootstrap 4] Fix validation error design for expanded choiceType

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -111,7 +111,7 @@
                 {{- form_widget(child, {
                     parent_label_class: label_attr.class|default(''),
                     translation_domain: choice_translation_domain,
-                    valid: valid,
+                    valid: true,
                 }) -}}
             {% endfor -%}
         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Unfortunately I didn't test https://github.com/symfony/symfony/pull/24802 with expanded option set to true, sorry about that. Without this fix, it applies form error style twice.

Before:
![screenshot from 2017-11-06 10 31 55](https://user-images.githubusercontent.com/496233/32434235-c13c02f8-c2dd-11e7-97da-6bfa312c5825.png)

After:
![screenshot from 2017-11-06 10 32 40](https://user-images.githubusercontent.com/496233/32434252-d30c2224-c2dd-11e7-86d6-fd06af3ef753.png)


