### PR TITLE
[#25830] PdoSessionHandler may not connect PDO when configured with DSN

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -273,6 +273,10 @@ class PdoSessionHandler implements \SessionHandlerInterface
     public function read($sessionId)
     {
         try {
+            if (null === $this->pdo) {
+                $this->connect($this->dsn);
+            }
+
             return $this->doRead($sessionId);
         } catch (\PDOException $e) {
             $this->rollback();

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -321,6 +321,13 @@ class PdoSessionHandlerTest extends TestCase
         $this->assertInstanceOf('\PDO', $method->invoke($storage));
     }
 
+    public function testConnectWithDsn()
+    {
+        $storage = new PdoSessionHandler('sqlite::memory:');
+        $this->expectExceptionMessage('General error: 1 no such table');
+        $storage->read('test');
+    }
+
     private function createStream($content)
     {
         $stream = tmpfile();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25830
| License       | MIT

PdoSessionHandler can be configured with dsn or pdo object. 
When configured with dsn, the PDO connection is made only on the open method. In the public read function no test is made to check if the PDO connection is open.
