### PR TITLE
Display the Welcome Page when there is no homepage defined

### DIFF
--- a/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
+++ b/src/Symfony/Component/HttpKernel/Resources/welcome.html.php
@@ -76,7 +76,7 @@
     </div>
     <div id="comment">
         <p>
-            You're seeing this message because you have debug mode enabled and you haven't configured any URLs.
+            You're seeing this page because debug mode is enabled and you haven't configured any homepage URL.
         </p>
     </div>
 </div>

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -153,11 +153,10 @@ EOF;
             }
         }
 
-        if ('' === $code) {
-            $code .= "        if ('/' === \$pathinfo) {\n";
-            $code .= "            throw new Symfony\Component\Routing\Exception\NoConfigurationException();\n";
-            $code .= "        }\n";
-        }
+        // used to display the Welcome Page in apps that don't define a homepage
+        $code .= "        if ('/' === \$pathinfo) {\n";
+        $code .= "            throw new Symfony\Component\Routing\Exception\NoConfigurationException();\n";
+        $code .= "        }\n";
 
         return $code;
     }

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -76,7 +76,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
             return $ret;
         }
 
-        if (0 === count($this->routes) && '/' === $pathinfo) {
+        if ('/' === $pathinfo) {
             throw new NoConfigurationException();
         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -305,6 +305,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         }
 
+        if ('/' === $pathinfo) {
+            throw new Symfony\Component\Routing\Exception\NoConfigurationException();
+        }
+
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -357,6 +357,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             return $ret;
         }
 
+        if ('/' === $pathinfo) {
+            throw new Symfony\Component\Routing\Exception\NoConfigurationException();
+        }
+
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -46,6 +46,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return array('_route' => 'with-condition');
         }
 
+        if ('/' === $pathinfo) {
+            throw new Symfony\Component\Routing\Exception\NoConfigurationException();
+        }
+
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -97,6 +97,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         }
 
+        if ('/' === $pathinfo) {
+            throw new Symfony\Component\Routing\Exception\NoConfigurationException();
+        }
+
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher5.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher5.php
@@ -200,6 +200,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         }
 
+        if ('/' === $pathinfo) {
+            throw new Symfony\Component\Routing\Exception\NoConfigurationException();
+        }
+
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher6.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher6.php
@@ -192,6 +192,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         }
 
+        if ('/' === $pathinfo) {
+            throw new Symfony\Component\Routing\Exception\NoConfigurationException();
+        }
+
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher7.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher7.php
@@ -248,6 +248,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         }
 
+        if ('/' === $pathinfo) {
+            throw new Symfony\Component\Routing\Exception\NoConfigurationException();
+        }
+
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony-docs/issues/9178
| License       | MIT
| Doc PR        | -

In 3.4 we added a trick to display the Welcome Page when the user browses `/` and there are no routes defined. However, when using the `website-skeleton` (which is what most newcomers use ... and they are the ones that mostly need the "Welcome Page") the premise about *"no routes are defined"* is never true and the Welcome Page is never shown (see https://github.com/symfony/symfony-docs/issues/9178 for one of the multiple error reports we've received).

So, I propose to make this change to always define the "Welcome Page" as the fallback:

* If no routes are defined for `/`, the Welcome Page is displayed.
* If there is a route defined for `/`, this code will never be executed because it's the last condition of the routing matcher.