### PR TITLE
Release v3.3.12

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -7,6 +7,12 @@ in 3.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.3.0...v3.3.1
 
+* 3.3.12 (2017-11-13)
+
+ * bug #24954 [DI] Fix dumping with custom base class (nicolas-grekas)
+ * bug #24952 [HttpFoundation] Fix session-related BC break (nicolas-grekas, sroze)
+ * bug #24929 [Console] Fix traversable autocomplete values (ro0NL)
+
 * 3.3.11 (2017-11-10)
 
  * bug #24888 [FrameworkBundle] Specifically inject the debug dispatcher in the collector (ogizanagi)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -61,12 +61,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
     private $projectDir;
 
-    const VERSION = '3.3.12-DEV';
+    const VERSION = '3.3.12';
     const VERSION_ID = 30312;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 3;
     const RELEASE_VERSION = 12;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2018';
     const END_OF_LIFE = '07/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.3.11...v3.3.12)

 * bug #24954 [DI] Fix dumping with custom base class (@nicolas-grekas)
 * bug #24952 [HttpFoundation] Fix session-related BC break (@nicolas-grekas, @sroze)
 * bug #24929 [Console] Fix traversable autocomplete values (@ro0NL)
