### PR TITLE
[HttpKernel] Read $_ENV when checking SHELL_VERBOSITY

### DIFF
--- a/src/Symfony/Component/HttpKernel/Log/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Log/Logger.php
@@ -42,8 +42,8 @@ class Logger extends AbstractLogger
         if (null === $minLevel) {
             $minLevel = LogLevel::WARNING;
 
-            if (isset($_SERVER['SHELL_VERBOSITY'])) {
-                switch ((int) $_SERVER['SHELL_VERBOSITY']) {
+            if (isset($_ENV['SHELL_VERBOSITY']) || isset($_SERVER['SHELL_VERBOSITY'])) {
+                switch ((int) (isset($_ENV['SHELL_VERBOSITY']) ? $_ENV['SHELL_VERBOSITY'] : $_SERVER['SHELL_VERBOSITY'])) {
                     case -1: $minLevel = LogLevel::ERROR; break;
                     case 1: $minLevel = LogLevel::NOTICE; break;
                     case 2: $minLevel = LogLevel::INFO; break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Needed so that we can set the env var from `phpunit.xml.dist`.