### PR TITLE
[HttpFoundation] AutExpireFlashBag should not clear new flashes

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Flash/AutoExpireFlashBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/AutoExpireFlashBag.php
@@ -106,7 +106,7 @@ class AutoExpireFlashBag implements FlashBagInterface
     public function all()
     {
         $return = $this->flashes['display'];
-        $this->flashes = array('new' => array(), 'display' => array());
+        $this->flashes['display'] = array();
 
         return $return;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
@@ -150,4 +150,12 @@ class AutoExpireFlashBagTest extends TestCase
     {
         $this->assertEquals(array('notice' => array('A previous flash message')), $this->bag->clear());
     }
+
+    public function testDoNotRemoveTheNewFlashesWhenDisplayingTheExistingOnes()
+    {
+        $this->bag->add('success', 'Something');
+        $this->bag->all();
+
+        $this->assertEquals(array('new' => array('success' => array('Something')), 'display' => array()), $this->array);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #9318
| License       | MIT
| Doc PR        | none

I feel like very happy ! :)
But don't worry I'm.

![img_2826](https://user-images.githubusercontent.com/3451634/33304006-99d44f38-d406-11e7-93f2-4dbc19891299.jpg)


