### PR TITLE
[HttpKernel] cast scalar controller arguments based on their metadata type

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * `RequestAttributeValueResolver` now tries to cast values based on argument's type hint
+
 4.0.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
@@ -35,6 +35,20 @@ final class RequestAttributeValueResolver implements ArgumentValueResolverInterf
      */
     public function resolve(Request $request, ArgumentMetadata $argument)
     {
-        yield $request->attributes->get($argument->getName());
+        yield $this->resolveByType($request, $argument);
+    }
+
+    private function resolveByType(Request $request, ArgumentMetadata $argument)
+    {
+        switch ($argument->getType()) {
+            case 'float':
+                return (float) $request->attributes->get($argument->getName());
+            case 'int':
+                return $request->attributes->getInt($argument->getName());
+            case 'bool':
+                return $request->attributes->getBoolean($argument->getName());
+            default:
+                return $request->attributes->get($argument->getName());
+        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -292,6 +292,60 @@ class ArgumentResolverTest extends TestCase
         self::$resolver->getArguments($request, $controller);
     }
 
+    public function testGetStringArgument()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('string', 'some string');
+        $controller = array(new self(), 'controllerWithStringTypeHint');
+
+        $this->assertSame(array('some string'), self::$resolver->getArguments($request, $controller));
+    }
+
+    public function testGetIntArgument()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('int', '123');
+        $controller = array(new self(), 'controllerWithIntTypeHint');
+
+        $this->assertSame(array(123), self::$resolver->getArguments($request, $controller));
+    }
+
+    public function testGetFloatArgument()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('float', '123.456');
+        $controller = array(new self(), 'controllerWithFloatTypeHint');
+
+        $this->assertSame(array(123.456), self::$resolver->getArguments($request, $controller));
+    }
+
+    /**
+     * @dataProvider boolishDataProvider
+     */
+    public function testGetBooleanArgument($boolish, $expected)
+    {
+        $request = Request::create('/');
+        $request->attributes->set('bool', $boolish);
+        $controller = array(new self(), 'controllerWithBoolTypeHint');
+
+        $this->assertSame(array($expected), self::$resolver->getArguments($request, $controller));
+    }
+
+    public function boolishDataProvider()
+    {
+        return array(
+            array('on', true),
+            array('1', true),
+            array('true', true),
+            array('yes', true),
+            array('off', false),
+            array('0', false),
+            array('false', false),
+            array('no', false),
+            array('', false),
+        );
+    }
+
     public function __invoke($foo, $bar = null)
     {
     }
@@ -329,6 +383,22 @@ class ArgumentResolverTest extends TestCase
     }
 
     protected function controllerWithExtendingSession(ExtendingSession $session)
+    {
+    }
+
+    protected function controllerWithIntTypeHint(int $int)
+    {
+    }
+
+    protected function controllerWithBoolTypeHint(bool $bool)
+    {
+    }
+
+    protected function controllerWithFloatTypeHint(float $float)
+    {
+    }
+
+    protected function controllerWithStringTypeHint(string $string)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This is a proposal to discuss the idea of transforming request attributes into the appropriate types before passing them to the controller.

The recent addition of/discussion around `declare(strict_types=1);` might be interesting to take into account, because the same feature is covered with coercive mode.

see http://php.net/manual/en/migration70.new-features.php#migration70.new-features.scalar-type-declarations
