### PR TITLE
[Console] Fixed BC bug when mixing short & long options

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -288,7 +288,7 @@ class ArgvInput extends Input
                     $token = $noValue[0];
                     $searchableToken = str_replace('-', '', $token);
                     $searchableValue = str_replace('-', '', $value);
-                    if ('' !== $searchableToken && '' !== $searchableValue && false !== strpos($searchableToken, $searchableValue)) {
+                    if ('' !== $searchableToken && 0 === strpos($searchableToken, $value.'=') && '' !== $searchableValue && false !== strpos($searchableToken, $searchableValue)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7+
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| License       | MIT

PR #25487 introduced BC break when call to command was mixing both, short & long options.

`v2.7.38` (notice `-e=test` at end):
```bash
$ app/console cache:warmup --no-ansi --no-interaction --no-debug -e=test
 // Warming up the cache for the test environment with debug false

 [OK] Cache for the "test" environment (debug=false) was successfully warmed.
```
`v2.7.39`:
```bash
$ app/console cache:warmup --no-ansi --no-interaction --no-debug -e=test

      _____                  __
     / ____|                / _|
    | (___  _   _ _ __ ___ | |_ ___  _ __  _   _
     \___ \| | | | '_ ` _ \|  _/ _ \| '_ \| | | |
     ____) | |_| | | | | | | || (_) | | | | |_| |
    |_____/ \__, |_| |_| |_|_| \___/|_| |_|\__, |
             __/ |                          __/ |
            |___/                          |___/


Welcome to the Symfony shell (2.8.32 - app/test).

At the prompt, type help for some help,
or list to get a list of available commands.

To exit the shell, type ^D.

Symfony >
```
