### PR TITLE
Update MongoDB extension on travis to make the builds green again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,8 +100,6 @@ before_install:
       [[ $PHP = 5.* ]] && echo extension = memcache.so >> $INI
       if [[ $PHP = 5.* ]]; then
           echo extension = mongo.so >> $INI
-      elif [[ $PHP = 7.* ]]; then
-          echo extension = mongodb.so >> $INI
       fi
 
       # Matrix lines for intermediate PHP versions are skipped for pull requests
@@ -127,6 +125,7 @@ before_install:
           tfold ext.apcu4 'echo yes | pecl install -f apcu-4.0.11'
       elif [[ ! $skip && $PHP = 7.* ]]; then
           tfold ext.apcu5 'echo yes | pecl install -f apcu-5.1.6'
+          tfold ext.mongodb pecl install -f mongodb-1.4.0RC1
       fi
 
 install:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Currently, php 7.1 and 7.2 runs on travis are failing because we're testing against `mongodb/mongodb` 1.3-dev which requires a more recent version of `ext-mongodb` than Travis provides.

This PR attempts to fix the issue by installing that version via PECL.