### PR TITLE
[Validator] 19 digits VISA card numbers are valid

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -79,9 +79,9 @@ class CardSchemeValidator extends ConstraintValidator
             '/^5[1-5][0-9]{14}$/',
             '/^2(22[1-9][0-9]{12}|2[3-9][0-9]{13}|[3-6][0-9]{14}|7[0-1][0-9]{13}|720[0-9]{12})$/',
         ),
-        // All Visa card numbers start with a 4. New cards have 16 digits. Old cards have 13.
+        // All Visa card numbers start with a 4 and have a length of 13, 16, or 19 digits.
         'VISA' => array(
-            '/^4([0-9]{12}|[0-9]{15})$/',
+            '/^4([0-9]{12}|[0-9]{15}|[0-9]{18})$/',
         ),
     );
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -111,6 +111,7 @@ class CardSchemeValidatorTest extends AbstractConstraintValidatorTest
             array('VISA', '4111111111111111'),
             array('VISA', '4012888888881881'),
             array('VISA', '4222222222222'),
+            array('VISA', '4917610000000000003'),
             array(array('AMEX', 'VISA'), '4111111111111111'),
             array(array('AMEX', 'VISA'), '378282246310005'),
             array(array('JCB', 'MASTERCARD'), '5105105105105100'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

some sources:

* https://en.wikipedia.org/wiki/Payment_card_number
* https://blog.vindicia.com/19-digit-visas-and-2-digit-mastercards/
* https://www.nccgroup.trust/de/uber-uns/newsroom-and-events/blogs/2016/november/prepare-for-19-digit-credit-cards/
* http://support.worldpay.com/support/kb/bg/testandgolive/tgl5103.html