### PR TITLE
[FrameworkBundle] Make cache:clear "atomic" and consistent with cache:warmup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -93,6 +93,7 @@ EOF
             $realCacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
         }
 
+        $fs = $this->filesystem;
         $io = new SymfonyStyle($input, $output);
 
         $kernel = $this->getApplication()->getKernel();
@@ -100,13 +101,10 @@ EOF
         // the old cache dir name must not be longer than the real one to avoid exceeding
         // the maximum length of a directory or file path within it (esp. Windows MAX_PATH)
         $oldCacheDir = substr($realCacheDir, 0, -1).('~' === substr($realCacheDir, -1) ? '+' : '~');
+        $fs->remove($oldCacheDir);
 
         if (!is_writable($realCacheDir)) {
             throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $realCacheDir));
-        }
-
-        if ($this->filesystem->exists($oldCacheDir)) {
-            $this->filesystem->remove($oldCacheDir);
         }
 
         $io->comment(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
@@ -115,10 +113,24 @@ EOF
         // The current event dispatcher is stale, let's not use it anymore
         $this->getApplication()->setDispatcher(new EventDispatcher());
 
-        if ($input->getOption('no-warmup')) {
-            $this->filesystem->rename($realCacheDir, $oldCacheDir);
-        } else {
-            $this->warmupCache($input, $output, $realCacheDir, $oldCacheDir);
+        $containerDir = new \ReflectionObject($kernel->getContainer());
+        $containerDir = basename(dirname($containerDir->getFileName()));
+
+        // the warmup cache dir name must have the same length as the real one
+        // to avoid the many problems in serialized resources files
+        $warmupDir = substr($realCacheDir, 0, -1).('_' === substr($realCacheDir, -1) ? '-' : '_');
+
+        if ($output->isVerbose() && $fs->exists($warmupDir)) {
+            $io->comment('Clearing outdated warmup directory...');
+        }
+        $fs->remove($warmupDir);
+        $fs->mkdir($warmupDir);
+
+        if (!$input->getOption('no-warmup')) {
+            if ($output->isVerbose()) {
+                $io->comment('Warming up cache...');
+            }
+            $this->warmup($warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
 
             if ($this->warning) {
                 @trigger_error($this->warning, E_USER_DEPRECATED);
@@ -127,12 +139,22 @@ EOF
             }
         }
 
+        $containerDir = $fs->exists($warmupDir.'/'.$containerDir) ? false : $containerDir;
+
+        $fs->rename($realCacheDir, $oldCacheDir);
+        $fs->rename($warmupDir, $realCacheDir);
+
+        if ($containerDir) {
+            $fs->rename($oldCacheDir.'/'.$containerDir, $realCacheDir.'/'.$containerDir);
+            touch($realCacheDir.'/'.$containerDir.'.legacy');
+        }
+
         if ($output->isVerbose()) {
             $io->comment('Removing old cache directory...');
         }
 
         try {
-            $this->filesystem->remove($oldCacheDir);
+            $fs->remove($oldCacheDir);
         } catch (IOException $e) {
             $io->warning($e->getMessage());
         }
@@ -142,34 +164,6 @@ EOF
         }
 
         $io->success(sprintf('Cache for the "%s" environment (debug=%s) was successfully cleared.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
-    }
-
-    private function warmupCache(InputInterface $input, OutputInterface $output, $realCacheDir, $oldCacheDir)
-    {
-        $io = new SymfonyStyle($input, $output);
-
-        // the warmup cache dir name must have the same length than the real one
-        // to avoid the many problems in serialized resources files
-        $realCacheDir = realpath($realCacheDir);
-        $warmupDir = substr($realCacheDir, 0, -1).('_' === substr($realCacheDir, -1) ? '-' : '_');
-
-        if ($this->filesystem->exists($warmupDir)) {
-            if ($output->isVerbose()) {
-                $io->comment('Clearing outdated warmup directory...');
-            }
-            $this->filesystem->remove($warmupDir);
-        }
-
-        if ($output->isVerbose()) {
-            $io->comment('Warming up cache...');
-        }
-        $this->warmup($warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
-
-        $this->filesystem->rename($realCacheDir, $oldCacheDir);
-        if ('\\' === DIRECTORY_SEPARATOR) {
-            sleep(1);  // workaround for Windows PHP rename bug
-        }
-        $this->filesystem->rename($warmupDir, $realCacheDir);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -


Here's what happens before/after this PR on `cache:clear` and `cache:clear --no-warmup`.

### Before PR

**`cache:clear`**

1. `rm var/cache_old`
1. Clearing cache in `var/cache`    &nbsp;<i>&lt;--- This is not in line and not atomic</i>
1. `rm var/cache_warmup`
1. Warming up cache in `var/cache_warmup`
1. `mv var/cache var/cache_old`
1. `mv var/cache_warmup var/cache`
1. `rm var/cache_old`

**`cache:clear --no-warmup`**

1. `rm var/cache_old`
1. Clearing cache in `var/cache`    &nbsp;<i>&lt;--- This is not in line and not atomic</i>
1. `mv var/cache var/cache_old`    <i>&lt;--- The old cache dir is completely obsolete in this workflow</i>
1. `rm var/cache_old`

---

### After PR

**`cache:clear`**

1. `rm var/cache_old`
1. `rm var/cache_new`
1. Clearing cache in `var/cache_new`
1. Warming up cache in `var/cache_new`
1. `mv var/cache var/cache_old`
1. `mv var/cache_new var/cache`
1. `rm var/cache_old`

**`cache:clear --no-warmup`**

1. `rm var/cache_old`
1. `rm var/cache_new`
1. Clearing cache in `var/cache_new`
1. `mv var/cache var/cache_old`
1. `mv var/cache_new var/cache`
1. `rm var/cache_old`

---

The main differences:
- Unify the flows and have each distinct operation only once in the code
- Clear the cache in the new cache directory and then switch to it atomically instead of clearing in the current one.
- Always have the cache directory present in the end. It was missing after `cache:clear --no-warmup` before.

I think this brings more consistency and is aligned with the present goals of the command as well.

However, I'm not really familiar with the Symfony framework and I might have wrong assumptions.