### PR TITLE
[Validator] Deprecate validating DateTimeInterface in Date|Time|DateTime constraints

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -162,3 +162,4 @@ Validator
 
  * The component is now decoupled from `symfony/translation` and uses `Symfony\Contracts\Translation\TranslatorInterface` instead
  * The `ValidatorBuilderInterface` has been deprecated and `ValidatorBuilder` made final
+ * Deprecated validating instances of `\DateTimeInterface` in `DateTimeValidator`, `DateValidator` and `TimeValidator`. Use `Type` instead or remove the constraint if the underlying model is type hinted to `\DateTimeInterface` already.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -163,6 +163,7 @@ Validator
  * Removed the `checkDNS` and `dnsMessage` options from the `Url` constraint.
  * The component is now decoupled from `symfony/translation` and uses `Symfony\Contracts\Translation\TranslatorInterface` instead
  * The `ValidatorBuilderInterface` has been removed and `ValidatorBuilder` is now final
+ * Removed support for validating instances of `\DateTimeInterface` in `DateTimeValidator`, `DateValidator` and `TimeValidator`. Use `Type` instead or remove the constraint if the underlying model is type hinted to `\DateTimeInterface` already.
 
 Workflow
 --------

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * decoupled from `symfony/translation` by using `Symfony\Contracts\Translation\TranslatorInterface`
  * deprecated `ValidatorBuilderInterface`
  * made `ValidatorBuilder` final
+ * marked `format` the default option in `DateTime` constraint
+ * deprecated validating instances of `\DateTimeInterface` in `DateTimeValidator`, `DateValidator` and `TimeValidator`.
 
 4.1.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -33,4 +33,9 @@ class DateTime extends Constraint
 
     public $format = 'Y-m-d H:i:s';
     public $message = 'This value is not a valid datetime.';
+
+    public function getDefaultOption()
+    {
+        return 'format';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -29,7 +29,13 @@ class DateTimeValidator extends DateValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\DateTime');
         }
 
-        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            @trigger_error(sprintf('Validating a \\DateTimeInterface with "%s" is deprecated since version 4.2. Use "%s" instead or remove the constraint if the underlying model is already type hinted to \\DateTimeInterface.', DateTime::class, Type::class), E_USER_DEPRECATED);
+
             return;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -47,7 +47,13 @@ class DateValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Date');
         }
 
-        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            @trigger_error(sprintf('Validating a \\DateTimeInterface with "%s" is deprecated since version 4.2. Use "%s" instead or remove the constraint if the underlying model is already type hinted to \\DateTimeInterface.', Date::class, Type::class), E_USER_DEPRECATED);
+
             return;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -47,7 +47,13 @@ class TimeValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Time');
         }
 
-        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            @trigger_error(sprintf('Validating a \\DateTimeInterface with "%s" is deprecated since version 4.2. Use "%s" instead or remove the constraint if the underlying model is already type hinted to \\DateTimeInterface.', Time::class, Type::class), E_USER_DEPRECATED);
+
             return;
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -36,6 +36,10 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Validating a \DateTimeInterface with "Symfony\Component\Validator\Constraints\DateTime" is deprecated since version 4.2. Use "Symfony\Component\Validator\Constraints\Type" instead or remove the constraint if the underlying model is already type hinted to \DateTimeInterface.
+     */
     public function testDateTimeClassIsValid()
     {
         $this->validator->validate(new \DateTime(), new DateTime());
@@ -43,6 +47,10 @@ class DateTimeValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Validating a \DateTimeInterface with "Symfony\Component\Validator\Constraints\DateTime" is deprecated since version 4.2. Use "Symfony\Component\Validator\Constraints\Type" instead or remove the constraint if the underlying model is already type hinted to \DateTimeInterface.
+     */
     public function testDateTimeImmutableClassIsValid()
     {
         $this->validator->validate(new \DateTimeImmutable(), new DateTime());

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -36,6 +36,10 @@ class DateValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Validating a \DateTimeInterface with "Symfony\Component\Validator\Constraints\Date" is deprecated since version 4.2. Use "Symfony\Component\Validator\Constraints\Type" instead or remove the constraint if the underlying model is already type hinted to \DateTimeInterface.
+     */
     public function testDateTimeClassIsValid()
     {
         $this->validator->validate(new \DateTime(), new Date());
@@ -43,6 +47,10 @@ class DateValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Validating a \DateTimeInterface with "Symfony\Component\Validator\Constraints\Date" is deprecated since version 4.2. Use "Symfony\Component\Validator\Constraints\Type" instead or remove the constraint if the underlying model is already type hinted to \DateTimeInterface.
+     */
     public function testDateTimeImmutableClassIsValid()
     {
         $this->validator->validate(new \DateTimeImmutable(), new Date());

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -36,6 +36,10 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Validating a \DateTimeInterface with "Symfony\Component\Validator\Constraints\Time" is deprecated since version 4.2. Use "Symfony\Component\Validator\Constraints\Type" instead or remove the constraint if the underlying model is already type hinted to \DateTimeInterface.
+     */
     public function testDateTimeClassIsValid()
     {
         $this->validator->validate(new \DateTime(), new Time());
@@ -100,6 +104,10 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
         );
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Validating a \DateTimeInterface with "Symfony\Component\Validator\Constraints\Time" is deprecated since version 4.2. Use "Symfony\Component\Validator\Constraints\Type" instead or remove the constraint if the underlying model is already type hinted to \DateTimeInterface.
+     */
     public function testDateTimeImmutableIsValid()
     {
         $this->validator->validate(new \DateTimeImmutable(), new Time());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #11925
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/7583 (old PR but not really needed now)

Easy version of #21905. I think individual naming has value. Also the goal is to move forward to use `Type` really, not to bother with constraint renames.