### PR TITLE
Web Profiler: Use whole screen

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -421,7 +421,6 @@ tr.status-warning td {
 {# Layout
    ========================================================================= #}
 .container {
-    max-width: 1300px;
     padding-right: 15px;
 }
 #header {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -99,6 +99,12 @@ code, pre {
     {{ mixins.monospace_font|raw }}
 }
 
+{# Elements containing a long plain text
+   ------------------------------------------------------------------------- #}
+p, blockquote {
+    max-width: 50em;
+}
+
 {# Buttons
    ------------------------------------------------------------------------- #}
 button {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -155,7 +155,6 @@ table, tr, th, td {
 table {
     {{ mixins.subtle_border_and_shadow|raw }};
     margin: 1em 0;
-    width: 100%;
 }
 
 table th, table td {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Drop max-width from Web Profiler CSS. This tiny change allows us to see more data and avoid wrapping of long lines in logs. Since the profiler is meant for practical usage rather than beauty, and there are barely any paragraphs of text, it makes no sense to limit the width of the content.
