### PR TITLE
[Console] Add box style table

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -635,11 +635,18 @@ class Table
             ->setCellHeaderFormat('%s')
         ;
 
+        $box = (new TableStyle())
+            ->setHorizontalBorderChar('─')
+            ->setVerticalBorderChar('│')
+            ->setCrossingChar('┼')
+        ;
+
         return array(
             'default' => new TableStyle(),
             'borderless' => $borderless,
             'compact' => $compact,
             'symfony-style-guide' => $styleGuide,
+            'box' => $box,
         );
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -139,6 +139,22 @@ TABLE
 TABLE
             ),
             array(
+                array('ISBN', 'Title', 'Author'),
+                $books,
+                'box',
+                <<<'TABLE'
+┼───────────────┼──────────────────────────┼──────────────────┼
+│ ISBN          │ Title                    │ Author           │
+┼───────────────┼──────────────────────────┼──────────────────┼
+│ 99921-58-10-7 │ Divine Comedy            │ Dante Alighieri  │
+│ 9971-5-0210-0 │ A Tale of Two Cities     │ Charles Dickens  │
+│ 960-425-059-0 │ The Lord of the Rings    │ J. R. R. Tolkien │
+│ 80-902734-1-6 │ And Then There Were None │ Agatha Christie  │
+┼───────────────┼──────────────────────────┼──────────────────┼
+
+TABLE
+            ),
+            array(
                 array('ISBN', 'Title'),
                 array(
                     array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

> Box-drawing characters, also known as line-drawing characters, are a form of semigraphics widely used in text user interfaces to draw various geometric frames and boxes. https://en.wikipedia.org/wiki/Box-drawing_character

Box-drawing characters are done for the `TableStyle`; use them!

Result:

![screenshot from 2017-12-04 17-09-56](https://user-images.githubusercontent.com/4578773/33540267-0e4052fe-d916-11e7-8401-eb3be59e8025.png)