### PR TITLE
[HttpKernel] Fix service arg resolver for controllers as array callables

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -35,7 +35,13 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
      */
     public function supports(Request $request, ArgumentMetadata $argument)
     {
-        return is_string($controller = $request->attributes->get('_controller')) && $this->container->has($controller) && $this->container->get($controller)->has($argument->getName());
+        $controller = $request->attributes->get('_controller');
+
+        if (\is_array($controller) && \is_callable($controller, true) && \is_string($controller[0])) {
+            $controller = $controller[0].'::'.$controller[1];
+        }
+
+        return \is_string($controller) && $this->container->has($controller) && $this->container->get($controller)->has($argument->getName());
     }
 
     /**
@@ -43,6 +49,10 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
      */
     public function resolve(Request $request, ArgumentMetadata $argument)
     {
-        yield $this->container->get($request->attributes->get('_controller'))->get($argument->getName());
+        if (\is_array($controller = $request->attributes->get('_controller'))) {
+            $controller = $controller[0].'::'.$controller[1];
+        }
+
+        yield $this->container->get($controller)->get($argument->getName());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -


As spotted today during a Symfony 4 workshop at SymfonyCon Cluj, setting a controller as an array `[SomeController::class, 'helloAction']` works, it is defined as a service, BUT the actions don't get the services as arguments. This is fixing it.