### PR TITLE
[YAML] Issue #26065 block indentation indicator for some multi-line string literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,15 @@ before_install:
           ([[ $deps ]] || tfold ext.symfony_debug 'cd src/Symfony/Component/Debug/Resources/ext && phpize && ./configure && make && echo extension = $(pwd)/modules/symfony_debug.so >> '"$INI")
           tfold ext.apcu tpecl apcu-4.0.11 apcu.so
       elif [[ ! $skip && $PHP = 7.* ]]; then
+          # install libsodium
+          if [[ ! -e ~/php-ext/$(php -r "echo basename(ini_get('extension_dir'));")/libsodium/sodium.so ]]; then
+              sudo add-apt-repository ppa:ondrej/php -y
+              sudo apt-get update -q
+              sudo apt-get install libsodium-dev -y
+          fi
+
           tfold ext.apcu tpecl apcu-5.1.6 apcu.so
+          tfold ext.libsodium tpecl libsodium sodium.so
           tfold ext.mongodb tpecl mongodb-1.4.0RC1 mongodb.so
       fi
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_encoder.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_encoder.yml
@@ -1,6 +1,6 @@
 security:
     encoders:
-        JMS\FooBundle\Entity\User6:
+        JMS\FooBundle\Entity\User7:
             algorithm: argon2i
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -86,7 +86,7 @@ class UserPasswordEncoderCommandTest extends WebTestCase
         $this->assertContains('Password encoding succeeded', $output);
 
         $encoder = new Argon2iPasswordEncoder();
-        preg_match('#  Encoded password\s+(\$argon2i\$[\w\d,=\$+\/]+={0,2})\s+#', $output, $matches);
+        preg_match('#  Encoded password\s+(\$argon2id\$[\w\d,=\$+\/]+={0,2})\s+#', $output, $matches);
         $hash = $matches[1];
         $this->assertTrue($encoder->isPasswordValid($hash, 'password', null));
     }
@@ -272,7 +272,7 @@ EOTXT
     private function setupArgon2i()
     {
         putenv('COLUMNS='.(119 + strlen(PHP_EOL)));
-        $kernel = $this->createKernel(array('test_case' => 'PasswordEncode', 'root_config' => 'argon2i'));
+        $kernel = $this->createKernel(array('test_case' => 'PasswordEncode', 'root_config' => 'argon2i.yml'));
         $kernel->boot();
 
         $application = new Application($kernel);

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -97,6 +97,7 @@ class ClientTest extends TestCase
     public function testUploadedFile()
     {
         $source = tempnam(sys_get_temp_dir(), 'source');
+        file_put_contents($source, '1');
         $target = sys_get_temp_dir().'/sf.moved.file';
         @unlink($target);
 
@@ -104,8 +105,8 @@ class ClientTest extends TestCase
         $client = new Client($kernel);
 
         $files = array(
-            array('tmp_name' => $source, 'name' => 'original', 'type' => 'mime/original', 'size' => 123, 'error' => UPLOAD_ERR_OK),
-            new UploadedFile($source, 'original', 'mime/original', 123, UPLOAD_ERR_OK, true),
+            array('tmp_name' => $source, 'name' => 'original', 'type' => 'mime/original', 'size' => 1, 'error' => UPLOAD_ERR_OK),
+            new UploadedFile($source, 'original', 'mime/original', 1, UPLOAD_ERR_OK, true),
         );
 
         $file = null;
@@ -120,7 +121,7 @@ class ClientTest extends TestCase
 
             $this->assertEquals('original', $file->getClientOriginalName());
             $this->assertEquals('mime/original', $file->getClientMimeType());
-            $this->assertEquals('123', $file->getClientSize());
+            $this->assertSame(1, $file->getClientSize());
             $this->assertTrue($file->isValid());
         }
 

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -77,35 +77,6 @@ EOF;
         $this->assertEquals($expected, $dumper->dump($this->array, 4, 0));
     }
 
-    /**
-     * @group legacy
-     */
-    public function testSetIndentation()
-    {
-        $this->dumper->setIndentation(7);
-
-        $expected = <<<'EOF'
-'': bar
-foo: '#bar'
-'foo''bar': {  }
-bar:
-       - 1
-       - foo
-foobar:
-       foo: bar
-       bar:
-              - 1
-              - foo
-       foobar:
-              foo: bar
-              bar:
-                     - 1
-                     - foo
-
-EOF;
-        $this->assertEquals($expected, $this->dumper->dump($this->array, 4, 0));
-    }
-
     public function testSpecifications()
     {
         $files = $this->parser->parse(file_get_contents($this->path.'/index.yml'));
@@ -213,16 +184,6 @@ EOF;
         $this->assertEquals('{ foo: !php/object \'O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}\', bar: 1 }', $dump, '->dump() is able to dump objects');
     }
 
-    /**
-     * @group legacy
-     */
-    public function testObjectSupportEnabledPassingTrue()
-    {
-        $dump = $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, false, true);
-
-        $this->assertEquals('{ foo: !php/object \'O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}\', bar: 1 }', $dump, '->dump() is able to dump objects');
-    }
-
     public function testObjectSupportDisabledButNoExceptions()
     {
         $dump = $this->dumper->dump(array('foo' => new A(), 'bar' => 1));
@@ -236,33 +197,6 @@ EOF;
     public function testObjectSupportDisabledWithExceptions()
     {
         $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE);
-    }
-
-    /**
-     * @group legacy
-     * @expectedException \Symfony\Component\Yaml\Exception\DumpException
-     */
-    public function testObjectSupportDisabledWithExceptionsPassingTrue()
-    {
-        $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, true);
-    }
-
-    public function testEmptyArray()
-    {
-        $dump = $this->dumper->dump(array());
-        $this->assertEquals('{  }', $dump);
-
-        $dump = $this->dumper->dump(array(), 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
-        $this->assertEquals('[]', $dump);
-
-        $dump = $this->dumper->dump(array(), 9, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
-        $this->assertEquals('[]', $dump);
-
-        $dump = $this->dumper->dump(new \ArrayObject(), 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_OBJECT_AS_MAP);
-        $this->assertEquals('{  }', $dump);
-
-        $dump = $this->dumper->dump(new \stdClass(), 0, 0, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_OBJECT_AS_MAP);
-        $this->assertEquals('{  }', $dump);
     }
 
     /**
@@ -452,6 +386,17 @@ YAML;
         );
 
         $this->assertSame(file_get_contents(__DIR__.'/Fixtures/multiple_lines_as_literal_block.yml'), $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
+    }
+
+    public function testDumpMultiLineStringAsScalarBlockWhenFirstLineHasLeadingSpace()
+    {
+        $data = array(
+            'data' => array(
+                'multi_line' => "    the first line has leading spaces\nThe second line does not.",
+            ),
+        );
+
+        $this->assertSame(file_get_contents(__DIR__.'/Fixtures/multiple_lines_as_literal_block_leading_space_in_first_line.yml'), $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
     }
 
     public function testCarriageReturnIsMaintainedWhenDumpingAsMultiLineLiteralBlock()

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block_leading_space_in_first_line.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block_leading_space_in_first_line.yml
@@ -1,0 +1,4 @@
+data:
+    multi_line: |4
+            the first line has leading spaces
+        The second line does not.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #26065 
| License       | MIT
| Doc PR        | no

Doing this:
    
    Yaml::dump(
        ["text" => "  leading space in first line\nno leading space in last line\n"],
        2, 
        4, 
        Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK
    );

Will produce this:

    text: |
           leading space in first line
         no leading space in last line
         
Which is invalid YAML because when the first line has leading spaces it needs a [block indentation indicator](http://www.yaml.org/spec/1.2/spec.html#id2793979) like this:

    text: |4
          leading space in first line
        no leading space in last line

So far, this pull request just has the unit test to show the failure.