### PR TITLE
Bump phpunit-bridge requirement to 3.4|4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "monolog/monolog": "~1.11",
         "ircmaxell/password-compat": "~1.0",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
-        "symfony/phpunit-bridge": "~3.2",
+        "symfony/phpunit-bridge": "~3.4|~4.0",
         "egulias/email-validator": "~1.2,>=1.2.1",
         "sensio/framework-extra-bundle": "^3.0.2"
     },

--- a/phpunit
+++ b/phpunit
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-// Cache-Id: https://github.com/symfony/phpunit-bridge/commit/29fa7b8196870591f35e1554dd69def482e01fb2
+// Cache-Id: https://github.com/symfony/phpunit-bridge/commit/6d344ad9be7566f875488aa14d905449716c06cf
 
 if (!file_exists(__DIR__.'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
     echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\nPlease run `composer update` before running this command.\n";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The bridge 4.0 is already used because of the way simple-phpunit works.
This just make it more explicit and will be required when #25056 will be merged.