### PR TITLE
[Security] Fix fatal error on non string username

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderAdapter;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use Symfony\Component\Security\Csrf\CsrfToken;
@@ -107,15 +108,17 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
             }
         }
 
-        if ($this->options['post_only']) {
-            $username = trim($request->request->get($this->options['username_parameter'], null, true));
-            $password = $request->request->get($this->options['password_parameter'], null, true);
-        } else {
-            $username = trim($request->get($this->options['username_parameter'], null, true));
-            $password = $request->get($this->options['password_parameter'], null, true);
+        $requestBag = $this->options['post_only'] ? $request->request : $request;
+        $username = $requestBag->get($this->options['username_parameter'], null, true);
+        $password = $requestBag->get($this->options['password_parameter'], null, true);
+
+        if (!\is_string($username) || (\is_object($username) && !\method_exists($username, '__toString'))) {
+            throw new BadRequestHttpException(sprintf('The key "%s" must be a string, "%s" given.', $this->options['username_parameter'], \gettype($username)));
         }
 
-        if (strlen($username) > Security::MAX_USERNAME_LENGTH) {
+        $username = trim($username);
+
+        if (\strlen($username) > Security::MAX_USERNAME_LENGTH) {
             throw new BadCredentialsException('Invalid username.');
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
@@ -14,8 +14,15 @@ namespace Symfony\Component\Security\Tests\Http\Firewall;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
 use Symfony\Component\Security\Http\Firewall\UsernamePasswordFormAuthenticationListener;
 use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 
 class UsernamePasswordFormAuthenticationListenerTest extends TestCase
 {
@@ -65,6 +72,31 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
             ->method('getRequest')
             ->will($this->returnValue($request))
         ;
+
+        $listener->handle($event);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     * @expectedExceptionMessage The key "_username" must be a string, "array" given.
+     */
+    public function testHandleNonStringUsername()
+    {
+        $request = Request::create('/login_check', 'POST', array('_username' => array()));
+        $request->setSession($this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock());
+
+        $listener = new UsernamePasswordFormAuthenticationListener(
+            new TokenStorage(),
+            $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock(),
+            new SessionAuthenticationStrategy(SessionAuthenticationStrategy::NONE),
+            $httpUtils = new HttpUtils(),
+            'foo',
+            new DefaultAuthenticationSuccessHandler($httpUtils),
+            new DefaultAuthenticationFailureHandler($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $httpUtils),
+            array('require_previous_session' => false)
+        );
+
+        $event = new GetResponseEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener->handle($event);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/25612
| License       | MIT
| Doc PR        | n/a

That's consistent with what #22569 did for the `json_login` listener.