### PR TITLE
[WebProfilerBundle] Fix Image/SVG display in WebProfiler toolbar.

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -23,6 +23,7 @@
     -moz-box-sizing: content-box;
     box-sizing: content-box;
     vertical-align: baseline;
+    width: auto;
 }
 
 .sf-toolbarreset {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This small fix prevents widths from "creeping in" from previously defined CSS rules into the WebProfiler toolbar. See before/after screenshot:

![screen_shot_2017-12-11_at_11_56_06](https://user-images.githubusercontent.com/1833361/33828617-1e59c2c2-de6d-11e7-8c5e-560eee847205.png)

Note: This PR fixes an other issue than #18469, which landed in SF 2.8.