### PR TITLE
allow autowire for http_utils class

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -182,6 +182,7 @@
             <argument type="service" id="router" on-invalid="null" />
             <argument type="service" id="router" on-invalid="null" />
         </service>
+        <service id="Symfony\Component\Security\Http\HttpUtils" alias="security.http_utils" />
 
 
         <!-- Validator -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | n.a.

This PR enables autowire for `Symfony\Component\Security\Http\HttpUtils`.
We use this for an custom authenticator.