### PR TITLE
[Security] Notify that symfony/expression-language is not installed if ExpressionLanguage is used

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
@@ -13,23 +13,27 @@ namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
 
-/**
- * Adds some function to the default ExpressionLanguage.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- *
- * @see ExpressionLanguageProvider
- */
-class ExpressionLanguage extends BaseExpressionLanguage
-{
+if (!class_exists(BaseExpressionLanguage::class)) {
+    throw new \LogicException(sprintf('The "%s" class requires the "ExpressionLanguage" component. Try running "composer require symfony/expression-language".', ExpressionLanguage::class));
+} else {
     /**
-     * {@inheritdoc}
+     * Adds some function to the default ExpressionLanguage.
+     *
+     * @author Fabien Potencier <fabien@symfony.com>
+     *
+     * @see ExpressionLanguageProvider
      */
-    public function __construct($cache = null, array $providers = array())
+    class ExpressionLanguage extends BaseExpressionLanguage
     {
-        // prepend the default provider to let users override it easily
-        array_unshift($providers, new ExpressionLanguageProvider());
+        /**
+         * {@inheritdoc}
+         */
+        public function __construct($cache = null, array $providers = array())
+        {
+            // prepend the default provider to let users override it easily
+            array_unshift($providers, new ExpressionLanguageProvider());
 
-        parent::__construct($cache, $providers);
+            parent::__construct($cache, $providers);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25742 
| License       | MIT
| Doc PR        | not requested