### PR TITLE
[FrameworkBundle] debug:autowiring: don't list FQCN when they are aliased

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -85,13 +85,17 @@ EOF
         }
         $io->newLine();
         $tableRows = array();
+        $hasAlias = array();
         foreach ($serviceIds as $serviceId) {
-            $tableRows[] = array(sprintf('<fg=cyan>%s</fg=cyan>', $serviceId));
             if ($builder->hasAlias($serviceId)) {
+                $tableRows[] = array(sprintf('<fg=cyan>%s</fg=cyan>', $serviceId));
                 $tableRows[] = array(sprintf('    alias to %s', $builder->getAlias($serviceId)));
+                $hasAlias[(string) $builder->getAlias($serviceId)] = true;
+            } else {
+                $tableRows[$serviceId] = array(sprintf('<fg=cyan>%s</fg=cyan>', $serviceId));
             }
         }
 
-        $io->table(array(), $tableRows);
+        $io->table(array(), array_diff_key($tableRows, $hasAlias));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In order to favor type-hinting for interfaces, I propose to not list the class as explicitly autowireable when an alias exists for it.

Which means displaying only
```
  App\FooInterface                                              
      alias to App\Foo                                          
```

instead of 
```
  App\Foo                                                       
  App\FooInterface                                              
      alias to App\Foo                                          
```

ping @weaverryan 