### PR TITLE
[Form] Rename `FormConfigBuilder::$nativeRequestProcessor` private variable to `::$nativeRequestHandler`

### DIFF
--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -32,7 +32,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @var NativeRequestHandler
      */
-    private static $nativeRequestProcessor;
+    private static $nativeRequestHandler;
 
     /**
      * The accepted request methods.
@@ -511,10 +511,10 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function getRequestHandler()
     {
         if (null === $this->requestHandler) {
-            if (null === self::$nativeRequestProcessor) {
-                self::$nativeRequestProcessor = new NativeRequestHandler();
+            if (null === self::$nativeRequestHandler) {
+                self::$nativeRequestHandler = new NativeRequestHandler();
             }
-            $this->requestHandler = self::$nativeRequestProcessor;
+            $this->requestHandler = self::$nativeRequestHandler;
         }
 
         return $this->requestHandler;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |2.7
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | Not confirmed, but the changes are completely minor
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I guess the term "processor" had been used until [this PR comes](https://github.com/symfony/symfony/pull/7732), but hadn't been renamed properly at the time. 
And I think "handler" sounds more relevant to me anyway.
