### PR TITLE
[HttpKernel] empty-session should mean no-cookie to AbstractTestSessionListener

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
@@ -58,7 +58,7 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
         }
 
         $session = $event->getRequest()->getSession();
-        if ($session && $session->isStarted()) {
+        if ($session && $session->isStarted() && $session->all()) {
             $session->save();
             $params = session_get_cookie_params();
             $event->getResponse()->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -121,6 +121,10 @@ class TestSessionListenerTest extends TestCase
         $this->session->expects($this->once())
             ->method('isStarted')
             ->will($this->returnValue(true));
+
+        $this->session->expects($this->once())
+            ->method('all')
+            ->will($this->returnValue(array('foo' => 'bar')));
     }
 
     private function sessionHasNotBeenStarted()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

With the new session logic, an empty session creates no cookies.
We have failing tests on Blackfire because of this when moving to 3.4.
ping @romainneutron 