### PR TITLE
Proposing Flex-specific error messages in the controller shortcuts

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -153,7 +153,7 @@ trait ControllerTrait
     protected function addFlash(string $type, string $message)
     {
         if (!$this->container->has('session')) {
-            throw new \LogicException('You can not use the addFlash method if sessions are disabled.');
+            throw new \LogicException('You can not use the addFlash method if sessions are disabled. Enable them in config/packages/framework.yaml.');
         }
 
         $this->container->get('session')->getFlashBag()->add($type, $message);
@@ -169,7 +169,7 @@ trait ControllerTrait
     protected function isGranted($attributes, $subject = null): bool
     {
         if (!$this->container->has('security.authorization_checker')) {
-            throw new \LogicException('The SecurityBundle is not registered in your application.');
+            throw new \LogicException('The SecurityBundle is not registered in your application. Try running "composer require security"');
         }
 
         return $this->container->get('security.authorization_checker')->isGranted($attributes, $subject);
@@ -206,7 +206,7 @@ trait ControllerTrait
         }
 
         if (!$this->container->has('twig')) {
-            throw new \LogicException('You can not use the "renderView" method if the Templating Component or the Twig Bundle are not available.');
+            throw new \LogicException('You can not use the "renderView" method if the Templating Component or the Twig Bundle are not available. Try running "composer require twig"');
         }
 
         return $this->container->get('twig')->render($view, $parameters);
@@ -224,7 +224,7 @@ trait ControllerTrait
         } elseif ($this->container->has('twig')) {
             $content = $this->container->get('twig')->render($view, $parameters);
         } else {
-            throw new \LogicException('You can not use the "render" method if the Templating Component or the Twig Bundle are not available.');
+            throw new \LogicException('You can not use the "render" method if the Templating Component or the Twig Bundle are not available. Try running "composer require twig"');
         }
 
         if (null === $response) {
@@ -256,7 +256,7 @@ trait ControllerTrait
                 $twig->display($view, $parameters);
             };
         } else {
-            throw new \LogicException('You can not use the "stream" method if the Templating Component or the Twig Bundle are not available.');
+            throw new \LogicException('You can not use the "stream" method if the Templating Component or the Twig Bundle are not available. Try running "composer require twig"');
         }
 
         if (null === $response) {
@@ -326,7 +326,7 @@ trait ControllerTrait
     protected function getDoctrine(): ManagerRegistry
     {
         if (!$this->container->has('doctrine')) {
-            throw new \LogicException('The DoctrineBundle is not registered in your application.');
+            throw new \LogicException('The DoctrineBundle is not registered in your application. Try running "composer require doctrine"');
         }
 
         return $this->container->get('doctrine');
@@ -346,7 +346,7 @@ trait ControllerTrait
     protected function getUser()
     {
         if (!$this->container->has('security.token_storage')) {
-            throw new \LogicException('The SecurityBundle is not registered in your application.');
+            throw new \LogicException('The SecurityBundle is not registered in your application. Try running "composer require security"');
         }
 
         if (null === $token = $this->container->get('security.token_storage')->getToken()) {
@@ -372,7 +372,7 @@ trait ControllerTrait
     protected function isCsrfTokenValid(string $id, string $token): bool
     {
         if (!$this->container->has('security.csrf.token_manager')) {
-            throw new \LogicException('CSRF protection is not enabled in your application.');
+            throw new \LogicException('CSRF protection is not enabled in your application. Enable it with the "csrf_protection" key in "config/packages/framework.yaml"');
         }
 
         return $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($id, $token));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

This is to help discoverability when you try to use a feature that's not installed. It's opinionated about Flex being installed, which is why this is done on 4.0. 

Two of the options relate to configuration. An alternative (if we don't like the short description) is to include a link instead (which could be some short URL - e.g. `http://symfony.com/docs/sessions` would be pretty cool).