### PR TITLE
[SecurityBundle] Add missing quotes in deprecation messages

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
@@ -46,7 +46,7 @@ class AddSecurityVotersPass implements CompilerPassInterface
             $class = $container->getParameterBag()->resolveValue($definition->getClass());
 
             if (!is_a($class, VoterInterface::class, true)) {
-                @trigger_error(sprintf('Using a security.voter tag on a class without implementing the %1$s is deprecated as of 3.4 and will be removed in 4.0. Implement the %1$s instead.', VoterInterface::class), E_USER_DEPRECATED);
+                @trigger_error(sprintf('Using a "security.voter" tag on a class without implementing the "%s" is deprecated as of 3.4 and will be removed in 4.0. Implement the interface instead.', VoterInterface::class), E_USER_DEPRECATED);
             }
 
             if (!method_exists($class, 'vote')) {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
@@ -28,7 +28,7 @@ class HttpDigestFactory implements SecurityFactoryInterface
     public function __construct($triggerDeprecation = true)
     {
         if ($triggerDeprecation) {
-            @trigger_error(sprintf('The %s class and the whole HTTP digest authentication system is deprecated since 3.4 and will be removed in 4.0.', __CLASS__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "%s" class and the whole HTTP digest authentication system is deprecated since 3.4 and will be removed in 4.0.', __CLASS__), E_USER_DEPRECATED);
         }
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -280,7 +280,7 @@ class SecurityExtension extends Extension
             }
 
             if (!isset($firewall['logout_on_user_change']) || !$firewall['logout_on_user_change']) {
-                @trigger_error('Setting logout_on_user_change to false is deprecated as of 3.4 and will always be true in 4.0. Set logout_on_user_change to true in your firewall configuration.', E_USER_DEPRECATED);
+                @trigger_error('Setting "logout_on_user_change" to false is deprecated as of 3.4 and will always be true in 4.0. Set it to true in your firewall configuration.', E_USER_DEPRECATED);
             }
 
             $contextListenerDefinition->addMethodCall('setLogoutOnUserChange', array($firewall['logout_on_user_change']));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
@@ -72,7 +72,7 @@ class AddSecurityVotersPassTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Using a security.voter tag on a class without implementing the Symfony\Component\Security\Core\Authorization\Voter\VoterInterface is deprecated as of 3.4 and will be removed in 4.0. Implement the Symfony\Component\Security\Core\Authorization\Voter\VoterInterface instead.
+     * @expectedDeprecation Using a "security.voter" tag on a class without implementing the "Symfony\Component\Security\Core\Authorization\Voter\VoterInterface" is deprecated as of 3.4 and will be removed in 4.0. Implement the interface instead.
      */
     public function testVoterMissingInterface()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -125,7 +125,7 @@ class SecurityExtensionTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Setting logout_on_user_change to false is deprecated as of 3.4 and will always be true in 4.0. Set logout_on_user_change to true in your firewall configuration.
+     * @expectedDeprecation Setting "logout_on_user_change" to false is deprecated as of 3.4 and will always be true in 4.0. Set it to true in your firewall configuration.
      */
     public function testDeprecationForUserLogout()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Quotes in deprecation messages allow prettier display in the profiler panel (quoted strings are in bold).
We should be more careful when writing/merging deprecation messages, as there are much more that are missing useful quotes (help welcomed, starting from 3.3).