### PR TITLE
[Process] Workaround PHP bug #75515 in ProcessTest::testSimpleInputStream()

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1223,13 +1223,9 @@ class ProcessTest extends TestCase
 
     public function testSimpleInputStream()
     {
-        if (\PHP_VERSION_ID === 70200 && \PHP_EXTRA_VERSION === 'RC6') {
-            $this->markTestSkipped('See bug #75515 in PHP 7.2RC6.');
-        }
-
         $input = new InputStream();
 
-        $process = $this->getProcessForCode('echo \'ping\'; stream_copy_to_stream(STDIN, STDOUT);');
+        $process = $this->getProcessForCode('echo \'ping\'; echo fread(STDIN, 4); echo fread(STDIN, 4);');
         $process->setInput($input);
 
         $process->start(function ($type, $data) use ($input) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fixes tests accounting for a bug in PHP7.2RC6