### PR TITLE
[WebServerBundle] Fix escaping of php binary with arguments

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/WebServer.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServer.php
@@ -146,11 +146,11 @@ class WebServer
     private function createServerProcess(WebServerConfig $config)
     {
         $finder = new PhpExecutableFinder();
-        if (false === $binary = $finder->find()) {
+        if (false === $binary = $finder->find(false)) {
             throw new \RuntimeException('Unable to find the PHP binary.');
         }
 
-        $process = new Process(array($binary, '-dvariables_order=EGPCS', '-S', $config->getAddress(), $config->getRouter()));
+        $process = new Process(array_merge(array($binary), $finder->findArguments(), array('-dvariables_order=EGPCS', '-S', $config->getAddress(), $config->getRouter())));
         $process->setWorkingDirectory($config->getDocumentRoot());
         $process->setTimeout(null);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Not really needed in practice, yet more correct, and will open some improvements in PhpExecutableFinder for master.