### PR TITLE
[XmlUtils] allow dashes in cwd pathname when running the tests

### DIFF
--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -55,7 +55,7 @@ class XmlUtilsTest extends TestCase
             XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate'));
             $this->fail();
         } catch (\InvalidArgumentException $e) {
-            $this->assertRegExp('/The XML file "[\w:\/\\\.]+" is not valid\./', $e->getMessage());
+            $this->assertRegExp('/The XML file "[\w:\/\\\.-]+" is not valid\./', $e->getMessage());
         }
 
         $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile($fixtures.'valid.xml', array($mock, 'validate')));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Small fix the allow dashes in cwd pathname when running tests. The change was introduced with ref 7473981c1499a030893213488a86c4fb58e37476 so 2.x and 3.x branches should be fine.
Steps to reproduce (assuming all required libraries are installed): 

    mkdir /tmp/folder-with-dashes/ && cd $_
    git clone git@github.com:symfony/symfony.git
    cd symfony && composer install --prefer-dist
    ./phpunit --stop-on-failure