### PR TITLE
[Process] Dont use getenv(), it returns arrays and can introduce subtle breaks accros PHP versions

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1718,15 +1718,11 @@ class Process implements \IteratorAggregate
 
     private function getDefaultEnv()
     {
-        if (\PHP_VERSION_ID >= 70100) {
-            $env = getenv();
-        } else {
-            $env = array();
+        $env = array();
 
-            foreach ($_SERVER as $k => $v) {
-                if (is_string($v) && false !== $v = getenv($k)) {
-                    $env[$k] = $v;
-                }
+        foreach ($_SERVER as $k => $v) {
+            if (is_string($v) && false !== $v = getenv($k)) {
+                $env[$k] = $v;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25511
| License       | MIT
| Doc PR        | -

