### PR TITLE
Always show all deprecations except legacy ones when not weak

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * all deprecations but those from tests marked with `@group legacy` are always
+   displayed when not in `weak` mode.
+
 4.0.0
 -----
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak.phpt
@@ -37,4 +37,3 @@ Unsilenced deprecation notices (1)
 Legacy deprecation notices (1)
 
 Other deprecation notices (1)
-

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_eval_d_deprecation.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_eval_d_deprecation.phpt
@@ -21,3 +21,5 @@ eval("@trigger_error('who knows where I come from?', E_USER_DEPRECATED);")
 --EXPECTF--
 
 Other deprecation notices (1)
+
+  1x: who knows where I come from?

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_phar_deprecation.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_phar_deprecation.phpt
@@ -23,3 +23,5 @@ include 'phar://deprecation.phar/deprecation.php';
 --EXPECTF--
 
 Other deprecation notices (1)
+
+  1x: I come from… afar! :D

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_vendor.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_vendor.phpt
@@ -22,8 +22,19 @@ require __DIR__.'/fake_vendor/acme/lib/deprecation_riddled.php';
 --EXPECTF--
 Unsilenced deprecation notices (2)
 
+  1x: unsilenced foo deprecation
+    1x in FooTestCase::testLegacyFoo
+
+  1x: unsilenced bar deprecation
+    1x in FooTestCase::testNonLegacyBar
+
 Remaining vendor deprecation notices (1)
+
+  1x: silenced bar deprecation
+    1x in FooTestCase::testNonLegacyBar
 
 Legacy deprecation notices (1)
 
 Other deprecation notices (1)
+
+  1x: root deprecation


### PR DESCRIPTION
When using any mode but the weak mode, you want your build to fail on some or
all deprecations, but it is still nice to be able to see what you could
fix without having to change modes.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->
