### PR TITLE
[HttpKernel] Fix logging of post-terminate errors/exceptions

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -36,6 +36,7 @@ class DebugHandlersListener implements EventSubscriberInterface
     private $scream;
     private $fileLinkFormat;
     private $firstCall = true;
+    private $hasTerminatedWithException;
 
     /**
      * @param callable|null        $exceptionHandler A handler that will be called on Exception
@@ -60,14 +61,16 @@ class DebugHandlersListener implements EventSubscriberInterface
      */
     public function configure(Event $event = null)
     {
-        if (!$this->firstCall) {
+        if (!$event instanceof KernelEvent ? !$this->firstCall : !$event->isMasterRequest()) {
             return;
         }
-        $this->firstCall = false;
+        $this->firstCall = $this->hasTerminatedWithException = false;
+
+        $handler = set_exception_handler('var_dump');
+        $handler = is_array($handler) ? $handler[0] : null;
+        restore_exception_handler();
+
         if ($this->logger || null !== $this->throwAt) {
-            $handler = set_error_handler('var_dump');
-            $handler = is_array($handler) ? $handler[0] : null;
-            restore_error_handler();
             if ($handler instanceof ErrorHandler) {
                 if ($this->logger) {
                     $handler->setDefaultLogger($this->logger, $this->levels);
@@ -91,8 +94,16 @@ class DebugHandlersListener implements EventSubscriberInterface
         }
         if (!$this->exceptionHandler) {
             if ($event instanceof KernelEvent) {
-                if (method_exists($event->getKernel(), 'terminateWithException')) {
-                    $this->exceptionHandler = array($event->getKernel(), 'terminateWithException');
+                if (method_exists($kernel = $event->getKernel(), 'terminateWithException')) {
+                    $request = $event->getRequest();
+                    $hasRun = &$this->hasTerminatedWithException;
+                    $this->exceptionHandler = function (\Exception $e) use ($kernel, $request, &$hasRun) {
+                        if ($hasRun) {
+                            throw $e;
+                        }
+                        $hasRun = true;
+                        $kernel->terminateWithException($e, $request);
+                    };
                 }
             } elseif ($event instanceof ConsoleEvent && $app = $event->getCommand()->getApplication()) {
                 $output = $event->getOutput();
@@ -105,9 +116,6 @@ class DebugHandlersListener implements EventSubscriberInterface
             }
         }
         if ($this->exceptionHandler) {
-            $handler = set_exception_handler('var_dump');
-            $handler = is_array($handler) ? $handler[0] : null;
-            restore_exception_handler();
             if ($handler instanceof ErrorHandler) {
                 $h = $handler->setExceptionHandler('var_dump') ?: $this->exceptionHandler;
                 $handler->setExceptionHandler($h);

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -78,14 +78,12 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     }
 
     /**
-     * @throws \LogicException If the request stack is empty
-     *
      * @internal
      */
-    public function terminateWithException(\Exception $exception)
+    public function terminateWithException(\Exception $exception, Request $request = null)
     {
-        if (!$request = $this->requestStack->getMasterRequest()) {
-            throw new \LogicException('Request stack is empty', 0, $exception);
+        if (!$request = $request ?: $this->requestStack->getMasterRequest()) {
+            throw $exception;
         }
 
         $response = $this->handleException($exception, $request, self::MASTER_REQUEST);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #19078
| License       | MIT
| Doc PR        | -

After terminate, the request stack is empty, thus `terminateWithException` currently fails, preventing listeners to know about the failure.