### PR TITLE
[SecurityBundle] add note to info text of no-op config logout_on_user_change

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -199,7 +199,7 @@ class MainConfiguration implements ConfigurationInterface
             ->scalarNode('context')->cannotBeEmpty()->end()
             ->booleanNode('logout_on_user_change')
                 ->defaultTrue()
-                ->info('When true, it will trigger a logout for the user if something has changed.')
+                ->info('When true, it will trigger a logout for the user if something has changed. Note: No-Op option since 4.0. Will always be true.')
             ->end()
             ->arrayNode('logout')
                 ->treatTrueLike(array())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

While discussing the "deprecation path" of the `logout_on_user_change` security option with @chalasr  I got a bit confused.

- on 3.4 we added the option (default=false) and triggered a deprecation in case it's false
- on 4.0 the default became true **and the option is no-op** (does not change anything if its set to false)
- on 4.1 the option is additionally also deprecated

So maybe we should change the info text of the config node to mention that its effectively no-op since 4.0. WDYT?