### PR TITLE
[ExpressionLanguage] throw an SyntaxError instead of an undefined index notice

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -84,6 +84,15 @@ class ExpressionLanguageTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @expectedException \Symfony\Component\ExpressionLanguage\SyntaxError
+     * @expectedExceptionMessage Unexpected end of expression around position 6 for expression `node.`.
+     */
+    public function testParseThrowsInsteadOfNotice()
+    {
+        (new ExpressionLanguage())->parse('node.', array('node'));
+    }
+
     public function shortCircuitProviderEvaluate()
     {
         $object = $this->getMockBuilder('stdClass')->setMethods(array('foo'))->getMock();

--- a/src/Symfony/Component/ExpressionLanguage/TokenStream.php
+++ b/src/Symfony/Component/ExpressionLanguage/TokenStream.php
@@ -50,11 +50,11 @@ class TokenStream
      */
     public function next()
     {
+        ++$this->position;
+
         if (!isset($this->tokens[$this->position])) {
             throw new SyntaxError('Unexpected end of expression', $this->current->cursor, $this->expression);
         }
-
-        ++$this->position;
 
         $this->current = $this->tokens[$this->position];
     }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #25214
| License       | MIT
| Doc PR        | none


I think this is a bug when the components throws a notice instead of an exception.

it's too early and too dark to see something outside so here is my couch :
![img_2915-2](https://user-images.githubusercontent.com/3451634/33592448-6b514050-d98b-11e7-8086-bc6e6b6e6e82.jpg)

