### PR TITLE
UploadedFile new helper - getClientOriginalNameWithoutExtension

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * setting session save handlers that do not implement `\SessionHandlerInterface` in 
    `NativeSessionStorage::setSaveHandler()` is not supported anymore and throws a 
    `\TypeError`
+ * The `getClientOriginalNameWithoutExtension()` helper was added to File/UploadedFile  
 
 3.4.0
 -----

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -80,6 +80,19 @@ class UploadedFile extends File
     }
 
     /**
+     * Returns the original file name without extension.
+     *
+     * It is extracted from the original file name that was uploaded.
+     * Then it should not be considered as a safe value.
+     *
+     * @return string The origin name without extension
+     */
+    public function getClientOriginalNameWithoutExtension()
+    {
+        return pathinfo($this->originalName, PATHINFO_FILENAME);
+    }
+
+    /**
      * Returns the original file extension.
      *
      * It is extracted from the original file name that was uploaded.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

just another helper to get the original file name. This is extremely helpful when you have to convert the basename (like converting the Cyrillic filename to Latin one).
