### PR TITLE
[Console] Fix ability to disable lazy commands

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -455,14 +455,11 @@ class Application
     {
         $this->init();
 
-        if (isset($this->commands[$name])) {
-            $command = $this->commands[$name];
-        } elseif ($this->commandLoader && $this->commandLoader->has($name)) {
-            $command = $this->commandLoader->get($name);
-            $this->add($command);
-        } else {
+        if (!$this->has($name)) {
             throw new CommandNotFoundException(sprintf('The command "%s" does not exist.', $name));
         }
+
+        $command = $this->commands[$name];
 
         if ($this->wantHelps) {
             $this->wantHelps = false;
@@ -487,7 +484,7 @@ class Application
     {
         $this->init();
 
-        return isset($this->commands[$name]) || ($this->commandLoader && $this->commandLoader->has($name));
+        return isset($this->commands[$name]) || ($this->commandLoader && $this->commandLoader->has($name) && $this->add($this->commandLoader->get($name)));
     }
 
     /**
@@ -649,7 +646,7 @@ class Application
 
             $commands = $this->commands;
             foreach ($this->commandLoader->getNames() as $name) {
-                if (!isset($commands[$name])) {
+                if (!isset($commands[$name]) && $this->has($name)) {
                     $commands[$name] = $this->get($name);
                 }
             }
@@ -666,7 +663,7 @@ class Application
 
         if ($this->commandLoader) {
             foreach ($this->commandLoader->getNames() as $name) {
-                if (!isset($commands[$name]) && $namespace === $this->extractNamespace($name, substr_count($namespace, ':') + 1)) {
+                if (!isset($commands[$name]) && $namespace === $this->extractNamespace($name, substr_count($namespace, ':') + 1) && $this->has($name)) {
                     $commands[$name] = $this->get($name);
                 }
             }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1532,6 +1532,30 @@ class ApplicationTest extends TestCase
         $this->assertSame(array('lazy:alias', 'lazy:alias2'), $command->getAliases());
     }
 
+    /**
+     * @expectedException \Symfony\Component\Console\Exception\CommandNotFoundException
+     */
+    public function testGetDisabledLazyCommand()
+    {
+        $application = new Application();
+        $application->setCommandLoader(new FactoryCommandLoader(array('disabled' => function () { return new DisabledCommand(); })));
+        $application->get('disabled');
+    }
+
+    public function testHasReturnsFalseForDisabledLazyCommand()
+    {
+        $application = new Application();
+        $application->setCommandLoader(new FactoryCommandLoader(array('disabled' => function () { return new DisabledCommand(); })));
+        $this->assertFalse($application->has('disabled'));
+    }
+
+    public function testAllExcludesDisabledLazyCommand()
+    {
+        $application = new Application();
+        $application->setCommandLoader(new FactoryCommandLoader(array('disabled' => function () { return new DisabledCommand(); })));
+        $this->assertArrayNotHasKey('disabled', $application->all());
+    }
+
     protected function getDispatcher($skipCommand = false)
     {
         $dispatcher = new EventDispatcher();
@@ -1632,5 +1656,13 @@ class LazyCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('lazy-command called');
+    }
+}
+
+class DisabledCommand extends Command
+{
+    public function isEnabled()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Properly throw when running them and don't show them in the list, as for non lazy ones.