### PR TITLE
When available use AnnotationRegistry::registerUniqueLoader

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -120,7 +120,11 @@ class SymfonyTestsListenerTrait
             $this->state = 0;
 
             if (!class_exists('Doctrine\Common\Annotations\AnnotationRegistry', false) && class_exists('Doctrine\Common\Annotations\AnnotationRegistry')) {
-                AnnotationRegistry::registerLoader('class_exists');
+                if (method_exists('Doctrine\Common\Annotations\AnnotationRegistry', 'registerUniqueLoader')) {
+                    AnnotationRegistry::registerUniqueLoader('class_exists');
+                } else {
+                    AnnotationRegistry::registerLoader('class_exists');
+                }
             }
 
             if ($this->skippedFile = getenv('SYMFONY_PHPUNIT_SKIPPED_TESTS')) {

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -28,7 +28,11 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL') && !class_exists('PHPUnit_TextUI_Comman
 setlocale(LC_ALL, 'C');
 
 if (!class_exists('Doctrine\Common\Annotations\AnnotationRegistry', false) && class_exists('Doctrine\Common\Annotations\AnnotationRegistry')) {
-    AnnotationRegistry::registerLoader('class_exists');
+    if (method_exists('Doctrine\Common\Annotations\AnnotationRegistry', 'registerUniqueLoader')) {
+        AnnotationRegistry::registerUniqueLoader('class_exists');
+    } else {
+        AnnotationRegistry::registerLoader('class_exists');
+    }
 }
 
 if ('disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
 use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -1086,6 +1087,11 @@ class FrameworkExtension extends Extension
         }
 
         $loader->load('annotations.xml');
+
+        if (!method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
+            $container->getDefinition('annotations.dummy_registry')
+                ->setMethodCalls(array(array('registerLoader', array('class_exists'))));
+        }
 
         if ('none' !== $config['cache']) {
             $cacheService = $config['cache'];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -10,14 +10,14 @@
         <service id="annotations.reader" class="Doctrine\Common\Annotations\AnnotationReader">
             <call method="addGlobalIgnoredName">
                 <argument>required</argument>
-                <argument type="service">
-                    <!-- dummy arg to register class_exists as annotation loader only when required -->
-                    <service class="Doctrine\Common\Annotations\AnnotationRegistry">
-                        <call method="registerLoader">
-                            <argument>class_exists</argument>
-                        </call>
-                    </service>
-                </argument>
+                <!-- dummy arg to register class_exists as annotation loader only when required -->
+                <argument type="service" id="annotations.dummy_registry" />
+            </call>
+        </service>
+
+        <service id="annotations.dummy_registry" class="Doctrine\Common\Annotations\AnnotationRegistry">
+            <call method="registerUniqueLoader">
+                <argument>class_exists</argument>
             </call>
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| References tickets | #24596
| License       | MIT

Take advantage of AnnotationRegistry::registerUniqueLoader which will only add 'class_exists' as an autoloader if it has not already been added. This helps alleviate a performance issue when the
same loader is added many times in tests.
