### PR TITLE
[Serializer] DateTimeNormalizer handling of null and empty values (returning it instead of new object)

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -67,6 +67,10 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
     {
         $dateTimeFormat = isset($context[self::FORMAT_KEY]) ? $context[self::FORMAT_KEY] : null;
 
+        if ('' === $data || null === $data) {
+            throw new UnexpectedValueException('The data is either an empty string or null, you should pass a string that can be parsed with the passed format or a valid DateTime string.');
+        }
+
         if (null !== $dateTimeFormat) {
             $object = \DateTime::class === $class ? \DateTime::createFromFormat($dateTimeFormat, $data) : \DateTimeImmutable::createFromFormat($dateTimeFormat, $data);
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -93,6 +93,24 @@ class DateTimeNormalizerTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
+     * @expectedExceptionMessage The data is either an empty string or null, you should pass a string that can be parsed with the passed format or a valid DateTime string.
+     */
+    public function testDenormalizeNullThrowsException()
+    {
+        $this->normalizer->denormalize(null, \DateTimeInterface::class);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
+     * @expectedExceptionMessage The data is either an empty string or null, you should pass a string that can be parsed with the passed format or a valid DateTime string.
+     */
+    public function testDenormalizeEmptyStringThrowsException()
+    {
+        $this->normalizer->denormalize('', \DateTimeInterface::class);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
      */
     public function testDenormalizeFormatMismatchThrowsException()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | no
| Fixed tickets | #23964
| License       | MIT
| Doc PR        | 

I'm openning the disucussion on this as I think that should be returning null and not a new object.

WDYT ?

Working at home ;)
![img_2914](https://user-images.githubusercontent.com/3451634/33526107-ec2a6ce8-d83b-11e7-8949-f8d360ebb4b9.JPG)

