### PR TITLE
[HttpKernel][Debug] Remove noise from stack frames of deprecations

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -707,7 +707,7 @@ class ErrorHandler
         }
         if (!($throw || $this->scopedErrors & $type)) {
             for ($i = 0; isset($lightTrace[$i]); ++$i) {
-                unset($lightTrace[$i]['args']);
+                unset($lightTrace[$i]['args'], $lightTrace[$i]['object']);
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -86,7 +86,7 @@ class DebugHandlersListener implements EventSubscriberInterface
                         $handler->screamAt($levels);
                     }
                     if ($this->scope) {
-                        $handler->scopeAt($this->levels);
+                        $handler->scopeAt($levels & ~E_USER_DEPRECATED & ~E_DEPRECATED);
                     } else {
                         $handler->scopeAt(0, true);
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24625
| License       | MIT
| Doc PR        | -

Collecting arguments of deprecations is too heavy, and was unintended in fact.