### PR TITLE
[FrameworkBundle] Hide server:log command based on deps

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/DependencyInjection/WebServerExtension.php
+++ b/src/Symfony/Bundle/WebServerBundle/DependencyInjection/WebServerExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebServerBundle\DependencyInjection;
 
+use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,5 +26,9 @@ class WebServerExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('webserver.xml');
+
+        if (!class_exists(ConsoleFormatter::class)) {
+            $container->removeDefinition('web_server.command.server_log');
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25025
| License       | MIT
| Doc PR        | ø

Remove the `server:log` command if monolog is not installed.