### PR TITLE
[travis] bump ext-mongodb to 1.4RC1 as required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,8 +100,6 @@ before_install:
       [[ $PHP = 5.* ]] && echo extension = memcache.so >> $INI
       if [[ $PHP = 5.* ]]; then
           echo extension = mongo.so >> $INI
-      elif [[ $PHP = 7.* ]]; then
-          echo extension = mongodb.so >> $INI
       fi
 
       # Matrix lines for intermediate PHP versions are skipped for pull requests
@@ -127,6 +125,7 @@ before_install:
           tfold ext.apcu4 'echo yes | pecl install -f apcu-4.0.11'
       elif [[ ! $skip && $PHP = 7.* ]]; then
           tfold ext.apcu5 'echo yes | pecl install -f apcu-5.1.6'
+          tfold ext.mongodb 'echo yes | pecl install -f mongodb-1.4.0RC1'
       fi
 
 install:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Related to https://github.com/mongodb/mongo-php-library/pull/467