### PR TITLE
Add type string to docblock for Process::setInput()

### DIFF
--- a/src/Symfony/Component/Process/InputStream.php
+++ b/src/Symfony/Component/Process/InputStream.php
@@ -28,7 +28,7 @@ class InputStream implements \IteratorAggregate
     /**
      * Sets a callback that is called when the write buffer becomes empty.
      *
-     * @param callable $onEmpty
+     * @param null|callable $onEmpty
      */
     public function onEmpty(callable $onEmpty = null)
     {

--- a/src/Symfony/Component/Process/InputStream.php
+++ b/src/Symfony/Component/Process/InputStream.php
@@ -22,7 +22,7 @@ class InputStream implements \IteratorAggregate
 {
     /** @var null|callable */
     private $onEmpty = null;
-    private $input = [];
+    private $input = array();
     private $open = true;
 
     /**

--- a/src/Symfony/Component/Process/InputStream.php
+++ b/src/Symfony/Component/Process/InputStream.php
@@ -20,12 +20,15 @@ use Symfony\Component\Process\Exception\RuntimeException;
  */
 class InputStream implements \IteratorAggregate
 {
+    /** @var null|callable */
     private $onEmpty = null;
-    private $input = array();
+    private $input = [];
     private $open = true;
 
     /**
      * Sets a callback that is called when the write buffer becomes empty.
+     *
+     * @param callable $onEmpty
      */
     public function onEmpty(callable $onEmpty = null)
     {
@@ -35,7 +38,8 @@ class InputStream implements \IteratorAggregate
     /**
      * Appends an input to the write buffer.
      *
-     * @param resource|scalar|\Traversable|null The input to append as stream resource, scalar or \Traversable
+     * @param resource|int|string|bool|float|\Traversable|null The input to append as stream
+     *                                                         resource, scalar or \Traversable
      */
     public function write($input)
     {

--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -27,7 +27,7 @@ abstract class AbstractPipes implements PipesInterface
     private $blocked = true;
 
     /**
-     * @param resource|scalar|\Iterator|null $input
+     * @param resource|int|string|bool|float|\Iterator|null $input
      */
     public function __construct($input)
     {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1154,7 +1154,7 @@ class Process implements \IteratorAggregate
      *
      * This content will be passed to the underlying process standard input.
      *
-     * @param resource|scalar|\Traversable|null $input The content
+     * @param string|resource|scalar|\Traversable|null $input The content
      *
      * @return self The current Process instance
      *

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1154,7 +1154,7 @@ class Process implements \IteratorAggregate
      *
      * This content will be passed to the underlying process standard input.
      *
-     * @param string|resource|scalar|\Traversable|null $input The content
+     * @param int|float|string|bool|resource|\Traversable|null $input The content
      *
      * @return self The current Process instance
      *

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -167,7 +167,7 @@ class ProcessBuilder
     /**
      * Sets the input of the process.
      *
-     * @param resource|scalar|\Traversable|null $input The input content
+     * @param resource|int|string|bool|float|\Traversable|null $input The input content
      *
      * @return $this
      *

--- a/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
@@ -27,7 +27,7 @@ interface EncoderInterface
      * @param string $format  Format name
      * @param array  $context Options that normalizers/encoders have access to
      *
-     * @return scalar
+     * @return int|string|bool|float
      *
      * @throws UnexpectedValueException
      */

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
@@ -36,5 +36,5 @@ interface DenormalizableInterface
      *
      * @return object
      */
-    public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = []);
+    public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = array());
 }

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
@@ -27,14 +27,14 @@ interface DenormalizableInterface
      * It is important to understand that the denormalize() call should denormalize
      * recursively all child objects of the implementor.
      *
-     * @param DenormalizerInterface $denormalizer The denormalizer is given so that you
-     *                                            can use it to denormalize objects contained within this object
-     * @param array|scalar          $data         The data from which to re-create the object
-     * @param string|null           $format       The format is optionally given to be able to denormalize differently
-     *                                            based on different input formats
-     * @param array                 $context      Options for denormalizing
+     * @param DenormalizerInterface       $denormalizer The denormalizer is given so that you
+     *                                                  can use it to denormalize objects contained within this object
+     * @param array|int|string|bool|float $data         The data from which to re-create the object
+     * @param string|null                 $format       The format is optionally given to be able to denormalize
+     *                                                  differently based on different input formats
+     * @param array                       $context      Options for denormalizing
      *
      * @return object
      */
-    public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = array());
+    public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = []);
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
@@ -33,7 +33,7 @@ interface NormalizableInterface
      *                                        based on different output formats
      * @param array               $context    Options for normalizing this object
      *
-     * @return array|scalar
+     * @return array|int|string|bool|float
      */
     public function normalize(NormalizerInterface $normalizer, $format = null, array $context = array());
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -29,7 +29,7 @@ interface NormalizerInterface
      * @param string $format  Format the normalization result will be encoded as
      * @param array  $context Context options for the normalizer
      *
-     * @return array|scalar
+     * @return array|int|string|bool|float
      *
      * @throws InvalidArgumentException   Occurs when the object given is not an attempted type for the normalizer
      * @throws CircularReferenceException Occurs when the normalizer detects a circular reference when no circular

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -63,7 +63,7 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * @param bool $recursive Whether values should be resolved recursively or not
      *
-     * @return scalar|array|null|Data[] A native representation of the original value
+     * @return int|string|bool|float|array|null|Data[] A native representation of the original value
      */
     public function getValue($recursive = false)
     {

--- a/src/Symfony/Component/VarDumper/Cloner/DumperInterface.php
+++ b/src/Symfony/Component/VarDumper/Cloner/DumperInterface.php
@@ -21,9 +21,9 @@ interface DumperInterface
     /**
      * Dumps a scalar value.
      *
-     * @param Cursor $cursor The Cursor position in the dump
-     * @param string $type   The PHP type of the value being dumped
-     * @param scalar $value  The scalar value being dumped
+     * @param Cursor                $cursor The Cursor position in the dump
+     * @param string                $type   The PHP type of the value being dumped
+     * @param int|string|bool|float $value  The scalar value being dumped
      */
     public function dumpScalar(Cursor $cursor, $type, $value);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Add `string` as valid `$input` for `Process::setInput()`. Since `getInput()` will also return as string and the internal method `ProcessUtils::validateInput()` will accept a string, this should be a viable input type.
