### PR TITLE
[SecurityBundle] Allow remember-me factory creation when multiple user providers are configured.

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -515,6 +515,9 @@ class SecurityExtension extends Extension
                             throw new InvalidConfigurationException(sprintf('Invalid firewall "%s": user provider "%s" not found.', $id, $firewall[$key]['provider']));
                         }
                         $userProvider = $providerIds[$normalizedName];
+                    } elseif ('remember_me' === $key) {
+                        // RememberMeFactory will use the firewall secret when created
+                        $userProvider = null;
                     } else {
                         $userProvider = $defaultProvider ?: $this->getFirstProvider($id, $key, $providerIds);
                     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -259,6 +259,28 @@ class SecurityExtensionTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testPerListenerProviderWithRememberMe()
+    {
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', array(
+            'providers' => array(
+                'first' => array('id' => 'foo'),
+                'second' => array('id' => 'bar'),
+            ),
+
+            'firewalls' => array(
+                'default' => array(
+                    'form_login' => array('provider' => 'second'),
+                    'logout_on_user_change' => true,
+                    'remember_me' => array('secret' => 'baz'),
+                ),
+            ),
+        ));
+
+        $container->compile();
+        $this->addToAssertionCount(1);
+    }
+
     protected function getRawContainer()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

When more than one user provider is configured, and `remember_me` is enabled on a firewall, this avoids the deprecation notice in 3.4 and thrown `InvalidConfigurationException` in 4.0 ("Not configuring explicitly the provider for the "remember_me" listener on "foo" firewall is ambiguous as there is more than one registered provider.").  The `RememberMeFactory` ignores the `$userProvider` argument and uses the secret configured for the firewall.  (If no secret is configured, it throws its own exception.)

The added test passes in 3.4 with a deprecation notice without the change, so would expect it to fail in 4.0 without the change.

Other tests in the `SecurityBundle` already included two errors and one failure, not related to this change.