### PR TITLE
Remove some unused variables and properties

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -112,7 +112,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                     }
                     $instance['event'] = array($instance['event']);
 
-                    if ($lazy = !empty($instance['lazy'])) {
+                    if (!empty($instance['lazy'])) {
                         $this->container->getDefinition($id)->setPublic(true);
                     }
                 }

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -112,7 +112,7 @@ final class Dotenv
         $this->end = strlen($this->data);
         $this->state = self::STATE_VARNAME;
         $this->values = array();
-        $name = $value = '';
+        $name = '';
 
         $this->skipEmptyLines();
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
@@ -23,20 +23,17 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 class DateIntervalToStringTransformer implements DataTransformerInterface
 {
     private $format;
-    private $parseSigned;
 
     /**
      * Transforms a \DateInterval instance to a string.
      *
      * @see \DateInterval::format() for supported formats
      *
-     * @param string $format      The date format
-     * @param bool   $parseSigned Whether to parse as a signed interval
+     * @param string $format The date format
      */
-    public function __construct($format = 'P%yY%mM%dDT%hH%iM%sS', $parseSigned = false)
+    public function __construct($format = 'P%yY%mM%dDT%hH%iM%sS')
     {
         $this->format = $format;
-        $this->parseSigned = $parseSigned;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
@@ -50,7 +50,7 @@ class RemoveEmptyControllerArgumentLocatorsPass implements CompilerPassInterface
                 $action = substr(strrchr($controller, ':'), 1);
                 $id = substr($controller, 0, -1 - strlen($action));
                 $controllerDef = $container->getDefinition($id);
-                foreach ($controllerDef->getMethodCalls() as list($method, $args)) {
+                foreach ($controllerDef->getMethodCalls() as list($method)) {
                     if (0 === strcasecmp($action, $method)) {
                         $reason = sprintf('Removing method "%s" of service "%s" from controller candidates: the method is called at instantiation, thus cannot be an action.', $action, $id);
                         break;

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -24,7 +24,6 @@ class JsonDecode implements DecoderInterface
 
     private $associative;
     private $recursionDepth;
-    private $lastError = JSON_ERROR_NONE;
 
     /**
      * Constructs a new JsonDecode instance.
@@ -75,7 +74,7 @@ class JsonDecode implements DecoderInterface
 
         $decodedData = json_decode($data, $associative, $recursionDepth, $options);
 
-        if (JSON_ERROR_NONE !== $this->lastError = json_last_error()) {
+        if (JSON_ERROR_NONE !== json_last_error()) {
             throw new UnexpectedValueException(json_last_error_msg());
         }
 

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -21,7 +21,6 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 class JsonEncode implements EncoderInterface
 {
     private $options;
-    private $lastError = JSON_ERROR_NONE;
 
     public function __construct($bitmask = 0)
     {
@@ -39,7 +38,7 @@ class JsonEncode implements EncoderInterface
 
         $encodedJson = json_encode($data, $context['json_encode_options']);
 
-        if (JSON_ERROR_NONE !== $this->lastError = json_last_error()) {
+        if (JSON_ERROR_NONE !== json_last_error()) {
             throw new UnexpectedValueException(json_last_error_msg());
         }
 

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -227,7 +227,6 @@ class ConstraintViolationAssertion
     private $parameters = array();
     private $invalidValue = 'InvalidValue';
     private $propertyPath = 'property.path';
-    private $translationDomain;
     private $plural;
     private $code;
     private $constraint;
@@ -264,7 +263,7 @@ class ConstraintViolationAssertion
 
     public function setTranslationDomain($translationDomain)
     {
-        $this->translationDomain = $translationDomain;
+        // no-op for BC
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Analyzing symfony/symfony using https://insight.sensiolabs.com, I found several chunks of dead code. This PR removes them in the 3.3 branch.