### PR TITLE
[WebProfilerBundle] Reset letter-spacing in toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -40,6 +40,7 @@
     -moz-box-sizing: content-box;
     box-sizing: content-box;
     vertical-align: baseline;
+    letter-spacing: normal;
 }
 
 .sf-toolbarreset {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Somewhere in our project we have

```scss
*,
*:before,
*:after {
	letter-spacing: 1px;
	box-sizing: border-box;
}
```

affecting the toolbar

<details>
 <summary>before</summary>

 ![image](https://user-images.githubusercontent.com/1047696/33201973-fa451bea-d0fa-11e7-8af4-230399f16223.png)

</details>


<details>
 <summary>after</summary>

![image](https://user-images.githubusercontent.com/1047696/33201946-e779b570-d0fa-11e7-86b6-db586c4c321e.png)

</details>
