### PR TITLE
[Serializer] Fixed throwing exception with option JSON_PARTIAL_OUTPUT_ON_ERROR

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -55,7 +55,8 @@ class JsonEncode implements EncoderInterface
 
         $encodedJson = json_encode($data, $context['json_encode_options']);
 
-        if (JSON_ERROR_NONE !== $this->lastError = json_last_error()) {
+        $this->lastError = json_last_error();
+        if (JSON_ERROR_NONE !== $this->lastError && (false === $encodedJson || \PHP_VERSION_ID < 50500 || !($context['json_encode_options'] & JSON_PARTIAL_OUTPUT_ON_ERROR))) {
             throw new UnexpectedValueException(JsonEncoder::getLastErrorMessage());
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/JsonEncoderTest.php
@@ -65,6 +65,47 @@ class JsonEncoderTest extends TestCase
         $this->assertEquals($expected, $this->serializer->serialize($arr, 'json'), 'Context should not be persistent');
     }
 
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
+     */
+    public function testEncodeNotUtf8WithoutPartialOnError()
+    {
+        $arr = array(
+            'utf8' => 'Hello World!',
+            'notUtf8' => "\xb0\xd0\xb5\xd0",
+        );
+
+        $this->encoder->encode($arr, 'json');
+    }
+
+    /**
+     * @requires PHP 5.5
+     */
+    public function testEncodeNotUtf8WithPartialOnError()
+    {
+        $context = array('json_encode_options' => JSON_PARTIAL_OUTPUT_ON_ERROR);
+
+        $arr = array(
+            'utf8' => 'Hello World!',
+            'notUtf8' => "\xb0\xd0\xb5\xd0",
+        );
+
+        $result = $this->encoder->encode($arr, 'json', $context);
+        $jsonLastError = json_last_error();
+
+        $this->assertSame(JSON_ERROR_UTF8, $jsonLastError);
+        $this->assertEquals('{"utf8":"Hello World!","notUtf8":null}', $result);
+
+        $this->assertEquals('0', $this->serializer->serialize(NAN, 'json', $context));
+    }
+
+    public function testDecodeFalseString()
+    {
+        $result = $this->encoder->decode('false', 'json');
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
+        $this->assertFalse($result);
+    }
+
     protected function getJsonSource()
     {
         return '{"foo":"foo","bar":["a","b"],"baz":{"key":"val","key2":"val","A B":"bar","item":[{"title":"title1"},{"title":"title2"}],"Barry":{"FooBar":{"Baz":"Ed","@id":1}}},"qux":"1"}';


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->

Php function json_encode/decode with option JSON_PARTIAL_OUTPUT_ON_ERROR  return result on error, but if have is error json_last_error() always return error code even if there is a result and it is not false. Because of this is impossible set JSON_PARTIAL_OUTPUT_ON_ERROR option across variable $context.

Current fix solves this problem.

Verification on the false is completely correct, since json_encode / decode returns false only on error if not set JSON_PARTIAL_OUTPUT_ON_ERROR option.

Such have a problem e.g when encoding data is not utf-8 (emoji from facebook).
