### PR TITLE
[Process] Make `PhpExecutableFinder` look for the `PHP_BINARY` env var

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added the `Process::isTtySupported()` method that allows to check for TTY support
+ * made `PhpExecutableFinder` look for the `PHP_BINARY` env var when searching the php binary
 
 4.0.0
 -----

--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -35,6 +35,14 @@ class PhpExecutableFinder
      */
     public function find($includeArgs = true)
     {
+        if ($php = getenv('PHP_BINARY')) {
+            if (!is_executable($php)) {
+                return false;
+            }
+
+            return $php;
+        }
+
         $args = $this->findArguments();
         $args = $includeArgs && $args ? ' '.implode(' ', $args) : '';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22101
| License       | MIT
| Doc PR        | -

I think this is enough to fix the linked issue and thus replace #23721.
ping @tomasfejfar FYI