### PR TITLE
[FrameworkBundle] fix tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/AnnotationReaderPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/AnnotationReaderPass.php
@@ -19,6 +19,6 @@ class AnnotationReaderPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         // simulate using "annotation_reader" in a compiler pass
-        $container->get('annotation_reader');
+        $container->get('test.annotation_reader');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/TestExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/DependencyInjection/TestExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -26,6 +27,8 @@ class TestExtension extends Extension implements PrependExtensionInterface
     {
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setAlias('test.annotation_reader', new Alias('annotation_reader', true));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Add a public alias so that we can retrieve the private aliased
annotation_reader service in an after removing compiler pass.

Looks like I actually should have committed #25745 for the `3.4` branch to make `deps=high` tests pass there too.