### PR TITLE
Fix for missing whitespace control modifier in form layout

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -301,7 +301,7 @@
         {% if not child.rendered %}
             {{- form_row(child) -}}
         {% endif %}
-    {%- endfor %}
+    {%- endfor -%}
 
     {% if not form.methodRendered and form.parent is null %}
         {%- do form.setMethodRendered() -%}
@@ -315,7 +315,7 @@
         {%- if form_method != method -%}
             <input type="hidden" name="_method" value="{{ method }}" />
         {%- endif -%}
-    {% endif %}
+    {% endif -%}
 {% endblock form_rest %}
 
 {# Support #}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25252
| License       | MIT
| Doc PR        | -

That single missing whitespace control modifier results in e.g. new line in `data-prototype` attribute when using CollectionType field type in form.