### PR TITLE
[Cache][WebProfiler][3.3] fix collecting cache stats with sub-requests

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -170,11 +170,7 @@ class TraceableAdapter implements AdapterInterface
 
     public function getCalls()
     {
-        try {
-            return $this->calls;
-        } finally {
-            $this->calls = array();
-        }
+        return $this->calls;
     }
 
     protected function start($name)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/23820
| License       | MIT
| Doc PR        | -

When performing sub-requests the `CacheDataCollector` will get the calls from the `TraceableAdapter` per request. So calling it multiple times was always overwriting the previously collected calls with the latest calls.

So when no cache calls were performed during a sub-request all collected calls from the master request were just lost and the panel did not show anything.

@Nyholm seems you added this specific code? What was the motivation to clear directly after getting the calls? Just prevent a memory leak?

As of 3.4+ there is a reset method and with this additional changeset we can therefore easily reset the `TraceableAdapter`?

```diff
diff --git a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
index e8563521ba..98d0e52693 100644
--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -204,11 +204,12 @@ class TraceableAdapter implements AdapterInterface, PruneableInterface, Resettab
 
     public function getCalls()
     {
-        try {
-            return $this->calls;
-        } finally {
-            $this->calls = array();
-        }
+        return $this->calls;
+    }
+
+    public function clearCalls()
+    {
+        $this->calls = array();
     }
 
     protected function start($name)
diff --git a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
index 62d502f01f..ceef45aa0b 100644
--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -57,8 +57,7 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
     {
         $this->data = array();
         foreach ($this->instances as $instance) {
-            // Calling getCalls() will clear the calls.
-            $instance->getCalls();
+            $instance->clearCalls();
         }
     }
```

See PR for 3.4+: https://github.com/symfony/symfony/pull/26082
