### PR TITLE
[HttpFoundation] Prevent PHP from sending Last-Modified on session start

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -32,6 +32,9 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
     public function open($savePath, $sessionName)
     {
         $this->sessionName = $sessionName;
+        if (!headers_sent() && !ini_get('session.cache_limiter')) {
+            header(sprintf('Cache-Control: max-age=%d, private, must-revalidate', 60 * (int) ini_get('session.cache_expire')));
+        }
 
         return true;
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -107,7 +107,7 @@ class NativeSessionStorage implements SessionStorageInterface
         }
 
         $options += array(
-            'cache_limiter' => 'private_no_expire',
+            'cache_limiter' => '',
             'cache_expire' => 0,
             'use_cookies' => 1,
             'lazy_write' => 1,

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/common.inc
@@ -38,14 +38,13 @@ ini_set('session.use_strict_mode', 1);
 ini_set('session.lazy_write', 1);
 ini_set('session.name', 'sid');
 ini_set('session.save_path', __DIR__);
-ini_set('session.cache_limiter', 'private_no_expire');
+ini_set('session.cache_limiter', '');
 
 header_remove('X-Powered-By');
 header('Content-Type: text/plain; charset=utf-8');
 
 register_shutdown_function(function () {
     echo "\n";
-    header_remove('Last-Modified');
     session_write_close();
     print_r(headers_list());
     echo "shutdown\n";

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/empty_destroys.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/empty_destroys.expected
@@ -11,7 +11,7 @@ close
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: private, max-age=10800
+    [1] => Cache-Control: max-age=10800, private, must-revalidate
     [2] => Set-Cookie: sid=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0; path=/; secure; HttpOnly
 )
 shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/read_only.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/read_only.expected
@@ -9,6 +9,6 @@ close
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: private, max-age=10800
+    [1] => Cache-Control: max-age=10800, private, must-revalidate
 )
 shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/regenerate.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/regenerate.expected
@@ -18,7 +18,7 @@ close
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: private, max-age=10800
+    [1] => Cache-Control: max-age=10800, private, must-revalidate
     [2] => Set-Cookie: sid=random_session_id; path=/; secure; HttpOnly
 )
 shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/storage.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/storage.expected
@@ -15,6 +15,6 @@ $_SESSION is not empty
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: private, max-age=0
+    [1] => Cache-Control: max-age=0, private, must-revalidate
 )
 shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/with_cookie.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/with_cookie.expected
@@ -9,7 +9,7 @@ close
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
-    [1] => Cache-Control: private, max-age=10800
+    [1] => Cache-Control: max-age=10800, private, must-revalidate
     [2] => Set-Cookie: abc=def
 )
 shutdown

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -150,7 +150,7 @@ class NativeSessionStorageTest extends TestCase
         $this->iniSet('session.cache_limiter', 'nocache');
 
         $storage = new NativeSessionStorage();
-        $this->assertEquals('private_no_expire', ini_get('session.cache_limiter'));
+        $this->assertEquals('', ini_get('session.cache_limiter'));
     }
 
     public function testExplicitSessionCacheLimiter()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24849
| License       | MIT
| Doc PR        | -

I really don't know why PHP sends this Last-Modified header.
Let's bypass that and throw headers ourselves instead.