### PR TITLE
Make debug:container search command case-insensitive

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -217,9 +217,8 @@ EOF
     {
         $serviceIds = $builder->getServiceIds();
         $foundServiceIds = array();
-        $name = strtolower($name);
         foreach ($serviceIds as $serviceId) {
-            if (false === strpos($serviceId, $name)) {
+            if (false === stripos($serviceId, $name)) {
                 continue;
             }
             $foundServiceIds[] = $serviceId;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #25107 
| License       | MIT
| Doc PR        | 

This bug fixes the #25107 - starts from 3.2 services may be written with uppercase (e.g. FQCN) and search fails to match those services.
