### PR TITLE
[Security] Adding a GuardAuthenticatorHandler alias

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
@@ -14,7 +14,7 @@
             <argument type="service" id="event_dispatcher" on-invalid="null" />
         </service>
         
-        <alias id="Symfony\Component\Security\Guard\GuardAuthenticatorHandler" service="security.authentication.guard_handler" />
+        <service id="Symfony\Component\Security\Guard\GuardAuthenticatorHandler" alias="security.authentication.guard_handler" />
 
         <!-- See GuardAuthenticationFactory -->
         <service id="security.authentication.provider.guard"

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
@@ -13,6 +13,8 @@
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="event_dispatcher" on-invalid="null" />
         </service>
+        
+        <alias id="Symfony\Component\Security\Guard\GuardAuthenticatorHandler" service="security.authentication.guard_handler" />
 
         <!-- See GuardAuthenticationFactory -->
         <service id="security.authentication.provider.guard"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | kinda
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | This feature is not currently documented

The `security.authentication.guard_handler` service *is* actually meant to be available for users to use. Specifically, the `authenticateUserAndHandleSuccess()` method is useful to auto-login the user after, for example, registration, but maintain all the behavior of a normal login (success behavior, trigger the login event).

So, it should have an autowiring alias.
