### PR TITLE
[Meta] add php version in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,6 +5,7 @@
 | BC Break report? | yes/no
 | RFC?             | yes/no
 | Symfony version  | x.y.z
+| PHP version      | x.y.z
 
 <!--
 - Please fill in this template according to your issue.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | no
| Fixed tickets | none
| License       | MIT
| Doc PR        |

I want to propose this file change on the issue template because of : https://github.com/symfony/symfony/issues/25515

If I had the php version in the beginning, it would helped me to have a reproducer faster and maybe to understand this behaviour faster.
