### PR TITLE
[Form][TwigBridge] Handle MoneyType with non UTF-8 charset

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -23,11 +23,11 @@
     <div class="input-group">
         {% set append = money_pattern starts with '{{' %}
         {% if not append %}
-            <span class="input-group-addon">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+            <span class="input-group-addon">{{ money_pattern|convert_encoding(_charset, 'UTF-8')|replace({ '{{ widget }}':''})|raw }}</span>
         {% endif %}
         {{- block('form_widget_simple') -}}
         {% if append %}
-            <span class="input-group-addon">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+            <span class="input-group-addon">{{ money_pattern|convert_encoding(_charset, 'UTF-8')|replace({ '{{ widget }}':''})|raw }}</span>
         {% endif %}
     </div>
 {%- endblock money_widget %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -142,7 +142,7 @@
 {%- endblock integer_widget -%}
 
 {%- block money_widget -%}
-    {{ money_pattern|replace({ '{{ widget }}': block('form_widget_simple') })|raw }}
+    {{ money_pattern|convert_encoding(_charset, 'UTF-8')|replace({ '{{ widget }}': block('form_widget_simple') })|raw }}
 {%- endblock money_widget -%}
 
 {%- block url_widget -%}

--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -43,7 +43,7 @@ class MoneyType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['money_pattern'] = self::getPattern($options['currency']);
+        $view->vars['money_pattern'] = htmlentities(self::getPattern($options['currency']), ENT_QUOTES | (defined('ENT_SUBSTITUTE') ? ENT_SUBSTITUTE : 0), 'UTF-8');
     }
 
     /**
@@ -83,7 +83,7 @@ class MoneyType extends AbstractType
     }
 
     /**
-     * Returns the pattern for this locale.
+     * Returns the pattern for this locale in UTF-8.
      *
      * The pattern contains the placeholder "{{ widget }}" where the HTML tag should
      * be inserted

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -62,7 +62,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         try {
             // Wrap in <root> node so we can load HTML with multiple tags at
             // the top level
-            $dom->loadXML('<root>'.$html.'</root>');
+            $dom->loadHTML('<!DOCTYPE html><html><body>'.$html.'</body></html>');
         } catch (\Exception $e) {
             $this->fail(sprintf(
                 "Failed loading HTML:\n\n%s\n\nError: %s",
@@ -71,17 +71,15 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             ));
         }
         $xpath = new \DOMXPath($dom);
-        $nodeList = $xpath->evaluate('/root'.$expression);
+        $nodeList = $xpath->evaluate('/html/body'.$expression);
 
         if ($nodeList->length != $count) {
-            $dom->formatOutput = true;
             $this->fail(sprintf(
                 "Failed asserting that \n\n%s\n\nmatches exactly %s. Matches %s in \n\n%s",
                 $expression,
                 1 == $count ? 'once' : $count.' times',
                 1 == $nodeList->length ? 'once' : $nodeList->length.' times',
-                // strip away <root> and </root>
-                substr($dom->saveHTML(), 6, -8)
+                $html
             ));
         } else {
             $this->addToAssertionCount(1);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -33,7 +33,7 @@ class MoneyTypeTest extends BaseTypeTest
         $view = $this->factory->create(static::TESTED_TYPE)
             ->createView();
 
-        $this->assertSame('{{ widget }} €', $view->vars['money_pattern']);
+        $this->assertSame('{{ widget }} &euro;', $view->vars['money_pattern']);
     }
 
     public function testMoneyPatternWorksForYen()
@@ -43,7 +43,7 @@ class MoneyTypeTest extends BaseTypeTest
         $view = $this->factory->create(static::TESTED_TYPE, null, array('currency' => 'JPY'))
             ->createView();
 
-        $this->assertTrue((bool) strstr($view->vars['money_pattern'], '¥'));
+        $this->assertTrue((bool) strstr($view->vars['money_pattern'], '&yen;'));
     }
 
     // https://github.com/symfony/symfony/issues/5458
@@ -54,8 +54,8 @@ class MoneyTypeTest extends BaseTypeTest
         $view1 = $this->factory->create(static::TESTED_TYPE, null, array('currency' => 'GBP'))->createView();
         $view2 = $this->factory->create(static::TESTED_TYPE, null, array('currency' => 'EUR'))->createView();
 
-        $this->assertSame('{{ widget }} £', $view1->vars['money_pattern']);
-        $this->assertSame('{{ widget }} €', $view2->vars['money_pattern']);
+        $this->assertSame('{{ widget }} &pound;', $view1->vars['money_pattern']);
+        $this->assertSame('{{ widget }} &euro;', $view2->vars['money_pattern']);
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25135
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Prevent wrong charset conversion in MoneyType when using a charset other then UTF-8.

@nzurita can you confirm it fixes your issue?