### PR TITLE
[TwigBridge] swap filter/function and package names

### DIFF
--- a/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
+++ b/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
@@ -62,7 +62,7 @@ class UndefinedCallableHandler
         }
 
         // Twig will append the source context to the message, so that it will end up being like "[...] Unknown filter "%s" in foo.html.twig on line 123."
-        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown filter "%s".', $name, self::$filterComponents[$name]));
+        throw new SyntaxError(sprintf('Unknown filter "%s". Did you forget to run "composer require symfony/%s"?', $name, self::$filterComponents[$name]));
     }
 
     public static function onUndefinedFunction($name)
@@ -71,6 +71,6 @@ class UndefinedCallableHandler
             return false;
         }
 
-        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown function "%s".', $name, self::$functionComponents[$name]));
+        throw new SyntaxError(sprintf('Unknown function "%s". Did you forget to run "composer require symfony/%s"?', $name, self::$functionComponents[$name]));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Error message was `Did you forget to run "composer require symfony/csrf_token"? Unknown function "form" in "Security/Pages/login.html".` and will now be `Unknown function "csrf_token" in "Security/Pages/login.html". Did you forget to run "composer require symfony/form"?`
  
Thanks to @Mediagone who reported this on Slack.