### PR TITLE
[VarDumper] New env var to select the dump format

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -204,7 +204,13 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
                 --$i;
             }
 
-            if (!\in_array(PHP_SAPI, array('cli', 'phpdbg'), true) && stripos($h[$i], 'html')) {
+            if (isset($_SERVER['VAR_DUMPER_FORMAT'])) {
+                $html = 'html' === $_SERVER['VAR_DUMPER_FORMAT'];
+            } else {
+                $html = !\in_array(PHP_SAPI, array('cli', 'phpdbg'), true) && stripos($h[$i], 'html');
+            }
+
+            if ($html) {
                 $dumper = new HtmlDumper('php://output', $this->charset);
                 $dumper->setDisplayOptions(array('fileLinkFormat' => $this->fileLinkFormat));
             } else {

--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.2.0
+-----
+
+ * support selecting the format to use by setting the environment variable `VAR_DUMPER_FORMAT` to `html` or `cli`
+
 4.1.0
 -----
 

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -27,15 +27,20 @@ class VarDumper
 
     public static function dump($var)
     {
-        if (null === self::$handler) {
-            $cloner = new VarCloner();
-            $dumper = \in_array(PHP_SAPI, array('cli', 'phpdbg'), true) ? new CliDumper() : new HtmlDumper();
-            self::$handler = function ($var) use ($cloner, $dumper) {
-                $dumper->dump($cloner->cloneVar($var));
-            };
+        if (null !== self::$handler) {
+            return \call_user_func(self::$handler, $var);
         }
 
-        return call_user_func(self::$handler, $var);
+        $cloner = new VarCloner();
+        if (isset($_SERVER['VAR_DUMPER_FORMAT'])) {
+            $dumper = 'html' === $_SERVER['VAR_DUMPER_FORMAT'] ? new HtmlDumper() : new CliDumper();
+        } else {
+            $dumper = \in_array(PHP_SAPI, array('cli', 'phpdbg')) ? new CliDumper() : new HtmlDumper();
+        }
+
+        self::$handler = function ($var) use ($cloner, $dumper) {
+            $dumper->dump($cloner->cloneVar($var));
+        };
     }
 
     public static function setHandler(callable $callable = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      |  no
| New feature?  |  yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10275

This PR introduces a new environment variable that can be used to force `dump()` to generate HTML even in CLI, or CLI even in a web context.
It allows to dump large objects when debugging a command, to open the resulting HTML in a browser, and to benefit of the nice JS UI (folded by default, search engine...).

Example usage:

    VAR_DUMPER_FORMAT=html vendor/bin/behat > tmp.html; open -a firefox tmp.html
    VAR_DUMPER_FORMAT=cli vendor/bin/behat > tmp.txt