### PR TITLE
[Debug] Remove false-positive deprecation from DebugClassLoader

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -31,7 +31,6 @@ class DebugClassLoader
     private static $final = array();
     private static $finalMethods = array();
     private static $deprecated = array();
-    private static $deprecatedMethods = array();
     private static $internal = array();
     private static $internalMethods = array();
     private static $php7Reserved = array('int', 'float', 'bool', 'string', 'true', 'false', 'null');
@@ -204,12 +203,11 @@ class DebugClassLoader
                 }
             }
 
-            // Inherit @final and @deprecated annotations for methods
+            // Inherit @final and @internal annotations for methods
             self::$finalMethods[$name] = array();
-            self::$deprecatedMethods[$name] = array();
             self::$internalMethods[$name] = array();
             foreach ($parentAndTraits as $use) {
-                foreach (array('finalMethods', 'deprecatedMethods', 'internalMethods') as $property) {
+                foreach (array('finalMethods', 'internalMethods') as $property) {
                     if (isset(self::${$property}[$use])) {
                         self::${$property}[$name] = array_merge(self::${$property}[$name], self::${$property}[$use]);
                     }
@@ -233,12 +231,6 @@ class DebugClassLoader
                 }
 
                 foreach ($parentAndTraits as $use) {
-                    if (isset(self::$deprecatedMethods[$use][$method->name])) {
-                        list($declaringClass, $message) = self::$deprecatedMethods[$use][$method->name];
-                        if (strncmp($ns, $declaringClass, $len)) {
-                            @trigger_error(sprintf('The "%s::%s()" method is deprecated%s. You should not extend it from "%s".', $declaringClass, $method->name, $message, $name), E_USER_DEPRECATED);
-                        }
-                    }
                     if (isset(self::$internalMethods[$use][$method->name])) {
                         list($declaringClass, $message) = self::$internalMethods[$use][$method->name];
                         if (strncmp($ns, $declaringClass, $len)) {
@@ -252,7 +244,7 @@ class DebugClassLoader
                     continue;
                 }
 
-                foreach (array('final', 'deprecated', 'internal') as $annotation) {
+                foreach (array('final', 'internal') as $annotation) {
                     if (false !== strpos($doc, '@'.$annotation) && preg_match('#\n\s+\* @'.$annotation.'(?:( .+?)\.?)?\r?\n\s+\*(?: @|/$)#s', $doc, $notice)) {
                         $message = isset($notice[1]) ? preg_replace('#\s*\r?\n \* +#', ' ', $notice[1]) : '';
                         self::${$annotation.'Methods'}[$name][$method->name] = array($name, $message);

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -332,7 +332,7 @@ class DebugClassLoaderTest extends TestCase
         $this->assertSame($xError, $lastError);
     }
 
-    public function testExtendedDeprecatedMethod()
+    public function testExtendedDeprecatedMethodDoesntTriggerAnyNotice()
     {
         set_error_handler(function () { return false; });
         $e = error_reporting(0);
@@ -346,12 +346,7 @@ class DebugClassLoaderTest extends TestCase
         $lastError = error_get_last();
         unset($lastError['file'], $lastError['line']);
 
-        $xError = array(
-            'type' => E_USER_DEPRECATED,
-            'message' => 'The "Symfony\Component\Debug\Tests\Fixtures\AnnotatedClass::deprecatedMethod()" method is deprecated since version 3.4. You should not extend it from "Test\Symfony\Component\Debug\Tests\ExtendsAnnotatedClass".',
-        );
-
-        $this->assertSame($xError, $lastError);
+        $this->assertSame(array('type' => E_USER_NOTICE, 'message' => ''), $lastError);
     }
 
     public function testInternalsUse()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

A fully up to date 3.4 standard edition still triggers deprecation notices such as
> The "Twig_Extension::getName()" method is deprecated since 1.26 (to be removed in 2.0), not used anymore internally. You should not extend it from "Symfony\Bridge\Twig\Extension\LogoutUrlExtension".

This is a false positive: extending a deprecated method is OK, unless you call the parent, which is another BC layer that should itself trigger the deprecation.