### PR TITLE
[Form] Remove group options without data on debug:form command

### DIFF
--- a/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/Descriptor.php
@@ -98,6 +98,8 @@ abstract class Descriptor implements DescriptorInterface
         }
 
         $this->overriddenOptions = array_filter($this->overriddenOptions);
+        $this->parentOptions = array_filter($this->parentOptions);
+        $this->extensionOptions = array_filter($this->extensionOptions);
         $this->requiredOptions = $optionsResolver->getRequiredOptions();
 
         $this->parents = array_keys($this->parents);

--- a/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
@@ -126,30 +126,32 @@ class TextDescriptor extends Descriptor
 
     private function normalizeAndSortOptionsColumns(array $options)
     {
-        foreach ($options as $group => &$opts) {
+        foreach ($options as $group => $opts) {
             $sorted = false;
             foreach ($opts as $class => $opt) {
+                if (is_string($class)) {
+                    unset($options[$group][$class]);
+                }
+
                 if (!is_array($opt) || 0 === count($opt)) {
                     continue;
                 }
 
-                unset($opts[$class]);
-
                 if (!$sorted) {
-                    $opts = array();
+                    $options[$group] = array();
                 } else {
-                    $opts[] = null;
+                    $options[$group][] = null;
                 }
-                $opts[] = sprintf('<info>%s</info>', (new \ReflectionClass($class))->getShortName());
-                $opts[] = new TableSeparator();
+                $options[$group][] = sprintf('<info>%s</info>', (new \ReflectionClass($class))->getShortName());
+                $options[$group][] = new TableSeparator();
 
                 sort($opt);
                 $sorted = true;
-                $opts = array_merge($opts, $opt);
+                $options[$group] = array_merge($options[$group], $opt);
             }
 
             if (!$sorted) {
-                sort($opts);
+                sort($options[$group]);
             }
         }
 

--- a/src/Symfony/Component/Form/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Component/Form/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -84,6 +84,7 @@ abstract class AbstractDescriptorTest extends TestCase
         $parent = new ResolvedFormType(new FormType(), $typeExtensions);
 
         yield array(new ResolvedFormType(new ChoiceType(), array(), $parent), array('decorated' => false), 'resolved_form_type_1');
+        yield array(new ResolvedFormType(new FormType()), array('decorated' => false), 'resolved_form_type_2');
     }
 
     public function getDescribeOptionTestData()

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
@@ -1,0 +1,37 @@
+{
+    "class": "Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType",
+    "block_prefix": "form",
+    "options": {
+        "own": [
+            "action",
+            "attr",
+            "auto_initialize",
+            "block_name",
+            "by_reference",
+            "compound",
+            "data",
+            "data_class",
+            "disabled",
+            "empty_data",
+            "error_bubbling",
+            "inherit_data",
+            "label",
+            "label_attr",
+            "label_format",
+            "mapped",
+            "method",
+            "post_max_size_message",
+            "property_path",
+            "required",
+            "translation_domain",
+            "trim",
+            "upload_max_size_message"
+        ],
+        "overridden": [],
+        "parent": [],
+        "extension": [],
+        "required": []
+    },
+    "parent_types": [],
+    "type_extensions": []
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
@@ -1,0 +1,32 @@
+
+Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")
+==========================================================================
+
+ ------------------------- 
+  Options                  
+ ------------------------- 
+  action                   
+  attr                     
+  auto_initialize          
+  block_name               
+  by_reference             
+  compound                 
+  data                     
+  data_class               
+  disabled                 
+  empty_data               
+  error_bubbling           
+  inherit_data             
+  label                    
+  label_attr               
+  label_format             
+  mapped                   
+  method                   
+  post_max_size_message    
+  property_path            
+  required                 
+  translation_domain       
+  trim                     
+  upload_max_size_message  
+ ------------------------- 
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25394
| License       | MIT
| Doc PR        | -

This also fix the normalization of the options column for text descriptor, regardless of changes in `collectOptions()` method (which is enough to fix the related bug).

@maidmaid could you confirm if these changes solve the problem?