### PR TITLE
[WebProfilerBundle] Exclude unintended files from being open-able

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -4,6 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="web_profiler.open_blacklist_regexp">/\.|(?&lt;!\.php|\.twig)$|^/(?:app/(?!Resources/(?:[^/]++/)?views/)|config/|var/)</parameter>
+    </parameters>
+
     <services>
         <defaults public="false" />
 
@@ -15,6 +19,7 @@
             <argument>%web_profiler.debug_toolbar.position%</argument>
             <argument type="service" id="web_profiler.csp.handler" />
             <argument>null</argument>
+            <argument>%web_profiler.open_blacklist_regexp%</argument>
         </service>
 
         <service id="web_profiler.controller.router" class="Symfony\Bundle\WebProfilerBundle\Controller\RouterController" public="true">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Even if the Web profiler already exposes many sensitive information because that's its job,
let's be a bit stricter and forbid opening files from folders that cannot be part of any source links.