### PR TITLE
[Form] Fixed empty data on expanded ChoiceType and FileType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -33,7 +33,6 @@ use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface as Lega
 use Symfony\Component\Form\Extension\Core\EventListener\MergeCollectionListener;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToValueTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToValuesTransformer;
-use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -91,12 +90,12 @@ class ChoiceType extends AbstractType
                 $form = $event->getForm();
                 $data = $event->getData();
 
+                // Since the type always use mapper an empty array will not be
+                // considered as empty in Form::submit(), we need to evaluate
+                // empty data here so its value is submitted to sub forms
                 if (null === $data) {
                     $emptyData = $form->getConfig()->getEmptyData();
-
-                    if (false === FormUtil::isEmpty($emptyData) && array() !== $emptyData) {
-                        $data = is_callable($emptyData) ? call_user_func($emptyData, $form, $data) : $emptyData;
-                    }
+                    $data = $emptyData instanceof \Closure ? $emptyData($form, $data) : $emptyData;
                 }
 
                 // Convert the submitted data to a string, if scalar, before

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -690,12 +690,57 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->assertSame('test', $form->getData());
     }
 
+    public function testSubmitSingleChoiceWithEmptyDataAndInitialData()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, 'initial', array(
+            'multiple' => false,
+            'expanded' => false,
+            'choices' => array('initial', 'test'),
+            'choices_as_values' => true,
+            'empty_data' => 'test',
+        ));
+
+        $form->submit(null);
+
+        $this->assertSame('test', $form->getData());
+    }
+
     public function testSubmitMultipleChoiceWithEmptyData()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => array('test'),
+            'choices_as_values' => true,
+            'empty_data' => array('test'),
+        ));
+
+        $form->submit(null);
+
+        $this->assertSame(array('test'), $form->getData());
+    }
+
+    public function testSubmitMultipleChoiceWithEmptyDataAndInitialEmptyArray()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, array(), array(
+            'multiple' => true,
+            'expanded' => false,
+            'choices' => array('test'),
+            'choices_as_values' => true,
+            'empty_data' => array('test'),
+        ));
+
+        $form->submit(null);
+
+        $this->assertSame(array('test'), $form->getData());
+    }
+
+    public function testSubmitMultipleChoiceWithEmptyDataAndInitialData()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, array('initial'), array(
+            'multiple' => true,
+            'expanded' => false,
+            'choices' => array('initial', 'test'),
             'choices_as_values' => true,
             'empty_data' => array('test'),
         ));
@@ -720,12 +765,57 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->assertSame('test', $form->getData());
     }
 
+    public function testSubmitSingleChoiceExpandedWithEmptyDataAndInitialData()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, 'initial', array(
+            'multiple' => false,
+            'expanded' => true,
+            'choices' => array('initial', 'test'),
+            'choices_as_values' => true,
+            'empty_data' => 'test',
+        ));
+
+        $form->submit(null);
+
+        $this->assertSame('test', $form->getData());
+    }
+
     public function testSubmitMultipleChoiceExpandedWithEmptyData()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => array('test'),
+            'choices_as_values' => true,
+            'empty_data' => array('test'),
+        ));
+
+        $form->submit(null);
+
+        $this->assertSame(array('test'), $form->getData());
+    }
+
+    public function testSubmitMultipleChoiceExpandedWithEmptyDataAndInitialEmptyArray()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, array(), array(
+            'multiple' => true,
+            'expanded' => true,
+            'choices' => array('test'),
+            'choices_as_values' => true,
+            'empty_data' => array('test'),
+        ));
+
+        $form->submit(null);
+
+        $this->assertSame(array('test'), $form->getData());
+    }
+
+    public function testSubmitMultipleChoiceExpandedWithEmptyDataAndInitialData()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, array('init'), array(
+            'multiple' => true,
+            'expanded' => true,
+            'choices' => array('init', 'test'),
             'choices_as_values' => true,
             'empty_data' => array('test'),
         ));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25896
| License       | MIT
| Doc PR        | ~

Alternative of https://github.com/symfony/symfony/pull/25924.

I don't think we have to do this by adding overhead in master and getting it properly fixed in 2 years.

This is bug I've introduced while fixing another bug #17822. Which then has been replicated in #20418 and #24993.

I propose instead to clean up the code for all LTS, since this is a wrong behaviour that has never been documented, and most of all unreliable.
The `empty_data` can by anything in the view format as long as the reverse view transformation supports it. Even an object derived from the data class could be invokable.

I think we should remain consistent with https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Form/Form.php#L615.