### PR TITLE
Release v2.8.30

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,11 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.30 (2017-11-13)
+
+ * bug #24952 [HttpFoundation] Fix session-related BC break (nicolas-grekas, sroze)
+ * bug #24929 [Console] Fix traversable autocomplete values (ro0NL)
+
 * 2.8.29 (2017-11-10)
 
  * bug #24888 [FrameworkBundle] Specifically inject the debug dispatcher in the collector (ogizanagi)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.30-DEV';
+    const VERSION = '2.8.30';
     const VERSION_ID = 20830;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
     const RELEASE_VERSION = 30;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';
     const END_OF_LIFE = '11/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.8.29...v2.8.30)

 * bug #24952 [HttpFoundation] Fix session-related BC break (@nicolas-grekas, @sroze)
 * bug #24929 [Console] Fix traversable autocomplete values (@ro0NL)
