### PR TITLE
Adding an array adapter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -104,6 +104,15 @@
             </call>
         </service>
 
+        <service id="cache.adapter.array" class="Symfony\Component\Cache\Adapter\ArrayAdapter" abstract="true">
+            <tag name="cache.pool" clearer="cache.default_clearer" />
+            <tag name="monolog.logger" channel="cache" />
+            <argument>0</argument> <!-- default lifetime -->
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore" />
+            </call>
+        </service>
+
         <service id="cache.default_clearer" class="Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer">
             <argument type="collection" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#9110

There's no simple way to *disable* caching (e.g. in the dev) environment. Setting up an array adapter is a very simple way to allow this :).