### PR TITLE
Use assertNan() instead of assertTrue(is_nan())

### DIFF
--- a/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
@@ -256,7 +256,7 @@ class FlattenExceptionTest extends TestCase
 
         // assertEquals() does not like NAN values.
         $this->assertEquals($array[$i][0], 'float');
-        $this->assertTrue(is_nan($array[$i++][1]));
+        $this->assertNan($array[$i][1]);
     }
 
     public function testRecursionInArguments()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no (but unrelated)
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

On #26028, fabbot complained about one assertion in `FlattenExceptionTest`. Since that piece of code already exists in 3.4, I've backported the fix.
