### PR TITLE
Update Repository Symlink Helper

### DIFF
--- a/link
+++ b/link
@@ -37,7 +37,12 @@ if (!is_dir("$argv[1]/vendor/symfony")) {
 $sfPackages = array('symfony/symfony' => __DIR__);
 
 $filesystem = new Filesystem();
-foreach (glob(__DIR__.'/src/Symfony/{Bundle,Bridge,Component,Component/Security}/*', GLOB_BRACE | GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
+$braces = array('Bundle', 'Bridge', 'Component', 'Component/Security');
+$directories = call_user_func_array('array_merge', array_values(array_map(function ($part) {
+    return glob(__DIR__.'/src/Symfony/'.$part.'/*', GLOB_ONLYDIR | GLOB_NOSORT);
+}, $braces)));
+
+foreach ($directories as $dir) {
     if ($filesystem->exists($composer = "$dir/composer.json")) {
         $sfPackages[json_decode(file_get_contents($composer))->name] = $dir;
     }


### PR DESCRIPTION
The `link` script is super-useful (thanks @dunglas!) for development - but for some it's unusable in its current form due to the use of `GLOB_BRACE` which is [unavailable on certain platforms](https://github.com/zendframework/zend-stdlib/issues/58#issue-147689568) (such as Alpine) and is a platform-specific problem that will not be fixed in future versions of PHP.

I know the code is a little condensed and not the easiest to read, but I thought that wasn't really an issue considering this is just a development helper script and not part of the 'official' Symfony code base.

| Q             | A
| ------------- | ---
| Branch?       | `3.3`
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | No tests for `/link`
| Fixed tickets | 
| License       | MIT
| Doc PR        | can't find documentation for `/link`

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->
