### PR TITLE
[FrameworkBundle] Auto-enable CSRF if the component *+ session* are loaded

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -21,6 +21,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\Store\SemaphoreStore;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Validation;
@@ -142,7 +143,14 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('csrf_protection')
-                    ->canBeEnabled()
+                    ->treatFalseLike(array('enabled' => false))
+                    ->treatTrueLike(array('enabled' => true))
+                    ->treatNullLike(array('enabled' => true))
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        // defaults to framework.session.enabled && !class_exists(FullStack::class) && interface_exists(CsrfTokenManagerInterface::class)
+                        ->booleanNode('enabled')->defaultNull()->end()
+                    ->end()
                 ->end()
             ->end()
         ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/recipes/issues/262
| License       | MIT
| Doc PR        | -

By binding CSRF and session default state, we provide better DX, but we also provide a way for bundles to enable session on its own: they just need to require "symfony/security-csrf".
Yes, that's a side effect, but I think that's a nice one for 3.4/4.0.
Of course, we might do better in 4.1, but for bug fix only releases, LGTM.
