### PR TITLE
[link] clear the cache after linking

### DIFF
--- a/link
+++ b/link
@@ -57,3 +57,8 @@ foreach (glob("$argv[1]/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) 
     $filesystem->symlink($sfDir, $dir);
     echo "\"$package\" has been linked to \"$sfPackages[$package]\".".PHP_EOL;
 }
+
+
+if ($filesystem->exists($cacheFiles = "$argv[1]/var/cache")) {
+    $filesystem->remove("$argv[1]/var/cache");
+}

--- a/link
+++ b/link
@@ -58,7 +58,6 @@ foreach (glob("$argv[1]/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) 
     echo "\"$package\" has been linked to \"$sfPackages[$package]\".".PHP_EOL;
 }
 
-
-if ($filesystem->exists($cacheFiles = "$argv[1]/var/cache")) {
-    $filesystem->remove("$argv[1]/var/cache");
+foreach (glob("$argv[1]/var/cache/*") as $cacheDir) {
+    $filesystem->remove($cacheDir);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Clearing the cache after linking prevents fatal errors when a container already exists.