### PR TITLE
improve FormType::getType exception message details

### DIFF
--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -82,11 +82,14 @@ class FormRegistry implements FormRegistryInterface
 
             if (!$type) {
                 // Support fully-qualified class names
-                if (class_exists($name) && in_array('Symfony\Component\Form\FormTypeInterface', class_implements($name))) {
-                    $type = new $name();
-                } else {
-                    throw new InvalidArgumentException(sprintf('Could not load type "%s"', $name));
+                if (!class_exists($name)) {
+                  throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not exist', $name));
                 }
+                else if (!in_array('Symfony\Component\Form\FormTypeInterface', class_implements($name))) {
+                  throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not implement "Symfony\Component\Form\FormTypeInterface"', $name));
+                }
+
+                $type = new $name();
             }
 
             $this->types[$name] = $this->resolveType($type);

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -83,10 +83,10 @@ class FormRegistry implements FormRegistryInterface
             if (!$type) {
                 // Support fully-qualified class names
                 if (!class_exists($name)) {
-                    throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not exist', $name));
+                    throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not exist.', $name));
                 }
                 if (!in_array(FormTypeInterface::class, class_implements($name))) {
-                    throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not implement "%s"', $name, FormTypeInterface::class));
+                    throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not implement "%s".', $name, FormTypeInterface::class));
                 }
 
                 $type = new $name();

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -85,7 +85,7 @@ class FormRegistry implements FormRegistryInterface
                 if (!class_exists($name)) {
                   throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not exist', $name));
                 }
-                else if (!in_array('Symfony\Component\Form\FormTypeInterface', class_implements($name))) {
+                if (!in_array('Symfony\Component\Form\FormTypeInterface', class_implements($name))) {
                   throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not implement "Symfony\Component\Form\FormTypeInterface"', $name));
                 }
 

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -85,8 +85,8 @@ class FormRegistry implements FormRegistryInterface
                 if (!class_exists($name)) {
                   throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not exist', $name));
                 }
-                if (!in_array('Symfony\Component\Form\FormTypeInterface', class_implements($name))) {
-                  throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not implement "Symfony\Component\Form\FormTypeInterface"', $name));
+                if (!in_array(FormTypeInterface::class, class_implements($name))) {
+                  throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not implement "%s"', $name, FormTypeInterface::class));
                 }
 
                 $type = new $name();

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -83,10 +83,10 @@ class FormRegistry implements FormRegistryInterface
             if (!$type) {
                 // Support fully-qualified class names
                 if (!class_exists($name)) {
-                  throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not exist', $name));
+                    throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not exist', $name));
                 }
                 if (!in_array(FormTypeInterface::class, class_implements($name))) {
-                  throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not implement "%s"', $name, FormTypeInterface::class));
+                    throw new InvalidArgumentException(sprintf('Could not load type "%s": class does not implement "%s"', $name, FormTypeInterface::class));
                 }
 
                 $type = new $name();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This pull request improves the exception thrown when a Type is requested from Symfony\Component\Form\FormRegistry.

The same exception message was thrown if either the Type class wasn't found or the Type class did not implement the Symfony\Component\Form\FormTypeInterface.

This pull request adds some explaination of the reason why a type could not be found and helps application developpers to find the source of the Symfony\Component\Form\Exception\InvalidArgumentException thrown when getting a Type.