### PR TITLE
[ExpressionLanguage] Fixed PhpDoc type-hints on Token value

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -116,6 +116,14 @@ class ExpressionLanguageTest extends TestCase
         $this->assertSame('($a + $B)', $result);
     }
 
+    public function testStrictEquality()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $expression = '123 === a';
+        $result = $expressionLanguage->compile($expression, array('a'));
+        $this->assertSame('(123 === $a)', $result);
+    }
+
     public function testCachingWithDifferentNamesOrder()
     {
         $cacheMock = $this->getMockBuilder('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface')->getMock();

--- a/src/Symfony/Component/ExpressionLanguage/Token.php
+++ b/src/Symfony/Component/ExpressionLanguage/Token.php
@@ -30,9 +30,9 @@ class Token
     const PUNCTUATION_TYPE = 'punctuation';
 
     /**
-     * @param string $type   The type of the token (self::*_TYPE)
-     * @param string $value  The token value
-     * @param int    $cursor The cursor position in the source
+     * @param string                $type   The type of the token (self::*_TYPE)
+     * @param string|int|float|null $value  The token value
+     * @param int                   $cursor The cursor position in the source
      */
     public function __construct($type, $value, $cursor)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Fixed PhpDoc type-hints on Token value and added test to prevent BC with Parser when treating numbers (example `a === 123` compile as `$a === "123"`)