### PR TITLE
[VarDumper] Allow VarDumperTestTrait expectation to be non-scalar

### DIFF
--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
@@ -19,14 +19,14 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
  */
 trait VarDumperTestTrait
 {
-    public function assertDumpEquals($dump, $data, $filter = 0, $message = '')
+    public function assertDumpEquals($expected, $data, $filter = 0, $message = '')
     {
-        $this->assertSame(rtrim($dump), $this->getDump($data, null, $filter), $message);
+        $this->assertSame($this->prepareExpectation($expected, $filter), $this->getDump($data, null, $filter), $message);
     }
 
-    public function assertDumpMatchesFormat($dump, $data, $filter = 0, $message = '')
+    public function assertDumpMatchesFormat($expected, $data, $filter = 0, $message = '')
     {
-        $this->assertStringMatchesFormat(rtrim($dump), $this->getDump($data, null, $filter), $message);
+        $this->assertStringMatchesFormat($this->prepareExpectation($expected, $filter), $this->getDump($data, null, $filter), $message);
     }
 
     protected function getDump($data, $key = null, $filter = 0)
@@ -44,5 +44,14 @@ trait VarDumperTestTrait
         }
 
         return rtrim($dumper->dump($data, true));
+    }
+
+    private function prepareExpectation($expected, $filter)
+    {
+        if (!is_string($expected)) {
+            $expected = $this->getDump($expected, null, $filter);
+        }
+
+        return rtrim($expected);
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Test/VarDumperTestTraitTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Test/VarDumperTestTraitTest.php
@@ -38,4 +38,9 @@ EODUMP;
 
         $this->assertDumpEquals($expected, $data);
     }
+
+    public function testAllowsNonScalarExpectation()
+    {
+        $this->assertDumpEquals(new \ArrayObject(array('bim' => 'bam')), new \ArrayObject(array('bim' => 'bam')));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

At the moment, when using the `VarDumperTestTrait` in unit test, expecting data object is as follow:

```php
class Toto
{
    private $foo;

    public function __construct($foo)
    {
        $this->foo = $foo;
    }
}

class MyTest extends \PHPUnit_Framework_TestCase
{
     use Symfony\Component\VarDumper\Test\VarDumperTestTrait;

    public function dummyTest()
    {
        $expected = <<<EOEXPECTED
Profiler\Tests\Model\CallGraph\Toto {
  -foo: "baz"
}
EOEXPECTED;

        $this->assertDumpEquals($expected, new Toto('baz'));
    }
}
```

The same test could be easily written like this with this change:

```php
    public function dummyTest()
    {
        $this->assertDumpEquals(new Toto('baz'), new Toto('baz'));
    }
```