### PR TITLE
[DI] Allow auto-configured method calls.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -118,11 +118,10 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 }
             }
 
-            foreach ($instanceofCalls as $calls) {
-                foreach ($calls as $call) {
-                    $definition->addMethodCall($call[0], $call[1]);
-                }
-            }
+
+            $instanceofCalls = array_filter($instanceofCalls);
+            $instanceofCalls = array_map('current', $instanceofCalls);
+            $definition->setMethodCalls(array_merge($instanceofCalls, $definition->getMethodCalls()));
 
             // reset fields with "merge" behavior
             $abstract

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -120,9 +120,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
 
             foreach ($instanceofCalls as $calls) {
                 foreach ($calls as $call) {
-                    if (!$definition->hasMethodCall($call[0])) {
-                        $definition->addMethodCall($call[0], $call[1]);
-                    }
+                    $definition->addMethodCall($call[0], $call[1]);
                 }
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -118,7 +118,6 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 }
             }
 
-
             $instanceofCalls = array_filter($instanceofCalls);
             $instanceofCalls = array_map('current', $instanceofCalls);
             $definition->setMethodCalls(array_merge($instanceofCalls, $definition->getMethodCalls()));

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -60,10 +60,8 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
 
         $definition->setInstanceofConditionals(array());
         $parent = $shared = null;
-        $instanceof = array(
-            'calls' => array(),
-            'tags' => array(),
-        );
+        $instanceofTags = array();
+        $instanceofCalls = array();
 
         foreach ($conditionals as $interface => $instanceofDefs) {
             if ($interface !== $class && (!$container->getReflectionClass($class, false))) {
@@ -80,8 +78,8 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 $instanceofDef->setAbstract(true)->setParent($parent ?: "abstract.instanceof.$id");
                 $parent = "instanceof.$interface.$key.$id";
                 $container->setDefinition($parent, $instanceofDef);
-                $instanceof['tags'][] = $instanceofDef->getTags();
-                $instanceof['calls'][] = $instanceofDef->getMethodCalls();
+                $instanceofTags[] = $instanceofDef->getTags();
+                $instanceofCalls[] = $instanceofDef->getMethodCalls();
                 $instanceofDef->setTags(array());
                 $instanceofDef->setMethodCalls(array());
 
@@ -108,9 +106,9 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 $definition->setShared($shared);
             }
 
-            $i = count($instanceof['tags']);
+            $i = count($instanceofTags);
             while (0 <= --$i) {
-                foreach ($instanceof['tags'][$i] as $k => $v) {
+                foreach ($instanceofTags[$i] as $k => $v) {
                     foreach ($v as $v) {
                         if ($definition->hasTag($k) && in_array($v, $definition->getTag($k))) {
                             continue;
@@ -120,7 +118,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 }
             }
 
-            foreach ($instanceof['calls'] as $calls) {
+            foreach ($instanceofCalls as $calls) {
                 foreach ($calls as $call) {
                     if (!$definition->hasMethodCall($call[0])) {
                         $definition->addMethodCall($call[0], $call[1]);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -75,8 +75,8 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
             foreach ($instanceofDefs as $key => $instanceofDef) {
                 /** @var ChildDefinition $instanceofDef */
                 $instanceofDef = clone $instanceofDef;
-                $instanceofDef->setAbstract(true)->setParent($parent ?: "abstract.instanceof.$id");
-                $parent = "instanceof.$interface.$key.$id";
+                $instanceofDef->setAbstract(true)->setParent($parent ?: 'abstract.instanceof.'.$id);
+                $parent = 'instanceof.'.$interface.'.'.$key.'.'.$id;
                 $container->setDefinition($parent, $instanceofDef);
                 $instanceofTags[] = $instanceofDef->getTags();
                 $instanceofCalls[] = $instanceofDef->getMethodCalls();
@@ -91,7 +91,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
 
         if ($parent) {
             $bindings = $definition->getBindings();
-            $abstract = $container->setDefinition("abstract.instanceof.$id", $definition);
+            $abstract = $container->setDefinition('abstract.instanceof.'.$id, $definition);
 
             // cast Definition to ChildDefinition
             $definition->setBindings(array());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -60,8 +60,8 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         (new ResolveChildDefinitionsPass())->process($container);
 
         $expected = array(
-            array('foo', array('foo')),
             array('foo', array('bar')),
+            array('foo', array('foo')),
         );
 
         $this->assertSame($expected, $container->getDefinition('parent')->getMethodCalls());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -205,15 +205,17 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
     public function testProcessForAutoconfiguredCalls()
     {
         $container = new ContainerBuilder();
-        $container->registerForAutoconfiguration(parent::class)
-            ->addMethodCall('setLogger');
+        $container->registerForAutoconfiguration(parent::class)->addMethodCall('setLogger');
 
         $def = $container->register('foo', self::class)->setAutoconfigured(true);
         $this->assertFalse($def->hasMethodCall('setLogger'), 'Definition shouldn\'t have method call yet.');
 
         (new ResolveInstanceofConditionalsPass())->process($container);
-        $def = $container->findDefinition('foo');
-        $this->assertTrue($def->hasMethodCall('setLogger'), 'Definition should have "setLogger" method call.');
+
+        $this->assertTrue(
+            $container->findDefinition('foo')->hasMethodCall('setLogger'),
+            'Definition should have "setLogger" method call.'
+        );
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -207,8 +207,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $container->registerForAutoconfiguration(parent::class)
             ->addMethodCall('setLogger');
 
-        $def = $container->register('foo', \get_class($this->createMock(self::class)))
-            ->setAutoconfigured(true);
+        $def = $container->register('foo', self::class)->setAutoconfigured(true);
         $this->assertFalse($def->hasMethodCall('setLogger'), 'Definition shouldn\'t have method call yet.');
 
         (new ResolveInstanceofConditionalsPass())->process($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -61,6 +61,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
 
         $expected = array(
             array('foo', array('foo')),
+            array('foo', array('bar')),
         );
 
         $this->assertSame($expected, $container->getDefinition('parent')->getMethodCalls());
@@ -213,32 +214,6 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         (new ResolveInstanceofConditionalsPass())->process($container);
         $def = $container->findDefinition('foo');
         $this->assertTrue($def->hasMethodCall('setLogger'), 'Definition should have "setLogger" method call.');
-    }
-
-    /**
-     * Test that explicit calls are kept intact.
-     */
-    public function testProcessDoesNotOverrideCalls()
-    {
-        $container = new ContainerBuilder();
-        $container->registerForAutoconfiguration(parent::class)
-            ->addMethodCall('setLogger', array('bar.logger'))
-            ->addMethodCall('setBar', array('bar'));
-
-        $container->register('foo', \get_class($this->createMock(self::class)))
-            ->addMethodCall('setLogger', array('foo.logger'))
-            ->setAutoconfigured(true);
-
-        (new ResolveInstanceofConditionalsPass())->process($container);
-
-        $def = $container->findDefinition('foo');
-        $this->assertEquals(
-            array(
-                array('setLogger', array('foo.logger')),
-                array('setBar', array('bar')),
-            ),
-            $def->getMethodCalls()
-        );
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/expected.yml
@@ -19,7 +19,8 @@ services:
             - { name: from_defaults }
         # calls from instanceof are kept, but this comes later
         calls:
-            # first call is from instanceof
             - [enableSummer, [true]]
             #
             - [setSunshine, [warm]]
+            # Call from instanceof
+            - [setSunshine, [bright]]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/expected.yml
@@ -20,7 +20,6 @@ services:
         # calls from instanceof are kept, but this comes later
         calls:
             # first call is from instanceof
-            - [setSunshine, [bright]]
-            #
             - [enableSummer, [true]]
+            #
             - [setSunshine, [warm]]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/expected.yml
@@ -20,7 +20,6 @@ services:
         # calls from instanceof are kept, but this comes later
         calls:
             - [enableSummer, [true]]
-            #
             - [setSunshine, [warm]]
             # Call from instanceof
             - [setSunshine, [bright]]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/expected.yml
@@ -19,7 +19,8 @@ services:
             - { name: from_defaults }
         # calls from instanceof are kept, but this comes later
         calls:
+            # first call is from instanceof
+            - [setSunshine, [bright]]
+            #
             - [enableSummer, [true]]
             - [setSunshine, [warm]]
-            # Call from instanceof
-            - [setSunshine, [bright]]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    |no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Allow to auto-configure method calls like:
```php
$container->registerForAutoconfiguration(LoggerAwareInterface::class)->addMethodCall('setLogger', array(new Reference(LoggerInterface::class)));
```
