### PR TITLE
Unwrap errors in FlattenException

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FatalThrowableError.php
+++ b/src/Symfony/Component/Debug/Exception/FatalThrowableError.php
@@ -18,21 +18,22 @@ namespace Symfony\Component\Debug\Exception;
  */
 class FatalThrowableError extends FatalErrorException
 {
+    private $originalClassName;
+
     public function __construct(\Throwable $e)
     {
+        $this->originalClassName = \get_class($e);
+
         if ($e instanceof \ParseError) {
-            $message = 'Parse error: '.$e->getMessage();
             $severity = E_PARSE;
         } elseif ($e instanceof \TypeError) {
-            $message = 'Type error: '.$e->getMessage();
             $severity = E_RECOVERABLE_ERROR;
         } else {
-            $message = $e->getMessage();
             $severity = E_ERROR;
         }
 
         \ErrorException::__construct(
-            $message,
+            $e->getMessage(),
             $e->getCode(),
             $severity,
             $e->getFile(),
@@ -40,5 +41,10 @@ class FatalThrowableError extends FatalErrorException
         );
 
         $this->setTrace($e->getTrace());
+    }
+
+    public function getOriginalClassName(): string
+    {
+        return $this->originalClassName;
     }
 }

--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -53,7 +53,7 @@ class FlattenException
         $e->setStatusCode($statusCode);
         $e->setHeaders($headers);
         $e->setTraceFromException($exception);
-        $e->setClass(get_class($exception));
+        $e->setClass($exception instanceof FatalThrowableError ? $exception->getOriginalClassName() : \get_class($exception));
         $e->setFile($exception->getFile());
         $e->setLine($exception->getLine());
 
@@ -157,7 +157,7 @@ class FlattenException
         return $this->previous;
     }
 
-    public function setPrevious(FlattenException $previous)
+    public function setPrevious(self $previous)
     {
         $this->previous = $previous;
     }

--- a/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Debug\Tests\Exception;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -123,6 +124,16 @@ class FlattenExceptionTest extends TestCase
         $this->assertInstanceOf($flattened->getClass(), $exception, 'The class is set to the class of the original exception');
     }
 
+    public function testThrowable()
+    {
+        $exception = new FatalThrowableError(new \DivisionByZeroError('Ouch', 42));
+        $flattened = FlattenException::create($exception);
+
+        $this->assertSame('Ouch', $flattened->getMessage(), 'The message is copied from the original error.');
+        $this->assertSame(42, $flattened->getCode(), 'The code is copied from the original error.');
+        $this->assertSame('DivisionByZeroError', $flattened->getClass(), 'The class is set to the class of the original error');
+    }
+
     /**
      * @dataProvider flattenDataProvider
      */
@@ -144,9 +155,9 @@ class FlattenExceptionTest extends TestCase
 
         $flattened = FlattenException::create($exception)->getPrevious();
 
-        $this->assertEquals($flattened->getMessage(), 'Parse error: Oh noes!', 'The message is copied from the original exception.');
+        $this->assertEquals($flattened->getMessage(), 'Oh noes!', 'The message is copied from the original exception.');
         $this->assertEquals($flattened->getCode(), 42, 'The code is copied from the original exception.');
-        $this->assertEquals($flattened->getClass(), 'Symfony\Component\Debug\Exception\FatalThrowableError', 'The class is set to the class of the original exception');
+        $this->assertEquals($flattened->getClass(), 'ParseError', 'The class is set to the class of the original exception');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | maybe
| Deprecations? | no
| Tests pass?   | no (but probably unrelated?)
| Fixed tickets | #26025
| License       | MIT
| Doc PR        | N/A

This is probably the most straightforward way to solve #26025. `FlattenException` is now unwrapping `FatalThrowableError` instances and logs the wrapped error instead. The consequence of this change is that the real error class is displayend on TwigBundle's exception page and the profiler.

Regarding BC: If we assume that `FlattenException` is used for rendering and logging, everything should be fine. But this PR changes `FlattenException`'s internal behavior. If a piece of code relied on errors appearing `FatalThrowableError` inside a `FlattenException`, that code would break.

<img width="402" alt="bildschirmfoto 2018-02-02 um 20 08 42" src="https://user-images.githubusercontent.com/1506493/35760077-0b202940-087e-11e8-9b98-8e4ba269780c.png">
