### PR TITLE
[FrameworkBundle] Fix using "annotations.cached_reader" in after-removing passes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAnnotationsCachedReaderPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAnnotationsCachedReaderPass.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @internal
@@ -29,14 +28,14 @@ class AddAnnotationsCachedReaderPass implements CompilerPassInterface
         // "annotation_reader" at build time don't get any cache
         if ($container->hasDefinition('annotations.cached_reader')) {
             $reader = $container->getDefinition('annotations.cached_reader');
-            $tags = $reader->getTags();
+            $properties = $reader->getProperties();
 
-            if (isset($tags['annotations.cached_reader'][0]['provider'])) {
-                if ($container->hasAlias($provider = $tags['annotations.cached_reader'][0]['provider'])) {
-                    $provider = (string) $container->getAlias($provider);
-                }
+            if (isset($properties['cacheProviderBackup'])) {
+                $provider = $properties['cacheProviderBackup']->getValues()[0];
+                unset($properties['cacheProviderBackup']);
+                $reader->setProperties($properties);
                 $container->set('annotations.cached_reader', null);
-                $container->setDefinition('annotations.cached_reader', $reader->replaceArgument(1, new Reference($provider)));
+                $container->setDefinition('annotations.cached_reader', $reader->replaceArgument(1, $provider));
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -25,6 +25,7 @@ use Symfony\Component\Config\ResourceCheckerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -1131,7 +1132,8 @@ class FrameworkExtension extends Extension
             $container
                 ->getDefinition('annotations.cached_reader')
                 ->replaceArgument(2, $config['debug'])
-                ->addTag('annotations.cached_reader', array('provider' => $cacheService))
+                // temporary property to lazy-reference the cache provider without using it until AddAnnotationsCachedReaderPass runs
+                ->setProperty('cacheProviderBackup', new ServiceClosureArgument(new Reference($cacheService)))
             ;
             $container->setAlias('annotation_reader', 'annotations.cached_reader');
             $container->setAlias(Reader::class, new Alias('annotations.cached_reader', false));

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -91,7 +91,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new TemplatingPass());
         $this->addCompilerPassIfExists($container, AddConstraintValidatorsPass::class, PassConfig::TYPE_BEFORE_REMOVING);
-        $container->addCompilerPass(new AddAnnotationsCachedReaderPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new AddAnnotationsCachedReaderPass(), PassConfig::TYPE_AFTER_REMOVING, -255);
         $this->addCompilerPassIfExists($container, AddValidatorInitializersPass::class);
         $this->addCompilerPassIfExists($container, AddConsoleCommandPass::class);
         $container->addCompilerPass(new TranslatorPass());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\DependencyInjection\AnnotationReaderPass;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\DependencyInjection\Config\CustomConfig;
@@ -27,6 +28,6 @@ class TestBundle extends Bundle
 
         $extension->setCustomConfig(new CustomConfig());
 
-        $container->addCompilerPass(new AnnotationReaderPass());
+        $container->addCompilerPass(new AnnotationReaderPass(), PassConfig::TYPE_AFTER_REMOVING);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25695
| License       | MIT
| Doc PR        | -

When `annotation_reader` is instantiated in an after-removing pass, it gets the real cache provider, instead of the dummy one that should be provided during compilation of the container.

This situation is found in e.g. `JMS\AopBundle\DependencyInjection\Compiler\PointcutMatchingPass`.

A workaround before next release could be to "get" the `annotation_reader` service somewhere before (like in a regular compiler pass of your own.)