### PR TITLE
[Lock] Log already-locked errors as "notice" instead of "warning"

### DIFF
--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -89,7 +89,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
             return true;
         } catch (LockConflictedException $e) {
             $this->dirty = false;
-            $this->logger->warning('Failed to acquire the "{resource}" lock. Someone else already acquired the lock.', array('resource' => $this->key));
+            $this->logger->notice('Failed to acquire the "{resource}" lock. Someone else already acquired the lock.', array('resource' => $this->key));
 
             if ($blocking) {
                 throw $e;
@@ -97,7 +97,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
 
             return false;
         } catch (\Exception $e) {
-            $this->logger->warning('Failed to acquire the "{resource}" lock.', array('resource' => $this->key, 'exception' => $e));
+            $this->logger->notice('Failed to acquire the "{resource}" lock.', array('resource' => $this->key, 'exception' => $e));
             throw new LockAcquiringException(sprintf('Failed to acquire the "%s" lock.', $this->key), 0, $e);
         }
     }
@@ -123,10 +123,10 @@ final class Lock implements LockInterface, LoggerAwareInterface
             $this->logger->info('Expiration defined for "{resource}" lock for "{ttl}" seconds.', array('resource' => $this->key, 'ttl' => $this->ttl));
         } catch (LockConflictedException $e) {
             $this->dirty = false;
-            $this->logger->warning('Failed to define an expiration for the "{resource}" lock, someone else acquired the lock.', array('resource' => $this->key));
+            $this->logger->notice('Failed to define an expiration for the "{resource}" lock, someone else acquired the lock.', array('resource' => $this->key));
             throw $e;
         } catch (\Exception $e) {
-            $this->logger->warning('Failed to define an expiration for the "{resource}" lock.', array('resource' => $this->key, 'exception' => $e));
+            $this->logger->notice('Failed to define an expiration for the "{resource}" lock.', array('resource' => $this->key, 'exception' => $e));
             throw new LockAcquiringException(sprintf('Failed to define an expiration for the "%s" lock.', $this->key), 0, $e);
         }
     }
@@ -148,7 +148,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
         $this->dirty = false;
 
         if ($this->store->exists($this->key)) {
-            $this->logger->warning('Failed to release the "{resource}" lock.', array('resource' => $this->key));
+            $this->logger->notice('Failed to release the "{resource}" lock.', array('resource' => $this->key));
             throw new LockReleasingException(sprintf('Failed to release the "%s" lock.', $this->key));
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #25887 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo

We add the ability to specify the log level we want in the lock component. That could be useful when parsing the logs.

![img_3186 heic](https://user-images.githubusercontent.com/3451634/35733664-8ed991dc-081e-11e8-89dd-9efff253e492.jpeg)
