### PR TITLE
[Form] AbstractLayoutTest - fix DOMDocument casing

### DIFF
--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -58,7 +58,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     protected function assertMatchesXpath($html, $expression, $count = 1)
     {
-        $dom = new \DomDocument('UTF-8');
+        $dom = new \DOMDocument('UTF-8');
         try {
             // Wrap in <root> node so we can load HTML with multiple tags at
             // the top level


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This actually breaks static analysis, because casing is incorrect
  