### PR TITLE
[FrameworkBundle] revert useless tests fixtures changes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_no_assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_no_assets.php
@@ -1,9 +1,6 @@
 <?php
 
 $container->loadFromExtension('framework', array(
-    'assets' => array(
-        'enabled' => true,
-    ),
     'templating' => array(
         'engines' => array('php', 'twig'),
     ),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/templating_no_assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/templating_no_assets.xml
@@ -6,7 +6,6 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
-        <framework:assets enabled="true" />
         <framework:templating>
             <framework:engine>php</framework:engine>
             <framework:engine>twig</framework:engine>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/templating_no_assets.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/templating_no_assets.yml
@@ -1,5 +1,3 @@
 framework:
-    assets:
-        enabled: true
     templating:
         engines: [php, twig]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This will revert #25847. Basically, the changes done in #25847 were not
wrong per se. However, those changes were not necessary as the tests
were not failing because of the missing "assets" config, but due to an
issue introduced in the Config component. Furthermore, removing this
part of the config fixtures gives us the benefit that our before
normalization logic that enables assets support when the templating
integration is enabled is properly tested.