### PR TITLE
[Serializer] Fixing PropertyNormalizer supports parent properties

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -60,11 +60,13 @@ class PropertyNormalizer extends AbstractObjectNormalizer
         $class = new \ReflectionClass($class);
 
         // We look for at least one non-static property
-        foreach ($class->getProperties() as $property) {
-            if (!$property->isStatic()) {
-                return true;
+        do {
+            foreach ($class->getProperties() as $property) {
+                if (!$property->isStatic()) {
+                    return true;
+                }
             }
-        }
+        } while ($class = $class->getParentClass());
 
         return false;
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -441,6 +441,11 @@ class PropertyNormalizerTest extends TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function testInheritedPropertiesSupport()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new PropertyChildDummy()));
+    }
 }
 
 class PropertyDummy
@@ -508,4 +513,13 @@ class PropertyCamelizedDummy
 class StaticPropertyDummy
 {
     private static $property = 'value';
+}
+
+class PropertyParentDummy
+{
+    private $foo = 'bar';
+}
+
+class PropertyChildDummy extends PropertyParentDummy
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

With 5ecafc5e25aa073f6cf109a6b87453689369c4a4 support for parent properties was added to 3.4, but supports method was not updated for child classes without properties.