### PR TITLE
[Serialized] add context to serialize and deserialize

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * added getter for extra attributes in `ExtraAttributesException`
  * improved `CsvEncoder` to handle variable nested structures
  * CSV headers can be passed to the `CsvEncoder` via the `csv_headers` serialization context variable 
+ * added `$context` when checking for encoding, decoding and normalizing in `Serializer`
 
 3.3.0
 -----

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -108,11 +108,11 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
      */
     final public function serialize($data, $format, array $context = array())
     {
-        if (!$this->supportsEncoding($format)) {
+        if (!$this->supportsEncoding($format, $context)) {
             throw new NotEncodableValueException(sprintf('Serialization for the format %s is not supported', $format));
         }
 
-        if ($this->encoder->needsNormalization($format)) {
+        if ($this->encoder->needsNormalization($format, $context)) {
             $data = $this->normalize($data, $format, $context);
         }
 
@@ -124,7 +124,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
      */
     final public function deserialize($data, $type, $format, array $context = array())
     {
-        if (!$this->supportsDecoding($format)) {
+        if (!$this->supportsDecoding($format, $context)) {
             throw new NotEncodableValueException(sprintf('Deserialization for the format %s is not supported', $format));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| Tests pass?   | yes
| License       | MIT

added context to `supportsDecoding` `needsNormalization` and `supportsEncoding`