### PR TITLE
do not conflict with egulias/email-validator 2.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,6 @@
         "sensio/framework-extra-bundle": "^3.0.2"
     },
     "conflict": {
-        "egulias/email-validator": ">=2.0",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -42,9 +42,6 @@
         "symfony/property-access": "For using the 2.4 Validator API",
         "symfony/expression-language": "For using the 2.4 Expression validator"
     },
-    "conflict": {
-        "egulias/email-validator": ">=2.0"
-    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Validator\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/25851#issuecomment-359166972
| License       | MIT
| Doc PR        | 

Not allowing `egulias/email-validator` 2.0+ will prevent applications using this package from updating to the next patch release.