### PR TITLE
[WebProfilerBundle] Improve controller linking

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -49,13 +49,6 @@
                 <span>{{ request_handler }}</span>
             </div>
 
-            {% if collector.controller.class is defined -%}
-                <div class="sf-toolbar-info-piece">
-                    <b>Controller class</b>
-                    <span>{{ collector.controller.class }}</span>
-                </div>
-            {%- endif %}
-
             <div class="sf-toolbar-info-piece">
                 <b>Route name</b>
                 <span>{{ collector.route|default('NONE') }}</span>
@@ -297,7 +290,7 @@
     {% if controller.class is defined -%}
         {%- if method|default(false) %}<span class="sf-toolbar-status sf-toolbar-redirection-method">{{ method }}</span>{% endif -%}
         {%- set link = controller.file|file_link(controller.line) %}
-        {%- if link %}<a href="{{ link }}" title="{{ controller.file }}">{% else %}<span>{% endif %}
+        {%- if link %}<a href="{{ link }}" title="{{ controller.class }}">{% else %}<span title="{{ controller.class }}">{% endif %}
 
             {%- if route|default(false) -%}
                 @{{ route }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

I propose to remove the `Controller class` entry from the request toolbar panel, IMHO it's confusing/useless compared to the linked `Controller` entry above. They represent the same.

To preserve its value it's now used as title attribute instead, favored over controller file currently being used here. We can read that from the statusbar anyway :-)

Before: (hovering ontroller link)

![image](https://user-images.githubusercontent.com/1047696/35796142-ce6cdff4-0a5b-11e8-9fa3-91897516c9fc.png)

After: (hovering ontroller link)

![image](https://user-images.githubusercontent.com/1047696/35796237-2855e556-0a5c-11e8-8dca-853c3eabd2e9.png)
