### PR TITLE
Added missing twig-bundle in order to load the twig service

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -21,6 +21,7 @@
         "symfony/routing": "~3.4|~4.0",
         "symfony/twig-bridge": "~3.4|~4.0",
         "symfony/var-dumper": "~3.4|~4.0",
+        "symfony/twig-bundle": "~3.4|~4.0",
         "twig/twig": "~1.34|~2.4"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3 (be-careful when merging, this targets 4.0)
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Hello,
while playing with the new SF4 I faced the following problem.
Although that's not a real big problem, maybe it can help new developers.

### PHP Version

PHP 7.1.12-3+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Dec 14 2017 15:37:13) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies
    with Zend OPcache v7.1.12-3+ubuntu16.04.1+deb.sury.org+1, Copyright (c) 1999-2017, by Zend Technologies
	
### Steps to reproduce

```
  composer create-project symfony/skeleton missing_require
  cd missing_require/
  composer require web-profiler-bundle
```
    
### Actual
  
  guigui@DESKTOP-312FNO3:/mnt/c/Users/guigui/Desktop/test_sf/missing_require$ composer require web-profiler-bundle
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 5 installs, 0 updates, 0 removals
  - Installing twig/twig (v2.4.4): Loading from cache
  - Installing symfony/polyfill-php72 (v1.6.0): Loading from cache
  - Installing symfony/var-dumper (v4.0.2): Loading from cache
  - Installing symfony/twig-bridge (v4.0.2): Loading from cache
  - Installing symfony/web-profiler-bundle (v4.0.2): Loading from cache
Writing lock file
Generating autoload files
Symfony operations: 1 recipe (277e06f526c52ac8ab42e3ba6ffa4520)
  - Configuring symfony/web-profiler-bundle (>=3.3): From github.com/symfony/recipes:master
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!
!!  In CheckExceptionOnInvalidReferenceBehaviorPass.php line 32:
!!
!!    The service "web_profiler.controller.profiler" has a dependency on a non-ex
!!    istent service "twig".
!!
!!
!!

### Expected

Successful installation

### Explanation 

It seems the twig service is not loaded. As this service is provided by symfony/twig-bundle, I simply added the missing require.
I successfully tested a new installation in https://github.com/guiguiboy/web-profiler-bundle/

