### PR TITLE
[Debug] Always decorate existing exception handlers to deal with fatal errors

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -147,10 +147,13 @@ class ErrorHandler
             $handler = $prev[0];
             $replace = false;
         }
-        if ($replace || !$prev) {
-            $handler->setExceptionHandler(set_exception_handler(array($handler, 'handleException')));
-        } else {
+        if (!$replace && $prev) {
             restore_error_handler();
+        }
+        if (is_array($prev = set_exception_handler(array($handler, 'handleException'))) && $prev[0] === $handler) {
+            restore_exception_handler();
+        } else {
+            $handler->setExceptionHandler($prev);
         }
 
         $handler->throwAt($levels & $handler->thrownErrors, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25827
| License       | MIT
| Doc PR        | -

Decorating the exception is seamless, let's always do it and fix handling of fatal errors.
Related to #25408 also.