### PR TITLE
Console script addOption array exception , edit InputOption

### DIFF
--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -113,7 +113,7 @@ class InputOption
      */
     public function acceptValue()
     {
-        return $this->isValueRequired() || $this->isValueOptional();
+        return $this->isValueRequired() || $this->isValueOptional() || $this->isArray();
     }
 
     /**


### PR DESCRIPTION
Console script addOption array exception

Desc info :
Function : acceptValue()
Notes : return bool true if value mode is not self::VALUE_NONE, false
otherwise.
Add code : ```$this->isArray()```

Bug show:
Console script add code :
```
$this->addOption('option9', null, 8, 'array', [1,2,3]);
```
Output exception :
[Symfony\Component\Console\Exception\InvalidArgumentException]
Impossible to have an option mode VALUE_IS_ARRAY if the option does not
accept a value.