### PR TITLE
Use AnnotationRegistry::registerUniqueLoader in FrameworkBundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -13,7 +13,7 @@
                 <argument type="service">
                     <!-- dummy arg to register class_exists as annotation loader only when required -->
                     <service class="Doctrine\Common\Annotations\AnnotationRegistry">
-                        <call method="registerLoader">
+                        <call method="registerUniqueLoader">
                             <argument>class_exists</argument>
                         </call>
                     </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | not sure
| Deprecations? | no
| Tests pass?   | no (needs dependency bump for doctrine/annotations)
| References tickets | #24596, #25425
| License       | MIT

Only adds 'class_exists' as an autoloader if it has not
already been added. This helps alleviate a performance issue when the
same loader is added many times in tests.

This requires doctrine/annotations v1.6+ which requires PHP 7.1+. I don't think there is a way to only call a method it exists using the XML service definition so it can only be applied to Symfony 4.0+. I could move this invocation into a PHP file elsewhere so it can be applied to earlier versions, but I don't know where the right place to do this would be.

I'm not sure where to define the minimum doctrine/annotations version for composer as I don't understand the build process for splitting these packages so I need some help with that.
