### PR TITLE
[Process] Create a "isTtySupported" static method

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -976,16 +976,9 @@ class Process implements \IteratorAggregate
         if ('\\' === DIRECTORY_SEPARATOR && $tty) {
             throw new RuntimeException('TTY mode is not supported on Windows platform.');
         }
-        if ($tty) {
-            static $isTtySupported;
 
-            if (null === $isTtySupported) {
-                $isTtySupported = (bool) @proc_open('echo 1 >/dev/null', array(array('file', '/dev/tty', 'r'), array('file', '/dev/tty', 'w'), array('file', '/dev/tty', 'w')), $pipes);
-            }
-
-            if (!$isTtySupported) {
-                throw new RuntimeException('TTY mode requires /dev/tty to be read/writable.');
-            }
+        if ($tty && !self::isTtySupported()) {
+            throw new RuntimeException('TTY mode requires /dev/tty to be read/writable.');
         }
 
         $this->tty = (bool) $tty;
@@ -1167,6 +1160,22 @@ class Process implements \IteratorAggregate
 
             throw new ProcessTimedOutException($this, ProcessTimedOutException::TYPE_IDLE);
         }
+    }
+
+    /**
+     * Returns whether TTY is supported on the current operating system.
+     *
+     * @return bool
+     */
+    public static function isTtySupported()
+    {
+        static $isTtySupported;
+
+        if (null === $isTtySupported) {
+            $isTtySupported = (bool) @proc_open('echo 1 >/dev/null', array(array('file', '/dev/tty', 'r'), array('file', '/dev/tty', 'w'), array('file', '/dev/tty', 'w')), $pipes);
+        }
+
+        return $isTtySupported;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | _none_
| License       | MIT
| Doc PR        | _none_

Currently, there is no way to enable the TTY mode without risking an exception. This PR extracts the code checking for TTY support and provides it in a `isTtySupported` static method.

Now we can enable the TTY mode everywhere it's available without risking an exception:

```php
$process = (new Process)->setTty(Process::isTtySupported());
```

_Old comment_:
> I'm targeting the 2.7 branch since this is not really a new feature, just a little refactoring of the existent code, and it is fully backward compatible.