### PR TITLE
[TwigBridge] Fixed the .form-check-input class in the bs4 templates

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -71,7 +71,7 @@
 
 {% block checkbox_widget -%}
     {%- set parent_label_class = parent_label_class|default(label_attr.class|default('')) -%}
-    {%- set attr = attr|merge({class: attr.class|default('form-check-input')}) -%}
+    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
     {% if 'checkbox-inline' in parent_label_class %}
         {{- form_label(form, null, { widget: parent() }) -}}
     {% else -%}
@@ -83,7 +83,7 @@
 
 {% block radio_widget -%}
     {%- set parent_label_class = parent_label_class|default(label_attr.class|default('')) -%}
-    {%- set attr = attr|merge({class: attr.class|default('form-check-input')}) -%}
+    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
     {%- if 'radio-inline' in parent_label_class -%}
         {{- form_label(form, null, { widget: parent() }) -}}
     {%- else -%}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -24,7 +24,7 @@
         "symfony/asset": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
-        "symfony/form": "~3.4-beta2|~4.0-beta2",
+        "symfony/form": "~3.4|~4.0",
         "symfony/http-foundation": "^3.3.11|~4.0",
         "symfony/http-kernel": "~3.2|~4.0",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -41,7 +41,7 @@
         "symfony/web-link": "~3.3|~4.0"
     },
     "conflict": {
-        "symfony/form": "<3.4",
+        "symfony/form": "<3.4-beta4|~4.0,<4.0-beta4",
         "symfony/console": "<3.4"
     },
     "suggest": {

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
@@ -164,7 +164,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
             [.=" [trans]Name[/trans]"]
             [@class="form-check-label required"]
             [
-                ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class"][@checked="checked"][@value="1"]
+                ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class form-check-input"][@checked="checked"][@value="1"]
             ]
     ]
 '
@@ -242,7 +242,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./label
             [.=" [trans]Name[/trans]"]
             [
-                ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class"][not(@checked)]
+                ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class form-check-input"][not(@checked)]
             ]
     ]
 '
@@ -262,7 +262,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./label
             [.=" [trans]Name[/trans]"]
             [
-                ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class"][@value="foo&bar"]
+                ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class form-check-input"][@value="foo&bar"]
             ]
     ]
 '
@@ -487,7 +487,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
                 ./label
                     [.=" [trans]Choice&B[/trans]"]
                     [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)][@class="foo&bar"]
+                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)][@class="foo&bar form-check-input"]
                     ]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
@@ -863,7 +863,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
                 ./label
                     [.=" [trans]Choice&B[/trans]"]
                     [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)][@class="foo&bar"]
+                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)][@class="foo&bar form-check-input"]
                     ]
             ]
         /following-sibling::div
@@ -896,7 +896,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
                     [@id="my&id"]
                     [@type="radio"]
                     [@name="name"]
-                    [@class="my&class"]
+                    [@class="my&class form-check-input"]
                     [@checked="checked"]
                     [@value="1"]
             ]
@@ -920,7 +920,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
                     [@id="my&id"]
                     [@type="radio"]
                     [@name="name"]
-                    [@class="my&class"]
+                    [@class="my&class form-check-input"]
                     [not(@checked)]
             ]
     ]
@@ -945,7 +945,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
                     [@id="my&id"]
                     [@type="radio"]
                     [@name="name"]
-                    [@class="my&class"]
+                    [@class="my&class form-check-input"]
                     [@value="foo&bar"]
             ]
     ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

If I am not mistaken, the `form-check-input` class should always be present in inputs of checkboxes and radios