### PR TITLE
[FrameworkBundle] Remove redundant translation path

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1154,9 +1154,6 @@ class FrameworkExtension extends Extension
             if ($container->fileExists($dir = $bundle['path'].'/Resources/translations')) {
                 $dirs[] = $dir;
             }
-            if ($container->fileExists($dir = $defaultDir.'/'.$name)) {
-                $dirs[] = $dir;
-            }
             if ($container->fileExists($dir = $rootDir.sprintf('/Resources/%s/translations', $name))) {
                 $dirs[] = $dir;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is only dead code, nothing change because all files are loaded from the `translations/` directory recursively and they override the ones from the bundle.

> http://symfony.com/doc/3.4/bundles/override.html#translations
> Translations are not related to bundles, but to domains. That means that you can override the translations from any translation file, as long as it is in the correct domain.
