### PR TITLE
[WebServerBundle] use interface_exists instead of class_exists

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
@@ -37,7 +37,7 @@ class ServerLogCommand extends Command
         }
 
         // based on a symfony/symfony package, it crashes due a missing FormatterInterface from monolog/monolog
-        if (!class_exists(FormatterInterface::class)) {
+        if (!interface_exists(FormatterInterface::class)) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This bug was introduced in #25026 
