### PR TITLE
[Validator] add missing parent isset and add test

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -215,6 +215,16 @@ abstract class Constraint
     }
 
     /**
+     * @param string $option The option name
+     *
+     * @return bool
+     */
+    public function __isset($option)
+    {
+        return 'groups' === $option;
+    }
+
+    /**
      * Adds the given group if this constraint is in the Default group.
      *
      * @param string $group

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileTest.php
@@ -26,6 +26,16 @@ class FileTest extends TestCase
 
         $this->assertSame($bytes, $file->maxSize);
         $this->assertSame($binaryFormat, $file->binaryFormat);
+        $this->assertTrue($file->__isset('maxSize'));
+    }
+
+    public function testMagicIsset()
+    {
+        $file = new File(array('maxSize' => 1));
+
+        $this->assertTrue($file->__isset('maxSize'));
+        $this->assertTrue($file->__isset('groups'));
+        $this->assertFalse($file->__isset('toto'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #25843 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | 

This is a little PR to fix the error and to add the parent::__isset to the Constraints class, I'm adding a test too to be sure that this is not possible again.

Btw, since this is instagihub, I'm coding at home and then I see a squirrel : 
![img_3187 heic](https://user-images.githubusercontent.com/3451634/35149517-a9ddc0ba-fd16-11e7-9e22-cdba0b677071.jpeg)
