### PR TITLE
[FrameworkBundle] [DI] Automatically add "setLogger" method call.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Psr\Log\LoggerAwareInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Automatically add setLogger method call to any service that implements Psr\Log\LoggerAwareInterface.
+ *
+ * @see http://www.php-fig.org/psr/psr-3/
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+class LoggerAwarePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('logger') && !$container->hasAlias('logger')) {
+            return;
+        }
+
+        $reference = new Reference('logger');
+
+        foreach ($container->getDefinitions() as $definition) {
+            if (!class_exists($definition->getClass())) {
+                continue;
+            }
+
+            $refl = new \ReflectionClass($definition->getClass());
+            if ($refl->implementsInterface(LoggerAwareInterface::class) && !$definition->hasMethodCall('setLogger')) {
+                $definition->addMethodCall('setLogger', [$reference]);
+            }
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
@@ -37,13 +37,13 @@ class LoggerAwarePass implements CompilerPassInterface
         $reference = new Reference('logger');
 
         foreach ($container->getDefinitions() as $definition) {
-            $class = $definition->getClass();
-            if (!class_exists($class) || !$definition->isAutoconfigured() || $definition->hasMethodCall('setLogger')) {
+            $class = $container->getReflectionClass($definition->getClass(), true);
+
+            if (!$class || !$definition->isAutoconfigured() || $definition->hasMethodCall('setLogger')) {
                 continue;
             }
 
-            $refl = $container->getReflectionClass($class);
-            if ($refl->implementsInterface(LoggerAwareInterface::class)) {
+            if ($class->implementsInterface(LoggerAwareInterface::class)) {
                 $definition->addMethodCall('setLogger', array($reference));
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
@@ -37,12 +37,13 @@ class LoggerAwarePass implements CompilerPassInterface
         $reference = new Reference('logger');
 
         foreach ($container->getDefinitions() as $definition) {
-            if (!class_exists($definition->getClass()) || !$definition->isAutoconfigured()) {
+            $class = $definition->getClass();
+            if (!class_exists($class) || !$definition->isAutoconfigured() || $definition->hasMethodCall('setLogger')) {
                 continue;
             }
 
-            $refl = new \ReflectionClass($definition->getClass());
-            if ($refl->implementsInterface(LoggerAwareInterface::class) && !$definition->hasMethodCall('setLogger')) {
+            $refl = $container->getReflectionClass($class);
+            if ($refl->implementsInterface(LoggerAwareInterface::class)) {
                 $definition->addMethodCall('setLogger', array($reference));
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
@@ -36,14 +36,11 @@ class LoggerAwarePass implements CompilerPassInterface
 
         $reference = new Reference('logger');
 
-        foreach ($container->getDefinitions() as $definition) {
-            $class = $container->getReflectionClass($definition->getClass(), true);
+        foreach (\array_keys($container->findTaggedServiceIds('logger.aware')) as $id) {
+            $definition = $container->findDefinition($id);
+            $class = $container->getReflectionClass($definition->getClass());
 
-            if (!$class || !$definition->isAutoconfigured() || $definition->hasMethodCall('setLogger')) {
-                continue;
-            }
-
-            if ($class->implementsInterface(LoggerAwareInterface::class)) {
+            if (!$definition->hasMethodCall('setLogger') && $class && $class->implementsInterface(LoggerAwareInterface::class)) {
                 $definition->addMethodCall('setLogger', array($reference));
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
@@ -37,7 +37,7 @@ class LoggerAwarePass implements CompilerPassInterface
         $reference = new Reference('logger');
 
         foreach ($container->getDefinitions() as $definition) {
-            if (!class_exists($definition->getClass())) {
+            if (!class_exists($definition->getClass()) || !$definition->isAutoconfigured()) {
                 continue;
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggerAwarePass.php
@@ -43,7 +43,7 @@ class LoggerAwarePass implements CompilerPassInterface
 
             $refl = new \ReflectionClass($definition->getClass());
             if ($refl->implementsInterface(LoggerAwareInterface::class) && !$definition->hasMethodCall('setLogger')) {
-                $definition->addMethodCall('setLogger', [$reference]);
+                $definition->addMethodCall('setLogger', array($reference));
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
 use Doctrine\Common\Annotations\Reader;
+use Psr\Log\LoggerAwareInterface;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand;
@@ -294,6 +295,8 @@ class FrameworkExtension extends Extension
             ->addTag('kernel.event_subscriber');
         $container->registerForAutoconfiguration(ResettableInterface::class)
             ->addTag('kernel.reset', array('method' => 'reset'));
+        $container->registerForAutoconfiguration(LoggerAwareInterface::class)
+            ->addTag('logger.aware');
         $container->registerForAutoconfiguration(PropertyListExtractorInterface::class)
             ->addTag('property_info.list_extractor');
         $container->registerForAutoconfiguration(PropertyTypeExtractorInterface::class)

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolClearerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolPrunerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DataCollectorTranslatorPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggerAwarePass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TemplatingPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggingTranslatorPass;
@@ -114,6 +115,7 @@ class FrameworkBundle extends Bundle
         $this->addCompilerPassIfExists($container, FormPass::class);
         $container->addCompilerPass(new WorkflowGuardListenerPass());
         $container->addCompilerPass(new ResettableServicePass());
+        $container->addCompilerPass(new LoggerAwarePass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
@@ -33,7 +33,10 @@ class LoggerAwarePassTest extends TestCase
         $container->register('logger', LoggerInterface::class);
 
         $definition = $container->register('foo', get_class($this->createMock(LoggerAwareInterface::class)));
+        $definition->setAutoconfigured(true);
+
         $container->register('bar', 'stdClass');
+        $container->register('not.autowired', LoggerInterface::class)->setAutoconfigured(false);
         $this->assertFalse(
             $definition->hasMethodCall('setLogger'),
             'Service should not have "setLogger" method call before Pass execution.'
@@ -42,9 +45,15 @@ class LoggerAwarePassTest extends TestCase
         (new LoggerAwarePass())->process($container);
 
         $this->assertTrue($definition->hasMethodCall('setLogger'), 'Service should have "setLogger" method call.');
+
         $this->assertFalse(
             $container->findDefinition('bar')->hasMethodCall('setLogger'),
             '"bar" service should not be affected'
+        );
+
+        $this->assertFalse(
+            $container->findDefinition('not.autowired')->hasMethodCall('setLogger'),
+            'Not autoconfigured service should not be affected.'
         );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggerAwarePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Unit tests for App\DependencyInjection\Compiler\LoggerAwarePass
+ *
+ * @author Gary PEGEOT <g.pegeot@highco-data.fr>
+ */
+class LoggerAwarePassTest extends TestCase
+{
+    /**
+     * @covers \Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggerAwarePass::process()
+     */
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container->register('logger', LoggerInterface::class);
+
+        $definition = $container->register('foo', get_class($this->createMock(LoggerAwareInterface::class)));
+        $container->register('bar', 'stdClass');
+        $this->assertFalse(
+            $definition->hasMethodCall('setLogger'),
+            'Service should not have "setLogger" method call before Pass execution.'
+        );
+
+        (new LoggerAwarePass())->process($container);
+
+        $this->assertTrue($definition->hasMethodCall('setLogger'), 'Service should have "setLogger" method call.');
+        $this->assertFalse(
+            $container->findDefinition('bar')->hasMethodCall('setLogger'),
+            '"bar" service should not be affected'
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
@@ -32,14 +32,14 @@ class LoggerAwarePassTest extends TestCase
         $container = new ContainerBuilder();
         $container->register('logger', LoggerInterface::class);
 
-        $definition = $container->register('foo', get_class($this->createMock(LoggerAwareInterface::class)));
-        $definition->setAutoconfigured(true);
+        $definition = $container->register('foo', get_class($this->createMock(LoggerAwareInterface::class)))
+            ->addTag('logger.aware');
 
         $container->register('bar', 'stdClass');
-        $container->register('not.autowired', LoggerInterface::class)->setAutoconfigured(false);
+        $container->register('not.autowired', LoggerInterface::class);
         $this->assertFalse(
             $definition->hasMethodCall('setLogger'),
-            'Service should not have "setLogger" method call before Pass execution.'
+            'Service should not have "setLogger" method call yet.'
         );
 
         (new LoggerAwarePass())->process($container);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * Unit tests for App\DependencyInjection\Compiler\LoggerAwarePass
  *
- * @author Gary PEGEOT <g.pegeot@highco-data.fr>
+ * @author Gary PEGEOT <garypegeot@gmail.com>
  */
 class LoggerAwarePassTest extends TestCase
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/LoggerAwarePassTest.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggerAwarePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Unit tests for App\DependencyInjection\Compiler\LoggerAwarePass
+ * Unit tests for Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggerAwarePass.
  *
  * @author Gary PEGEOT <garypegeot@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Automatically add `setLogger` method call to any service that implements `Psr\Log\LoggerAwareInterface`.

Not sure if this belong to FrameworkBundle or MonologBundle.
