### PR TITLE
[FrameworkBundle] Wire the translation.reader service instead of deprecated translation.loader in commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -76,14 +76,14 @@
 
         <service id="Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand">
             <argument type="service" id="translator" />
-            <argument type="service" id="translation.loader" />
+            <argument type="service" id="translation.reader" />
             <argument type="service" id="translation.extractor" />
             <tag name="console.command" command="debug:translation" />
         </service>
 
         <service id="Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand">
             <argument type="service" id="translation.writer" />
-            <argument type="service" id="translation.loader" />
+            <argument type="service" id="translation.reader" />
             <argument type="service" id="translation.extractor" />
             <argument>%kernel.default_locale%</argument>
             <tag name="console.command" command="translation:update" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see comment below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

to get rid of the following deprec:

> The class "Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader" is deprecated since version 3.4 and will be removed in 4.0. Use "Symfony\Component\Translation\Reader\TranslationReader"