### PR TITLE
[FrameworkBundle] Update default translations path

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -679,7 +679,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('formatter')->defaultValue('translator.formatter.default')->end()
                         ->scalarNode('default_path')
                             ->info('The default path used to load translations')
-                            ->defaultValue('%kernel.project_dir%/config/translations')
+                            ->defaultValue('%kernel.project_dir%/translations')
                         ->end()
                         ->arrayNode('paths')
                             ->prototype('scalar')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -257,7 +257,7 @@ class ConfigurationTest extends TestCase
                 'logging' => true,
                 'formatter' => 'translator.formatter.default',
                 'paths' => array(),
-                'default_path' => '%kernel.project_dir%/config/translations',
+                'default_path' => '%kernel.project_dir%/translations',
             ),
             'validation' => array(
                 'enabled' => !class_exists(FullStack::class),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -42,7 +42,7 @@ framework:
     translator:
         enabled:  true
         fallback: fr
-        default_path: '%kernel.root_dir%/config/translations'
+        default_path: '%kernel.root_dir%/translations'
         paths: ['%kernel.root_dir%/Fixtures/translations']
     validation:
         enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -503,7 +503,7 @@ abstract class FrameworkExtensionTest extends TestCase
             '->registerTranslatorConfiguration() finds translation resources in custom paths'
         );
         $this->assertContains(
-            strtr(__DIR__.'/config/translations/test_default.en.xlf', '/', DIRECTORY_SEPARATOR),
+            strtr(__DIR__.'/translations/test_default.en.xlf', '/', DIRECTORY_SEPARATOR),
             $files,
             '->registerTranslatorConfiguration() finds translation resources in default path'
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/recipes/pull/253#issuecomment-345993146
| License       | MIT
| Doc PR        | -

Moving default `translations/` dir to the root project again.