### PR TITLE
[HttpKernel] Fix issue when resetting DumpDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -166,7 +166,9 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
     public function reset()
     {
-        $this->stopwatch->reset();
+        if ($this->stopwatch) {
+            $this->stopwatch->reset();
+        }
         $this->data = array();
         $this->dataCount = 0;
         $this->isCollected = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Fixes issue when resetting the collector and no stopwatch was provided in the constructor.

By the way, current workaround is to `composer require symfony/stopwatch`, so this is not a "big blocker".