### PR TITLE
[Validator] Conflict with egulias/email-validator 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
         "sensio/framework-extra-bundle": "^3.0.2"
     },
     "conflict": {
+        "egulias/email-validator": ">=2.0",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -42,6 +42,9 @@
         "symfony/property-access": "For using the 2.4 Validator API",
         "symfony/expression-language": "For using the 2.4 Expression validator"
     },
+    "conflict": {
+        "egulias/email-validator": ">=2.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Validator\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 (and 2.8)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

For code that uses `EmailValidator` with strict email checking using `egulias/email-validator` and that aims to support both Symfony 2.8 LTS and Symfony 3.4/4.0, it is impossible to have a working set of dependencies with Symfony 2.7/Symfony 2.8 if one wishes to use `egulias/email-validator: ^1.2|^2.1`. 

This is because Composer happily installs `egulias/email-validator` latest 2.1.x which is not compatible with Symfony 2.8.

This would prevent installation of v2.1.x on Symfony 2.7/2.8.