### PR TITLE
[Console] Improve phpdoc on StyleInterface::ask()

### DIFF
--- a/src/Symfony/Component/Console/Style/StyleInterface.php
+++ b/src/Symfony/Component/Console/Style/StyleInterface.php
@@ -91,7 +91,7 @@ interface StyleInterface
      * @param string|null   $default
      * @param callable|null $validator
      *
-     * @return string
+     * @return mixed
      */
     public function ask($question, $default = null, $validator = null);
 
@@ -101,7 +101,7 @@ interface StyleInterface
      * @param string        $question
      * @param callable|null $validator
      *
-     * @return string
+     * @return mixed
      */
     public function askHidden($question, $validator = null);
 
@@ -122,7 +122,7 @@ interface StyleInterface
      * @param array           $choices
      * @param string|int|null $default
      *
-     * @return string
+     * @return mixed
      */
     public function choice($question, array $choices, $default = null);
 

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -314,7 +314,7 @@ class SymfonyStyle extends OutputStyle
     }
 
     /**
-     * @return string
+     * @return mixed
      */
     public function askQuestion(Question $question)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

In a CLI command i keep asking an optional question until i get an answer. So interactively it's a required question. It looks like..

```php
do {
    $value = $io->ask('Value', null, function ($value) { return $value; });
} while (null === $value);
```

Which works nice.. but SA is complaining about

```
Strict comparison using === between null and string will always evaluate to false.
```

This should fix it. The mixed API goes back to https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Helper/QuestionHelper.php#L38
  