### PR TITLE
[DI] Improve service not found in service subscribers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -13,9 +13,21 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Container;
 
 class AbstractControllerTest extends ControllerTraitTest
 {
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     * @expectedExceptionMessage You have requested a non-existent service "unknown". Did you forget to add it to "Symfony\Bundle\FrameworkBundle\Tests\Controller\TestAbstractController::getSubscribedServices()"?
+     */
+    public function testServiceNotFound()
+    {
+        $controller = $this->createController();
+        $controller->setContainer(new Container());
+        $controller->serviceNotFoundAction();
+    }
+
     protected function createController()
     {
         return new TestAbstractController();
@@ -59,5 +71,10 @@ class TestAbstractController extends AbstractController
 
     public function fooAction()
     {
+    }
+
+    public function serviceNotFoundAction()
+    {
+        $this->get('unknown');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25196
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Here you go. Not sure about silently ignoring alternatives though.. but from `ServiceLocator` this are _all_ available services (not levenshtein tested or so) so this seems more useful.

Perhaps do a levenshtein test here to reduce alternatives and then combine?