### PR TITLE
[Bridge/PhpUnit] Remove trailing "\n" from ClockMock::microtime(false)

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -66,7 +66,7 @@ class ClockMock
             return self::$now;
         }
 
-        return sprintf("%0.6f %d\n", self::$now - (int) self::$now, (int) self::$now);
+        return sprintf('%0.6f %d', self::$now - (int) self::$now, (int) self::$now);
     }
 
     public static function register($class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25050
| License       | MIT
| Doc PR        | -

