### PR TITLE
[OptionsResolver] Fix options resolver with array allowed types

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -883,7 +883,7 @@ class OptionsResolver implements Options
             $invalidValues = array_filter( // Filter out valid values, keeping invalid values in the resulting array
                 $value,
                 function ($value) use ($type) {
-                    return (function_exists($isFunction = 'is_'.$type) && !$isFunction($value)) || !$value instanceof $type;
+                    return !self::isValueValidType($type, $value);
                 }
             );
 
@@ -896,7 +896,7 @@ class OptionsResolver implements Options
             return false;
         }
 
-        if ((function_exists($isFunction = 'is_'.$type) && $isFunction($value)) || $value instanceof $type) {
+        if (self::isValueValidType($type, $value)) {
             return true;
         }
 
@@ -1072,5 +1072,10 @@ class OptionsResolver implements Options
         }
 
         return implode(', ', $values);
+    }
+
+    private static function isValueValidType($type, $value)
+    {
+        return (function_exists($isFunction = 'is_'.$type) && $isFunction($value)) || $value instanceof $type;
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -486,6 +486,15 @@ class OptionsResolverTest extends TestCase
         $this->resolver->setAllowedTypes('foo', 'string');
     }
 
+    public function testResolveTypedArray()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'string[]');
+        $options = $this->resolver->resolve(array('foo' => array('bar', 'baz')));
+
+        $this->assertSame(array('foo' => array('bar', 'baz')), $options);
+    }
+
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\AccessException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

When playing a simple test:

```php
use Symfony\Component\OptionsResolver\Options;

$resolver = new OptionsResolver();
$resolver->setDefined('foo');
$resolver->setAllowedTypes('foo', 'string[]');
$options = $resolver->resolve(['foo' => ['bar', 'baz']]);
```

I get this error:

```
Symfony\Component\OptionsResolver\Exception\InvalidOptionsException: The option "foo" with value array is expected to be of type "string[]", but is of type "string[]"
```

This PR should fix this.