### PR TITLE
change accessibility for getStepWidth to public

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -197,7 +197,7 @@ class ProgressBar
      *
      * @return int The progress bar step width
      */
-    private function getStepWidth()
+    public function getStepWidth()
     {
         return $this->stepWidth;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 


In line 555 the method is used from outside (a closure that gets any object of class `ProgressBar` or a subclass of it). So the method has to be public. It's magic that it is working and not good coding style.

see discussions in #25512