### PR TITLE
[Process] Skip ProcessTest::testSimpleInputStream() because of bug #75515 in PHP 7.2RC6

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1223,6 +1223,10 @@ class ProcessTest extends TestCase
 
     public function testSimpleInputStream()
     {
+        if (\PHP_VERSION_ID === 70200 && \PHP_EXTRA_VERSION === 'RC6') {
+            $this->markTestSkipped('See bug #75515 in PHP 7.2RC6.');
+        }
+
         $input = new InputStream();
 
         $process = $this->getProcessForCode('echo \'ping\'; stream_copy_to_stream(STDIN, STDOUT);');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Our CI hangs on 7.2 RC6 because of https://bugs.php.net/75515
Let's skip it, hoping it to be fixed with RC7.
Ping @remicollet @sgolemon FYI.