### PR TITLE
Removed unused parameter from flattenDataProvider()

### DIFF
--- a/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
@@ -105,7 +105,7 @@ class FlattenExceptionTest extends TestCase
     /**
      * @dataProvider flattenDataProvider
      */
-    public function testFlattenHttpException(\Exception $exception, $statusCode)
+    public function testFlattenHttpException(\Exception $exception)
     {
         $flattened = FlattenException::create($exception);
         $flattened2 = FlattenException::create($exception);
@@ -120,7 +120,7 @@ class FlattenExceptionTest extends TestCase
     /**
      * @dataProvider flattenDataProvider
      */
-    public function testPrevious(\Exception $exception, $statusCode)
+    public function testPrevious(\Exception $exception)
     {
         $flattened = FlattenException::create($exception);
         $flattened2 = FlattenException::create($exception);
@@ -167,7 +167,7 @@ class FlattenExceptionTest extends TestCase
     /**
      * @dataProvider flattenDataProvider
      */
-    public function testToArray(\Exception $exception, $statusCode)
+    public function testToArray(\Exception $exception)
     {
         $flattened = FlattenException::create($exception);
         $flattened->setTrace(array(), 'foo.php', 123);
@@ -187,7 +187,7 @@ class FlattenExceptionTest extends TestCase
     public function flattenDataProvider()
     {
         return array(
-            array(new \Exception('test', 123), 500),
+            array(new \Exception('test', 123)),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no, but unrelated
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

While working on #26028, I noticed that FlattenExceptionTest::FlattenExceptionTest.php() exposes two arguments although all tests consuming that provider only use the first one. This PR removes the unnecessary second argument.