### PR TITLE
[HttpFoundation] Just skip PHP's `session_set_save_handler`, not the full `setSaveHandler`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -103,8 +103,9 @@ class NativeSessionStorage implements SessionStorageInterface
     public function __construct(array $options = array(), $handler = null, MetadataBag $metaBag = null)
     {
         $this->setMetadataBag($metaBag);
+        $this->setSaveHandler($handler);
 
-        if (\PHP_VERSION_ID >= 50400 && \PHP_SESSION_ACTIVE === session_status()) {
+        if (!$this->canUpdatePhpSession()) {
             return;
         }
 
@@ -121,7 +122,6 @@ class NativeSessionStorage implements SessionStorageInterface
         }
 
         $this->setOptions($options);
-        $this->setSaveHandler($handler);
     }
 
     /**
@@ -408,7 +408,7 @@ class NativeSessionStorage implements SessionStorageInterface
         }
         $this->saveHandler = $saveHandler;
 
-        if ($this->saveHandler instanceof \SessionHandlerInterface) {
+        if ($this->saveHandler instanceof \SessionHandlerInterface && $this->canUpdatePhpSession()) {
             if (\PHP_VERSION_ID >= 50400) {
                 session_set_save_handler($this->saveHandler, false);
             } else {
@@ -448,5 +448,15 @@ class NativeSessionStorage implements SessionStorageInterface
 
         $this->started = true;
         $this->closed = false;
+    }
+
+    /**
+     * Return true if we can update PHP's session.
+     *
+     * @return bool
+     */
+    private function canUpdatePhpSession()
+    {
+        return \PHP_VERSION_ID <= 50400 || \PHP_SESSION_ACTIVE !== session_status();
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -296,4 +296,19 @@ class NativeSessionStorageTest extends TestCase
         // Assert no exception has been thrown by `getStorage()`
         $this->addToAssertionCount(1);
     }
+
+    /**
+     * @requires PHP 5.4
+     */
+    public function testGetBagsOnceSessionStartedIsIgnored()
+    {
+        session_start();
+        $bag = new AttributeBag();
+        $bag->setName('flashes');
+
+        $storage = $this->getStorage();
+        $storage->registerBag($bag);
+
+        $this->assertEquals($storage->getBag('flashes'), $bag);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24934, 
| License       | MIT
| Doc PR        | ø

We've removed the `setSaveHandler` call while all we needed was remove the call to PHP's `session_set_save_handler` function.