### PR TITLE
[DependencyInjection][4.0] Fix regression about private synthetic services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -38,7 +38,7 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
     {
         foreach ($container->getDefinitions() as $id => $definition) {
             // synthetic service is public
-            if ($definition->isSynthetic() && !$definition->isPublic()) {
+            if ($definition->isSynthetic() && (!$definition->isPublic() || $definition->isPrivate())) {
                 throw new RuntimeException(sprintf('A synthetic service ("%s") must be public.', $id));
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -31,6 +31,17 @@ class CheckDefinitionValidityPassTest extends TestCase
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      */
+    public function testProcessDetectsSyntheticNonPublicDefinitionsRegression()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a')->setSynthetic(true)->setPrivate(true);
+
+        $this->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     */
     public function testProcessDetectsNonSyntheticNonAbstractDefinitionWithoutClass()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25253
| License       | MIT

This PR is conveniently splitted in two, because the bug is not present in 3.4, so 30f7d49 (the regression test) should be backported to that branch. 

[EDIT] According to @nicolas-grekas in https://github.com/symfony/symfony/issues/25253#issuecomment-348550019, no backport is necessary, a deprecation covers it.