### PR TITLE
[WebProfilerBundle] set the var in the right scope

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -14,9 +14,10 @@
     } %}
 {% endif %}
 
-{% set has_time_events = collector.events|length > 0 %}
 
 {% block toolbar %}
+    {% set has_time_events = collector.events|length > 0 %}
+
     {% set total_time = has_time_events ? '%.0f'|format(collector.duration) : 'n/a' %}
     {% set initialization_time = collector.events|length ? '%.0f'|format(collector.inittime) : 'n/a' %}
     {% set status_color = has_time_events and collector.duration > 1000 ? 'yellow' : '' %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -50,6 +50,7 @@
 {% endblock %}
 
 {% block panel %}
+    {% set has_time_events = collector.events|length > 0 %}
     <h2>Performance metrics</h2>
 
     <div class="metrics">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | - 
| License       | MIT
| Doc PR        | - 

![2018-01-04 um 09 29 54](https://user-images.githubusercontent.com/1322118/34555989-de6fd11c-f134-11e7-81f7-9b840a946073.png)

This PR fixes the bug when displaying the toolbar. The variable "has_time_events" was not created in the scope of the toolbar.