### PR TITLE
[Console][SymfonyStyle] Costumize listing icon

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * Allow customization of icon in `SymfonyStyle::listing()`
+
 4.0.0
 -----
 

--- a/src/Symfony/Component/Console/Style/StyleInterface.php
+++ b/src/Symfony/Component/Console/Style/StyleInterface.php
@@ -34,8 +34,11 @@ interface StyleInterface
 
     /**
      * Formats a list.
+     *
+     * @param array  $elements
+     * @param string $icon
      */
-    public function listing(array $elements);
+    public function listing(array $elements, $icon = '*');
 
     /**
      * Formats informational text.

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -99,11 +99,11 @@ class SymfonyStyle extends OutputStyle
     /**
      * {@inheritdoc}
      */
-    public function listing(array $elements)
+    public function listing(array $elements, $icon = '*')
     {
         $this->autoPrependText();
-        $elements = array_map(function ($element) {
-            return sprintf(' * %s', $element);
+        $elements = array_map(function ($element) use ($icon) {
+            return sprintf(' %s %s', $icon, $element);
         }, $elements);
 
         $this->writeln($elements);

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_18.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_18.php
@@ -1,0 +1,25 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+//Ensure symfony style helper methods handle custom listing icons
+return function (InputInterface $input, OutputInterface $output) {
+    $output = new SymfonyStyle($input, $output);
+
+    $output->listing(array(
+        'Lorem ipsum dolor sit amet',
+        'consectetur adipiscing elit',
+    ), '-');
+
+    $output->listing(array(
+        'Lorem ipsum dolor sit amet',
+        'consectetur adipiscing elit',
+    ), '->');
+
+    $output->listing(array(
+        'Lorem ipsum dolor sit amet',
+        'consectetur adipiscing elit',
+    ), '');
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_18.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_18.txt
@@ -1,0 +1,10 @@
+
+ - Lorem ipsum dolor sit amet
+ - consectetur adipiscing elit
+
+ -> Lorem ipsum dolor sit amet
+ -> consectetur adipiscing elit
+
+  Lorem ipsum dolor sit amet
+  consectetur adipiscing elit
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | (_not yet_)

With this PR, I want to propose to customization of the icons in the `SymfonyStyle::listing()` command.

I discovered it recently, so I could clean up some `for` loops, but I really liked icons to be dashes `-` instead of stars `*`.

I've added tests to blank space, so we can ensure we do not `trim` it.
