### PR TITLE
[Console] typehint addCommands() with iterable, to allow to pass a Generator

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -408,7 +408,7 @@ class Application
      *
      * @param Command[] $commands An array of commands
      */
-    public function addCommands(array $commands)
+    public function addCommands(iterable $commands)
     {
         foreach ($commands as $command) {
             $this->add($command);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT


I need to add commands without FrameworkBundle and I'd like to get rid of custom compiler pass:

https://github.com/Symplify/Symplify/blob/f869b70a39bdab323629d04cb1cfb66fd15c85df/packages/Statie/src/DependencyInjection/CompilerPass/CollectorCompilerPass.php#L24-L32

I used syntax helped by @pierredup (thanks!)

```yaml
services:
    _instanceof:
        Symfony\Component\Console\Command\Command:
            tags: ['console.command']

    Symplify\EasyCodingStandard\Console\Application:
        calls:
          - ['addCommands', [!tagged console.command]]
```

But this breaks, due to typehint.

This PR allows that