### PR TITLE
[FrameworkBundle] fix DI extension tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_no_assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_no_assets.php
@@ -1,6 +1,9 @@
 <?php
 
 $container->loadFromExtension('framework', array(
+    'assets' => array(
+        'enabled' => true,
+    ),
     'templating' => array(
         'engines' => array('php', 'twig'),
     ),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/templating_no_assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/templating_no_assets.xml
@@ -6,6 +6,7 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
+        <framework:assets enabled="true" />
         <framework:templating>
             <framework:engine>php</framework:engine>
             <framework:engine>twig</framework:engine>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/templating_no_assets.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/templating_no_assets.yml
@@ -1,3 +1,5 @@
 framework:
+    assets:
+        enabled: true
     templating:
         engines: [php, twig]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The failing tests relied on the assets integration being enabled. Since
we never did enable this explicitly, the assets related definitions are
removed now that #25789 was merged which fixed #25760.