### PR TITLE
[FrameworkBundle] Move AbstractController::getParameter() from the trait to the class & use PSR-11

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 
 use Psr\Container\ContainerInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -53,6 +52,22 @@ abstract class AbstractController implements ServiceSubscriberInterface
         return $previous;
     }
 
+    /**
+     * Gets a container parameter by its name.
+     *
+     * @return mixed
+     *
+     * @final
+     */
+    protected function getParameter(string $name)
+    {
+        if (!$this->container->has('parameter_bag')) {
+            throw new \LogicException('The "parameter_bag" service is not available. Try running "composer require dependency-injection:^4.1"');
+        }
+
+        return $this->container->get('parameter_bag')->get($name);
+    }
+
     public static function getSubscribedServices()
     {
         return array(
@@ -68,7 +83,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
             'form.factory' => '?'.FormFactoryInterface::class,
             'security.token_storage' => '?'.TokenStorageInterface::class,
             'security.csrf.token_manager' => '?'.CsrfTokenManagerInterface::class,
-            'parameter_bag' => '?'.ContainerBagInterface::class,
+            'parameter_bag' => '?'.ContainerInterface::class,
         );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -377,20 +377,4 @@ trait ControllerTrait
 
         return $this->container->get('security.csrf.token_manager')->isTokenValid(new CsrfToken($id, $token));
     }
-
-    /**
-     * Gets a container parameter by its name.
-     *
-     * @return mixed
-     *
-     * @final
-     */
-    protected function getParameter(string $name)
-    {
-        if (!$this->container->has('parameter_bag')) {
-            throw new \LogicException('The "parameter_bag" service is not available. Try running "composer require dependency-injection:^4.1"');
-        }
-
-        return $this->container->get('parameter_bag')->get($name);
-    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -13,12 +13,32 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 class AbstractControllerTest extends ControllerTraitTest
 {
     protected function createController()
     {
         return new TestAbstractController();
+    }
+
+    public function testGetParameter()
+    {
+        $container = new Container(new FrozenParameterBag(array('foo' => 'bar')));
+
+        $controller = $this->createController();
+        $controller->setContainer($container);
+
+        if (!class_exists(ContainerBag::class)) {
+            $this->expectException(\LogicException::class);
+            $this->expectExceptionMessage('The "parameter_bag" service is not available. Try running "composer require dependency-injection:^4.1"');
+        } else {
+            $container->set('parameter_bag', new ContainerBag($container));
+        }
+
+        $this->assertSame('bar', $controller->getParameter('foo'));
     }
 }
 
@@ -55,6 +75,11 @@ class TestAbstractController extends AbstractController
         }
 
         return parent::setContainer($container);
+    }
+
+    public function getParameter(string $name)
+    {
+        return parent::getParameter($name);
     }
 
     public function fooAction()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -14,9 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -531,23 +528,6 @@ abstract class ControllerTraitTest extends TestCase
 
         $this->assertEquals($doctrine, $controller->getDoctrine());
     }
-
-    public function testGetParameter()
-    {
-        $container = new Container(new FrozenParameterBag(array('foo' => 'bar')));
-
-        $controller = $this->createController();
-        $controller->setContainer($container);
-
-        if (!interface_exists(ContainerBagInterface::class)) {
-            $this->expectException(\LogicException::class);
-            $this->expectExceptionMessage('The "parameter_bag" service is not available. Try running "composer require dependency-injection:^4.1"');
-        } else {
-            $container->set('parameter_bag', new ContainerBag($container));
-        }
-
-        $this->assertSame('bar', $controller->getParameter('foo'));
-    }
 }
 
 trait TestControllerTrait
@@ -572,6 +552,5 @@ trait TestControllerTrait
         createForm as public;
         createFormBuilder as public;
         getDoctrine as public;
-        getParameter as public;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Feels more specific this way to me. Ping @chalasr 