### PR TITLE
[DI] Don't override existing definitions when doing a PSR-4 discovery

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -59,6 +59,10 @@ abstract class FileLoader extends BaseFileLoader
         $prototype = serialize($prototype);
 
         foreach ($classes as $class) {
+            if ($this->container->has($class)) {
+                continue;
+            }
+
             $this->setDefinition($class, unserialize($prototype));
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype2/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype2/Foo.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype2;
+
+class Foo implements ServiceAlreadyDefinedInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype2/ServiceAlreadyDefined.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype2/ServiceAlreadyDefined.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype2;
+
+class ServiceAlreadyDefined
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype2/ServiceAlreadyDefinedInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype2/ServiceAlreadyDefinedInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype2;
+
+interface ServiceAlreadyDefinedInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype2.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype2.yml
@@ -1,0 +1,9 @@
+services:
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype2\ServiceAlreadyDefined:
+        tags: [test]
+
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype2\ServiceAlreadyDefinedInterface:
+        alias: foo
+
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype2\:
+        resource: ../Prototype2

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype2;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy;
 use Symfony\Component\ExpressionLanguage\Expression;
 
@@ -386,6 +387,16 @@ class YamlFileLoaderTest extends TestCase
         $resources = array_map('strval', $resources);
         $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo', $resources);
         $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
+    }
+
+    public function testPrototypeDoNotOverrideExistingServiceDefinition()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_prototype2.yml');
+
+        $this->assertSame('foo', (string) $container->getAlias(Prototype2\ServiceAlreadyDefinedInterface::class));
+        $this->assertTrue($container->getDefinition(Prototype2\ServiceAlreadyDefined::class)->hasTag('test'));
     }
 
     public function testDefaults()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe?
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Currently, the PSR-4 discovery mechanism doesn't check if a service already exists before registering all the classes found in a repository. This is tricky, especially with Flex, because any service already defined in package's config file is silently replaced:

```yaml
# config/packages/api_platform.yaml
api_platform:
    # ...

services:
    _defaults:
        autowire: true
        public: false

    App\Doctrine\ORM\Extension\PublishableExtension:
        tags:
            - { name: api_platform.doctrine.orm.query_extension.collection, priority: 9 }
```
 
```yaml
# config/services.yaml
services:
    # ...
    App\:
        resource: '../src'
        exclude: '../src/{DependencyInjection,Entity,Migrations}'
```

Just because the class `App\Doctrine\ORM\Extension\PublishableExtension` exists, the existing definition is silently overrode, it's most likely unwanted.

I propose to change this behavior to never let the discovery system overriding an already existing service (of course an explicit definition will take precedence, as usual).

(tests regarding interfaces have been done with 3.4 in mind, the patch works well on this branch too)