### PR TITLE
[DI] Clear service reference graph

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
@@ -159,6 +159,8 @@ class Compiler
             }
 
             throw $e;
+        } finally {
+            $this->getServiceReferenceGraph()->clear();
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -75,6 +75,9 @@ class ServiceReferenceGraph
      */
     public function clear()
     {
+        foreach ($this->nodes as $node) {
+            $node->clear();
+        }
         $this->nodes = array();
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
@@ -107,4 +107,12 @@ class ServiceReferenceGraphNode
     {
         return $this->value;
     }
+
+    /**
+     * Clears all edges.
+     */
+    public function clear()
+    {
+        $this->inEdges = $this->outEdges = array();
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -142,6 +142,7 @@ class PhpDumper extends Dumper
             $currentPath = array($id => $id);
             $this->analyzeCircularReferences($node->getOutEdges(), $checkedNodes, $currentPath);
         }
+        $this->container->getCompiler()->getServiceReferenceGraph()->clear();
 
         $this->docStar = $options['debug'] ? '*' : '';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes (memory usage)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Spotted while playing with the container: we keep this graph in memory even it its stale already.
Clearing it also leave circular refs for the php garbage collector, better clean ourselves.