### PR TITLE
Lock ternary_to_null_coalescing in PHPCS

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -10,6 +10,7 @@ return PhpCsFixer\Config::create()
         '@Symfony:risky' => true,
         'array_syntax' => array('syntax' => 'long'),
         'protected_to_private' => false,
+        'ternary_to_null_coalescing' => false,
     ))
     ->setRiskyAllowed(true)
     ->setFinder(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 (be careful when merging)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25416 
| License       | MIT
| Doc PR        | -

To avoid other developers PR like #25416 :sweat_smile: 