### PR TITLE
[HttpKernel] Fix session handling: decouple "save" from setting response "private"

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -29,6 +29,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     private $flashName;
     private $attributeName;
     private $data = array();
+    private $hasBeenStarted;
 
     /**
      * @param SessionStorageInterface $storage    A SessionStorageInterface instance
@@ -145,6 +146,16 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      *
      * @internal
      */
+    public function hasBeenStarted()
+    {
+        return $this->hasBeenStarted;
+    }
+
+    /**
+     * @return bool
+     *
+     * @internal
+     */
     public function isEmpty()
     {
         foreach ($this->data as &$data) {
@@ -227,7 +238,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function registerBag(SessionBagInterface $bag)
     {
-        $this->storage->registerBag(new SessionBagProxy($bag, $this->data));
+        $this->storage->registerBag(new SessionBagProxy($bag, $this->data, $this->hasBeenStarted));
     }
 
     /**
@@ -257,6 +268,6 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     private function getAttributeBag()
     {
-        return $this->storage->getBag($this->attributeName)->getBag();
+        return $this->getBag($this->attributeName);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
@@ -20,11 +20,13 @@ final class SessionBagProxy implements SessionBagInterface
 {
     private $bag;
     private $data;
+    private $hasBeenStarted;
 
-    public function __construct(SessionBagInterface $bag, array &$data)
+    public function __construct(SessionBagInterface $bag, array &$data, &$hasBeenStarted)
     {
         $this->bag = $bag;
         $this->data = &$data;
+        $this->hasBeenStarted = &$hasBeenStarted;
     }
 
     /**
@@ -56,6 +58,7 @@ final class SessionBagProxy implements SessionBagInterface
      */
     public function initialize(array &$array)
     {
+        $this->hasBeenStarted = true;
         $this->data[$this->bag->getStorageKey()] = &$array;
 
         $this->bag->initialize($array);

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
@@ -58,13 +58,17 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
             return;
         }
 
-        $session = $event->getRequest()->getSession();
-        if ($session && $session->isStarted()) {
+        if (!$session = $event->getRequest()->getSession()) {
+            return;
+        }
+
+        if ($wasStarted = $session->isStarted()) {
             $session->save();
-            if (!$session instanceof Session || !\method_exists($session, 'isEmpty') || !$session->isEmpty()) {
-                $params = session_get_cookie_params();
-                $event->getResponse()->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
-            }
+        }
+
+        if ($session instanceof Session ? !$session->isEmpty() : $wasStarted) {
+            $params = session_get_cookie_params();
+            $event->getResponse()->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/SaveSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SaveSessionListener.php
@@ -53,10 +53,6 @@ class SaveSessionListener implements EventSubscriberInterface
         $session = $event->getRequest()->getSession();
         if ($session && $session->isStarted()) {
             $session->save();
-            $event->getResponse()
-                ->setPrivate()
-                ->setMaxAge(0)
-                ->headers->addCacheControlDirective('must-revalidate');
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SaveSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SaveSessionListenerTest.php
@@ -32,7 +32,7 @@ class SaveSessionListenerTest extends TestCase
         $listener->onKernelResponse($event);
     }
 
-    public function testSessionSavedAndResponsePrivate()
+    public function testSessionSaved()
     {
         $listener = new SaveSessionListener();
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)->disableOriginalConstructor()->getMock();
@@ -45,9 +45,5 @@ class SaveSessionListenerTest extends TestCase
         $request->setSession($session);
         $response = new Response();
         $listener->onKernelResponse(new FilterResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
-
-        $this->assertTrue($response->headers->hasCacheControlDirective('private'));
-        $this->assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
-        $this->assertSame('0', $response->headers->getCacheControlDirective('max-age'));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
+use Symfony\Component\HttpKernel\EventListener\SessionListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class SessionListenerTest extends TestCase
+{
+    public function testOnlyTriggeredOnMasterRequest()
+    {
+        $listener = $this->getMockForAbstractClass(AbstractSessionListener::class);
+        $event = $this->getMockBuilder(GetResponseEvent::class)->disableOriginalConstructor()->getMock();
+        $event->expects($this->once())->method('isMasterRequest')->willReturn(false);
+        $event->expects($this->never())->method('getRequest');
+
+        // sub request
+        $listener->onKernelRequest($event);
+    }
+
+    public function testSessionIsSet()
+    {
+        $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+
+        $container = new Container();
+        $container->set('session', $session);
+
+        $request = new Request();
+        $listener = new SessionListener($container);
+
+        $event = $this->getMockBuilder(GetResponseEvent::class)->disableOriginalConstructor()->getMock();
+        $event->expects($this->once())->method('isMasterRequest')->willReturn(true);
+        $event->expects($this->once())->method('getRequest')->willReturn($request);
+
+        $listener->onKernelRequest($event);
+
+        $this->assertTrue($request->hasSession());
+        $this->assertSame($session, $request->getSession());
+    }
+
+    public function testResponseIsPrivate()
+    {
+        $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+        $session->expects($this->once())->method('isStarted')->willReturn(false);
+        $session->expects($this->once())->method('hasBeenStarted')->willReturn(true);
+
+        $container = new Container();
+        $container->set('session', $session);
+
+        $listener = new SessionListener($container);
+        $kernel = $this->getMockBuilder(HttpKernelInterface::class)->disableOriginalConstructor()->getMock();
+
+        $request = new Request();
+        $response = new Response();
+        $listener->onKernelRequest(new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
+        $listener->onKernelResponse(new FilterResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
+
+        $this->assertTrue($response->headers->hasCacheControlDirective('private'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
+        $this->assertSame('0', $response->headers->getCacheControlDirective('max-age'));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.5.9|>=7.0.8",
         "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-        "symfony/http-foundation": "^3.3.11|~4.0",
+        "symfony/http-foundation": "^3.4.4|^4.0.4",
         "symfony/debug": "~2.8|~3.0|~4.0",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fixes https://github.com/symfony/symfony/pull/25583#issuecomment-355717344 from @Tobion, and provides extra laziness for the "session" service, related to https://github.com/symfony/recipes/pull/333.

(deps=high failure will be fixed by merging to upper branches.)
  