### PR TITLE
[YAML] Issue #26065: leading spaces in YAML multi-line string literals

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -98,7 +98,10 @@ class Dumper
 
             foreach ($input as $key => $value) {
                 if ($inline >= 1 && Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK & $flags && is_string($value) && false !== strpos($value, "\n") && false === strpos($value, "\r\n")) {
-                    $output .= sprintf("%s%s%s |\n", $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', '');
+                    // If the first line starts with a space character, the spec requires a blockIndicationIndicator
+                    // http://www.yaml.org/spec/1.2/spec.html#id2793979
+                    $blockIndentationIndicator = (' ' === substr($value, 0, 1)) ? (string) $this->indentation : '';
+                    $output .= sprintf("%s%s%s |%s\n", $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', '', $blockIndentationIndicator);
 
                     foreach (preg_split('/\n|\r\n/', $value) as $row) {
                         $output .= sprintf("%s%s%s\n", $prefix, str_repeat(' ', $this->indentation), $row);

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -454,6 +454,17 @@ YAML;
         $this->assertSame(file_get_contents(__DIR__.'/Fixtures/multiple_lines_as_literal_block.yml'), $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
     }
 
+    public function testDumpMultiLineStringAsScalarBlockWhenFirstLineHasLeadingSpace()
+    {
+        $data = array(
+            'data' => array(
+                'multi_line' => "    the first line has leading spaces\nThe second line does not.",
+            ),
+        );
+
+        $this->assertSame(file_get_contents(__DIR__.'/Fixtures/multiple_lines_as_literal_block_leading_space_in_first_line.yml'), $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
+    }
+
     public function testCarriageReturnIsMaintainedWhenDumpingAsMultiLineLiteralBlock()
     {
         $this->assertSame("- \"a\\r\\nb\\nc\"\n", $this->dumper->dump(array("a\r\nb\nc"), 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block_leading_space_in_first_line.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block_leading_space_in_first_line.yml
@@ -1,0 +1,4 @@
+data:
+    multi_line: |4
+            the first line has leading spaces
+        The second line does not.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26065 
| License       | MIT
| Doc PR        | no

Doing this:
    
    Yaml::dump(
        ["text" => "  leading space in first line\nno leading space in last line\n"],
        2, 
        4, 
        Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK
    );

Will produce this:

    text: |
           leading space in first line
         no leading space in last line
         
Which is invalid YAML because when the first line has leading spaces it needs a [block indentation indicator](http://www.yaml.org/spec/1.2/spec.html#id2793979) like this:

    text: |4
          leading space in first line
        no leading space in last line

This pull requests contains a test and a patch. 