### PR TITLE
[Validator] Deprecated "checkDNS" option in Url constraint

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -30,7 +30,7 @@ Validator
 
  * The `Email::__construct()` 'strict' property is deprecated and will be removed in 5.0. Use 'mode'=>"strict" instead.
  * Calling `EmailValidator::__construct()` method with a boolean parameter is deprecated and will be removed in 5.0, use `EmailValidator("strict")` instead.
- * Deprecated the `checkDNS` and `dnsMessage` options in the `Url` constraint. They will be removed in 5.0.
+ * Deprecated the `checkDNS` and `dnsMessage` options of the `Url` constraint. They will be removed in 5.0.
 
 Workflow
 --------

--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -30,6 +30,7 @@ Validator
 
  * The `Email::__construct()` 'strict' property is deprecated and will be removed in 5.0. Use 'mode'=>"strict" instead.
  * Calling `EmailValidator::__construct()` method with a boolean parameter is deprecated and will be removed in 5.0, use `EmailValidator("strict")` instead.
+ * Deprecated the `checkDNS` and `dnsMessage` options in the `Url` constraint. They will be removed in 5.0.
 
 Workflow
 --------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -29,7 +29,7 @@ Validator
 
  * The `Email::__construct()` 'strict' property has been removed. Use 'mode'=>"strict" instead.
  * Calling `EmailValidator::__construct()` method with a boolean parameter has been removed, use `EmailValidator("strict")` instead.
-
+ * Removed the `checkDNS` and `dnsMessage` options in the `Url` constraint.
 
 Workflow
 --------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -29,7 +29,7 @@ Validator
 
  * The `Email::__construct()` 'strict' property has been removed. Use 'mode'=>"strict" instead.
  * Calling `EmailValidator::__construct()` method with a boolean parameter has been removed, use `EmailValidator("strict")` instead.
- * Removed the `checkDNS` and `dnsMessage` options in the `Url` constraint.
+ * Removed the `checkDNS` and `dnsMessage` options from the `Url` constraint.
 
 Workflow
 --------

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * Deprecated the `checkDNS` and `dnsMessage` options in the `Url` constraint. They will be removed in 5.0.
+
 4.0.0
 -----
 

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 4.1.0
 -----
 
- * Deprecated the `checkDNS` and `dnsMessage` options in the `Url` constraint. They will be removed in 5.0.
+ * Deprecated the `checkDNS` and `dnsMessage` options of the `Url` constraint. They will be removed in 5.0.
 
 4.0.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -21,18 +21,57 @@ use Symfony\Component\Validator\Constraint;
  */
 class Url extends Constraint
 {
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_ANY = 'ANY';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_NONE = false;
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_A = 'A';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_A6 = 'A6';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_AAAA = 'AAAA';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_CNAME = 'CNAME';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_MX = 'MX';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_NAPTR = 'NAPTR';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_NS = 'NS';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_PTR = 'PTR';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_SOA = 'SOA';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_SRV = 'SRV';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     const CHECK_DNS_TYPE_TXT = 'TXT';
 
     const INVALID_URL_ERROR = '57c2f299-1154-4870-89bb-ef3b1f5ad229';
@@ -42,7 +81,27 @@ class Url extends Constraint
     );
 
     public $message = 'This value is not a valid URL.';
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     public $dnsMessage = 'The host could not be resolved.';
     public $protocols = array('http', 'https');
+    /**
+     * @deprecated since Symfony 4.1, to be removed in 5.0
+     */
     public $checkDNS = self::CHECK_DNS_TYPE_NONE;
+
+    public function __construct($options = null)
+    {
+        if (is_array($options)) {
+            if (array_key_exists('checkDNS', $options)) {
+                @trigger_error(sprintf('The "checkDNS" option in "%s" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.', self::class), E_USER_DEPRECATED);
+            }
+            if (array_key_exists('dnsMessage', $options)) {
+                @trigger_error(sprintf('The "dnsMessage" option in "%s" is deprecated since Symfony 4.1 and will be removed in 5.0.', self::class), E_USER_DEPRECATED);
+            }
+        }
+
+        parent::__construct($options);
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -200,6 +200,8 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getCheckDns
      * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
+     * @group legacy
+     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.
      */
     public function testCheckDns($violation)
     {
@@ -230,6 +232,8 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getCheckDnsTypes
      * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
+     * @group legacy
+     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.
      */
     public function testCheckDnsByType($type)
     {
@@ -266,6 +270,9 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
     /**
      * @expectedException \Symfony\Component\Validator\Exception\InvalidOptionsException
      * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
+     * @group legacy
+     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.
+     * @expectedDeprecation The "dnsMessage" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0.
      */
     public function testCheckDnsWithInvalidType()
     {
@@ -274,6 +281,19 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Url(array(
             'checkDNS' => 'BOGUS',
             'dnsMessage' => 'myMessage',
+        ));
+
+        $this->validator->validate('http://example.com', $constraint);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.
+     */
+    public function testCheckDnsOptionIsDeprecated()
+    {
+        $constraint = new Url(array(
+            'checkDNS' => Url::CHECK_DNS_TYPE_NONE,
         ));
 
         $this->validator->validate('http://example.com', $constraint);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #23538
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/8921