### PR TITLE
[TwigBridge][Form] Fix hidden currency element with Bootstrap 3 theme

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -20,16 +20,21 @@
 {%- endblock %}
 
 {% block money_widget -%}
-    <div class="input-group">
-        {% set append = money_pattern starts with '{{' %}
-        {% if not append %}
-            <span class="input-group-addon">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
-        {% endif %}
+    {% set prepend = not (money_pattern starts with '{{') %}
+    {% set append = not (money_pattern ends with '}}') %}
+    {% if prepend or append %}
+        <div class="input-group">
+            {% if prepend %}
+                <span class="input-group-addon">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+            {% endif %}
+            {{- block('form_widget_simple') -}}
+            {% if append %}
+                <span class="input-group-addon">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+            {% endif %}
+        </div>
+    {% else %}
         {{- block('form_widget_simple') -}}
-        {% if append %}
-            <span class="input-group-addon">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
-        {% endif %}
-    </div>
+    {% endif %}
 {%- endblock money_widget %}
 
 {% block percent_widget -%}

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -1899,6 +1899,25 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
+    public function testMoneyWithoutCurrency()
+    {
+        $form = $this->factory->createNamed('name', 'money', 1234.56, array(
+            'currency' => false,
+        ));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+'/input
+    [@id="my&id"]
+    [@type="text"]
+    [@name="name"]
+    [@class="my&class form-control"]
+    [@value="1234.56"]
+    [not(preceding-sibling::*)]
+    [not(following-sibling::*)]
+'
+        );
+    }
+
     public function testNumber()
     {
         $form = $this->factory->createNamed('name', 'number', 1234.56);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -43,7 +43,7 @@ class MoneyTypeTest extends BaseTypeTest
         $view = $this->factory->create(static::TESTED_TYPE, null, array('currency' => 'JPY'))
             ->createView();
 
-        $this->assertTrue((bool) strstr($view->vars['money_pattern'], '¥'));
+        $this->assertSame('¥ {{ widget }}', $view->vars['money_pattern']);
     }
 
     // https://github.com/symfony/symfony/issues/5458
@@ -61,5 +61,13 @@ class MoneyTypeTest extends BaseTypeTest
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
         parent::testSubmitNull($expected, $norm, '');
+    }
+
+    public function testMoneyPatternWithoutCurrency()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, array('currency' => false))
+            ->createView();
+
+        $this->assertSame('{{ widget }}', $view->vars['money_pattern']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When using a `MoneyType` field, one can pass `currency=false` option to hide the currency symbol. This does not work well when using the Bootstrap 3 theme: the symbol is not displayed but HTML elements that are supposed to contain it are still rendered.