### PR TITLE
[SecurityBundle] fix setLogoutOnUserChange calls for context listeners

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -340,17 +340,6 @@ class MainConfiguration implements ConfigurationInterface
                     return $firewall;
                 })
             ->end()
-            ->validate()
-                ->ifTrue(function ($v) {
-                    return (isset($v['stateless']) && true === $v['stateless']) || (isset($v['security']) && false === $v['security']);
-                })
-                ->then(function ($v) {
-                    // this option doesn't change behavior when true when stateless, so prevent deprecations
-                    $v['logout_on_user_change'] = true;
-
-                    return $v;
-                })
-            ->end()
         ;
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -276,17 +276,18 @@ class SecurityExtension extends Extension
                 $customUserChecker = true;
             }
 
-            $configId = 'security.firewall.map.config.'.$name;
-
-            list($matcher, $listeners, $exceptionListener) = $this->createFirewall($container, $name, $firewall, $authenticationProviders, $providerIds, $configId);
-
             if (!isset($firewall['logout_on_user_change']) || !$firewall['logout_on_user_change']) {
                 @trigger_error(sprintf('Not setting "logout_on_user_change" to true on firewall "%s" is deprecated as of 3.4, it will always be true in 4.0.', $name), E_USER_DEPRECATED);
             }
 
+            $configId = 'security.firewall.map.config.'.$name;
+
+            list($matcher, $listeners, $exceptionListener) = $this->createFirewall($container, $name, $firewall, $authenticationProviders, $providerIds, $configId);
+
             foreach ($listeners as $listener) {
                 if (0 === strpos($listenerId = (string) $listener, 'security.context_listener.')) {
                     $container->getDefinition($listenerId)->addMethodCall('setLogoutOnUserChange', array($firewall['logout_on_user_change']));
+                    break;
                 }
             }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -485,7 +485,7 @@ class SecurityExtension extends Extension
         return array($matcher, $listeners, $exceptionListener);
     }
 
-    private function createContextListener(ContainerBuilder $container, $contextKey, $logoutUserOnChange)
+    private function createContextListener($container, $contextKey, $logoutUserOnChange)
     {
         if (isset($this->contextListeners[$contextKey])) {
             return $this->contextListeners[$contextKey];

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -43,6 +43,7 @@ class SecurityExtension extends Extension
     private $factories = array();
     private $userProviderFactories = array();
     private $expressionLanguage;
+    private $firewallsByContextKey = array();
 
     public function __construct()
     {
@@ -368,6 +369,11 @@ class SecurityExtension extends Extension
                 @trigger_error(sprintf('Not setting "logout_on_user_change" to true on firewall "%s" is deprecated as of 3.4, it will always be true in 4.0.', $id), E_USER_DEPRECATED);
             }
 
+            if (isset($this->firewallsByContextKey[$contextKey]) && $firewall['logout_on_user_change'] !== $this->firewallsByContextKey[$contextKey][1]['logout_on_user_change']) {
+                throw new InvalidConfigurationException(sprintf('Firewalls "%s" and "%s" need to have the same value for option "logout_on_user_change" as they are sharing the context "%s"', $this->firewallsByContextKey[$contextKey][0], $id, $contextKey));
+            }
+
+            $this->firewallsByContextKey[$contextKey] = array($id, $firewall);
             $listeners[] = new Reference($this->createContextListener($container, $contextKey, $firewall['logout_on_user_change']));
         }
 
@@ -479,7 +485,7 @@ class SecurityExtension extends Extension
         return array($matcher, $listeners, $exceptionListener);
     }
 
-    private function createContextListener($container, $contextKey, $logoutUserOnChange)
+    private function createContextListener(ContainerBuilder $container, $contextKey, $logoutUserOnChange)
     {
         if (isset($this->contextListeners[$contextKey])) {
             return $this->contextListeners[$contextKey];

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -369,7 +369,7 @@ class SecurityExtension extends Extension
                 @trigger_error(sprintf('Not setting "logout_on_user_change" to true on firewall "%s" is deprecated as of 3.4, it will always be true in 4.0.', $id), E_USER_DEPRECATED);
             }
 
-            if (isset($this->firewallsByContextKey[$contextKey]) && $firewall['logout_on_user_change'] !== $this->firewallsByContextKey[$contextKey][1]['logout_on_user_change']) {
+            if (isset($this->firewallsByContextKey[$contextKey]) && $this->firewallsByContextKey[$contextKey][1]['logout_on_user_change'] !== $firewall['logout_on_user_change']) {
                 throw new InvalidConfigurationException(sprintf('Firewalls "%s" and "%s" need to have the same value for option "logout_on_user_change" as they are sharing the context "%s"', $this->firewallsByContextKey[$contextKey][0], $id, $contextKey));
             }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -43,7 +43,7 @@ class SecurityExtension extends Extension
     private $factories = array();
     private $userProviderFactories = array();
     private $expressionLanguage;
-    private $firewallsByContextKey = array();
+    private $logoutOnUserChangeByContextKey = array();
 
     public function __construct()
     {
@@ -365,16 +365,16 @@ class SecurityExtension extends Extension
                 $contextKey = $firewall['context'];
             }
 
-            if (!isset($firewall['logout_on_user_change']) || !$firewall['logout_on_user_change']) {
+            if (!$logoutOnUserChange = $firewall['logout_on_user_change']) {
                 @trigger_error(sprintf('Not setting "logout_on_user_change" to true on firewall "%s" is deprecated as of 3.4, it will always be true in 4.0.', $id), E_USER_DEPRECATED);
             }
 
-            if (isset($this->firewallsByContextKey[$contextKey]) && $this->firewallsByContextKey[$contextKey][1]['logout_on_user_change'] !== $firewall['logout_on_user_change']) {
-                throw new InvalidConfigurationException(sprintf('Firewalls "%s" and "%s" need to have the same value for option "logout_on_user_change" as they are sharing the context "%s"', $this->firewallsByContextKey[$contextKey][0], $id, $contextKey));
+            if (isset($this->logoutOnUserChangeByContextKey[$contextKey]) && $this->logoutOnUserChangeByContextKey[$contextKey][1] !== $logoutOnUserChange) {
+                throw new InvalidConfigurationException(sprintf('Firewalls "%s" and "%s" need to have the same value for option "logout_on_user_change" as they are sharing the context "%s"', $this->logoutOnUserChangeByContextKey[$contextKey][0], $id, $contextKey));
             }
 
-            $this->firewallsByContextKey[$contextKey] = array($id, $firewall);
-            $listeners[] = new Reference($this->createContextListener($container, $contextKey, $firewall['logout_on_user_change']));
+            $this->logoutOnUserChangeByContextKey[$contextKey] = array($id, $logoutOnUserChange);
+            $listeners[] = new Reference($this->createContextListener($container, $contextKey, $logoutOnUserChange));
         }
 
         $config->replaceArgument(6, $contextKey);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider\DummyProvider;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SecurityExtensionTest extends TestCase

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -127,7 +127,7 @@ class SecurityExtensionTest extends TestCase
      * @group legacy
      * @expectedDeprecation Not setting "logout_on_user_change" to true on firewall "some_firewall" is deprecated as of 3.4, it will always be true in 4.0.
      */
-    public function testDeprecationForUserLogout()
+    public function testConfiguresLogoutOnUserChangeForContextListenersCorrectly()
     {
         $container = $this->getRawContainer();
 
@@ -142,10 +142,18 @@ class SecurityExtensionTest extends TestCase
                     'http_basic' => null,
                     'logout_on_user_change' => false,
                 ),
+                'some_other_firewall' => array(
+                    'pattern' => '/.*',
+                    'http_basic' => null,
+                    'logout_on_user_change' => true,
+                ),
             ),
         ));
 
         $container->compile();
+
+        $this->assertEquals(array(array('setLogoutOnUserChange', array(false))), $container->getDefinition('security.context_listener.0')->getMethodCalls());
+        $this->assertEquals(array(array('setLogoutOnUserChange', array(true))), $container->getDefinition('security.context_listener.1')->getMethodCalls());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25267
| License       | MIT
| Doc PR        | -

As pointed out in https://github.com/symfony/symfony/issues/25267 the `setLogoutOnUserChange` method calls were added to the parent definition `security.context_listener` instead of the concrete child definitions `security.context_listener.*`.

ping @iltar @chalasr 
