### PR TITLE
[FrameworkBundle] Fix using annotation_reader in compiler pass to inject configured cache provider

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAnnotationsCachedReaderPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddAnnotationsCachedReaderPass.php
@@ -26,16 +26,16 @@ class AddAnnotationsCachedReaderPass implements CompilerPassInterface
     {
         // "annotations.cached_reader" is wired late so that any passes using
         // "annotation_reader" at build time don't get any cache
-        if ($container->hasDefinition('annotations.cached_reader')) {
-            $reader = $container->getDefinition('annotations.cached_reader');
+        foreach ($container->findTaggedServiceIds('annotations.cached_reader') as $id => $tags) {
+            $reader = $container->getDefinition($id);
             $properties = $reader->getProperties();
 
             if (isset($properties['cacheProviderBackup'])) {
                 $provider = $properties['cacheProviderBackup']->getValues()[0];
                 unset($properties['cacheProviderBackup']);
                 $reader->setProperties($properties);
-                $container->set('annotations.cached_reader', null);
-                $container->setDefinition('annotations.cached_reader', $reader->replaceArgument(1, $provider));
+                $container->set($id, null);
+                $container->setDefinition($id, $reader->replaceArgument(1, $provider));
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class UnusedTagsPass implements CompilerPassInterface
 {
     private $whitelist = array(
+        'annotations.cached_reader',
         'cache.pool.clearer',
         'console.command',
         'container.hot_path',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1395,7 +1395,9 @@ class FrameworkExtension extends Extension
                 ->replaceArgument(2, $config['debug'])
                 // temporary property to lazy-reference the cache provider without using it until AddAnnotationsCachedReaderPass runs
                 ->setProperty('cacheProviderBackup', new ServiceClosureArgument(new Reference($cacheService)))
+                ->addTag('annotations.cached_reader')
             ;
+
             $container->setAlias('annotation_reader', 'annotations.cached_reader')->setPrivate(true);
             $container->setAlias(Reader::class, new Alias('annotations.cached_reader', false));
         } else {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
@@ -589,10 +590,12 @@ abstract class FrameworkExtensionTest extends TestCase
 
     public function testAnnotations()
     {
-        $container = $this->createContainerFromFile('full');
+        $container = $this->createContainerFromFile('full', array(), true, false);
+        $container->addCompilerPass(new TestAnnotationsPass());
+        $container->compile();
 
         $this->assertEquals($container->getParameter('kernel.cache_dir').'/annotations', $container->getDefinition('annotations.filesystem_cache')->getArgument(0));
-        $this->assertSame('annotations.filesystem_cache', (string) $container->getDefinition('annotations.cached_reader')->getArgument(1));
+        $this->assertSame('annotations.filesystem_cache', (string) $container->getDefinition('annotation_reader')->getArgument(1));
     }
 
     public function testFileLinkFormat()
@@ -1051,10 +1054,10 @@ abstract class FrameworkExtensionTest extends TestCase
         ), $data)));
     }
 
-    protected function createContainerFromFile($file, $data = array(), $resetCompilerPasses = true)
+    protected function createContainerFromFile($file, $data = array(), $resetCompilerPasses = true, $compile = true)
     {
         $cacheKey = md5(get_class($this).$file.serialize($data));
-        if (isset(self::$containerCache[$cacheKey])) {
+        if ($compile && isset(self::$containerCache[$cacheKey])) {
             return self::$containerCache[$cacheKey];
         }
         $container = $this->createContainer($data);
@@ -1065,7 +1068,12 @@ abstract class FrameworkExtensionTest extends TestCase
             $container->getCompilerPassConfig()->setOptimizationPasses(array());
             $container->getCompilerPassConfig()->setRemovingPasses(array());
         }
-        $container->getCompilerPassConfig()->setBeforeRemovingPasses(array(new AddAnnotationsCachedReaderPass(), new AddConstraintValidatorsPass(), new TranslatorPass('translator.default', 'translation.reader')));
+        $container->getCompilerPassConfig()->setBeforeRemovingPasses(array(new AddConstraintValidatorsPass(), new TranslatorPass('translator.default', 'translation.reader')));
+        $container->getCompilerPassConfig()->setAfterRemovingPasses(array(new AddAnnotationsCachedReaderPass()));
+
+        if (!$compile) {
+            return $container;
+        }
         $container->compile();
 
         return self::$containerCache[$cacheKey] = $container;
@@ -1156,5 +1164,17 @@ abstract class FrameworkExtensionTest extends TestCase
             default:
                 $this->fail('Unresolved adapter: '.$adapter);
         }
+    }
+}
+
+/**
+ * Simulates ReplaceAliasByActualDefinitionPass.
+ */
+class TestAnnotationsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $container->setDefinition('annotation_reader', $container->getDefinition('annotations.cached_reader'));
+        $container->removeDefinition('annotations.cached_reader');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26086 
| License       | MIT
| Doc PR        | -

The compilation pass of AddAnnotationsCachedReaderPass relies on already removed definition `annotations.cached_reader` due to an alias to `annotation_reader`.

Since the definition is being removed because of alias, configured annotation cache provider is not injected and will default back to ArrayCache.

This PR replaces the use of `annotations.cached_reader` to `annotation_reader` to complete the injection of configured cache provider.