### PR TITLE
[dotenv] Support array notation

### DIFF
--- a/src/Symfony/Component/Dotenv/CHANGELOG.md
+++ b/src/Symfony/Component/Dotenv/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * Support array notation
+
 3.3.0
 -----
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -137,6 +137,12 @@ class DotenvTest extends TestCase
             array('BAR=$LOCAL', array('BAR' => 'local')),
             array('BAR=$REMOTE', array('BAR' => 'remote')),
             array('FOO=$NOTDEFINED', array('FOO' => '')),
+
+            // array
+            array('FOO[]=', array('FOO' => array(''))),
+            array('FOO[]=BAR', array('FOO' => array('BAR'))),
+            array("FOO[]=BAR\nFOO[]=BAZ", array('FOO' => array('BAR', 'BAZ'))),
+            array("FOO[bar]=BAR\nFOO[baz]=BAZ", array('FOO' => array('bar' => 'BAR', 'baz' => 'BAZ'))),
         );
 
         if ('\\' !== DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#9150

In addition of `FOO[bar]=BAR` notation, supported by bash, this PR adds support for empty keys. I don’t know if it’s a good idea.