### PR TITLE
[Bridge\PhpUnit] Disable broken auto-require mechanism of phpunit

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Blacklist.php
+++ b/src/Symfony/Bridge/PhpUnit/Blacklist.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit;
+
+/**
+ * Utility class replacing PHPUnit's implementation of the same class.
+ *
+ * All files are blacklisted so that process-isolated tests don't start with broken
+ * "require_once" statements. Composer is the only supported way to load code there.
+ */
+class Blacklist
+{
+    public static $blacklistedClassNames = array();
+
+    public function getBlacklistedDirectories()
+    {
+        $root = dirname(__DIR__);
+        while ($root !== $parent = dirname($root)) {
+            $root = $parent;
+        }
+
+        return array($root);
+    }
+
+    public function isBlacklisted($file)
+    {
+        return true;
+    }
+}
+
+class_alias('Symfony\Bridge\PhpUnit\Blacklist', 'PHPUnit\Util\Blacklist');
+class_alias('Symfony\Bridge\PhpUnit\Blacklist', 'PHPUnit_Util_Blacklist');

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -15,7 +15,6 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
-use PHPUnit\Util\Blacklist;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Bridge\PhpUnit\DnsMock;
 
@@ -46,17 +45,6 @@ class SymfonyTestsListenerTrait
      */
     public function __construct(array $mockedNamespaces = array())
     {
-        if (class_exists('PHPUnit_Util_Blacklist')) {
-            \PHPUnit_Util_Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\DeprecationErrorHandler'] = 1;
-            \PHPUnit_Util_Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\SymfonyTestsListener'] = 1;
-            \PHPUnit_Util_Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListener'] = 1;
-            \PHPUnit_Util_Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerTrait'] = 1;
-        } else {
-            Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\DeprecationErrorHandler'] = 1;
-            Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\SymfonyTestsListener'] = 1;
-            Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerTrait'] = 1;
-        }
-
         $warn = false;
         foreach ($mockedNamespaces as $type => $namespaces) {
             if (!is_array($namespaces)) {
@@ -103,7 +91,7 @@ class SymfonyTestsListenerTrait
 
     public function startTestSuite($suite)
     {
-        if (class_exists('PHPUnit_Util_Blacklist', false)) {
+        if (class_exists('PHPUnit_Util_Test', false)) {
             $Test = 'PHPUnit_Util_Test';
         } else {
             $Test = 'PHPUnit\Util\Test';
@@ -190,7 +178,7 @@ class SymfonyTestsListenerTrait
                 putenv('SYMFONY_DEPRECATIONS_SERIALIZE='.$this->runsInSeparateProcess);
             }
 
-            if (class_exists('PHPUnit_Util_Blacklist', false)) {
+            if (class_exists('PHPUnit_Util_Test', false)) {
                 $Test = 'PHPUnit_Util_Test';
                 $AssertionFailedError = 'PHPUnit_Framework_AssertionFailedError';
             } else {
@@ -236,7 +224,7 @@ class SymfonyTestsListenerTrait
 
     public function endTest($test, $time)
     {
-        if (class_exists('PHPUnit_Util_Blacklist', false)) {
+        if (class_exists('PHPUnit_Util_Test', false)) {
             $Test = 'PHPUnit_Util_Test';
             $BaseTestRunner = 'PHPUnit_Runner_BaseTestRunner';
             $Warning = 'PHPUnit_Framework_Warning';

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -82,17 +82,6 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
 define('PHPUNIT_COMPOSER_INSTALL', __DIR__.'/vendor/autoload.php');
 require PHPUNIT_COMPOSER_INSTALL;
 
-if (!class_exists('SymfonyBlacklistPhpunit', false)) {
-    class SymfonyBlacklistPhpunit {}
-}
-if (class_exists('PHPUnit_Util_Blacklist')) {
-    PHPUnit_Util_Blacklist::$blacklistedClassNames['SymfonyBlacklistPhpunit'] = 1;
-    PHPUnit_Util_Blacklist::$blacklistedClassNames['SymfonyBlacklistSimplePhpunit'] = 1;
-} else {
-    PHPUnit\Util\Blacklist::$blacklistedClassNames['SymfonyBlacklistPhpunit'] = 1;
-    PHPUnit\Util\Blacklist::$blacklistedClassNames['SymfonyBlacklistSimplePhpunit'] = 1;
-}
-
 Symfony\Bridge\PhpUnit\TextUI\Command::main();
 
 EOPHP
@@ -211,9 +200,6 @@ if ($components) {
         }
     }
 } elseif (!isset($argv[1]) || 'install' !== $argv[1] || file_exists('install')) {
-    if (!class_exists('SymfonyBlacklistSimplePhpunit', false)) {
-        class SymfonyBlacklistSimplePhpunit {}
-    }
     array_splice($argv, 1, 0, array('--colors=always'));
     $_SERVER['argv'] = $argv;
     $_SERVER['argc'] = ++$argc;

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -12,6 +12,9 @@
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
+// Replace the native phpunit Blacklist, it's a broken artifact from the past
+require_once __DIR__.'/Blacklist.php';
+
 // Detect if we need to serialize deprecations to a file.
 if ($file = getenv('SYMFONY_DEPRECATIONS_SERIALIZE')) {
     DeprecationErrorHandler::collectDeprecations($file);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25017
| License       | MIT
| Doc PR        | -

It took me all the flight back from Cluj to figure out this is the only way to solve this nasty issue created by phpunit generating inlined `require_once` in the global scope for isolated tests.
This mechanism predates the autoloading mechanism, and it's behavior is just hardcoded.
Needs to be merged in 3.4, where the split container triggers this situation very quickly.

Will allow removing the `function_exists('__phpunit_run_isolated_test')` workarounds already in place in the code base (2.7 up to master.)