### PR TITLE
Prefer composer install instead for using Symfony Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Drupal and Magento).
 Installation
 ------------
 
-* [Install Symfony][4] with Composer or with our own installer (see
-  [requirements details][3]).
+* [Install Symfony][4] with Composer (see [requirements details][3]).
 * Symfony follows the [semantic versioning][5] strictly, publishes "Long Term
   Support" (LTS) versions and has a [release process][6] that is predictable and
   business-friendly.


### PR DESCRIPTION
Looks like Symfony Installer should be replaced by `composer create-project` (flex)

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yno
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
