### PR TITLE
Disable CSP header on exception pages only in debug

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -129,6 +129,7 @@
             <tag name="monolog.logger" channel="request" />
             <argument>%twig.exception_listener.controller%</argument>
             <argument type="service" id="logger" on-invalid="null" />
+            <argument>%kernel.debug%</argument>
         </service>
 
         <service id="twig.controller.exception" class="%twig.controller.exception.class%">

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -32,11 +32,13 @@ class ExceptionListener implements EventSubscriberInterface
 {
     protected $controller;
     protected $logger;
+    protected $debug;
 
-    public function __construct($controller, LoggerInterface $logger = null)
+    public function __construct($controller, LoggerInterface $logger = null, $debug = false)
     {
         $this->controller = $controller;
         $this->logger = $logger;
+        $this->debug = $debug;
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
@@ -71,7 +73,7 @@ class ExceptionListener implements EventSubscriberInterface
 
         $event->setResponse($response);
 
-        if ($eventDispatcher instanceof EventDispatcherInterface) {
+        if ($this->debug && $eventDispatcher instanceof EventDispatcherInterface) {
             $cspRemovalListener = function (FilterResponseEvent $event) use (&$cspRemovalListener, $eventDispatcher) {
                 $event->getResponse()->headers->remove('Content-Security-Policy');
                 $eventDispatcher->removeListener(KernelEvents::RESPONSE, $cspRemovalListener);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -134,7 +134,7 @@ class ExceptionListenerTest extends TestCase
             return new Response($request->getRequestFormat());
         }));
 
-        $listener = new ExceptionListener('foo', $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock());
+        $listener = new ExceptionListener('foo', $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock(), true);
 
         $dispatcher->addSubscriber($listener);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24772
| License       | MIT
| Doc PR        | 

Based on a feedback we received, there are situations on production when it's desired to have CSP header in place even if exception occurred.

This uses now same condition that is used by ExceptionController in TwigBridge to evaluate if styled exception template is going to be shown, minus `showException` request attribute which don't make sense in this context, because it's used by PreviewController only and in such case this listener isn't triggered.

Overriding CSP header via HTML meta tag unfortunately, but not surprisingly, doesn't work.