### PR TITLE
[DependencyInjection] Removal of service definition with alias dont leave orphan aliases

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -490,6 +490,14 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
     }
 
+    public function removeDefinitionAndAlias(string $id, string $aliasId)
+    {
+        if (isset($this->definitions[$id], $this->aliasDefinitions[$aliasId])) {
+            unset($this->definitions[$id], $this->aliasDefinitions[$aliasId]);
+            $this->removedIds[$id] = true;
+        }
+    }
+
     /**
      * Returns true if the given service is defined.
      *

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -86,6 +86,34 @@ class ContainerBuilderTest extends TestCase
         }
     }
 
+    public function testRemoveDefinitionWithAlias()
+    {
+        $definition = new Definition(\stdClass::class);
+        $definition->setPublic(true);
+
+        $alias = new Alias($definition->getClass(), true);
+
+        $container = new ContainerBuilder();
+        $container->setDefinition($definition->getClass(), $definition);
+        $container->setAlias('stdSvc', $alias);
+        $container->removeDefinitionAndAlias($definition->getClass(), 'stdSvc');
+        $this->assertArrayNotHasKey('stdSvc', $container->getAliases());
+    }
+
+    public function testRemoveDefinition()
+    {
+        $definition = new Definition(\stdClass::class);
+        $definition->setPublic(true);
+
+        $alias = new Alias($definition->getClass(), true);
+
+        $container = new ContainerBuilder();
+        $container->setDefinition($definition->getClass(), $definition);
+        $container->setAlias('stdSvc', $alias);
+        $container->removeDefinition($definition->getClass());
+        $this->assertArrayHasKey('stdSvc', $container->getAliases());
+    }
+
     /**
      * @group legacy
      * @expectedDeprecation The "deprecated_foo" service is deprecated. You should stop using it, as it will soon be removed.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #25060 
| License       | MIT
| Doc PR        | will add.

I'm adding a new method in order to tell to remove the alias to the services.

This is one of the implementation, the other could be to search all class with an alias and remove them.


![img_2664](https://user-images.githubusercontent.com/3451634/33055228-90a40b34-ce7e-11e7-80b9-433528d2f478.JPG)
