### PR TITLE
[HttpFoundation] Always call proxied handler::destroy() in StrictSessionHandler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/StrictSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/StrictSessionHandler.php
@@ -19,6 +19,7 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 class StrictSessionHandler extends AbstractSessionHandler
 {
     private $handler;
+    private $doDestroy;
 
     public function __construct(\SessionHandlerInterface $handler)
     {
@@ -66,8 +67,21 @@ class StrictSessionHandler extends AbstractSessionHandler
     /**
      * {@inheritdoc}
      */
+    public function destroy($sessionId)
+    {
+        $this->doDestroy = true;
+        $destroyed = parent::destroy($sessionId);
+
+        return $this->doDestroy ? $this->doDestroy($sessionId) : $destroyed;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doDestroy($sessionId)
     {
+        $this->doDestroy = false;
+
         return $this->handler->destroy($sessionId);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
@@ -118,7 +118,7 @@ class StrictSessionHandlerTest extends TestCase
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('');
         $handler->expects($this->never())->method('write');
-        $handler->expects($this->never())->method('destroy');
+        $handler->expects($this->once())->method('destroy')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
 
         $this->assertFalse($proxy->validateId('id'));
@@ -154,7 +154,7 @@ class StrictSessionHandlerTest extends TestCase
         $handler = $this->getMockBuilder('SessionHandlerInterface')->getMock();
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('');
-        $handler->expects($this->never())->method('destroy');
+        $handler->expects($this->once())->method('destroy')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
 
         $this->assertSame('', $proxy->read('id'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Noticed by @jpauli: the native file session handler needs a call to `destroy()` to remove session files, even for new empty sessions.
  