### PR TITLE
[Console] Fix broken table generation

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -565,7 +565,7 @@ class Table
     /**
      * Calculates columns widths.
      */
-    private function calculateColumnsWidth(array $rows)
+    private function calculateColumnsWidth(iterable $rows)
     {
         for ($column = 0; $column < $this->numberOfColumns; ++$column) {
             $lengths = array();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes (in an optimisation which is only in `master`)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (partially, at least they don't break badly anymore)
| Fixed tickets | #26081
| License       | MIT

In 2c9922e8afc8f4b2d6d93b63dbfb865b139eac48 the code was optimised but the order of method calls was incorrect, leading to several errors in the test suite.
