### PR TITLE
[FrameworkBundle] Fine-tune generated annotations.php cache

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -27,16 +27,18 @@ use Symfony\Component\Cache\DoctrineProvider;
 class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
 {
     private $annotationReader;
+    private $excludeRegexp;
 
     /**
      * @param Reader                 $annotationReader
      * @param string                 $phpArrayFile     The PHP file where annotations are cached
      * @param CacheItemPoolInterface $fallbackPool     The pool where runtime-discovered annotations are cached
      */
-    public function __construct(Reader $annotationReader, $phpArrayFile, CacheItemPoolInterface $fallbackPool)
+    public function __construct(Reader $annotationReader, $phpArrayFile, CacheItemPoolInterface $fallbackPool, $excludeRegexp = null)
     {
         parent::__construct($phpArrayFile, $fallbackPool);
         $this->annotationReader = $annotationReader;
+        $this->excludeRegexp = $excludeRegexp;
     }
 
     /**
@@ -54,6 +56,9 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         $reader = new CachedReader($this->annotationReader, new DoctrineProvider($arrayAdapter));
 
         foreach ($annotatedClasses as $class) {
+            if (null !== $this->excludeRegexp && preg_match($this->excludeRegexp, $class)) {
+                continue;
+            }
             try {
                 $this->readAllComponents($reader, $class);
             } catch (\ReflectionException $e) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -310,6 +310,7 @@ class FrameworkExtension extends Extension
             '**\\Entity\\',
 
             // Added explicitly so that we don't rely on the class map being dumped to make it work
+            'Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController',
             'Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller',
         ));
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -37,6 +37,7 @@
             <argument type="service" id="annotations.reader" />
             <argument>%kernel.cache_dir%/annotations.php</argument>
             <argument type="service" id="cache.annotations" />
+            <argument>#^Symfony\\(?:Component\\HttpKernel\\|Bundle\\FrameworkBundle\\Controller\\(?!AbstractController$|Controller$))#</argument>
         </service>
 
         <service id="annotations.cache" class="Symfony\Component\Cache\DoctrineProvider">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I noticed that the `annotations.php` file generated by `AnnotationsCacheWarmer` contains some noise.
This PR removes it.