### PR TITLE
Micro optim using explicit root namespaces

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -209,7 +209,7 @@ class EventDispatcher implements EventDispatcherInterface
             if ($event->isPropagationStopped()) {
                 break;
             }
-            call_user_func($listener, $event, $eventName, $this);
+            \call_user_func($listener, $event, $eventName, $this);
         }
     }
 
@@ -225,7 +225,7 @@ class EventDispatcher implements EventDispatcherInterface
 
         foreach ($this->listeners[$eventName] as $priority => $listeners) {
             foreach ($listeners as $k => $listener) {
-                if (is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure) {
+                if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure) {
                     $listener[0] = $listener[0]();
                     $this->listeners[$eventName][$priority][$k] = $listener;
                 }

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -121,7 +121,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
         }
 
         if ($first) {
-            return count($headers[$key]) ? $headers[$key][0] : $default;
+            return \count($headers[$key]) ? $headers[$key][0] : $default;
         }
 
         return $headers[$key];
@@ -138,12 +138,20 @@ class HeaderBag implements \IteratorAggregate, \Countable
     {
         $key = str_replace('_', '-', strtolower($key));
 
-        $values = array_values((array) $values);
+        if (\is_array($values)) {
+            $values = array_values($values);
 
-        if (true === $replace || !isset($this->headers[$key])) {
-            $this->headers[$key] = $values;
+            if (true === $replace || !isset($this->headers[$key])) {
+                $this->headers[$key] = $values;
+            } else {
+                $this->headers[$key] = array_merge($this->headers[$key], $values);
+            }
         } else {
-            $this->headers[$key] = array_merge($this->headers[$key], $values);
+            if (true === $replace || !isset($this->headers[$key])) {
+                $this->headers[$key] = array($values);
+            } else {
+                $this->headers[$key][] = $values;
+            }
         }
 
         if ('cache-control' === $key) {

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -122,7 +122,7 @@ class ResponseHeaderBag extends HeaderBag
         parent::set($key, $values, $replace);
 
         // ensure the cache-control header has sensible defaults
-        if (in_array($uniqueKey, array('cache-control', 'etag', 'last-modified', 'expires'))) {
+        if (\in_array($uniqueKey, array('cache-control', 'etag', 'last-modified', 'expires'), true)) {
             $computed = $this->computeCacheControlValue();
             $this->headers['cache-control'] = array($computed);
             $this->headerNames['cache-control'] = 'Cache-Control';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Just doing that makes my local hello world as fast on 3.3 as on 4.0.
Spotted using Blackfire to identify the hot path.
Confirmed using both `ab` and `blackfire curl` on a local `php -S`.

It's not the first time these root namespaces make a measurable difference (on a selected list of functions only, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3048.)

https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3222 might become a more generic fix for this kind of optims.