### PR TITLE
Allow EnumNode name to be null

### DIFF
--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -22,7 +22,7 @@ class EnumNode extends ScalarNode
 {
     private $values;
 
-    public function __construct(string $name, NodeInterface $parent = null, array $values = array())
+    public function __construct(?string $name, NodeInterface $parent = null, array $values = array())
     {
         $values = array_unique($values);
         if (empty($values)) {

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -45,7 +45,8 @@ class EnumNodeTest extends TestCase
 
     public function testConstructionWithNullName()
     {
-        new EnumNode(null, null, array('foo'));
+        $node = new EnumNode(null, null, array('foo'));
+        $this->assertSame('foo', $node->finalize('foo'));
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/EnumNodeTest.php
@@ -43,6 +43,11 @@ class EnumNodeTest extends TestCase
         $this->assertSame('foo', $node->finalize('foo'));
     }
 
+    public function testConstructionWithNullName()
+    {
+        new EnumNode(null, null, array('foo'));
+    }
+
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage The value "foobar" is not allowed for path "foo". Permissible values: "foo", "bar"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25046
| License       | MIT
