### PR TITLE
[Bridge\PhpUnit] Use phpdbg instead of xdebug in tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -16,20 +16,24 @@ class CoverageListenerTest extends TestCase
             $this->markTestSkipped('This test cannot be run on HHVM.');
         }
 
-        exec('php --ri xdebug -d zend_extension=xdebug.so 2> /dev/null', $output, $returnCode);
-        if (0 !== $returnCode) {
-            $this->markTestSkipped('Xdebug is required to run this test.');
+        if (\PHP_VERSION_ID >= 70000) {
+            $php = 'phpdbg -qrr';
+        } else {
+            exec('php --ri xdebug -d zend_extension=xdebug.so 2> /dev/null', $output, $returnCode);
+            if (0 !== $returnCode) {
+                $this->markTestSkipped('Xdebug is required to run this test.');
+            }
+            $php = 'php -d zend_extension=xdebug.so';
         }
 
         $dir = __DIR__.'/../Tests/Fixtures/coverage';
-        $php = PHP_BINARY;
         $phpunit = $_SERVER['argv'][0];
 
-        exec("$php -d zend_extension=xdebug.so $phpunit -c $dir/phpunit-without-listener.xml.dist $dir/tests/ --coverage-text", $output);
+        exec("$php $phpunit -c $dir/phpunit-without-listener.xml.dist $dir/tests/ --coverage-text", $output);
         $output = implode("\n", $output);
         $this->assertContains('FooCov', $output);
 
-        exec("$php -d zend_extension=xdebug.so $phpunit -c $dir/phpunit-with-listener.xml.dist $dir/tests/ --coverage-text", $output);
+        exec("$php $phpunit -c $dir/phpunit-with-listener.xml.dist $dir/tests/ --coverage-text", $output);
         $output = implode("\n", $output);
         $this->assertNotContains('FooCov', $output);
         $this->assertContains("SutNotFoundTest::test\nCould not find the tested class.", $output);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

ping @lyrixx FYI