### PR TITLE
[WebProfilerBundle] TwigBundle needed as composer dependency

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -19,9 +19,8 @@
         "php": "^7.1.3",
         "symfony/http-kernel": "~3.4|~4.0",
         "symfony/routing": "~3.4|~4.0",
-        "symfony/twig-bridge": "~3.4|~4.0",
-        "symfony/var-dumper": "~3.4|~4.0",
-        "twig/twig": "~1.34|~2.4"
+        "symfony/twig-bundle": "~3.4|~4.0",
+        "symfony/var-dumper": "~3.4|~4.0"
     },
     "require-dev": {
         "symfony/config": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

When installing a blank project with symfony / skeleton 4.0 and the web profiler bundle, it needs the twig service that is provided in the twigbundle.
Better than catcher if the service exists (because it is necessary for me in the use of the profiler ...) as much to declare twigbundle as an depdency in the composer.json

![capture du 2018-01-13 18-07-27](https://user-images.githubusercontent.com/2427947/34908488-b17a38ce-f890-11e7-8a76-4116fab7edaa.png)

