### PR TITLE
[DI] Fix cannot bind env var

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -66,6 +66,7 @@ class ResolveParameterPlaceHoldersPass extends AbstractRecursivePass
             return $this->resolveArrays || !$v || !is_array($v) ? $v : $value;
         }
         if ($value instanceof Definition) {
+            $value->setBindings($this->processValue($value->getBindings()));
             $changes = $value->getChanges();
             if (isset($changes['class'])) {
                 $value->setClass($this->bag->resolveValue($value->getClass()));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -64,6 +64,13 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
         $this->assertSame('foo', $this->container->getAlias('bar')->__toString());
     }
 
+    public function testBindingsShouldBeResolved()
+    {
+        list($boundValue) = $this->container->getDefinition('foo')->getBindings()['$baz']->getValues();
+
+        $this->assertSame($this->container->getParameterBag()->resolveValue('%env(BAZ)%'), $boundValue);
+    }
+
     private function createContainerBuilder()
     {
         $containerBuilder = new ContainerBuilder();
@@ -84,6 +91,7 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
         $fooDefinition->addMethodCall('%foo.method%', array('%foo.arg1%', '%foo.arg2%'));
         $fooDefinition->setProperty('%foo.property.name%', '%foo.property.value%');
         $fooDefinition->setFile('%foo.file%');
+        $fooDefinition->setBindings(array('$baz' => '%env(BAZ)%'));
 
         $containerBuilder->setAlias('%alias.id%', 'foo');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
@@ -29,6 +29,7 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
 
         $this->services = array();
         $this->methodMap = array(
+            'bar' => 'getBarService',
             'test' => 'getTestService',
         );
 
@@ -58,6 +59,16 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
         @trigger_error(sprintf('The %s() method is deprecated since version 3.3 and will be removed in 4.0. Use the isCompiled() method instead.', __METHOD__), E_USER_DEPRECATED);
 
         return true;
+    }
+
+    /**
+     * Gets the public 'bar' shared service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
+     */
+    protected function getBarService()
+    {
+        return $this->services['bar'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\Bar($this->getEnv('QUZ'));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services26.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services26.yml
@@ -15,3 +15,8 @@ services:
             - '%env(Bar)%'
             - 'foo%bar%baz'
             - '%baz%'
+    bar:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Bar
+        public: true
+        bind:
+            $quz: '%env(QUZ)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24845 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

In #24602 we removed the processing of bindings from the `AbstractRecursivePass`. But there is actually one case where we want a recursive pass to process them: to resolve env param placeholders.