### PR TITLE
[HttpFoundation] Use the correct syntax for session gc based on Pdo driver

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -401,7 +401,13 @@ class PdoSessionHandler extends AbstractSessionHandler
             $this->gcCalled = false;
 
             // delete the session records that have expired
-            $sql = "DELETE FROM $this->table WHERE $this->lifetimeCol < :time - $this->timeCol";
+            switch ($this->driver) {
+              case 'mysql':
+                $sql = "DELETE FROM $this->table WHERE $this->lifetimeCol + $this->timeCol < :time";
+                break;
+              default:
+                $sql = "DELETE FROM $this->table WHERE $this->lifetimeCol < :time - $this->timeCol";
+            }
 
             $stmt = $this->pdo->prepare($sql);
             $stmt->bindValue(':time', time(), \PDO::PARAM_INT);

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -737,7 +737,7 @@ class PdoSessionHandler extends AbstractSessionHandler
     /**
      * Returns a merge/upsert (i.e. insert or update) statement when supported by the database for writing session data.
      */
-    private function getMergeStatement(string $sessionId, string $data, int$maxlifetime): ?\PDOStatement
+    private function getMergeStatement(string $sessionId, string $data, int $maxlifetime): ?\PDOStatement
     {
         switch (true) {
             case 'mysql' === $this->driver:

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -401,11 +401,9 @@ class PdoSessionHandler extends AbstractSessionHandler
             $this->gcCalled = false;
 
             // delete the session records that have expired
-            switch ($this->driver) {
-              case 'mysql':
+            if ('mysql' === $this->driver) {
                 $sql = "DELETE FROM $this->table WHERE $this->lifetimeCol + $this->timeCol < :time";
-                break;
-              default:
+            } else {
                 $sql = "DELETE FROM $this->table WHERE $this->lifetimeCol < :time - $this->timeCol";
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25665 #24456
| License       | MIT
| Doc PR        | 

The initial fix for #24456 was wrong, since it only accounted for Postgres. @WhiteEagle88 correctly identified #25665 - but having time as SIGNED is ... off, since time shouldn't be negative. Using CAST to solve this issue surely has a performance penalty, so I believe the best approach is to have a switch based on the driver.
