### PR TITLE
[Lock] Add MysqlStore that use GET_LOCK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ cache:
 services:
     - memcached
     - mongodb
+    - mysql
     - redis-server
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,7 @@ install:
     - echo extension=php_intl.dll >> php.ini-max
     - echo extension=php_mbstring.dll >> php.ini-max
     - echo extension=php_fileinfo.dll >> php.ini-max
+    - echo extension=php_pdo_mysql.dll >> php.ini-max
     - echo extension=php_pdo_sqlite.dll >> php.ini-max
     - echo extension=php_curl.dll >> php.ini-max
     - copy /Y php.ini-max php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ build: false
 clone_depth: 1
 clone_folder: c:\projects\symfony
 
+services:
+    - mysql
+
 cache:
     - composer.phar
     - .phpunit -> phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,9 @@
         <env name="LDAP_PORT" value="3389" />
         <env name="REDIS_HOST" value="localhost" />
         <env name="MEMCACHED_HOST" value="localhost" />
+        <env name="MYSQL_HOST" value="127.0.0.1" />
+        <env name="MYSQL_USERNAME" value="root" />
+        <env name="MYSQL_PASSWORD" value="" />
     </php>
 
     <testsuites>

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * added Mysql store using GET_LOCK
+
 3.4.0
 -----
 

--- a/src/Symfony/Component/Lock/Store/MysqlStore.php
+++ b/src/Symfony/Component/Lock/Store/MysqlStore.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Store;
+
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\StoreInterface;
+
+/**
+ * MysqlStore is a StoreInterface implementation using MySQL/MariaDB GET_LOCK function.
+ *
+ * @author Jérôme TAMARELLE <jerome@tamarelle.net>
+ */
+class MysqlStore implements StoreInterface
+{
+    private $dsn;
+    private $username;
+    private $password;
+    private $options;
+
+    private $waitTimeout;
+
+    /**
+     * List of available options:
+     *  * db_username: The username when lazy-connect [default: '']
+     *  * db_password: The password when lazy-connect [default: '']
+     *  * db_connection_options: An array of driver-specific connection options [default: array()]
+     *  * wait_timeout: Time in seconds to wait for a lock to be released. A negative value means infinite. [default: -1].
+     *
+     * @param string $dsn     The connection DSN string
+     * @param array  $options configuration options
+     */
+    public function __construct($dsn, array $options)
+    {
+        $this->dsn = $dsn;
+        $this->username = $options['db_username'] ?? '';
+        $this->password = $options['db_password'] ?? '';
+        $this->options = $options['db_connection_options'] ?? array();
+        $this->waitTimeout = $options['wait_timeout'] ?? -1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(Key $key)
+    {
+        $this->lock($key, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function waitAndSave(Key $key)
+    {
+        $this->lock($key, true);
+    }
+
+    private function lock(Key $key, bool $blocking)
+    {
+        // The lock is maybe already acquired.
+        if ($key->hasState(__CLASS__)) {
+            return;
+        }
+
+        // no timeout for impatient
+        $timeout = $blocking ? $this->waitTimeout : 0;
+
+        $connection = new \PDO($this->dsn, $this->username, $this->password, $this->options);
+        $connection->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $stmt = $connection->prepare('SELECT GET_LOCK(:key, :timeout)');
+        $stmt->bindValue(':key', hash('sha256', $key), \PDO::PARAM_STR);
+        $stmt->bindValue(':timeout', $timeout, \PDO::PARAM_INT);
+        $stmt->setFetchMode(\PDO::FETCH_COLUMN, 0);
+        $stmt->execute();
+        $success = $stmt->fetchColumn();
+
+        if ('0' === $success) {
+            throw new LockConflictedException();
+        }
+
+        // store the release statement in the state
+        $releaseStmt = $connection->prepare('SELECT RELEASE_LOCK(:key)');
+        $releaseStmt->bindValue(':key', hash('sha256', $key), \PDO::PARAM_STR);
+
+        $key->setState(__CLASS__, $releaseStmt);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function putOffExpiration(Key $key, $ttl)
+    {
+        // do nothing, the GET_LOCK locks forever, until the session terminates.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(Key $key)
+    {
+        if (!$key->hasState(__CLASS__)) {
+            return;
+        }
+
+        $releaseStmt = $key->getState(__CLASS__);
+        $releaseStmt->execute();
+
+        // Close the connection.
+        $key->removeState(__CLASS__);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function exists(Key $key)
+    {
+        return $key->hasState(__CLASS__);
+    }
+}

--- a/src/Symfony/Component/Lock/Store/MysqlStore.php
+++ b/src/Symfony/Component/Lock/Store/MysqlStore.php
@@ -26,7 +26,6 @@ class MysqlStore implements StoreInterface
     private $username;
     private $password;
     private $options;
-
     private $waitTimeout;
 
     /**

--- a/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
@@ -22,6 +22,8 @@ trait BlockingStoreTestTrait
 {
     /**
      * @see AbstractStoreTest::getStore()
+     *
+     * @return StoreInterface
      */
     abstract protected function getStore();
 
@@ -38,8 +40,6 @@ trait BlockingStoreTestTrait
         // Amount a microsecond used to order async actions
         $clockDelay = 50000;
 
-        /** @var StoreInterface $store */
-        $store = $this->getStore();
         $key = new Key(uniqid(__METHOD__, true));
         $parentPID = posix_getpid();
 
@@ -50,6 +50,7 @@ trait BlockingStoreTestTrait
             // Wait the start of the child
             pcntl_sigwaitinfo(array(SIGHUP), $info);
 
+            $store = $this->getStore();
             try {
                 // This call should failed given the lock should already by acquired by the child
                 $store->save($key);
@@ -71,6 +72,8 @@ trait BlockingStoreTestTrait
         } else {
             // Block SIGHUP signal
             pcntl_sigprocmask(SIG_BLOCK, array(SIGHUP));
+
+            $store = $this->getStore();
             try {
                 $store->save($key);
                 // send the ready signal to the parent

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -27,21 +27,17 @@ class MysqlStoreTest extends AbstractStoreTest
      */
     public function getStore()
     {
-        return new MysqlStore(getenv('MYSQL_DSN'), array(
-            'db_username' => getenv('MYSQL_USER'),
+        return new MysqlStore('mysql:host='.getenv('MYSQL_HOST'), array(
+            'db_username' => getenv('MYSQL_USERNAME'),
             'db_password' => getenv('MYSQL_PASSWORD'),
+            'wait_timeout' => 1,
         ));
     }
 
-    /**
-     * @medium
-     *
-     * @todo use phpunit/php-invoker to avoid infinite wait ?
-     */
     public function testConfigurableWaitTimeout()
     {
-        $store = new MysqlStore(getenv('MYSQL_DSN'), array(
-            'db_username' => getenv('MYSQL_USER'),
+        $store = new MysqlStore('mysql:host='.getenv('MYSQL_HOST'), array(
+            'db_username' => getenv('MYSQL_USERNAME'),
             'db_password' => getenv('MYSQL_PASSWORD'),
             'wait_timeout' => 1,
         ));
@@ -50,7 +46,7 @@ class MysqlStoreTest extends AbstractStoreTest
         $key1 = new Key($resource);
         $key2 = new Key($resource);
 
-        $store->waitAndSave($key1);
+        $store->save($key1);
 
         $startTime = microtime(true);
 

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\Store\MysqlStore;
+
+/**
+ * @author Jérôme TAMARELLE <jerome@tamarelle.net>
+ */
+class MysqlStoreTest extends AbstractStoreTest
+{
+    use BlockingStoreTestTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStore()
+    {
+        return new MysqlStore(getenv('MYSQL_DSN'), array(
+            'db_username' => getenv('MYSQL_USER'),
+            'db_password' => getenv('MYSQL_PASSWORD'),
+        ));
+    }
+
+    /**
+     * @medium
+     *
+     * @todo use phpunit/php-invoker to avoid infinite wait ?
+     */
+    public function testConfigurableWaitTimeout()
+    {
+        $store = new MysqlStore(getenv('MYSQL_DSN'), array(
+            'db_username' => getenv('MYSQL_USER'),
+            'db_password' => getenv('MYSQL_PASSWORD'),
+            'wait_timeout' => 1,
+        ));
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $key2 = new Key($resource);
+
+        $store->waitAndSave($key1);
+
+        $startTime = microtime(true);
+
+        try {
+            $store->waitAndSave($key2);
+
+            $this->fail('The store shouldn\'t save the second key');
+        } catch (LockConflictedException $e) {
+            // Expected
+        }
+
+        $waitTime = microtime(true) - $startTime;
+
+        $this->assertGreaterThanOrEqual(1, $waitTime);
+        $this->assertLessThan(2, $waitTime);
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -88,8 +88,20 @@ class MysqlStoreTest extends AbstractStoreTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Lock\Exception\LockAcquiringException
-     * @expectedExceptionMessage Lock already acquired with the same MySQL connection.
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage "Symfony\Component\Lock\Store\MysqlStore" requires a positive wait timeout, "-1" given. For infine wait, acquire a "blocking" lock.
+     */
+    public function testOnlyPositiveWaitTimeoutIsSupported()
+    {
+        $connection = $this->createMock(\PDO::class);
+        $connection->method('getAttribute')->willReturn('mysql');
+
+        return new MysqlStore($connection, -1);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Lock\Exception\LockConflictedException
+     * @expectedExceptionMessage Lock already acquired with by same connection.
      */
     public function testWaitTheSameResourceOnTheSameConnectionIsNotSupported()
     {

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -20,6 +20,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
+        "doctrine/dbal": "~2.4",
         "predis/predis": "~1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Lock/phpunit.xml.dist
+++ b/src/Symfony/Component/Lock/phpunit.xml.dist
@@ -12,8 +12,8 @@
         <ini name="error_reporting" value="-1" />
         <env name="REDIS_HOST" value="localhost" />
         <env name="MEMCACHED_HOST" value="localhost" />
-        <env name="MYSQL_DSN" value="mysql:host=localhost" />
-        <env name="MYSQL_USER" value="root" />
+        <env name="MYSQL_HOST" value="127.0.0.1" />
+        <env name="MYSQL_USERNAME" value="root" />
         <env name="MYSQL_PASSWORD" value="" />
     </php>
 

--- a/src/Symfony/Component/Lock/phpunit.xml.dist
+++ b/src/Symfony/Component/Lock/phpunit.xml.dist
@@ -12,6 +12,9 @@
         <ini name="error_reporting" value="-1" />
         <env name="REDIS_HOST" value="localhost" />
         <env name="MEMCACHED_HOST" value="localhost" />
+        <env name="MYSQL_DSN" value="mysql:host=localhost" />
+        <env name="MYSQL_USER" value="root" />
+        <env name="MYSQL_PASSWORD" value="" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25400
| License       | MIT
| Doc PR        | WIP


* Key is hashed with sha256 to ensure it stays between 1 and 64 characters.

> MySQL 5.7.5 and later enforces a maximum length on lock names of 64 characters. Previously, no limit was enforced. 

* Create a new PDO connection for each lock, to avoid multiple locks on the same name in the same session. Using a shared PDO connection lead to edge cases when using multiple lock simultaneously. 

>  It is even possible for a given session to acquire multiple locks for the same name. Other sessions cannot acquire a lock with that name until the acquiring session releases all its locks for the name. 

