### PR TITLE
Remove polyfill-util dependency from fullstack and security

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php56": "~1.0",
-        "symfony/polyfill-php70": "~1.0",
-        "symfony/polyfill-util": "~1.0"
+        "symfony/polyfill-php70": "~1.0"
     },
     "replace": {
         "symfony/asset": "self.version",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -22,7 +22,6 @@
         "symfony/http-kernel": "~3.3",
         "symfony/polyfill-php56": "~1.0",
         "symfony/polyfill-php70": "~1.0",
-        "symfony/polyfill-util": "~1.0",
         "symfony/property-access": "~2.8|~3.0"
     },
     "replace": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | kinda
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Applies #22709 to the two higher-level packages. I've applied it to 3.3 as that's where that change was merged (though it was `master` as the time); these may actually apply earlier though?

(#16382 was mentioned and applied to 2.8, though is for the serializer which is unrelated? Should have been 3.0 when `StringUtils` was removed?)