### PR TITLE
[DI][Routing] Fix tracking of globbed resources

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -38,7 +38,7 @@
             <argument type="service" id="file_locator" />
         </service>
 
-        <service id="routing.loader.glob" class="Symfony\Component\Config\Loader\GlobFileLoader">
+        <service id="routing.loader.glob" class="Symfony\Component\Routing\Loader\GlobFileLoader">
             <tag name="routing.loader" />
             <argument type="service" id="file_locator" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
-        "symfony/routing": "~3.4|~4.0"
+        "symfony/routing": "^3.4.5|^4.0.5"
     },
     "require-dev": {
         "doctrine/cache": "~1.0",

--- a/src/Symfony/Component/DependencyInjection/Loader/GlobFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/GlobFileLoader.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * GlobFileLoader loads files from a glob pattern.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class GlobFileLoader extends FileLoader
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load($resource, $type = null)
+    {
+        foreach ($this->glob($resource, false, $globResource) as $path => $info) {
+            $this->import($path);
+        }
+
+        $this->container->addResource($globResource);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return 'glob' === $type;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/GlobFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/GlobFileLoaderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Resource\GlobResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\GlobFileLoader;
+use Symfony\Component\Config\FileLocator;
+
+class GlobFileLoaderTest extends TestCase
+{
+    public function testSupports()
+    {
+        $loader = new GlobFileLoader(new ContainerBuilder(), new FileLocator());
+
+        $this->assertTrue($loader->supports('any-path', 'glob'), '->supports() returns true if the resource has the glob type');
+        $this->assertFalse($loader->supports('any-path'), '->supports() returns false if the resource is not of glob type');
+    }
+
+    public function testLoadAddsTheGlobResourceToTheContainer()
+    {
+        $loader = new GlobFileLoaderWithoutImport($container = new ContainerBuilder(), new FileLocator());
+        $loader->load(__DIR__.'/../Fixtures/config/*');
+
+        $this->assertEquals(new GlobResource(__DIR__.'/../Fixtures/config', '/*', false), $container->getResources()[1]);
+    }
+}
+
+class GlobFileLoaderWithoutImport extends GlobFileLoader
+{
+    public function import($resource, $type = null, $ignoreErrors = false, $sourceResource = null)
+    {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\GlobFileLoader;
 use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\Filesystem\Filesystem;
@@ -32,7 +33,6 @@ use Symfony\Component\HttpKernel\Config\EnvParametersResource;
 use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass;
 use Symfony\Component\HttpKernel\DependencyInjection\AddAnnotatedClassesToCachePass;
-use Symfony\Component\Config\Loader\GlobFileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\ConfigCache;
@@ -880,7 +880,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             new YamlFileLoader($container, $locator),
             new IniFileLoader($container, $locator),
             new PhpFileLoader($container, $locator),
-            new GlobFileLoader($locator),
+            new GlobFileLoader($container, $locator),
             new DirectoryLoader($container, $locator),
             new ClosureLoader($container),
         ));

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -28,7 +28,7 @@
         "symfony/config": "~2.8|~3.0|~4.0",
         "symfony/console": "~2.8|~3.0|~4.0",
         "symfony/css-selector": "~2.8|~3.0|~4.0",
-        "symfony/dependency-injection": "~3.4|~4.0",
+        "symfony/dependency-injection": "^3.4.5|^4.0.5",
         "symfony/dom-crawler": "~2.8|~3.0|~4.0",
         "symfony/expression-language": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
@@ -45,7 +45,7 @@
     },
     "conflict": {
         "symfony/config": "<2.8",
-        "symfony/dependency-injection": "<3.4",
+        "symfony/dependency-injection": "<3.4.5|<4.0.5,>=4",
         "symfony/var-dumper": "<3.3",
         "twig/twig": "<1.34|<2.4,>=2"
     },

--- a/src/Symfony/Component/Routing/Loader/GlobFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/GlobFileLoader.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader;
+
+use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * GlobFileLoader loads files from a glob pattern.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class GlobFileLoader extends FileLoader
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load($resource, $type = null)
+    {
+        $collection = new RouteCollection();
+
+        foreach ($this->glob($resource, false, $globResource) as $path => $info) {
+            $collection->addCollection($this->import($path));
+        }
+
+        $collection->addResource($globResource);
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return 'glob' === $type;
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/GlobFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/GlobFileLoaderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Resource\GlobResource;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Loader\GlobFileLoader;
+use Symfony\Component\Routing\RouteCollection;
+
+class GlobFileLoaderTest extends TestCase
+{
+    public function testSupports()
+    {
+        $loader = new GlobFileLoader(new FileLocator());
+
+        $this->assertTrue($loader->supports('any-path', 'glob'), '->supports() returns true if the resource has the glob type');
+        $this->assertFalse($loader->supports('any-path'), '->supports() returns false if the resource is not of glob type');
+    }
+
+    public function testLoadAddsTheGlobResourceToTheContainer()
+    {
+        $loader = new GlobFileLoaderWithoutImport(new FileLocator());
+        $collection = $loader->load(__DIR__.'/../Fixtures/directory/*.yml');
+
+        $this->assertEquals(new GlobResource(__DIR__.'/../Fixtures/directory', '/*.yml', false), $collection->getResources()[0]);
+    }
+}
+
+class GlobFileLoaderWithoutImport extends GlobFileLoader
+{
+    public function import($resource, $type = null, $ignoreErrors = false, $sourceResource = null)
+    {
+        return new RouteCollection();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25904
| License       | MIT
| Doc PR        | -

The current `GlobFileLoader` in `Config` misses resource tracking, so we can't use it and have to use a per-component one instead.

(deps=high failures will be fixed after merging up to master.)