### PR TITLE
Properly assign label class to legend elements in Bootstrap 4 form layout

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -123,7 +123,7 @@
 {% block form_label -%}
     {%- if compound is defined and compound -%}
         {%- set element = 'legend' -%}
-        {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' col-form-legend')|trim}) -%}
+        {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' col-form-label')|trim}) -%}
     {%- else -%}
         {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' form-control-label')|trim}) -%}
     {%- endif -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| License       | MIT

When generating certain form type fields with the Bootstrap 4 layout (like `DateType`), the label of the element is disproportionately sized due to the assigned `col-form-legend` class. See https://embed.plnkr.co/dznSTr1obOoXi5tg4XQK/ for a visual example of the problem.

I also came across this example online: https://www.quackit.com/html/html_editors/scratchpad/?example=/bootstrap/bootstrap_4/tutorial/bootstrap_4_forms_horizontal_legend which shows that the old way was correct, but this example is running on beta2, beta3 seems to have fixed the problem.

The form type simply defined the field as:

    $builder->add('publishedAt', DateType::class)

