### PR TITLE
[WebServerBundle] Prevent console.terminate from being fired when server:start finishes

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * Runs a local web server in a background process.
@@ -131,6 +132,10 @@ EOF
         if ('prod' === $env) {
             $io->error('Running this server in production environment is NOT recommended!');
         }
+
+        // replace event dispatcher with an empty one to prevent console.terminate from firing
+        // as container could have changed between start and stop
+        $this->getApplication()->setDispatcher(new EventDispatcher());
 
         try {
             $server = new WebServer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24885 
| License       | MIT
| Doc PR        | n/a

When the cache is cleared between `server:start` and `server:stop` the container used in `server:start` is no longer valid. Firing the `console.terminate` event throws an exception. This PR clears the event dispatcher so `console.terminate` is not fired.