### PR TITLE
[Form] Add support for IntegerType in DateTimeToArrayTransformer

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -60,12 +60,12 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
     {
         if (null === $dateTime) {
             return array_intersect_key(array(
-                'year' => '',
-                'month' => '',
-                'day' => '',
-                'hour' => '',
-                'minute' => '',
-                'second' => '',
+                'year' => null,
+                'month' => null,
+                'day' => null,
+                'hour' => null,
+                'minute' => null,
+                'second' => null,
             ), array_flip($this->fields));
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
@@ -38,12 +38,12 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $transformer = new DateTimeToArrayTransformer();
 
         $output = array(
-            'year' => '',
-            'month' => '',
-            'day' => '',
-            'hour' => '',
-            'minute' => '',
-            'second' => '',
+            'year' => null,
+            'month' => null,
+            'day' => null,
+            'hour' => null,
+            'minute' => null,
+            'second' => null,
         );
 
         $this->assertSame($output, $transformer->transform(null));
@@ -54,9 +54,9 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $transformer = new DateTimeToArrayTransformer(null, null, array('year', 'minute', 'second'));
 
         $output = array(
-            'year' => '',
-            'minute' => '',
-            'second' => '',
+            'year' => null,
+            'minute' => null,
+            'second' => null,
         );
 
         $this->assertSame($output, $transformer->transform(null));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -520,8 +520,8 @@ class DateTimeTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull($expected, $norm, array(
             // View data is an array of choice values array
-            'date' => array('year' => '', 'month' => '', 'day' => ''),
-            'time' => array('hour' => '', 'minute' => ''),
+            'date' => array('year' => null, 'month' => null, 'day' => null),
+            'time' => array('hour' => null, 'minute' => null),
         ));
     }
 
@@ -536,8 +536,8 @@ class DateTimeTypeTest extends BaseTypeTest
         $this->assertNull($form->getNormData());
         $this->assertSame(array(
             // View data is an array of choice values array
-            'date' => array('year' => '', 'month' => '', 'day' => ''),
-            'time' => array('hour' => '', 'minute' => ''),
+            'date' => array('year' => null, 'month' => null, 'day' => null),
+            'time' => array('hour' => null, 'minute' => null),
         ), $form->getViewData());
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -942,7 +942,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
-        parent::testSubmitNull($expected, $norm, array('year' => '', 'month' => '', 'day' => ''));
+        parent::testSubmitNull($expected, $norm, array('year' => null, 'month' => null, 'day' => null));
     }
 
     public function testSubmitNullWithSingleText()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -745,7 +745,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
-        $view = array('hour' => '', 'minute' => '');
+        $view = array('hour' => null, 'minute' => null);
 
         parent::testSubmitNull($expected, $norm, $view);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->

The `TextType` was working with empty strings as default values but the `IntegerType` was throwing an exception since it was expected the numeric type not a `string`. This way it works with both `TextType` and `IntegerType`.


Not sure if there is particular reason why there were empty strings instead of `null` but hope that this won't break anything.