### PR TITLE
Make DOM Crawler countable in PHP 7.2

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -932,6 +932,10 @@ class Crawler implements \Countable, \IteratorAggregate
      */
     public function count()
     {
+        if (null === $this->nodes) {
+            return 0;
+        }
+
         return count($this->nodes);
     }
 


### PR DESCRIPTION
When applying an xpath filter to the crawler that results in no nodes
being found, a crawler with `null` as `$nodes` property will be
returned. And since `null` is not countable you well get a PHP warning
when you try to `count()` the crawler in PHP 7.2:

    Warning: count(): Parameter must be an array or an object that implements Countable

| Q             | A
| ------------- | ---
| Branch?       | 3.0 and up
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A, no ticket created
| License       | MIT
| Doc PR        | N/A

PR is against 3.0 even though it is EOL, but that is the first Symfony version where the bug occurs. In Symfony 2.X Crawler does not implement \Countable, so no need to fix it there.

Should I have created this PR against the supported 3.2 instead?