### PR TITLE
[Console] Fix console tests by adding the missing condition

### DIFF
--- a/src/Symfony/Component/Console/Event/ConsoleErrorEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleErrorEvent.php
@@ -78,6 +78,6 @@ final class ConsoleErrorEvent extends ConsoleEvent
      */
     public function getExitCode()
     {
-        return null !== $this->exitCode ? $this->exitCode : (is_int($this->error->getCode()) ? $this->error->getCode() : 1);
+        return null !== $this->exitCode ? $this->exitCode : (is_int($this->error->getCode()) && 0 !== $this->error->getCode() ? $this->error->getCode() : 1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | 


The old conditions was testing that the exit code is different than 0. I just add this tests back since it is needed.
![resized_20171211_192030_2217](https://user-images.githubusercontent.com/3451634/33872253-5db07958-df16-11e7-85e9-4fc0cb5002ce.jpeg)

