### PR TITLE
[DependencyInjection] Detect case mismatch in autowiring

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -336,13 +336,14 @@ class AutowirePass extends AbstractRecursivePass
         if ($message = $this->getAliasesSuggestionForType($type = $reference->getType())) {
             return ' '.$message;
         }
-
         if (isset($this->ambiguousServiceTypes[$type])) {
             $message = sprintf('one of these existing services: "%s"', implode('", "', $this->ambiguousServiceTypes[$type]));
         } elseif (isset($this->types[$type])) {
             $message = sprintf('the existing "%s" service', $this->types[$type]);
         } elseif ($reference->getRequiringClass() && !$reference->canBeAutoregistered()) {
             return ' It cannot be auto-registered because it is from a different root namespace.';
+        } elseif (is_array($this->types) && (null !== $key = array_search(strtolower($type), array_map('strtolower', $this->types)))) {
+            return sprintf(' Maybe you mean %s instead of %s ?', $key, $type);
         } else {
             return;
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -336,14 +336,16 @@ class AutowirePass extends AbstractRecursivePass
         if ($message = $this->getAliasesSuggestionForType($type = $reference->getType())) {
             return ' '.$message;
         }
-        if (isset($this->ambiguousServiceTypes[$type])) {
+
+        $servicesAndAliases = $this->container->getServiceIds();
+        if (!$this->container->has($type) && false !== $key = array_search(strtolower($type), array_map('strtolower', $servicesAndAliases))) {
+            return sprintf(' Did you mean "%s"?', $servicesAndAliases[$key]);
+        } elseif (isset($this->ambiguousServiceTypes[$type])) {
             $message = sprintf('one of these existing services: "%s"', implode('", "', $this->ambiguousServiceTypes[$type]));
         } elseif (isset($this->types[$type])) {
             $message = sprintf('the existing "%s" service', $this->types[$type]);
         } elseif ($reference->getRequiringClass() && !$reference->canBeAutoregistered()) {
             return ' It cannot be auto-registered because it is from a different root namespace.';
-        } elseif (is_array($this->types) && (null !== $key = array_search(strtolower($type), array_map('strtolower', $this->types)))) {
-            return sprintf(' Maybe you mean %s instead of %s ?', $key, $type);
         } else {
             return;
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -687,6 +687,24 @@ class AutowirePassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
+     * @expectedExceptionMessage Cannot autowire service "foo": argument "$sam" of method "Symfony\Component\DependencyInjection\Tests\Compiler\NotWireable::setNotAutowireableBecauseOfATypo()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\lesTilleuls" but no such service exists. Did you mean "Symfony\Component\DependencyInjection\Tests\Compiler\LesTilleuls"?
+     */
+    public function testSuggestRegisteredServicesWithSimilarCase()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(LesTilleuls::class, LesTilleuls::class);
+        $container->register('foo', NotWireable::class)->setAutowired(true)
+            ->addMethodCall('setNotAutowireableBecauseOfATypo', array())
+        ;
+
+        (new ResolveClassPass())->process($container);
+        (new AutowireRequiredMethodsPass())->process($container);
+        (new AutowirePass())->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\AutowiringFailedException
      * @expectedExceptionMessage Cannot autowire service "j": argument "$i" of method "Symfony\Component\DependencyInjection\Tests\Compiler\J::__construct()" references class "Symfony\Component\DependencyInjection\Tests\Compiler\I" but no such service exists. Try changing the type-hint to "Symfony\Component\DependencyInjection\Tests\Compiler\IInterface" instead.
      */
     public function testByIdAlternative()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -6,6 +6,13 @@ class Foo
 {
 }
 
+class FooFoo
+{
+    public function __construct(Foo $foo)
+    {
+    }
+}
+
 class Bar
 {
     public function __construct(Foo $foo)
@@ -289,6 +296,17 @@ class SetterInjectionParent
 
     /** @required */
     public function setChildMethodWithoutDocBlock(A $a)
+    {
+    }
+}
+
+class ARealClass {
+
+}
+
+class ClassMisMatch {
+
+    public function __construct(arealclass $n = null)
     {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -6,13 +6,6 @@ class Foo
 {
 }
 
-class FooFoo
-{
-    public function __construct(Foo $foo)
-    {
-    }
-}
-
 class Bar
 {
     public function __construct(Foo $foo)
@@ -300,20 +293,13 @@ class SetterInjectionParent
     }
 }
 
-class ARealClass {
-
-}
-
-class ClassMisMatch {
-
-    public function __construct(arealclass $n = null)
-    {
-    }
-}
-
 class NotWireable
 {
     public function setNotAutowireable(NotARealClass $n)
+    {
+    }
+
+    public function setNotAutowireableBecauseOfATypo(lesTilleuls $sam)
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25122
| License       | MIT
| Doc PR        | ø

If there is a case-sensitive typo in the service injection, this will suggest the non-typoed version.