### PR TITLE
[Dotenv] Changed preg_match flags from null to 0

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -173,7 +173,7 @@ final class Dotenv
 
     private function lexValue()
     {
-        if (preg_match('/[ \t]*+(?:#.*)?$/Am', $this->data, $matches, null, $this->cursor)) {
+        if (preg_match('/[ \t]*+(?:#.*)?$/Am', $this->data, $matches, 0, $this->cursor)) {
             $this->moveCursor($matches[0]);
             $this->skipEmptyLines();
 
@@ -295,7 +295,7 @@ final class Dotenv
 
     private function skipEmptyLines()
     {
-        if (preg_match('/(?:\s*+(?:#[^\n]*+)?+)++/A', $this->data, $match, null, $this->cursor)) {
+        if (preg_match('/(?:\s*+(?:#[^\n]*+)?+)++/A', $this->data, $match, 0, $this->cursor)) {
             $this->moveCursor($match[0]);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

I came across this bug while using HHVM in PHP7 mode. The flag should be changed to match type in function signature and bring it in line with other uses of [preg_match](https://secure.php.net/manual/en/function.preg-match.php) (https://github.com/symfony/dotenv/blob/3.3/Dotenv.php#L149)

Applicable to 3.3, 3.4, 4.0
