### PR TITLE
[Routing] Redirection from route configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveRedirectControllerSubscriber.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveRedirectControllerSubscriber.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\EventListener;
+
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Resolve the controller for requests containing the `_redirect_to` attributes.
+ *
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ */
+class ResolveRedirectControllerSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array('onKernelRequest', 20),
+        );
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $requestAttributes = $event->getRequest()->attributes;
+
+        if (!$requestAttributes->has('_controller') && $redirectTo = $requestAttributes->get('_redirect_to')) {
+            if ($this->looksLikeUrl($redirectTo)) {
+                $requestAttributes->set('_controller', array(RedirectController::class, 'urlRedirectAction'));
+                $requestAttributes->set('path', $redirectTo);
+            } else {
+                $requestAttributes->set('_controller', array(RedirectController::class, 'redirectAction'));
+                $requestAttributes->set('route', $redirectTo);
+            }
+
+            if (!$requestAttributes->has('permanent')) {
+                $requestAttributes->set('permanent', $requestAttributes->get('_redirect_permanent', false));
+            }
+        }
+    }
+
+    private function looksLikeUrl(string $urlOrRouteName): bool
+    {
+        foreach (array('/', 'http://', 'https://') as $pattern) {
+            if (0 === strpos($urlOrRouteName, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -75,5 +75,9 @@
             <argument type="service" id="controller_name_converter" />
             <tag name="kernel.event_subscriber" />
         </service>
+
+        <service id="resolve_redirect_controller_name_subscriber" class="Symfony\Bundle\FrameworkBundle\EventListener\ResolveRedirectControllerSubscriber">
+            <tag name="kernel.event_subscriber" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/EventListener/ResolveRedirectControllerSubscriberTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/EventListener/ResolveRedirectControllerSubscriberTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\EventListener;
+
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+use Symfony\Bundle\FrameworkBundle\EventListener\ResolveRedirectControllerSubscriber;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class ResolveRedirectControllerSubscriberTest extends TestCase
+{
+    /**
+     * @dataProvider provideRedirectionExamples
+     */
+    public function testSetControllerForRedirectToRoute(Request $request, array $expectedAttributes)
+    {
+        $httpKernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
+        $subscriber = new ResolveRedirectControllerSubscriber();
+        $subscriber->onKernelRequest(new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST));
+
+        foreach ($expectedAttributes as $name => $value) {
+            $this->assertEquals($value, $request->attributes->get($name));
+        }
+    }
+
+    public function provideRedirectionExamples()
+    {
+        // No redirection
+        yield array($this->requestWithAttributes(array(
+            '_controller' => 'AppBundle:Starting:format',
+        )), array(
+            '_controller' => 'AppBundle:Starting:format',
+        ));
+
+        // Controller win over redirection
+        yield array($this->requestWithAttributes(array(
+            '_controller' => 'AppBundle:Starting:format',
+            '_redirect_to' => 'https://google.com',
+        )), array(
+            '_controller' => 'AppBundle:Starting:format',
+        ));
+
+        // Redirection to URL
+        yield array($this->requestWithAttributes(array(
+            '_redirect_to' => 'https://google.com',
+        )), array(
+            '_controller' => array(RedirectController::class, 'urlRedirectAction'),
+            'path' => 'https://google.com',
+        ));
+
+        // Redirection to route
+        yield array($this->requestWithAttributes(array(
+            '_redirect_to' => 'route',
+        )), array(
+            '_controller' => array(RedirectController::class, 'redirectAction'),
+            'route' => 'route',
+        ));
+
+        // Permanent redirection to route
+        yield array($this->requestWithAttributes(array(
+            '_redirect_to' => 'route',
+            '_redirect_permanent' => true,
+        )), array(
+            '_controller' => array(RedirectController::class, 'redirectAction'),
+            'route' => 'route',
+            'permanent' => true,
+        ));
+    }
+
+    private function requestWithAttributes(array $attributes): Request
+    {
+        $request = new Request();
+
+        foreach ($attributes as $name => $value) {
+            $request->attributes->set($name, $value);
+        }
+
+        return $request;
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -243,6 +243,15 @@ class XmlFileLoader extends FileLoader
             $defaults['_controller'] = $controller;
         }
 
+        if ($redirectTo = $node->getAttribute('redirect-to')) {
+            if (isset($defaults['_controller'])) {
+                throw new \InvalidArgumentException(sprintf('The routing file "%s" must not specify both a controller and a redirection.', $path));
+            }
+
+            $defaults['_redirect_to'] = $redirectTo;
+            $defaults['_redirect_permanent'] = (bool) $node->getAttribute('redirect-permanent');
+        }
+
         return array($defaults, $requirements, $options, $condition);
     }
 

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -28,7 +28,7 @@ use Symfony\Component\Config\Loader\FileLoader;
 class YamlFileLoader extends FileLoader
 {
     private static $availableKeys = array(
-        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix',
+        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix', 'redirect_to', 'redirect_permanent',
     );
     private $yamlParser;
 
@@ -118,6 +118,15 @@ class YamlFileLoader extends FileLoader
 
         if (isset($config['controller'])) {
             $defaults['_controller'] = $config['controller'];
+        }
+
+        if (isset($config['redirect_to'])) {
+            if (isset($defaults['_controller'])) {
+                throw new \InvalidArgumentException(sprintf('The routing file "%s" must not specify both a controller and a redirection.', $path));
+            }
+
+            $defaults['_redirect_to'] = $config['redirect_to'];
+            $defaults['_redirect_permanent'] = $config['redirect_permanent'] ?? false;
         }
 
         $route = new Route($config['path'], $defaults, $requirements, $options, $host, $schemes, $methods, $condition);

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -42,6 +42,8 @@
     <xsd:attribute name="schemes" type="xsd:string" />
     <xsd:attribute name="methods" type="xsd:string" />
     <xsd:attribute name="controller" type="xsd:string" />
+    <xsd:attribute name="redirect-to" type="xsd:string" />
+    <xsd:attribute name="redirect-permanent" type="xsd:boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="import">

--- a/src/Symfony/Component/Routing/Tests/Fixtures/redirect_to/redirect_with_controller.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/redirect_to/redirect_with_controller.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="app_symfony" path="/symfony" redirect-to="https://symfony.com" controller="App\Controller\Symfony" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/redirect_to/redirect_with_controller.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/redirect_to/redirect_with_controller.yml
@@ -1,0 +1,4 @@
+app_symfony:
+    path: /symfony
+    controller: App\Controller\Symfony
+    redirect_to: https://symfony.com

--- a/src/Symfony/Component/Routing/Tests/Fixtures/redirect_to/routing.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/redirect_to/routing.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="app_homepage" path="/" controller="AppBundle:Homepage:show" />
+    <route id="app_temporary_redirect" path="/home" redirect-to="app_homepage" />
+    <route id="app_permanent_redirect" path="/permanent-home" redirect-to="/" redirect-permanent="true" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/redirect_to/routing.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/redirect_to/routing.yml
@@ -1,0 +1,12 @@
+app_homepage:
+    path: /
+    controller: AppBundle:Homepage:show
+
+app_temporary_redirect:
+    path: /home
+    redirect_to: app_homepage
+
+app_permanent_redirect:
+    path: /permanent-home
+    redirect_to: /
+    redirect_permanent: true

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -372,4 +372,31 @@ class XmlFileLoaderTest extends TestCase
         $this->assertNotNull($routeCollection->get('api_app_blog'));
         $this->assertEquals('/api/blog', $routeCollection->get('api_app_blog')->getPath());
     }
+
+    public function testRedirections()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/redirect_to')));
+        $routeCollection = $loader->load('routing.xml');
+
+        $route = $routeCollection->get('app_homepage');
+        $this->assertSame('AppBundle:Homepage:show', $route->getDefault('_controller'));
+
+        $route = $routeCollection->get('app_temporary_redirect');
+        $this->assertSame('app_homepage', $route->getDefault('_redirect_to'));
+        $this->assertFalse($route->getDefault('_redirect_permanent'));
+
+        $route = $routeCollection->get('app_permanent_redirect');
+        $this->assertSame('/', $route->getDefault('_redirect_to'));
+        $this->assertTrue($route->getDefault('_redirect_permanent'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /The routing file "[^"]*" must not specify both a controller and a redirection\./
+     */
+    public function testRedirectionCannotBeUsedWithController()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/redirect_to')));
+        $loader->load('redirect_with_controller.xml');
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -193,4 +193,31 @@ class YamlFileLoaderTest extends TestCase
         $this->assertNotNull($routeCollection->get('api_app_blog'));
         $this->assertEquals('/api/blog', $routeCollection->get('api_app_blog')->getPath());
     }
+
+    public function testRedirections()
+    {
+        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/redirect_to')));
+        $routeCollection = $loader->load('routing.yml');
+
+        $route = $routeCollection->get('app_homepage');
+        $this->assertSame('AppBundle:Homepage:show', $route->getDefault('_controller'));
+
+        $route = $routeCollection->get('app_temporary_redirect');
+        $this->assertSame('app_homepage', $route->getDefault('_redirect_to'));
+        $this->assertFalse($route->getDefault('_redirect_permanent'));
+
+        $route = $routeCollection->get('app_permanent_redirect');
+        $this->assertSame('/', $route->getDefault('_redirect_to'));
+        $this->assertTrue($route->getDefault('_redirect_permanent'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /The routing file "[^"]*" must not specify both a controller and a redirection\./
+     */
+    public function testRedirectionCannotBeUsedWithController()
+    {
+        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/redirect_to')));
+        $loader->load('redirect_with_controller.yml');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24640
| License       | MIT
| Doc PR        | ø

Following @javiereguiluz's proposal (#24640), this PR allows developers to configure the redirection directly in the routing configuration.

```yaml
app_entrypoint:
    path: /
    redirect_to: /homepage
``` 