### PR TITLE
[WebProfilerBundle] Fix sub request link

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -271,9 +271,7 @@
             <div class="tab-content">
                 {% for child in profile.children %}
                     <h3>
-                        <a href="{{ path('_profiler', { token: child.token }) }}">
-                            {{ helper.set_handler(child.getcollector('request').controller) }}
-                        </a>
+                        {{ helper.set_handler(child.getcollector('request').controller) }}
                         <small>(token = <a href="{{ path('_profiler', { token: child.token }) }}">{{ child.token }}</a>)</small>
                     </h3>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Split from #25164

before:

```html
<a href="/_profiler/395a5c">
    <a href="/_profiler/open?file=symfony/src/Controller/MainController.php&amp;line=20#line20" title="symfony/src/Controller/MainController.php">MainController :: bar</a>
</a>
<small>(token = <a href="/_profiler/395a5c">395a5c</a>)</small>
```

after:

```html
<a href="/_profiler/open?file=symfony/src/Controller/MainController.php&amp;line=20#line20" title="symfony/src/Controller/MainController.php">MainController :: bar</a>
<small>(token = <a href="/_profiler/395a5c">395a5c</a>)</small>
```