### PR TITLE
Restore RoleInterface import

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
+use Symfony\Component\Security\Core\Role\RoleInterface;
+
 /**
  * PreAuthenticatedToken implements a pre-authenticated token.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| License       | MIT

The import is use on PHPDoc but was accidentally removed. Maybe because PHPStorm does not match with the import when you use parenthesis.

Not really a bug as it is concerning only PHPDoc, but it make some analysis tools like PHPStan yelling:

```
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/AppBundle/Security/Authentication/ApiKeyAuthenticator.php                                                                                                                                                                                                          
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  64     Parameter #4 $roles of class Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken constructor expects array<string|Symfony\Component\Security\Core\Authentication\Token\RoleInterface>, array<string|Symfony\Component\Security\Core\Role\Role>  
         given.                                                                                                                                                                                                                                                                 
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/AppBundle/Controller/WebTestCase.php                                                                                                                                                                                                                             
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  59     Parameter #4 $roles of class Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken constructor expects array<string|Symfony\Component\Security\Core\Authentication\Token\RoleInterface>, array<string|Symfony\Component\Security\Core\Role\Role>  
         given.                                                                                                                                                                                                                                                                 
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```