### PR TITLE
[Security] The AuthenticationException should implements Security's ExceptionInterface

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Security\Core\Exception;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class AccessDeniedException extends \RuntimeException
+class AccessDeniedException extends RuntimeException
 {
     private $attributes = array();
     private $subject;

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Alexander <iam.asm89@gmail.com>
  */
-class AuthenticationException extends \RuntimeException implements \Serializable
+class AuthenticationException extends RuntimeException implements \Serializable
 {
     private $token;
 

--- a/src/Symfony/Component/Security/Core/Exception/LogoutException.php
+++ b/src/Symfony/Component/Security/Core/Exception/LogoutException.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Security\Core\Exception;
  *
  * @author Jeremy Mikola <jmikola@gmail.com>
  */
-class LogoutException extends \RuntimeException
+class LogoutException extends RuntimeException
 {
     public function __construct(string $message = 'Logout Exception', \Exception $previous = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25770
| License       | MIT
| Doc PR        | ø

Dunno why this is the case right now but this probably should not. Was reported by @paq85.