### PR TITLE
[Console] Allow a command iterator to be added to console app

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -390,9 +390,9 @@ class Application
      *
      * If a Command is not enabled it will not be added.
      *
-     * @param Command[] $commands An array of commands
+     * @param Command[] $commands An array or iterator of commands
      */
-    public function addCommands(array $commands)
+    public function addCommands(iterable $commands)
     {
         foreach ($commands as $command) {
             $this->add($command);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | 

Symfony 3.4/4.0 brings in the ability to use !tagged in service definitions to pass tagged services as a argument. It uses a RewindableGenerator class, so the typehint here doesn't accept it even though it just iterates over the commands.

This change will allow a custom console app to be created with a service method call in the definition.

The typehint is only available in PHP 7.1+ though, so isn't compatible with Symfony 3.4's targeted PHP versions, but is for 4.0.