### PR TITLE
[DomCrawler] ->each() should not add null to the results

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -352,7 +352,9 @@ class Crawler extends \SplObjectStorage
     {
         $data = array();
         foreach ($this as $i => $node) {
-            $data[] = $closure($this->createSubCrawler($node), $i);
+            if (null !== $result = $closure($this->createSubCrawler($node), $i)) {
+                $data[] = $result;
+            }
         }
 
         return $data;

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -281,6 +281,16 @@ EOF
         $this->assertEquals(array('0-One', '1-Two', '2-Three'), $data, '->each() executes an anonymous function on each node of the list');
     }
 
+
+    public function testEachNullGetsNotAddedToResult()
+    {
+        $data = $this->createTestCrawler()->filterXPath('//a')->each(function ($node, $i) {
+            return false !== strpos($node->attr('href'),'foo') ? $node : null;
+        });
+
+        $this->assertCount(4, $data, '->each() does not add null to the results');
+    }
+
     public function testSlice()
     {
         $crawler = $this->createTestCrawler()->filterXPath('//ul[1]/li');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

From https://github.com/symfony/dom-crawler/pull/19