### PR TITLE
[Workflow] Add a MetadataStore to fetch some metadata

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -104,3 +104,4 @@ Workflow
  * Deprecated the `add` method in favor of the `addWorkflow` method in `Workflow\Registry`.
  * Deprecated `SupportStrategyInterface` in favor of `WorkflowSupportStrategyInterface`.
  * Deprecated the class `ClassInstanceSupportStrategy` in favor of the class `InstanceOfSupportStrategy`.
+ * Deprecated passing the workflow name as 4th parameter of `Event` constructor in favor of the workflow itself.

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * add a `workflow_metadata` function
+
 3.4.0
 -----
 

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -37,6 +37,7 @@ class WorkflowExtension extends AbstractExtension
             new TwigFunction('workflow_transitions', array($this, 'getEnabledTransitions')),
             new TwigFunction('workflow_has_marked_place', array($this, 'hasMarkedPlace')),
             new TwigFunction('workflow_marked_places', array($this, 'getMarkedPlaces')),
+            new TwigFunction('workflow_metadata', array($this, 'getMetadata')),
         );
     }
 
@@ -99,6 +100,24 @@ class WorkflowExtension extends AbstractExtension
         }
 
         return $places;
+    }
+
+    /**
+     * Returns the metadata for a specific subject.
+     *
+     * @param object                 $subject         A subject
+     * @param null|string|Transition $metadataSubject Use null to get workflow metadata
+     *                                                Use a string (the place name) to get place metadata
+     *                                                Use a Transition instance to get transition metadata
+     */
+    public function getMetadata($subject, string $key, $metadataSubject = null, string $name = null): ?string
+    {
+        return $this
+            ->workflowRegistry
+            ->get($subject, $name)
+            ->getMetadataStore()
+            ->getMetadata($key, $metadataSubject)
+        ;
     }
 
     public function getName()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -273,8 +273,9 @@
         <xsd:sequence>
             <xsd:element name="marking-store" type="marking_store" minOccurs="0" maxOccurs="1" />
             <xsd:element name="support" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
-            <xsd:element name="place" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="place" type="place" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="transition" type="transition" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="metadata" type="metadata" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" />
         <xsd:attribute name="type" type="workflow_type" />
@@ -302,8 +303,22 @@
         <xsd:sequence>
             <xsd:element name="from" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
             <xsd:element name="to" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
+            <xsd:element name="metadata" type="metadata" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="place" mixed="true">
+        <xsd:sequence>
+            <xsd:element name="metadata" type="metadata" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="name" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="metadata">
+        <xsd:sequence>
+            <xsd:any minOccurs="0" processContents="lax"/>
+        </xsd:sequence>
     </xsd:complexType>
 
     <xsd:simpleType name="workflow_type">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
@@ -48,18 +48,29 @@ $container->loadFromExtension('framework', array(
                 FrameworkExtensionTest::class,
             ),
             'initial_place' => 'start',
+            'metadata' => array(
+                'title' => 'workflow title',
+            ),
             'places' => array(
-                'start',
-                'coding',
-                'travis',
-                'review',
-                'merged',
-                'closed',
+                'start_name_not_used' => array(
+                    'name' => 'start',
+                    'metadata' => array(
+                        'title' => 'place start title',
+                    ),
+                ),
+                'coding' => null,
+                'travis' => null,
+                'review' => null,
+                'merged' => null,
+                'closed' => null,
             ),
             'transitions' => array(
                 'submit' => array(
                     'from' => 'start',
                     'to' => 'travis',
+                    'metadata' => array(
+                        'title' => 'transition submit title',
+                    ),
                 ),
                 'update' => array(
                     'from' => array('coding', 'travis', 'review'),
@@ -96,8 +107,8 @@ $container->loadFromExtension('framework', array(
                 FrameworkExtensionTest::class,
             ),
             'places' => array(
-                'first',
-                'last',
+                array('name' => 'first'),
+                array('name' => 'last'),
             ),
             'transitions' => array(
                 'go' => array(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_arguments_and_service.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_arguments_and_service.xml
@@ -13,8 +13,8 @@
                 <framework:argument>a</framework:argument>
             </framework:marking-store>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
-            <framework:place>first</framework:place>
-            <framework:place>last</framework:place>
+            <framework:place name="first" />
+            <framework:place name="last" />
             <framework:transition name="foobar">
                 <framework:from>a</framework:from>
                 <framework:to>a</framework:to>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_multiple_transitions_with_same_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_multiple_transitions_with_same_name.xml
@@ -13,12 +13,12 @@
                 <framework:argument>a</framework:argument>
             </framework:marking-store>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
-            <framework:place>draft</framework:place>
-            <framework:place>wait_for_journalist</framework:place>
-            <framework:place>approved_by_journalist</framework:place>
-            <framework:place>wait_for_spellchecker</framework:place>
-            <framework:place>approved_by_spellchecker</framework:place>
-            <framework:place>published</framework:place>
+            <framework:place name="draft" />
+            <framework:place name="wait_for_journalist" />
+            <framework:place name="approved_by_journalist" />
+            <framework:place name="wait_for_spellchecker" />
+            <framework:place name="approved_by_spellchecker" />
+            <framework:place name="published" />
             <framework:transition name="request_review">
                 <framework:from>draft</framework:from>
                 <framework:to>wait_for_journalist</framework:to>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_support_and_support_strategy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_support_and_support_strategy.xml
@@ -10,8 +10,8 @@
         <framework:workflow name="my_workflow" support-strategy="foobar">
             <framework:marking-store type="multiple_state"/>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
-            <framework:place>first</framework:place>
-            <framework:place>last</framework:place>
+            <framework:place name="first" />
+            <framework:place name="last" />
             <framework:transition name="foobar">
                 <framework:from>a</framework:from>
                 <framework:to>a</framework:to>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_type_and_service.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_type_and_service.xml
@@ -10,8 +10,8 @@
         <framework:workflow name="my_workflow">
             <framework:marking-store type="multiple_state" service="workflow_service" />
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
-            <framework:place>first</framework:place>
-            <framework:place>last</framework:place>
+            <framework:place name="first" />
+            <framework:place name="last" />
             <framework:transition name="foobar">
                 <framework:from>a</framework:from>
                 <framework:to>a</framework:to>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_without_support_and_support_strategy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_without_support_and_support_strategy.xml
@@ -9,8 +9,8 @@
     <framework:config>
         <framework:workflow name="my_workflow">
             <framework:marking-store type="multiple_state"/>
-            <framework:place>first</framework:place>
-            <framework:place>last</framework:place>
+            <framework:place name="first" />
+            <framework:place name="last" />
             <framework:transition name="foobar">
                 <framework:from>a</framework:from>
                 <framework:to>a</framework:to>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
@@ -13,12 +13,12 @@
                 <framework:argument>a</framework:argument>
             </framework:marking-store>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
-            <framework:place>draft</framework:place>
-            <framework:place>wait_for_journalist</framework:place>
-            <framework:place>approved_by_journalist</framework:place>
-            <framework:place>wait_for_spellchecker</framework:place>
-            <framework:place>approved_by_spellchecker</framework:place>
-            <framework:place>published</framework:place>
+            <framework:place name="draft"></framework:place>
+            <framework:place name="wait_for_journalist"></framework:place>
+            <framework:place name="approved_by_journalist"></framework:place>
+            <framework:place name="wait_for_spellchecker"></framework:place>
+            <framework:place name="approved_by_spellchecker"></framework:place>
+            <framework:place name="published"></framework:place>
             <framework:transition name="request_review">
                 <framework:from>draft</framework:from>
                 <framework:to>wait_for_journalist</framework:to>
@@ -42,15 +42,22 @@
         <framework:workflow name="pull_request" initial-place="start">
             <framework:marking-store type="single_state"/>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
-            <framework:place>start</framework:place>
-            <framework:place>coding</framework:place>
-            <framework:place>travis</framework:place>
-            <framework:place>review</framework:place>
-            <framework:place>merged</framework:place>
-            <framework:place>closed</framework:place>
+            <framework:place name="start">
+                <framework:metadata>
+                    <framework:title>place start title</framework:title>
+                </framework:metadata>
+            </framework:place>
+            <framework:place name="coding"></framework:place>
+            <framework:place name="travis"></framework:place>
+            <framework:place name="review"></framework:place>
+            <framework:place name="merged"></framework:place>
+            <framework:place name="closed"></framework:place>
             <framework:transition name="submit">
                 <framework:from>start</framework:from>
                 <framework:to>travis</framework:to>
+                <framework:metadata>
+                    <framework:title>transition submit title</framework:title>
+                </framework:metadata>
             </framework:transition>
             <framework:transition name="update">
                 <framework:from>coding</framework:from>
@@ -78,11 +85,15 @@
                 <framework:from>closed</framework:from>
                 <framework:to>review</framework:to>
             </framework:transition>
+            <framework:metadata>
+                <framework:title>workflow title</framework:title>
+            </framework:metadata>
         </framework:workflow>
 
         <framework:workflow name="service_marking_store_workflow" type="workflow">
             <framework:marking-store service="workflow_service"/>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
+            <!-- Simple format -->
             <framework:place>first</framework:place>
             <framework:place>last</framework:place>
             <framework:transition name="go">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
@@ -8,6 +8,7 @@ framework:
                 - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest
             initial_place: draft
             places:
+                # simple format
                 - draft
                 - wait_for_journalist
                 - approved_by_journalist
@@ -33,17 +34,24 @@ framework:
             supports:
                 - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest
             initial_place: start
+            metadata:
+                title: workflow title
             places:
-                - start
-                - coding
-                - travis
-                - review
-                - merged
-                - closed
+                start_name_not_used:
+                    name: start
+                    metadata:
+                        title: place start title
+                coding: ~
+                travis: ~
+                review: ~
+                merged: ~
+                closed: ~
             transitions:
                 submit:
                     from: start
                     to: travis
+                    metadata:
+                        title: transition submit title
                 update:
                     from: [coding, travis, review]
                     to: travis
@@ -69,8 +77,8 @@ framework:
             supports:
                 - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest
             places:
-                - first
-                - last
+                - { name: first }
+                - { name: last }
             transitions:
                 go:
                     from:

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Deprecated the class `ClassInstanceSupportStrategy` in favor of the class `InstanceOfSupportStrategy`.
  * Added TransitionBlockers as a way to pass around reasons why exactly
    transitions can't be made.
+ * Added a `MetadataStore`.
 
 4.0.0
 -----

--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Workflow;
 
 use Symfony\Component\Workflow\Exception\LogicException;
+use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
+use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -23,13 +25,14 @@ final class Definition
     private $places = array();
     private $transitions = array();
     private $initialPlace;
+    private $metadataStore;
 
     /**
      * @param string[]     $places
      * @param Transition[] $transitions
      * @param string|null  $initialPlace
      */
-    public function __construct(array $places, array $transitions, string $initialPlace = null)
+    public function __construct(array $places, array $transitions, string $initialPlace = null, MetadataStoreInterface $metadataStore = null)
     {
         foreach ($places as $place) {
             $this->addPlace($place);
@@ -40,6 +43,8 @@ final class Definition
         }
 
         $this->setInitialPlace($initialPlace);
+
+        $this->metadataStore = $metadataStore ?: new InMemoryMetadataStore();
     }
 
     /**
@@ -64,6 +69,11 @@ final class Definition
     public function getTransitions(): array
     {
         return $this->transitions;
+    }
+
+    public function getMetadataStore(): MetadataStoreInterface
+    {
+        return $this->metadataStore;
     }
 
     private function setInitialPlace(string $place = null)

--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Workflow\Event;
 
 use Symfony\Component\EventDispatcher\Event as BaseEvent;
+use Symfony\Component\Workflow\Exception\InvalidArgumentException;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -24,20 +26,28 @@ class Event extends BaseEvent
     private $subject;
     private $marking;
     private $transition;
+    private $workflow;
     private $workflowName;
 
     /**
      * @param object     $subject
      * @param Marking    $marking
      * @param Transition $transition
-     * @param string     $workflowName
+     * @param Workflow   $workflow
      */
-    public function __construct($subject, Marking $marking, Transition $transition, string $workflowName = 'unnamed')
+    public function __construct($subject, Marking $marking, Transition $transition, $workflow = null)
     {
         $this->subject = $subject;
         $this->marking = $marking;
         $this->transition = $transition;
-        $this->workflowName = $workflowName;
+        if (is_string($workflow)) {
+            @trigger_error(sprintf('Passing a string as 4th parameter of "%s" is deprecated since Symfony 4.1. Pass a %s instance instead.', __METHOD__, WorkflowInterface::class), E_USER_DEPRECATED);
+            $this->workflowName = $workflow;
+        } elseif ($workflow instanceof WorkflowInterface) {
+            $this->workflow = $workflow;
+        } else {
+            throw new InvalidArgumentException(sprintf('The 4th parameter of "%s"  should be a "%s" instance instead.', __METHOD__, WorkflowInterface::class));
+        }
     }
 
     public function getMarking()
@@ -55,8 +65,38 @@ class Event extends BaseEvent
         return $this->transition;
     }
 
+    public function getWorkflow(): WorkflowInterface
+    {
+        // BC layer
+        if (!$this->workflow instanceof WorkflowInterface) {
+            throw new \RuntimeException(sprintf('The 4th parameter of "%s"::__construct() should be a "%s" instance.', __CLASS__, WorkflowInterface::class));
+        }
+
+        return $this->workflow;
+    }
+
     public function getWorkflowName()
     {
-        return $this->workflowName;
+        // BC layer
+        if ($this->workflowName) {
+            return $this->workflowName;
+        }
+
+        // BC layer
+        if (!$this->workflow instanceof WorkflowInterface) {
+            throw new \RuntimeException(sprintf('The 4th parameter of "%s"::__construct() should be a "%s" instance.', __CLASS__, WorkflowInterface::class));
+        }
+
+        return $this->workflow->getName();
+    }
+
+    public function getMetadata(string $key, $subject)
+    {
+        // BC layer
+        if (!$this->workflow instanceof WorkflowInterface) {
+            throw new \RuntimeException(sprintf('The 4th parameter of "%s"::__construct() should be a "%s" instance.', __CLASS__, WorkflowInterface::class));
+        }
+
+        return $this->workflow->getMetadataStore()->getMetadata($key, $subject);
     }
 }

--- a/src/Symfony/Component/Workflow/Metadata/GetMetadataTrait.php
+++ b/src/Symfony/Component/Workflow/Metadata/GetMetadataTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Metadata;
+
+use Symfony\Component\Workflow\Exception\InvalidArgumentException;
+use Symfony\Component\Workflow\Transition;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+trait GetMetadataTrait
+{
+    public function getMetadata(string $key, $subject = null)
+    {
+        if (null === $subject) {
+            return $this->getWorkflowMetadata()[$key] ?? null;
+        }
+
+        if (\is_string($subject)) {
+            $metadataBag = $this->getPlaceMetadata($subject);
+            if (!$metadataBag) {
+                return null;
+            }
+
+            return $metadataBag[$key] ?? null;
+        }
+
+        if ($subject instanceof Transition) {
+            $metadataBag = $this->getTransitionMetadata($subject);
+            if (!$metadataBag) {
+                return null;
+            }
+
+            return $metadataBag[$key] ?? null;
+        }
+
+        throw new InvalidArgumentException(sprintf('Could not find a MetadataBag for the subject of type "%s".', is_object($subject) ? get_class($subject) : gettype($subject)));
+    }
+}

--- a/src/Symfony/Component/Workflow/Metadata/InMemoryMetadataStore.php
+++ b/src/Symfony/Component/Workflow/Metadata/InMemoryMetadataStore.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Metadata;
+
+use Symfony\Component\Workflow\Transition;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+final class InMemoryMetadataStore implements MetadataStoreInterface
+{
+    use GetMetadataTrait;
+
+    private $workflowMetadata;
+    private $placesMetadata;
+    private $transitionsMetadata;
+
+    public function __construct($workflowMetadata = array(), array $placesMetadata = array(), \SplObjectStorage $transitionsMetadata = null)
+    {
+        $this->workflowMetadata = $workflowMetadata;
+        $this->placesMetadata = $placesMetadata;
+        $this->transitionsMetadata = $transitionsMetadata ?: new \SplObjectStorage();
+    }
+
+    public function getWorkflowMetadata(): array
+    {
+        return $this->workflowMetadata;
+    }
+
+    public function getPlaceMetadata(string $place): array
+    {
+        return $this->placesMetadata[$place] ?? array();
+    }
+
+    public function getTransitionMetadata(Transition $transition): array
+    {
+        return $this->transitionsMetadata[$transition] ?? array();
+    }
+}

--- a/src/Symfony/Component/Workflow/Metadata/MetadataStoreInterface.php
+++ b/src/Symfony/Component/Workflow/Metadata/MetadataStoreInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Metadata;
+
+use Symfony\Component\Workflow\Transition;
+
+/**
+ * MetadataStoreInterface is able to fetch metadata for a specific workflow.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+interface MetadataStoreInterface
+{
+    public function getWorkflowMetadata(): array;
+
+    public function getPlaceMetadata(string $place): array;
+
+    public function getTransitionMetadata(Transition $transition): array;
+
+    /**
+     * Returns the metadata for a specific subject.
+     *
+     * This is a proxy method.
+     *
+     * @param null|string|Transition $subject Use null to get workflow metadata
+     *                                        Use a string (the place name) to get place metadata
+     *                                        Use a Transition instance to get transition metadata
+     */
+    public function getMetadata(string $key, $subject = null);
+}

--- a/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
+++ b/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Workflow\EventListener\GuardListener;
 use Symfony\Component\Workflow\Event\GuardEvent;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowInterface;
 
 class GuardListenerTest extends TestCase
 {
@@ -102,7 +103,9 @@ class GuardListenerTest extends TestCase
         $subject->marking = new Marking();
         $transition = new Transition('name', 'from', 'to');
 
-        return new GuardEvent($subject, $subject->marking, $transition);
+        $workflow = $this->getMockBuilder(WorkflowInterface::class)->getMock();
+
+        return new GuardEvent($subject, $subject->marking, $transition, $workflow);
     }
 
     private function configureAuthenticationChecker($isUsed, $granted = true)

--- a/src/Symfony/Component/Workflow/Tests/Metadata/InMemoryMetadataStoreTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Metadata/InMemoryMetadataStoreTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Symfony\Component\Workflow\Tests\Metadata;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
+use Symfony\Component\Workflow\Transition;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class InMemoryMetadataStoreTest extends TestCase
+{
+    private $store;
+    private $transition;
+
+    protected function setUp()
+    {
+        $workflowMetadata = array(
+            'title' => 'workflow title',
+        );
+        $placesMetadata = array(
+            'place_a' => array(
+                'title' => 'place_a title',
+            ),
+        );
+        $transitionsMetadata = new \SplObjectStorage();
+        $this->transition = new Transition('transition_1', array(), array());
+        $transitionsMetadata[$this->transition] = array(
+            'title' => 'transition_1 title',
+        );
+
+        $this->store = new InMemoryMetadataStore($workflowMetadata, $placesMetadata, $transitionsMetadata);
+    }
+
+    public function testGetWorkflowMetadata()
+    {
+        $metadataBag = $this->store->getWorkflowMetadata();
+        $this->assertSame('workflow title', $metadataBag['title']);
+    }
+
+    public function testGetUnexistingPlaceMetadata()
+    {
+        $metadataBag = $this->store->getPlaceMetadata('place_b');
+        $this->assertSame(array(), $metadataBag);
+    }
+
+    public function testGetExistingPlaceMetadata()
+    {
+        $metadataBag = $this->store->getPlaceMetadata('place_a');
+        $this->assertSame('place_a title', $metadataBag['title']);
+    }
+
+    public function testGetUnexistingTransitionMetadata()
+    {
+        $metadataBag = $this->store->getTransitionMetadata(new Transition('transition_2', array(), array()));
+        $this->assertSame(array(), $metadataBag);
+    }
+
+    public function testGetExistingTransitionMetadata()
+    {
+        $metadataBag = $this->store->getTransitionMetadata($this->transition);
+        $this->assertSame('transition_1 title', $metadataBag['title']);
+    }
+
+    public function testGetMetadata()
+    {
+        $this->assertSame('workflow title', $this->store->getMetadata('title'));
+        $this->assertNull($this->store->getMetadata('description'));
+        $this->assertSame('place_a title', $this->store->getMetadata('title', 'place_a'));
+        $this->assertNull($this->store->getMetadata('description', 'place_a'));
+        $this->assertNull($this->store->getMetadata('description', 'place_b'));
+        $this->assertSame('transition_1 title', $this->store->getMetadata('title', $this->transition));
+        $this->assertNull($this->store->getMetadata('description', $this->transition));
+        $this->assertNull($this->store->getMetadata('description', new Transition('transition_2', array(), array())));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Workflow\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Could not find a MetadataBag for the subject of type "boolean".
+     */
+    public function testGetMetadataWithUnknownType()
+    {
+        $this->store->getMetadata('title', true);
+    }
+}

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -19,6 +19,7 @@ use Symfony\Component\Workflow\Exception\NotEnabledTransitionException;
 use Symfony\Component\Workflow\Exception\UndefinedTransitionException;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 use Symfony\Component\Workflow\MarkingStore\MultipleStateMarkingStore;
+use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -219,6 +220,14 @@ class Workflow implements WorkflowInterface
         return $this->markingStore;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataStore(): MetadataStoreInterface
+    {
+        return $this->definition->getMetadataStore();
+    }
+
     private function buildTransitionBlockerListForTransition($subject, Marking $marking, Transition $transition)
     {
         foreach ($transition->getFroms() as $place) {
@@ -248,7 +257,7 @@ class Workflow implements WorkflowInterface
             return null;
         }
 
-        $event = new GuardEvent($subject, $marking, $transition, $this->name);
+        $event = new GuardEvent($subject, $marking, $transition, $this);
 
         $this->dispatcher->dispatch('workflow.guard', $event);
         $this->dispatcher->dispatch(sprintf('workflow.%s.guard', $this->name), $event);
@@ -262,7 +271,7 @@ class Workflow implements WorkflowInterface
         $places = $transition->getFroms();
 
         if (null !== $this->dispatcher) {
-            $event = new Event($subject, $marking, $transition, $this->name);
+            $event = new Event($subject, $marking, $transition, $this);
 
             $this->dispatcher->dispatch('workflow.leave', $event);
             $this->dispatcher->dispatch(sprintf('workflow.%s.leave', $this->name), $event);
@@ -283,7 +292,7 @@ class Workflow implements WorkflowInterface
             return;
         }
 
-        $event = new Event($subject, $marking, $transition, $this->name);
+        $event = new Event($subject, $marking, $transition, $this);
 
         $this->dispatcher->dispatch('workflow.transition', $event);
         $this->dispatcher->dispatch(sprintf('workflow.%s.transition', $this->name), $event);
@@ -295,7 +304,7 @@ class Workflow implements WorkflowInterface
         $places = $transition->getTos();
 
         if (null !== $this->dispatcher) {
-            $event = new Event($subject, $marking, $transition, $this->name);
+            $event = new Event($subject, $marking, $transition, $this);
 
             $this->dispatcher->dispatch('workflow.enter', $event);
             $this->dispatcher->dispatch(sprintf('workflow.%s.enter', $this->name), $event);
@@ -316,7 +325,7 @@ class Workflow implements WorkflowInterface
             return;
         }
 
-        $event = new Event($subject, $marking, $transition, $this->name);
+        $event = new Event($subject, $marking, $transition, $this);
 
         $this->dispatcher->dispatch('workflow.entered', $event);
         $this->dispatcher->dispatch(sprintf('workflow.%s.entered', $this->name), $event);
@@ -332,7 +341,7 @@ class Workflow implements WorkflowInterface
             return;
         }
 
-        $event = new Event($subject, $marking, $transition, $this->name);
+        $event = new Event($subject, $marking, $transition, $this);
 
         $this->dispatcher->dispatch('workflow.completed', $event);
         $this->dispatcher->dispatch(sprintf('workflow.%s.completed', $this->name), $event);
@@ -345,7 +354,7 @@ class Workflow implements WorkflowInterface
             return;
         }
 
-        $event = new Event($subject, $marking, $initialTransition, $this->name);
+        $event = new Event($subject, $marking, $initialTransition, $this);
 
         $this->dispatcher->dispatch('workflow.announce', $event);
         $this->dispatcher->dispatch(sprintf('workflow.%s.announce', $this->name), $event);

--- a/src/Symfony/Component/Workflow/WorkflowInterface.php
+++ b/src/Symfony/Component/Workflow/WorkflowInterface.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Workflow;
 
 use Symfony\Component\Workflow\Exception\LogicException;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
+use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
 
 /**
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
@@ -82,4 +83,6 @@ interface WorkflowInterface
      * @return MarkingStoreInterface
      */
     public function getMarkingStore();
+
+    public function getMetadataStore(): MetadataStoreInterface;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #23257
| License       | MIT
| Doc PR        | TODO

---

This is an attempt to fix #23257. I first started to implement
`Ẁorkflow::getMetadata()`, `Transition::getMetadata()` and
`Place::getMetadata()`. **BUT**, there are no `Place` class. For now it's just a
`string`. So dealing with BC is a nightmare.


So I tried to find another way to fix the issue. [This
comment](https://github.com/symfony/symfony/issues/23257#issuecomment-315551397)
summary well the two options. But this PR is (will be) a mix of theses 2
options.

First it will be possible to configure the workflow/metadata like this:

```yaml
blog_publishing:
    supports:
        - AppBundle\Entity\BlogPost
    metada:
         label: Blog publishing
         description: Manages blog publishing
    places:
        draft:
            metadata:
                 description: Blog has just been created
                 color: grey
        review:
            metadata:
                 description: Blog is waiting for review
                 color: blue
    transitions:
        to_review:
            from: draft
            to: review
            metadata:
                label: Submit for review
                route: admin.blog.review
```

I think is very good for the DX. Simple to understand.

All metadata will live in a `MetadataStoreInterface`. If metadata are set via
the configuration (workflows.yaml), then we will use the
`InMemoryMetadataStore`.

Having a MetadataStoreInterface allow user to get dynamic value for a place /
transitions. It's really flexible. (But is it a valid use case ?)

Then, to retrieve these data, the end user will have to write this code:

```php
public function onReview(Event $event) {
    $metadataStore = $event->getWorkflow()->getMetadataStore();
    foreach ($event->getTransition()->getTos() as $place) {
        $this->flashbag->add('info', $metadataStore->getPlaceMetadata($place)->get('description'));
    }
}
```

Note: I might add some shortcut to the Event class


or in twig:

```jinja
{% for transition in workflow_transitions(post) %}
    <a href="{{ workflow_metadata_transition(post, route) }}">
         {{ workflow_metadata_transition(post, transition) }}
   </a>
{% endfor %}
```

---

WDYT ?

Should I continue this way, or should I introduce a `Place` class (there will be
so many deprecation ...)