### PR TITLE
[Form] Disallow transform dates beyond the year 9999

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -22,9 +22,6 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
  */
 class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
 {
-    // Midnight of last day of 9999 to prevent 5 digit years from being transformed
-    const MAX_TIMESTAMP = 253402214400;
-
     private $dateFormat;
     private $timeFormat;
     private $pattern;
@@ -126,7 +123,8 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
 
         if (0 != intl_get_error_code()) {
             throw new TransformationFailedException(intl_get_error_message());
-        } elseif ($timestamp > self::MAX_TIMESTAMP) {
+        } elseif ($timestamp > 253402214400) {
+            // This timestamp represents UTC midnight of 9999-12-31 to prevent 5+ digit years
             throw new TransformationFailedException('Years beyond 9999 are not supported.');
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -23,7 +23,7 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
 {
     // Midnight of last day of 9999 to prevent 5 digit years from being transformed
-    const MAX_TIMESTAMP = 253370674800;
+    const MAX_TIMESTAMP = 253402214400;
 
     private $dateFormat;
     private $timeFormat;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -22,6 +22,9 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
  */
 class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
 {
+    // Midnight of last day of 9999 to prevent 5 digit years from being transformed
+    const MAX_TIMESTAMP = 253370674800;
+
     private $dateFormat;
     private $timeFormat;
     private $pattern;
@@ -123,6 +126,8 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
 
         if (0 != intl_get_error_code()) {
             throw new TransformationFailedException(intl_get_error_message());
+        } elseif ($timestamp > self::MAX_TIMESTAMP) {
+            throw new TransformationFailedException('Years beyond 9999 are not supported.');
         }
 
         try {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -343,4 +343,22 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC');
         $transformer->reverseTransform('1789-07-14');
     }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformFiveDigitYears()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::GREGORIAN, 'yyyy-MM-dd');
+        $transformer->reverseTransform('20107-03-21');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformFiveDigitYearsWithTimestamp()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::GREGORIAN, 'yyyy-MM-dd HH:mm:ss');
+        $transformer->reverseTransform('20107-03-21 12:34:56');
+    }
 }


### PR DESCRIPTION
Fixes #14727

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | not really
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14727 
| License       | MIT

Explicitly locked out submission of dates beyond December 31st 9999 in forms as PHP is highly incapable of consistently handling such dates. Before this patch dates were randomly transformed or mangled.

Technically there is a BC break as this will now cause validation to fail on input that was *accepted* before, but it was mangled. Not my call but I prefer the rejection over data corruption:
```
// Old behavior
$transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::GREGORIAN, 'yyyy-MM-dd');
$result = $transformer->reverseTransform('20107-03-21');

// $result is now 2007-03-21
```