### PR TITLE
[HttpKernel] Disable CSP header on exception pages

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -12,8 +12,11 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpFoundation\Request;
@@ -121,6 +124,32 @@ class ExceptionListenerTest extends TestCase
 
         $response = $event->getResponse();
         $this->assertEquals('xml', $response->getContent());
+    }
+
+    public function testCSPHeaderIsRemoved()
+    {
+        $dispatcher = new EventDispatcher();
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
+        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+            return new Response($request->getRequestFormat());
+        }));
+
+        $listener = new ExceptionListener('foo', $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock());
+
+        $dispatcher->addSubscriber($listener);
+
+        $request = Request::create('/');
+        $event = new GetResponseForExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, new \Exception('foo'));
+        $dispatcher->dispatch(KernelEvents::EXCEPTION, $event);
+
+        $response = new Response('', 200, array('content-security-policy' => "style-src 'self'"));
+        $this->assertTrue($response->headers->has('content-security-policy'));
+
+        $event = new FilterResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        $dispatcher->dispatch(KernelEvents::RESPONSE, $event);
+
+        $this->assertFalse($response->headers->has('content-security-policy'), 'CSP header has been removed');
+        $this->assertFalse($dispatcher->hasListeners(KernelEvents::RESPONSE), 'CSP removal listener has been removed');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24772
| License       | MIT
| Doc PR        | -

This makes exception pages styled normally when using CSP listener. Technically it's new feature, but from user POV it's bugfix, because it's really confusing to get a blank page. It takes a while to realize it is because of enabled CSP. Therefore I'm trying to push it as patch release.