### PR TITLE
[Serializer] Unset attributes when creating child context

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -402,6 +402,8 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
     {
         if (isset($parentContext[self::ATTRIBUTES][$attribute])) {
             $parentContext[self::ATTRIBUTES] = $parentContext[self::ATTRIBUTES][$attribute];
+        } else {
+            unset($parentContext[self::ATTRIBUTES]);
         }
 
         return $parentContext;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -673,6 +673,16 @@ class ObjectNormalizerTest extends TestCase
             ),
             $serializer->normalize($objectDummy, null, $context)
         );
+
+        $context = array('attributes' => array('foo', 'baz', 'object'));
+        $this->assertEquals(
+            array(
+                'foo' => 'foo',
+                'baz' => true,
+                'object' => array('foo' => 'innerFoo', 'bar' => 'innerBar'),
+            ),
+            $serializer->normalize($objectDummy, null, $context)
+        );
     }
 
     public function testAttributesContextDenormalize()


### PR DESCRIPTION
 | Q             | A
 | ------------- | ---
 | Branch?       | 3.3
 | Bug fix?      | yes
 | New feature?  | no
 | BC breaks?    | no
 | Deprecations? | no
 | Tests pass?   | yes
 | Fixed tickets | n/a
 | License       | MIT
 | Doc PR        | n/a

In some cases, the `attributes` key isn't overrode when creating the context passed to nested normalizers.
 It's definitely a bug, but an attacker cannot access to non public data (ignored attributes are checked before the `attributes` key). However some data that must be public may be missing as highlighted by the test.

I've introduced the initial bug here: https://github.com/symfony/symfony/pull/18834