### PR TITLE
[link] Prevent warnings when running link with 2.7

### DIFF
--- a/link
+++ b/link
@@ -35,11 +35,14 @@ if (!is_dir("$argv[1]/vendor/symfony")) {
 }
 
 $sfPackages = array('symfony/symfony' => __DIR__);
-foreach (glob(__DIR__.'/src/Symfony/{Bundle,Bridge,Component,Component/Security}/*', GLOB_BRACE | GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
-    $sfPackages[json_decode(file_get_contents("$dir/composer.json"))->name] = $dir;
-}
 
 $filesystem = new Filesystem();
+foreach (glob(__DIR__.'/src/Symfony/{Bundle,Bridge,Component,Component/Security}/*', GLOB_BRACE | GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
+    if ($filesystem->exists($composer = "$dir/composer.json")) {
+        $sfPackages[json_decode(file_get_contents($composer))->name] = $dir;
+    }
+}
+
 foreach (glob("$argv[1]/vendor/symfony/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
     $package = 'symfony/'.basename($dir);
     if (is_link($dir)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Prevent warnings when linking from 2.7 because some directories (like the Bridge/Propel1) don't contain `composer.json` files.