### PR TITLE
[FrameworkBundle] add autowiring aliases for TranslationReaderInterface, ExtractorInterface & TranslationWriterInterface

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -126,10 +126,13 @@
         </service>
 
         <service id="translation.reader" class="Symfony\Component\Translation\Reader\TranslationReader" />
+        <service id="Symfony\Component\Translation\Reader\TranslationReaderInterface" alias="translation.reader" />
 
         <service id="translation.extractor" class="Symfony\Component\Translation\Extractor\ChainExtractor" />
+        <service id="Symfony\Component\Translation\Extractor\ExtractorInterface" alias="translation.extractor" />
 
         <service id="translation.writer" class="Symfony\Component\Translation\Writer\TranslationWriter" />
+        <service id="Symfony\Component\Translation\Writer\TranslationWriterInterface" alias="translation.writer" />
 
         <service id="translation.warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\TranslationsCacheWarmer">
             <tag name="container.service_subscriber" id="translator" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #25679
| License       | MIT
| Doc PR        | 

Supporting symfony/symfony#25679
