### PR TITLE
[Serializer] improved CsvEncoder::decode performance

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -115,6 +115,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
         $headers = null;
         $nbHeaders = 0;
+        $headerCount = array();
         $result = array();
 
         list($delimiter, $enclosure, $escapeChar, $keySeparator) = $this->getCsvOptions($context);
@@ -126,7 +127,9 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
                 $nbHeaders = $nbCols;
 
                 foreach ($cols as $col) {
-                    $headers[] = explode($keySeparator, $col);
+                    $header = explode($keySeparator, $col);
+                    $headers[] = $header;
+                    $headerCount[] = count($header);
                 }
 
                 continue;
@@ -134,7 +137,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
 
             $item = array();
             for ($i = 0; ($i < $nbCols) && ($i < $nbHeaders); ++$i) {
-                $depth = count($headers[$i]);
+                $depth = $headerCount[$i];
                 $arr = &$item;
                 for ($j = 0; $j < $depth; ++$j) {
                     // Handle nested arrays


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Improved CsvEncoder::decode performance by caching duplicate count calls.
Blackfire profiles before and after change tested on collection of 10000 elements:
[before] https://blackfire.io/profiles/9c08f789-cd29-4eae-92c8-046e3849a2b8/graph
[after] https://blackfire.io/profiles/a17bfb6b-ef82-41ee-9edd-9403f829d6ab/graph