### PR TITLE
[Translation] modify definitions only if the do exist

### DIFF
--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
@@ -80,8 +80,15 @@ class TranslatorPass implements CompilerPassInterface
             ->replaceArgument(3, $loaders)
         ;
 
-        if ($container->hasParameter('twig.default_path')) {
+        if (!$container->hasParameter('twig.default_path')) {
+            return;
+        }
+
+        if ($container->hasDefinition($this->debugCommandServiceId)) {
             $container->getDefinition($this->debugCommandServiceId)->replaceArgument(4, $container->getParameter('twig.default_path'));
+        }
+
+        if ($container->hasDefinition($this->updateCommandServiceId)) {
             $container->getDefinition($this->updateCommandServiceId)->replaceArgument(5, $container->getParameter('twig.default_path'));
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

If the `TranslatorPass` is used an application without the Console
component, the commands will not be registered. Thus, their service
definitions must not be modified.