### PR TITLE
[Form] Fix debug:form command definition

### DIFF
--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Form\Command\DebugCommand;
 
 /**
  * Adds all services with the tags "form.type", "form.type_extension" and
@@ -36,7 +35,7 @@ class FormPass implements CompilerPassInterface
     private $formTypeGuesserTag;
     private $formDebugCommandService;
 
-    public function __construct($formExtensionService = 'form.extension', $formTypeTag = 'form.type', $formTypeExtensionTag = 'form.type_extension', $formTypeGuesserTag = 'form.type_guesser', $formDebugCommandService = DebugCommand::class)
+    public function __construct($formExtensionService = 'form.extension', $formTypeTag = 'form.type', $formTypeExtensionTag = 'form.type_extension', $formTypeGuesserTag = 'form.type_guesser', $formDebugCommandService = 'console.command.form_debug')
     {
         $this->formExtensionService = $formExtensionService;
         $this->formTypeTag = $formTypeTag;

--- a/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
+++ b/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Form\Tests\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
-use Symfony\Component\Form\Command\DebugCommand;
 use Symfony\Component\Form\DependencyInjection\FormPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -43,7 +42,7 @@ class FormPassTest extends TestCase
 
         $container->compile();
 
-        $this->assertFalse($container->hasDefinition(DebugCommand::class));
+        $this->assertFalse($container->hasDefinition('console.command.form_debug'));
     }
 
     public function testAddTaggedTypes()
@@ -72,13 +71,13 @@ class FormPassTest extends TestCase
         $container = $this->createContainerBuilder();
 
         $container->setDefinition('form.extension', $this->createExtensionDefinition());
-        $container->setDefinition(DebugCommand::class, $this->createDebugCommandDefinition());
+        $container->setDefinition('console.command.form_debug', $this->createDebugCommandDefinition());
         $container->register('my.type1', __CLASS__.'_Type1')->addTag('form.type')->setPublic(true);
         $container->register('my.type2', __CLASS__.'_Type2')->addTag('form.type')->setPublic(true);
 
         $container->compile();
 
-        $cmdDefinition = $container->getDefinition(DebugCommand::class);
+        $cmdDefinition = $container->getDefinition('console.command.form_debug');
 
         $this->assertEquals(
             array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Sadly these changes were forgotten in https://github.com/symfony/symfony/pull/25011 and the `debug:form` command does not work properly right now :(
