### PR TITLE
[YAML] Allow to parse custom tags when linting yaml files

### DIFF
--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -52,6 +52,7 @@ class LintCommand extends Command
             ->setDescription('Lints a file and outputs encountered errors')
             ->addArgument('filename', null, 'A file or a directory or STDIN')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'txt')
+            ->addOption('parse-tags', null, InputOption::VALUE_NONE, 'Parse custom tags')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command lints a YAML file and outputs to STDOUT
 the first encountered syntax error.
@@ -80,13 +81,14 @@ EOF
         $filename = $input->getArgument('filename');
         $this->format = $input->getOption('format');
         $this->displayCorrectFiles = $output->isVerbose();
+        $flags = $input->getOption('parse-tags') ? Yaml::PARSE_CUSTOM_TAGS : 0;
 
         if (!$filename) {
             if (!$stdin = $this->getStdin()) {
                 throw new \RuntimeException('Please provide a filename or pipe file content to STDIN.');
             }
 
-            return $this->display($io, array($this->validate($stdin)));
+            return $this->display($io, array($this->validate($stdin, $flags)));
         }
 
         if (!$this->isReadable($filename)) {
@@ -95,13 +97,13 @@ EOF
 
         $filesInfo = array();
         foreach ($this->getFiles($filename) as $file) {
-            $filesInfo[] = $this->validate(file_get_contents($file), $file);
+            $filesInfo[] = $this->validate(file_get_contents($file), $flags, $file);
         }
 
         return $this->display($io, $filesInfo);
     }
 
-    private function validate($content, $file = null)
+    private function validate($content, $flags, $file = null)
     {
         $prevErrorHandler = set_error_handler(function ($level, $message, $file, $line) use (&$prevErrorHandler) {
             if (E_USER_DEPRECATED === $level) {
@@ -112,7 +114,7 @@ EOF
         });
 
         try {
-            $this->getParser()->parse($content, Yaml::PARSE_CONSTANT | Yaml::PARSE_CUSTOM_TAGS);
+            $this->getParser()->parse($content, Yaml::PARSE_CONSTANT | $flags);
         } catch (ParseException $e) {
             return array('file' => $file, 'valid' => false, 'message' => $e->getMessage());
         } finally {

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -112,7 +112,7 @@ EOF
         });
 
         try {
-            $this->getParser()->parse($content, Yaml::PARSE_CONSTANT);
+            $this->getParser()->parse($content, Yaml::PARSE_CONSTANT | Yaml::PARSE_CUSTOM_TAGS);
         } catch (ParseException $e) {
             return array('file' => $file, 'valid' => false, 'message' => $e->getMessage());
         } finally {

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -60,6 +60,15 @@ YAML;
         $this->assertSame(0, $ret, 'lint:yaml exits with code 0 in case of success');
     }
 
+    public function testCustomTags()
+    {
+        $yaml = <<<YAML
+foo: !my_tag {foo: bar}
+YAML;
+        $ret = $this->createCommandTester()->execute(array('filename' => $this->createFile($yaml)), array('verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false));
+        $this->assertSame(0, $ret, 'lint:yaml exits with code 0 in case of success');
+    }
+
     /**
      * @expectedException \RuntimeException
      */

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -65,8 +65,17 @@ YAML;
         $yaml = <<<YAML
 foo: !my_tag {foo: bar}
 YAML;
-        $ret = $this->createCommandTester()->execute(array('filename' => $this->createFile($yaml)), array('verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false));
+        $ret = $this->createCommandTester()->execute(array('filename' => $this->createFile($yaml), '--parse-tags' => true), array('verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false));
         $this->assertSame(0, $ret, 'lint:yaml exits with code 0 in case of success');
+    }
+
+    public function testCustomTagsError()
+    {
+        $yaml = <<<YAML
+foo: !my_tag {foo: bar}
+YAML;
+        $ret = $this->createCommandTester()->execute(array('filename' => $this->createFile($yaml)), array('verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false));
+        $this->assertSame(1, $ret, 'lint:yaml exits with code 1 in case of error');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

When using custom tags in yaml, currently the `lint:yaml` command fails since the flag `Yaml::PARSE_CUSTOM_TAGS` is not passed through