### PR TITLE
Value could be a zero value

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
@@ -34,7 +34,7 @@ abstract class AbstractComparison extends Constraint
             $options = array();
         }
 
-        if (is_array($options) && !isset($options['value'])) {
+        if (is_array($options) && ! array_key_exists('value', $options)) {
             throw new ConstraintDefinitionException(sprintf(
                 'The %s constraint requires the "value" option to be set.',
                 get_class($this)


### PR DESCRIPTION
If I want construct a positive integer value constraint, I have : 

new Assert\GreaterThanOrEqual(array('value'=>0, 'message'=>'sample message'));

But it's failing, because isset(0) is false

It should use array_key_exists

| Q             | A
| ------------- | ---
| Branch?       | master / 2.7, 2.8, 3.3, or 3.4 <!-- see comment below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | yes/no
| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
