### PR TITLE
[Console] Improve compatibility of output formatter

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -141,7 +141,7 @@ class OutputFormatter implements OutputFormatterInterface
             $pos = $match[1];
             $text = $match[0];
 
-            if (0 != $pos && '\\' == mb_substr($message, $pos - 1, 1, 'ASCII')) {
+            if (0 != $pos && '\\' == $message[$pos - 1]) {
                 continue;
             }
 
@@ -150,7 +150,7 @@ class OutputFormatter implements OutputFormatterInterface
             $offset = $pos + strlen($text);
 
             // opening tag?
-            if ($open = '/' != mb_substr($text, 1, 1, 'ASCII')) {
+            if ($open = '/' != $text[1]) {
                 $tag = $matches[1][$i][0];
             } else {
                 $tag = isset($matches[3][$i][0]) ? $matches[3][$i][0] : '';
@@ -170,7 +170,7 @@ class OutputFormatter implements OutputFormatterInterface
 
         $output .= $this->applyCurrentStyle(mb_substr($message, $offset, null, 'ASCII'));
 
-        if (false !== mb_strpos($output, "\0", 0, 'ASCII')) {
+        if (false !== strpos($output, "\0")) {
             return strtr($output, array("\0" => '\\', '\\<' => '<'));
         }
 

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -322,6 +322,18 @@ more text
 EOF
         ));
     }
+
+    public function testMultibyteStringSupport()
+    {
+        $formatter = new OutputFormatter(true);
+
+        // Formats a Unicode ballot x mark U+2717. This should work with
+        // mbstring function overloading on and off.
+        $this->assertEquals(
+            "\033[32m\xE2\x9C\x97\033[39m",
+            $formatter->format("<info>\xE2\x9C\x97</info>")
+        );
+    }
 }
 
 class TableCell


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 2.7 up to 4.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

preg_match with offset capture returns string offsets in bytes. If
mbstring function overloading is enabled this means subsequent
calculations on characters will not line up.

In practice this causes parts of the formatting tags to appear inline in
the formatted string.

This updates the code to use mb_string function with encoding explicitly
set to ASCII. This works for servers where function overloading is
enabled and servers where it is disabled.
