### PR TITLE
Add methods used by TranslationUpdateCommand

### DIFF
--- a/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
@@ -31,4 +31,16 @@ interface TranslationWriterInterface
      * @throws InvalidArgumentException
      */
     public function write(MessageCatalogue $catalogue, $format, $options = array());
+    
+    /**
+     * Disables dumper backup.
+     */
+    public function disableBackup();
+    
+    /**
+     * Obtains the list of supported formats.
+     *
+     * @return array
+     */
+    public function getFormats();
 }

--- a/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriterInterface.php
@@ -31,12 +31,12 @@ interface TranslationWriterInterface
      * @throws InvalidArgumentException
      */
     public function write(MessageCatalogue $catalogue, $format, $options = array());
-    
+
     /**
      * Disables dumper backup.
      */
     public function disableBackup();
-    
+
     /**
      * Obtains the list of supported formats.
      *


### PR DESCRIPTION
``Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand`` uses ``TranslationWriterInterface`` methods ``disableBackup`` and ``getFormats`` not defined by the interface but by the implementation ``Symfony\Component\Translation\Writer\TranslationWriter``.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      |no
| New feature?  |no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | yes (
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

