### PR TITLE
[DI] Impossible to set an environment variable and then an array as container parameter

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1294,6 +1294,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             $format = '%%env(%s)%%';
         }
 
+        $bag = $this->getParameterBag();
+        if (true === $format) {
+            $value = $bag->resolveValue($value);
+        }
+
         if (is_array($value)) {
             $result = array();
             foreach ($value as $k => $v) {
@@ -1305,11 +1310,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
         if (!is_string($value)) {
             return $value;
-        }
-
-        $bag = $this->getParameterBag();
-        if (true === $format) {
-            $value = $bag->resolveValue($value);
         }
         $envPlaceholders = $bag instanceof EnvPlaceholderParameterBag ? $bag->getEnvPlaceholders() : $this->envPlaceholders;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -615,6 +615,20 @@ class ContainerBuilderTest extends TestCase
         unset($_ENV['DUMMY_ENV_VAR'], $_SERVER['DUMMY_SERVER_VAR'], $_SERVER['HTTP_DUMMY_VAR']);
     }
 
+    public function testResolveEnvValuesWithArray()
+    {
+        $_ENV['ANOTHER_DUMMY_ENV_VAR'] = 'dummy';
+
+        $container = new ContainerBuilder();
+        $container->setParameter('dummy', '%env(ANOTHER_DUMMY_ENV_VAR)%');
+        $container->setParameter('dummy2', ['1' => 'one', '2' => 'two']);
+
+        $container->resolveEnvPlaceholders('%dummy%', true);
+        $container->resolveEnvPlaceholders('%dummy2%', true);
+
+        unset($_ENV['ANOTHER_DUMMY_ENV_VAR']);
+    }
+
     public function testCompileWithResolveEnv()
     {
         putenv('DUMMY_ENV_VAR=du%%y');

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -619,12 +619,20 @@ class ContainerBuilderTest extends TestCase
     {
         $_ENV['ANOTHER_DUMMY_ENV_VAR'] = 'dummy';
 
+        $dummyArray = array('1' => 'one', '2' => 'two');
+
         $container = new ContainerBuilder();
         $container->setParameter('dummy', '%env(ANOTHER_DUMMY_ENV_VAR)%');
-        $container->setParameter('dummy2', array('1' => 'one', '2' => 'two'));
+        $container->setParameter('dummy2', $dummyArray);
 
         $container->resolveEnvPlaceholders('%dummy%', true);
         $container->resolveEnvPlaceholders('%dummy2%', true);
+
+        $this->assertInternalType('array', $container->resolveEnvPlaceholders('%dummy2%', true));
+
+        foreach ($dummyArray as $key => $value) {
+            $this->assertArrayHasKey($key, $container->resolveEnvPlaceholders('%dummy2%', true));
+        }
 
         unset($_ENV['ANOTHER_DUMMY_ENV_VAR']);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -621,7 +621,7 @@ class ContainerBuilderTest extends TestCase
 
         $container = new ContainerBuilder();
         $container->setParameter('dummy', '%env(ANOTHER_DUMMY_ENV_VAR)%');
-        $container->setParameter('dummy2', ['1' => 'one', '2' => 'two']);
+        $container->setParameter('dummy2', array('1' => 'one', '2' => 'two'));
 
         $container->resolveEnvPlaceholders('%dummy%', true);
         $container->resolveEnvPlaceholders('%dummy2%', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #25245
| License       | MIT

When an environment variables and then an array is set as container parameters, an error is thrown (Warning: stripos() expects parameter 1 to be string, array given).

You can run my test without the fix in the Container builder to see it.
