### PR TITLE
[Console] Add placeholder for line number in console exception fixtures

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1626,7 +1626,7 @@ class ApplicationTest extends TestCase
         }
     }
 
-    private function replaceExceptionLine(string $file)
+    private function replaceExceptionLine($file)
     {
         return str_replace('{line}', $this->exceptionLine, file_get_contents($file));
     }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -41,13 +41,6 @@ class ApplicationTest extends TestCase
 {
     protected static $fixturesPath;
 
-    private $exceptionLine;
-
-    public function setUp()
-    {
-        $this->exceptionLine = null;
-    }
-
     public static function setUpBeforeClass()
     {
         self::$fixturesPath = realpath(__DIR__.'/Fixtures/');
@@ -730,27 +723,25 @@ class ApplicationTest extends TestCase
         $application->setAutoExit(false);
         putenv('COLUMNS=120');
         $application->register('foo')->setCode(function () {
-            $this->exceptionLine = __LINE__ + 1;
             throw new \Exception('エラーメッセージ');
         });
         $tester = new ApplicationTester($application);
 
         $tester->run(array('command' => 'foo'), array('decorated' => false, 'capture_stderr_separately' => true));
-        $this->assertEquals($this->replaceExceptionLine(self::$fixturesPath.'/application_renderexception_doublewidth1.txt'), $tester->getErrorOutput(true), '->renderException() renders a pretty exceptions with previous exceptions');
+        $this->assertStringMatchesFormatFile(self::$fixturesPath.'/application_renderexception_doublewidth1.txt', $tester->getErrorOutput(true), '->renderException() renders a pretty exceptions with previous exceptions');
 
         $tester->run(array('command' => 'foo'), array('decorated' => true, 'capture_stderr_separately' => true));
-        $this->assertEquals($this->replaceExceptionLine(self::$fixturesPath.'/application_renderexception_doublewidth1decorated.txt'), $tester->getErrorOutput(true), '->renderException() renders a pretty exceptions with previous exceptions');
+        $this->assertStringMatchesFormatFile(self::$fixturesPath.'/application_renderexception_doublewidth1decorated.txt', $tester->getErrorOutput(true), '->renderException() renders a pretty exceptions with previous exceptions');
 
         $application = new Application();
         $application->setAutoExit(false);
         putenv('COLUMNS=32');
         $application->register('foo')->setCode(function () {
-            $this->exceptionLine = __LINE__ + 1;
             throw new \Exception('コマンドの実行中にエラーが発生しました。');
         });
         $tester = new ApplicationTester($application);
         $tester->run(array('command' => 'foo'), array('decorated' => false, 'capture_stderr_separately' => true));
-        $this->assertEquals($this->replaceExceptionLine(self::$fixturesPath.'/application_renderexception_doublewidth2.txt'), $tester->getErrorOutput(true), '->renderException() wraps messages when they are bigger than the terminal');
+        $this->assertStringMatchesFormatFile(self::$fixturesPath.'/application_renderexception_doublewidth2.txt', $tester->getErrorOutput(true), '->renderException() wraps messages when they are bigger than the terminal');
         putenv('COLUMNS=120');
     }
 
@@ -760,13 +751,12 @@ class ApplicationTest extends TestCase
         $application->setAutoExit(false);
         putenv('COLUMNS=22');
         $application->register('foo')->setCode(function () {
-            $this->exceptionLine = __LINE__ + 1;
             throw new \Exception('dont break here <info>!</info>');
         });
         $tester = new ApplicationTester($application);
 
         $tester->run(array('command' => 'foo'), array('decorated' => false));
-        $this->assertEquals($this->replaceExceptionLine(self::$fixturesPath.'/application_renderexception_escapeslines.txt'), $tester->getDisplay(true), '->renderException() escapes lines containing formatting');
+        $this->assertStringMatchesFormatFile(self::$fixturesPath.'/application_renderexception_escapeslines.txt', $tester->getDisplay(true), '->renderException() escapes lines containing formatting');
         putenv('COLUMNS=120');
     }
 
@@ -778,13 +768,12 @@ class ApplicationTest extends TestCase
             ->method('getTerminalWidth')
             ->will($this->returnValue(120));
         $application->register('foo')->setCode(function () {
-            $this->exceptionLine = __LINE__ + 1;
             throw new \InvalidArgumentException("\n\nline 1 with extra spaces        \nline 2\n\nline 4\n");
         });
         $tester = new ApplicationTester($application);
 
         $tester->run(array('command' => 'foo'), array('decorated' => false));
-        $this->assertEquals($this->replaceExceptionLine(self::$fixturesPath.'/application_renderexception_linebreaks.txt'), $tester->getDisplay(true), '->renderException() keep multiple line breaks');
+        $this->assertStringMatchesFormatFile(self::$fixturesPath.'/application_renderexception_linebreaks.txt', $tester->getDisplay(true), '->renderException() keep multiple line breaks');
     }
 
     public function testRun()
@@ -1624,11 +1613,6 @@ class ApplicationTest extends TestCase
         } catch (\Error $e) {
             $this->assertSame($e->getMessage(), 'Class \'UnknownClass\' not found');
         }
-    }
-
-    private function replaceExceptionLine($file)
-    {
-        return str_replace('{line}', $this->exceptionLine, file_get_contents($file));
     }
 
     protected function tearDown()

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line 726:
+In ApplicationTest.php line {line}:
                     
   エラーメッセージ  
                     

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line {line}:
+In ApplicationTest.php line %d:
                     
   エラーメッセージ  
                     

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1decorated.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1decorated.txt
@@ -1,5 +1,5 @@
 
-[33mIn ApplicationTest.php line 726:[39m
+[33mIn ApplicationTest.php line {line}:[39m
 [37;41m                    [39;49m
 [37;41m  エラーメッセージ  [39;49m
 [37;41m                    [39;49m

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1decorated.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth1decorated.txt
@@ -1,5 +1,5 @@
 
-[33mIn ApplicationTest.php line {line}:[39m
+[33mIn ApplicationTest.php line %d:[39m
 [37;41m                    [39;49m
 [37;41m  エラーメッセージ  [39;49m
 [37;41m                    [39;49m

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth2.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line 740:
+In ApplicationTest.php line {line}:
                               
   コマンドの実行中にエラーが  
   発生しました。              

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_doublewidth2.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line {line}:
+In ApplicationTest.php line %d:
                               
   コマンドの実行中にエラーが  
   発生しました。              

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_escapeslines.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_escapeslines.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line 754:
+In ApplicationTest.php line {line}:
                      
   dont break here <  
   info>!</info>      

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_escapeslines.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_escapeslines.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line {line}:
+In ApplicationTest.php line %d:
                      
   dont break here <  
   info>!</info>      

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_linebreaks.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_linebreaks.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line 771:
+In ApplicationTest.php line {line}:
                                     
   line 1 with extra spaces          
   line 2                            

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_linebreaks.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_renderexception_linebreaks.txt
@@ -1,5 +1,5 @@
 
-In ApplicationTest.php line {line}:
+In ApplicationTest.php line %d:
                                     
   line 1 with extra spaces          
   line 2                            


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Add placeholders for exception line numbers for tests in `ApplicationTest` to make the tests more flexible
