### PR TITLE
[FrameworkBundle] Specifically inject the debug dispatcher in the collector

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -36,7 +36,7 @@
 
         <service id="data_collector.events" class="%data_collector.events.class%" public="false">
             <tag name="data_collector" template="@WebProfiler/Collector/events.html.twig" id="events" priority="255" />
-            <argument type="service" id="event_dispatcher" on-invalid="ignore" />
+            <argument type="service" id="debug.event_dispatcher" on-invalid="ignore" />
         </service>
 
         <service id="data_collector.logger" class="%data_collector.logger.class%" public="false">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This ensures we always collect data about events, even when the `event_dispatcher` service is decorated, no matter the decoration order.