### PR TITLE
[HttpKernel] Fix race condition when clearing old containers

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -644,19 +644,18 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             return;
         }
 
-        if ($oldContainer) {
+        if ($oldContainer && get_class($this->container) !== $oldContainer->name) {
             // Because concurrent requests might still be using them,
             // old container files are not removed immediately,
             // but on a next dump of the container.
             $oldContainerDir = dirname($oldContainer->getFileName());
             foreach (glob(dirname($oldContainerDir).'/*.legacyContainer') as $legacyContainer) {
-                if (@unlink($legacyContainer)) {
+                if ($oldContainerDir.'.legacyContainer' !== $legacyContainer && @unlink($legacyContainer)) {
                     (new Filesystem())->remove(substr($legacyContainer, 0, -16));
                 }
             }
-            if (get_class($this->container) !== $oldContainer->name) {
-                touch($oldContainerDir.'.legacyContainer');
-            }
+
+            touch($oldContainerDir.'.legacyContainer');
         }
 
         if ($this->container->has('cache_warmer')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Missed in #25190: when two concurrent requests create the new container concurrently, the last one would drop the old container files, because the first one just created the `*.legacyContainer` file.