### PR TITLE
[Security] #25091 add target user to SwitchUserListener

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,6 +1,8 @@
 CHANGELOG for 4.0.x
 ===================
 
+* feature #25091 [Security] Add target user to SwitchUserListener (jwmickey)
+
 This changelog references the relevant changes (bug and security fixes) done
 in 4.0 minor versions.
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,8 +1,6 @@
 CHANGELOG for 4.0.x
 ===================
 
-* feature #25091 [Security] Add target user to SwitchUserListener (jwmickey)
-
 This changelog references the relevant changes (bug and security fixes) done
 in 4.0 minor versions.
 

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * removed HTTP digest authentication
  * removed `GuardAuthenticatorInterface` in favor of `AuthenticatorInterface`
  * removed `AbstractGuardAuthenticator::supports()`
+ * added target user to `SwitchUserListener`
 
 3.4.0
 -----

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -126,7 +126,6 @@ class SwitchUserListener implements ListenerInterface
             throw new \LogicException(sprintf('You are already switched to "%s" user.', $token->getUsername()));
         }
 
-        $username = $request->get($this->usernameParameter);
         $user = $this->provider->loadUserByUsername($username);
 
         if (false === $this->accessDecisionManager->decide($token, array($this->role), $user)) {

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -130,7 +130,9 @@ class SwitchUserListener implements ListenerInterface
         $user = $this->provider->loadUserByUsername($username);
 
         if (false === $this->accessDecisionManager->decide($token, array($this->role), $user)) {
-            throw new AccessDeniedException();
+            $exception = new AccessDeniedException();
+            $exception->setAttributes($this->role);
+            throw $exception;
         }
 
         if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -126,18 +126,17 @@ class SwitchUserListener implements ListenerInterface
             throw new \LogicException(sprintf('You are already switched to "%s" user.', $token->getUsername()));
         }
 
-        if (false === $this->accessDecisionManager->decide($token, array($this->role))) {
-            $exception = new AccessDeniedException();
-            $exception->setAttributes($this->role);
+        $username = $request->get($this->usernameParameter);
+        $user = $this->provider->loadUserByUsername($username);
 
-            throw $exception;
+        if (false === $this->accessDecisionManager->decide($token, array($this->role), $user)) {
+            throw new AccessDeniedException();
         }
 
         if (null !== $this->logger) {
             $this->logger->info('Attempting to switch to user.', array('username' => $username));
         }
 
-        $user = $this->provider->loadUserByUsername($username);
         $this->userChecker->checkPostAuth($user);
 
         $roles = $user->getRoles();

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -131,6 +131,7 @@ class SwitchUserListener implements ListenerInterface
         if (false === $this->accessDecisionManager->decide($token, array($this->role), $user)) {
             $exception = new AccessDeniedException();
             $exception->setAttributes($this->role);
+            
             throw $exception;
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -131,7 +131,7 @@ class SwitchUserListener implements ListenerInterface
         if (false === $this->accessDecisionManager->decide($token, array($this->role), $user)) {
             $exception = new AccessDeniedException();
             $exception->setAttributes($this->role);
-            
+
             throw $exception;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -182,7 +182,7 @@ class SwitchUserListenerTest extends TestCase
         $this->request->query->set('_switch_user', 'kuba');
 
         $this->accessDecisionManager->expects($this->once())
-            ->method('decide')->with($token, array('ROLE_ALLOWED_TO_SWITCH'))
+            ->method('decide')->with($token, array('ROLE_ALLOWED_TO_SWITCH'), $user)
             ->will($this->returnValue(true));
 
         $this->userProvider->expects($this->once())

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -212,7 +212,7 @@ class SwitchUserListenerTest extends TestCase
         ));
 
         $this->accessDecisionManager->expects($this->once())
-            ->method('decide')->with($token, array('ROLE_ALLOWED_TO_SWITCH'))
+            ->method('decide')->with($token, array('ROLE_ALLOWED_TO_SWITCH'), $user)
             ->will($this->returnValue(true));
 
         $this->userProvider->expects($this->once())
@@ -240,7 +240,7 @@ class SwitchUserListenerTest extends TestCase
         $this->request->query->set('_switch_user', 'kuba');
 
         $this->accessDecisionManager->expects($this->any())
-            ->method('decide')->with($token, array('ROLE_ALLOWED_TO_SWITCH'))
+            ->method('decide')->with($token, array('ROLE_ALLOWED_TO_SWITCH'), $user)
             ->will($this->returnValue(true));
 
         $this->userProvider->expects($this->any())
@@ -276,7 +276,7 @@ class SwitchUserListenerTest extends TestCase
         $this->request->query->set('_switch_user', 'kuba');
 
         $this->accessDecisionManager->expects($this->once())
-            ->method('decide')->with($token, array('ROLE_ALLOWED_TO_SWITCH'))
+            ->method('decide')->with($token, array('ROLE_ALLOWED_TO_SWITCH'), $user)
             ->will($this->returnValue(true));
 
         $this->userProvider->expects($this->once())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25091
| License       | MIT
| Doc PR        | 

This patch provides the target user to the SwitchUserListener's
accessDecisionManager->decide() call as the $object parameter to
give any registered voters extra information.