### PR TITLE
[FrameworkBundle] fix merge of 3.3 into 3.4

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -141,13 +141,6 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('esi_disabled');
 
         $this->assertFalse($container->hasDefinition('fragment.renderer.esi'), 'The ESI fragment renderer is not registered');
-    }
-
-    public function testEsiInactive()
-    {
-        $container = $this->createContainerFromFile('default_config');
-
-        $this->assertFalse($container->hasDefinition('fragment.renderer.esi'));
         $this->assertFalse($container->hasDefinition('esi'));
     }
 
@@ -164,6 +157,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('ssi_disabled');
 
         $this->assertFalse($container->hasDefinition('fragment.renderer.ssi'), 'The SSI fragment renderer is not registered');
+        $this->assertFalse($container->hasDefinition('ssi'));
     }
 
     public function testEsiAndSsiWithoutFragments()
@@ -173,14 +167,6 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition('fragment.renderer.hinclude'), 'The HInclude fragment renderer is not registered');
         $this->assertTrue($container->hasDefinition('fragment.renderer.esi'), 'The ESI fragment renderer is registered');
         $this->assertTrue($container->hasDefinition('fragment.renderer.ssi'), 'The SSI fragment renderer is registered');
-    }
-
-    public function testSsiInactive()
-    {
-        $container = $this->createContainerFromFile('default_config');
-
-        $this->assertFalse($container->hasDefinition('fragment.renderer.ssi'));
-        $this->assertFalse($container->hasDefinition('ssi'));
     }
 
     public function testEnabledProfiler()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In 3.4+ there were tests for disabled esi/ssi already so now they have been duplicated by merging https://github.com/symfony/symfony/pull/25489 up from 2.7

This just cleans up the duplication.