### PR TITLE
Affirmative strategy in lock component

### DIFF
--- a/src/Symfony/Component/Lock/Strategy/AffirmativeStrategy.php
+++ b/src/Symfony/Component/Lock/Strategy/AffirmativeStrategy.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Strategy;
+
+/**
+ * Affirmative is a StrategyInterface implementation where at least one item should be successful.
+ *
+ * @author Valentin Faugeroux <faugerouxvalentin@gmail.com>
+ */
+class AffirmativeStrategy implements StrategyInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isMet($numberOfSuccess, $numberOfItems)
+    {
+        return $numberOfSuccess >= 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canBeMet($numberOfFailure, $numberOfItems)
+    {
+        return $numberOfFailure < $numberOfItems;
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Strategy/AffirmativeStrategyTest.php
+++ b/src/Symfony/Component/Lock/Tests/Strategy/AffirmativeStrategyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\Strategy\AffirmativeStrategy;
+
+/**
+ * @author Valentin Faugeroux <faugerouxvalentin@gmail.com>
+ */
+class AffirmativeStrategyTest extends TestCase
+{
+    /** @var AffirmativeStrategy */
+    private $strategy;
+
+    public function setup()
+    {
+        $this->strategy = new AffirmativeStrategy();
+    }
+
+    public function provideMetResults()
+    {
+        // success, failure, total, isMet
+        yield array(3, 0, 3, true);
+        yield array(2, 1, 3, true);
+        yield array(2, 0, 3, true);
+        yield array(1, 2, 3, true);
+        yield array(1, 1, 3, true);
+        yield array(1, 0, 3, true);
+        yield array(0, 3, 3, false);
+        yield array(0, 2, 3, false);
+        yield array(0, 1, 3, false);
+        yield array(0, 0, 3, false);
+
+        yield array(2, 0, 2, true);
+        yield array(1, 1, 2, true);
+        yield array(1, 0, 2, true);
+        yield array(0, 2, 2, false);
+        yield array(0, 1, 2, false);
+        yield array(0, 0, 2, false);
+    }
+
+    public function provideIndeterminate()
+    {
+        // success, failure, total, canBeMet
+        yield array(3, 0, 3, true);
+        yield array(2, 1, 3, true);
+        yield array(2, 0, 3, true);
+        yield array(1, 2, 3, true);
+        yield array(1, 1, 3, true);
+        yield array(1, 0, 3, true);
+        yield array(0, 3, 3, false);
+        yield array(0, 2, 3, true);
+        yield array(0, 1, 3, true);
+        yield array(0, 0, 3, true);
+
+        yield array(2, 0, 2, true);
+        yield array(1, 1, 2, true);
+        yield array(1, 0, 2, true);
+        yield array(0, 2, 2, false);
+        yield array(0, 1, 2, true);
+        yield array(0, 0, 2, true);
+    }
+
+    /**
+     * @dataProvider provideMetResults
+     */
+    public function testMet($success, $failure, $total, $isMet)
+    {
+        $this->assertSame($isMet, $this->strategy->isMet($success, $total));
+    }
+
+    /**
+     * @dataProvider provideIndeterminate
+     */
+    public function testCanBeMet($success, $failure, $total, $isMet)
+    {
+        $this->assertSame($isMet, $this->strategy->canBeMet($failure, $total));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | n/a

Add the possibility to use the affirmative strategy in the lock component (need only one store that match the key)
