### PR TITLE
[TwigBundle] Deprecating "false" in favor of "kernel.debug" as default value of "strict_variable"

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -47,6 +47,11 @@ Translation
  * The `FileDumper::setBackup()` method is deprecated and will be removed in 5.0.
  * The `TranslationWriter::disableBackup()` method is deprecated and will be removed in 5.0.
 
+TwigBundle
+----------
+
+ * Deprecated relying on the default value (`false`) of the `twig.strict_variables` configuration option. You should use `%kernel.debug%` explicitly instead, which will be the new default in 5.0.
+
 Validator
 --------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -40,6 +40,11 @@ Translation
  * The `FileDumper::setBackup()` method has been removed.
  * The `TranslationWriter::disableBackup()` method has been removed.
 
+TwigBundle
+----------
+
+ * The default value (`false`) of the `twig.strict_variables` configuration option has been changed to `%kernel.debug%`.
+
 Validator
 --------
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: ./../config/framework.yml }
+    - { resource: ./../config/default.yml }
 
 security:
     encoders:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: ./../config/framework.yml }
+    - { resource: ./../config/default.yml }
 
 security:
     encoders:

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added priority to Twig extensions 
+ * deprecated relying on the default value (`false`) of the `twig.strict_variables` configuration option. The `%kernel.debug%` parameter will be the new default in 5.0
 
 4.0.0
 -----

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -127,7 +127,13 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('cache')->defaultValue('%kernel.cache_dir%/twig')->end()
                 ->scalarNode('charset')->defaultValue('%kernel.charset%')->end()
                 ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
-                ->booleanNode('strict_variables')->end()
+                ->booleanNode('strict_variables')
+                    ->defaultValue(function () {
+                        @trigger_error('Relying on the default value ("false") of the "twig.strict_variables" configuration option is deprecated since Symfony 4.1. You should use "%kernel.debug%" explicitly instead, which will be the new default in 5.0.', E_USER_DEPRECATED);
+
+                        return false;
+                    })
+                ->end()
                 ->scalarNode('auto_reload')->end()
                 ->integerNode('optimizations')->min(-1)->end()
                 ->scalarNode('default_path')

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -20,6 +20,7 @@ class ConfigurationTest extends TestCase
     public function testDoNoDuplicateDefaultFormResources()
     {
         $input = array(
+            'strict_variables' => false, // to be removed in 5.0 relying on default
             'form_themes' => array('form_div_layout.html.twig'),
         );
 
@@ -27,5 +28,17 @@ class ConfigurationTest extends TestCase
         $config = $processor->processConfiguration(new Configuration(), array($input));
 
         $this->assertEquals(array('form_div_layout.html.twig'), $config['form_themes']);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Relying on the default value ("false") of the "twig.strict_variables" configuration option is deprecated since Symfony 4.1. You should use "%kernel.debug%" explicitly instead, which will be the new default in 5.0.
+     */
+    public function testGetStrictVariablesDefaultFalse()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), array(array()));
+
+        $this->assertFalse($config['strict_variables']);
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/customTemplateEscapingGuesser.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/customTemplateEscapingGuesser.php
@@ -3,4 +3,5 @@
 $container->loadFromExtension('twig', array(
     'autoescape_service' => 'my_project.some_bundle.template_escaping_guesser',
     'autoescape_service_method' => 'guess',
+    'strict_variables' => false, // to be removed in 5.0 relying on default
 ));

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/empty.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/empty.php
@@ -1,3 +1,5 @@
 <?php
 
-$container->loadFromExtension('twig', array());
+$container->loadFromExtension('twig', array(
+    'strict_variables' => false, // to be removed in 5.0 relying on default
+));

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/extra.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/extra.php
@@ -1,7 +1,8 @@
 <?php
 
 $container->loadFromExtension('twig', array(
-     'paths' => array(
-         'namespaced_path3' => 'namespace3',
-      ),
+    'paths' => array(
+        'namespaced_path3' => 'namespace3',
+    ),
+    'strict_variables' => false, // to be removed in 5.0 relying on default
 ));

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/formats.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/formats.php
@@ -11,4 +11,5 @@ $container->loadFromExtension('twig', array(
         'decimal_point' => ',',
         'thousands_separator' => '.',
     ),
+    'strict_variables' => false, // to be removed in 5.0 relying on default
 ));

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/customTemplateEscapingGuesser.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/customTemplateEscapingGuesser.xml
@@ -6,5 +6,5 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/twig http://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-    <twig:config autoescape-service="my_project.some_bundle.template_escaping_guesser" autoescape-service-method="guess" />
+    <twig:config autoescape-service="my_project.some_bundle.template_escaping_guesser" autoescape-service-method="guess" strict-variables="false" />
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/empty.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/empty.xml
@@ -6,5 +6,5 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/twig http://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-    <twig:config />
+    <twig:config strict-variables="false" />
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/formats.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/formats.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
         http://symfony.com/schema/dic/twig http://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-    <twig:config>
+    <twig:config strict-variables="false">
         <twig:date format="Y-m-d" interval-format="%d" timezone="Europe/Berlin" />
         <twig:number-format decimals="2" decimal-point="," thousands-separator="." />
     </twig:config>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/customTemplateEscapingGuesser.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/customTemplateEscapingGuesser.yml
@@ -1,3 +1,4 @@
 twig:
     autoescape_service: my_project.some_bundle.template_escaping_guesser
     autoescape_service_method: guess
+    strict_variables: false # to be removed in 5.0 relying on default

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/empty.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/empty.yml
@@ -1,1 +1,2 @@
 twig:
+    strict_variables: false # to be removed in 5.0 relying on default

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/extra.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/extra.yml
@@ -1,3 +1,4 @@
 twig:
+    strict_variables: false # to be removed in 5.0 relying on default
     paths:
         namespaced_path3: namespace3

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/formats.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/formats.yml
@@ -1,4 +1,5 @@
 twig:
+    strict_variables: false # to be removed in 5.0 relying on default
     date:
         format: Y-m-d
         interval_format: '%d'

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -29,7 +29,9 @@ class TwigExtensionTest extends TestCase
     {
         $container = $this->createContainer();
         $container->registerExtension(new TwigExtension());
-        $container->loadFromExtension('twig', array());
+        $container->loadFromExtension('twig', array(
+            'strict_variables' => false, // to be removed in 5.0 relying on default
+        ));
         $this->compileContainer($container);
 
         $this->assertEquals('Twig\Environment', $container->getDefinition('twig')->getClass(), '->load() loads the twig.xml file');
@@ -151,7 +153,10 @@ class TwigExtensionTest extends TestCase
 
         $container = $this->createContainer();
         $container->registerExtension(new TwigExtension());
-        $container->loadFromExtension('twig', array('globals' => $globals));
+        $container->loadFromExtension('twig', array(
+            'globals' => $globals,
+            'strict_variables' => false, // // to be removed in 5.0 relying on default
+        ));
         $this->compileContainer($container);
 
         $calls = $container->getDefinition('twig')->getMethodCalls();
@@ -217,7 +222,9 @@ class TwigExtensionTest extends TestCase
             $container->register('debug.stopwatch', 'Symfony\Component\Stopwatch\Stopwatch');
         }
         $container->registerExtension(new TwigExtension());
-        $container->loadFromExtension('twig', array());
+        $container->loadFromExtension('twig', array(
+            'strict_variables' => false, // to be removed in 5.0 relying on default
+        ));
         $container->setAlias('test.twig.extension.debug.stopwatch', 'twig.extension.debug.stopwatch')->setPublic(true);
         $this->compileContainer($container);
 
@@ -242,7 +249,9 @@ class TwigExtensionTest extends TestCase
     {
         $container = $this->createContainer();
         $container->registerExtension(new TwigExtension());
-        $container->loadFromExtension('twig', array());
+        $container->loadFromExtension('twig', array(
+            'strict_variables' => false, // to be removed in 5.0 relying on default
+        ));
         $container->setParameter('kernel.environment', 'test');
         $container->setParameter('debug.file_link_format', 'test');
         $container->setParameter('foo', 'FooClass');

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
@@ -89,10 +89,15 @@ class CacheWarmingKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load(function ($container) {
-            $container->loadFromExtension('framework', array(
-                'secret' => '$ecret',
-                'form' => array('enabled' => false),
-            ));
+            $container
+                ->loadFromExtension('framework', array(
+                    'secret' => '$ecret',
+                    'form' => array('enabled' => false),
+                ))
+                ->loadFromExtension('twig', array( // to be removed in 5.0 relying on default
+                    'strict_variables' => false,
+                ))
+            ;
         });
 
         if ($this->withTemplating) {

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -61,10 +61,15 @@ class NoTemplatingEntryKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load(function ($container) {
-            $container->loadFromExtension('framework', array(
-                'secret' => '$ecret',
-                'form' => array('enabled' => false),
-            ));
+            $container
+                ->loadFromExtension('framework', array(
+                    'secret' => '$ecret',
+                    'form' => array('enabled' => false),
+                ))
+                ->loadFromExtension('twig', array( // to be removed in 5.0 relying on default
+                    'strict_variables' => false,
+                ))
+            ;
         });
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

> http://symfony.com/doc/current/reference/configuration/twig.html#strict-variables
>**strict_variables**
> **type**: boolean **default**: `'%kernel.debug%'`

Nope, really it's `false` by default:
https://github.com/symfony/symfony/blob/1df45e43563a37633b50d4a36478090361a0b9de/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php#L130

Fixing it in https://github.com/symfony/symfony-docs/pull/9050, but yes `'%kernel.debug%'` is a better default value, the [TwigBundle recipe](https://github.com/symfony/recipes/blob/bf2148f9f1fe5af7e19c3145b6f7246c6cabb3a5/symfony/twig-bundle/3.3/config/packages/twig.yaml#L4:) affirms that:
```yaml
twig:
    # ...
    strict_variables: '%kernel.debug%'
```
So yeah, it definitely looks like it should be the default value, wdyt?

