### PR TITLE
Don't right trim the deprecation message

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -228,7 +228,7 @@ class DeprecationErrorHandler
                         uasort($deprecations[$group], $cmp);
 
                         foreach ($deprecations[$group] as $msg => $notices) {
-                            echo "\n", rtrim($msg, '.'), ': ', $notices['count'], "x\n";
+                            echo "\n  ", $msg, "\n";
 
                             arsort($notices);
 

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -228,7 +228,7 @@ class DeprecationErrorHandler
                         uasort($deprecations[$group], $cmp);
 
                         foreach ($deprecations[$group] as $msg => $notices) {
-                            echo "\n  ", $msg, "\n";
+                            echo "\n  ", $notices['count'], 'x: ', $msg, "\n";
 
                             arsort($notices);
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/default.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/default.phpt
@@ -63,20 +63,20 @@ $foo->testNonLegacyBar();
 --EXPECTF--
 Unsilenced deprecation notices (3)
 
-unsilenced foo deprecation: 2x
+  unsilenced foo deprecation
     2x in FooTestCase::testLegacyFoo
 
-unsilenced bar deprecation: 1x
+  unsilenced bar deprecation
     1x in FooTestCase::testNonLegacyBar
 
 Remaining deprecation notices (1)
 
-silenced bar deprecation: 1x
+  silenced bar deprecation
     1x in FooTestCase::testNonLegacyBar
 
 Legacy deprecation notices (1)
 
 Other deprecation notices (1)
 
-root deprecation: 1x
+  root deprecation
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/default.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/default.phpt
@@ -63,20 +63,20 @@ $foo->testNonLegacyBar();
 --EXPECTF--
 Unsilenced deprecation notices (3)
 
-  unsilenced foo deprecation
+  2x: unsilenced foo deprecation
     2x in FooTestCase::testLegacyFoo
 
-  unsilenced bar deprecation
+  1x: unsilenced bar deprecation
     1x in FooTestCase::testNonLegacyBar
 
 Remaining deprecation notices (1)
 
-  silenced bar deprecation
+  1x: silenced bar deprecation
     1x in FooTestCase::testNonLegacyBar
 
 Legacy deprecation notices (1)
 
 Other deprecation notices (1)
 
-  root deprecation
+  1x: root deprecation
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_non_vendor.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_non_vendor.phpt
@@ -55,20 +55,20 @@ $foo->testNonLegacyBar();
 --EXPECTF--
 Unsilenced deprecation notices (3)
 
-  unsilenced foo deprecation
+  2x: unsilenced foo deprecation
     2x in FooTestCase::testLegacyFoo
 
-  unsilenced bar deprecation
+  1x: unsilenced bar deprecation
     1x in FooTestCase::testNonLegacyBar
 
 Remaining deprecation notices (1)
 
-  silenced bar deprecation
+  1x: silenced bar deprecation
     1x in FooTestCase::testNonLegacyBar
 
 Legacy deprecation notices (1)
 
 Other deprecation notices (1)
 
-  root deprecation
+  1x: root deprecation
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_non_vendor.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_non_vendor.phpt
@@ -55,20 +55,20 @@ $foo->testNonLegacyBar();
 --EXPECTF--
 Unsilenced deprecation notices (3)
 
-unsilenced foo deprecation: 2x
+  unsilenced foo deprecation
     2x in FooTestCase::testLegacyFoo
 
-unsilenced bar deprecation: 1x
+  unsilenced bar deprecation
     1x in FooTestCase::testNonLegacyBar
 
 Remaining deprecation notices (1)
 
-silenced bar deprecation: 1x
+  silenced bar deprecation
     1x in FooTestCase::testNonLegacyBar
 
 Legacy deprecation notices (1)
 
 Other deprecation notices (1)
 
-root deprecation: 1x
+  root deprecation
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | maybe yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->

The PhpUnit bridge lists deprecation messages after a test. In order to do this it outputs the message but it right trims the message - removing any fullstops. This is unexpected. It does this to add the number of time the message appears but this is not really necessary because the number of the times a deprecation message is triggered and from where is added below.