### PR TITLE
[Form] Fixed Button::setParent() when already submitted

### DIFF
--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -106,6 +106,10 @@ class Button implements \IteratorAggregate, FormInterface
      */
     public function setParent(FormInterface $parent = null)
     {
+        if ($this->submitted) {
+            throw new AlreadySubmittedException('You cannot set the parent of a submitted button');
+        }
+
         $this->parent = $parent;
     }
 

--- a/src/Symfony/Component/Form/Tests/ButtonTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonTest.php
@@ -31,17 +31,33 @@ class ButtonTest extends TestCase
     }
 
     /**
+     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
+     */
+    public function testSetParentOnSubmittedButton()
+    {
+        $button = $this->getButtonBuilder('button')
+            ->getForm()
+        ;
+
+        $button->submit('');
+
+        $button->setParent($this->getFormBuilder('form')->getForm());
+    }
+
+    /**
      * @dataProvider getDisabledStates
      */
     public function testDisabledIfParentIsDisabled($parentDisabled, $buttonDisabled, $result)
     {
         $form = $this->getFormBuilder('form')
             ->setDisabled($parentDisabled)
-            ->getForm();
+            ->getForm()
+        ;
 
         $button = $this->getButtonBuilder('button')
             ->setDisabled($buttonDisabled)
-            ->getForm();
+            ->getForm()
+        ;
 
         $button->setParent($form);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

The `Button` does not respect the [FormInterface](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/FormInterface.php#L28), by extension the `SubmitButton` neither.