### PR TITLE
[Console] Remove remaining dead code

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -113,11 +113,10 @@ class Application
             $e = null;
             $exitCode = $this->doRun($input, $output);
         } catch (\Exception $e) {
-        } catch (\Throwable $e) {
         }
 
         if (null !== $e) {
-            if (!$this->catchExceptions || !$e instanceof \Exception) {
+            if (!$this->catchExceptions) {
                 throw $e;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Since they are always re-thrown, no need to catch `\Error` instances at all.
