### PR TITLE
[WebProfilerBundle] Fix panel break when stopwatch component is not installed.

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -14,10 +14,12 @@
     } %}
 {% endif %}
 
+{% set has_time_events = collector.events|length > 0 %}
+
 {% block toolbar %}
-    {% set total_time = collector.events|length ? '%.0f'|format(collector.duration) : 'n/a' %}
+    {% set total_time = has_time_events ? '%.0f'|format(collector.duration) : 'n/a' %}
     {% set initialization_time = collector.events|length ? '%.0f'|format(collector.inittime) : 'n/a' %}
-    {% set status_color = collector.events|length and collector.duration > 1000 ? 'yellow' : '' %}
+    {% set status_color = has_time_events and collector.duration > 1000 ? 'yellow' : '' %}
 
     {% set icon %}
         {{ include('@WebProfiler/Icon/time.svg') }}
@@ -75,10 +77,14 @@
                 <span class="label">Sub-Request{{ profile.children|length > 1 ? 's' }}</span>
             </div>
 
-            {% set subrequests_time = 0 %}
-            {% for child in profile.children %}
-                {% set subrequests_time = subrequests_time + child.getcollector('time').events.__section__.duration %}
-            {% endfor %}
+            {% if has_time_events %}
+                {% set subrequests_time = 0 %}
+                {% for child in profile.children %}
+                    {% set subrequests_time = subrequests_time + child.getcollector('time').events.__section__.duration %}
+                {% endfor %}
+            {% else %}
+                {% set subrequests_time = 0 %}
+            {% endif %}
 
             <div class="metric">
                 <span class="value">{{ subrequests_time }} <span class="unit">ms</span></span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -83,7 +83,7 @@
                     {% set subrequests_time = subrequests_time + child.getcollector('time').events.__section__.duration %}
                 {% endfor %}
             {% else %}
-                {% set subrequests_time = 0 %}
+                {% set subrequests_time = 'n/a' %}
             {% endif %}
 
             <div class="metric">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25350 
| License       | MIT
| Doc PR        | -

Fixes a crash in the time profiler panel when the stopwatch is not installed. This avoids a hard dependency like the ticket author requested, as the rest of the component can already deal with that case.

I think this is an issue in 3.4+, but I only tested against 4.0.2 locally (code in the affected file only differs in whitespace between 3.4 and 4.0).
