### PR TITLE
[FrameworkBundle] Update translation commands to work with default paths

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -78,6 +78,8 @@
             <argument type="service" id="translator" />
             <argument type="service" id="translation.reader" />
             <argument type="service" id="translation.extractor" />
+            <argument>%translator.default_path%</argument>
+            <argument /> <!-- %twig.default_path% -->
             <tag name="console.command" command="debug:translation" />
         </service>
 
@@ -86,6 +88,8 @@
             <argument type="service" id="translation.reader" />
             <argument type="service" id="translation.extractor" />
             <argument>%kernel.default_locale%</argument>
+            <argument>%translator.default_path%</argument>
+            <argument /> <!-- %twig.default_path% -->
             <tag name="console.command" command="translation:update" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -64,6 +64,21 @@ class TranslationDebugCommandTest extends TestCase
         $this->assertRegExp('/unused/', $tester->getDisplay());
     }
 
+    public function testDebugDefaultRootDirectory()
+    {
+        $this->fs->remove($this->translationDir);
+        $this->fs = new Filesystem();
+        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf2_translation', true);
+        $this->fs->mkdir($this->translationDir.'/translations');
+        $this->fs->mkdir($this->translationDir.'/templates');
+
+        $tester = $this->createCommandTester(array('foo' => 'foo'), array('bar' => 'bar'));
+        $tester->execute(array('locale' => 'en'));
+
+        $this->assertRegExp('/missing/', $tester->getDisplay());
+        $this->assertRegExp('/unused/', $tester->getDisplay());
+    }
+
     public function testDebugCustomDirectory()
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
@@ -100,6 +115,8 @@ class TranslationDebugCommandTest extends TestCase
         $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf2_translation', true);
         $this->fs->mkdir($this->translationDir.'/Resources/translations');
         $this->fs->mkdir($this->translationDir.'/Resources/views');
+        $this->fs->mkdir($this->translationDir.'/translations');
+        $this->fs->mkdir($this->translationDir.'/templates');
     }
 
     protected function tearDown()
@@ -174,7 +191,7 @@ class TranslationDebugCommandTest extends TestCase
             ->method('getContainer')
             ->will($this->returnValue($this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock()));
 
-        $command = new TranslationDebugCommand($translator, $loader, $extractor);
+        $command = new TranslationDebugCommand($translator, $loader, $extractor, $this->translationDir.'/translations', $this->translationDir.'/templates');
 
         $application = new Application($kernel);
         $application->add($command);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -31,6 +31,19 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertRegExp('/1 message was successfully extracted/', $tester->getDisplay());
     }
 
+    public function testDumpMessagesAndCleanInRootDirectory()
+    {
+        $this->fs->remove($this->translationDir);
+        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf2_translation', true);
+        $this->fs->mkdir($this->translationDir.'/translations');
+        $this->fs->mkdir($this->translationDir.'/templates');
+
+        $tester = $this->createCommandTester(array('messages' => array('foo' => 'foo')));
+        $tester->execute(array('command' => 'translation:update', 'locale' => 'en', '--dump-messages' => true, '--clean' => true));
+        $this->assertRegExp('/foo/', $tester->getDisplay());
+        $this->assertRegExp('/1 message was successfully extracted/', $tester->getDisplay());
+    }
+
     public function testDumpTwoMessagesAndClean()
     {
         $tester = $this->createCommandTester(array('messages' => array('foo' => 'foo', 'bar' => 'bar')));
@@ -55,6 +68,18 @@ class TranslationUpdateCommandTest extends TestCase
         $this->assertRegExp('/Translation files were successfully updated./', $tester->getDisplay());
     }
 
+    public function testWriteMessagesInRootDirectory()
+    {
+        $this->fs->remove($this->translationDir);
+        $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf2_translation', true);
+        $this->fs->mkdir($this->translationDir.'/translations');
+        $this->fs->mkdir($this->translationDir.'/templates');
+
+        $tester = $this->createCommandTester(array('messages' => array('foo' => 'foo')));
+        $tester->execute(array('command' => 'translation:update', 'locale' => 'en', '--force' => true));
+        $this->assertRegExp('/Translation files were successfully updated./', $tester->getDisplay());
+    }
+
     public function testWriteMessagesForSpecificDomain()
     {
         $tester = $this->createCommandTester(array('messages' => array('foo' => 'foo'), 'mydomain' => array('bar' => 'bar')));
@@ -68,6 +93,8 @@ class TranslationUpdateCommandTest extends TestCase
         $this->translationDir = sys_get_temp_dir().'/'.uniqid('sf2_translation', true);
         $this->fs->mkdir($this->translationDir.'/Resources/translations');
         $this->fs->mkdir($this->translationDir.'/Resources/views');
+        $this->fs->mkdir($this->translationDir.'/translations');
+        $this->fs->mkdir($this->translationDir.'/templates');
     }
 
     protected function tearDown()
@@ -152,7 +179,7 @@ class TranslationUpdateCommandTest extends TestCase
             ->method('getContainer')
             ->will($this->returnValue($this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock()));
 
-        $command = new TranslationUpdateCommand($writer, $loader, $extractor, 'en');
+        $command = new TranslationUpdateCommand($writer, $loader, $extractor, 'en', $this->translationDir.'/translations', $this->translationDir.'/templates');
 
         $application = new Application($kernel);
         $application->add($command);

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
@@ -21,8 +21,10 @@ class TranslatorPass implements CompilerPassInterface
     private $translatorServiceId;
     private $readerServiceId;
     private $loaderTag;
+    private $debugCommandServiceId;
+    private $updateCommandServiceId;
 
-    public function __construct($translatorServiceId = 'translator.default', $readerServiceId = 'translation.loader', $loaderTag = 'translation.loader')
+    public function __construct($translatorServiceId = 'translator.default', $readerServiceId = 'translation.loader', $loaderTag = 'translation.loader', $debugCommandServiceId = 'console.command.translation_debug', $updateCommandServiceId = 'console.command.translation_update')
     {
         if ('translation.loader' === $readerServiceId && 2 > func_num_args()) {
             @trigger_error('The default value for $readerServiceId will change in 4.0 to "translation.reader".', E_USER_DEPRECATED);
@@ -31,6 +33,8 @@ class TranslatorPass implements CompilerPassInterface
         $this->translatorServiceId = $translatorServiceId;
         $this->readerServiceId = $readerServiceId;
         $this->loaderTag = $loaderTag;
+        $this->debugCommandServiceId = $debugCommandServiceId;
+        $this->updateCommandServiceId = $updateCommandServiceId;
     }
 
     public function process(ContainerBuilder $container)
@@ -75,5 +79,10 @@ class TranslatorPass implements CompilerPassInterface
             ->replaceArgument(0, ServiceLocatorTagPass::register($container, $loaderRefs))
             ->replaceArgument(3, $loaders)
         ;
+
+        if ($container->hasParameter('twig.default_path')) {
+            $container->getDefinition($this->debugCommandServiceId)->replaceArgument(4, $container->getParameter('twig.default_path'));
+            $container->getDefinition($this->updateCommandServiceId)->replaceArgument(5, $container->getParameter('twig.default_path'));
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/25062
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/8634

This should make translation commands (debug & update) work with `translator.default_path` and `twig.default_path` directories (introduced here in 3.4) and their overridden paths if available.

Would be great to include also the custom paths mapping by the user, either `translator.paths` as `twig.paths`, but I'm not sure about the right way and probably it should be implemented on another branch.

TODO
- [x]  Add some tests.