### PR TITLE
#25187 Lookup php binary in PHP_BINDIR first

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -62,9 +62,17 @@ class PhpExecutableFinder
             }
         }
 
-        $dirs = array(PHP_BINDIR);
+        $dirs = array();
         if ('\\' === DIRECTORY_SEPARATOR) {
             $dirs[] = 'C:\xampp\php\\';
+        }
+
+        $name = 'php';
+        foreach (array('', '.exe', '.bat', '.cmd', '.com') as $suffix) {
+            if (@is_file($file = PHP_BINDIR.DIRECTORY_SEPARATOR.$name.$suffix) &&
+                ('\\' === DIRECTORY_SEPARATOR || is_executable($file))) {
+                return $file;
+            }
         }
 
         return $this->executableFinder->find('php', false, $dirs);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25187
| License       | MIT

Refactored ``Symfony\Component\Process\ExecutableFinder``. Reusing ``Symfony\Component\Process\ExecutableFinder::findIn`` in ``Symfony\Component\Process\PhpExecutableFinder::find`` to fix #25187.