### PR TITLE
Fixing a bug where the dump() function depended on bundle ordering

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -85,7 +85,11 @@ class ExtensionPass implements CompilerPassInterface
 
         if ($container->getParameter('kernel.debug')) {
             $container->getDefinition('twig.extension.profiler')->addTag('twig.extension');
-            $container->getDefinition('twig.extension.debug')->addTag('twig.extension');
+
+            // only register if the improved version from DebugBundle is *not* present
+            if (!$container->has('twig.extension.dump')) {
+                $container->getDefinition('twig.extension.debug')->addTag('twig.extension');
+            }
         }
 
         $twigLoader = $container->getDefinition('twig.loader.native_filesystem');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

If DebugBundle is registered *before* TwigBundle, then the simpler `dump()` function wins over the fancy, var-dumper one from DebugBundle. In other words, you get different functionality based on the *order* in which you install libraries. To get the "bad" way, you can:

```
composer create-project symfony/skeleton show_bad_dump
cd show_bad_dump
composer require symfony/debug-bundle
composer require twig
```

Then create a Twig template with a `dump()` inside. It will use the less-fancy XDebug version.

I'm not sure if there's a more elegant fix for this or not... I have verified locally that this DOES fix the issue.

Thanks!