### PR TITLE
 Enableable ArrayNodeDefinition is disabled for empty configuration

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -227,7 +227,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
                 ->ifArray()
                 ->then(function ($v) {
                     if (!isset($v['enabled'])) {
-                        $v['enabled'] = empty($v) ? false : true;
+                        $v['enabled'] = !empty($v);
                     }
 
                     return $v;

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -226,7 +226,9 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
             ->beforeNormalization()
                 ->ifArray()
                 ->then(function ($v) {
-                    $v['enabled'] = isset($v['enabled']) ? $v['enabled'] : true;
+                    if (!isset($v['enabled'])) {
+                        $v['enabled'] = empty($v) ? false : true;
+                    }
 
                     return $v;
                 })

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -207,34 +207,17 @@ class ArrayNodeDefinitionTest extends TestCase
         $this->assertTrue($this->getField($enabledNode, 'defaultValue'));
     }
 
-    public function testNodeThatCanBeEnabledIsDisabledByDefault()
+    public function testEnableableNodeIsDisabledForEmptyConfigurationWhenNormalized()
     {
-        $node = new ArrayNodeDefinition('root');
-        $node->canBeEnabled();
+        $config = [];
 
-        $this->assertTrue($this->getField($node, 'addDefaults'));
-        $this->assertEquals(array('enabled' => false), $this->getField($node, 'falseEquivalent'));
-        $this->assertEquals(array('enabled' => true), $this->getField($node, 'trueEquivalent'));
-        $this->assertEquals(array('enabled' => true), $this->getField($node, 'nullEquivalent'));
-
-        $nodeChildren = $this->getField($node, 'children');
-        $this->assertArrayHasKey('enabled', $nodeChildren);
-
-        $enabledNode = $nodeChildren['enabled'];
-        $this->assertTrue($this->getField($enabledNode, 'default'));
-        $this->assertFalse($this->getField($enabledNode, 'defaultValue'));
-    }
-
-    public function testEnableableNodeIsDisabledForEmptyConfiguration()
-    {
-        $processor = new Processor();
         $node = new ArrayNodeDefinition('root');
         $node->canBeEnabled();
 
         $this->assertEquals(
             array('enabled' => false),
-            $processor->process($node->getNode(), array()),
-                'An enableable node is disabled by default'
+            $node->getNode()->normalize($config),
+            'An enableable node is disabled by default'
         );
     }
 
@@ -271,6 +254,7 @@ class ArrayNodeDefinitionTest extends TestCase
             array(array('enabled' => true, 'foo' => 'baz'), array(array('foo' => 'baz')), 'any configuration enables an enableable node'),
             array(array('enabled' => false, 'foo' => 'baz'), array(array('foo' => 'baz', 'enabled' => false)), 'An enableable node can be disabled'),
             array(array('enabled' => false, 'foo' => 'bar'), array(false), 'false disables an enableable node'),
+            array(array('enabled' => false, 'foo' => 'bar'), array(), 'enableable node is disabled by default'),
         );
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -207,6 +207,37 @@ class ArrayNodeDefinitionTest extends TestCase
         $this->assertTrue($this->getField($enabledNode, 'defaultValue'));
     }
 
+    public function testNodeThatCanBeEnabledIsDisabledByDefault()
+    {
+        $node = new ArrayNodeDefinition('root');
+        $node->canBeEnabled();
+
+        $this->assertTrue($this->getField($node, 'addDefaults'));
+        $this->assertEquals(array('enabled' => false), $this->getField($node, 'falseEquivalent'));
+        $this->assertEquals(array('enabled' => true), $this->getField($node, 'trueEquivalent'));
+        $this->assertEquals(array('enabled' => true), $this->getField($node, 'nullEquivalent'));
+
+        $nodeChildren = $this->getField($node, 'children');
+        $this->assertArrayHasKey('enabled', $nodeChildren);
+
+        $enabledNode = $nodeChildren['enabled'];
+        $this->assertTrue($this->getField($enabledNode, 'default'));
+        $this->assertFalse($this->getField($enabledNode, 'defaultValue'));
+    }
+
+    public function testEnableableNodeIsDisabledForEmptyConfiguration()
+    {
+        $processor = new Processor();
+        $node = new ArrayNodeDefinition('root');
+        $node->canBeEnabled();
+
+        $this->assertEquals(
+            array('enabled' => false),
+            $processor->process($node->getNode(), array()),
+                'An enableable node is disabled by default'
+        );
+    }
+
     public function testIgnoreExtraKeys()
     {
         $node = new ArrayNodeDefinition('root');

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -209,7 +209,7 @@ class ArrayNodeDefinitionTest extends TestCase
 
     public function testEnableableNodeIsDisabledForEmptyConfigurationWhenNormalized()
     {
-        $config = [];
+        $config = array();
 
         $node = new ArrayNodeDefinition('root');
         $node->canBeEnabled();

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Tests\Definition\Builder;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Tests\Fixtures\Builder\NodeBuilder as CustomNodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
@@ -130,5 +131,23 @@ class TreeBuilderTest extends TestCase
 
         $this->assertInternalType('array', $tree->getExample());
         $this->assertEquals('example', $children['child']->getExample());
+    }
+
+    public function testRootNodeThatCanBeEnabledIsDisabledByDefault()
+    {
+        $builder = new TreeBuilder();
+
+        $builder->root('test')
+            ->canBeEnabled();
+
+        $tree = $builder->buildTree();
+        $children = $tree->getChildren();
+
+        $this->assertFalse($children['enabled']->getDefaultValue());
+
+        $processor = new Processor();
+        $result = $processor->process($tree, []);
+
+        $this->assertEquals(array('enabled' => false), $result);
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
@@ -146,7 +146,7 @@ class TreeBuilderTest extends TestCase
         $this->assertFalse($children['enabled']->getDefaultValue());
 
         $processor = new Processor();
-        $result = $processor->process($tree, []);
+        $result = $processor->process($tree, array());
 
         $this->assertEquals(array('enabled' => false), $result);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7+
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25760
| License       | MIT

Fixes #25760.

Currently, documented behavior is not true:

https://github.com/symfony/symfony/blob/70c8c2d47bd71861c8205985a17e68cedf828e1f/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php#L207-L208