### PR TITLE
Stop DebugHandler silencing errors

### DIFF
--- a/src/Symfony/Component/Debug/Debug.php
+++ b/src/Symfony/Component/Debug/Debug.php
@@ -46,7 +46,6 @@ class Debug
         }
 
         if ('cli' !== PHP_SAPI) {
-            ini_set('display_errors', 0);
             ExceptionHandler::register();
         } elseif ($displayErrors && (!ini_get('log_errors') || ini_get('error_log'))) {
             // CLI - display errors only if they're not already logged to STDERR


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8703
| License       | MIT
| Doc PR        | 

I don't know if this is best fix for the issue, but I want to get things moving here. ErrorHandler silencing errors has been rampant in Symfony for years. Can be reproduced easily, dunno why there isn't more traction in fixing this.

The line I am removing has been introduced in https://github.com/symfony/symfony/pull/10921, I didn't find explanation why though. 
Will add test case if this approach is approved.