### PR TITLE
Use glob pattern to include routing annotations

### DIFF
--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -152,29 +152,58 @@ class YamlFileLoader extends FileLoader
         $this->setCurrentDir(dirname($path));
 
         $subCollection = $this->import($config['resource'], $type, false, $file);
-        /* @var $subCollection RouteCollection */
-        $subCollection->addPrefix($prefix);
-        if (null !== $host) {
-            $subCollection->setHost($host);
-        }
-        if (null !== $condition) {
-            $subCollection->setCondition($condition);
-        }
-        if (null !== $schemes) {
-            $subCollection->setSchemes($schemes);
-        }
-        if (null !== $methods) {
-            $subCollection->setMethods($methods);
-        }
-        $subCollection->addDefaults($defaults);
-        $subCollection->addRequirements($requirements);
-        $subCollection->addOptions($options);
+        
+        if (is_array($subCollection)) {
+            /* @var $value RouteCollection */
+            foreach($subCollection as $value) {
+                $value->addPrefix($prefix);
+                if (null !== $host) {
+                    $value->setHost($host);
+                }
+                if (null !== $condition) {
+                    $value->setCondition($condition);
+                }
+                if (null !== $schemes) {
+                    $value->setSchemes($schemes);
+                }
+                if (null !== $methods) {
+                    $value->setMethods($methods);
+                }
+                $value->addDefaults($defaults);
+                $value->addRequirements($requirements);
+                $value->addOptions($options);
+                
+                if (isset($config['name_prefix'])) {
+                    $value->addNamePrefix($config['name_prefix']);
+                }
 
-        if (isset($config['name_prefix'])) {
-            $subCollection->addNamePrefix($config['name_prefix']);
-        }
+                $collection->addCollection($value);
+            }
+        } else {
+            /* @var $subCollection RouteCollection */
+            $subCollection->addPrefix($prefix);
+            if (null !== $host) {
+                $subCollection->setHost($host);
+            }
+            if (null !== $condition) {
+                $subCollection->setCondition($condition);
+            }
+            if (null !== $schemes) {
+                $subCollection->setSchemes($schemes);
+            }
+            if (null !== $methods) {
+                $subCollection->setMethods($methods);
+            }
+            $subCollection->addDefaults($defaults);
+            $subCollection->addRequirements($requirements);
+            $subCollection->addOptions($options);
 
-        $collection->addCollection($subCollection);
+            if (isset($config['name_prefix'])) {
+                $subCollection->addNamePrefix($config['name_prefix']);
+            }
+
+            $collection->addCollection($subCollection);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -153,56 +153,34 @@ class YamlFileLoader extends FileLoader
 
         $subCollection = $this->import($config['resource'], $type, false, $file);
         
-        if (is_array($subCollection)) {
-            /* @var $value RouteCollection */
-            foreach($subCollection as $value) {
-                $value->addPrefix($prefix);
-                if (null !== $host) {
-                    $value->setHost($host);
-                }
-                if (null !== $condition) {
-                    $value->setCondition($condition);
-                }
-                if (null !== $schemes) {
-                    $value->setSchemes($schemes);
-                }
-                if (null !== $methods) {
-                    $value->setMethods($methods);
-                }
-                $value->addDefaults($defaults);
-                $value->addRequirements($requirements);
-                $value->addOptions($options);
-                
-                if (isset($config['name_prefix'])) {
-                    $value->addNamePrefix($config['name_prefix']);
-                }
+        if (!is_array($subCollection)) {
+            $subCollection = array($subCollection);
+        }
 
-                $collection->addCollection($value);
-            }
-        } else {
-            /* @var $subCollection RouteCollection */
-            $subCollection->addPrefix($prefix);
+        /* @var $value RouteCollection */
+        foreach ($subCollection as $value) {
+            $value->addPrefix($prefix);
             if (null !== $host) {
-                $subCollection->setHost($host);
+                $value->setHost($host);
             }
             if (null !== $condition) {
-                $subCollection->setCondition($condition);
+                $value->setCondition($condition);
             }
             if (null !== $schemes) {
-                $subCollection->setSchemes($schemes);
+                $value->setSchemes($schemes);
             }
             if (null !== $methods) {
-                $subCollection->setMethods($methods);
+                $value->setMethods($methods);
             }
-            $subCollection->addDefaults($defaults);
-            $subCollection->addRequirements($requirements);
-            $subCollection->addOptions($options);
+            $value->addDefaults($defaults);
+            $value->addRequirements($requirements);
+            $value->addOptions($options);
 
             if (isset($config['name_prefix'])) {
-                $subCollection->addNamePrefix($config['name_prefix']);
+                $value->addNamePrefix($config['name_prefix']);
             }
 
-            $collection->addCollection($subCollection);
+            $collection->addCollection($value);
         }
     }
 


### PR DESCRIPTION
``FileLoader::import`` method can return an array, this PR fix the error "Call to a member function addPrefix() on array".

Use case "I want to import routes from controllers in different directories"; given a ``route/annotation.yaml`` like this:

```
controllers:
    resource: ../../src/*/Controller/*Controller.php
    type: annotation
```

(``/*Controller.php`` is required to make the glob return something).

I dont know how to code this properly, that why I just copied/paste the code like this, but the idea is here.

| Q             | A
| ------------- | ---
| Branch?       | master for features / 2.7 up to 4.0 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->
