### PR TITLE
[WebProfiler] Disallow viewing dot-files in Profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -385,7 +385,7 @@ class ProfilerController
 
         $filename = $this->baseDir.DIRECTORY_SEPARATOR.$file;
 
-        if (preg_match("'(^|[/\\\\])\.\.?([/\\\\]|$)'", $file) || !is_readable($filename)) {
+        if (preg_match("'(^|[/\\\\])\.'", $file) || !is_readable($filename)) {
             throw new NotFoundHttpException(sprintf('The file "%s" cannot be opened.', $file));
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\WebProfilerBundle\Tests\Controller;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController;
 use Symfony\Bundle\WebProfilerBundle\Csp\ContentSecurityPolicyHandler;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -43,6 +44,42 @@ class ProfilerControllerTest extends TestCase
             array(null),
             // "empty" is also a valid empty token case, see https://github.com/symfony/symfony/issues/10806
             array('empty'),
+        );
+    }
+
+    /**
+     * @dataProvider getOpenFileCases
+     */
+    public function testOpeningDisallowedPaths($path, $isAllowed)
+    {
+        $urlGenerator = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')->getMock();
+        $twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
+        $profiler = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Profiler\Profiler')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $controller = new ProfilerController($urlGenerator, $profiler, $twig, array(), 'bottom', null, __DIR__.'/../..');
+
+        try {
+            $response = $controller->openAction(Request::create('/_wdt/open', Request::METHOD_GET, array('file' => $path)));
+            $this->assertEquals(200, $response->getStatusCode());
+            $this->assertTrue($isAllowed);
+        } catch (NotFoundHttpException $e) {
+            $this->assertFalse($isAllowed);
+        }
+    }
+
+    public function getOpenFileCases()
+    {
+        return array(
+            array('README.md', true),
+            array('composer.json', true),
+            array('Controller/ProfilerController.php', true),
+            array('.gitignore', false),
+            array('../TwigBundle/README.md', false),
+            array('Controller/../README.md', false),
+            array('Controller/./ProfilerController.php', false),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

The file viewer in the profiler should not open files that were specifically intended to be hidden, like specifically .env files, but similarly files like .htaccess that might expose server configuration knowledge.

Added tests validating both the new and old behavior.