### PR TITLE
[Workflow] add get available on workflow component

### DIFF
--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -162,6 +162,25 @@ class Workflow implements WorkflowInterface
     }
 
     /**
+     * Returns all available transitions (without taking care of guard handlers).
+     *
+     * @param object $subject A subject
+     *
+     * @return Transition[] All available transitions
+     */
+    public function getAvailableTransitions($subject)
+    {
+        $available = array();
+        $marking = $this->getMarking($subject);
+
+        foreach ($this->definition->getTransitions() as $transition) {
+            $available[] = $transition;
+        }
+
+        return $available;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getName()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Returns all available transitions (without taking care of guard handlers). It's may be really useful in the case we have to get the available and not juste enabled.
