### PR TITLE
[Console] Fixed exit code with non-integer throwable code

### DIFF
--- a/src/Symfony/Component/Console/Event/ConsoleErrorEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleErrorEvent.php
@@ -53,6 +53,6 @@ final class ConsoleErrorEvent extends ConsoleEvent
 
     public function getExitCode(): int
     {
-        return null !== $this->exitCode ? $this->exitCode : ($this->error->getCode() ?: 1);
+        return null !== $this->exitCode ? $this->exitCode : (is_int($this->error->getCode()) ? $this->error->getCode() : 1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The exception/error code in PHP doesn't have to be an integer:

 > Returns the exception code as integer in Exception but possibly as other type in Exception descendants (for example as string in PDOException).
> http://php.net/manual/en/exception.getcode.php#refsect1-exception.getcode-returnvalues

This means that a "Return value of Symfony\Component\Console\Event\ConsoleErrorEvent::getExitCode() must be of the type integer, string returned" error is shown when e.g. an uncatched PDOException is handled by the console error event.