### PR TITLE
Env var maps to undefined constant.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -111,11 +111,13 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         }
 
         if ('const' === $prefix) {
+            $env = \str_replace("\\\\","\\", $env);
+            
             if (!defined($env)) {
                 throw new RuntimeException(sprintf('Env var "%s" maps to undefined constant "%s".', $name, $env));
             }
 
-            return constant($name);
+            return constant($env);
         }
 
         if ('base64' === $prefix) {


### PR DESCRIPTION
When I try to use a constant as an environment variable, as described in the blog item, 
I run into the following problem.

Env var "SOME_CONST" maps to undefined constant "App\\Util\\SomeClass::SOME_CONST".

The proposed solution works for me, however, I'm not sure if this is the best and conform Symfony standards.

Blog:
https://symfony.com/blog/new-in-symfony-3-4-advanced-environment-variables

| Q             | A
| ------------- | ---
| Branch?       | master for features / 2.7 up to 4.0 for bug fixes <!-- see below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | yes/no
| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->
