### PR TITLE
[TwigBridge] Allow label translation to be safe

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -219,7 +219,13 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</label>
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+            {%- if translation_domain is same as(false) -%}
+                {{- label -}}
+            {%- else -%}
+                {{- label|trans({}, translation_domain) -}}
+            {%- endif -%}
+        </label>
     {%- endif -%}
 {%- endblock form_label -%}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ~
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

After overriding `TranslationExtension`'s `trans` filter to make it safe I noticed form labels were still escaped because of `label` in

```twig
{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}
```

Replacing this ternary with `if`/`else` allows `trans` return to be safe.

WDYT?