### PR TITLE
PHP CS Fixer: clean up repo and adjust config

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -12,6 +12,9 @@ return PhpCsFixer\Config::create()
         'php_unit_no_expectation_annotation' => false, // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
         'array_syntax' => array('syntax' => 'long'),
         'protected_to_private' => false,
+        // rule disabled due to https://bugs.php.net/bug.php?id=60573 bug;
+        // to be re-enabled (by dropping next line, rule is part of @Symfony already) on branch that requires PHP 5.4+
+        'self_accessor' => false,
     ))
     ->setRiskyAllowed(true)
     ->setFinder(
@@ -39,5 +42,9 @@ return PhpCsFixer\Config::create()
             ->notPath('Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Custom/_name_entry_label.html.php')
             // explicit heredoc test
             ->notPath('Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php')
+            // explicit trigger_error tests
+            ->notPath('Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/default.phpt')
+            ->notPath('Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak.phpt')
+            ->notPath('Symfony/Component/Debug/Tests/DebugClassLoaderTest.php')
     )
 ;

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -89,18 +89,35 @@ class TranslationExtensionTest extends TestCase
             array('{% trans into "fr"%}Hello{% endtrans %}', 'Hello'),
 
             // transchoice
-            array('{% transchoice count from "messages" %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
-                'There is no apples', array('count' => 0)),
-            array('{% transchoice count %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
-                'There is 5 apples', array('count' => 5)),
-            array('{% transchoice count %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}',
-                'There is 5 apples (Symfony)', array('count' => 5, 'name' => 'Symfony')),
-            array('{% transchoice count with { \'%name%\': \'Symfony\' } %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}',
-                'There is 5 apples (Symfony)', array('count' => 5)),
-            array('{% transchoice count into "fr"%}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
-                'There is no apples', array('count' => 0)),
-            array('{% transchoice 5 into "fr"%}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
-                'There is 5 apples'),
+            array(
+                '{% transchoice count from "messages" %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
+                'There is no apples',
+                array('count' => 0),
+            ),
+            array(
+                '{% transchoice count %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
+                'There is 5 apples',
+                array('count' => 5),
+            ),
+            array(
+                '{% transchoice count %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}',
+                'There is 5 apples (Symfony)',
+                array('count' => 5, 'name' => 'Symfony'),
+            ),
+            array(
+                '{% transchoice count with { \'%name%\': \'Symfony\' } %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}',
+                'There is 5 apples (Symfony)',
+                array('count' => 5),
+            ),
+            array(
+                '{% transchoice count into "fr"%}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
+                'There is no apples',
+                array('count' => 0),
+            ),
+            array(
+                '{% transchoice 5 into "fr"%}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
+                'There is 5 apples',
+            ),
 
             // trans filter
             array('{{ "Hello"|trans }}', 'Hello'),

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -46,7 +46,7 @@ class Translator extends BaseTranslator implements WarmableInterface
     private $resources = array();
 
     /**
-     * Constructing new translator.
+     * Constructor.
      *
      * Available options:
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -46,6 +46,8 @@ class Translator extends BaseTranslator implements WarmableInterface
     private $resources = array();
 
     /**
+     * Constructing new translator.
+     *
      * Available options:
      *
      *   * cache_dir: The cache directory (or null to disable caching)

--- a/src/Symfony/Component/Debug/Resources/ext/tests/001.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/001.phpt
@@ -1,7 +1,9 @@
 --TEST--
 Test symfony_zval_info API
 --SKIPIF--
-<?php if (!extension_loaded('symfony_debug')) print 'skip'; ?>
+<?php if (!extension_loaded('symfony_debug')) {
+    echo 'skip';
+} ?>
 --FILE--
 <?php
 

--- a/src/Symfony/Component/Debug/Resources/ext/tests/002.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/002.phpt
@@ -1,7 +1,9 @@
 --TEST--
 Test symfony_debug_backtrace in case of fatal error
 --SKIPIF--
-<?php if (!extension_loaded('symfony_debug')) print 'skip'; ?>
+<?php if (!extension_loaded('symfony_debug')) {
+    echo 'skip';
+} ?>
 --FILE--
 <?php
 

--- a/src/Symfony/Component/Debug/Resources/ext/tests/002_1.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/002_1.phpt
@@ -1,7 +1,9 @@
 --TEST--
 Test symfony_debug_backtrace in case of non fatal error
 --SKIPIF--
-<?php if (!extension_loaded('symfony_debug')) print 'skip'; ?>
+<?php if (!extension_loaded('symfony_debug')) {
+    echo 'skip';
+} ?>
 --FILE--
 <?php
 

--- a/src/Symfony/Component/Debug/Resources/ext/tests/003.phpt
+++ b/src/Symfony/Component/Debug/Resources/ext/tests/003.phpt
@@ -1,7 +1,9 @@
 --TEST--
 Test ErrorHandler in case of fatal error
 --SKIPIF--
-<?php if (!extension_loaded('symfony_debug')) print 'skip'; ?>
+<?php if (!extension_loaded('symfony_debug')) {
+    echo 'skip';
+} ?>
 --FILE--
 <?php
 

--- a/src/Symfony/Component/Debug/Tests/phpt/exception_rethrown.phpt
+++ b/src/Symfony/Component/Debug/Tests/phpt/exception_rethrown.phpt
@@ -26,7 +26,6 @@ ErrorHandler::register()->setDefaultLogger(new TestLogger());
 ini_set('display_errors', 1);
 
 throw new \Exception('foo');
-
 ?>
 --EXPECTF--
 Uncaught Exception: foo

--- a/src/Symfony/Component/Debug/Tests/phpt/fatal_with_nested_handlers.phpt
+++ b/src/Symfony/Component/Debug/Tests/phpt/fatal_with_nested_handlers.phpt
@@ -24,7 +24,9 @@ var_dump(array(
 $eHandler[0]->setExceptionHandler('print_r');
 
 if (true) {
-    class Broken implements \Serializable {};
+    class Broken implements \Serializable
+    {
+    }
 }
 
 ?>

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/LegacyPdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/LegacyPdoSessionHandler.php
@@ -54,6 +54,8 @@ class LegacyPdoSessionHandler implements \SessionHandlerInterface
     private $timeCol;
 
     /**
+     * Construct new legacy PDO session handler.
+     *
      * List of available options:
      *  * db_table: The name of the table [required]
      *  * db_id_col: The column where to store the session id [default: sess_id]

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
@@ -29,7 +29,7 @@ class MemcacheSessionHandler implements \SessionHandlerInterface
     private $prefix;
 
     /**
-     * Constructing new Memcache session handler.
+     * Constructor.
      *
      * List of available options:
      *  * prefix: The prefix to use for the memcache keys in order to avoid collision

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
@@ -29,6 +29,8 @@ class MemcacheSessionHandler implements \SessionHandlerInterface
     private $prefix;
 
     /**
+     * Constructing new Memcache session handler.
+     *
      * List of available options:
      *  * prefix: The prefix to use for the memcache keys in order to avoid collision
      *  * expiretime: The time to live in seconds

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -34,7 +34,7 @@ class MemcachedSessionHandler implements \SessionHandlerInterface
     private $prefix;
 
     /**
-     * Constructing new Memcached session handler.
+     * Constructor.
      *
      * List of available options:
      *  * prefix: The prefix to use for the memcached keys in order to avoid collision

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcachedSessionHandler.php
@@ -34,6 +34,8 @@ class MemcachedSessionHandler implements \SessionHandlerInterface
     private $prefix;
 
     /**
+     * Constructing new Memcached session handler.
+     *
      * List of available options:
      *  * prefix: The prefix to use for the memcached keys in order to avoid collision
      *  * expiretime: The time to live in seconds

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -29,6 +29,8 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
     private $options;
 
     /**
+     * Constructing new MongoDB session handler.
+     *
      * List of available options:
      *  * database: The name of the database [required]
      *  * collection: The name of the collection [required]

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -29,7 +29,7 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
     private $options;
 
     /**
-     * Constructing new MongoDB session handler.
+     * Constructor.
      *
      * List of available options:
      *  * database: The name of the database [required]

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @method Request|null getRequest() A Request instance
+ * @method Request|null  getRequest()  A Request instance
  * @method Response|null getResponse() A Response instance
  */
 class Client extends BaseClient

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -36,7 +36,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     private $traces = array();
 
     /**
-     * Constructing new HTTP cache.
+     * Constructor.
      *
      * The available options are:
      *

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -36,6 +36,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     private $traces = array();
 
     /**
+     * Constructing new HTTP cache.
+     *
      * The available options are:
      *
      *   * debug:                 If true, the traces are added as a HTTP header to ease debugging

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -34,6 +34,8 @@ class Route implements \Serializable
     private $compiled;
 
     /**
+     * Constructing new route.
+     *
      * Available options:
      *
      *  * compiler_class: A class name able to compile this route instance (RouteCompiler by default)

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -34,7 +34,7 @@ class Route implements \Serializable
     private $compiled;
 
     /**
-     * Constructing new route.
+     * Constructor.
      *
      * Available options:
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Reason for this PR is that one want to have `php-cs-fixer fix -v` command executed without changes that shall not be applied for this repo. To achieve that, we need to groom config to exclude files that violate CS willingly, fix files that are violating CS unwillingly, and deliver missing case handling at PHP CS Fixer itself (https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3359) (already merged!).
  