### PR TITLE
[DependencyInjection] Add test for autoconfigure instanceof does not override tags and preserve attributes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -153,6 +153,28 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $this->assertSame(array('duplicated_tag' => array(array(), array('and_attributes' => 1))), $def->getTags());
     }
 
+    public function testAutoconfigureInstanceofPreserveExplicitTagsAsPrimary()
+    {
+        $container = new ContainerBuilder();
+        $def = $container->register('normal_service', self::class);
+        $def
+            ->addTag('duplicated_tag', array('and_attributes' => 1))
+        ;
+        $def->setInstanceofConditionals(array(
+            parent::class => (new ChildDefinition(''))->addTag('duplicated_tag'),
+        ));
+        $def->setAutoconfigured(true);
+        $container->registerForAutoconfiguration(parent::class)
+            ->addTag('duplicated_tag')
+        ;
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+        (new ResolveChildDefinitionsPass())->process($container);
+
+        $def = $container->getDefinition('normal_service');
+        $this->assertSame(array('duplicated_tag' => array(array('and_attributes' => 1), array())), $def->getTags());
+    }
+
     public function testProcessDoesNotUseAutoconfiguredInstanceofIfNotEnabled()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no, but add test for prove that bug exists
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I am afraid that since autoconfigure enabled we cann't explictly define priorities for some services. And they defined twice with setted priority and default `0` priority. Relates to #25592

For example there are some providers, all of them implements `DataProvider` interface and autoconfigured by it. I want to set low priority (`-100`) for my new `NewProvider`. I've explictly define it inside config, tagged by hand and set priority.  But it also registered by autoconfigure with default priority (`0`), so my DI config not working as expected.

1. Is it possible do disable autoconfigure for specific service?
2. Is described behavior expected? IMHO better do not autoconfigure services wich already has been explictly tagged with same tag
3. Maybe create some annotation that would give advices how to autoconfigure this class, ref #25592