### PR TITLE
[FrameworkBundle] Empty event dispatcher earlier in CacheClearCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -111,6 +111,9 @@ EOF
         $io->comment(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
         $this->cacheClearer->clear($realCacheDir);
 
+        // The current event dispatcher is stale, let's not use it anymore
+        $this->getApplication()->setDispatcher(new EventDispatcher());
+
         if ($input->getOption('no-warmup')) {
             $this->filesystem->rename($realCacheDir, $oldCacheDir);
         } else {
@@ -128,9 +131,6 @@ EOF
         }
 
         $this->filesystem->remove($oldCacheDir);
-
-        // The current event dispatcher is stale, let's not use it anymore
-        $this->getApplication()->setDispatcher(new EventDispatcher());
 
         if ($output->isVerbose()) {
             $io->comment('Finished');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Once the cache folder is emptied, the event dispatcher cannot be used because service factories are gone. This currently fails very badly when an error is dispatched, but the error listeners are themselves failing to be loaded for this reason.