### PR TITLE
Exit as late as possible

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -127,32 +127,53 @@ class DeprecationErrorHandler
                     return $b['count'] - $a['count'];
                 };
 
-                foreach (array('unsilenced', 'remaining', 'legacy', 'other') as $group) {
-                    if ($deprecations[$group.'Count']) {
-                        echo "\n", $colorize(sprintf('%s deprecation notices (%d)', ucfirst($group), $deprecations[$group.'Count']), 'legacy' !== $group), "\n";
+                $displayDeprecations = function ($deprecations) use ($colorize, $cmp) {
+                    foreach (array('unsilenced', 'remaining', 'legacy', 'other') as $group) {
+                        if ($deprecations[$group.'Count']) {
+                            echo "\n", $colorize(sprintf('%s deprecation notices (%d)', ucfirst($group), $deprecations[$group.'Count']), 'legacy' !== $group), "\n";
 
-                        uasort($deprecations[$group], $cmp);
+                            uasort($deprecations[$group], $cmp);
 
-                        foreach ($deprecations[$group] as $msg => $notices) {
-                            echo "\n  ", $notices['count'], 'x: ', $msg, "\n";
+                            foreach ($deprecations[$group] as $msg => $notices) {
+                                echo "\n  ", $notices['count'], 'x: ', $msg, "\n";
 
-                            arsort($notices);
+                                arsort($notices);
 
-                            foreach ($notices as $method => $count) {
-                                if ('count' !== $method) {
-                                    echo '    ', $count, 'x in ', preg_replace('/(.*)\\\\(.*?::.*?)$/', '$2 from $1', $method), "\n";
+                                foreach ($notices as $method => $count) {
+                                    if ('count' !== $method) {
+                                        echo '    ', $count, 'x in ', preg_replace('/(.*)\\\\(.*?::.*?)$/', '$2 from $1', $method), "\n";
+                                    }
                                 }
                             }
                         }
                     }
-                }
-                if (!empty($notices)) {
-                    echo "\n";
+                    if (!empty($notices)) {
+                        echo "\n";
+                    }
+                };
+
+                $displayDeprecations($deprecations);
+
+                // store failing status
+                $isFailing = 'weak' !== $mode && ($deprecations['unsilenced'] || $deprecations['remaining'] || $deprecations['other']);
+
+                // reset deprecations array
+                foreach ($deprecations as $group => $arrayOrInt) {
+                    $deprecations[$group] = is_int($arrayOrInt) ? 0 : array();
                 }
 
-                if ('weak' !== $mode && ($deprecations['unsilenced'] || $deprecations['remaining'] || $deprecations['other'])) {
-                    exit(1);
-                }
+                register_shutdown_function(function () use (&$deprecations, $isFailing, $displayDeprecations, $mode) {
+                    foreach ($deprecations as $group => $arrayOrInt) {
+                        if (0 < (is_int($arrayOrInt) ? $arrayOrInt : count($arrayOrInt))) {
+                            echo "Shutdown-time deprecations:\n";
+                            break;
+                        }
+                    }
+                    $displayDeprecations($deprecations);
+                    if ($isFailing || 'weak' !== $mode && ($deprecations['unsilenced'] || $deprecations['remaining'] || $deprecations['other'])) {
+                        exit(1);
+                    }
+                });
             });
         }
     }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/shutdown_deprecations.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/shutdown_deprecations.phpt
@@ -60,7 +60,7 @@ $foo->testLegacyFoo();
 $foo->testNonLegacyBar();
 
 register_shutdown_function(function () {
-    exit('I get precedence over any exit statements inside the deprecation error handler.');
+    @trigger_error('root deprecation during shutdown', E_USER_DEPRECATED);
 });
 
 ?>
@@ -84,4 +84,8 @@ Other deprecation notices (1)
 
   1x: root deprecation
 
-I get precedence over any exit statements inside the deprecation error handler.
+Shutdown-time deprecations:
+
+Other deprecation notices (1)
+
+  1x: root deprecation during shutdown


### PR DESCRIPTION
People might want to register other shutdown functions that should be
able to control the exit code themselves, without the deprecation error
handler taking over. The php manual says:

> If you call exit() within one registered shutdown function, processing
> will stop completely and no other registered shutdown functions will be
> called.

See https://secure.php.net/manual/en/function.register-shutdown-function.php

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->
