### PR TITLE
[DI] Prevent a ReflectionException during cache:clear when the parent class doesn't exist

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -378,7 +378,11 @@ EOTXT;
         if (isset($lineage[$class])) {
             return;
         }
-        if (!$r = $this->container->getReflectionClass($class)) {
+        try {
+            if (!$r = $this->container->getReflectionClass($class)) {
+                return;
+            }
+        } catch (\ReflectionException $e) {
             return;
         }
         if ($this->container instanceof $class) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -378,11 +378,7 @@ EOTXT;
         if (isset($lineage[$class])) {
             return;
         }
-        try {
-            if (!$r = $this->container->getReflectionClass($class)) {
-                return;
-            }
-        } catch (\ReflectionException $e) {
+        if (!$r = $this->container->getReflectionClass($class, false)) {
             return;
         }
         if ($this->container instanceof $class) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ParentNotExists.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ParentNotExists.php
@@ -1,19 +1,7 @@
 <?php
 
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
-/**
- * @author Kévin Dunglas <dunglas@gmail.com>
- */
 class ParentNotExists extends \NotExists
 {
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ParentNotExists.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ParentNotExists.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ParentNotExists extends \NotExists
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_inline_requires.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_inline_requires.php
@@ -14,6 +14,6 @@ $container = new ContainerBuilder();
 $container->register(HotPath\C1::class)->addTag('container.hot_path')->setPublic(true);
 $container->register(HotPath\C2::class)->addArgument(new Reference(HotPath\C3::class))->setPublic(true);
 $container->register(HotPath\C3::class);
-$container->register(ParentNotExists::class);
+$container->register(ParentNotExists::class)->setPublic(true);
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_inline_requires.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_inline_requires.php
@@ -7,11 +7,13 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists;
 
 $container = new ContainerBuilder();
 
 $container->register(HotPath\C1::class)->addTag('container.hot_path')->setPublic(true);
 $container->register(HotPath\C2::class)->addArgument(new Reference(HotPath\C3::class))->setPublic(true);
 $container->register(HotPath\C3::class);
+$container->register(ParentNotExists::class);
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/container_inline_requires.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/container_inline_requires.php
@@ -41,7 +41,6 @@ class ProjectServiceContainer extends Container
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C3' => 'getC3Service',
         );
         $this->privates = array(
-            'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\ParentNotExists' => true,
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C3' => true,
         );
 
@@ -79,6 +78,16 @@ class ProjectServiceContainer extends Container
     }
 
     /**
+     * Gets the public 'Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists' shared service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists
+     */
+    protected function getParentNotExistsService()
+    {
+        return $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists();
+    }
+
+    /**
      * Gets the public 'Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C1' shared service.
      *
      * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C1
@@ -99,16 +108,6 @@ class ProjectServiceContainer extends Container
         require_once $this->targetDirs[1].'/includes/HotPath/C3.php';
 
         return $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2(${($_ = isset($this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3']) ? $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3'] : $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3()) && false ?: '_'});
-    }
-
-    /**
-     * Gets the private 'Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists' shared service.
-     *
-     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists
-     */
-    protected function getParentNotExistsService()
-    {
-        return $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/container_inline_requires.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/container_inline_requires.php
@@ -32,13 +32,16 @@ class ProjectServiceContainer extends Container
             'symfony\\component\\dependencyinjection\\tests\\fixtures\\includes\\hotpath\\c1' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C1',
             'symfony\\component\\dependencyinjection\\tests\\fixtures\\includes\\hotpath\\c2' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C2',
             'symfony\\component\\dependencyinjection\\tests\\fixtures\\includes\\hotpath\\c3' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C3',
+            'symfony\\component\\dependencyinjection\\tests\\fixtures\\parentnotexists' => 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\ParentNotExists',
         );
         $this->methodMap = array(
+            'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\ParentNotExists' => 'getParentNotExistsService',
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C1' => 'getC1Service',
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C2' => 'getC2Service',
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C3' => 'getC3Service',
         );
         $this->privates = array(
+            'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\ParentNotExists' => true,
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C3' => true,
         );
 
@@ -96,6 +99,16 @@ class ProjectServiceContainer extends Container
         require_once $this->targetDirs[1].'/includes/HotPath/C3.php';
 
         return $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2(${($_ = isset($this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3']) ? $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3'] : $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3()) && false ?: '_'});
+    }
+
+    /**
+     * Gets the private 'Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists' shared service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists
+     */
+    protected function getParentNotExistsService()
+    {
+        return $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  |  no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Currently, if you just run the following commands:

```
composer create-project -s beta symfony/skeleton:^3.4 test
composer req orm
```

You get the following error:

```
In UniqueEntityValidator.php line 27:
                                                                   
  [ReflectionException]                                            
  Class Symfony\Component\Validator\ConstraintValidator not found  
```

`UniqueEntityValidator` is in the bridge, but it's parent class is in the validator (that is not installed by default). The hot path optimization feature (enabled by default) uses reflection, and the reflection API throws an exception in this specific case.

This PR fixes the error.