### PR TITLE
[Form] Don't rely on `Symfony\Component\HttpFoundation\File\File` if http-foundation isn't installed in FileType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -92,9 +92,12 @@ class FileType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $dataClass = function (Options $options) {
-            return $options['multiple'] || !class_exists('Symfony\Component\HttpFoundation\File\File') ? null : 'Symfony\Component\HttpFoundation\File\File';
-        };
+        $dataClass = null;
+        if (class_exists('Symfony\Component\HttpFoundation\File\File')) {
+            $dataClass = function (Options $options) {
+                return $options['multiple'] ? null : 'Symfony\Component\HttpFoundation\File\File';
+            };
+        }
 
         $emptyData = function (Options $options) {
             return $options['multiple'] ? array() : null;

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -93,7 +93,7 @@ class FileType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $dataClass = function (Options $options) {
-            return $options['multiple'] ? null : 'Symfony\Component\HttpFoundation\File\File';
+            return $options['multiple'] || !class_exists('Symfony\Component\HttpFoundation\File\File') ? null : 'Symfony\Component\HttpFoundation\File\File';
         };
 
         $emptyData = function (Options $options) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | may need discussion
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Currently `FileType` may depend on `Symfony\Component\HttpFoundation\File\File` regardless `http-foundation` has been installed or not.
It leads to occur the class-not-found error.
(Attached the screen capture, please see below and I provided the representation [here](https://github.com/issei-m/form-bug-representation/issues/1) for your information)

So I ensure `Symfony\Component\HttpFoundation\File\File` does exist, and if not, we don't specify any classes for this type.
While setting no specified class to `data_class` means making [property path behavior changed](https://github.com/symfony/symfony/blob/7234bfd56a9aa388db839af066f24c7ec70f86e9/src/Symfony/Component/Form/Form.php#L229-L231),
[NativeRequestHandler](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/NativeRequestHandler.php) which is usually expected to be used in non-full-stack env handles a pure array like `$_FILES` holds, fully intended behavior AFAIK.

![image](https://user-images.githubusercontent.com/1135118/33216654-14706a56-d178-11e7-8e4b-c38c14ec7532.png)
