### PR TITLE
[FrameworkBundle] Make MicroKernelTraitTest green

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -18,7 +18,7 @@ class MicroKernelTraitTest extends TestCase
 {
     public function test()
     {
-        $kernel = new ConcreteMicroKernel('test', true);
+        $kernel = new ConcreteMicroKernel('test', false);
         $kernel->boot();
 
         $request = Request::create('/');
@@ -31,7 +31,7 @@ class MicroKernelTraitTest extends TestCase
 
     public function testAsEventSubscriber()
     {
-        $kernel = new ConcreteMicroKernel('test', true);
+        $kernel = new ConcreteMicroKernel('test', false);
         $kernel->boot();
 
         $request = Request::create('/danger');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fixes the current failure on PHP 5.6:
```
1) Symfony\Bundle\FrameworkBundle\Tests\Kernel\MicroKernelTraitTest::testAsEventSubscriber

filemtime(): stat failed for /tmp/sf_micro_kernel/KernelTestDebugProjectContainer.php

/home/travis/build/symfony/symfony/src/Symfony/Component/Config/ResourceCheckerConfigCache.php:91
/home/travis/build/symfony/symfony/src/Symfony/Component/Config/ConfigCache.php:60
/home/travis/build/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:585
/home/travis/build/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:137
/home/travis/build/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php:35
```