### PR TITLE
Refactoring tests

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -143,7 +143,7 @@ abstract class CompleteConfigurationTest extends TestCase
             list($matcherId, $attributes, $channel) = $rule;
             $requestMatcher = $container->getDefinition($matcherId);
 
-            $this->assertFalse(isset($matcherIds[$matcherId]));
+            $this->assertArrayNotHasKey($matcherId, $matcherIds);
             $matcherIds[$matcherId] = true;
 
             $i = count($matcherIds);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -84,9 +84,9 @@ class MainConfigurationTest extends TestCase
         $processor = new Processor();
         $configuration = new MainConfiguration(array(), array());
         $processedConfig = $processor->processConfiguration($configuration, array($config));
-        $this->assertTrue(isset($processedConfig['firewalls']['stub']['logout']['csrf_token_generator']));
+        $this->assertArrayHasKey('csrf_token_generator', $processedConfig['firewalls']['stub']['logout']);
         $this->assertEquals('a_token_generator', $processedConfig['firewalls']['stub']['logout']['csrf_token_generator']);
-        $this->assertTrue(isset($processedConfig['firewalls']['stub']['logout']['csrf_token_id']));
+        $this->assertArrayHasKey('csrf_token_id', $processedConfig['firewalls']['stub']['logout']);
         $this->assertEquals('a_token_id', $processedConfig['firewalls']['stub']['logout']['csrf_token_id']);
     }
 

--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -112,7 +112,7 @@ class ConfigCacheTest extends TestCase
         $cache->write('FOOBAR');
 
         $this->assertFileExists($this->cacheFile, 'Cache file is created');
-        $this->assertSame('FOOBAR', file_get_contents($this->cacheFile));
+        $this->assertStringEqualsFile($this->cacheFile, 'FOOBAR');
         $this->assertFileNotExists($this->metaFile, 'Meta file is not created');
     }
 
@@ -128,7 +128,7 @@ class ConfigCacheTest extends TestCase
 
         $this->assertFileExists($this->cacheFile, 'Cache file is created');
         $this->assertFileExists($this->metaFile, 'Meta file is created');
-        $this->assertSame(serialize($metadata), file_get_contents($this->metaFile));
+        $this->assertStringEqualsFile($this->metaFile, serialize($metadata));
     }
 
     private function makeCacheFresh()

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -32,7 +32,7 @@ class ArrayNodeDefinitionTest extends TestCase
             ->append($child);
 
         $this->assertCount(3, $this->getField($parent, 'children'));
-        $this->assertTrue(in_array($child, $this->getField($parent, 'children')));
+        $this->assertContains($child, $this->getField($parent, 'children'));
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -164,6 +164,6 @@ class DirectoryResourceTest extends TestCase
         $resourceA = new DirectoryResource($this->directory, '/.xml$/');
         $resourceB = new DirectoryResource($this->directory, '/.yaml$/');
 
-        $this->assertEquals(2, count(array_unique(array($resourceA, $resourceB))));
+        $this->assertCount(2, array_unique(array($resourceA, $resourceB)));
     }
 }

--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -37,7 +37,7 @@ class TranslatorTest extends TestCase
         $translator = new Translator();
         $document = new \SimpleXMLElement(file_get_contents(__DIR__.'/Fixtures/lang.xml'));
         $elements = $document->xpath($translator->cssToXPath($css));
-        $this->assertEquals(count($elementsId), count($elements));
+        $this->assertCount(count($elementsId), $elements);
         foreach ($elements as $element) {
             $this->assertTrue(in_array($element->attributes()->id, $elementsId));
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -49,7 +49,7 @@ class ContainerBuilderTest extends TestCase
 
         $builder->setDefinition('foobar', $foo = new Definition('FooBarClass'));
         $this->assertEquals($foo, $builder->getDefinition('foobar'), '->getDefinition() returns a service definition if defined');
-        $this->assertTrue($builder->setDefinition('foobar', $foo = new Definition('FooBarClass')) === $foo, '->setDefinition() implements a fluid interface by returning the service reference');
+        $this->assertSame($builder->setDefinition('foobar', $foo = new Definition('FooBarClass')), $foo, '->setDefinition() implements a fluid interface by returning the service reference');
 
         $builder->addDefinitions($defs = array('foobar' => new Definition('FooBarClass')));
         $this->assertEquals(array_merge($definitions, $defs), $builder->getDefinitions(), '->addDefinitions() adds the service definitions');
@@ -163,7 +163,7 @@ class ContainerBuilderTest extends TestCase
         $this->assertFalse($builder->hasAlias('foobar'), '->hasAlias() returns false if the alias does not exist');
         $this->assertEquals('foo', (string) $builder->getAlias('bar'), '->getAlias() returns the aliased service');
         $this->assertTrue($builder->has('bar'), '->setAlias() defines a new service');
-        $this->assertTrue($builder->get('bar') === $builder->get('foo'), '->setAlias() creates a service that is an alias to another one');
+        $this->assertSame($builder->get('bar'), $builder->get('foo'), '->setAlias() creates a service that is an alias to another one');
 
         try {
             $builder->setAlias('foobar', 'foobar');
@@ -208,8 +208,8 @@ class ContainerBuilderTest extends TestCase
         $builder->setAliases(array('bar' => 'foo', 'foobar' => 'foo'));
 
         $aliases = $builder->getAliases();
-        $this->assertTrue(isset($aliases['bar']));
-        $this->assertTrue(isset($aliases['foobar']));
+        $this->assertArrayHasKey('bar', $aliases);
+        $this->assertArrayHasKey('foobar', $aliases);
     }
 
     public function testAddAliases()
@@ -219,8 +219,8 @@ class ContainerBuilderTest extends TestCase
         $builder->addAliases(array('foobar' => 'foo'));
 
         $aliases = $builder->getAliases();
-        $this->assertTrue(isset($aliases['bar']));
-        $this->assertTrue(isset($aliases['foobar']));
+        $this->assertArrayHasKey('bar', $aliases);
+        $this->assertArrayHasKey('foobar', $aliases);
     }
 
     public function testSetReplacesAlias()
@@ -480,7 +480,7 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals(array('foo', 'bar', 'baz'), array_keys($container->getDefinitions()), '->merge() merges definitions already defined ones');
 
         $aliases = $container->getAliases();
-        $this->assertTrue(isset($aliases['alias_for_foo']));
+        $this->assertArrayHasKey('alias_for_foo', $aliases);
         $this->assertEquals('foo', (string) $aliases['alias_for_foo']);
 
         $container = new ContainerBuilder();
@@ -619,7 +619,7 @@ class ContainerBuilderTest extends TestCase
         $container->setResourceTracking(false);
 
         $container->registerExtension($extension = new \ProjectExtension());
-        $this->assertTrue($container->getExtension('project') === $extension, '->registerExtension() registers an extension');
+        $this->assertSame($container->getExtension('project'), $extension, '->registerExtension() registers an extension');
 
         $this->{method_exists($this, $_ = 'expectException') ? $_ : 'setExpectedException'}('LogicException');
         $container->getExtension('no_registered');

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -172,7 +172,7 @@ class ContainerTest extends TestCase
         $c->set('foo', $foo = new \stdClass(), 'foo');
 
         $scoped = $this->getField($c, 'scopedServices');
-        $this->assertTrue(isset($scoped['foo']['foo']), '->set() sets a scoped service');
+        $this->assertArrayHasKey('foo', $scoped['foo'], '->set() sets a scoped service');
         $this->assertSame($foo, $scoped['foo']['foo'], '->set() sets a scoped service');
     }
 
@@ -340,14 +340,14 @@ class ContainerTest extends TestCase
         $container->set('a', $a, 'bar');
 
         $scoped = $this->getField($container, 'scopedServices');
-        $this->assertTrue(isset($scoped['bar']['a']));
+        $this->assertArrayHasKey('a', $scoped['bar']);
         $this->assertSame($a, $scoped['bar']['a']);
         $this->assertTrue($container->has('a'));
 
         $container->leaveScope('foo');
 
         $scoped = $this->getField($container, 'scopedServices');
-        $this->assertFalse(isset($scoped['bar']));
+        $this->assertArrayNotHasKey('bar', $scoped);
         $this->assertFalse($container->isScopeActive('foo'));
         $this->assertFalse($container->has('a'));
     }
@@ -370,14 +370,14 @@ class ContainerTest extends TestCase
         $container->set('a', $a, 'foo');
 
         $scoped = $this->getField($container, 'scopedServices');
-        $this->assertTrue(isset($scoped['foo']['a']));
+        $this->assertArrayHasKey('a', $scoped['foo']);
         $this->assertSame($a, $scoped['foo']['a']);
         $this->assertTrue($container->has('a'));
 
         $container->enterScope('foo');
 
         $scoped = $this->getField($container, 'scopedServices');
-        $this->assertFalse(isset($scoped['a']));
+        $this->assertArrayNotHasKey('a', $scoped);
         $this->assertTrue($container->isScopeActive('foo'));
         $this->assertFalse($container->isScopeActive('bar'));
         $this->assertFalse($container->has('a'));
@@ -409,14 +409,14 @@ class ContainerTest extends TestCase
         $container->set('a', $a, 'bar');
 
         $scoped = $this->getField($container, 'scopedServices');
-        $this->assertTrue(isset($scoped['bar']['a']));
+        $this->assertArrayHasKey('a', $scoped['bar']);
         $this->assertSame($a, $scoped['bar']['a']);
         $this->assertTrue($container->has('a'));
 
         $container->enterScope('bar');
 
         $scoped = $this->getField($container, 'scopedServices');
-        $this->assertFalse(isset($scoped['a']));
+        $this->assertArrayNotHasKey('a', $scoped);
         $this->assertTrue($container->isScopeActive('foo'));
         $this->assertTrue($container->isScopeActive('bar'));
         $this->assertFalse($container->has('a'));

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -94,7 +94,7 @@ class XmlFileLoaderTest extends TestCase
 
         libxml_disable_entity_loader($disableEntities);
 
-        $this->assertTrue(count($containerBuilder->getParameterBag()->all()) > 0, 'Parameters can be read from the config file.');
+        $this->assertGreaterThan(0, $containerBuilder->getParameterBag()->all(), 'Parameters can be read from the config file.');
     }
 
     public function testLoadParameters()
@@ -182,7 +182,7 @@ class XmlFileLoaderTest extends TestCase
         $args = $services['foo']->getArguments();
         $this->assertCount(1, $args, '->load() references anonymous services as "normal" ones');
         $this->assertInstanceOf('Symfony\\Component\\DependencyInjection\\Reference', $args[0], '->load() converts anonymous services to references to "normal" services');
-        $this->assertTrue(isset($services[(string) $args[0]]), '->load() makes a reference to the created ones');
+        $this->assertArrayHasKey((string) $args[0], $services, '->load() makes a reference to the created ones');
         $inner = $services[(string) $args[0]];
         $this->assertEquals('BarClass', $inner->getClass(), '->load() uses the same configuration as for the anonymous ones');
         $this->assertFalse($inner->isPublic());
@@ -191,7 +191,7 @@ class XmlFileLoaderTest extends TestCase
         $args = $inner->getArguments();
         $this->assertCount(1, $args, '->load() references anonymous services as "normal" ones');
         $this->assertInstanceOf('Symfony\\Component\\DependencyInjection\\Reference', $args[0], '->load() converts anonymous services to references to "normal" services');
-        $this->assertTrue(isset($services[(string) $args[0]]), '->load() makes a reference to the created ones');
+        $this->assertArrayHasKey((string) $args[0], $services, '->load() makes a reference to the created ones');
         $inner = $services[(string) $args[0]];
         $this->assertEquals('BazClass', $inner->getClass(), '->load() uses the same configuration as for the anonymous ones');
         $this->assertFalse($inner->isPublic());
@@ -200,7 +200,7 @@ class XmlFileLoaderTest extends TestCase
         $properties = $services['foo']->getProperties();
         $property = $properties['p'];
         $this->assertInstanceOf('Symfony\\Component\\DependencyInjection\\Reference', $property, '->load() converts anonymous services to references to "normal" services');
-        $this->assertTrue(isset($services[(string) $property]), '->load() makes a reference to the created ones');
+        $this->assertArrayHasKey((string) $property, $services, '->load() makes a reference to the created ones');
         $inner = $services[(string) $property];
         $this->assertEquals('BuzClass', $inner->getClass(), '->load() uses the same configuration as for the anonymous ones');
         $this->assertFalse($inner->isPublic());
@@ -249,7 +249,7 @@ class XmlFileLoaderTest extends TestCase
         $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('services6.xml');
         $services = $container->getDefinitions();
-        $this->assertTrue(isset($services['foo']), '->load() parses <service> elements');
+        $this->assertArrayHasKey('foo', $services, '->load() parses <service> elements');
         $this->assertInstanceOf('Symfony\\Component\\DependencyInjection\\Definition', $services['foo'], '->load() converts <service> element to Definition instances');
         $this->assertEquals('FooClass', $services['foo']->getClass(), '->load() parses the class attribute');
         $this->assertEquals('container', $services['scope.container']->getScope());
@@ -267,10 +267,10 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals(array('BazClass', 'getInstance'), $services['new_factory3']->getFactory(), '->load() parses the factory tag');
 
         $aliases = $container->getAliases();
-        $this->assertTrue(isset($aliases['alias_for_foo']), '->load() parses <service> elements');
+        $this->assertArrayHasKey('alias_for_foo', $aliases, '->load() parses <service> elements');
         $this->assertEquals('foo', (string) $aliases['alias_for_foo'], '->load() parses aliases');
         $this->assertTrue($aliases['alias_for_foo']->isPublic());
-        $this->assertTrue(isset($aliases['another_alias_for_foo']));
+        $this->assertArrayHasKey('another_alias_for_foo', $aliases);
         $this->assertEquals('foo', (string) $aliases['another_alias_for_foo']);
         $this->assertFalse($aliases['another_alias_for_foo']->isPublic());
 
@@ -366,8 +366,8 @@ class XmlFileLoaderTest extends TestCase
         $services = $container->getDefinitions();
         $parameters = $container->getParameterBag()->all();
 
-        $this->assertTrue(isset($services['project.service.bar']), '->load() parses extension elements');
-        $this->assertTrue(isset($parameters['project.parameter.bar']), '->load() parses extension elements');
+        $this->assertArrayHasKey('project.service.bar', $services, '->load() parses extension elements');
+        $this->assertArrayHasKey('project.parameter.bar', $parameters, '->load() parses extension elements');
 
         $this->assertEquals('BAR', $services['project.service.foo']->getClass(), '->load() parses extension elements');
         $this->assertEquals('BAR', $parameters['project.parameter.foo'], '->load() parses extension elements');
@@ -382,8 +382,8 @@ class XmlFileLoaderTest extends TestCase
         $services = $container->getDefinitions();
         $parameters = $container->getParameterBag()->all();
 
-        $this->assertTrue(isset($services['project.service.bar']), '->load() parses extension elements');
-        $this->assertTrue(isset($parameters['project.parameter.bar']), '->load() parses extension elements');
+        $this->assertArrayHasKey('project.service.bar', $services, '->load() parses extension elements');
+        $this->assertArrayHasKey('project.parameter.bar', $parameters, '->load() parses extension elements');
 
         $this->assertEquals('BAR', $services['project.service.foo']->getClass(), '->load() parses extension elements');
         $this->assertEquals('BAR', $parameters['project.parameter.foo'], '->load() parses extension elements');
@@ -504,8 +504,8 @@ class XmlFileLoaderTest extends TestCase
         $loader->load('namespaces.xml');
         $services = $container->getDefinitions();
 
-        $this->assertTrue(isset($services['foo']), '->load() parses <srv:service> elements');
-        $this->assertEquals(1, count($services['foo']->getTag('foo.tag')), '->load parses <srv:tag> elements');
+        $this->assertArrayHasKey('foo', $services, '->load() parses <srv:service> elements');
+        $this->assertCount(1, $services['foo']->getTag('foo.tag'), '->load parses <srv:tag> elements');
         $this->assertEquals(array(array('setBar', array('foo'))), $services['foo']->getMethodCalls(), '->load() parses the <srv:call> tag');
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -142,7 +142,7 @@ class YamlFileLoaderTest extends TestCase
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('services6.yml');
         $services = $container->getDefinitions();
-        $this->assertTrue(isset($services['foo']), '->load() parses service elements');
+        $this->assertArrayHasKey('foo', $services, '->load() parses service elements');
         $this->assertInstanceOf('Symfony\\Component\\DependencyInjection\\Definition', $services['foo'], '->load() converts service element to Definition instances');
         $this->assertEquals('FooClass', $services['foo']->getClass(), '->load() parses the class attribute');
         $this->assertEquals('container', $services['scope.container']->getScope());
@@ -160,10 +160,10 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(array('BazClass', 'getInstance'), $services['new_factory3']->getFactory(), '->load() parses the factory tag');
 
         $aliases = $container->getAliases();
-        $this->assertTrue(isset($aliases['alias_for_foo']), '->load() parses aliases');
+        $this->assertArrayHasKey('alias_for_foo', $aliases, '->load() parses aliases');
         $this->assertEquals('foo', (string) $aliases['alias_for_foo'], '->load() parses aliases');
         $this->assertTrue($aliases['alias_for_foo']->isPublic());
-        $this->assertTrue(isset($aliases['another_alias_for_foo']));
+        $this->assertArrayHasKey('another_alias_for_foo', $aliases);
         $this->assertEquals('foo', (string) $aliases['another_alias_for_foo']);
         $this->assertFalse($aliases['another_alias_for_foo']->isPublic());
 
@@ -192,8 +192,8 @@ class YamlFileLoaderTest extends TestCase
         $services = $container->getDefinitions();
         $parameters = $container->getParameterBag()->all();
 
-        $this->assertTrue(isset($services['project.service.bar']), '->load() parses extension elements');
-        $this->assertTrue(isset($parameters['project.parameter.bar']), '->load() parses extension elements');
+        $this->assertArrayHasKey('project.service.bar', $services, '->load() parses extension elements');
+        $this->assertArrayHasKey('project.parameter.bar', $parameters, '->load() parses extension elements');
 
         $this->assertEquals('BAR', $services['project.service.foo']->getClass(), '->load() parses extension elements');
         $this->assertEquals('BAR', $parameters['project.parameter.foo'], '->load() parses extension elements');

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -172,7 +172,7 @@ EOF
 EOF
         , 'UTF-8');
 
-        $this->assertTrue(count(libxml_get_errors()) > 1);
+        $this->assertGreaterThan(1, libxml_get_errors());
 
         libxml_clear_errors();
         libxml_use_internal_errors($internalErrors);

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -370,15 +370,15 @@ class FormTest extends TestCase
     {
         $form = $this->createForm('<form><input type="text" name="foo" value="foo" /><input type="submit" /></form>');
         unset($form['foo']);
-        $this->assertFalse(isset($form['foo']), '->offsetUnset() removes a field');
+        $this->assertArrayNotHasKey('foo', $form, '->offsetUnset() removes a field');
     }
 
     public function testOffsetExists()
     {
         $form = $this->createForm('<form><input type="text" name="foo" value="foo" /><input type="submit" /></form>');
 
-        $this->assertTrue(isset($form['foo']), '->offsetExists() return true if the field exists');
-        $this->assertFalse(isset($form['bar']), '->offsetExists() return false if the field does not exist');
+        $this->assertArrayHasKey('foo', $form, '->offsetExists() return true if the field exists');
+        $this->assertArrayNotHasKey('bar', $form, '->offsetExists() return false if the field does not exist');
     }
 
     public function testGetValues()

--- a/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
@@ -206,7 +206,7 @@ class ContainerAwareEventDispatcherTest extends AbstractEventDispatcherTest
 
         $listeners = $dispatcher->getListeners();
 
-        $this->assertTrue(isset($listeners['onEvent']));
+        $this->assertArrayHasKey('onEvent', $listeners);
 
         $this->assertCount(1, $dispatcher->getListeners('onEvent'));
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
@@ -114,8 +114,8 @@ class GenericEventTest extends TestCase
 
     public function testOffsetIsset()
     {
-        $this->assertTrue(isset($this->event['name']));
-        $this->assertFalse(isset($this->event['nameNotExist']));
+        $this->assertArrayHasKey('name', $this->event);
+        $this->assertArrayNotHasKey('nameNotExist', $this->event);
     }
 
     public function testHasArgument()

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -26,7 +26,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->copy($sourceFilePath, $targetFilePath);
 
         $this->assertFileExists($targetFilePath);
-        $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
+        $this->assertStringEqualsFile($targetFilePath, 'SOURCE FILE');
     }
 
     /**
@@ -73,7 +73,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->copy($sourceFilePath, $targetFilePath);
 
         $this->assertFileExists($targetFilePath);
-        $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
+        $this->assertStringEqualsFile($targetFilePath, 'SOURCE FILE');
     }
 
     public function testCopyDoesNotOverrideExistingFileByDefault()
@@ -92,7 +92,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->copy($sourceFilePath, $targetFilePath);
 
         $this->assertFileExists($targetFilePath);
-        $this->assertEquals('TARGET FILE', file_get_contents($targetFilePath));
+        $this->assertStringEqualsFile($targetFilePath, 'TARGET FILE');
     }
 
     public function testCopyOverridesExistingFileIfForced()
@@ -111,7 +111,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->copy($sourceFilePath, $targetFilePath, true);
 
         $this->assertFileExists($targetFilePath);
-        $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
+        $this->assertStringEqualsFile($targetFilePath, 'SOURCE FILE');
     }
 
     /**
@@ -153,7 +153,7 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->assertTrue(is_dir($targetFileDirectory));
         $this->assertFileExists($targetFilePath);
-        $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
+        $this->assertStringEqualsFile($targetFilePath, 'SOURCE FILE');
     }
 
     /**
@@ -772,9 +772,9 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->filesystem->remove($link);
 
-        $this->assertTrue(!is_link($link));
-        $this->assertTrue(!is_file($link));
-        $this->assertTrue(!is_dir($link));
+        $this->assertFalse(is_link($link));
+        $this->assertFalse(is_file($link));
+        $this->assertFalse(is_dir($link));
     }
 
     public function testSymlinkIsOverwrittenIfPointsToDifferentTarget()
@@ -1095,7 +1095,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->dumpFile($filename, 'bar');
 
         $this->assertFileExists($filename);
-        $this->assertSame('bar', file_get_contents($filename));
+        $this->assertStringEqualsFile($filename, 'bar');
     }
 
     /**
@@ -1108,7 +1108,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->dumpFile($filename, 'bar', 0753);
 
         $this->assertFileExists($filename);
-        $this->assertSame('bar', file_get_contents($filename));
+        $this->assertStringEqualsFile($filename, 'bar');
 
         // skip mode check on Windows
         if ('\\' !== DIRECTORY_SEPARATOR) {
@@ -1123,7 +1123,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->dumpFile($filename, 'bar', null);
 
         $this->assertFileExists($filename);
-        $this->assertSame('bar', file_get_contents($filename));
+        $this->assertStringEqualsFile($filename, 'bar');
 
         // skip mode check on Windows
         if ('\\' !== DIRECTORY_SEPARATOR) {
@@ -1139,7 +1139,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->dumpFile($filename, 'bar');
 
         $this->assertFileExists($filename);
-        $this->assertSame('bar', file_get_contents($filename));
+        $this->assertStringEqualsFile($filename, 'bar');
     }
 
     public function testDumpKeepsExistingPermissionsWhenOverwritingAnExistingFile()

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -309,12 +309,12 @@ class CompoundFormTest extends AbstractFormTest
 
         $this->form[] = $child;
 
-        $this->assertTrue(isset($this->form['foo']));
+        $this->assertArrayHasKey('foo', $this->form);
         $this->assertSame($child, $this->form['foo']);
 
         unset($this->form['foo']);
 
-        $this->assertFalse(isset($this->form['foo']));
+        $this->assertArrayNotHasKey('foo', $this->form);
     }
 
     public function testCountable()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -243,7 +243,7 @@ class ChoiceTypeTest extends BaseTypeTest
             'choices_as_values' => true,
         ));
 
-        $this->assertTrue(isset($form['placeholder']));
+        $this->assertArrayHasKey('placeholder', $form);
         $this->assertCount(count($this->choices) + 1, $form, 'Each choice should become a new field');
     }
 
@@ -257,7 +257,7 @@ class ChoiceTypeTest extends BaseTypeTest
             'choices_as_values' => true,
         ));
 
-        $this->assertFalse(isset($form['placeholder']));
+        $this->assertArrayNotHasKey('placeholder', $form);
         $this->assertCount(count($this->choices), $form, 'Each choice should become a new field');
     }
 
@@ -271,7 +271,7 @@ class ChoiceTypeTest extends BaseTypeTest
             'choices_as_values' => true,
         ));
 
-        $this->assertFalse(isset($form['placeholder']));
+        $this->assertArrayNotHasKey('placeholder', $form);
         $this->assertCount(count($this->choices), $form, 'Each choice should become a new field');
     }
 
@@ -288,7 +288,7 @@ class ChoiceTypeTest extends BaseTypeTest
             'choices_as_values' => true,
         ));
 
-        $this->assertFalse(isset($form['placeholder']));
+        $this->assertArrayNotHasKey('placeholder', $form);
         $this->assertCount(2, $form, 'Each choice should become a new field');
     }
 
@@ -348,7 +348,7 @@ class ChoiceTypeTest extends BaseTypeTest
             'choices_as_values' => true,
         ));
 
-        $this->assertTrue(isset($form['placeholder']), 'Placeholder should be set');
+        $this->assertArrayHasKey('placeholder', $form, 'Placeholder should be set');
         $this->assertCount(3, $form, 'Each choice should become a new field, placeholder included');
 
         $view = $form->createView();
@@ -373,7 +373,7 @@ class ChoiceTypeTest extends BaseTypeTest
             'choices_as_values' => true,
         ));
 
-        $this->assertTrue(isset($form['placeholder']), 'Placeholder should be set');
+        $this->assertArrayHasKey('placeholder', $form, 'Placeholder should be set');
         $this->assertCount(3, $form, 'Each choice should become a new field, placeholder included');
 
         $view = $form->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -49,7 +49,7 @@ class CollectionTypeTest extends BaseTypeTest
 
         $form->setData(array('foo@baz.com'));
         $this->assertInstanceOf('Symfony\Component\Form\Form', $form[0]);
-        $this->assertFalse(isset($form[1]));
+        $this->assertArrayNotHasKey(1, $form);
         $this->assertCount(1, $form);
         $this->assertEquals('foo@baz.com', $form[0]->getData());
         $formAttrs0 = $form[0]->getConfig()->getOption('attr');
@@ -228,7 +228,7 @@ class CollectionTypeTest extends BaseTypeTest
         ));
 
         $data = $form->getData();
-        $this->assertFalse(isset($data['__name__']));
+        $this->assertArrayNotHasKey('__name__', $data);
     }
 
     public function testGetDataDoesNotContainsPrototypeNameAfterDataAreSet()
@@ -241,7 +241,7 @@ class CollectionTypeTest extends BaseTypeTest
 
         $form->setData(array('foobar.png'));
         $data = $form->getData();
-        $this->assertFalse(isset($data['__name__']));
+        $this->assertArrayNotHasKey('__name__', $data);
     }
 
     public function testPrototypeNameOption()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -444,7 +444,7 @@ class DateTimeTypeTest extends BaseTypeTest
         ))
             ->createView();
 
-        $this->assertFalse(isset($view->vars['type']));
+        $this->assertArrayNotHasKey('type', $view->vars);
     }
 
     public function testDontPassHtml5TypeIfNotHtml5Format()
@@ -455,7 +455,7 @@ class DateTimeTypeTest extends BaseTypeTest
         ))
             ->createView();
 
-        $this->assertFalse(isset($view->vars['type']));
+        $this->assertArrayNotHasKey('type', $view->vars);
     }
 
     public function testDontPassHtml5TypeIfNotSingleText()
@@ -465,7 +465,7 @@ class DateTimeTypeTest extends BaseTypeTest
         ))
             ->createView();
 
-        $this->assertFalse(isset($view->vars['type']));
+        $this->assertArrayNotHasKey('type', $view->vars);
     }
 
     public function testDateTypeChoiceErrorsBubbleUp()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -678,7 +678,7 @@ class DateTypeTest extends BaseTypeTest
         ))
             ->createView();
 
-        $this->assertFalse(isset($view->vars['date_pattern']));
+        $this->assertArrayNotHasKey('date_pattern', $view->vars);
     }
 
     public function testDatePatternFormatWithQuotedStrings()
@@ -844,7 +844,7 @@ class DateTypeTest extends BaseTypeTest
         ))
             ->createView();
 
-        $this->assertFalse(isset($view->vars['type']));
+        $this->assertArrayNotHasKey('type', $view->vars);
     }
 
     public function testDontPassHtml5TypeIfNotHtml5Format()
@@ -855,7 +855,7 @@ class DateTypeTest extends BaseTypeTest
         ))
             ->createView();
 
-        $this->assertFalse(isset($view->vars['type']));
+        $this->assertArrayNotHasKey('type', $view->vars);
     }
 
     public function testDontPassHtml5TypeIfNotSingleText()
@@ -865,7 +865,7 @@ class DateTypeTest extends BaseTypeTest
         ))
             ->createView();
 
-        $this->assertFalse(isset($view->vars['type']));
+        $this->assertArrayNotHasKey('type', $view->vars);
     }
 
     public function provideCompoundWidgets()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -536,7 +536,7 @@ class TimeTypeTest extends BaseTypeTest
         ));
 
         $view = $form->createView();
-        $this->assertFalse(isset($view->vars['type']));
+        $this->assertArrayNotHasKey('type', $view->vars);
     }
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -77,7 +77,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ))
             ->createView();
 
-        $this->assertTrue(isset($view['csrf']));
+        $this->assertArrayHasKey('csrf', $view);
     }
 
     public function testNoCsrfProtectionByDefaultIfCompoundButNotRoot()
@@ -94,7 +94,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->get('form')
             ->createView();
 
-        $this->assertFalse(isset($view['csrf']));
+        $this->assertArrayNotHasKey('csrf', $view);
     }
 
     public function testNoCsrfProtectionByDefaultIfRootButNotCompound()
@@ -106,7 +106,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ))
             ->createView();
 
-        $this->assertFalse(isset($view['csrf']));
+        $this->assertArrayNotHasKey('csrf', $view);
     }
 
     public function testCsrfProtectionCanBeDisabled()
@@ -119,7 +119,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ))
             ->createView();
 
-        $this->assertFalse(isset($view['csrf']));
+        $this->assertArrayNotHasKey('csrf', $view);
     }
 
     public function testGenerateCsrfToken()
@@ -362,7 +362,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->createView()
             ->vars['prototype'];
 
-        $this->assertFalse(isset($prototypeView['csrf']));
+        $this->assertArrayNotHasKey('csrf', $prototypeView);
         $this->assertCount(1, $prototypeView);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationPathTest.php
@@ -96,7 +96,7 @@ class ViolationPathTest extends TestCase
         $path = new ViolationPath($string);
 
         $this->assertSame($slicedPath, $path->__toString());
-        $this->assertSame(count($entries), count($path->getElements()));
+        $this->assertCount(count($entries), $path->getElements());
         $this->assertSame(count($entries), $path->getLength());
 
         foreach ($entries as $index => $entry) {

--- a/src/Symfony/Component/Form/Tests/Util/OrderedHashMapTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/OrderedHashMapTest.php
@@ -91,14 +91,14 @@ class OrderedHashMapTest extends TestCase
         $map = new OrderedHashMap();
         $map['first'] = 1;
 
-        $this->assertTrue(isset($map['first']));
+        $this->assertArrayHasKey('first', $map);
     }
 
     public function testIssetReturnsFalseForNonExisting()
     {
         $map = new OrderedHashMap();
 
-        $this->assertFalse(isset($map['first']));
+        $this->assertArrayNotHasKey('first', $map);
     }
 
     public function testIssetReturnsFalseForNull()
@@ -106,7 +106,7 @@ class OrderedHashMapTest extends TestCase
         $map = new OrderedHashMap();
         $map['first'] = null;
 
-        $this->assertFalse(isset($map['first']));
+        $this->assertArrayNotHasKey('first', $map);
     }
 
     public function testUnset()

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
@@ -191,6 +191,6 @@ class HeaderBagTest extends TestCase
         $headers = array('foo' => 'bar', 'HELLO' => 'WORLD');
         $headerBag = new HeaderBag($headers);
 
-        $this->assertEquals(count($headers), count($headerBag));
+        $this->assertCount(count($headers), $headerBag);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -210,7 +210,7 @@ class ParameterBagTest extends TestCase
         $parameters = array('foo' => 'bar', 'hello' => 'world');
         $bag = new ParameterBag($parameters);
 
-        $this->assertEquals(count($parameters), count($bag));
+        $this->assertCount(count($parameters), $bag);
     }
 
     public function testGetBoolean()

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -183,10 +183,10 @@ class ResponseHeaderBagTest extends TestCase
         $this->assertSetCookieHeader('foo=bar; path=/; httponly', $bag);
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
-        $this->assertTrue(isset($cookies['foo.bar']['/path/foo']['foo']));
-        $this->assertTrue(isset($cookies['foo.bar']['/path/bar']['foo']));
-        $this->assertTrue(isset($cookies['bar.foo']['/path/bar']['foo']));
-        $this->assertTrue(isset($cookies['']['/']['foo']));
+        $this->assertArrayHasKey('foo', $cookies['foo.bar']['/path/foo']);
+        $this->assertArrayHasKey('foo', $cookies['foo.bar']['/path/bar']);
+        $this->assertArrayHasKey('foo', $cookies['bar.foo']['/path/bar']);
+        $this->assertArrayHasKey('foo', $cookies['']['/']);
     }
 
     public function testRemoveCookie()
@@ -196,17 +196,17 @@ class ResponseHeaderBagTest extends TestCase
         $bag->setCookie(new Cookie('bar', 'foo', 0, '/path/bar', 'foo.bar'));
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
-        $this->assertTrue(isset($cookies['foo.bar']['/path/foo']));
+        $this->assertArrayHasKey('/path/foo', $cookies['foo.bar']);
 
         $bag->removeCookie('foo', '/path/foo', 'foo.bar');
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
-        $this->assertFalse(isset($cookies['foo.bar']['/path/foo']));
+        $this->assertArrayNotHasKey('/path/foo', $cookies['foo.bar']);
 
         $bag->removeCookie('bar', '/path/bar', 'foo.bar');
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
-        $this->assertFalse(isset($cookies['foo.bar']));
+        $this->assertArrayNotHasKey('foo.bar', $cookies);
     }
 
     public function testRemoveCookieWithNullRemove()
@@ -216,11 +216,11 @@ class ResponseHeaderBagTest extends TestCase
         $bag->setCookie(new Cookie('bar', 'foo', 0));
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
-        $this->assertTrue(isset($cookies['']['/']));
+        $this->assertArrayHasKey('/', $cookies['']);
 
         $bag->removeCookie('foo', null);
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
-        $this->assertFalse(isset($cookies['']['/']['foo']));
+        $this->assertArrayNotHasKey('foo', $cookies['']['/']);
 
         $bag->removeCookie('bar', null);
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);

--- a/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
@@ -74,8 +74,8 @@ class ServerBagTest extends TestCase
 
         // Username and passwords should not be set as the header is bogus
         $headers = $bag->getHeaders();
-        $this->assertFalse(isset($headers['PHP_AUTH_USER']));
-        $this->assertFalse(isset($headers['PHP_AUTH_PW']));
+        $this->assertArrayNotHasKey('PHP_AUTH_USER', $headers);
+        $this->assertArrayNotHasKey('PHP_AUTH_PW', $headers);
     }
 
     public function testHttpBasicAuthWithPhpCgiRedirect()
@@ -118,8 +118,8 @@ class ServerBagTest extends TestCase
 
         // Username and passwords should not be set as the header is bogus
         $headers = $bag->getHeaders();
-        $this->assertFalse(isset($headers['PHP_AUTH_USER']));
-        $this->assertFalse(isset($headers['PHP_AUTH_PW']));
+        $this->assertArrayNotHasKey('PHP_AUTH_USER', $headers);
+        $this->assertArrayNotHasKey('PHP_AUTH_PW', $headers);
     }
 
     public function testHttpDigestAuthWithPhpCgiRedirect()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/AttributeBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/AttributeBagTest.php
@@ -181,6 +181,6 @@ class AttributeBagTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(count($this->array), count($this->bag));
+        $this->assertCount(count($this->array), $this->bag);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -255,7 +255,7 @@ class NativeSessionStorageTest extends TestCase
         $this->assertFalse($storage->isStarted());
 
         $key = $storage->getMetadataBag()->getStorageKey();
-        $this->assertFalse(isset($_SESSION[$key]));
+        $this->assertArrayNotHasKey($key, $_SESSION);
         $storage->start();
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -79,9 +79,9 @@ class PhpBridgeSessionStorageTest extends TestCase
         $this->assertFalse($storage->isStarted());
 
         $key = $storage->getMetadataBag()->getStorageKey();
-        $this->assertFalse(isset($_SESSION[$key]));
+        $this->assertArrayNotHasKey($key, $_SESSION);
         $storage->start();
-        $this->assertTrue(isset($_SESSION[$key]));
+        $this->assertArrayHasKey($key, $_SESSION);
     }
 
     /**
@@ -102,9 +102,9 @@ class PhpBridgeSessionStorageTest extends TestCase
         $this->assertFalse($storage->isStarted());
 
         $key = $storage->getMetadataBag()->getStorageKey();
-        $this->assertFalse(isset($_SESSION[$key]));
+        $this->assertArrayNotHasKey($key, $_SESSION);
         $storage->start();
-        $this->assertTrue(isset($_SESSION[$key]));
+        $this->assertArrayHasKey($key, $_SESSION);
     }
 
     public function testClear()

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -35,7 +35,7 @@ class DumpDataCollectorTest extends TestCase
         $this->assertSame(1, $collector->getDumpsCount());
 
         $dump = $collector->getDumps('html');
-        $this->assertTrue(isset($dump[0]['data']));
+        $this->assertArrayHasKey('data', $dump[0]);
         $dump[0]['data'] = preg_replace('/^.*?<pre/', '<pre', $dump[0]['data']);
         $dump[0]['data'] = preg_replace('/sf-dump-\d+/', 'sf-dump', $dump[0]['data']);
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -530,8 +530,8 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->request('GET', '/');
         $this->assertHttpKernelIsNotCalled();
         $this->assertEquals(200, $this->response->getStatusCode());
-        $this->assertTrue(strtotime($this->responses[0]->headers->get('Date')) - strtotime($this->response->headers->get('Date')) < 2);
-        $this->assertTrue($this->response->headers->get('Age') > 0);
+        $this->assertLessThan(2, strtotime($this->responses[0]->headers->get('Date')) - strtotime($this->response->headers->get('Date')));
+        $this->assertGreaterThan(0, $this->response->headers->get('Age'));
         $this->assertNotNull($this->response->headers->get('X-Content-Digest'));
         $this->assertTraceContains('fresh');
         $this->assertTraceNotContains('store');
@@ -554,8 +554,8 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->request('GET', '/');
         $this->assertHttpKernelIsNotCalled();
         $this->assertEquals(200, $this->response->getStatusCode());
-        $this->assertTrue(strtotime($this->responses[0]->headers->get('Date')) - strtotime($this->response->headers->get('Date')) < 2);
-        $this->assertTrue($this->response->headers->get('Age') > 0);
+        $this->assertLessThan(2, strtotime($this->responses[0]->headers->get('Date')) - strtotime($this->response->headers->get('Date')));
+        $this->assertGreaterThan(0, $this->response->headers->get('Age'));
         $this->assertNotNull($this->response->headers->get('X-Content-Digest'));
         $this->assertTraceContains('fresh');
         $this->assertTraceNotContains('store');
@@ -578,8 +578,8 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->request('GET', '/');
         $this->assertHttpKernelIsNotCalled();
         $this->assertEquals(200, $this->response->getStatusCode());
-        $this->assertTrue(strtotime($this->responses[0]->headers->get('Date')) - strtotime($this->response->headers->get('Date')) < 2);
-        $this->assertTrue($this->response->headers->get('Age') > 0);
+        $this->assertLessThan(2, strtotime($this->responses[0]->headers->get('Date')) - strtotime($this->response->headers->get('Date')));
+        $this->assertGreaterThan(0, $this->response->headers->get('Age'));
         $this->assertNotNull($this->response->headers->get('X-Content-Digest'));
         $this->assertTraceContains('fresh');
         $this->assertTraceNotContains('store');
@@ -753,7 +753,7 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->request('GET', '/');
         $this->assertHttpKernelIsCalled();
         $this->assertEquals(200, $this->response->getStatusCode());
-        $this->assertTrue($this->response->headers->get('Age') <= 1);
+        $this->assertLessThanOrEqual(1, $this->response->headers->get('Age'));
         $this->assertNotNull($this->response->headers->get('X-Content-Digest'));
         $this->assertTraceContains('stale');
         $this->assertTraceNotContains('fresh');
@@ -791,7 +791,7 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals(200, $this->response->getStatusCode());
         $this->assertNotNull($this->response->headers->get('Last-Modified'));
         $this->assertNotNull($this->response->headers->get('X-Content-Digest'));
-        $this->assertTrue($this->response->headers->get('Age') <= 1);
+        $this->assertLessThanOrEqual(1, $this->response->headers->get('Age'));
         $this->assertEquals('Hello World', $this->response->getContent());
         $this->assertTraceContains('stale');
         $this->assertTraceContains('valid');
@@ -841,7 +841,7 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals(200, $this->response->getStatusCode());
         $this->assertNotNull($this->response->headers->get('ETag'));
         $this->assertNotNull($this->response->headers->get('X-Content-Digest'));
-        $this->assertTrue($this->response->headers->get('Age') <= 1);
+        $this->assertLessThanOrEqual(1, $this->response->headers->get('Age'));
         $this->assertEquals('Hello World', $this->response->getContent());
         $this->assertTraceContains('stale');
         $this->assertTraceContains('valid');

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/AbstractProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/AbstractProfilerStorageTest.php
@@ -64,22 +64,22 @@ abstract class AbstractProfilerStorageTest extends TestCase
         $profile = new Profile('simple_quote');
         $profile->setUrl('http://foo.bar/\'');
         $this->getStorage()->write($profile);
-        $this->assertTrue(false !== $this->getStorage()->read('simple_quote'), '->write() accepts single quotes in URL');
+        $this->assertNotFalse($this->getStorage()->read('simple_quote'), '->write() accepts single quotes in URL');
 
         $profile = new Profile('double_quote');
         $profile->setUrl('http://foo.bar/"');
         $this->getStorage()->write($profile);
-        $this->assertTrue(false !== $this->getStorage()->read('double_quote'), '->write() accepts double quotes in URL');
+        $this->assertNotFalse($this->getStorage()->read('double_quote'), '->write() accepts double quotes in URL');
 
         $profile = new Profile('backslash');
         $profile->setUrl('http://foo.bar/\\');
         $this->getStorage()->write($profile);
-        $this->assertTrue(false !== $this->getStorage()->read('backslash'), '->write() accepts backslash in URL');
+        $this->assertNotFalse($this->getStorage()->read('backslash'), '->write() accepts backslash in URL');
 
         $profile = new Profile('comma');
         $profile->setUrl('http://foo.bar/,');
         $this->getStorage()->write($profile);
-        $this->assertTrue(false !== $this->getStorage()->read('comma'), '->write() accepts comma in URL');
+        $this->assertNotFalse($this->getStorage()->read('comma'), '->write() accepts comma in URL');
     }
 
     public function testStoreDuplicateToken()
@@ -214,7 +214,7 @@ abstract class AbstractProfilerStorageTest extends TestCase
         $profile->setMethod('GET');
         $this->getStorage()->write($profile);
 
-        $this->assertTrue(false !== $this->getStorage()->read('token1'));
+        $this->assertNotFalse($this->getStorage()->read('token1'));
         $this->assertCount(1, $this->getStorage()->find('127.0.0.1', '', 10, 'GET'));
 
         $profile = new Profile('token2');
@@ -223,7 +223,7 @@ abstract class AbstractProfilerStorageTest extends TestCase
         $profile->setMethod('GET');
         $this->getStorage()->write($profile);
 
-        $this->assertTrue(false !== $this->getStorage()->read('token2'));
+        $this->assertNotFalse($this->getStorage()->read('token2'));
         $this->assertCount(2, $this->getStorage()->find('127.0.0.1', '', 10, 'GET'));
 
         $this->getStorage()->purge();

--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -36,7 +36,7 @@ class UriSignerTest extends TestCase
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar')));
         $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar&0=integer')));
 
-        $this->assertTrue($signer->sign('http://example.com/foo?foo=bar&bar=foo') === $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
+        $this->assertSame($signer->sign('http://example.com/foo?foo=bar&bar=foo'), $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
     }
 
     public function testCheckWithDifferentArgSeparator()

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/IntlBundleReaderTest.php
@@ -36,7 +36,7 @@ class IntlBundleReaderTest extends TestCase
 
         $this->assertInstanceOf('\ArrayAccess', $data);
         $this->assertSame('Bar', $data['Foo']);
-        $this->assertFalse(isset($data['ExistsNot']));
+        $this->assertArrayNotHasKey('ExistsNot', $data);
     }
 
     public function testReadFollowsAlias()
@@ -46,7 +46,7 @@ class IntlBundleReaderTest extends TestCase
 
         $this->assertInstanceOf('\ArrayAccess', $data);
         $this->assertSame('Bar', $data['Foo']);
-        $this->assertFalse(isset($data['ExistsNot']));
+        $this->assertArrayNotHasKey('ExistsNot', $data);
     }
 
     public function testReadDoesNotFollowFallback()
@@ -64,9 +64,9 @@ class IntlBundleReaderTest extends TestCase
 
         $this->assertInstanceOf('\ArrayAccess', $data);
         $this->assertSame('Bam', $data['Baz']);
-        $this->assertFalse(isset($data['Foo']));
+        $this->assertArrayNotHasKey('Foo', $data);
         $this->assertNull($data['Foo']);
-        $this->assertFalse(isset($data['ExistsNot']));
+        $this->assertArrayNotHasKey('ExistsNot', $data);
     }
 
     public function testReadDoesNotFollowFallbackAlias()
@@ -84,9 +84,9 @@ class IntlBundleReaderTest extends TestCase
 
         $this->assertInstanceOf('\ArrayAccess', $data);
         $this->assertSame('Bam', $data['Baz'], 'data from the aliased locale can be accessed');
-        $this->assertFalse(isset($data['Foo']));
+        $this->assertArrayNotHasKey('Foo', $data);
         $this->assertNull($data['Foo']);
-        $this->assertFalse(isset($data['ExistsNot']));
+        $this->assertArrayNotHasKey('ExistsNot', $data);
     }
 
     /**

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/JsonBundleReaderTest.php
@@ -35,7 +35,7 @@ class JsonBundleReaderTest extends TestCase
 
         $this->assertInternalType('array', $data);
         $this->assertSame('Bar', $data['Foo']);
-        $this->assertFalse(isset($data['ExistsNot']));
+        $this->assertArrayNotHasKey('ExistsNot', $data);
     }
 
     /**

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/PhpBundleReaderTest.php
@@ -35,7 +35,7 @@ class PhpBundleReaderTest extends TestCase
 
         $this->assertInternalType('array', $data);
         $this->assertSame('Bar', $data['Foo']);
-        $this->assertFalse(isset($data['ExistsNot']));
+        $this->assertArrayNotHasKey('ExistsNot', $data);
     }
 
     /**

--- a/src/Symfony/Component/Intl/Tests/Data/Util/RingBufferTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Util/RingBufferTest.php
@@ -34,8 +34,8 @@ class RingBufferTest extends TestCase
         $this->buffer[0] = 'foo';
         $this->buffer['bar'] = 'baz';
 
-        $this->assertTrue(isset($this->buffer[0]));
-        $this->assertTrue(isset($this->buffer['bar']));
+        $this->assertArrayHasKey(0, $this->buffer);
+        $this->assertArrayHasKey('bar', $this->buffer);
         $this->assertSame('foo', $this->buffer[0]);
         $this->assertSame('baz', $this->buffer['bar']);
     }
@@ -46,8 +46,8 @@ class RingBufferTest extends TestCase
         $this->buffer['bar'] = 'baz';
         $this->buffer[2] = 'bam';
 
-        $this->assertTrue(isset($this->buffer['bar']));
-        $this->assertTrue(isset($this->buffer[2]));
+        $this->assertArrayHasKey('bar', $this->buffer);
+        $this->assertArrayHasKey(2, $this->buffer);
         $this->assertSame('baz', $this->buffer['bar']);
         $this->assertSame('bam', $this->buffer[2]);
     }
@@ -62,14 +62,14 @@ class RingBufferTest extends TestCase
 
     public function testQueryNonExisting()
     {
-        $this->assertFalse(isset($this->buffer['foo']));
+        $this->assertArrayNotHasKey('foo', $this->buffer);
     }
 
     public function testUnsetNonExistingSucceeds()
     {
         unset($this->buffer['foo']);
 
-        $this->assertFalse(isset($this->buffer['foo']));
+        $this->assertArrayNotHasKey('foo', $this->buffer);
     }
 
     /**
@@ -86,7 +86,7 @@ class RingBufferTest extends TestCase
 
     public function testQueryOverwritten()
     {
-        $this->assertFalse(isset($this->buffer[0]));
+        $this->assertArrayNotHasKey(0, $this->buffer);
     }
 
     public function testUnsetOverwrittenSucceeds()
@@ -97,6 +97,6 @@ class RingBufferTest extends TestCase
 
         unset($this->buffer[0]);
 
-        $this->assertFalse(isset($this->buffer[0]));
+        $this->assertArrayNotHasKey(0, $this->buffer);
     }
 }

--- a/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
@@ -43,6 +43,6 @@ class StubLocaleTest extends TestCase
     public function testGetCurrencies()
     {
         $currencies = StubLocale::getCurrencies();
-        $this->assertTrue(in_array('BRL', $currencies));
+        $this->assertContains('BRL', $currencies);
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
@@ -124,7 +124,7 @@ class LegacyOptionsResolverTest extends TestCase
         $this->resolver->setDefaults(array(
             'two' => function (Options $options) use ($test) {
                 /* @var TestCase $test */
-                $test->assertFalse(isset($options['one']));
+                $test->assertArrayNotHasKey('one', $options);
 
                 return '2';
             },
@@ -148,7 +148,7 @@ class LegacyOptionsResolverTest extends TestCase
         $this->resolver->setDefaults(array(
             'two' => function (Options $options) use ($test) {
                 /* @var TestCase $test */
-                $test->assertTrue(isset($options['one']));
+                $test->assertArrayHasKey('one', $options);
 
                 return $options['one'].'2';
             },

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -1419,12 +1419,12 @@ class OptionsResolver2Dot6Test extends TestCase
         });
 
         $this->resolver->setDefault('lazy2', function (Options $options) {
-            Assert::assertTrue(isset($options['default1']));
-            Assert::assertTrue(isset($options['default2']));
-            Assert::assertTrue(isset($options['required']));
-            Assert::assertTrue(isset($options['lazy1']));
-            Assert::assertTrue(isset($options['lazy2']));
-            Assert::assertFalse(isset($options['defined']));
+            Assert::assertArrayHasKey('default1', $options);
+            Assert::assertArrayHasKey('default2', $options);
+            Assert::assertArrayHasKey('required', $options);
+            Assert::assertArrayHasKey('lazy1', $options);
+            Assert::assertArrayHasKey('lazy2', $options);
+            Assert::assertArrayNotHasKey('defined', $options);
 
             Assert::assertSame(0, $options['default1']);
             Assert::assertSame(42, $options['default2']);

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -567,7 +567,7 @@ class ProcessTest extends TestCase
     {
         $process = $this->getProcess('echo foo');
         $process->run();
-        $this->assertTrue(strlen($process->getOutput()) > 0);
+        $this->assertGreaterThan(0, strlen($process->getOutput()));
     }
 
     public function testGetExitCodeIsNullOnStart()

--- a/src/Symfony/Component/Security/Acl/Tests/Dbal/MutableAclProviderTest.php
+++ b/src/Symfony/Component/Security/Acl/Tests/Dbal/MutableAclProviderTest.php
@@ -181,7 +181,7 @@ class MutableAclProviderTest extends TestCase
 
         $provider->propertyChanged($acl, 'entriesInheriting', false, true);
         $changes = $propertyChanges->offsetGet($acl);
-        $this->assertTrue(isset($changes['entriesInheriting']));
+        $this->assertArrayHasKey('entriesInheriting', $changes);
         $this->assertFalse($changes['entriesInheriting'][0]);
         $this->assertTrue($changes['entriesInheriting'][1]);
 
@@ -189,7 +189,7 @@ class MutableAclProviderTest extends TestCase
         $provider->propertyChanged($acl, 'entriesInheriting', false, true);
         $provider->propertyChanged($acl, 'entriesInheriting', true, false);
         $changes = $propertyChanges->offsetGet($acl);
-        $this->assertFalse(isset($changes['entriesInheriting']));
+        $this->assertArrayNotHasKey('entriesInheriting', $changes);
     }
 
     public function testPropertyChangedTracksChangesToAceProperties()
@@ -202,42 +202,42 @@ class MutableAclProviderTest extends TestCase
 
         $provider->propertyChanged($ace, 'mask', 1, 3);
         $changes = $propertyChanges->offsetGet($acl);
-        $this->assertTrue(isset($changes['aces']));
+        $this->assertArrayHasKey('aces', $changes);
         $this->assertInstanceOf('\SplObjectStorage', $changes['aces']);
         $this->assertTrue($changes['aces']->contains($ace));
         $aceChanges = $changes['aces']->offsetGet($ace);
-        $this->assertTrue(isset($aceChanges['mask']));
+        $this->assertArrayHasKey('mask', $aceChanges);
         $this->assertEquals(1, $aceChanges['mask'][0]);
         $this->assertEquals(3, $aceChanges['mask'][1]);
 
         $provider->propertyChanged($ace, 'strategy', 'all', 'any');
         $changes = $propertyChanges->offsetGet($acl);
-        $this->assertTrue(isset($changes['aces']));
+        $this->assertArrayHasKey('aces', $changes);
         $this->assertInstanceOf('\SplObjectStorage', $changes['aces']);
         $this->assertTrue($changes['aces']->contains($ace));
         $aceChanges = $changes['aces']->offsetGet($ace);
-        $this->assertTrue(isset($aceChanges['mask']));
-        $this->assertTrue(isset($aceChanges['strategy']));
+        $this->assertArrayHasKey('mask', $aceChanges);
+        $this->assertArrayHasKey('strategy', $aceChanges);
         $this->assertEquals('all', $aceChanges['strategy'][0]);
         $this->assertEquals('any', $aceChanges['strategy'][1]);
 
         $provider->propertyChanged($ace, 'mask', 3, 1);
         $changes = $propertyChanges->offsetGet($acl);
         $aceChanges = $changes['aces']->offsetGet($ace);
-        $this->assertFalse(isset($aceChanges['mask']));
-        $this->assertTrue(isset($aceChanges['strategy']));
+        $this->assertArrayNotHasKey('mask', $aceChanges);
+        $this->assertArrayHasKey('strategy', $aceChanges);
 
         $provider->propertyChanged($ace2, 'mask', 1, 3);
         $provider->propertyChanged($ace, 'strategy', 'any', 'all');
         $changes = $propertyChanges->offsetGet($acl);
-        $this->assertTrue(isset($changes['aces']));
+        $this->assertArrayHasKey('aces', $changes);
         $this->assertFalse($changes['aces']->contains($ace));
         $this->assertTrue($changes['aces']->contains($ace2));
 
         $provider->propertyChanged($ace2, 'mask', 3, 4);
         $provider->propertyChanged($ace2, 'mask', 4, 1);
         $changes = $propertyChanges->offsetGet($acl);
-        $this->assertFalse(isset($changes['aces']));
+        $this->assertArrayNotHasKey('aces', $changes);
     }
 
     /**
@@ -319,7 +319,7 @@ class MutableAclProviderTest extends TestCase
 
         $aces = $acl->getObjectAces();
         $reloadedAces = $reloadedAcl->getObjectAces();
-        $this->assertEquals(count($aces), count($reloadedAces));
+        $this->assertCount(count($aces), $reloadedAces);
         foreach ($aces as $index => $ace) {
             $this->assertAceEquals($ace, $reloadedAces[$index]);
         }
@@ -437,7 +437,7 @@ class MutableAclProviderTest extends TestCase
 
         $aces = $acl->getObjectAces();
         $reloadedAces = $reloadedAcl->getObjectAces();
-        $this->assertEquals(count($aces), count($reloadedAces));
+        $this->assertCount(count($aces), $reloadedAces);
         foreach ($reloadedAces as $ace) {
             $this->assertTrue($ace->getSecurityIdentity()->equals($newSid));
         }

--- a/src/Symfony/Component/Security/Acl/Tests/Permission/MaskBuilderTest.php
+++ b/src/Symfony/Component/Security/Acl/Tests/Permission/MaskBuilderTest.php
@@ -96,7 +96,7 @@ class MaskBuilderTest extends TestCase
         $this->assertEquals(0, $builder->get());
 
         $builder->add('view');
-        $this->assertTrue($builder->get() > 0);
+        $this->assertGreaterThan(0, $builder->get());
 
         $builder->reset();
         $this->assertEquals(0, $builder->get());

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -61,9 +61,9 @@ class AuthorizationCheckerTest extends TestCase
             ->will($this->returnValue(true));
 
         // first run the token has not been re-authenticated yet, after isGranted is called, it should be equal
-        $this->assertFalse($newToken === $this->tokenStorage->getToken());
+        $this->assertNotSame($newToken, $this->tokenStorage->getToken());
         $this->assertTrue($this->authorizationChecker->isGranted('foo'));
-        $this->assertTrue($newToken === $this->tokenStorage->getToken());
+        $this->assertSame($newToken, $this->tokenStorage->getToken());
     }
 
     /**
@@ -90,7 +90,7 @@ class AuthorizationCheckerTest extends TestCase
             ->method('decide')
             ->will($this->returnValue($decide));
         $this->tokenStorage->setToken($token);
-        $this->assertTrue($decide === $this->authorizationChecker->isGranted('ROLE_FOO'));
+        $this->assertSame($decide, $this->authorizationChecker->isGranted('ROLE_FOO'));
     }
 
     public function isGrantedProvider()

--- a/src/Symfony/Component/Security/Core/Tests/LegacySecurityContextTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/LegacySecurityContextTest.php
@@ -39,7 +39,7 @@ class LegacySecurityContextTest extends TestCase
             ->method('getToken')
             ->will($this->returnValue($token));
 
-        $this->assertTrue($token === $this->securityContext->getToken());
+        $this->assertSame($token, $this->securityContext->getToken());
     }
 
     public function testSetTokenDelegation()

--- a/src/Symfony/Component/Templating/Tests/Helper/HelperTest.php
+++ b/src/Symfony/Component/Templating/Tests/Helper/HelperTest.php
@@ -20,7 +20,7 @@ class HelperTest extends TestCase
     {
         $helper = new ProjectTemplateHelper();
         $helper->setCharset('ISO-8859-1');
-        $this->assertTrue('ISO-8859-1' === $helper->getCharset(), '->setCharset() sets the charset set related to this helper');
+        $this->assertSame('ISO-8859-1', $helper->getCharset(), '->setCharset() sets the charset set related to this helper');
     }
 }
 

--- a/src/Symfony/Component/Templating/Tests/Loader/CacheLoaderTest.php
+++ b/src/Symfony/Component/Templating/Tests/Loader/CacheLoaderTest.php
@@ -23,7 +23,7 @@ class CacheLoaderTest extends TestCase
     public function testConstructor()
     {
         $loader = new ProjectTemplateLoader($varLoader = new ProjectTemplateLoaderVar(), sys_get_temp_dir());
-        $this->assertTrue($loader->getLoader() === $varLoader, '__construct() takes a template loader as its first argument');
+        $this->assertSame($loader->getLoader(), $varLoader, '__construct() takes a template loader as its first argument');
         $this->assertEquals(sys_get_temp_dir(), $loader->getDir(), '__construct() takes a directory where to store the cache as its second argument');
     }
 

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -65,7 +65,7 @@ class PhpEngineTest extends TestCase
         $engine[$foo] = 'bar';
         $this->assertEquals($foo, $engine->get('bar'), '->set() takes an alias as a second argument');
 
-        $this->assertTrue(isset($engine['bar']));
+        $this->assertArrayHasKey('bar', $engine);
 
         try {
             $engine->get('foobar');
@@ -75,7 +75,7 @@ class PhpEngineTest extends TestCase
             $this->assertEquals('The helper "foobar" is not defined.', $e->getMessage(), '->get() throws an InvalidArgumentException if the helper is not defined');
         }
 
-        $this->assertTrue(isset($engine['bar']));
+        $this->assertArrayHasKey('bar', $engine);
         $this->assertTrue($engine->has('foo'), '->has() returns true if the helper exists');
         $this->assertFalse($engine->has('foobar'), '->has() returns false if the helper does not exist');
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/CsvFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/CsvFileDumperTest.php
@@ -27,7 +27,7 @@ foo', 'foo;foo' => 'bar'));
         $dumper = new CsvFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir));
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/valid.csv'), file_get_contents($tempDir.'/messages.en.csv'));
+        $this->assertFileEquals(__DIR__.'/../fixtures/valid.csv', $tempDir.'/messages.en.csv');
 
         unlink($tempDir.'/messages.en.csv');
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/IcuResFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/IcuResFileDumperTest.php
@@ -29,7 +29,7 @@ class IcuResFileDumperTest extends TestCase
         $dumper = new IcuResFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir));
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resourcebundle/res/en.res'), file_get_contents($tempDir.'/messages/en.res'));
+        $this->assertFileEquals(__DIR__.'/../fixtures/resourcebundle/res/en.res', $tempDir.'/messages/en.res');
 
         @unlink($tempDir.'/messages/en.res');
         @rmdir($tempDir.'/messages');

--- a/src/Symfony/Component/Translation/Tests/Dumper/IniFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/IniFileDumperTest.php
@@ -26,7 +26,7 @@ class IniFileDumperTest extends TestCase
         $dumper = new IniFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir));
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resources.ini'), file_get_contents($tempDir.'/messages.en.ini'));
+        $this->assertFileEquals(__DIR__.'/../fixtures/resources.ini', $tempDir.'/messages.en.ini');
 
         unlink($tempDir.'/messages.en.ini');
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/JsonFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/JsonFileDumperTest.php
@@ -30,7 +30,7 @@ class JsonFileDumperTest extends TestCase
         $dumper = new JsonFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir));
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resources.json'), file_get_contents($tempDir.'/messages.en.json'));
+        $this->assertFileEquals(__DIR__.'/../fixtures/resources.json', $tempDir.'/messages.en.json');
 
         unlink($tempDir.'/messages.en.json');
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/MoFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/MoFileDumperTest.php
@@ -25,7 +25,7 @@ class MoFileDumperTest extends TestCase
         $tempDir = sys_get_temp_dir();
         $dumper = new MoFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir));
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resources.mo'), file_get_contents($tempDir.'/messages.en.mo'));
+        $this->assertFileEquals(__DIR__.'/../fixtures/resources.mo', $tempDir.'/messages.en.mo');
 
         unlink($tempDir.'/messages.en.mo');
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/PhpFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/PhpFileDumperTest.php
@@ -26,7 +26,7 @@ class PhpFileDumperTest extends TestCase
         $dumper = new PhpFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir));
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resources.php'), file_get_contents($tempDir.'/messages.en.php'));
+        $this->assertFileEquals(__DIR__.'/../fixtures/resources.php', $tempDir.'/messages.en.php');
 
         unlink($tempDir.'/messages.en.php');
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
@@ -25,7 +25,7 @@ class PoFileDumperTest extends TestCase
         $tempDir = sys_get_temp_dir();
         $dumper = new PoFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir));
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resources.po'), file_get_contents($tempDir.'/messages.en.po'));
+        $this->assertFileEquals(__DIR__.'/../fixtures/resources.po', $tempDir.'/messages.en.po');
 
         unlink($tempDir.'/messages.en.po');
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/QtFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/QtFileDumperTest.php
@@ -26,7 +26,7 @@ class QtFileDumperTest extends TestCase
         $dumper = new QtFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir));
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resources.ts'), file_get_contents($tempDir.'/resources.en.ts'));
+        $this->assertFileEquals(__DIR__.'/../fixtures/resources.ts', $tempDir.'/resources.en.ts');
 
         unlink($tempDir.'/resources.en.ts');
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/XliffFileDumperTest.php
@@ -32,10 +32,7 @@ class XliffFileDumperTest extends TestCase
         $dumper = new XliffFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir, 'default_locale' => 'fr_FR'));
 
-        $this->assertEquals(
-            file_get_contents(__DIR__.'/../fixtures/resources-clean.xlf'),
-            file_get_contents($tempDir.'/messages.en_US.xlf')
-        );
+        $this->assertFileEquals(__DIR__.'/../fixtures/resources-clean.xlf', $tempDir.'/messages.en_US.xlf');
 
         unlink($tempDir.'/messages.en_US.xlf');
     }

--- a/src/Symfony/Component/Translation/Tests/Dumper/YamlFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/YamlFileDumperTest.php
@@ -26,7 +26,7 @@ class YamlFileDumperTest extends TestCase
         $dumper = new YamlFileDumper();
         $dumper->dump($catalogue, array('path' => $tempDir));
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resources.yml'), file_get_contents($tempDir.'/messages.en.yml'));
+        $this->assertFileEquals(__DIR__.'/../fixtures/resources.yml', $tempDir.'/messages.en.yml');
 
         unlink($tempDir.'/messages.en.yml');
     }

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -89,16 +89,16 @@ class ConstraintViolationListTest extends TestCase
         $this->list[] = $violation;
 
         $this->assertSame($violation, $this->list[0]);
-        $this->assertTrue(isset($this->list[0]));
+        $this->assertArrayHasKey(0, $this->list);
 
         unset($this->list[0]);
 
-        $this->assertFalse(isset($this->list[0]));
+        $this->assertArrayNotHasKey(0, $this->list);
 
         $this->list[10] = $violation;
 
         $this->assertSame($violation, $this->list[10]);
-        $this->assertTrue(isset($this->list[10]));
+        $this->assertArrayHasKey(10, $this->list);
     }
 
     public function testToString()

--- a/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GroupSequenceTest.php
@@ -62,15 +62,15 @@ class GroupSequenceTest extends TestCase
 
         $this->assertSame('Group 1', $sequence[0]);
         $this->assertSame('Group 2', $sequence[1]);
-        $this->assertTrue(isset($sequence[0]));
-        $this->assertFalse(isset($sequence[2]));
+        $this->assertArrayHasKey(0, $sequence);
+        $this->assertArrayNotHasKey(2, $sequence);
         unset($sequence[0]);
-        $this->assertFalse(isset($sequence[0]));
+        $this->assertArrayNotHasKey(0, $sequence);
         $sequence[] = 'Group 3';
-        $this->assertTrue(isset($sequence[2]));
+        $this->assertArrayHasKey(2, $sequence);
         $this->assertSame('Group 3', $sequence[2]);
         $sequence[0] = 'Group 1';
-        $this->assertTrue(isset($sequence[0]));
+        $this->assertArrayHasKey(0, $sequence);
         $this->assertSame('Group 1', $sequence[0]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertArrayHasKey`, `assertArrayNotHasKey`, `assertObjectHasAttribute` and `assertObjectNotHasAttribute` instead of `isset` function;
- `assertContains` instead of `in_array` function;
- `assertSame` and `assertNotSame` instead os strict comparisons `===`;
- `assertNotFalse` instead of strict comparisons `!==` with `false` keyword;
- `assertGreaterThan`, `assertLessThan` and `assertLessThanOrEqual` for mathematical comparisons;
