### PR TITLE
Formatting fix in upgrade 3.0 document

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1098,7 +1098,7 @@ UPGRADE FROM 2.x to 3.0
            'http_digest' => array('secret' => '%secret%'),
        ),
    ));
-  ```
+   ```
 
  * The `AbstractVoter` class was removed. Instead, extend the new `Voter` class,
    introduced in 2.8, and move your voting logic to the to the `supports($attribute, $subject)`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

Fixes formatting in upgrade file.
This fix was already done in https://github.com/symfony/symfony/pull/22436 but applied to 3.2.
Formatting error still exists in 2.8, 3.0, 3.1. I don't know if this was intentional.