### PR TITLE
[FrameworkBundle] Rename getDotEnvVars to getDotenvVars

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -89,7 +89,7 @@ EOT
             array('Xdebug', extension_loaded('xdebug') ? 'true' : 'false'),
         );
 
-        if ($dotenv = self::getDotEnvVars()) {
+        if ($dotenv = self::getDotenvVars()) {
             $rows = array_merge($rows, array(
                 new TableSeparator(),
                 array('<info>Environment (.env)</>'),
@@ -128,7 +128,7 @@ EOT
         return false !== $date && new \DateTime() > $date->modify('last day of this month 23:59:59');
     }
 
-    private static function getDotEnvVars()
+    private static function getDotenvVars()
     {
         $vars = array();
         foreach (explode(',', getenv('SYMFONY_DOTENV_VARS')) as $name) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

For consistency with #25166 :) 