### PR TITLE
Allow to use underscores in domains and subdomains

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -25,7 +25,7 @@ class UrlValidator extends ConstraintValidator
             (%s)://                                 # protocol
             (([\.\pL\pN-]+:)?([\.\pL\pN-]+)@)?      # basic auth
             (
-                ([\pL\pN\pS\-\.])+(\.?([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
+                ([\pL\pN\pS\-_\.])+(\.?([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
                     |                                                 # or
                 \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}                    # an IP address
                     |                                                 # or

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -127,6 +127,9 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             array('http://symfony.com#fragment'),
             array('http://symfony.com/#fragment'),
             array('http://symfony.com/#one_more%20test'),
+            array('http://sym_fony.com'),
+            array('http://foo_bar.symfony.com'),
+            array('http://foor_bar.sym_fony.com'),
         );
     }
 
@@ -154,7 +157,6 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             array('://google.com'),
             array('http ://google.com'),
             array('http:/google.com'),
-            array('http://goog_le.com'),
             array('http://google.com::aa'),
             array('http://google.com:aa'),
             array('ftp://google.fr'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #10467
| License       | MIT
| Doc PR        | -

This implements #10467 in case we decide that underscores in domains are allowed according to modern specs.