### PR TITLE
[WebProfilerBundle] Allow open file with absolute path

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -383,7 +383,7 @@ class ProfilerController
         $file = $request->query->get('file');
         $line = $request->query->get('line');
 
-        $filename = $this->baseDir.DIRECTORY_SEPARATOR.$file;
+        $filename = file_exists($file) ? $file : $this->baseDir.DIRECTORY_SEPARATOR.$file;
 
         if (preg_match("'(^|[/\\\\])\.\.?([/\\\\]|$)'", $file) || !is_readable($filename)) {
             throw new NotFoundHttpException(sprintf('The file "%s" cannot be opened.', $file));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

The new `link` feature effectively breaks `/_profiler/open?file=` as `FileLinkFormatter` will not make it relative anymore. This deals with it.