### PR TITLE
[2.7] Remove some unused variables, properties and methods

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
@@ -43,7 +43,7 @@ class AssetsHelper extends Helper
     public function getUrl($path, $packageName = null, $version = null)
     {
         // BC layer to be removed in 3.0
-        if (3 === $count = func_num_args()) {
+        if (3 === func_num_args()) {
             @trigger_error('Forcing a version for an asset was deprecated in 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
 
             $args = func_get_args();

--- a/src/Symfony/Component/CssSelector/Parser/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/Parser/TokenStream.php
@@ -30,11 +30,6 @@ class TokenStream
     private $tokens = array();
 
     /**
-     * @var bool
-     */
-    private $frozen = false;
-
-    /**
      * @var Token[]
      */
     private $used = array();
@@ -47,7 +42,7 @@ class TokenStream
     /**
      * @var Token|null
      */
-    private $peeked = null;
+    private $peeked;
 
     /**
      * @var bool
@@ -73,8 +68,6 @@ class TokenStream
      */
     public function freeze()
     {
-        $this->frozen = true;
-
         return $this;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -30,7 +30,6 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
     private $container;
     private $currentId;
     private $currentDefinition;
-    private $repeatedPass;
     private $onlyConstructorArguments;
 
     /**
@@ -46,7 +45,7 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
      */
     public function setRepeatedPass(RepeatedPass $repeatedPass)
     {
-        $this->repeatedPass = $repeatedPass;
+        // no-op for BC
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -23,7 +23,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class InlineServiceDefinitionsPass implements RepeatablePassInterface
 {
-    private $repeatedPass;
     private $graph;
     private $compiler;
     private $formatter;
@@ -34,7 +33,7 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
      */
     public function setRepeatedPass(RepeatedPass $repeatedPass)
     {
-        $this->repeatedPass = $repeatedPass;
+        // no-op for BC
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -67,7 +67,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
 
         if (isset($this->listenerIds[$eventName])) {
             foreach ($this->listenerIds[$eventName] as $i => $args) {
-                list($serviceId, $method, $priority) = $args;
+                list($serviceId, $method) = $args;
                 $key = $serviceId.'.'.$method;
                 if (isset($this->listeners[$eventName][$key]) && $listener === array($this->listeners[$eventName][$key], $method)) {
                     unset($this->listeners[$eventName][$key]);

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -24,13 +24,6 @@ class TimezoneType extends AbstractType
     private static $timezones;
 
     /**
-     * Stores the available timezone choices.
-     *
-     * @var array
-     */
-    private static $flippedTimezones;
-
-    /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -27,7 +27,6 @@ class ConfigDataCollector extends DataCollector
     private $kernel;
     private $name;
     private $version;
-    private $cacheVersionInfo = true;
 
     /**
      * @param string $name    The name of the application using the web profiler
@@ -123,7 +122,7 @@ class ConfigDataCollector extends DataCollector
 
     public function setCacheVersionInfo($cacheVersionInfo)
     {
-        $this->cacheVersionInfo = $cacheVersionInfo;
+        // no-op for BC
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -151,7 +151,7 @@ class Store implements StoreInterface
             return;
         }
 
-        list($req, $headers) = $match;
+        $headers = $match[1];
         if (file_exists($body = $this->getPath($headers['x-content-digest'][0]))) {
             return $this->restoreResponse($headers, $body);
         }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -24,7 +24,6 @@ class ConfigDataCollectorTest extends TestCase
     {
         $kernel = new KernelForTest('test', true);
         $c = new ConfigDataCollector();
-        $c->setCacheVersionInfo(false);
         $c->setKernel($kernel);
         $c->collect(new Request(), new Response());
 

--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -94,7 +94,7 @@ abstract class AbstractPipes implements PipesInterface
         $w = array($this->pipes[0]);
 
         // let's have a look if something changed in streams
-        if (false === $n = @stream_select($r, $w, $e, 0, 0)) {
+        if (false === @stream_select($r, $w, $e, 0, 0)) {
             return;
         }
 

--- a/src/Symfony/Component/Process/Pipes/UnixPipes.php
+++ b/src/Symfony/Component/Process/Pipes/UnixPipes.php
@@ -99,7 +99,7 @@ class UnixPipes extends AbstractPipes
         unset($r[0]);
 
         // let's have a look if something changed in streams
-        if (($r || $w) && false === $n = @stream_select($r, $w, $e, 0, $blocking ? Process::TIMEOUT_PRECISION * 1E6 : 0)) {
+        if (($r || $w) && false === @stream_select($r, $w, $e, 0, $blocking ? Process::TIMEOUT_PRECISION * 1E6 : 0)) {
             // if a system call has been interrupted, forget about it, let's try again
             // otherwise, an error occurred, let's reset pipes
             if (!$this->hasSystemCallBeenInterrupted()) {

--- a/src/Symfony/Component/Validator/Context/LegacyExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/LegacyExecutionContext.php
@@ -26,8 +26,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 class LegacyExecutionContext extends ExecutionContext
 {
-    private $metadataFactory;
-
     /**
      * Creates a new context.
      *
@@ -44,7 +42,5 @@ class LegacyExecutionContext extends ExecutionContext
             $translator,
             $translationDomain
         );
-
-        $this->metadataFactory = $metadataFactory;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | kind of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Analyzing symfony/symfony using https://insight.sensiolabs.com, I found several chunks of dead code. This PR removes them in the 2.7 branch.

fabbot failure is unrelated.