### PR TITLE
Pr/workflow name as graph label

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,7 +8,8 @@ CHANGELOG
  * Allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
  * Added a new `parameter_bag` service with related autowiring aliases to access parameters as-a-service
  * Allowed the `Router` to work with any PSR-11 container
- * added option in workflow dump command to label graph with custom label
+ * allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
+ * added option in workflow dump command to label graph with a custom label
 
 4.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,13 +1,14 @@
 CHANGELOG
 =========
 
+<<<<<<< HEAD
 4.1.0
 -----
 
  * Allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
  * Added a new `parameter_bag` service with related autowiring aliases to access parameters as-a-service
  * Allowed the `Router` to work with any PSR-11 container
- * added option in workflow dump command to label graph with workflow name
+ * added option in workflow dump command to label graph with custom label
 
 4.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
  * Added a new `parameter_bag` service with related autowiring aliases to access parameters as-a-service
  * Allowed the `Router` to work with any PSR-11 container
+ * added option in workflow dump command to label graph with workflow name
 
 4.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,14 +1,12 @@
 CHANGELOG
 =========
 
-<<<<<<< HEAD
 4.1.0
 -----
 
  * Allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
  * Added a new `parameter_bag` service with related autowiring aliases to access parameters as-a-service
  * Allowed the `Router` to work with any PSR-11 container
- * allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
  * added option in workflow dump command to label graph with a custom label
 
 4.0.0

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -37,6 +37,7 @@ class WorkflowDumpCommand extends Command
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::REQUIRED, 'A workflow name'),
                 new InputArgument('marking', InputArgument::IS_ARRAY, 'A marking (a list of places)'),
+                new InputOption('workflow-name-label', null, null, 'Labels graph with workflow name'),
             ))
             ->setDescription('Dump a workflow')
             ->setHelp(<<<'EOF'
@@ -73,6 +74,11 @@ EOF
             $marking->mark($place);
         }
 
-        $output->writeln($dumper->dump($workflow->getDefinition(), $marking));
+        $options = [];
+        if ($input->getOption('workflow-name-label')) {
+            $options = ['graph' => ['label' => $serviceId]];
+        }
+
+        $output->writeln($dumper->dump($workflow->getDefinition(), $marking, $options));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -78,7 +78,7 @@ EOF
         $options = array();
         $label = $input->getOption('label');
         if (null !== $label && '' !== trim($label)) {
-            $options = array('graph' => array('label' => $input->getOption('label')));
+            $options = array('graph' => array('label' => $label));
         }
         $output->writeln($dumper->dump($workflow->getDefinition(), $marking, $options));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -38,7 +38,7 @@ class WorkflowDumpCommand extends Command
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::REQUIRED, 'A workflow name'),
                 new InputArgument('marking', InputArgument::IS_ARRAY, 'A marking (a list of places)'),
-                new InputOption('label', 'l',  InputArgument::OPTIONAL,  'Labels a graph'),
+                new InputOption('label', 'l', InputArgument::OPTIONAL, 'Labels a graph'),
             ))
             ->setDescription('Dump a workflow')
             ->setHelp(<<<'EOF'

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Workflow\Dumper\GraphvizDumper;
 use Symfony\Component\Workflow\Dumper\StateMachineGraphvizDumper;
@@ -37,7 +38,7 @@ class WorkflowDumpCommand extends Command
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::REQUIRED, 'A workflow name'),
                 new InputArgument('marking', InputArgument::IS_ARRAY, 'A marking (a list of places)'),
-                new InputOption('workflow-name-label', null, null, 'Labels graph with workflow name'),
+                new InputOption('label', 'l',  InputArgument::OPTIONAL,  'Labels a graph'),
             ))
             ->setDescription('Dump a workflow')
             ->setHelp(<<<'EOF'
@@ -75,10 +76,10 @@ EOF
         }
 
         $options = array();
-        if ($input->getOption('workflow-name-label')) {
-            $options = array('graph' => array('label' => $serviceId));
+        $label = $input->getOption('label');
+        if (null !== $label && '' !== trim($label)) {
+            $options = array('graph' => array('label' => $input->getOption('label')));
         }
-
         $output->writeln($dumper->dump($workflow->getDefinition(), $marking, $options));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -74,9 +74,9 @@ EOF
             $marking->mark($place);
         }
 
-        $options = [];
+        $options = array();
         if ($input->getOption('workflow-name-label')) {
-            $options = ['graph' => ['label' => $serviceId]];
+            $options = array('graph' => array('label' => $serviceId));
         }
 
         $output->writeln($dumper->dump($workflow->getDefinition(), $marking, $options));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This pull request added an option to the workflow dumper command, which allows you to add a graph label with the workflow name to the output. Without the option nothing changed the behavior from before.

Example call:

```bash
bin/console workflow:dump <workflowname> --label=custom_label
```