### PR TITLE
Add option to use a parameter as command name

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -585,6 +585,11 @@ class Application
         // if no commands matched or we just matched namespaces
         if (empty($commands) || count(preg_grep('{^'.$expr.'$}i', $commands)) < 1) {
             if (false !== $pos = strrpos($name, ':')) {
+                $command = $this->findCommandWithParameterInName($name);
+
+                if($command !== null) {
+                    return $command;
+                }
                 // check if a namespace exists and contains commands
                 $this->findNamespace(substr($name, 0, $pos));
             }
@@ -636,6 +641,30 @@ class Application
         }
 
         return $this->get($exact ? $name : reset($commands));
+    }
+
+    /**
+     * Find a command with a parameter by name
+     * 
+     * @param string $name A command name
+     *
+     * @return Command A Command instance
+     */
+    private function findCommandWithParameterInName($name) 
+    {
+        $allCommands = array_keys($this->commands);
+
+        // Get the name of the command before the options
+        $extractedName = explode(' ', $name)[0];
+
+        foreach($allCommands as $command) {
+            // Change the parameters of the command to [^:]*
+            $expr = preg_replace('/\{[^:{}]*\}/', '[^:]*', $command);
+
+            if(preg_match('/^'.$expr.'$/', $extractedName)) {
+                return $this->get($command);
+            }
+        } 
     }
 
     /**

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -587,7 +587,7 @@ class Application
             if (false !== $pos = strrpos($name, ':')) {
                 $command = $this->findCommandWithParameterInName($name);
 
-                if($command !== null) {
+                if (null !== $command) {
                     return $command;
                 }
                 // check if a namespace exists and contains commands
@@ -644,27 +644,27 @@ class Application
     }
 
     /**
-     * Find a command with a parameter by name
-     * 
+     * Find a command with a parameter by name.
+     *
      * @param string $name A command name
      *
      * @return Command A Command instance
      */
-    private function findCommandWithParameterInName($name) 
+    private function findCommandWithParameterInName($name)
     {
         $allCommands = array_keys($this->commands);
 
         // Get the name of the command before the options
         $extractedName = explode(' ', $name)[0];
 
-        foreach($allCommands as $command) {
+        foreach ($allCommands as $command) {
             // Change the parameters of the command to [^:]*
             $expr = preg_replace('/\{[^:{}]*\}/', '[^:]*', $command);
 
-            if(preg_match('/^'.$expr.'$/', $extractedName)) {
+            if (preg_match('/^'.$expr.'$/', $extractedName)) {
                 return $this->get($command);
             }
-        } 
+        }
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -50,6 +50,8 @@ class ApplicationTest extends TestCase
         require_once self::$fixturesPath.'/Foo3Command.php';
         require_once self::$fixturesPath.'/Foo4Command.php';
         require_once self::$fixturesPath.'/Foo5Command.php';
+        require_once self::$fixturesPath.'/Foo7Command.php';
+        require_once self::$fixturesPath.'/Foo8Command.php';
         require_once self::$fixturesPath.'/FooSameCaseUppercaseCommand.php';
         require_once self::$fixturesPath.'/FooSameCaseLowercaseCommand.php';
         require_once self::$fixturesPath.'/FoobarCommand.php';
@@ -636,6 +638,58 @@ class ApplicationTest extends TestCase
         $application->add(new \FooCommand());
         $application->add(new \Foo4Command());
         $application->find('foo::bar');
+    }
+
+    public function testFindWithParameterName()
+    {
+        $foo = new \Foo7Command();
+
+        $application = new Application();
+        $application->add($foo);
+
+        $result = $application->find('foo:a_random_string a_random_option');
+
+        $this->assertSame($foo, $result);
+    }
+
+    public function testFindWithTwoParametersInName()
+    {
+        $foo = new \Foo8Command();
+
+        $application = new Application();
+        $application->add($foo);
+
+        $result = $application->find('foo:stringA:stringB a_random_option');
+
+        $this->assertSame($foo, $result);
+    }
+
+    public function testFindCommandWithExactAndParameterName()
+    {
+        $foo = new \FooCommand();
+        $foo7 = new \Foo7Command();
+
+        $application = new Application();
+        $application->add($foo7);
+        $application->add($foo);
+
+        $result = $application->find('foo:bar');
+
+        $this->assertSame($foo, $result);
+    }
+    
+    public function testFindCommandWithExactAndParameterNameDifferentOrder()
+    {
+        $foo = new \FooCommand();
+        $foo7 = new \Foo7Command();
+
+        $application = new Application();
+        $application->add($foo);
+        $application->add($foo7);
+
+        $result = $application->find('foo:bar');
+
+        $this->assertSame($foo, $result);
     }
 
     public function testSetCatchExceptions()

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -677,7 +677,7 @@ class ApplicationTest extends TestCase
 
         $this->assertSame($foo, $result);
     }
-    
+
     public function testFindCommandWithExactAndParameterNameDifferentOrder()
     {
         $foo = new \FooCommand();

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo7Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo7Command.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+
+class Foo7Command extends Command
+{
+    protected function configure()
+    {
+        $this->setName('foo:{bar}');
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo8Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo8Command.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+
+class Foo8Command extends Command
+{
+    protected function configure()
+    {
+        $this->setName('foo:{bar}:{random}');
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line 725:
+In ApplicationTest.php line 779:
                     
   エラーメッセージ  
                     

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1decorated.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1decorated.txt
@@ -1,5 +1,5 @@
 
-[33mIn ApplicationTest.php line 725:[39m
+[33mIn ApplicationTest.php line 779:[39m
 [37;41m                    [39;49m
 [37;41m  エラーメッセージ  [39;49m
 [37;41m                    [39;49m

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth2.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line 739:
+In ApplicationTest.php line 793:
                               
   コマンドの実行中にエラーが  
   発生しました。              

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_escapeslines.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_escapeslines.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line 753:
+In ApplicationTest.php line 807:
                      
   dont break here <  
   info>!</info>      

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_linebreaks.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_linebreaks.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line 770:
+In ApplicationTest.php line 824:
                                     
   line 1 with extra spaces          
   line 2                            


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes TODO if accepted: update src/**/CHANGELOG.md
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | TODO if accepted

Currently I have a few commands:

```shell
php bin/console make:job
php bin/console make:model
php bin/console make:command
```

These commands will create a class in the correct directory with a stub class.
(Namespace set, some methods specific for that stub, ...)

But now I wanted to create a Service class without creating a new Command.
```shell
php bin/console make:service
```

So I was thinking, what if I can define a command like ``php bin/console make:{type}``
I made this possible with this current PR.

![image](https://user-images.githubusercontent.com/5346497/34877916-469de796-f7a8-11e7-9bd1-8da7cb5e6f8b.png)

This is my first contribution to Symfony, so please provide feedback 👍 



  
  