### PR TITLE
[FrameworkBundle] add a notice when passing a routerInterface without warmupInterface in RouterCacheWarmer

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -12,6 +12,11 @@ EventDispatcher
 
  * The `TraceableEventDispatcherInterface` has been deprecated and will be removed in 5.0.
 
+FrameworkBundle
+---------------
+
+ * A `RouterInterface` that does not implement the `WarmableInterface` is deprecated and will not be supported in Symfony 5.0.
+
 HttpFoundation
 --------------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -11,11 +11,15 @@ EventDispatcher
 
  * The `TraceableEventDispatcherInterface` has been removed.
 
+FrameworkBundle
+---------------
+
+ * Using a `RouterInterface` that does not implement the `WarmableInterface` is not supported anymore.
+
 HttpFoundation
 --------------
 
  * The `$size` argument of the `UploadedFile` constructor has been removed.
-
  * The `getClientSize()` method of the `UploadedFile` class has been removed.
 
 Security

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,8 +7,9 @@ CHANGELOG
  * Allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
  * Added a new `parameter_bag` service with related autowiring aliases to access parameters as-a-service
  * Allowed the `Router` to work with any PSR-11 container
- * added option in workflow dump command to label graph with a custom label
-
+ * Added option in workflow dump command to label graph with a custom label
+ * Using a `RouterInterface` that does not implement the `WarmableInterface` is deprecated and will not be supported in Symfony 5.0.
+ 
 4.0.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
@@ -45,7 +45,11 @@ class RouterCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInterf
 
         if ($router instanceof WarmableInterface) {
             $router->warmUp($cacheDir);
+
+            return;
         }
+
+        @trigger_error(sprintf('Passing a %s without implementing %s is deprecated since Symfony 4.1.', RouterInterface::class, WarmableInterface::class), \E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/RouterCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/RouterCacheWarmerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class RouterCacheWarmerTest extends TestCase
+{
+    public function testWarmUpWithWarmebleInterface()
+    {
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->setMethods(array('get', 'has'))->getMock();
+
+        $routerMock = $this->getMockBuilder(testRouterInterfaceWithWarmebleInterface::class)->setMethods(array('match', 'generate', 'getContext', 'setContext', 'getRouteCollection', 'warmUp'))->getMock();
+        $containerMock->expects($this->any())->method('get')->with('router')->willReturn($routerMock);
+        $routerCacheWarmer = new RouterCacheWarmer($containerMock);
+
+        $routerCacheWarmer->warmUp('/tmp');
+        $routerMock->expects($this->any())->method('warmUp')->with('/tmp')->willReturn('');
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @expectedDeprecation Passing a Symfony\Component\Routing\RouterInterface without implementing Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface is deprecated since Symfony 4.1.
+     * @group legacy
+     */
+    public function testWarmUpWithoutWarmebleInterface()
+    {
+        $containerMock = $this->getMockBuilder(ContainerInterface::class)->setMethods(array('get', 'has'))->getMock();
+
+        $routerMock = $this->getMockBuilder(testRouterInterfaceWithoutWarmebleInterface::class)->setMethods(array('match', 'generate', 'getContext', 'setContext', 'getRouteCollection'))->getMock();
+        $containerMock->expects($this->any())->method('get')->with('router')->willReturn($routerMock);
+        $routerCacheWarmer = new RouterCacheWarmer($containerMock);
+        $routerCacheWarmer->warmUp('/tmp');
+    }
+}
+
+interface testRouterInterfaceWithWarmebleInterface extends RouterInterface, WarmableInterface
+{
+}
+
+interface testRouterInterfaceWithoutWarmebleInterface extends RouterInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yesish
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #23403
| License       | MIT
| Doc PR        | none

I'm adding a test to RouterCacheWarmer since there were none.
