### PR TITLE
[FrameworkBundle][Serializer] Remove YamlEncoder definition if Yaml component isn't installed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -56,6 +56,7 @@ use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\ObjectInitializerInterface;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Symfony\Component\Workflow;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * FrameworkExtension.
@@ -1170,6 +1171,10 @@ class FrameworkExtension extends Extension
         if (!class_exists('Symfony\Component\PropertyAccess\PropertyAccessor')) {
             $container->removeAlias('serializer.property_accessor');
             $container->removeDefinition('serializer.normalizer.object');
+        }
+
+        if (!class_exists(Yaml::class)) {
+            $container->removeDefinition('serializer.encoder.yaml');
         }
 
         $serializerLoaders = array();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/24634#discussion_r153192689 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Do we need a `"symfony/yaml": "<3.2"` conflict here (the version used in `require-dev`)? Otherwise I'll re-introduce the `!defined('Symfony\Component\Yaml\Yaml::DUMP_OBJECT')` check instead.