### PR TITLE
Clean up

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -26,7 +26,6 @@
  * The `standalone` option is deprecated and will be replaced with the `strategy` option in 2.3.
  * The values `true`, `false`, `js` for the `standalone` option were deprecated and replaced respectively with the `esi`, `inline`, `hinclude` in 2.3.
 
-
    Before:
 
    ```jinja
@@ -42,7 +41,6 @@
    {{ render(controller('BlogBundle:Post:list', { 'limit': 2 }), { 'strategy': 'inline'}) }}
    {{ render(controller('BlogBundle:Post:list', { 'limit': 2 }), { 'strategy': 'hinclude'}) }}
    ```
-
 
 ### HttpFoundation
 

--- a/UPGRADE-2.5.md
+++ b/UPGRADE-2.5.md
@@ -245,7 +245,6 @@ Validator
        ->getValidator();
    ```
 
-
 Yaml Component
 --------------
 

--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -32,10 +32,10 @@ Router
 
  * The `getMatcherDumperInstance()` and `getGeneratorDumperInstance()` methods in the
    `Symfony\Component\Routing\Router` have been changed from `protected` to `public`.
-   If you override these methods in a subclass, you will need to change your 
+   If you override these methods in a subclass, you will need to change your
    methods to `public` as well. Note however that this is a temporary change needed for
    PHP 5.3 compatibility only. It will be reverted in Symfony 3.0.
- 
+
 Form
 ----
 
@@ -530,9 +530,9 @@ PropertyAccess
 Config
 ------
 
- * The `__toString()` method of the `\Symfony\Component\Config\ConfigCache` is marked as 
+ * The `__toString()` method of the `\Symfony\Component\Config\ConfigCache` is marked as
    deprecated in favor of the new `getPath()` method.
-   
+
 Validator
 ---------
 
@@ -601,7 +601,7 @@ FrameworkBundle
  * The `templating.helper.assets` service was refactored and now returns an object of type
    `Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper` instead of
    `Symfony\Component\Templating\Helper\CoreAssetsHelper`. You can update your class definition
-   or use the `assets.packages` service instead. Using the `assets.packages` service is the recommended 
+   or use the `assets.packages` service instead. Using the `assets.packages` service is the recommended
    way.
 
    Before:
@@ -676,48 +676,48 @@ Form
 
  * In order to fix a few regressions in the new `ChoiceList` implementation,
    a few details had to be changed compared to 2.7.
-   
-   The legacy `Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface` 
+
+   The legacy `Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface`
    now does not extend the new `Symfony\Component\Form\ChoiceList\ChoiceListInterface`
    anymore. If you pass an implementation of the old interface in a context
    where the new interface is required, wrap the list into a
    `LegacyChoiceListAdapter`:
-   
+
    Before:
-   
+
    ```php
    use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
-   
+
    function doSomething(ChoiceListInterface $choiceList)
    {
        // ...
    }
-   
+
    doSomething($legacyList);
    ```
-   
+
    After:
-   
+
    ```php
    use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
    use Symfony\Component\Form\ChoiceList\LegacyChoiceListAdapter;
-   
+
    function doSomething(ChoiceListInterface $choiceList)
    {
        // ...
    }
-   
+
    doSomething(new LegacyChoiceListAdapter($legacyList));
    ```
-   
+
    The new `ChoiceListInterface` now has two additional methods
    `getStructuredValues()` and `getOriginalKeys()`. You should add these methods
    if you implement this interface. See their doc blocks and the implementation
    of the core choice lists for inspiration.
-   
+
    The method `ArrayKeyChoiceList::toArrayKey()` was marked as internal. This
    method was never supposed to be used outside the class.
-   
+
    The method `ChoiceListFactoryInterface::createView()` does not accept arrays
    and `Traversable` instances anymore for the `$groupBy` parameter. Pass a
    callable instead.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -49,7 +49,6 @@ UPGRADE FROM 2.x to 3.0
    `DebugClassLoader`. The difference is that the constructor now takes a
    loader to wrap.
 
-
 ### Config
 
  * The `__toString()` method of the `\Symfony\Component\Config\ConfigCache` class

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * Added the possibility to override the default success/failure handler
    to get the provider key and the options injected
- * Deprecated the `security.context` service for the `security.token_storage` and 
+ * Deprecated the `security.context` service for the `security.token_storage` and
    `security.authorization_checker` services.
 
 2.4.0

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * [BC BREAK] `Client::followRedirect()` won't redirect responses with
-   a non-3xx Status Code and `Location` header anymore, as per 
+   a non-3xx Status Code and `Location` header anymore, as per
    http://tools.ietf.org/html/rfc2616#section-14.30
 
  * added `Client::getInternalRequest()` and `Client::getInternalResponse()` to

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * added `ConfigCacheInterface`, `ConfigCacheFactoryInterface` and a basic `ConfigCacheFactory`
    implementation to delegate creation of ConfigCache instances
-   
+
 2.2.0
 -----
 

--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -25,7 +25,7 @@ CHANGELOG
  * deprecated OptionsResolver::isKnown() in favor of isDefined()
  * [BC BREAK] OptionsResolver::isRequired() returns true now if a required
    option has a default value set
- * [BC BREAK] merged Options into OptionsResolver and turned Options into an 
+ * [BC BREAK] merged Options into OptionsResolver and turned Options into an
    interface
  * deprecated Options::overload() (now in OptionsResolver)
  * deprecated Options::set() (now in OptionsResolver)
@@ -36,7 +36,7 @@ CHANGELOG
    lazy option/normalizer closures now
  * [BC BREAK] removed Traversable interface from Options since using within
    lazy option/normalizer closures resulted in exceptions
- * [BC BREAK] removed Options::all() since using within lazy option/normalizer 
+ * [BC BREAK] removed Options::all() since using within lazy option/normalizer
    closures resulted in exceptions
  * [BC BREAK] OptionDefinitionException now extends LogicException instead of
    RuntimeException


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I've removed all white spaces and extra lines from our `markdown` files. Recently [I did it in our documentation](https://github.com/symfony/symfony-docs/pull/8944), and thought would be interesting to replicate here :smile: