### PR TITLE
BUGFIX check for apc.enable_cli if PHP_SAPI==cli

### DIFF
--- a/src/Symfony/Component/Cache/Traits/ApcuTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ApcuTrait.php
@@ -23,7 +23,7 @@ trait ApcuTrait
 {
     public static function isSupported()
     {
-        return function_exists('apcu_fetch') && ini_get('apc.enabled');
+        return function_exists('apcu_fetch') && ini_get('cli' === PHP_SAPI ? 'apc.enable_cli' : 'apc.enabled');
     }
 
     private function init($namespace, $defaultLifetime, $version)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | TODO
| License       | MIT

Experienced an issue when running PHPUnit via CLI on my application. A slew of errors like:

```
[2017-11-21 11:50:15] manifestcache-log.WARNING: Failed to save values {"keys":["ErrorPageErrorFormatter_php_6bac9d263304c06cb35951dcecaa888d"],"exception":null} []
```

Issue was that I was missing `apc.enable_cli=1` in my `apcu.ini` - however, APCU was still being detected as `isSupported()` because the check wasn't taking into account that I was running via CLI. This PR checks based on `PHP_SAPI`.

TODO
- [x] Ensure tests pass
