### PR TITLE
APCU error on property accessor

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -884,7 +884,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         $propertyPathInstance = new PropertyPath($propertyPath);
-        if (isset($item)) {
+        if (isset($item) && $item->get() instanceof PropertyPathInterface) {
             $item->set($propertyPathInstance);
             $this->cacheItemPool->save($item);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 3.4
| Bug fix      | yes
| New feature  | no
| BC breaks    | no
| Deprecations | no
| Tests pass   | yes/no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Sometime I see this kind of error in my logs:

apache error logs:
Got error 'PHP message: PHP Notice: apcu_fetch(): Error at offset 0 of 426 bytes in .../vendor/symfony/symfony/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php on line 53

Followed by a symfony log
Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Call to a member function getLength() on null" at .../vendor/symfony/symfony/src/Symfony/Component/PropertyAccess/PropertyAccessor.php line 194

Once this problem occured theses errors are repeated until the apcu cache is cleared (which can take hours).

As this problem occured randomly, I can not repeat it when I want.

Serveur Debian 9 / apache 2.4.25 with php-fpm / PHP 7.0.27 / apcu 5.1.3
