### PR TITLE
[Yaml] do not evaluate PHP constant names

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -707,7 +707,8 @@ class Inline
                         return;
                     case 0 === strpos($scalar, '!php/const'):
                         if (self::$constantSupport) {
-                            if (defined($const = self::parseScalar(substr($scalar, 11)))) {
+                            $i = 0;
+                            if (defined($const = self::parseScalar(substr($scalar, 11), 0, null, $i, false))) {
                                 return constant($const);
                             }
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -58,6 +58,7 @@ class InlineTest extends TestCase
             array('!php/const PHP_INT_MAX', PHP_INT_MAX),
             array('[!php/const PHP_INT_MAX]', array(PHP_INT_MAX)),
             array('{ foo: !php/const PHP_INT_MAX }', array('foo' => PHP_INT_MAX)),
+            array('!php/const NULL', null),
         );
     }
 
@@ -82,10 +83,22 @@ class InlineTest extends TestCase
     /**
      * @group legacy
      * @expectedDeprecation The !php/const: tag to indicate dumped PHP constants is deprecated since version 3.4 and will be removed in 4.0. Use the !php/const (without the colon) tag instead on line 1.
+     * @dataProvider getTestsForParseLegacyPhpConstants
      */
-    public function testDeprecatedConstantTag()
+    public function testDeprecatedConstantTag($yaml, $expectedValue)
     {
-        Inline::parse('!php/const:PHP_INT_MAX', Yaml::PARSE_CONSTANT);
+        $this->assertSame($expectedValue, Inline::parse($yaml, Yaml::PARSE_CONSTANT));
+    }
+
+    public function getTestsForParseLegacyPhpConstants()
+    {
+        return array(
+            array('!php/const:Symfony\Component\Yaml\Yaml::PARSE_CONSTANT', Yaml::PARSE_CONSTANT),
+            array('!php/const:PHP_INT_MAX', PHP_INT_MAX),
+            array('[!php/const:PHP_INT_MAX]', array(PHP_INT_MAX)),
+            array('{ foo: !php/const:PHP_INT_MAX }', array('foo' => PHP_INT_MAX)),
+            array('!php/const:NULL', null),
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25307
| License       | MIT
| Doc PR        | 

PHP constant identifiers must be strings anyway. Thus, we only need to
parse quoted strings, but do not have to evaluate the data types.
