### PR TITLE
[Debug] Skip DebugClassLoader checks for already parsed files

### DIFF
--- a/src/Symfony/Component/Debug/Tests/phpt/debug_class_loader.phpt
+++ b/src/Symfony/Component/Debug/Tests/phpt/debug_class_loader.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test DebugClassLoader with previoulsy loaded parents
+--FILE--
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+use Symfony\Component\Debug\DebugClassLoader;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+class_exists(FinalMethod::class);
+
+set_error_handler(function ($type, $msg) { echo $msg, "\n"; });
+
+DebugClassLoader::enable();
+
+class_exists(ExtendedFinalMethod::class);
+
+?>
+--EXPECTF--
+The "Symfony\Component\Debug\Tests\Fixtures\FinalMethod::finalMethod()" method is considered final since version 3.3. It may change without further notice as of its next major version. You should not extend it from "Symfony\Component\Debug\Tests\Fixtures\ExtendedFinalMethod".


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Perf. fix for the dev mode only: I propose to run the checks done by DebugClassLoader only once, when the file is changed/parsed.

This should improve DX much, by making the dev env faster. Here is a bench on the hello world of the standard edition (class inlining by the DIC disabled, but still):

![image](https://user-images.githubusercontent.com/243674/34224242-8852ee9a-e5c2-11e7-94ae-6edc6ab41de5.png)


https://blackfire.io/profiles/compare/31ff0792-9992-4658-9707-cac87a320d1f/graph

