### PR TITLE
[Console] Commands with an alias should not be recognized as ambiguous when using register

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -499,7 +499,20 @@ class Application
     {
         $this->init();
 
+        foreach ($this->commands as $command) {
+            foreach ($command->getAliases() as $alias) {
+                if (!isset($this->commands[$alias])) {
+                    $this->commands[$alias] = $command;
+                }
+            }
+        }
+
         $allCommands = array_keys($this->commands);
+
+        if (\in_array($name, $allCommands, true)) {
+            return $this->get($name);
+        }
+
         $expr = preg_replace_callback('{([^:]+|)}', function ($matches) { return preg_quote($matches[1]).'[^:]*'; }, $name);
         $commands = preg_grep('{^'.$expr.'}', $allCommands);
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -49,6 +49,8 @@ class ApplicationTest extends TestCase
         require_once self::$fixturesPath.'/BarBucCommand.php';
         require_once self::$fixturesPath.'/FooSubnamespaced1Command.php';
         require_once self::$fixturesPath.'/FooSubnamespaced2Command.php';
+        require_once self::$fixturesPath.'/TestTiti.php';
+        require_once self::$fixturesPath.'/TestToto.php';
     }
 
     protected function normalizeLineBreaks($text)
@@ -118,6 +120,27 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $command = $application->register('foo');
         $this->assertEquals('foo', $command->getName(), '->register() registers a new command');
+    }
+
+    public function testRegisterAmbiugous()
+    {
+        $code = function (InputInterface $input, OutputInterface $output) {
+            $output->writeln('It works!');
+        };
+
+        $application = new Application();
+        $application
+            ->register('test-foo')
+            ->setAliases(array('test'))
+            ->setCode($code);
+
+        $application
+            ->register('test-bar')
+            ->setCode($code);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('test'));
+        $this->assertContains('It works!', $tester->getDisplay(true));
     }
 
     public function testAdd()

--- a/src/Symfony/Component/Console/Tests/Fixtures/TestTiti.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/TestTiti.php
@@ -1,0 +1,21 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestTiti extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('test-titi')
+            ->setDescription('The test:titi command')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->write('test-titi');
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/TestToto.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/TestToto.php
@@ -1,0 +1,22 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestToto extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('test-toto')
+            ->setDescription('The test-toto command')
+            ->setAliases(array('test'))
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->write('test-toto');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25355 
| License       | MIT
| Doc PR        | 


I think when passing an alias, it should not be treated as a ambiguous command since it's configured to response to it.

I've [pushed a commit](https://github.com/Simperfit/symfony-reproducer/commit/2f5209a6876101a5f47ed589baa392d37e55aa40) that reproduce the bug and with this patch it does work.