### PR TITLE
[Validator] Fixed the @Valid(groups={"group"}) against null exception case

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ValidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ValidValidator.php
@@ -26,6 +26,10 @@ class ValidValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Valid');
         }
 
+        if (null === $value) {
+            return;
+        }
+
         $this->context
             ->getValidator()
             ->inContext($this->context)

--- a/src/Symfony/Component/Validator/Tests/Constraints/ValidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ValidValidatorTest.php
@@ -20,6 +20,18 @@ class ValidValidatorTest extends TestCase
         $this->assertSame('fooBar.fooBarBaz.foo', $violations->get(0)->getPropertyPath());
     }
 
+    public function testNullValues()
+    {
+        $validatorBuilder = new ValidatorBuilder();
+        $validator = $validatorBuilder->enableAnnotationMapping()->getValidator();
+
+        $foo = new Foo();
+        $foo->fooBar = null;
+        $violations = $validator->validate($foo, null, array('nested'));
+
+        $this->assertCount(0, $violations);
+    }
+
     protected function createValidator()
     {
         return new ValidValidator();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When `@Valid(groups={"group"})` has non-empty groups and the value is `null`, validator throws `Cannot validate values of type "NULL" automatically. Please provide a constraint.` at `RecursiveContextualValidator:164`.

I don't really understand, why everything is okay for `@Valid()` without groups, but hope that my fix is correct anyway.