### PR TITLE
[DependencyInjection] Single typed argument can be applied on multiple parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -68,15 +68,17 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
                     throw new InvalidArgumentException(sprintf('Invalid service "%s": the value of argument "%s" of method "%s()" must be null, an instance of %s or an instance of %s, %s given.', $this->currentId, $key, $class !== $this->currentId ? $class.'::'.$method : $method, Reference::class, Definition::class, gettype($argument)));
                 }
 
+                $typeFound = false;
                 foreach ($parameters as $j => $p) {
-                    if (ProxyHelper::getTypeHint($r, $p, true) === $key) {
+                    if (!array_key_exists($j, $resolvedArguments) && ProxyHelper::getTypeHint($r, $p, true) === $key) {
                         $resolvedArguments[$j] = $argument;
-
-                        continue 2;
+                        $typeFound = true;
                     }
                 }
 
-                throw new InvalidArgumentException(sprintf('Invalid service "%s": method "%s()" has no argument type-hinted as "%s". Check your service definition.', $this->currentId, $class !== $this->currentId ? $class.'::'.$method : $method, $key));
+                if (!$typeFound) {
+                    throw new InvalidArgumentException(sprintf('Invalid service "%s": method "%s()" has no argument type-hinted as "%s". Check your service definition.', $this->currentId, $class !== $this->currentId ? $class.'::'.$method : $method, $key));
+                }
             }
 
             if ($resolvedArguments !== $call[1]) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveNamedArgumentsPassTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\SimilarArgumentsDummy;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -124,6 +125,32 @@ class ResolveNamedArgumentsPassTest extends TestCase
         $pass->process($container);
 
         $this->assertEquals(array(new Reference('foo'), '123'), $definition->getArguments());
+    }
+
+    public function testResolvesMultipleArgumentsOfTheSameType()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = $container->register(SimilarArgumentsDummy::class, SimilarArgumentsDummy::class);
+        $definition->setArguments(array(CaseSensitiveClass::class => new Reference('foo'), '$token' => 'qwerty'));
+
+        $pass = new ResolveNamedArgumentsPass();
+        $pass->process($container);
+
+        $this->assertEquals(array(new Reference('foo'), 'qwerty', new Reference('foo')), $definition->getArguments());
+    }
+
+    public function testResolvePrioritizeNamedOverType()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = $container->register(SimilarArgumentsDummy::class, SimilarArgumentsDummy::class);
+        $definition->setArguments(array(CaseSensitiveClass::class => new Reference('foo'), '$token' => 'qwerty', '$class1' => new Reference('bar')));
+
+        $pass = new ResolveNamedArgumentsPass();
+        $pass->process($container);
+
+        $this->assertEquals(array(new Reference('bar'), 'qwerty', new Reference('foo')), $definition->getArguments());
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CaseSensitiveClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CaseSensitiveClass.php
@@ -13,4 +13,10 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 class CaseSensitiveClass
 {
+    public $identifier;
+
+    public function __construct($identifier = null)
+    {
+        $this->identifier = $identifier;
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/SimilarArgumentsDummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/SimilarArgumentsDummy.php
@@ -13,7 +13,12 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 class SimilarArgumentsDummy
 {
+    public $class1;
+    public $class2;
+
     public function __construct(CaseSensitiveClass $class1, string $token, CaseSensitiveClass $class2)
     {
+        $this->class1 = $class1;
+        $this->class2 = $class2;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/SimilarArgumentsDummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/SimilarArgumentsDummy.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class SimilarArgumentsDummy
+{
+    public function __construct(CaseSensitiveClass $class1, string $token, CaseSensitiveClass $class2)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

I'm @nicolas-grekas' test writer today. This makes the argument resolution working when injecting the same type multiple times (sub-set of PR #24978)