### PR TITLE
Fix issue #25051 - Allow to overwrite AccessDecisionManager

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -35,10 +35,10 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
 
         if ($this->manager instanceof AccessDecisionManager) {
             // The strategy and voters are stored in a private properties of the decorated service
-            $reflection = new \ReflectionProperty(AccessDecisionManager::class, 'strategy');
+            $reflection = new \ReflectionProperty(get_class($this->manager), 'strategy');
             $reflection->setAccessible(true);
             $this->strategy = $reflection->getValue($manager);
-            $reflection = new \ReflectionProperty(AccessDecisionManager::class, 'voters');
+            $reflection = new \ReflectionProperty(get_class($this->manager), 'voters');
             $reflection->setAccessible(true);
             $this->voters = $reflection->getValue($manager);
         }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Stub/ExtendedAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Stub/ExtendedAccessDecisionManager.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authorization\Stub;
+
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+
+class ExtendedAccessDecisionManager extends AccessDecisionManager
+{
+    private $voters;
+    private $strategy;
+
+    public function __construct($voters = array(), $strategy = self::STRATEGY_AFFIRMATIVE, $allowIfAllAbstainDecisions = false, $allowIfEqualGrantedDeniedDecisions = true)
+    {
+        $strategyMethod = 'decide'.ucfirst($strategy);
+
+        $this->voters = $voters;
+        $this->strategy = $strategyMethod;
+        $this->allowIfAllAbstainDecisions = (bool) $allowIfAllAbstainDecisions;
+        $this->allowIfEqualGrantedDeniedDecisions = (bool) $allowIfEqualGrantedDeniedDecisions;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\DebugAccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Tests\Authorization\Stub\ExtendedAccessDecisionManager;
 
 class TraceableAccessDecisionManagerTest extends TestCase
 {
@@ -48,5 +49,19 @@ class TraceableAccessDecisionManagerTest extends TestCase
         $adm = new TraceableAccessDecisionManager(new AccessDecisionManager());
 
         $this->assertInstanceOf(DebugAccessDecisionManager::class, $adm, 'For BC, TraceableAccessDecisionManager must be an instance of DebugAccessDecisionManager');
+    }
+
+    public function testAccessDecisionManagePropertiesRetrieving()
+    {
+        $adm = new TraceableAccessDecisionManager(new AccessDecisionManager(array(), AccessDecisionManager::STRATEGY_UNANIMOUS));
+
+        $this->assertEquals(array(), $adm->getVoters());
+        $this->assertEquals(AccessDecisionManager::STRATEGY_UNANIMOUS, $adm->getStrategy());
+
+        // Same tests for an extended AccessDecisionManager
+        $adm = new TraceableAccessDecisionManager(new ExtendedAccessDecisionManager(array(), AccessDecisionManager::STRATEGY_UNANIMOUS));
+
+        $this->assertEquals(array(), $adm->getVoters());
+        $this->assertEquals(AccessDecisionManager::STRATEGY_UNANIMOUS, $adm->getStrategy());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25051 
| License       | MIT

This simple changes allow to overwrite again the AccessDecisionManager in dev envionment.