### PR TITLE
[Routing] Make sure we only build routes once

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -76,10 +76,10 @@ class RouteCollectionBuilder
             foreach ($collection->getResources() as $resource) {
                 $builder->addResource($resource);
             }
-
-            // mount into this builder
-            $this->mount($prefix, $builder);
         }
+
+        // mount into this builder
+        $this->mount($prefix, $builder);
 
         return $builder;
     }

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
@@ -335,4 +335,30 @@ class RouteCollectionBuilderTest extends TestCase
         // there are 2 routes (i.e. with non-conflicting names)
         $this->assertCount(3, $collection->all());
     }
+
+    public function testAddsThePrefixOnlyOnceWhenLoadingMultipleCollections()
+    {
+        $firstCollection = new RouteCollection();
+        $firstCollection->add('a', new Route('/a'));
+
+        $secondCollection = new RouteCollection();
+        $secondCollection->add('b', new Route('/b'));
+
+        $loader = $this->getMockBuilder('Symfony\Component\Config\Loader\LoaderInterface')->getMock();
+        $loader->expects($this->any())
+            ->method('supports')
+            ->will($this->returnValue(true));
+        $loader
+            ->expects($this->any())
+            ->method('load')
+            ->will($this->returnValue(array($firstCollection, $secondCollection)));
+
+        $routeCollectionBuilder = new RouteCollectionBuilder($loader);
+        $routeCollectionBuilder->import('/directory/recurse/*', '/other/', 'glob');
+        $routes = $routeCollectionBuilder->build()->all();
+
+        $this->assertEquals(2, count($routes));
+        $this->assertEquals('/other/a', $routes['a']->getPath());
+        $this->assertEquals('/other/b', $routes['b']->getPath());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25746
| License       | MIT
| Doc PR        | ø

We need to build the collection(s) only once, else the prefix would be duplicated.