### PR TITLE
[HttpFoundation] Incorrect documentation and method name for UploadedFile::getClientSize()

### DIFF
--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -609,7 +609,7 @@ class CompoundFormTest extends AbstractFormTest
             'author' => array(
                 'error' => array('image' => UPLOAD_ERR_OK),
                 'name' => array('image' => 'upload.png'),
-                'size' => array('image' => 123),
+                'size' => array('image' => null),
                 'tmp_name' => array('image' => $path),
                 'type' => array('image' => 'image/png'),
             ),
@@ -630,7 +630,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $form->handleRequest($request);
 
-        $file = new UploadedFile($path, 'upload.png', 'image/png', 123, UPLOAD_ERR_OK);
+        $file = new UploadedFile($path, 'upload.png', 'image/png', null, UPLOAD_ERR_OK);
 
         $this->assertEquals('Bernhard', $form['name']->getData());
         $this->assertEquals($file, $form['image']->getData());
@@ -655,7 +655,7 @@ class CompoundFormTest extends AbstractFormTest
             'image' => array(
                 'error' => UPLOAD_ERR_OK,
                 'name' => 'upload.png',
-                'size' => 123,
+                'size' => null,
                 'tmp_name' => $path,
                 'type' => 'image/png',
             ),
@@ -676,7 +676,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $form->handleRequest($request);
 
-        $file = new UploadedFile($path, 'upload.png', 'image/png', 123, UPLOAD_ERR_OK);
+        $file = new UploadedFile($path, 'upload.png', 'image/png', null, UPLOAD_ERR_OK);
 
         $this->assertEquals('Bernhard', $form['name']->getData());
         $this->assertEquals($file, $form['image']->getData());
@@ -697,7 +697,7 @@ class CompoundFormTest extends AbstractFormTest
             'image' => array(
                 'error' => UPLOAD_ERR_OK,
                 'name' => 'upload.png',
-                'size' => 123,
+                'size' => null,
                 'tmp_name' => $path,
                 'type' => 'image/png',
             ),
@@ -714,7 +714,7 @@ class CompoundFormTest extends AbstractFormTest
 
         $form->handleRequest($request);
 
-        $file = new UploadedFile($path, 'upload.png', 'image/png', 123, UPLOAD_ERR_OK);
+        $file = new UploadedFile($path, 'upload.png', 'image/png', null, UPLOAD_ERR_OK);
 
         $this->assertEquals($file, $form->getData());
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -188,7 +188,7 @@ class FileTypeTest extends BaseTypeTest
     private function createUploadedFileMock(RequestHandlerInterface $requestHandler, $path, $originalName)
     {
         if ($requestHandler instanceof HttpFoundationRequestHandler) {
-            return new UploadedFile($path, $originalName, null, 10, null, true);
+            return new UploadedFile($path, $originalName, null, null, null, true);
         }
 
         return array(
@@ -196,7 +196,7 @@ class FileTypeTest extends BaseTypeTest
             'error' => 0,
             'type' => 'text/plain',
             'tmp_name' => $path,
-            'size' => 10,
+            'size' => null,
         );
     }
 }

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -60,6 +60,9 @@ class UploadedFile extends File
         $this->originalName = $this->getName($originalName);
         $this->mimeType = $mimeType ?: 'application/octet-stream';
         $this->size = $size;
+        if (null !== $size) {
+            @trigger_error('Passing a size in the constructor is deprecated since 4.1 and will be removed in 5.0. Use getSize() instead.', E_USER_DEPRECATED);
+        }
         $this->error = $error ?: UPLOAD_ERR_OK;
         $this->test = $test;
 
@@ -141,10 +144,14 @@ class UploadedFile extends File
      * It is extracted from the request from which the file has been uploaded.
      * Then it should not be considered as a safe value.
      *
-     * @return int|null The file size
+     * @deprecated since 4.1 will be removed in 5.0 use getSize() instead.
+     *
+     * @return int|null The file sizes
      */
     public function getClientSize()
     {
+        @trigger_error(sprintf('"%s" is deprecated since 4.1 and will be removed in 5.0. Use getSize() instead.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->size;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -40,7 +40,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             null,
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             UPLOAD_ERR_OK
         );
 
@@ -57,7 +57,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/.unknownextension',
             'original.gif',
             null,
-            filesize(__DIR__.'/Fixtures/.unknownextension'),
+            null,
             UPLOAD_ERR_OK
         );
 
@@ -70,7 +70,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             'image/gif',
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             null
         );
 
@@ -83,7 +83,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             'image/jpeg',
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             null
         );
 
@@ -96,7 +96,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             'image/gif',
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             null
         );
 
@@ -109,7 +109,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             'image/gif',
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             null
         );
 
@@ -122,7 +122,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             'image/gif',
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             null
         );
 
@@ -138,7 +138,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             'image/gif',
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             UPLOAD_ERR_OK
         );
 
@@ -158,7 +158,7 @@ class UploadedFileTest extends TestCase
             $path,
             'original.gif',
             'image/gif',
-            filesize($path),
+            null,
             UPLOAD_ERR_OK,
             true
         );
@@ -178,7 +178,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             '../../original.gif',
             'image/gif',
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             null
         );
 
@@ -191,7 +191,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             'image/gif',
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             null
         );
 
@@ -204,6 +204,23 @@ class UploadedFileTest extends TestCase
         );
 
         $this->assertEquals(filesize(__DIR__.'/Fixtures/test'), $file->getSize());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a size in the constructor is deprecated since 4.1 and will be removed in 5.0. Use getSize instead.
+     */
+    public function testConstructDeprecatedSize()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            'image/gif',
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            null
+        );
+
+        $this->assertEquals(filesize(__DIR__.'/Fixtures/test.gif'), $file->getSize());
     }
 
     public function testGetExtension()
@@ -223,7 +240,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             null,
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             UPLOAD_ERR_OK,
             true
         );
@@ -240,7 +257,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             null,
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             $error
         );
 
@@ -264,7 +281,7 @@ class UploadedFileTest extends TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             null,
-            filesize(__DIR__.'/Fixtures/test.gif'),
+            null,
             UPLOAD_ERR_OK
         );
 

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -34,14 +34,14 @@ class FileBagTest extends TestCase
     public function testShouldConvertsUploadedFiles()
     {
         $tmpFile = $this->createTempFile();
-        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain', 100, 0);
+        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain', null, 0);
 
         $bag = new FileBag(array('file' => array(
             'name' => basename($tmpFile),
             'type' => 'text/plain',
             'tmp_name' => $tmpFile,
             'error' => 0,
-            'size' => 100,
+            'size' => null,
         )));
 
         $this->assertEquals($file, $bag->get('file'));
@@ -89,7 +89,7 @@ class FileBagTest extends TestCase
     public function testShouldConvertUploadedFilesWithPhpBug()
     {
         $tmpFile = $this->createTempFile();
-        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain', 100, 0);
+        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain', null, 0);
 
         $bag = new FileBag(array(
             'child' => array(
@@ -106,7 +106,7 @@ class FileBagTest extends TestCase
                     'file' => 0,
                 ),
                 'size' => array(
-                    'file' => 100,
+                    'file' => null,
                 ),
             ),
         ));
@@ -118,7 +118,7 @@ class FileBagTest extends TestCase
     public function testShouldConvertNestedUploadedFilesWithPhpBug()
     {
         $tmpFile = $this->createTempFile();
-        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain', 100, 0);
+        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain', null, 0);
 
         $bag = new FileBag(array(
             'child' => array(
@@ -135,7 +135,7 @@ class FileBagTest extends TestCase
                     'sub' => array('file' => 0),
                 ),
                 'size' => array(
-                    'sub' => array('file' => 100),
+                    'sub' => array('file' => null),
                 ),
             ),
         ));
@@ -147,7 +147,7 @@ class FileBagTest extends TestCase
     public function testShouldNotConvertNestedUploadedFiles()
     {
         $tmpFile = $this->createTempFile();
-        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain', 100, 0);
+        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain', null, 0);
         $bag = new FileBag(array('image' => array('file' => $file)));
 
         $files = $bag->all();

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -168,7 +168,7 @@ EOF;
                         '',
                         $value->getClientOriginalName(),
                         $value->getClientMimeType(),
-                        0,
+                        null,
                         UPLOAD_ERR_INI_SIZE,
                         true
                     );
@@ -177,7 +177,7 @@ EOF;
                         $value->getPathname(),
                         $value->getClientOriginalName(),
                         $value->getClientMimeType(),
-                        $value->getClientSize(),
+                        null,
                         $value->getError(),
                         true
                     );

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -104,8 +104,8 @@ class ClientTest extends TestCase
         $client = new Client($kernel);
 
         $files = array(
-            array('tmp_name' => $source, 'name' => 'original', 'type' => 'mime/original', 'size' => 123, 'error' => UPLOAD_ERR_OK),
-            new UploadedFile($source, 'original', 'mime/original', 123, UPLOAD_ERR_OK, true),
+            array('tmp_name' => $source, 'name' => 'original', 'type' => 'mime/original', 'size' => null, 'error' => UPLOAD_ERR_OK),
+            new UploadedFile($source, 'original', 'mime/original', null, UPLOAD_ERR_OK, true),
         );
 
         $file = null;
@@ -120,7 +120,6 @@ class ClientTest extends TestCase
 
             $this->assertEquals('original', $file->getClientOriginalName());
             $this->assertEquals('mime/original', $file->getClientMimeType());
-            $this->assertEquals('123', $file->getClientSize());
             $this->assertTrue($file->isValid());
         }
 
@@ -154,7 +153,7 @@ class ClientTest extends TestCase
 
         $file = $this
             ->getMockBuilder('Symfony\Component\HttpFoundation\File\UploadedFile')
-            ->setConstructorArgs(array($source, 'original', 'mime/original', 123, UPLOAD_ERR_OK, true))
+            ->setConstructorArgs(array($source, 'original', 'mime/original', null, UPLOAD_ERR_OK, true))
             ->setMethods(array('getSize'))
             ->getMock()
         ;
@@ -176,7 +175,7 @@ class ClientTest extends TestCase
         $this->assertEquals(UPLOAD_ERR_INI_SIZE, $file->getError());
         $this->assertEquals('mime/original', $file->getClientMimeType());
         $this->assertEquals('original', $file->getClientOriginalName());
-        $this->assertEquals(0, $file->getClientSize());
+        $this->assertEquals(0, $file->getSize());
 
         unlink($source);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -411,7 +411,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
      */
     public function testUploadedFileError($error, $message, array $params = array(), $maxSize = null)
     {
-        $file = new UploadedFile('/path/to/file', 'originalName', 'mime', 0, $error);
+        $file = new UploadedFile('/path/to/file', 'originalName', 'mime', null, $error);
 
         $constraint = new File(array(
             $message => 'myMessage',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #23791
| License       | MIT
| Doc PR        | none

Replace the wrong named and documented method by another with better doc and better naming
