### PR TITLE
[Security] fix merge of 2.7 into 2.8 + add test case

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -96,9 +96,13 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
             }
         }
 
-        $requestBag = $this->options['post_only'] ? $request->request : $request;
-        $username = ParameterBagUtils::getParameterBagValue($requestBag, $this->options['username_parameter']);
-        $password = ParameterBagUtils::getParameterBagValue($requestBag, $this->options['password_parameter']);
+        if ($this->options['post_only']) {
+            $username = ParameterBagUtils::getParameterBagValue($request->request, $this->options['username_parameter']);
+            $password = ParameterBagUtils::getParameterBagValue($request->request, $this->options['password_parameter']);
+        } else {
+            $username = ParameterBagUtils::getRequestParameterValue($request, $this->options['username_parameter']);
+            $password = ParameterBagUtils::getRequestParameterValue($request, $this->options['password_parameter']);
+        }
 
         if (!\is_string($username) || (\is_object($username) && !\method_exists($username, '__toString'))) {
             throw new BadRequestHttpException(sprintf('The key "%s" must be a string, "%s" given.', $this->options['username_parameter'], \gettype($username)));

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php
@@ -77,10 +77,11 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
     }
 
     /**
+     * @dataProvider postOnlyDataProvider
      * @expectedException \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
      * @expectedExceptionMessage The key "_username" must be a string, "array" given.
      */
-    public function testHandleNonStringUsername()
+    public function testHandleNonStringUsername($postOnly)
     {
         $request = Request::create('/login_check', 'POST', array('_username' => array()));
         $request->setSession($this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock());
@@ -93,12 +94,20 @@ class UsernamePasswordFormAuthenticationListenerTest extends TestCase
             'foo',
             new DefaultAuthenticationSuccessHandler($httpUtils),
             new DefaultAuthenticationFailureHandler($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $httpUtils),
-            array('require_previous_session' => false)
+            array('require_previous_session' => false, 'post_only' => $postOnly)
         );
 
         $event = new GetResponseEvent($this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener->handle($event);
+    }
+
+    public function postOnlyDataProvider()
+    {
+        return array(
+            array(true),
+            array(false),
+        );
     }
 
     public function getUsernameForLength()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/26109
| License       | MIT
| Doc PR        | -

This fixes the merge mistake done in https://github.com/symfony/symfony/commit/899bf99879dfb9ecc795c03c9f0f2c7a3930b6bb

that caused this fail with the added test case:

```
There was 1 failure:

1) Symfony\Component\Security\Tests\Http\Firewall\UsernamePasswordFormAuthenticationListenerTest::testHandleNonStringUsername with data set #1 (false)
Failed asserting that exception of type "TypeError" matches expected exception "\Symfony\Component\HttpKernel\Exception\BadRequestHttpException". Message was: "Argument 1 passed to Symfony\Component\Security\Http\ParameterBagUtils::getParameterBagValue() must be an instance of Symfony\Component\HttpFoundation\ParameterBag, instance of Symfony\Component\HttpFoundation\Request given, called in /var/www/symfony/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php on line 100" at
/var/www/symfony/src/Symfony/Component/Security/Http/ParameterBagUtils.php:39
/var/www/symfony/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php:100
/var/www/symfony/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php:140
/var/www/symfony/src/Symfony/Component/Security/Http/Tests/Firewall/UsernamePasswordFormAuthenticationListenerTest.php:102
```

Original fix in 2.7: https://github.com/symfony/symfony/pull/25657/files#diff-e07c3e5653e210d017545d47c1bd7e76R111

