### PR TITLE
Added normalized env getter in kernel for correct container compile.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -425,15 +425,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     protected function getContainerClass()
     {
-        return $this->name.ucfirst($this->getNormalizedEnv()).($this->debug ? 'Debug' : '').'ProjectContainer';
-    }
-
-    /**
-     * @return null|string|string[]
-     */
-    protected function getNormalizedEnv()
-    {
-        return preg_replace('/[^\p{L}\p{Nd}]+/im', null, $this->environment);
+        return $this->name.ucfirst(preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '', $this->environment)).($this->debug ? 'Debug' : '').'ProjectContainer';
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -425,7 +425,15 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     protected function getContainerClass()
     {
-        return $this->name.ucfirst($this->environment).($this->debug ? 'Debug' : '').'ProjectContainer';
+        return $this->name.ucfirst($this->getNormalizedEnv()).($this->debug ? 'Debug' : '').'ProjectContainer';
+    }
+
+    /**
+     * @return null|string|string[]
+     */
+    protected function getNormalizedEnv()
+    {
+        return preg_replace('/[^\p{L}\p{Nd}]+/im', null, $this->environment);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -523,6 +523,44 @@ EOF;
         $this->assertSame('foo', $kernel->getContainer()->getParameter('kernel.project_dir'));
     }
 
+    /**
+     * @param $env
+     * @param $expected
+     * @dataProvider envDataProvider
+     */
+    public function testKernelNormalizedEnv($env, $expected)
+    {
+        $kernel = new class($env, true) extends Kernel {
+            public function registerContainerConfiguration(LoaderInterface $loader)
+            {
+                // TODO: Implement registerContainerConfiguration() method.
+            }
+            public function registerBundles()
+            {
+                // TODO: Implement registerBundles() method.
+            }
+        };
+
+        $reflection = new \ReflectionObject($kernel);
+        $normalizeEnvMethod = $reflection->getMethod('getNormalizedEnv');
+        $normalizeEnvMethod->setAccessible(true);
+        $normalizedEnv = $normalizeEnvMethod->invoke($kernel);
+
+        $this->assertSame($expected, $normalizedEnv);
+    }
+
+    /**
+     * @return array
+     */
+    public function envDataProvider()
+    {
+        return [
+            ['dev-server', 'devserver'],
+            ['local', 'local'],
+            ['env_#8', 'env8']
+        ];
+    }
+
     public function testKernelReset()
     {
         (new Filesystem())->remove(__DIR__.'/Fixtures/cache');

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -535,6 +535,7 @@ EOF;
             {
                 // TODO: Implement registerContainerConfiguration() method.
             }
+
             public function registerBundles()
             {
                 // TODO: Implement registerBundles() method.
@@ -554,11 +555,11 @@ EOF;
      */
     public function envDataProvider()
     {
-        return [
-            ['dev-server', 'devserver'],
-            ['local', 'local'],
-            ['env_#8', 'env8']
-        ];
+        return array(
+            array('dev-server', 'devserver'),
+            array('local', 'local'),
+            array('env_#8', 'env8')
+        );
     }
 
     public function testKernelReset()

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -526,9 +526,9 @@ EOF;
     /**
      * @param $env
      * @param $expected
-     * @dataProvider envDataProvider
+     * @dataProvider envAndContainerClassDataProvider
      */
-    public function testKernelNormalizedEnv($env, $expected)
+    public function testContainerClassNormalization($env, $expected)
     {
         $kernel = new class($env, true) extends Kernel {
             public function registerContainerConfiguration(LoaderInterface $loader)
@@ -542,23 +542,22 @@ EOF;
             }
         };
 
-        $reflection = new \ReflectionObject($kernel);
-        $normalizeEnvMethod = $reflection->getMethod('getNormalizedEnv');
-        $normalizeEnvMethod->setAccessible(true);
-        $normalizedEnv = $normalizeEnvMethod->invoke($kernel);
+        $containerClassMethod = (new \ReflectionObject($kernel))->getMethod('getContainerClass');
+        $containerClassMethod->setAccessible(true);
+        $class = $containerClassMethod->invoke($kernel);
 
-        $this->assertSame($expected, $normalizedEnv);
+        $this->assertSame($expected, $class);
     }
 
     /**
      * @return array
      */
-    public function envDataProvider()
+    public function envAndContainerClassDataProvider()
     {
         return array(
-            array('dev-server', 'devserver'),
-            array('local', 'local'),
-            array('env_#8', 'env8'),
+            array('dev-server', 'TestsDevserverDebugProjectContainer'),
+            array('local', 'TestsLocalDebugProjectContainer'),
+            array('env_#8---*1', 'TestsEnv_81DebugProjectContainer'),
         );
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -524,23 +524,11 @@ EOF;
     }
 
     /**
-     * @param $env
-     * @param $expected
-     * @dataProvider envAndContainerClassDataProvider
+     * @dataProvider envAndContainerClassDataProviderForCustomProjectDirKernel
      */
     public function testContainerClassNormalization($env, $expected)
     {
-        $kernel = new class($env, true) extends Kernel {
-            public function registerContainerConfiguration(LoaderInterface $loader)
-            {
-                // TODO: Implement registerContainerConfiguration() method.
-            }
-
-            public function registerBundles()
-            {
-                // TODO: Implement registerBundles() method.
-            }
-        };
+        $kernel = new CustomProjectDirKernel(null, null, $env);
 
         $containerClassMethod = (new \ReflectionObject($kernel))->getMethod('getContainerClass');
         $containerClassMethod->setAccessible(true);
@@ -552,12 +540,12 @@ EOF;
     /**
      * @return array
      */
-    public function envAndContainerClassDataProvider()
+    public function envAndContainerClassDataProviderForCustomProjectDirKernel()
     {
         return array(
-            array('dev-server', 'TestsDevserverDebugProjectContainer'),
-            array('local', 'TestsLocalDebugProjectContainer'),
-            array('env_#8---*1', 'TestsEnv_81DebugProjectContainer'),
+            array('dev-server', 'FixturesDevserverDebugProjectContainer'),
+            array('local', 'FixturesLocalDebugProjectContainer'),
+            array('env_#8---*1', 'FixturesEnv_81DebugProjectContainer'),
         );
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -558,7 +558,7 @@ EOF;
         return array(
             array('dev-server', 'devserver'),
             array('local', 'local'),
-            array('env_#8', 'env8')
+            array('env_#8', 'env8'),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#

I don't think it's a big bug, but it's a case when symfony wasn't work properly.
When you have a specific env name, you can't even install symfony correctly.
Steps to reproduce:
```bash
export APP_ENV=dev-server
composer create-project symfony/skeleton symfony_will_crash
```

And you will get an error `[KO]  [KO] Script cache:clear returned with error code 255
!!  PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Undefined constant 'ContainerCPr692s\srcDev' in /home/project/symfony_will_crash/var/cache/dev-server/srcDev-serverDebugProjectContainer.php:5`. 

Full installation log will be like this:

```bash
Installing symfony/skeleton (v4.0.5)
  - Installing symfony/skeleton (v4.0.5): Loading from cache
Created project in symfony_will_crash
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 21 installs, 0 updates, 0 removals
  - Installing symfony/flex (v1.0.66): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.6.0): Loading from cache
  - Installing symfony/console (v4.0.3): Loading from cache
  - Installing symfony/routing (v4.0.3): Loading from cache
  - Installing symfony/http-foundation (v4.0.3): Loading from cache
  - Installing symfony/yaml (v4.0.3): Loading from cache
  - Installing symfony/framework-bundle (v4.0.3): Loading from cache
  - Installing symfony/http-kernel (v4.0.3): Loading from cache
  - Installing symfony/event-dispatcher (v4.0.3): Loading from cache
  - Installing psr/log (1.0.2): Loading from cache
  - Installing symfony/debug (v4.0.3): Loading from cache
  - Installing symfony/finder (v4.0.3): Loading from cache
  - Installing symfony/filesystem (v4.0.3): Loading from cache
  - Installing psr/container (1.0.0): Loading from cache
  - Installing symfony/dependency-injection (v4.0.3): Loading from cache
  - Installing symfony/config (v4.0.3): Loading from cache
  - Installing psr/simple-cache (1.0.0): Loading from cache
  - Installing psr/cache (1.0.1): Loading from cache
  - Installing symfony/cache (v4.0.3): Loading from cache
  - Installing symfony/dotenv (v4.0.3): Loading from cache
Writing lock file
Generating autoload files
Symfony operations: 4 recipes (2129a2681f34fe264097ab9136e6141a)
  - Configuring symfony/flex (>=1.0): From github.com/symfony/recipes:master
  - Configuring symfony/framework-bundle (>=3.3): From github.com/symfony/recipes:master
  - Configuring symfony/console (>=3.3): From github.com/symfony/recipes:master
  - Configuring symfony/routing (>=4.0): From github.com/symfony/recipes:master
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Undefined constant 'ContainerCPr692s\srcDev' in /home/project/symfony_will_crash/var/cache/dev-server/srcDev-serverDebugProjectContainer.php:5
!!  Stack trace:
...
```

The main thing is compiler tries to create container with filename and classname uses our $APP_ENV and in this case it will be `srcDev-serverDebugProjectContainer` which is not valid for php syntax.

One of suggestions is always to use `normalized` environment name. In our case it will be `devserver`.
Another one is throw an exception if env is not valid.
What do think ?