### PR TITLE
Added a README entry to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,10 @@
 | Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->
 
 <!--
-- Bug fixes must be submitted against the lowest branch where they apply
-  (lowest branches are regularly merged to upper ones so they get the fixes too).
-- Features and deprecations must be submitted against the master branch.
-- Replace this comment by a description of what your PR is solving.
+Write a short README entry for your feature here (replace this comment block.)
+This will help people understand your PR and can be used as a start of the Doc PR.
+Additionally:
+ - Bug fixes must be submitted against the lowest branch where they apply
+   (lowest branches are regularly merged to upper ones so they get the fixes too).
+ - Features and deprecations must be submitted against the master branch.
 -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Recently, in the [Diversity Initiative post]() @fabpot mentioned: "A major version of a project should be about improving all aspects of it: community, docs, and code in this order of importance." Also, Symfony advocates that [“an undocumented line is a line that does not exist”](https://symfony.com/six-good-reasons).

This order of importance is not yet followed. Most of the resources are spent on the code, instead of the docs. And with good reason: there's a way bigger contributor base to take care of in the code, compared to the docs.

During a doc meeting this evening, @symfony/team-symfony-docs has discussed this problem. We think it can be improved by two pragmatic changes in the Code repository:

* Focus on creating a Doc PR before a feature is merged. We used to do this, but it seems to not be the case anymore.
* Add a `README` section to the PR template, as done by this PR. This readme section should contain a readme focused entry of the feature introduced by the PR. This has multiple advantages, among which: it helps the PR author to focus on usage ([Readme driven development](http://tom.preston-werner.com/2010/08/23/readme-driven-development.html)); it can function as a great bootstrap for the doc team; it helps reviewers to understand the PR more easily.

Of course, I've just created this PR to start the discussion. I'm happy to change all wording in the PR template.