### PR TITLE
[Cache][WebProfiler][3.4] fix collecting cache stats with sub-requests + allow clearing calls

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -204,11 +204,12 @@ class TraceableAdapter implements AdapterInterface, PruneableInterface, Resettab
 
     public function getCalls()
     {
-        try {
-            return $this->calls;
-        } finally {
-            $this->calls = array();
-        }
+        return $this->calls;
+    }
+
+    public function clearCalls()
+    {
+        $this->calls = array();
     }
 
     protected function start($name)

--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -57,8 +57,7 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
     {
         $this->data = array();
         foreach ($this->instances as $instance) {
-            // Calling getCalls() will clear the calls.
-            $instance->getCalls();
+            $instance->clearCalls();
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/23820
| License       | MIT
| Doc PR        | -

This is a follow-up PR for https://github.com/symfony/symfony/pull/26080. It additionally adds the reset behavior for the `TraceableAdapter` back.
