### PR TITLE
Add CODE_OF_CONDUCT.md

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows a [Code of Conduct][code_of_conduct] in order to ensure an open and welcoming environment.
+Please read the full text for understanding the accepted and unaccepted behavior.
+Please read also the [reporting guidelines][guidelines], in case you encountered or witnessed any misbehavior.
+
+[code_of_conduct]: https://symfony.com/doc/current/contributing/code_of_conduct/index.html
+[guidelines]: https://symfony.com/doc/current/contributing/code_of_conduct/reporting_guidelines.html


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

GitHub allows specifying a code of conduct for an open source project https://help.github.com/articles/adding-a-code-of-conduct-to-your-project/

The rule set seems maybe obvious, but it's good to have it included.

I've adopted the version http://contributor-covenant.org/version/1/4/ with the email coc@sensiolabs.com

Moved initial proposal to https://github.com/symfony/symfony-docs/pull/9394
  