### PR TITLE
[HttpKernel] Arrays with scalar values passed to ESI fragment renderer throw deprecation notice

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -98,8 +98,8 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
     private function containsNonScalars(array $values)
     {
         foreach ($values as $value) {
-            if (is_array($value) && $this->containsNonScalars($value)) {
-                return true;
+            if (is_array($value)) {
+                return $this->containsNonScalars($value);
             } elseif (!is_scalar($value) && null !== $value) {
                 return true;
             }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -34,7 +34,15 @@ class EsiFragmentRendererTest extends TestCase
     {
         $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true), new UriSigner('foo'));
         $request = Request::create('/');
-        $reference = new ControllerReference('main_controller', array('foo' => array('a' => array(), 'b' => new \stdClass())), array());
+        $reference = new ControllerReference('main_controller', array('foo' => new \stdClass()), array());
+        $strategy->render($reference, $request);
+    }
+
+    public function testRenderFallbackWithScalarIsNotDeprecated()
+    {
+        $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true), new UriSigner('foo'));
+        $request = Request::create('/');
+        $reference = new ControllerReference('main_controller', array('foo' => array(true)), array());
         $strategy->render($reference, $request);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #25191 
| License       | MIT
| Doc PR        | none

Coding in the train to Paris !

![img_2832](https://user-images.githubusercontent.com/3451634/33361971-8aa17a70-d4da-11e7-90a0-b2f08a60d0e6.JPG)