### PR TITLE
[MonologBridge][WebServerBundle] Add suggestions for using the log server

### DIFF
--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -31,7 +31,8 @@
     "suggest": {
         "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",
         "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings. You need version ~2.3 of the console for it.",
-        "symfony/event-dispatcher": "Needed when using log messages in console commands."
+        "symfony/event-dispatcher": "Needed when using log messages in console commands.",
+        "symfony/var-dumper": "For using the debugging handlers like the console handler or the log server handler."
      },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\Monolog\\": "" },

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebServerBundle\Command;
 
+use Monolog\Formatter\FormatterInterface;
 use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
 use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
 use Symfony\Component\Console\Command\Command;
@@ -32,6 +33,11 @@ class ServerLogCommand extends Command
     public function isEnabled()
     {
         if (!class_exists(ConsoleFormatter::class)) {
+            return false;
+        }
+
+        // based on a symfony/symfony package, it crashes due a missing FormatterInterface from monolog/monolog
+        if (!class_exists(FormatterInterface::class)) {
             return false;
         }
 

--- a/src/Symfony/Bundle/WebServerBundle/composer.json
+++ b/src/Symfony/Bundle/WebServerBundle/composer.json
@@ -30,6 +30,10 @@
     "conflict": {
         "symfony/dependency-injection": "<3.3"
     },
+    "suggest": {
+        "symfony/monolog-bridge": "For using the log server.",
+        "symfony/expression-language": "For using the filter option of the log server."
+    },
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

If you want launch `server:log`, you need the monolog bridge and the VarDumper. Optionally, you need EL if you want use `server:log --filter`.