### PR TITLE
[HttpKernel] remove services resetter even when it's an alias

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ResettableServicePass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ResettableServicePass.php
@@ -53,6 +53,7 @@ class ResettableServicePass implements CompilerPassInterface
         }
 
         if (empty($services)) {
+            $container->removeAlias('services_resetter');
             $container->removeDefinition('services_resetter');
 
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

All the other places in the compiler pass do not care whether the
resetter service is aliased or not. Let's just also properly deal with
the case that the services resetter service was aliased by another
bundle.