### PR TITLE
[TwigBridge] Fix layout of submit_row in bootstrap_4_layout

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -169,6 +169,10 @@
     </{{ element|default('div') }}>
 {%- endblock form_row %}
 
+{% block submit_row -%}
+    {{- form_widget(form) -}}
+{%- endblock submit_row %}
+
 {# Errors #}
 
 {% block form_errors -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->

Fix default layout of submit button in `bootstrap_4_layout.html.twig` just like below.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4360663/34511237-5db35f9a-f09d-11e7-953a-f9820ab87f83.png) | ![image](https://user-images.githubusercontent.com/4360663/34511245-6aa830ae-f09d-11e7-9c84-29d9cfd8b2a3.png) |
