### PR TITLE
[Form] Avoid button label translation when it's set to false

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -216,12 +216,14 @@
 {%- endblock range_widget %}
 
 {%- block button_widget -%}
-    {%- if label is not same as(false) and label is empty -%}
+    {%- if label is empty -%}
         {%- if label_format is not empty -%}
             {% set label = label_format|replace({
                 '%name%': name,
                 '%id%': id,
             }) %}
+        {%- elseif label is same as(false) -%}
+            {% set translation_domain = false %}
         {%- else -%}
             {% set label = name|humanize %}
         {%- endif -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Improve my previous contribution to hide button label when it's set to false (#24148) because a missing translation error appears
