### PR TITLE
[Console] Fix a bug when passing a letter that could be an alias

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -284,6 +284,8 @@ class ArgvInput extends Input
                 }
 
                 if (0 === strpos($token, '-') && 0 !== strpos($token, '--')) {
+                    $noValue = explode('=', $token);
+                    $token = $noValue[0];
                     $searchableToken = str_replace('-', '', $token);
                     $searchableValue = str_replace('-', '', $value);
                     if ('' !== $searchableToken && '' !== $searchableValue && false !== strpos($searchableToken, $searchableValue)) {

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -299,6 +299,9 @@ class ArgvInputTest extends TestCase
         $input = new ArgvInput(array('cli.php', '-fh'));
         $this->assertTrue($input->hasParameterOption('-fh'), '->hasParameterOption() returns true if the given short option is in the raw input');
 
+        $input = new ArgvInput(array('cli.php', '-e=test'));
+        $this->assertFalse($input->hasParameterOption('-s'), '->hasParameterOption() returns true if the given short option is in the raw input');
+
         $input = new ArgvInput(array('cli.php', '--foo', 'foo'));
         $this->assertTrue($input->hasParameterOption('--foo'), '->hasParameterOption() returns true if the given short option is in the raw input');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | see https://github.com/symfony/symfony/pull/24987#issuecomment-351482175
| License       | MIT
| Doc PR        | 

Fixing the global in console commands I've introduced a bug where when you pass -e=test it finds it a --shell, this fix the wrong behaviour.
cc @Zwartpet
