### PR TITLE
[Form] issue-13589: adding custom false-values to BooleanToString transformer

### DIFF
--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -55,7 +55,7 @@ class XmlUtilsTest extends TestCase
             XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate'));
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertRegExp('/The XML file "[\w:\/\\\.]+" is not valid\./', $e->getMessage());
+            $this->assertRegExp('/The XML file "[\w:\/\\\.-]+" is not valid\./', $e->getMessage());
         }
 
         $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate')));

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -55,7 +55,7 @@ class XmlUtilsTest extends TestCase
             XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate'));
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertRegExp('/The XML file "[\w:\/\\\.-]+" is not valid\./', $e->getMessage());
+            $this->assertRegExp('/The XML file "[\w:\/\\\.]+" is not valid\./', $e->getMessage());
         }
 
         $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate')));

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -19,7 +19,7 @@ CHANGELOG
  * removed passing guesser services ids as the fourth argument of `DependencyInjectionExtension::__construct()`
  * removed the ability to validate an unsubmitted form.
  * removed `ChoiceLoaderInterface` implementation in `TimezoneType`
- * added support for custom false-values to BooleanToStringTransformer and CheckBoxType, so e.g. submitted string "false" will be evaluated to false instead of true
+ * added the `false_values` option to the `CheckboxType` which allows to configure custom values which will be treated as `false` during submission
 
 3.4.0
 -----

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * removed passing guesser services ids as the fourth argument of `DependencyInjectionExtension::__construct()`
  * removed the ability to validate an unsubmitted form.
  * removed `ChoiceLoaderInterface` implementation in `TimezoneType`
+ * added support for custom false-values to BooleanToStringTransformer and CheckBoxType, so e.g. submitted string "false" will be evaluated to false instead of true
 
 3.4.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -27,8 +27,8 @@ class BooleanToStringTransformer implements DataTransformerInterface
     private $falseValues;
 
     /**
-     * @param string $trueValue The value emitted upon transform if the input is true
-     * @param array $falseValues
+     * @param string $trueValue   The value emitted upon transform if the input is true
+     * @param array  $falseValues
      */
     public function __construct(string $trueValue, array $falseValues = array(null))
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -35,7 +35,7 @@ class BooleanToStringTransformer implements DataTransformerInterface
     {
         $this->trueValue = $trueValue;
         $this->falseValues = $falseValues;
-        if (in_array($this->trueValue, $this->falseValues)) {
+        if (in_array($this->trueValue, $this->falseValues, true)) {
             throw new InvalidArgumentException('The specified "true" value is contained in the false-values');
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -24,12 +24,16 @@ class BooleanToStringTransformer implements DataTransformerInterface
 {
     private $trueValue;
 
+    private $falseValues;
+
     /**
      * @param string $trueValue The value emitted upon transform if the input is true
+     * @param array $falseValues
      */
-    public function __construct(string $trueValue)
+    public function __construct(string $trueValue, array $falseValues = array(null))
     {
         $this->trueValue = $trueValue;
+        $this->falseValues = $falseValues;
     }
 
     /**
@@ -65,7 +69,7 @@ class BooleanToStringTransformer implements DataTransformerInterface
      */
     public function reverseTransform($value)
     {
-        if (null === $value) {
+        if (in_array($value, $this->falseValues, true)) {
             return false;
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
@@ -34,6 +35,9 @@ class BooleanToStringTransformer implements DataTransformerInterface
     {
         $this->trueValue = $trueValue;
         $this->falseValues = $falseValues;
+        if (in_array($this->trueValue, $this->falseValues)) {
+            throw new InvalidArgumentException('The specified "true" value is contained in the false-values');
+        }
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -32,7 +32,7 @@ class CheckboxType extends AbstractType
         // We cannot solve this case via overriding the "data" option, because
         // doing so also calls setDataLocked(true).
         $builder->setData(isset($options['data']) ? $options['data'] : false);
-        $builder->addViewTransformer(new BooleanToStringTransformer($options['value']));
+        $builder->addViewTransformer(new BooleanToStringTransformer($options['value'], $options['false_values']));
     }
 
     /**
@@ -59,6 +59,7 @@ class CheckboxType extends AbstractType
             'value' => '1',
             'empty_data' => $emptyData,
             'compound' => false,
+            'false_values' => array(null)
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -61,6 +61,8 @@ class CheckboxType extends AbstractType
             'compound' => false,
             'false_values' => array(null),
         ));
+
+        $resolver->setAllowedTypes('false_values', 'array');
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -59,7 +59,7 @@ class CheckboxType extends AbstractType
             'value' => '1',
             'empty_data' => $emptyData,
             'compound' => false,
-            'false_values' => array(null)
+            'false_values' => array(null),
         ));
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -76,4 +76,12 @@ class BooleanToStringTransformerTest extends TestCase
         $this->assertFalse($customFalseTransformer->reverseTransform('0'));
         $this->assertFalse($customFalseTransformer->reverseTransform(true));
     }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     */
+    public function testTrueValueContainedInFalseValues()
+    {
+        new BooleanToStringTransformer('0', array(null, '0'));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -84,4 +84,10 @@ class BooleanToStringTransformerTest extends TestCase
     {
         new BooleanToStringTransformer('0', array(null, '0'));
     }
+
+    public function testBeStrictOnTrueInFalseValueCheck()
+    {
+        $transformer = new BooleanToStringTransformer('0', array(null, false));
+        $this->assertInstanceOf(BooleanToStringTransformer::class, $transformer);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -71,7 +71,7 @@ class BooleanToStringTransformerTest extends TestCase
 
     public function testCustomFalseValues()
     {
-        $customFalseTransformer = new BooleanToStringTransformer(self::TRUE_VALUE, ['0', 'myFalse', true]);
+        $customFalseTransformer = new BooleanToStringTransformer(self::TRUE_VALUE, array('0', 'myFalse', true));
         $this->assertFalse($customFalseTransformer->reverseTransform('myFalse'));
         $this->assertFalse($customFalseTransformer->reverseTransform('0'));
         $this->assertFalse($customFalseTransformer->reverseTransform(true));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -68,4 +68,12 @@ class BooleanToStringTransformerTest extends TestCase
         $this->assertTrue($this->transformer->reverseTransform(''));
         $this->assertFalse($this->transformer->reverseTransform(null));
     }
+
+    public function testCustomFalseValues()
+    {
+        $customFalseTransformer = new BooleanToStringTransformer(self::TRUE_VALUE, ['0', 'myFalse', true]);
+        $this->assertFalse($customFalseTransformer->reverseTransform('myFalse'));
+        $this->assertFalse($customFalseTransformer->reverseTransform('0'));
+        $this->assertFalse($customFalseTransformer->reverseTransform(true));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\CallbackTransformer;
-use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class CheckboxTypeTest extends BaseTypeTest
 {
@@ -195,9 +194,11 @@ class CheckboxTypeTest extends BaseTypeTest
         );
     }
 
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
     public function testDontAllowNonArrayFalseValues()
     {
-        $this->expectException(InvalidOptionsException::class);
         $this->expectExceptionMessageRegExp('/"false_values" with value "invalid" is expected to be of type "array"/');
         $this->factory->create(static::TESTED_TYPE, null, array(
             'false_values' => 'invalid',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 class CheckboxTypeTest extends BaseTypeTest
 {
@@ -192,6 +193,15 @@ class CheckboxTypeTest extends BaseTypeTest
             array('false'),
             array('0'),
         );
+    }
+
+    public function testDontAllowNonArrayFalseValues()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessageRegExp('/"false_values" with value "invalid" is expected to be of type "array"/');
+        $this->factory->create(static::TESTED_TYPE, null, array(
+            'false_values' => 'invalid',
+        ));
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -171,7 +171,7 @@ class CheckboxTypeTest extends BaseTypeTest
 
         foreach ($falseValuesToTest as $falseValue) {
             $form = $this->factory->create(static::TESTED_TYPE, null, array(
-                'false_values' => array($falseValue)
+                'false_values' => array($falseValue),
             ));
             $form->submit($falseValue);
             $this->assertFalse($form->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -165,6 +165,19 @@ class CheckboxTypeTest extends BaseTypeTest
         $this->assertEquals($checked, $view->vars['checked']);
     }
 
+    public function testCustomFalseValues()
+    {
+        $falseValuesToTest = array('', 'false', '0');
+
+        foreach ($falseValuesToTest as $falseValue) {
+            $form = $this->factory->create(static::TESTED_TYPE, null, array(
+                'false_values' => array($falseValue)
+            ));
+            $form->submit($falseValue);
+            $this->assertFalse($form->getData());
+        }
+    }
+
     public function provideCustomModelTransformerData()
     {
         return array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -165,24 +165,32 @@ class CheckboxTypeTest extends BaseTypeTest
         $this->assertEquals($checked, $view->vars['checked']);
     }
 
-    public function testCustomFalseValues()
-    {
-        $falseValuesToTest = array('', 'false', '0');
-
-        foreach ($falseValuesToTest as $falseValue) {
-            $form = $this->factory->create(static::TESTED_TYPE, null, array(
-                'false_values' => array($falseValue),
-            ));
-            $form->submit($falseValue);
-            $this->assertFalse($form->getData());
-        }
-    }
-
     public function provideCustomModelTransformerData()
     {
         return array(
             array('checked', true),
             array('unchecked', false),
+        );
+    }
+
+    /**
+     * @dataProvider provideCustomFalseValues
+     */
+    public function testCustomFalseValues($falseValue)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'false_values' => array($falseValue),
+        ));
+        $form->submit($falseValue);
+        $this->assertFalse($form->getData());
+    }
+
+    public function provideCustomFalseValues()
+    {
+        return array(
+            array(''),
+            array('false'),
+            array('0'),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13589
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/9031

As suggested in #13589 , this PR adds the option to specify custom false-values, so we can use the CheckBoxType to handle strings '1' / '0' and eval them to true / false. While HTTP defines that checkbox types are either submitted=true or not-submitted=false, no matter of what value was submitted, it would be nice to have this option. 
Also refs (which read like "the basic idea of the feature was accepted, PR almost done, then something-happend so PR wasnt merged"..?)

https://github.com/symfony/symfony/pull/15054
https://github.com/symfony/symfony/pull/18005
