### PR TITLE
[Form] allow to pass the \DateTimeZone::PER_COUNTRY flag to list identifier per country

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -38,19 +38,22 @@ class TimezoneType extends AbstractType
         $resolver->setDefaults(array(
             'choice_loader' => function (Options $options) {
                 $regions = $options['regions'];
+                $country = $options['country'];
 
-                return new CallbackChoiceLoader(function () use ($regions) {
-                    return self::getTimezones($regions);
+                return new CallbackChoiceLoader(function () use ($regions, $country) {
+                    return self::getTimezones($regions, $country);
                 });
             },
             'choice_translation_domain' => false,
             'input' => 'string',
-            'regions' => \DateTimeZone::ALL,
+            'regions' => isset($options['country']) ? \DateTimeZone::PER_COUNTRY : \DateTimeZone::ALL,
+            'country' => null,
         ));
 
         $resolver->setAllowedValues('input', array('string', 'datetimezone'));
 
         $resolver->setAllowedTypes('regions', 'int');
+        $resolver->setAllowedTypes('country', array('string', 'null'));
     }
 
     /**
@@ -72,11 +75,11 @@ class TimezoneType extends AbstractType
     /**
      * Returns a normalized array of timezone choices.
      */
-    private static function getTimezones(int $regions): array
+    private static function getTimezones(int $regions, ?string $country = null): array
     {
         $timezones = array();
 
-        foreach (\DateTimeZone::listIdentifiers($regions) as $timezone) {
+        foreach (\DateTimeZone::listIdentifiers($regions, $country) as $timezone) {
             $parts = explode('/', $timezone);
 
             if (count($parts) > 2) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -34,6 +34,13 @@ class TimezoneTypeTest extends BaseTypeTest
         parent::testSubmitNull($expected, $norm, '');
     }
 
+    public function testFilterByRegionsAndByCountry()
+    {
+        $choices = $this->factory->create(static::TESTED_TYPE, null, array('regions' => \DateTimeZone::PER_COUNTRY, 'country' => 'US'))
+            ->createView()->vars['choices'];
+        $this->assertEquals(new ChoiceView('America/Adak', 'America/Adak', 'Adak'), $choices['America']->getIterator()[0]);
+    }
+
     public function testDateTimeZoneInput()
     {
         $form = $this->factory->create(static::TESTED_TYPE, new \DateTimeZone('America/New_York'), array('input' => 'datetimezone'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #25105 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->
![img_2813](https://user-images.githubusercontent.com/3451634/33243033-4f0be2e6-d2de-11e7-92d9-1633a446e65c.jpg)
Working with a hot chocolate ;).

This PR allows passing the PER_COUNTRY flag to DateTimeZone in the TimeZoneType.