### PR TITLE
[DI] Fix infinite loop in InlineServiceDefinitionsPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -61,10 +61,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
                 $this->container->log($this, sprintf('Inlined service "%s" to "%s".', $id, $this->currentId));
                 $this->inlinedServiceIds[$id][] = $this->currentId;
 
-                if ($definition->isShared()) {
-                    return $definition;
-                }
-                $value = clone $definition;
+                return $definition->isShared() ? $definition : clone $definition;
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -92,6 +92,25 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $this->assertNotSame($container->getDefinition('bar'), $arguments[2]);
     }
 
+    public function testProcessInlinesMixedServicesLoop()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->addArgument(new Reference('bar'))
+            ->setShared(false)
+        ;
+        $container
+            ->register('bar')
+            ->setPublic(false)
+            ->addMethodCall('setFoo', array(new Reference('foo')))
+        ;
+
+        $this->process($container);
+
+        $this->assertEquals($container->getDefinition('foo')->getArgument(0), $container->getDefinition('bar'));
+    }
+
     public function testProcessInlinesIfMultipleReferencesButAllFromTheSameDefinition()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When a non-shared is involved in a setter-circular loop, the pass enters an infinite loop right now.