### PR TITLE
[DoctrineBridge] DoctrineDataCollector comments the non runnable part of the query

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -162,8 +162,8 @@ class DoctrineDataCollector extends DataCollector
             $className = get_class($var);
 
             return method_exists($var, '__toString') ?
-                array(sprintf('Object(%s): "%s"', $className, $var->__toString()), false) :
-                array(sprintf('Object(%s)', $className), false);
+                array(sprintf('/* Object(%s): */"%s"', $className, $var->__toString()), false) :
+                array(sprintf('/* Object(%s) */', $className), false);
         }
 
         if (is_array($var)) {
@@ -179,7 +179,7 @@ class DoctrineDataCollector extends DataCollector
         }
 
         if (is_resource($var)) {
-            return array(sprintf('Resource(%s)', get_resource_type($var)), false);
+            return array(sprintf('/* Resource(%s) */', get_resource_type($var)), false);
         }
 
         return array($var, true);

--- a/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeDoctrineCollectionListener.php
+++ b/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeDoctrineCollectionListener.php
@@ -45,7 +45,7 @@ class MergeDoctrineCollectionListener implements EventSubscriberInterface
 
         // If all items were removed, call clear which has a higher
         // performance on persistent collections
-        if ($collection instanceof Collection && count($data) === 0) {
+        if ($collection instanceof Collection && 0 === count($data)) {
             $collection->clear();
         }
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -126,12 +126,12 @@ class DoctrineDataCollectorTest extends TestCase
             array(true, array(), true, true),
             array(null, array(), null, true),
             array(new \DateTime('2011-09-11'), array('date'), '2011-09-11', true),
-            array(fopen(__FILE__, 'r'), array(), 'Resource(stream)', false),
-            array(new \stdClass(), array(), 'Object(stdClass)', false),
+            array(fopen(__FILE__, 'r'), array(), '/* Resource(stream) */', false),
+            array(new \stdClass(), array(), '/* Object(stdClass) */', false),
             array(
                 new StringRepresentableClass(),
                 array(),
-                'Object(Symfony\Bridge\Doctrine\Tests\DataCollector\StringRepresentableClass): "string representation"',
+                '/* Object(Symfony\Bridge\Doctrine\Tests\DataCollector\StringRepresentableClass): */"string representation"',
                 false,
             ),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #24782
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

![img_2932](https://user-images.githubusercontent.com/3451634/33648180-f6c7a5ac-da58-11e7-8bf8-95fc943d16ff.jpeg)

I think the idea in this ticket is good and it should be implemented. Could we go further by adding more things to this feature, or will it be ok to just comment out the un-needed part to make the kiri 
![kiri](https://user-images.githubusercontent.com/3451634/33648278-5eccc830-da59-11e7-8034-a1b9efee7673.png)
(french joke for query) runnable ?