### PR TITLE
Extend Argon2i support check to account for sodium_compat

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/Argon2iPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/Argon2iPasswordEncoder.php
@@ -22,9 +22,15 @@ class Argon2iPasswordEncoder extends BasePasswordEncoder implements SelfSaltingE
 {
     public static function isSupported()
     {
-        return (\PHP_VERSION_ID >= 70200 && \defined('PASSWORD_ARGON2I'))
-            || \function_exists('sodium_crypto_pwhash_str')
-            || \extension_loaded('libsodium');
+        if (\PHP_VERSION_ID >= 70200 && \defined('PASSWORD_ARGON2I')) {
+            return true;
+        }
+
+        if (\class_exists('ParagonIE_Sodium_Compat') && \method_exists('ParagonIE_Sodium_Compat', 'crypto_pwhash_is_available')) {
+            return \ParagonIE_Sodium_Compat::crypto_pwhash_is_available();
+        }
+
+        return \function_exists('sodium_crypto_pwhash_str') || \extension_loaded('libsodium');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

In the Argon2i password encoder, if in an environment where `sodium_compat` is installed without either natively running PHP 7.2 or the (lib)sodium extension, the `isSupported` check can return true because the library exposes the `sodium_crypto_pwhash_str()` function however a pure PHP implementation of the method is not implemented, so the library does not actually support the hashes.

https://github.com/paragonie/sodium_compat/issues/55 requested a way to check support through the polyfill to avoid this condition and the 1.4 release added it.  This PR extends the encoder's `isSupported` check to be aware of the `sodium_compat` library and use its support check if able to avoid misreporting that `sodium_crypto_pwhash_str()` is available for use when it isn't.