### PR TITLE
IBAN validator now accept Costa Rica IBAN with zero. (https://en.wiki…

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -58,7 +58,7 @@ class IbanValidator extends ConstraintValidator
         'CH' => 'CH\d{2}\d{5}[\dA-Z]{12}', // Switzerland
         'CI' => 'CI\d{2}[A-Z]{1}\d{23}', // Ivory Coast
         'CM' => 'CM\d{2}\d{23}', // Cameron
-        'CR' => 'CR\d{2}?0?\d{3}\d{14}', // Costa Rica
+        'CR' => 'CR\d{2}0\d{3}\d{14}', // Costa Rica
         'CV' => 'CV\d{2}\d{21}', // Cape Verde
         'CY' => 'CY\d{2}\d{3}\d{5}[\dA-Z]{16}', // Cyprus
         'CZ' => 'CZ\d{2}\d{20}', // Czech Republic

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -50,6 +50,7 @@ class IbanValidator extends ConstraintValidator
         'BG' => 'BG\d{2}[A-Z]{4}\d{4}\d{2}[\dA-Z]{8}', // Bulgaria
         'BH' => 'BH\d{2}[A-Z]{4}[\dA-Z]{14}', // Bahrain
         'BI' => 'BI\d{2}\d{12}', // Burundi
+        'BY' => 'BY\d{2}[\dA-Z]{4}\d{4}[\dA-Z]{16}', // Belarus - https://bank.codes/iban/structure/belarus/
         'BJ' => 'BJ\d{2}[A-Z]{1}\d{23}', // Benin
         'BL' => 'FR\d{2}\d{5}\d{5}[\dA-Z]{11}\d{2}', // Saint Barthelemy
         'BR' => 'BR\d{2}\d{8}\d{5}\d{10}[A-Z][\dA-Z]', // Brazil

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -57,7 +57,7 @@ class IbanValidator extends ConstraintValidator
         'CH' => 'CH\d{2}\d{5}[\dA-Z]{12}', // Switzerland
         'CI' => 'CI\d{2}[A-Z]{1}\d{23}', // Ivory Coast
         'CM' => 'CM\d{2}\d{23}', // Cameron
-        'CR' => 'CR\d{2}\d{3}\d{14}', // Costa Rica
+        'CR' => 'CR\d{2}?0?\d{3}\d{14}', // Costa Rica
         'CV' => 'CV\d{2}\d{21}', // Cape Verde
         'CY' => 'CY\d{2}\d{3}\d{5}[\dA-Z]{16}', // Cyprus
         'CZ' => 'CZ\d{2}\d{20}', // Czech Republic

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -133,6 +133,7 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
             array('FR7630007000110009970004942'), //Central African Republic
             array('CG5230011000202151234567890'), //Congo
             array('CR0515202001026284066'), //Costa Rica
+            array('CR05015202001026284066'), //Costa Rica with zero
             array('DO28BAGR00000001212453611324'), //Dominican Republic
             array('GT82TRAJ01020000001210029690'), //Guatemala
             array('IR580540105180021273113007'), //Iran

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -133,8 +133,7 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
             array('CV64000300004547069110176'), //Cape Verde
             array('FR7630007000110009970004942'), //Central African Republic
             array('CG5230011000202151234567890'), //Congo
-            array('CR0515202001026284066'), //Costa Rica
-            array('CR05015202001026284066'), //Costa Rica with zero
+            array('CR05015202001026284066'), //Costa Rica
             array('DO28BAGR00000001212453611324'), //Dominican Republic
             array('GT82TRAJ01020000001210029690'), //Guatemala
             array('IR580540105180021273113007'), //Iran
@@ -185,7 +184,7 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
             array('BA39 1290 0794 0102 8494 4'), //Bosnia and Herzegovina
             array('BG80 BNBG 9661 1020 3456 7'), //Bulgaria
             array('BG80 B2BG 9661 1020 3456 78'), //Bulgaria
-            array('BY 13 NBRB 3600 900000002Z00AB002'), //Bulgaria
+            array('BY 13 NBRB 3600 900000002Z00AB002'), //Belarus
             array('HR12 1001 0051 8630 0016 01'), //Croatia
             array('CY17 0020 0128 0000 0012 0052 7600 1'), //Cyprus
             array('CZ65 0800 0000 1920 0014 5399 1'), //Czech Republic

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -68,6 +68,7 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
             array('BE62 5100 0754 7061'), //Belgium
             array('BA39 1290 0794 0102 8494'), //Bosnia and Herzegovina
             array('BG80 BNBG 9661 1020 3456 78'), //Bulgaria
+            array('BY 13 NBRB 3600 900000002Z00AB00'), //Belarus
             array('HR12 1001 0051 8630 0016 0'), //Croatia
             array('CY17 0020 0128 0000 0012 0052 7600'), //Cyprus
             array('CZ65 0800 0000 1920 0014 5399'), //Czech Republic
@@ -184,6 +185,7 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
             array('BA39 1290 0794 0102 8494 4'), //Bosnia and Herzegovina
             array('BG80 BNBG 9661 1020 3456 7'), //Bulgaria
             array('BG80 B2BG 9661 1020 3456 78'), //Bulgaria
+            array('BY 13 NBRB 3600 900000002Z00AB002'), //Bulgaria
             array('HR12 1001 0051 8630 0016 01'), //Croatia
             array('CY17 0020 0128 0000 0012 0052 7600 1'), //Cyprus
             array('CZ65 0800 0000 1920 0014 5399 1'), //Czech Republic


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

According [wikipedia](https://en.wikipedia.org/wiki/International_Bank_Account_Number) IBAN format for Costa Rica is 

CRkk 0bbb cccc cccc cccc cc 
where 
0= always zero
b = bank code
c = Account number