### PR TITLE
[Serializer] add a constructor arguement to return csv always as collection 

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -150,6 +150,10 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         }
         fclose($handle);
 
+        if ($context['as_collection'] ?? false) {
+            return $result;
+        }
+
         if (empty($result) || isset($result[1])) {
             return $result;
         }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -208,6 +208,22 @@ CSV
         , 'csv'));
     }
 
+    public function testDecodeOnlyOneAsCollection()
+    {
+        $this->encoder = new CsvEncoder(',', '"', '\\', '.');
+
+        $expected = array(
+            array('foo' => 'a'),
+        );
+
+        $this->assertEquals($expected, $this->encoder->decode(<<<'CSV'
+foo
+a
+
+CSV
+            , 'csv', array('as_collection' => true)));
+    }
+
     public function testDecodeToManyRelation()
     {
         $expected = array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.1
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #21616
| License       | MIT
| Doc PR        | TODO create a doc PR for the 3 ways of getting csv collection, or a single

Coding in the train again ;).
![img_9980](https://user-images.githubusercontent.com/3451634/33417042-f13063e4-d59f-11e7-8f30-143da768b1d7.JPG)

This is to be able to add a new behaviour to the csv encoder when passing the alwaysAsCollection context key, this will return a collection even if there is only one element.
