### PR TITLE
[DI] Fix typo in PhpDoc for `resolveEnvPlaceholders`

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1286,7 +1286,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *                                    true to resolve to the actual values of the referenced env vars
      * @param array            &$usedEnvs Env vars found while resolving are added to this array
      *
-     * @return string The string with env parameters resolved
+     * @return mixed The value with env parameters resolved if a string or an array is passed
      */
     public function resolveEnvPlaceholders($value, $format = null, array &$usedEnvs = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT

`resolveEnvPlaceholders` will return a mixed value.