### PR TITLE
[Form] DateType storing wrong format date

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -50,6 +50,10 @@ class DateType extends AbstractType
             throw new InvalidOptionsException('The "format" option must be one of the IntlDateFormatter constants (FULL, LONG, MEDIUM, SHORT) or a string representing a custom format.');
         }
 
+        if (null !== $pattern && !preg_match('/^(([yMd]+)[^yMd]*([yMd]+)[^yMd]*([yMd]+))|(^y{1}$|^M{1}$|^d{1}$)$/', $pattern)) {
+            throw new InvalidOptionsException(sprintf('The DateTime format "%s" is not supported in ICU. Please be aware that the data may not reflect the format.', $pattern));
+        }
+
         if ('single_text' === $options['widget']) {
             if (null !== $pattern && false === strpos($pattern, 'y') && false === strpos($pattern, 'M') && false === strpos($pattern, 'd')) {
                 throw new InvalidOptionsException(sprintf('The "format" option should contain the letters "y", "M" or "d". Its current value is "%s".', $pattern));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -258,6 +258,26 @@ class DateTypeTest extends BaseTypeTest
         $this->assertEquals('06*2010*02', $form->getViewData());
     }
 
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The DateTime format "dmm" is not supported in ICU. Please be aware that the data may not reflect the format.
+     */
+    public function testSubmitFromInputDateTimeInvalidFormat()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'format' => 'dmm',
+            'widget' => 'single_text',
+            'input' => 'datetime',
+        ));
+
+        $form->submit('102');
+
+        $this->assertDateTimeEquals(new \DateTime('1970-01-01 00:02:00 UTC'), $form->getData());
+        $this->assertEquals('102', $form->getViewData());
+    }
+
     public function testSubmitFromInputStringDifferentPattern()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, array(
@@ -353,7 +373,7 @@ class DateTypeTest extends BaseTypeTest
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The "format" option should contain the letters "y", "M" and "d". Its current value is "yy".
+     * @expectedExceptionMessage The DateTime format "yy" is not supported in ICU. Please be aware that the data may not reflect the format.
      */
     public function testThrowExceptionIfFormatDoesNotContainYearMonthAndDay()
     {
@@ -365,7 +385,7 @@ class DateTypeTest extends BaseTypeTest
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The "format" option should contain the letters "y", "M" or "d". Its current value is "wrong".
+     * @expectedExceptionMessage The DateTime format "wrong" is not supported in ICU. Please be aware that the data may not reflect the format.
      */
     public function testThrowExceptionIfFormatMissesYearMonthAndDayWithSingleTextWidget()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #24791
| License       | MIT
| Doc PR        | 

I don't think adding the logger as a dependencies to the form is a good idea, how could we log without it directly and without using trigger_error ?


EDIT: throw added.