### PR TITLE
[DX] [DI] Improve exception for invalid setter injection arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -476,6 +476,9 @@ class YamlFileLoader extends FileLoader
                     $args = isset($call[1]) ? $this->resolveServices($call[1], $file) : array();
                 }
 
+                if (!is_array($args)) {
+                    throw new InvalidArgumentException(sprintf('The second parameter for function call "%s" must be an array of its arguments for service "%s" in %s. Check your YAML syntax.', $method, $id, $file));
+                }
                 $definition->addMethodCall($method, $args);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| License       | MIT

Improve the exception message for when you accidentally write setter injection wrong as I did too many times:
```yaml
My\Logging\Service:
  calls: [ [ setLogger, "@logger" ] ]
```
Used to throw:

> Type error: Argument 2 passed to Symfony\Component\DependencyInjection\Definition::addMethodCall() must be of the type array, object given, called in /var/www/project/vendor/symfony/dependency-injection/Loader/YamlFileLoader.php on line 457

Now throws:

> The second parameter for function call "setLogger" must be an array of its arguments for service "My\Namespace\Service" in /var/www/project/config/services.yaml. Check your YAML syntax in /var/www/project/config/services.yaml (which is loaded in resource "/var/www/project/config/services.yaml").

(semi-offtopic: why isn't `LoggerAwareInterface` in the default autoconfigure for FrameworkExtension?)

  