### PR TITLE
Release v3.4.0-RC2

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -7,6 +7,22 @@ in 3.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.4.0...v3.4.1
 
+* 3.4.0-RC2 (2017-11-24)
+
+ * bug #25146 [DI] Dont resolve envs in service ids (nicolas-grekas)
+ * bug #25113 [Routing] Fix "config-file-relative" annotation loader resources (nicolas-grekas, sroze)
+ * bug #25065 [FrameworkBundle] Update translation commands to work with default paths (yceruto)
+ * bug #25109 Make debug:container search command case-insensitive (jzawadzki)
+ * bug #25121 [FrameworkBundle] Fix AssetsInstallCommand (nicolas-grekas)
+ * bug #25102 [Form] Fixed ContextErrorException in FileType (chihiro-adachi)
+ * bug #25130 [DI] Fix handling of inlined definitions by ContainerBuilder (nicolas-grekas)
+ * bug #25119 [DI] Fix infinite loop when analyzing references (nicolas-grekas)
+ * bug #25094 [FrameworkBundle][DX] Display a nice error message if an enabled component is missing (derrabus)
+ * bug #25100 [SecurityBundle] providerIds is undefined error when firewall provider is not specified (karser)
+ * bug #25100 [SecurityBundle] providerIds is undefined error when firewall provider is not specified (karser)
+ * bug #25100 [SecurityBundle] providerIds is undefined error when firewall provider is not specified (karser)
+ * bug #25097 [Bridge\PhpUnit] Turn "preserveGlobalState" to false by default, revert "Blacklist" removal (nicolas-grekas)
+
 * 3.4.0-RC1 (2017-11-21)
 
  * bug #25077 [Bridge/Twig] Let getFlashes starts the session (MatTheCat)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -67,12 +67,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '3.4.0-DEV';
+    const VERSION = '3.4.0-RC2';
     const VERSION_ID = 30400;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 4;
     const RELEASE_VERSION = 0;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = 'RC2';
 
     const END_OF_MAINTENANCE = '11/2020';
     const END_OF_LIFE = '11/2021';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.4.0-RC1...v3.4.0-RC2)

 * bug #25146 [DI] Dont resolve envs in service ids (@nicolas-grekas)
 * bug #25113 [Routing] Fix "config-file-relative" annotation loader resources (@nicolas-grekas, @sroze)
 * bug #25065 [FrameworkBundle] Update translation commands to work with default paths (@yceruto)
 * bug #25109 Make debug:container search command case-insensitive (@jzawadzki)
 * bug #25121 [FrameworkBundle] Fix AssetsInstallCommand (@nicolas-grekas)
 * bug #25102 [Form] Fixed ContextErrorException in FileType (@chihiro-adachi)
 * bug #25130 [DI] Fix handling of inlined definitions by ContainerBuilder (@nicolas-grekas)
 * bug #25119 [DI] Fix infinite loop when analyzing references (@nicolas-grekas)
 * bug #25094 [FrameworkBundle][DX] Display a nice error message if an enabled component is missing (@derrabus)
 * bug #25100 [SecurityBundle] providerIds is undefined error when firewall provider is not specified (@karser)
 * bug #25100 [SecurityBundle] providerIds is undefined error when firewall provider is not specified (@karser)
 * bug #25100 [SecurityBundle] providerIds is undefined error when firewall provider is not specified (@karser)
 * bug #25097 [Bridge\PhpUnit] Turn "preserveGlobalState" to false by default, revert "Blacklist" removal (@nicolas-grekas)
