### PR TITLE
[VarDumper] Dont use empty(), it chokes on eg GMP objects

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -118,8 +118,8 @@ class Caster
 
             if (null === $v) {
                 $type |= self::EXCLUDE_NULL & $filter;
-            }
-            if (empty($v)) {
+                $type |= self::EXCLUDE_EMPTY & $filter;
+            } elseif (false === $v || '' === $v || '0' === $v || 0 === $v || 0.0 === $v || array() === $v) {
                 $type |= self::EXCLUDE_EMPTY & $filter;
             }
             if ((self::EXCLUDE_NOT_IMPORTANT & $filter) && !in_array($k, $listedProperties, true)) {

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -94,13 +94,16 @@ class VarCloner extends AbstractCloner
                 // Create $stub when the original value $v can not be used directly
                 // If $v is a nested structure, put that structure in array $a
                 switch (true) {
-                    case empty($v):
-                    case true === $v:
+                    case null === $v:
+                    case \is_bool($v):
                     case \is_int($v):
                     case \is_float($v):
                         continue 2;
 
                     case \is_string($v):
+                        if ('' === $v) {
+                            continue 2;
+                        }
                         if (!\preg_match('//u', $v)) {
                             $stub = new Stub();
                             $stub->type = Stub::TYPE_STRING;
@@ -124,6 +127,9 @@ class VarCloner extends AbstractCloner
                         break;
 
                     case \is_array($v):
+                        if (!$v) {
+                            continue 2;
+                        }
                         $stub = $arrayStub;
                         $stub->class = Stub::ARRAY_INDEXED;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25198
| License       | MIT
| Doc PR        | -

