### PR TITLE
[Bridge/ProxyManager] Remove direct reference to value holder property

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -93,7 +93,11 @@ EOF;
      */
     public function getProxyCode(Definition $definition)
     {
-        return $this->classGenerator->generate($this->generateProxyClass($definition));
+        return preg_replace(
+            '/(\$this->initializer[0-9a-f]++) && \1->__invoke\(\$this->(valueHolder[0-9a-f]++), (.*?), \1\);/',
+            '$1 && ($1->__invoke(\$$2, $3, $1) || 1) && $this->$2 = \$$2;',
+            $this->classGenerator->generate($this->generateProxyClass($definition))
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23110
| License       | MIT
| Doc PR        | -

This fixes https://github.com/Ocramius/ProxyManager/issues/394 on Symfony's side, because proxy-manager v1 is not maintained anymore, but is the only one that works on PHP 5.3/5.5, which we still support.
Cannot be tested easily (but code is run by the existing test suite.)