### PR TITLE
Fixed 'RouterInteface' typo

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -204,12 +204,12 @@ FrameworkBundle
     a `TypeError` in 4.0.
 
  * `RouterDebugCommand::__construct()` now takes an instance of
-   `Symfony\Component\Routing\RouterInteface` as
+   `Symfony\Component\Routing\RouterInterface` as
     first argument. Not passing it is deprecated and will throw
     a `TypeError` in 4.0.
 
  * `RouterMatchCommand::__construct()` now takes an instance of
-   `Symfony\Component\Routing\RouterInteface` as
+   `Symfony\Component\Routing\RouterInterface` as
     first argument. Not passing it is deprecated and will throw
     a `TypeError` in 4.0.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -535,11 +535,11 @@ FrameworkBundle
     first argument.
 
  * `RouterDebugCommand::__construct()` now requires an instance of
-   `Symfony\Component\Routing\RouterInteface` as
+   `Symfony\Component\Routing\RouterInterface` as
     first argument.
 
  * `RouterMatchCommand::__construct()` now requires an instance of
-   `Symfony\Component\Routing\RouterInteface` as
+   `Symfony\Component\Routing\RouterInterface` as
     first argument.
 
  * `TranslationDebugCommand::__construct()` now requires an instance of

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -44,10 +44,10 @@ CHANGELOG
    `Symfony\Component\EventDispatcher\EventDispatcherInterface` as
     first argument
  * `RouterDebugCommand::__construct()` now takes an instance of
-   `Symfony\Component\Routing\RouterInteface` as
+   `Symfony\Component\Routing\RouterInterface` as
     first argument
  * `RouterMatchCommand::__construct()` now takes an instance of
-   `Symfony\Component\Routing\RouterInteface` as
+   `Symfony\Component\Routing\RouterInterface` as
     first argument
  * `TranslationDebugCommand::__construct()` now takes an instance of
    `Symfony\Component\Translation\TranslatorInterface` as


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 - 4.0 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | - <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | -

This fixes a minor typo in UPGRADE and README files. My proposal is to add a check for this common mistake on fabpot.io too.