### PR TITLE
[Console] Simplify parameters in DI

### DIFF
--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -41,13 +41,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
         $lazyCommandMap = array();
         $lazyCommandRefs = array();
         $serviceIds = array();
-        $lazyServiceIds = array();
 
         foreach ($commandServices as $id => $tags) {
             $definition = $container->getDefinition($id);
             $class = $container->getParameterBag()->resolveValue($definition->getClass());
-
-            $commandId = 'console.command.'.strtolower(str_replace('\\', '_', $class));
 
             if (isset($tags[0]['command'])) {
                 $commandName = $tags[0]['command'];
@@ -62,20 +59,16 @@ class AddConsoleCommandPass implements CompilerPassInterface
             }
 
             if (null === $commandName) {
-                if (isset($serviceIds[$commandId]) || $container->hasAlias($commandId)) {
-                    $commandId = $commandId.'_'.$id;
-                }
                 if (!$definition->isPublic() || $definition->isPrivate()) {
+                    $commandId = 'console.command.public_alias.'.$id;
                     $container->setAlias($commandId, $id)->setPublic(true);
                     $id = $commandId;
                 }
-                $serviceIds[$commandId] = $id;
+                $serviceIds[] = $id;
 
                 continue;
             }
 
-            $serviceIds[$commandId] = $id;
-            $lazyServiceIds[$id] = true;
             unset($tags[0]);
             $lazyCommandMap[$commandName] = $id;
             $lazyCommandRefs[$id] = new TypedReference($id, $class);
@@ -101,6 +94,5 @@ class AddConsoleCommandPass implements CompilerPassInterface
             ->setArguments(array(ServiceLocatorTagPass::register($container, $lazyCommandRefs), $lazyCommandMap));
 
         $container->setParameter('console.command.ids', $serviceIds);
-        $container->setParameter('console.lazy_command.ids', $lazyServiceIds);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | no
| New feature?  |no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Currently the container gets filled with alot of ugly params like

```
'console.command.ids' => array(
                'console.command.symfony_bundle_frameworkbundle_command_aboutcommand' => 'console.command.about',
                'console.command.symfony_bundle_frameworkbundle_command_assetsinstallcommand' => 'console.command.assets_install',
                'console.command.symfony_bundle_frameworkbundle_command_cacheclearcommand' => 'console.command.cache_clear',
...
            ),
'console.lazy_command.ids' => array(
                'console.command.about' => true,
                'console.command.assets_install' => true,
                'console.command.cache_clear' => true,
...
```

We can get rid of these in 4.0 with a little refactoring.
- SF 4.0 does not include the auto-registration of commands anymore which was the reason why the `console.command.ids` used the class name as index to prevent commands already defined as service to not triggger auto-registration. -> The param does not need the index lookup anymore in 4.0
- What I now also changed is that this param only contains the command IDs of services that are NOT lazy loaded. This way, we don't need `console.lazy_command.ids` at all. This is a simplification of #24073 and still ensures framework bundle console application is compatible with console component 3.x and 4.x 