### PR TITLE
[Twig Bridge] Show errors in expanded choice widget.

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -129,7 +129,7 @@
     {% if 'radio-inline' in parent_label_class %}
         {{- form_label(form, null, { widget: parent() }) -}}
     {% else -%}
-        <div class="radio">
+        <div class="radio{% if not valid %} has-error{% endif %}">
             {{- form_label(form, null, { widget: parent() }) -}}
         </div>
     {%- endif %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -107,6 +107,7 @@
                     parent_label_class: label_attr.class|default(''),
                     translation_domain: choice_translation_domain,
                 }) -}}
+                {{ form_errors(child) }}
             {% endfor -%}
         </div>
     {%- endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | I think no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

I have several choices - I want to attach error to specific choice - but it's not shown.
Let's say that specific code is executed behind every choice - I want to show error at that specific choice - because that's error behind the chosen option - not the whole choice field.

![screen shot 2017-11-23 at 2 48 29 pm](https://user-images.githubusercontent.com/3340882/33173643-9891f370-d05d-11e7-95c5-442d7c9e9fcf.png)
