### PR TITLE
[FrameworkBundle] Ignore failures when removing the old cache dir

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -130,7 +131,11 @@ EOF
             $io->comment('Removing old cache directory...');
         }
 
-        $this->filesystem->remove($oldCacheDir);
+        try {
+            $this->filesystem->remove($oldCacheDir);
+        } catch (IOException $e) {
+            $io->warning($e->getMessage());
+        }
 
         if ($output->isVerbose()) {
             $io->comment('Finished');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25066
| License       | MIT
| Doc PR        | -

ping @phoenixgao can you please check if this improves the situation?