### PR TITLE
Don't stop PSR-4 service discovery if a parent class is missing

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/BadClasses/MissingParent.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/BadClasses/MissingParent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\BadClasses;
+
+class MissingParent extends MissingClass
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype.php
@@ -9,7 +9,7 @@ return function (ContainerConfigurator $c) {
         ->tag('baz');
     $di->load(Prototype::class.'\\', '../Prototype')
         ->autoconfigure()
-        ->exclude('../Prototype/{OtherDir}')
+        ->exclude('../Prototype/{OtherDir,BadClasses}')
         ->factory('f')
         ->deprecate('%service_id%')
         ->args(array(0))

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <services>
-      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*" exclude="../Prototype/{OtherDir}" />
+      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*" exclude="../Prototype/{OtherDir,BadClasses}" />
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_prototype.yml
@@ -1,4 +1,4 @@
 services:
     Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\:
         resource: ../Prototype
-        exclude: '../Prototype/{OtherDir}'
+        exclude: '../Prototype/{OtherDir,BadClasses}'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25929
| License       | MIT
| Doc PR        | N/A
