### PR TITLE
[VarDumper] add a GMP caster in order to cast GMP resources into string or integer

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/GmpCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/GmpCaster.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Casts GMP objects to array representation.
+ *
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class GmpCaster
+{
+    public static function castGmp(\GMP $gmp, array $a, Stub $stub, $isNested, $filter): array
+    {
+        $a[Caster::PREFIX_VIRTUAL.'value'] = new ConstStub(gmp_strval($gmp), gmp_strval($gmp));
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -112,6 +112,8 @@ abstract class AbstractCloner implements ClonerInterface
         'DateTimeZone' => array('Symfony\Component\VarDumper\Caster\DateCaster', 'castTimeZone'),
         'DatePeriod' => array('Symfony\Component\VarDumper\Caster\DateCaster', 'castPeriod'),
 
+        'GMP' => array('Symfony\Component\VarDumper\Caster\GmpCaster', 'castGmp'),
+
         ':curl' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castCurl'),
         ':dba' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'),
         ':dba persistent' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'),

--- a/src/Symfony/Component/VarDumper/Tests/Caster/GmpCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/GmpCasterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Caster\GmpCaster;
+use Symfony\Component\VarDumper\Cloner\Stub;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+class GmpCasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    /**
+     * @requires extension gmp
+     */
+    public function testCastGmp()
+    {
+        $gmpString = gmp_init('1234');
+        $gmpOctal = gmp_init(010);
+        $gmp = gmp_init('01101');
+        $gmpDump = <<<EODUMP
+array:1 [
+  "\\x00~\\x00value" => %s
+]
+EODUMP;
+        $this->assertDumpEquals(sprintf($gmpDump, $gmpString), GmpCaster::castGmp($gmpString, array(), new Stub(), false, 0));
+        $this->assertDumpEquals(sprintf($gmpDump, $gmpOctal), GmpCaster::castGmp($gmpOctal, array(), new Stub(), false, 0));
+        $this->assertDumpEquals(sprintf($gmpDump, $gmp), GmpCaster::castGmp($gmp, array(), new Stub(), false, 0));
+
+        $dump = <<<EODUMP
+GMP {
+  value: 577
+}
+EODUMP;
+
+        $this->assertDumpEquals($dump, $gmp);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #25222 
| License       | MIT
| Doc PR        | todo

Do you want to dump that kind of resources ? Then it means that the app you are writing is doing some math... why?! :p 


It quite nice the little snow that we have in the north of france right now:
![img_2844](https://user-images.githubusercontent.com/3451634/33472917-8b48913e-d674-11e7-923f-ad951f7f2966.JPG)
