### PR TITLE
[HttpKernel] Keep legacy container files for concurrent requests

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -643,8 +643,19 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             return;
         }
 
-        if ($oldContainer && get_class($this->container) !== $oldContainer->name) {
-            (new Filesystem())->remove(dirname($oldContainer->getFileName()));
+        if ($oldContainer) {
+            // Because concurrent requests might still be using them,
+            // old container files are not removed immediately,
+            // but on a next dump of the container.
+            $oldContainerDir = dirname($oldContainer->getFileName());
+            foreach (glob(dirname($oldContainerDir).'/*.legacyContainer') as $legacyContainer) {
+                if (@unlink($legacyContainer)) {
+                    (new Filesystem())->remove(substr($legacyContainer, 0, -16));
+                }
+            }
+            if (get_class($this->container) !== $oldContainer->name) {
+                touch($oldContainerDir.'.legacyContainer');
+            }
         }
 
         if ($this->container->has('cache_warmer')) {

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -832,7 +832,8 @@ EOF;
         $kernel->boot();
 
         $this->assertTrue(get_class($kernel->getContainer()) !== $containerClass);
-        $this->assertFileNotExists($containerFile);
+        $this->assertFileExists($containerFile);
+        $this->assertFileExists(dirname($containerFile).'.legacyContainer');
     }
 
     public function testKernelPass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25177
| License       | MIT
| Doc PR        | -

Because concurrent requests might still be using them,
old container files should not be removed immediately,
but on a next dump of the container.