### PR TITLE
PHP CS Fixer: use PHPUnit Migration ruleset

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,6 +8,8 @@ return PhpCsFixer\Config::create()
     ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
+        '@PHPUnit48Migration:risky' => true,
+        'php_unit_no_expectation_annotation' => false, // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
         'array_syntax' => array('syntax' => 'long'),
         'protected_to_private' => false,
         'php_unit_dedicate_assert' => array('target' => '3.5'),

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -12,7 +12,6 @@ return PhpCsFixer\Config::create()
         'php_unit_no_expectation_annotation' => false, // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
         'array_syntax' => array('syntax' => 'long'),
         'protected_to_private' => false,
-        'php_unit_dedicate_assert' => array('target' => '3.5'),
     ))
     ->setRiskyAllowed(true)
     ->setFinder(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not related
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

replaces #25553