### PR TITLE
[HttpKernel] [DX] Configurable controller layout

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -35,12 +35,14 @@ class RouterDebugCommand extends Command
 {
     protected static $defaultName = 'debug:router';
     private $router;
+    private $parser;
 
-    public function __construct(RouterInterface $router)
+    public function __construct(RouterInterface $router, ControllerNameParser $parser)
     {
         parent::__construct();
 
         $this->router = $router;
+        $this->parser = $parser;
     }
 
     /**
@@ -109,9 +111,8 @@ EOF
     private function convertController(Route $route)
     {
         if ($route->hasDefault('_controller')) {
-            $nameParser = new ControllerNameParser($this->getApplication()->getKernel());
             try {
-                $route->setDefault('_controller', $nameParser->build($route->getDefault('_controller')));
+                $route->setDefault('_controller', $this->parser->build($route->getDefault('_controller')));
             } catch (\InvalidArgumentException $e) {
             }
         }
@@ -133,9 +134,8 @@ EOF
             }
         }
 
-        $nameParser = new ControllerNameParser($this->getApplication()->getKernel());
         try {
-            $shortNotation = $nameParser->build($controller);
+            $shortNotation = $this->parser->build($controller);
             $route->setDefault('_controller', $shortNotation);
 
             return $controller;

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -92,6 +92,6 @@ class ControllerNameParser
     {
         $reference = $this->layout->parse($controller);
 
-        return sprintf('%s:%s:%s', $reference->bundle->getName(), $reference->controller, $reference->action);
+        return sprintf('%s:%s:%s', $reference->getBundle()->getName(), $reference->getController(), $reference->getAction());
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -66,6 +66,7 @@
 
         <service id="console.command.router_debug" class="Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand">
             <argument type="service" id="router" />
+            <argument type="service" id="controller_name_converter" />
             <tag name="console.command" command="debug:router" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -7,9 +7,14 @@
     <services>
         <defaults public="false" />
 
+        <service id="controller_layout.generic" class="Symfony\Component\HttpKernel\Controller\Layout\GenericControllerLayout">
+            <argument type="service" id="kernel" />
+        </service>
+
         <service id="controller_name_converter" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser">
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="kernel" />
+            <argument type="service" id="controller_layout.generic" />
         </service>
 
         <service id="controller_resolver" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -52,8 +53,9 @@ class RouterDebugCommandTest extends TestCase
      */
     private function createCommandTester()
     {
-        $application = new Application($this->getKernel());
-        $application->add(new RouterDebugCommand($this->getRouter()));
+        $kernel = $this->getKernel();
+        $application = new Application($kernel);
+        $application->add(new RouterDebugCommand($this->getRouter(), new ControllerNameParser($kernel)));
 
         return new CommandTester($application->find('debug:router'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterMatchCommandTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand;
 use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
@@ -46,9 +47,10 @@ class RouterMatchCommandTest extends TestCase
      */
     private function createCommandTester()
     {
-        $application = new Application($this->getKernel());
+        $kernel = $this->getKernel();
+        $application = new Application($kernel);
         $application->add(new RouterMatchCommand($this->getRouter()));
-        $application->add(new RouterDebugCommand($this->getRouter()));
+        $application->add(new RouterDebugCommand($this->getRouter(), new ControllerNameParser($kernel)));
 
         return new CommandTester($application->find('router:match'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -145,6 +145,7 @@ class ControllerNameParserTest extends TestCase
     {
         $bundles = array(
             'SensioCmsFooBundle' => $this->getBundle('TestBundle\Sensio\Cms\FooBundle', 'SensioCmsFooBundle'),
+            'FoooooBundle' => $this->getBundle('TestBundle\FooBundle', 'FoooooBundle'),
             'FooBundle' => $this->getBundle('TestBundle\FooBundle', 'FooBundle'),
         );
 
@@ -161,11 +162,6 @@ class ControllerNameParserTest extends TestCase
             }))
         ;
 
-        $bundles = array(
-            'SensioCmsFooBundle' => $this->getBundle('TestBundle\Sensio\Cms\FooBundle', 'SensioCmsFooBundle'),
-            'FoooooBundle' => $this->getBundle('TestBundle\FooBundle', 'FoooooBundle'),
-            'FooBundle' => $this->getBundle('TestBundle\FooBundle', 'FooBundle'),
-        );
         $kernel
             ->expects($this->any())
             ->method('getBundles')

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/config": "~3.4|~4.0",
         "symfony/event-dispatcher": "~3.4|~4.0",
         "symfony/http-foundation": "~3.4|~4.0",
-        "symfony/http-kernel": "~3.4|~4.0",
+        "symfony/http-kernel": "~3.4|~4.1",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~3.4|~4.0",
         "symfony/finder": "~3.4|~4.0",

--- a/src/Symfony/Component/HttpKernel/Controller/ActionReference.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ActionReference.php
@@ -18,19 +18,34 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  *
  * @author Pavel Batanov <pavel@batanov.me>
  */
-class ActionReference
+final class ActionReference
 {
     /** @var BundleInterface */
-    public $bundle;
+    private $bundle;
     /** @var string */
-    public $controller;
+    private $controller;
     /** @var string */
-    public $action;
+    private $action;
 
     public function __construct(BundleInterface $bundle, string $controller, string $action)
     {
         $this->bundle = $bundle;
         $this->controller = $controller;
         $this->action = $action;
+    }
+
+    public function getBundle(): BundleInterface
+    {
+        return $this->bundle;
+    }
+
+    public function getController(): string
+    {
+        return $this->controller;
+    }
+
+    public function getAction(): string
+    {
+        return $this->action;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ActionReference.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ActionReference.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\HttpKernel\Controller;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
- * Class for holding bundle + controller name + action name
+ * Class for holding bundle + controller name + action name.
  *
  * @author Pavel Batanov <pavel@batanov.me>
  */

--- a/src/Symfony/Component/HttpKernel/Controller/ActionReference.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ActionReference.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller;
+
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+/**
+ * Class for holding bundle + controller name + action name
+ *
+ * @author Pavel Batanov <pavel@batanov.me>
+ */
+class ActionReference
+{
+    /** @var BundleInterface */
+    public $bundle;
+    /** @var string */
+    public $controller;
+    /** @var string */
+    public $action;
+
+    public function __construct(BundleInterface $bundle, string $controller, string $action)
+    {
+        $this->bundle = $bundle;
+        $this->controller = $controller;
+        $this->action = $action;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerLayoutInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerLayoutInterface.php
@@ -15,14 +15,14 @@ use Symfony\Component\HttpKernel\Exception\ControllerLayoutException;
 
 /**
  * Responsible for build FQCN::action from bundle + controller name + action name
- * and parse FQCN::action into bundle + controller name + action name
+ * and parse FQCN::action into bundle + controller name + action name.
  *
  * @author Pavel Batanov <pavel@batanov.me>
  */
 interface ControllerLayoutInterface
 {
     /**
-     * Decompose controller string into bundle, controller and action
+     * Decompose controller string into bundle, controller and action.
      *
      * @param string $controller
      *
@@ -33,7 +33,7 @@ interface ControllerLayoutInterface
     public function parse(string $controller): ActionReference;
 
     /**
-     * Builds a controller string for given bundle, controller, and action
+     * Builds a controller string for given bundle, controller, and action.
      *
      * @param ActionReference $action
      *

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerLayoutInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerLayoutInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller;
+
+use Symfony\Component\HttpKernel\Exception\ControllerLayoutException;
+
+/**
+ * Responsible for build FQCN::action from bundle + controller name + action name
+ * and parse FQCN::action into bundle + controller name + action name
+ *
+ * @author Pavel Batanov <pavel@batanov.me>
+ */
+interface ControllerLayoutInterface
+{
+    /**
+     * Decompose controller string into bundle, controller and action
+     *
+     * @param string $controller
+     *
+     * @return ActionReference
+     *
+     * @throws ControllerLayoutException
+     */
+    public function parse(string $controller): ActionReference;
+
+    /**
+     * Builds a controller string for given bundle, controller, and action
+     *
+     * @param ActionReference $action
+     *
+     * @return string
+     *
+     * @throws ControllerLayoutException
+     */
+    public function build(ActionReference $action): string;
+}

--- a/src/Symfony/Component/HttpKernel/Controller/Layout/GenericControllerLayout.php
+++ b/src/Symfony/Component/HttpKernel/Controller/Layout/GenericControllerLayout.php
@@ -47,9 +47,7 @@ final class GenericControllerLayout implements ControllerLayoutInterface
             );
         }
 
-        $className = $match[1];
-        $controllerName = $match[2];
-        $actionName = $match[3];
+        [,$className, $controllerName, $actionName] = $match;
         foreach ($this->kernel->getBundles() as $name => $bundle) {
             if (0 !== strpos($className, $bundle->getNamespace())) {
                 continue;

--- a/src/Symfony/Component/HttpKernel/Controller/Layout/GenericControllerLayout.php
+++ b/src/Symfony/Component/HttpKernel/Controller/Layout/GenericControllerLayout.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\Layout;
+
+use Symfony\Component\HttpKernel\Controller\ActionReference;
+use Symfony\Component\HttpKernel\Controller\ControllerLayoutInterface;
+use Symfony\Component\HttpKernel\Exception\ControllerLayoutException;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Class for generic *Bundle/Controller/*Controller::*Action layout
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Pavel Batanov <pavel@batanov.me>
+ */
+final class GenericControllerLayout implements ControllerLayoutInterface
+{
+    /**
+     * @var KernelInterface
+     */
+    private $kernel;
+
+    /**
+     * GenericControllerLayout constructor.
+     * @param KernelInterface $kernel
+     */
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    public function parse(string $controller): ActionReference
+    {
+        if (0 === preg_match('#^(.*?\\\\Controller\\\\(.+)Controller)::(.+)Action$#', $controller, $match)) {
+            throw new \InvalidArgumentException(
+                sprintf('The "%s" controller is not a valid "class::method" string.', $controller)
+            );
+        }
+
+        $className = $match[1];
+        $controllerName = $match[2];
+        $actionName = $match[3];
+        foreach ($this->kernel->getBundles() as $name => $bundle) {
+            if (0 !== strpos($className, $bundle->getNamespace())) {
+                continue;
+            }
+
+            return new ActionReference($this->kernel->getBundle($name), $controllerName, $actionName);
+        }
+
+        throw ControllerLayoutException::unknownBundleForController($controller);
+    }
+
+    /** {@inheritdoc} */
+    public function build(ActionReference $reference): string
+    {
+        $try = $reference->bundle->getNamespace().'\\Controller\\'.$reference->controller.'Controller';
+
+        if (!class_exists($try)) {
+            throw ControllerLayoutException::unknownControllerClass($reference, $try);
+        }
+
+        return $try.'::'.$reference->action.'Action';
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/Layout/GenericControllerLayout.php
+++ b/src/Symfony/Component/HttpKernel/Controller/Layout/GenericControllerLayout.php
@@ -62,12 +62,12 @@ final class GenericControllerLayout implements ControllerLayoutInterface
     /** {@inheritdoc} */
     public function build(ActionReference $reference): string
     {
-        $try = $reference->bundle->getNamespace().'\\Controller\\'.$reference->controller.'Controller';
+        $try = $reference->getBundle()->getNamespace().'\\Controller\\'.$reference->getController().'Controller';
 
         if (!class_exists($try)) {
             throw ControllerLayoutException::unknownControllerClass($reference, $try);
         }
 
-        return $try.'::'.$reference->action.'Action';
+        return $try.'::'.$reference->getAction().'Action';
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/Layout/GenericControllerLayout.php
+++ b/src/Symfony/Component/HttpKernel/Controller/Layout/GenericControllerLayout.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\Exception\ControllerLayoutException;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * Class for generic *Bundle/Controller/*Controller::*Action layout
+ * Class for generic *Bundle/Controller/*Controller::*Action layout.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Pavel Batanov <pavel@batanov.me>
@@ -31,6 +31,7 @@ final class GenericControllerLayout implements ControllerLayoutInterface
 
     /**
      * GenericControllerLayout constructor.
+     *
      * @param KernelInterface $kernel
      */
     public function __construct(KernelInterface $kernel)

--- a/src/Symfony/Component/HttpKernel/Exception/ControllerLayoutException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ControllerLayoutException.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+use Symfony\Component\HttpKernel\Controller\ActionReference;
+
+/**
+ * @author Pavel Batanov <pavel@batanov.me>
+ */
+class ControllerLayoutException extends \InvalidArgumentException
+{
+    public static function unknownControllerClass(ActionReference $reference, string $try): ControllerLayoutException
+    {
+        throw new static(
+            sprintf(
+                'The _controller value "%s:%s:%s" maps to a "%s" class, but this class was not found. Create this class or check the spelling of the class and its namespace.',
+                $reference->bundle->getName(),
+                $reference->controller,
+                $reference->action,
+                $try
+            )
+        );
+    }
+
+    public static function unknownBundleForController(string $controller): ControllerLayoutException
+    {
+        return new static(sprintf('Unable to find a bundle that defines controller "%s".', $controller));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Exception/ControllerLayoutException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ControllerLayoutException.php
@@ -23,9 +23,9 @@ class ControllerLayoutException extends \InvalidArgumentException
         throw new static(
             sprintf(
                 'The _controller value "%s:%s:%s" maps to a "%s" class, but this class was not found. Create this class or check the spelling of the class and its namespace.',
-                $reference->bundle->getName(),
-                $reference->controller,
-                $reference->action,
+                $reference->getBundle()->getName(),
+                $reference->getController(),
+                $reference->getAction(),
                 $try
             )
         );

--- a/src/Symfony/Component/HttpKernel/Exception/ControllerLayoutException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ControllerLayoutException.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Controller\ActionReference;
  */
 class ControllerLayoutException extends \InvalidArgumentException
 {
-    public static function unknownControllerClass(ActionReference $reference, string $try): ControllerLayoutException
+    public static function unknownControllerClass(ActionReference $reference, string $try): self
     {
         throw new static(
             sprintf(
@@ -31,7 +31,7 @@ class ControllerLayoutException extends \InvalidArgumentException
         );
     }
 
-    public static function unknownBundleForController(string $controller): ControllerLayoutException
+    public static function unknownBundleForController(string $controller): self
     {
         return new static(sprintf('Unable to find a bundle that defines controller "%s".', $controller));
     }

--- a/src/Symfony/Component/HttpKernel/Util/AlternativeBundleNameProvider.php
+++ b/src/Symfony/Component/HttpKernel/Util/AlternativeBundleNameProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Util;
+
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class AlternativeBundleNameProvider
+{
+    /** @var KernelInterface */
+    private $kernel;
+
+    /**
+     * AlternativeBundleNameProvider constructor.
+     * @param KernelInterface $kernel
+     */
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * Attempts to find a bundle that is *similar* to the given bundle name.
+     */
+    public function findAlternative(string $nonExistentBundleName): ?string
+    {
+        $bundleNames = array_map(function (BundleInterface $b) {
+            return $b->getName();
+        }, $this->kernel->getBundles());
+
+        $alternative = null;
+        $shortest = null;
+        foreach ($bundleNames as $bundleName) {
+            // if there's a partial match, return it immediately
+            if (false !== strpos($bundleName, $nonExistentBundleName)) {
+                return $bundleName;
+            }
+
+            $lev = levenshtein($nonExistentBundleName, $bundleName);
+            if ($lev <= strlen($nonExistentBundleName) / 3 && (null === $alternative || $lev < $shortest)) {
+                $alternative = $bundleName;
+                $shortest = $lev;
+            }
+        }
+
+        return $alternative;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Util/AlternativeBundleNameProvider.php
+++ b/src/Symfony/Component/HttpKernel/Util/AlternativeBundleNameProvider.php
@@ -21,6 +21,7 @@ final class AlternativeBundleNameProvider
 
     /**
      * AlternativeBundleNameProvider constructor.
+     *
      * @param KernelInterface $kernel
      */
     public function __construct(KernelInterface $kernel)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes 
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   |  yes
| Fixed tickets | part of #23259
| License       | MIT
| Doc PR        | none

First part of #23259 RFC (cc @iltar @nicolas-grekas). 

The general idea is to allow reusing `ControllerNameParser` for different than original `*Bundle\*Controller::*Action` layout.

Original layout is now stored in `GenericControllerLayout` implementation which nicely covers the structure logic from users

- [ ] add unit tests for new classes
- [ ] discuss the interface method names

For me building bundle+controller+action into string looks like `build` method and parsing string into bundle+controller+action looks like `parse` method. But it turns out than ControllerNameParser::build uses `parse`  (to build from parsed results) and ControllerNameParser::parse uses `build` one (to build from exploded parts). Does this makes sence?