### PR TITLE
isCsrfTokenValid() replace string  by ?string

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -371,7 +371,7 @@ trait ControllerTrait
      * Checks the validity of a CSRF token.
      *
      * @param string $id    The id used when generating the token
-     * @param string $token The actual token sent with the request that should be validated
+     * @param string|null $token The actual token sent with the request that should be validated
      *
      * @final since version 3.4
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -375,7 +375,7 @@ trait ControllerTrait
      *
      * @final since version 3.4
      */
-    protected function isCsrfTokenValid(string $id, string $token): bool
+    protected function isCsrfTokenValid(string $id, ?string $token): bool
     {
         if (!$this->container->has('security.csrf.token_manager')) {
             throw new \LogicException('CSRF protection is not enabled in your application. Enable it with the "csrf_protection" key in "config/packages/framework.yaml".');

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -370,7 +370,7 @@ trait ControllerTrait
     /**
      * Checks the validity of a CSRF token.
      *
-     * @param string $id    The id used when generating the token
+     * @param string      $id    The id used when generating the token
      * @param string|null $token The actual token sent with the request that should be validated
      *
      * @final since version 3.4


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| License       | MIT
| PHP version | 7.1.13

Hello,

In my controller : 

```php
    class PostController extends Controller
    {
        public function delete(Request $request, Post $post): Response
        {
            if (!$this->isCsrfTokenValid('delete', $request->request->get('token'))) {
                return $this->render('administration/post/delete.html.twig', [
                    'post' => $post,
                ]);
            }
            ... // flush is database
        }
````

Generate this error : 

> Type error: Argument 2 passed to Symfony\Bundle\FrameworkBundle\Controller\Controller::isCsrfTokenValid() must be of the type string, null given, called in ...

In `CsrfToken` class, you have :
````php
    namespace Symfony\Component\Security\Csrf;

    class CsrfToken
    {
        public function __construct(string $id, ?string $value)
````
And in ControllerTrait :
````php
    trait ControllerTrait
   {
        protected function isCsrfTokenValid(string $id, string $token): bool
        {
````
Sorry for my bad english, I'm French and this is my first bug report :)
