### PR TITLE
[Routing] Allow to set name prefixes from the configuration

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -124,4 +124,14 @@ trait RouteTrait
 
         return $this;
     }
+
+    /**
+     * Adds a prefix to the name of all the routes within the collection.
+     */
+    final public function addNamePrefix(string $prefix): self
+    {
+        $this->route->addNamePrefix($prefix);
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -165,6 +165,10 @@ class XmlFileLoader extends FileLoader
         $subCollection->addRequirements($requirements);
         $subCollection->addOptions($options);
 
+        if ($namePrefix = $node->getAttribute('name-prefix')) {
+            $subCollection->addNamePrefix($namePrefix);
+        }
+
         $collection->addCollection($subCollection);
     }
 

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -27,7 +27,7 @@ use Symfony\Component\Config\Loader\FileLoader;
 class YamlFileLoader extends FileLoader
 {
     private static $availableKeys = array(
-        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller',
+        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix',
     );
     private $yamlParser;
 
@@ -168,6 +168,10 @@ class YamlFileLoader extends FileLoader
         $subCollection->addDefaults($defaults);
         $subCollection->addRequirements($requirements);
         $subCollection->addOptions($options);
+
+        if (isset($config['name_prefix'])) {
+            $subCollection->addNamePrefix($config['name_prefix']);
+        }
 
         $collection->addCollection($subCollection);
     }

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -50,6 +50,7 @@
     <xsd:attribute name="resource" type="xsd:string" use="required" />
     <xsd:attribute name="type" type="xsd:string" />
     <xsd:attribute name="prefix" type="xsd:string" />
+    <xsd:attribute name="name-prefix" type="xsd:string" />
     <xsd:attribute name="host" type="xsd:string" />
     <xsd:attribute name="schemes" type="xsd:string" />
     <xsd:attribute name="methods" type="xsd:string" />

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -154,16 +154,17 @@ class RouteCollection implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Add a prefix to the name of all the routes within in the collection.
-     *
-     * @param string $prefix
+     * Adds a prefix to the name of all the routes within in the collection.
      */
     public function addNamePrefix(string $prefix)
     {
+        $prefixedRoutes = array();
+
         foreach ($this->routes as $name => $route) {
-            $this->routes[$prefix.$name] = $route;
-            unset($this->routes[$name]);
+            $prefixedRoutes[$prefix.$name] = $route;
         }
+
+        $this->routes = $prefixedRoutes;
     }
 
     /**

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -154,6 +154,19 @@ class RouteCollection implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Add a prefix to the name of all the routes within in the collection.
+     *
+     * @param string $prefix
+     */
+    public function addNamePrefix(string $prefix)
+    {
+        foreach ($this->routes as $name => $route) {
+            $this->routes[$prefix.$name] = $route;
+            unset($this->routes[$name]);
+        }
+    }
+
+    /**
      * Sets the host pattern on all routes.
      *
      * @param string $pattern      The pattern

--- a/src/Symfony/Component/Routing/Tests/Fixtures/import_with_name_prefix/routing.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/import_with_name_prefix/routing.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import resource="../controller/routing.xml" />
+    <import resource="../controller/routing.xml" prefix="/api" name-prefix="api_" />
+
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/import_with_name_prefix/routing.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/import_with_name_prefix/routing.yml
@@ -1,0 +1,7 @@
+app:
+    resource: ../controller/routing.yml
+
+api:
+    resource: ../controller/routing.yml
+    name_prefix: api_
+    prefix: /api

--- a/src/Symfony/Component/Routing/Tests/Fixtures/nonvalidkeys.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/nonvalidkeys.yml
@@ -1,3 +1,3 @@
 someroute:
   resource: path/to/some.yml
-  name_prefix: test_
+  not_valid_key: test_

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -361,4 +361,15 @@ class XmlFileLoaderTest extends TestCase
         $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/controller')));
         $loader->load('import_override_defaults.xml');
     }
+
+    public function testImportRouteWithNamePrefix()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/import_with_name_prefix')));
+        $routeCollection = $loader->load('routing.xml');
+
+        $this->assertNotNull($routeCollection->get('app_blog'));
+        $this->assertEquals('/blog', $routeCollection->get('app_blog')->getPath());
+        $this->assertNotNull($routeCollection->get('api_app_blog'));
+        $this->assertEquals('/api/blog', $routeCollection->get('api_app_blog')->getPath());
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -182,4 +182,15 @@ class YamlFileLoaderTest extends TestCase
         $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/controller')));
         $loader->load('import_override_defaults.yml');
     }
+
+    public function testImportRouteWithNamePrefix()
+    {
+        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/import_with_name_prefix')));
+        $routeCollection = $loader->load('routing.yml');
+
+        $this->assertNotNull($routeCollection->get('app_blog'));
+        $this->assertEquals('/blog', $routeCollection->get('app_blog')->getPath());
+        $this->assertNotNull($routeCollection->get('api_app_blog'));
+        $this->assertEquals('/api/blog', $routeCollection->get('api_app_blog')->getPath());
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -118,7 +118,7 @@ class RouteCollectionTest extends TestCase
         $collection->add('foo', new Route('/{placeholder}'));
         $collection1 = new RouteCollection();
         $collection1->add('bar', new Route('/{placeholder}',
-                array('_controller' => 'fixed', 'placeholder' => 'default'), array('placeholder' => '.+'), array('option' => 'value'))
+            array('_controller' => 'fixed', 'placeholder' => 'default'), array('placeholder' => '.+'), array('option' => 'value'))
         );
         $collection->addCollection($collection1);
 
@@ -308,10 +308,12 @@ class RouteCollectionTest extends TestCase
         $collection = new RouteCollection();
         $collection->add('foo', $foo = new Route('/foo'));
         $collection->add('bar', $bar = new Route('/bar'));
+        $collection->add('api_foo', $apiFoo = new Route('/api/foo'));
         $collection->addNamePrefix('api_');
 
         $this->assertEquals($foo, $collection->get('api_foo'));
         $this->assertEquals($bar, $collection->get('api_bar'));
+        $this->assertEquals($apiFoo, $collection->get('api_api_foo'));
         $this->assertNull($collection->get('foo'));
         $this->assertNull($collection->get('bar'));
     }

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -118,7 +118,7 @@ class RouteCollectionTest extends TestCase
         $collection->add('foo', new Route('/{placeholder}'));
         $collection1 = new RouteCollection();
         $collection1->add('bar', new Route('/{placeholder}',
-            array('_controller' => 'fixed', 'placeholder' => 'default'), array('placeholder' => '.+'), array('option' => 'value'))
+                array('_controller' => 'fixed', 'placeholder' => 'default'), array('placeholder' => '.+'), array('option' => 'value'))
         );
         $collection->addCollection($collection1);
 
@@ -301,5 +301,18 @@ class RouteCollectionTest extends TestCase
 
         $this->assertEquals(array('PUT'), $routea->getMethods());
         $this->assertEquals(array('PUT'), $routeb->getMethods());
+    }
+
+    public function testAddNamePrefix()
+    {
+        $collection = new RouteCollection();
+        $collection->add('foo', $foo = new Route('/foo'));
+        $collection->add('bar', $bar = new Route('/bar'));
+        $collection->addNamePrefix('api_');
+
+        $this->assertEquals($foo, $collection->get('api_foo'));
+        $this->assertEquals($bar, $collection->get('api_bar'));
+        $this->assertNull($collection->get('foo'));
+        $this->assertNull($collection->get('bar'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #19612
| License       | MIT
| Doc PR        | ø

This allows setting name prefixes to routes while importing them. Typically, we can then import multiple times a similar file. This was originally requested by 🎸 @chrisguitarguy in https://github.com/symfony/symfony/issues/19612

```yaml
app:
    resource: ../controller/routing.yml

api:
    resource: ../controller/routing.yml
    name_prefix: api_
    prefix: /api
```

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<routes xmlns="http://symfony.com/schema/routing"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://symfony.com/schema/routing
        http://symfony.com/schema/routing/routing-1.0.xsd">

    <import resource="../controller/routing.xml" />
    <import resource="../controller/routing.xml" prefix="/api" name-prefix="api_" />

</routes>
```