### PR TITLE
[TwigBundle/Brige] catch missing requirements to throw meaningful exceptions

### DIFF
--- a/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
+++ b/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig;
+
+use Twig\Error\SyntaxError;
+
+/**
+ * @internal
+ */
+class UndefinedCallableHandler
+{
+    private static $filterComponents = array(
+        'humanize' => 'form',
+        'trans' => 'translation',
+        'transchoice' => 'translation',
+        'yaml_encode' => 'yaml',
+        'yaml_dump' => 'yaml',
+    );
+
+    private static $functionComponents = array(
+        'asset' => 'asset',
+        'asset_version' => 'asset',
+        'dump' => 'debug-bundle',
+        'expression' => 'expression-language',
+        'form_widget' => 'form',
+        'form_errors' => 'form',
+        'form_label' => 'form',
+        'form_row' => 'form',
+        'form_rest' => 'form',
+        'form' => 'form',
+        'form_start' => 'form',
+        'form_end' => 'form',
+        'csrf_token' => 'form',
+        'logout_url' => 'security-http',
+        'logout_path' => 'security-http',
+        'is_granted' => 'security-core',
+        'link' => 'web-link',
+        'preload' => 'web-link',
+        'dns_prefetch' => 'web-link',
+        'preconnect' => 'web-link',
+        'prefetch' => 'web-link',
+        'prerender' => 'web-link',
+        'workflow_can' => 'workflow',
+        'workflow_transitions' => 'workflow',
+        'workflow_has_marked_place' => 'workflow',
+        'workflow_marked_places' => 'workflow',
+    );
+
+    public static function onUndefinedFilter($name)
+    {
+        if (!isset(self::$filterComponents[$name])) {
+            return false;
+        }
+
+        // Twig will append the source context to the message, so that it will end up being like "[...] Unknown filter "%s" in foo.html.twig on line 123."
+        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown filter "%s".', $name, self::$filterComponents[$name]));
+    }
+
+    public static function onUndefinedFunction($name)
+    {
+        if (!isset(self::$functionComponents[$name])) {
+            return false;
+        }
+
+        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown function "%s".', $name, self::$functionComponents[$name]));
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfigurator.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configurator/EnvironmentConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\DependencyInjection\Configurator;
 
+use Symfony\Bridge\Twig\UndefinedCallableHandler;
 use Twig\Environment;
 
 // BC/FC with namespaced Twig
@@ -49,5 +50,9 @@ class EnvironmentConfigurator
         }
 
         $environment->getExtension('Twig\Extension\CoreExtension')->setNumberFormat($this->decimals, $this->decimalPoint, $this->thousandsSeparator);
+
+        // wrap UndefinedCallableHandler in closures for lazy-autoloading
+        $environment->registerUndefinedFilterCallback(function ($name) { return UndefinedCallableHandler::onUndefinedFilter($name); });
+        $environment->registerUndefinedFunctionCallback(function ($name) { return UndefinedCallableHandler::onUndefinedFunction($name); });
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.5.9|>=7.0.8",
         "symfony/config": "~3.2|~4.0",
-        "symfony/twig-bridge": "^3.4|~4.0",
+        "symfony/twig-bridge": "^3.4.3|~4.0",
         "symfony/http-foundation": "~2.8|~3.0|~4.0",
         "symfony/http-kernel": "^3.3|~4.0",
         "twig/twig": "~1.34|~2.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25256, https://github.com/symfony/webpack-encore/issues/173
| License       | MIT
| Doc PR        | -

It is possible to register a handler for undefined twig functions/filters.
IMHO, this is the hook point we should leverage to throw meaningful exception messages.

This works well on its own. We now just need to list the functions/filters with appropriate messages.

There is one case we could enhance: at warmup time, Twig exceptions are swallowed, thus not visible.
Shouldn't we make these visible instead?

ping @weaverryan since this is related to two issues of yours.