### PR TITLE
Remove function_exists(__phpunit_run_isolated_test) checks

### DIFF
--- a/src/Symfony/Component/Debug/Tests/Fixtures/Throwing.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/Throwing.php
@@ -1,5 +1,3 @@
 <?php
 
-if (!function_exists('__phpunit_run_isolated_test')) {
-    throw new \Exception('boo');
-}
+throw new \Exception('boo');

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validresource.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validresource.php
@@ -1,8 +1,5 @@
 <?php
 
-if (function_exists('__phpunit_run_isolated_test')) {
-    return;
-}
 /** @var $loader \Symfony\Component\Routing\Loader\PhpFileLoader */
 /** @var \Symfony\Component\Routing\RouteCollection $collection */
 $collection = $loader->import('validpattern.php');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As now permitted by #25032