### PR TITLE
[WebServerBundle] Fixed docroot path for Symfony 3.4

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Resources/config/webserver.xml
+++ b/src/Symfony/Bundle/WebServerBundle/Resources/config/webserver.xml
@@ -8,13 +8,13 @@
         <defaults public="false" />
 
         <service id="web_server.command.server_run" class="Symfony\Bundle\WebServerBundle\Command\ServerRunCommand">
-            <argument>%kernel.project_dir%/public</argument>
+            <argument>%kernel.project_dir%/web</argument>
             <argument>%kernel.environment%</argument>
             <tag name="console.command" command="server:run" />
         </service>
 
         <service id="web_server.command.server_start" class="Symfony\Bundle\WebServerBundle\Command\ServerStartCommand">
-            <argument>%kernel.project_dir%/public</argument>
+            <argument>%kernel.project_dir%/web</argument>
             <argument>%kernel.environment%</argument>
             <tag name="console.command" command="server:start" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->

When you try to start a webserver with server:start, you'll get an error message: 

>  [ERROR] The document root directory
         "/Users/serkanyildiz/Projects/symfony-34/public/" does not exist.
>

According to [Best Practices of Symfony 3.4](https://symfony.com/doc/3.4/best_practices/creating-the-project.html#structuring-the-application) the front-controller (docroot) path for Symfony 3.4 is **web** instead of **public**, so this PR will fix this issue.