### PR TITLE
[Cache] Use direct invocation of closures

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -147,7 +147,6 @@ abstract class AbstractAdapter implements AdapterInterface, LoggerAwareInterface
         }
         $id = $this->getId($key);
 
-        $f = $this->createCacheItem;
         $isHit = false;
         $value = null;
 
@@ -159,7 +158,7 @@ abstract class AbstractAdapter implements AdapterInterface, LoggerAwareInterface
             CacheItem::log($this->logger, 'Failed to fetch key "{key}"', array('key' => $key, 'exception' => $e));
         }
 
-        return $f($key, $value, $isHit);
+        return ($this->createCacheItem)($key, $value, $isHit);
     }
 
     /**
@@ -276,8 +275,6 @@ abstract class AbstractAdapter implements AdapterInterface, LoggerAwareInterface
 
     private function generateItems($items, &$keys)
     {
-        $f = $this->createCacheItem;
-
         try {
             foreach ($items as $id => $value) {
                 if (!isset($keys[$id])) {
@@ -285,14 +282,14 @@ abstract class AbstractAdapter implements AdapterInterface, LoggerAwareInterface
                 }
                 $key = $keys[$id];
                 unset($keys[$id]);
-                yield $key => $f($key, $value, true);
+                yield $key => ($this->createCacheItem)($key, $value, true);
             }
         } catch (\Exception $e) {
             CacheItem::log($this->logger, 'Failed to fetch requested items', array('keys' => array_values($keys), 'exception' => $e));
         }
 
         foreach ($keys as $key) {
-            yield $key => $f($key, null, false);
+            yield $key => ($this->createCacheItem)($key, null, false);
         }
     }
 }

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -70,9 +70,8 @@ class ArrayAdapter implements AdapterInterface, LoggerAwareInterface, Resettable
             $this->values[$key] = $value = null;
             $isHit = false;
         }
-        $f = $this->createCacheItem;
 
-        return $f($key, $value, $isHit);
+        return ($this->createCacheItem)($key, $value, $isHit);
     }
 
     /**

--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -41,9 +41,7 @@ class NullAdapter implements AdapterInterface
      */
     public function getItem($key)
     {
-        $f = $this->createCacheItem;
-
-        return $f($key);
+        return ($this->createCacheItem)($key);
     }
 
     /**
@@ -112,10 +110,8 @@ class NullAdapter implements AdapterInterface
 
     private function generateItems(array $keys)
     {
-        $f = $this->createCacheItem;
-
         foreach ($keys as $key) {
-            yield $key => $f($key);
+            yield $key => ($this->createCacheItem)($key);
         }
     }
 }

--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -110,9 +110,7 @@ class PhpArrayAdapter implements AdapterInterface, PruneableInterface, Resettabl
             }
         }
 
-        $f = $this->createCacheItem;
-
-        return $f($key, $value, $isHit);
+        return ($this->createCacheItem)($key, $value, $isHit);
     }
 
     /**
@@ -233,7 +231,6 @@ class PhpArrayAdapter implements AdapterInterface, PruneableInterface, Resettabl
      */
     private function generateItems(array $keys)
     {
-        $f = $this->createCacheItem;
         $fallbackKeys = array();
 
         foreach ($keys as $key) {
@@ -241,17 +238,17 @@ class PhpArrayAdapter implements AdapterInterface, PruneableInterface, Resettabl
                 $value = $this->values[$key];
 
                 if ('N;' === $value) {
-                    yield $key => $f($key, null, true);
+                    yield $key => ($this->createCacheItem)($key, null, true);
                 } elseif (is_string($value) && isset($value[2]) && ':' === $value[1]) {
                     try {
-                        yield $key => $f($key, unserialize($value), true);
+                        yield $key => ($this->createCacheItem)($key, unserialize($value), true);
                     } catch (\Error $e) {
-                        yield $key => $f($key, null, false);
+                        yield $key => ($this->createCacheItem)($key, null, false);
                     } catch (\Exception $e) {
-                        yield $key => $f($key, null, false);
+                        yield $key => ($this->createCacheItem)($key, null, false);
                     }
                 } else {
-                    yield $key => $f($key, $value, true);
+                    yield $key => ($this->createCacheItem)($key, $value, true);
                 }
             } else {
                 $fallbackKeys[] = $key;

--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -59,10 +59,9 @@ class ProxyAdapter implements AdapterInterface, PruneableInterface, ResettableIn
      */
     public function getItem($key)
     {
-        $f = $this->createCacheItem;
         $item = $this->pool->getItem($this->getId($key));
 
-        return $f($key, $item);
+        return ($this->createCacheItem)($key, $item);
     }
 
     /**
@@ -160,14 +159,12 @@ class ProxyAdapter implements AdapterInterface, PruneableInterface, ResettableIn
 
     private function generateItems($items)
     {
-        $f = $this->createCacheItem;
-
         foreach ($items as $key => $item) {
             if ($this->namespaceLen) {
                 $key = substr($key, $this->namespaceLen);
             }
 
-            yield $key => $f($key, $item);
+            yield $key => ($this->createCacheItem)($key, $item);
         }
     }
 

--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -111,9 +111,8 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
                 $tags[$k] = $tag.static::TAGS_PREFIX;
             }
         }
-        $f = $this->invalidateTags;
 
-        return $f($this->tags, $tags);
+        return ($this->invalidateTags)($this->tags, $tags);
     }
 
     /**
@@ -252,14 +251,12 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
                 }
             }
 
-            $f = $this->getTagsByKey;
-            $tagsByKey = $f($items);
+            $tagsByKey = ($this->getTagsByKey)($items);
             $this->deferred = array();
             $tagVersions = $this->getTagVersions($tagsByKey);
-            $f = $this->createCacheItem;
 
             foreach ($tagsByKey as $key => $tags) {
-                $this->pool->saveDeferred($f(static::TAGS_PREFIX.$key, array_intersect_key($tagVersions, $tags), $items[$key]));
+                $this->pool->saveDeferred(($this->createCacheItem)(static::TAGS_PREFIX.$key, array_intersect_key($tagVersions, $tags), $items[$key]));
             }
         }
 
@@ -274,11 +271,10 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
     private function generateItems($items, array $tagKeys)
     {
         $bufferedItems = $itemTags = array();
-        $f = $this->setCacheItemTags;
 
         foreach ($items as $key => $item) {
             if (!$tagKeys) {
-                yield $key => $f($item, static::TAGS_PREFIX.$key, $itemTags);
+                yield $key => ($this->setCacheItemTags)($item, static::TAGS_PREFIX.$key, $itemTags);
                 continue;
             }
             if (!isset($tagKeys[$key])) {
@@ -303,7 +299,7 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
                 $tagVersions = $tagKeys = null;
 
                 foreach ($bufferedItems as $key => $item) {
-                    yield $key => $f($item, static::TAGS_PREFIX.$key, $itemTags);
+                    yield $key => ($this->setCacheItemTags)($item, static::TAGS_PREFIX.$key, $itemTags);
                 }
                 $bufferedItems = null;
             }

--- a/src/Symfony/Component/Cache/Simple/Psr6Cache.php
+++ b/src/Symfony/Component/Cache/Simple/Psr6Cache.php
@@ -43,9 +43,8 @@ class Psr6Cache implements CacheInterface, PruneableInterface, ResettableInterfa
                     } else {
                         CacheItem::validateKey($key);
                     }
-                    $f = $this->createCacheItem;
 
-                    return $f($key, $value, false);
+                    return ($this->createCacheItem)($key, $value, false);
                 },
                 $pool,
                 AbstractAdapter::class
@@ -75,8 +74,8 @@ class Psr6Cache implements CacheInterface, PruneableInterface, ResettableInterfa
     public function set($key, $value, $ttl = null)
     {
         try {
-            if (null !== $f = $this->createCacheItem) {
-                $item = $f($key, $value);
+            if (null !== $this->createCacheItem) {
+                $item = ($this->createCacheItem)($key, $value);
             } else {
                 $item = $this->pool->getItem($key)->set($value);
             }
@@ -153,10 +152,10 @@ class Psr6Cache implements CacheInterface, PruneableInterface, ResettableInterfa
         $items = array();
 
         try {
-            if (null !== $f = $this->createCacheItem) {
+            if (null !== $this->createCacheItem) {
                 $valuesIsArray = false;
                 foreach ($values as $key => $value) {
-                    $items[$key] = $f($key, $value, true);
+                    $items[$key] = ($this->createCacheItem)($key, $value, true);
                 }
             } elseif ($valuesIsArray) {
                 $items = array();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        |

Since PHP 7 a `\Closure` can be invoked directly, so there is no more need to assign them before.  