### PR TITLE
Release v2.7.40

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,26 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.40 (2018-01-05)
+
+ * bug #25532 [HttpKernel] Disable CSP header on exception pages (ostrolucky)
+ * bug #25491 [Routing] Use the default host even if context is empty (sroze)
+ * bug #25662 Dumper shouldn't use html format for phpdbg / cli-server (jhoff)
+ * bug #25529 [Validator] Fix access to root object when using composite constraint (ostrolucky)
+ * bug #25430 Fixes for Oracle in PdoSessionHandler (elislenio)
+ * bug #25599 Add application/ld+json format associated to json (vincentchalamon)
+ * bug #25407 [Console] Commands with an alias should not be recognized as ambiguous (Simperfit)
+ * bug #25521 [Console] fix a bug when you are passing a default value and passing -n would output the index (Simperfit)
+ * bug #25489 [FrameworkBundle] remove esi/ssi renderers if inactive (dmaicher)
+ * bug #25427 Preserve percent-encoding in URLs when performing redirects in the UrlMatcher (mpdude)
+ * bug #25480 [FrameworkBundle] add missing validation options to XSD file (xabbuh)
+ * bug #25487 [Console] Fix a bug when passing a letter that could be an alias (Simperfit)
+ * bug #25233 [TwigBridge][Form] Fix hidden currency element with Bootstrap 3 theme (julienfalque)
+ * bug #25408 [Debug] Fix catching fatal errors in case of nested error handlers (nicolas-grekas)
+ * bug #25330 [HttpFoundation] Support 0 bit netmask in IPv6 (`::/0`) (stephank)
+ * bug #25410 [HttpKernel] Fix logging of post-terminate errors/exceptions (nicolas-grekas)
+ * bug #25323 [ExpressionLanguage] throw an SyntaxError instead of an undefined index notice (Simperfit)
+
 * 2.7.39 (2017-12-04)
 
  * bug #25278 Fix for missing whitespace control modifier in form layout (kubawerlos)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,13 +13,13 @@ Symfony is the result of the work of many people who made the code better
  - Jordi Boggiano (seldaek)
  - Victor Berchet (victor)
  - Johannes S (johannes)
- - Jakub Zalas (jakubzalas)
  - Kévin Dunglas (dunglas)
+ - Jakub Zalas (jakubzalas)
  - Kris Wallsmith (kriswallsmith)
  - Ryan Weaver (weaverryan)
+ - Robin Chalas (chalas_r)
  - Javier Eguiluz (javier.eguiluz)
  - Maxime Steinhausser (ogizanagi)
- - Robin Chalas (chalas_r)
  - Hugo Hamon (hhamon)
  - Abdellatif Ait boudad (aitboudad)
  - Grégoire Pineau (lyrixx)
@@ -48,21 +48,22 @@ Symfony is the result of the work of many people who made the code better
  - stealth35 ‏ (stealth35)
  - Alexander Mols (asm89)
  - Iltar van der Berg (kjarli)
+ - Yonel Ceruto (yonelceruto)
  - Bulat Shakirzyanov (avalanche123)
  - Peter Rehm (rpet)
  - Saša Stamenković (umpirsky)
  - Henrik Bjørnskov (henrikbjorn)
- - Yonel Ceruto (yonelceruto)
  - Miha Vrhovnik
  - Matthias Pigulla (mpdude)
  - Diego Saint Esteben (dii3g0)
- - Konstantin Kudryashov (everzet)
- - Bilal Amarni (bamarni)
- - Kevin Bond (kbond)
  - Dany Maillard (maidmaid)
+ - Konstantin Kudryashov (everzet)
+ - Kevin Bond (kbond)
+ - Bilal Amarni (bamarni)
  - Pierre du Plessis (pierredup)
  - Florin Patan (florinpatan)
  - Jérémy DERUSSÉ (jderusse)
+ - Amrouche Hamza (simperfit)
  - Gábor Egyed (1ed)
  - Michel Weimerskirch (mweimerskirch)
  - Andrej Hudec (pulzarraider)
@@ -70,16 +71,17 @@ Symfony is the result of the work of many people who made the code better
  - Eric Clemmons (ericclemmons)
  - Jáchym Toušek (enumag)
  - Charles Sarrazin (csarrazi)
+ - Titouan Galopin (tgalopin)
+ - Samuel ROZE (sroze)
  - Konstantin Myakshin (koc)
  - Christian Raue
  - Arnout Boks (aboks)
  - Deni
  - Henrik Westphal (snc)
  - Dariusz Górecki (canni)
- - Titouan Galopin (tgalopin)
+ - Issei Murasawa (issei_m)
  - Douglas Greenshields (shieldo)
  - Tobias Nyholm (tobias)
- - Issei Murasawa (issei_m)
  - Lee McDermott
  - Brandon Turner
  - Luis Cordova (cordoval)
@@ -97,12 +99,11 @@ Symfony is the result of the work of many people who made the code better
  - Arnaud Le Blanc (arnaud-lb)
  - Maxime STEINHAUSSER
  - Michal Piotrowski (eventhorizon)
- - Samuel ROZE (sroze)
  - Tim Nagel (merk)
- - Amrouche Hamza (simperfit)
- - Brice BERNARD (brikou)
- - Baptiste Clavié (talus)
  - Vladimir Reznichenko (kalessil)
+ - Brice BERNARD (brikou)
+ - David Maicher (dmaicher)
+ - Baptiste Clavié (talus)
  - marc.weistroff
  - lenar
  - Alexander Schwenn (xelaris)
@@ -118,17 +119,16 @@ Symfony is the result of the work of many people who made the code better
  - Tomáš Votruba (tomas_votruba)
  - Fabien Pennequin (fabienpennequin)
  - Gordon Franke (gimler)
- - David Maicher (dmaicher)
  - Eric GELOEN (gelo)
  - Daniel Wehner (dawehner)
  - Tugdual Saunier (tucksaun)
+ - Grégoire Paris (greg0ire)
  - Théo FIDRY (theofidry)
  - Robert Schönthal (digitalkaoz)
  - Florian Lonqueu-Brochard (florianlb)
  - Sebastiaan Stok (sstok)
  - Stefano Sala (stefano.sala)
  - Evgeniy (ewgraf)
- - Grégoire Paris (greg0ire)
  - Vincent AUBERT (vincent)
  - Juti Noppornpitak (shiroyuki)
  - Tigran Azatyan (tigranazatyan)
@@ -139,6 +139,8 @@ Symfony is the result of the work of many people who made the code better
  - Pablo Godel (pgodel)
  - Jérémie Augustin (jaugustin)
  - Andréia Bohner (andreia)
+ - Alex Pott
+ - Julien Falque (julienfalque)
  - Rafael Dohms (rdohms)
  - Arnaud Kleinpeter (nanocom)
  - jwdeitch
@@ -147,11 +149,9 @@ Symfony is the result of the work of many people who made the code better
  - Jérôme Vasseur (jvasseur)
  - Oleg Voronkovich
  - Philipp Wahala (hifi)
- - Alex Pott
  - Vyacheslav Pavlov
  - Richard van Laak (rvanlaak)
  - Javier Spagnoletti (phansys)
- - Julien Falque (julienfalque)
  - Richard Shank (iampersistent)
  - Thomas Rabaix (rande)
  - Rouven Weßling (realityking)
@@ -174,6 +174,7 @@ Symfony is the result of the work of many people who made the code better
  - Dmitrii Chekaliuk (lazyhammer)
  - Clément JOBEILI (dator)
  - Daniel Espendiller
+ - Valentin Udaltsov (vudaltsov)
  - Possum
  - Dorian Villet (gnutix)
  - Sergey Linnik (linniksa)
@@ -190,7 +191,6 @@ Symfony is the result of the work of many people who made the code better
  - Stepan Anchugov (kix)
  - bronze1man
  - sun (sun)
- - Valentin Udaltsov (vudaltsov)
  - Larry Garfield (crell)
  - Martin Schuhfuß (usefulthink)
  - apetitpa
@@ -247,11 +247,13 @@ Symfony is the result of the work of many people who made the code better
  - Alessandro Chitolina
  - Kristen Gilden (kgilden)
  - Pierre-Yves LEBECQ (pylebecq)
+ - Niels Keurentjes (curry684)
  - Jordan Samouh (jordansamouh)
  - Jakub Kucharovic (jkucharovic)
  - Uwe Jäger (uwej711)
  - Eugene Leonovich (rybakit)
  - Filippo Tessarotto
+ - Gabriel Ostrolucký
  - Joseph Rouff (rouffj)
  - Félix Labrecque (woodspire)
  - GordonsLondon
@@ -270,9 +272,11 @@ Symfony is the result of the work of many people who made the code better
  - DQNEO
  - jdhoek
  - Pavel Batanov (scaytrase)
+ - Bob den Otter (bopp)
  - Nikita Konstantinov
  - Wodor Wodorski
  - Oskar Stark (oskarstark)
+ - Dariusz
  - Thomas Lallement (raziel057)
  - Giorgio Premi
  - Matthieu Napoli (mnapoli)
@@ -284,6 +288,7 @@ Symfony is the result of the work of many people who made the code better
  - Kim Hemsø Rasmussen (kimhemsoe)
  - Wouter Van Hecke
  - Jérôme Parmentier (lctrs)
+ - Michael Babker (mbabker)
  - Peter Kruithof (pkruithof)
  - Michael Holm (hollo)
  - Marc Weistroff (futurecat)
@@ -301,6 +306,7 @@ Symfony is the result of the work of many people who made the code better
  - Andrey Esaulov (andremaha)
  - Grégoire Passault (gregwar)
  - Jerzy Zawadzki (jzawadzki)
+ - Wouter J
  - Ismael Ambrosi (iambrosi)
  - Baptiste Lafontaine
  - Aurelijus Valeiša (aurelijus)
@@ -311,7 +317,6 @@ Symfony is the result of the work of many people who made the code better
  - Tiago Ribeiro (fixe)
  - Hidde Boomsma (hboomsma)
  - John Bafford (jbafford)
- - Bob den Otter (bopp)
  - Adrian Rudnik (kreischweide)
  - Francesc Rosàs (frosas)
  - Massimiliano Arione (garak)
@@ -324,7 +329,6 @@ Symfony is the result of the work of many people who made the code better
  - Thierry Thuon (lepiaf)
  - Ricard Clau (ricardclau)
  - Mark Challoner (markchalloner)
- - Dariusz
  - Gennady Telegin (gtelegin)
  - Ben Davies (bendavies)
  - Erin Millard
@@ -339,16 +343,15 @@ Symfony is the result of the work of many people who made the code better
  - Inal DJAFAR (inalgnu)
  - Christian Gärtner (dagardner)
  - Tomasz Kowalczyk (thunderer)
- - Michael Babker (mbabker)
  - François-Xavier de Guillebon (de-gui_f)
  - Damien Alexandre (damienalexandre)
  - Felix Labrecque
  - Yaroslav Kiliba
  - Terje Bråten
+ - Yanick Witschi (toflar)
  - Robbert Klarenbeek (robbertkl)
  - Edi Modrić (emodric)
  - Thomas Calvet (fancyweb)
- - Niels Keurentjes (curry684)
  - JhonnyL
  - David Badura (davidbadura)
  - hossein zolfi (ocean)
@@ -414,6 +417,7 @@ Symfony is the result of the work of many people who made the code better
  - Jan Schumann
  - Niklas Fiekas
  - Markus Bachmann (baachi)
+ - Gabriel Caruso
  - lancergr
  - Mihai Stancu
  - Olivier Dolbeau (odolbeau)
@@ -450,7 +454,6 @@ Symfony is the result of the work of many people who made the code better
  - Anton Bakai
  - Maxime Veber (nek-)
  - Alex Bakhturin
- - Yanick Witschi (toflar)
  - Alexander Obuhovich (aik099)
  - boombatower
  - Fabrice Bernhard (fabriceb)
@@ -478,7 +481,6 @@ Symfony is the result of the work of many people who made the code better
  - Roy Van Ginneken (rvanginneken)
  - ondrowan
  - Barry vd. Heuvel (barryvdh)
- - Wouter J
  - Florent Mata
  - Evan S Kaufman (evanskaufman)
  - mcben
@@ -562,6 +564,7 @@ Symfony is the result of the work of many people who made the code better
  - Max Rath (drak3)
  - Stéphane Escandell (sescandell)
  - Konstantin S. M. Möllers (ksmmoellers)
+ - Alessandro Lai (jean85)
  - James Johnston
  - Sinan Eldem
  - Alexandre Dupuy (satchette)
@@ -617,6 +620,7 @@ Symfony is the result of the work of many people who made the code better
  - Antoine Corcy
  - Sascha Grossenbacher
  - Szijarto Tamas
+ - Robin Lehrmann (robinlehrmann)
  - Catalin Dan
  - Stephan Vock
  - Benjamin Zikarsky (bzikarsky)
@@ -692,6 +696,7 @@ Symfony is the result of the work of many people who made the code better
  - Andrew Hilobok (hilobok)
  - Noah Heck (myesain)
  - Christian Soronellas (theunic)
+ - Johann Pardanaud
  - Adam Szaraniec (mimol)
  - Yosmany Garcia (yosmanyga)
  - Wouter de Wild
@@ -811,6 +816,7 @@ Symfony is the result of the work of many people who made the code better
  - Gábor Tóth
  - Daniel Cestari
  - David Lima
+ - Brian Freytag (brianfreytag)
  - Brunet Laurent (lbrunet)
  - Mikhail Yurasov (mym)
  - LOUARDI Abdeltif (ouardisoft)
@@ -843,9 +849,9 @@ Symfony is the result of the work of many people who made the code better
  - Colin O&#039;Dell (colinodell)
  - xaav
  - Mahmoud Mostafa (mahmoud)
- - Alessandro Lai
  - Pieter
  - Michael Tibben
+ - Billie Thompson
  - Sander Marechal
  - Radosław Benkel
  - jean pasqualini (darkilliant)
@@ -898,10 +904,10 @@ Symfony is the result of the work of many people who made the code better
  - Goran Juric
  - Laurent Ghirardotti (laurentg)
  - Nicolas Macherey
+ - Guido Donnari
  - AKeeman (akeeman)
  - Lin Clark
  - Jeremy David (jeremy.david)
- - Robin Lehrmann (robinlehrmann)
  - Troy McCabe
  - Ville Mattila
  - ilyes kooli
@@ -952,6 +958,7 @@ Symfony is the result of the work of many people who made the code better
  - DerManoMann
  - Olaf Klischat
  - orlovv
+ - Haralan Dobrev (hkdobrev)
  - Jhonny Lidfors (jhonny)
  - Julien Bianchi (jubianchi)
  - Robert Meijers
@@ -967,7 +974,6 @@ Symfony is the result of the work of many people who made the code better
  - Alex Bowers
  - Jeremy Bush
  - wizhippo
- - Gabriel Ostrolucký
  - Viacheslav Sychov
  - Carlos Ortega Huetos
  - rpg600
@@ -1033,6 +1039,7 @@ Symfony is the result of the work of many people who made the code better
  - Marco
  - Marc Torres
  - Alberto Aldegheri
+ - Dalibor Karlović
  - heccjj
  - Alexandre Melard
  - Jay Klehr
@@ -1042,6 +1049,7 @@ Symfony is the result of the work of many people who made the code better
  - Jakub Kulhan
  - Ilia (aliance)
  - Mo Di (modi)
+ - Pablo Schläpfer
  - Jelte Steijaert (jelte)
  - Quique Porta (quiqueporta)
  - stoccc
@@ -1084,6 +1092,7 @@ Symfony is the result of the work of many people who made the code better
  - Grzegorz Zdanowski (kiler129)
  - sl_toto (sl_toto)
  - Walter Dal Mut (wdalmut)
+ - Matthieu
  - Albin Kerouaton
  - Sébastien HOUZÉ
  - Jingyu Wang
@@ -1103,6 +1112,7 @@ Symfony is the result of the work of many people who made the code better
  - Jules Lamur
  - Renato Mendes Figueiredo
  - ShiraNai7
+ - Antal Áron (antalaron)
  - Markus Fasselt (digilist)
  - Vašek Purchart (vasek-purchart)
  - Janusz Jabłoński (yanoosh)
@@ -1144,6 +1154,7 @@ Symfony is the result of the work of many people who made the code better
  - Tomaz Ahlin
  - Marcus Stöhr (dafish)
  - Emmanuel Vella (emmanuel.vella)
+ - Jonathan Johnson (jrjohnson)
  - Carsten Nielsen (phreaknerd)
  - Mathieu Rochette
  - Jay Severson
@@ -1218,6 +1229,7 @@ Symfony is the result of the work of many people who made the code better
  - Antoine Bellion (abellion)
  - Ramon Kleiss (akathos)
  - César Suárez (csuarez)
+ - Bjorn Twachtmann (dotbjorn)
  - Nicolas Badey (nico-b)
  - Shane Preece (shane)
  - Johannes Goslar
@@ -1266,6 +1278,7 @@ Symfony is the result of the work of many people who made the code better
  - Stefan Hüsges (tronsha)
  - Dan Blows
  - Matt Wells
+ - Nicolas Appriou
  - stloyd
  - Chris Tickner
  - Andrew Coulton
@@ -1281,7 +1294,9 @@ Symfony is the result of the work of many people who made the code better
  - Matthew Donadio
  - Andreas
  - Thomas Chmielowiec
+ - shdev
  - Andrey Ryaguzov
+ - Stefan
  - Peter Bex
  - Manatsawin Hanmongkolchai
  - Gunther Konig
@@ -1350,6 +1365,7 @@ Symfony is the result of the work of many people who made the code better
  - Grinbergs Reinis (shima5)
  - Artem Lopata (bumz)
  - Nicole Cordes
+ - Roman Orlov
  - VolCh
  - Alexey Popkov
  - Gijs Kunze
@@ -1372,12 +1388,13 @@ Symfony is the result of the work of many people who made the code better
  - Dmitry Korotovsky
  - mcorteel
  - Michael van Tricht
+ - Tim Strehle
  - Sam Ward
  - Walther Lalk
  - Adam
+ - Stéphan Kochen
  - devel
  - taiiiraaa
- - Johann Pardanaud
  - Trevor Suarez
  - gedrox
  - Alan Bondarchuk
@@ -1393,6 +1410,7 @@ Symfony is the result of the work of many people who made the code better
  - bertillon
  - Bertalan Attila
  - Yannick Bensacq (cibou)
+ - Frédéric G. Marand (fgm)
  - Freek Van der Herten (freekmurze)
  - Luca Genuzio (genuzio)
  - Hans Nilsson (hansnilsson)
@@ -1440,9 +1458,11 @@ Symfony is the result of the work of many people who made the code better
  - Alex Pods
  - hadriengem
  - timaschew
+ - Jochen Mandl
  - Ian Phillips
  - Haritz
  - Matthieu Prat
+ - Ion Bazan
  - Grummfy
  - Filipe Guerra
  - Gerben Wijnja
@@ -1469,6 +1489,7 @@ Symfony is the result of the work of many people who made the code better
  - Juan M Martínez
  - Gilles Gauthier
  - ddebree
+ - Kuba Werłos
  - Tomas Liubinas
  - Alex
  - Klaas Naaijkens
@@ -1541,6 +1562,7 @@ Symfony is the result of the work of many people who made the code better
  - Kristof Van Cauwenbergh (kristofvc)
  - Paulius Jarmalavičius (pjarmalavicius)
  - Ramon Henrique Ornelas (ramonornela)
+ - Ricardo de Vries (ricknox)
  - Markus S. (staabm)
  - Till Klampaeckel (till)
  - Tobias Weinert (tweini)
@@ -1548,6 +1570,7 @@ Symfony is the result of the work of many people who made the code better
  - Wotre
  - goohib
  - Xavier HAUSHERR
+ - Ron Gähler
  - Edwin Hageman
  - Mantas Urnieža
  - Cas
@@ -1563,12 +1586,14 @@ Symfony is the result of the work of many people who made the code better
  - BenjaminBeck
  - Aurelijus Rožėnas
  - Vladimir Tsykun
+ - Jordan Hoff
  - znerol
  - Christian Eikermann
  - Antonio Angelino
  - Matt Fields
  - Niklas Keller
  - Vladimir Sazhin
+ - Tomas Kmieliauskas
  - Billie Thompson
  - lol768
  - jamogon
@@ -1582,6 +1607,7 @@ Symfony is the result of the work of many people who made the code better
  - patrick-mcdougle
  - Dariusz Czech
  - Anonymous User
+ - Paweł Tomulik
  - Eric J. Duran
  - Alexandru Bucur
  - cmfcmf
@@ -1605,7 +1631,6 @@ Symfony is the result of the work of many people who made the code better
  - vlechemin
  - Brian Corrigan
  - Ladislav Tánczos
- - Brian Freytag
  - Skorney
  - fmarchalemisys
  - mieszko4
@@ -1617,6 +1642,7 @@ Symfony is the result of the work of many people who made the code better
  - Markus Staab
  - Pierre-Louis LAUNAY
  - djama
+ - Michael Gwynne
  - Eduardo Conceição
  - Jon Cave
  - Sébastien HOUZE
@@ -1626,6 +1652,7 @@ Symfony is the result of the work of many people who made the code better
  - Shude
  - Ondřej Führer
  - Sema
+ - Michael Käfer
  - Elan Ruusamäe
  - Thorsten Hallwas
  - Michael Squires
@@ -1653,6 +1680,7 @@ Symfony is the result of the work of many people who made the code better
  - Diego Campoy
  - TeLiXj
  - Oncle Tom
+ - Sam Anthony
  - Christian Stocker
  - Dawid Nowak
  - Lesnykh Ilia
@@ -1671,6 +1699,7 @@ Symfony is the result of the work of many people who made the code better
  - arduanov
  - sualko
  - Bilge
+ - ADmad
  - Nicolas Roudaire
  - Alfonso (afgar)
  - Andreas Forsblom (aforsblo)
@@ -1764,6 +1793,7 @@ Symfony is the result of the work of many people who made the code better
  - Moritz Kraft (userfriendly)
  - Víctor Mateo (victormateo)
  - Vincent (vincent1870)
+ - Vincent CHALAMON (vincentchalamon)
  - Eugene Babushkin (warl)
  - Wouter Sioen (wouter_sioen)
  - Xavier Amado (xamado)
@@ -1786,6 +1816,7 @@ Symfony is the result of the work of many people who made the code better
  - Michael
  - fh-github@fholzhauer.de
  - AbdElKader Bouadjadja
+ - DSeemiller
  - Jan Emrich
  - Mark Topper
  - Xavier REN
@@ -1799,6 +1830,7 @@ Symfony is the result of the work of many people who made the code better
  - Marc Lemay (flug)
  - Henne Van Och (hennevo)
  - Jeroen De Dauw (jeroendedauw)
+ - Daniel Alejandro Castro Arellano (lexcast)
  - Maxime COLIN (maximecolin)
  - Muharrem Demirci (mdemirci)
  - Evgeny Z (meze)
@@ -1808,3 +1840,4 @@ Symfony is the result of the work of many people who made the code better
  - Thomas BERTRAND (sevrahk)
  - Matej Žilák (teo_sk)
  - Vladislav Vlastovskiy (vlastv)
+ - RENAUDIN Xavier (xorrox)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.40-DEV';
+    const VERSION = '2.7.40';
     const VERSION_ID = 20740;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 40;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.7.39...v2.7.40)

 * bug #25532 [HttpKernel] Disable CSP header on exception pages (@ostrolucky)
 * bug #25491 [Routing] Use the default host even if context is empty (@sroze)
 * bug #25662 Dumper shouldn't use html format for phpdbg / cli-server (@jhoff)
 * bug #25529 [Validator] Fix access to root object when using composite constraint (@ostrolucky)
 * bug #25430 Fixes for Oracle in PdoSessionHandler (@elislenio)
 * bug #25599 Add application/ld+json format associated to json (@vincentchalamon)
 * bug #25407 [Console] Commands with an alias should not be recognized as ambiguous (@Simperfit)
 * bug #25521 [Console] fix a bug when you are passing a default value and passing -n would output the index (@Simperfit)
 * bug #25489 [FrameworkBundle] remove esi/ssi renderers if inactive (@dmaicher)
 * bug #25427 Preserve percent-encoding in URLs when performing redirects in the UrlMatcher (@mpdude)
 * bug #25480 [FrameworkBundle] add missing validation options to XSD file (@xabbuh)
 * bug #25487 [Console] Fix a bug when passing a letter that could be an alias (@Simperfit)
 * bug #25233 [TwigBridge][Form] Fix hidden currency element with Bootstrap 3 theme (@julienfalque)
 * bug #25408 [Debug] Fix catching fatal errors in case of nested error handlers (@nicolas-grekas)
 * bug #25330 [HttpFoundation] Support 0 bit netmask in IPv6 (`::/0`) (@stephank)
 * bug #25410 [HttpKernel] Fix logging of post-terminate errors/exceptions (@nicolas-grekas)
 * bug #25323 [ExpressionLanguage] throw an SyntaxError instead of an undefined index notice (@Simperfit)
