### PR TITLE
Add watch option to lint commands

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+  * added `--watch` option to the `lint:twig` command to watch the filesystem for changes and re-lint any changed files
+
 3.4.0
 -----
 

--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+  * added `watch()` method to watch filesystem for changes
+
 4.0.0
 -----
 

--- a/src/Symfony/Component/Filesystem/Tests/Fixtures/ChangeFileResource.php
+++ b/src/Symfony/Component/Filesystem/Tests/Fixtures/ChangeFileResource.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Fixtures;
+
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\Resource\ResourceInterface;
+
+class ChangeFileResource implements ResourceInterface
+{
+    private $path;
+
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    public function detectChanges(): array
+    {
+        return array(new FileChangeEvent($this->path, FileChangeEvent::FILE_CHANGED));
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/FileSystemWatchTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/FileSystemWatchTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Tests\Fixtures\ChangeFileResource;
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\FileChangeWatcher;
+use Symfony\Component\Filesystem\Watcher\Resource\Locator\LocatorInterface;
+use Symfony\Component\Filesystem\Watcher\Resource\ResourceInterface;
+
+class FileSystemWatchTest extends FilesystemTestCase
+{
+    public function testWatch()
+    {
+        $workspace = $this->workspace;
+
+        $locator = new class($workspace) implements LocatorInterface {
+            private $workspace;
+
+            public function __construct($workspace)
+            {
+                $this->workspace = $workspace;
+            }
+
+            public function locate($path): ?ResourceInterface
+            {
+                return new ChangeFileResource($this->workspace.'/foobar.txt');
+            }
+        };
+
+        $watcher = new FileChangeWatcher($locator, 2);
+
+        $count = 0;
+        $watcher->watch($this->workspace, function ($file, $code) use (&$count) {
+            $this->assertSame($this->workspace.'/foobar.txt', $file);
+            $this->assertSame(FileChangeEvent::FILE_CHANGED, $code);
+            ++$count;
+        });
+
+        $this->assertSame(2, $count);
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/ArrayResourceTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/ArrayResourceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the symfony project.
+ *
+ * @author     pierre
+ * @copyright  Copyright (c) 2018
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\Resource\ArrayResource;
+use Symfony\Component\Filesystem\Watcher\Resource\FileResource;
+
+class ArrayResourceTest extends FilesystemTestCase
+{
+    public function testFileChange()
+    {
+        $file = $this->workspace.'/foo.txt';
+        touch($file);
+
+        $resource = new ArrayResource(array(new FileResource($file)));
+
+        $this->assertSame(array(), $resource->detectChanges());
+
+        touch($file, time() + 1);
+
+        $this->assertEquals(array(new FileChangeEvent($file, FileChangeEvent::FILE_CHANGED)), $resource->detectChanges());
+        $this->assertSame(array(), $resource->detectChanges());
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/DirectoryResourceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the symfony project.
+ *
+ * @author     pierre
+ * @copyright  Copyright (c) 2018
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\Resource\DirectoryResource;
+
+class DirectoryResourceTest extends FilesystemTestCase
+{
+    public function testCreateFile()
+    {
+        $dir = $this->workspace.'/foo';
+        mkdir($dir);
+
+        $resource = new DirectoryResource($dir);
+
+        $this->assertSame(array(), $resource->detectChanges());
+
+        touch($dir.'/foo.txt');
+
+        $this->assertEquals(array(new FileChangeEvent($dir.'/foo.txt', FileChangeEvent::FILE_CREATED)), $resource->detectChanges());
+        $this->assertSame(array(), $resource->detectChanges());
+    }
+
+    public function testDeleteFile()
+    {
+        $dir = $this->workspace.'/foo';
+        mkdir($dir);
+
+        touch($dir.'/foo.txt');
+        touch($dir.'/bar.txt');
+
+        $resource = new DirectoryResource($dir);
+
+        $this->assertSame(array(), $resource->detectChanges());
+
+        unlink($dir.'/foo.txt');
+
+        $this->assertEquals(array(new FileChangeEvent($dir.'/foo.txt', FileChangeEvent::FILE_DELETED)), $resource->detectChanges());
+        $this->assertSame(array(), $resource->detectChanges());
+    }
+
+    public function testFileChanges()
+    {
+        $dir = $this->workspace.'/foo';
+        mkdir($dir);
+
+        touch($dir.'/foo.txt');
+        touch($dir.'/bar.txt');
+
+        $resource = new DirectoryResource($dir);
+
+        $this->assertSame(array(), $resource->detectChanges());
+
+        touch($dir.'/foo.txt', time() + 1);
+
+        $this->assertEquals(array(new FileChangeEvent($dir.'/foo.txt', FileChangeEvent::FILE_CHANGED)), $resource->detectChanges());
+        $this->assertSame(array(), $resource->detectChanges());
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/FileResourceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the symfony project.
+ *
+ * @author     pierre
+ * @copyright  Copyright (c) 2018
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+use Symfony\Component\Filesystem\Watcher\Resource\FileResource;
+
+class FileResourceTest extends FilesystemTestCase
+{
+    public function testFileChanges()
+    {
+        $file = $this->workspace.'/foo.txt';
+        touch($file);
+
+        $resource = new FileResource($file);
+
+        $this->assertSame(array(), $resource->detectChanges());
+
+        touch($file, time() + 1);
+
+        $this->assertEquals(array(new FileChangeEvent($file, FileChangeEvent::FILE_CHANGED)), $resource->detectChanges());
+        $this->assertSame(array(), $resource->detectChanges());
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/Locator/FileResourceLocatorTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/Watcher/Resource/Locator/FileResourceLocatorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Watcher\Resource\Locator;
+
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+use Symfony\Component\Filesystem\Watcher\Resource\ArrayResource;
+use Symfony\Component\Filesystem\Watcher\Resource\DirectoryResource;
+use Symfony\Component\Filesystem\Watcher\Resource\FileResource;
+use Symfony\Component\Filesystem\Watcher\Resource\Locator\FileResourceLocator;
+
+class FileResourceLocatorTest extends FilesystemTestCase
+{
+    public function testLocateIterator()
+    {
+        $locator = new FileResourceLocator();
+
+        $path = new \ArrayIterator(array($this->createFile('foo.txt')));
+
+        $this->assertEquals(new ArrayResource(array(new FileResource($this->workspace.'/foo.txt'))), $locator->locate($path));
+    }
+
+    public function testLocateSplFileInfo()
+    {
+        $locator = new FileResourceLocator();
+
+        $path = new \SplFileInfo($this->createFile('foo.txt'));
+
+        $this->assertEquals(new FileResource($this->workspace.'/foo.txt'), $locator->locate($path));
+    }
+
+    public function testFilePath()
+    {
+        $locator = new FileResourceLocator();
+
+        $path = $this->createFile('foo.txt');
+
+        $this->assertEquals(new FileResource($this->workspace.'/foo.txt'), $locator->locate($path));
+    }
+
+    public function testGlob()
+    {
+        $locator = new FileResourceLocator();
+
+        $this->createFile('bar.txt');
+        $this->createFile('foo.txt');
+
+        $this->assertEquals(
+            new ArrayResource(array(new FileResource($this->workspace.'/bar.txt'), new FileResource($this->workspace.'/foo.txt'))),
+            $locator->locate($this->workspace.'/*.txt')
+        );
+    }
+
+    public function testArray()
+    {
+        $locator = new FileResourceLocator();
+
+        $path = array($this->createFile('foo.txt'));
+
+        $this->assertEquals(new ArrayResource(array(new FileResource($this->workspace.'/foo.txt'))), $locator->locate($path));
+    }
+
+    public function testDirectory()
+    {
+        $locator = new FileResourceLocator();
+
+        $dir = $this->createDirecty('foobar');
+
+        $this->assertEquals(new DirectoryResource($this->workspace.'/foobar'), $locator->locate($dir));
+    }
+
+    private function createFile(string $file)
+    {
+        $fullPath = $this->workspace.'/'.$file;
+        touch($fullPath);
+
+        return $fullPath;
+    }
+
+    private function createDirecty(string $dir)
+    {
+        $fullPath = $this->workspace.'/'.$dir;
+
+        mkdir($fullPath, 0777, true);
+
+        return $fullPath;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/FileChangeEvent.php
+++ b/src/Symfony/Component/Filesystem/Watcher/FileChangeEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher;
+
+class FileChangeEvent
+{
+    public const FILE_CHANGED = 1;
+    public const FILE_DELETED = 2;
+    public const FILE_CREATED = 3;
+
+    private $file;
+
+    private $event;
+
+    public function __construct(string $file, int $event)
+    {
+        $this->file = $file;
+        $this->event = $event;
+    }
+
+    public function getFile(): string
+    {
+        return $this->file;
+    }
+
+    public function getEvent(): int
+    {
+        return $this->event;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
+++ b/src/Symfony/Component/Filesystem/Watcher/FileChangeWatcher.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher;
+
+use Symfony\Component\Filesystem\Watcher\Resource\Locator\FileResourceLocator;
+use Symfony\Component\Filesystem\Watcher\Resource\Locator\LocatorInterface;
+
+class FileChangeWatcher implements WatcherInterface
+{
+    private $wait;
+
+    private $timeout;
+
+    private $locator;
+
+    public function __construct(LocatorInterface $locator = null, int $timeout = -1, int $wait = 1)
+    {
+        $this->locator = $locator ?: new FileResourceLocator();
+        $this->timeout = $timeout;
+        $this->wait = $wait;
+    }
+
+    public function watch($path, callable $callback)
+    {
+        $resource = $this->locator->locate($path);
+
+        if (!$resource) {
+            throw new \InvalidArgumentException(sprintf('%s is not a valid path to watch', gettype($path)));
+        }
+
+        $time = 0;
+
+        while (true) {
+            if ($changes = $resource->detectChanges()) {
+                foreach ($changes as $change) {
+                    $callback($change->getFile(), $change->getEvent());
+                }
+            }
+
+            sleep($this->wait);
+
+            $time += $this->wait;
+
+            if ($this->timeout > -1 && $time >= $this->timeout) {
+                break;
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/INotifyWatcher.php
+++ b/src/Symfony/Component/Filesystem/Watcher/INotifyWatcher.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher;
+
+class INotifyWatcher implements WatcherInterface
+{
+    public function watch($path, callable $callback)
+    {
+        $inotifyInit = inotify_init();
+        $dir = false;
+
+        stream_set_blocking($inotifyInit, 0);
+
+        if (is_dir($path)) {
+            $watchId = inotify_add_watch($inotifyInit, $path, IN_CREATE | IN_DELETE | IN_MODIFY);
+            $dir = true;
+        } else {
+            $watchId = inotify_add_watch($inotifyInit, $path, IN_MODIFY);
+        }
+
+        while (true) {
+            $events = inotify_read($inotifyInit);
+
+            foreach ($events as $event) {
+                $code = null;
+                switch ($event['mask']) {
+                    case IN_CREATE:
+                        $code = FileChangeEvent::FILE_CREATED;
+                        break;
+                    case IN_DELETE:
+                        $code = FileChangeEvent::FILE_DELETED;
+                        break;
+                    case IN_MODIFY:
+                        $code = FileChangeEvent::FILE_CHANGED;
+                        break;
+                }
+
+                $callback(($dir ? $path : '').$event['name'], $code);
+            }
+        }
+
+        inotify_rm_watch($inotifyInit, $watchId);
+        fclose($inotifyInit);
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/ArrayResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/ArrayResource.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource;
+
+class ArrayResource implements ResourceInterface
+{
+    /**
+     * @var ResourceInterface[]
+     */
+    private $resources;
+
+    public function __construct(array $resources)
+    {
+        $this->resources = $resources;
+    }
+
+    public function detectChanges(): array
+    {
+        $events = array();
+
+        foreach ($this->resources as $resource) {
+            if ($changed = $resource->detectChanges()) {
+                $events = array_merge($events, $changed);
+            }
+        }
+
+        return $events;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/DirectoryResource.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+
+class DirectoryResource implements ResourceInterface
+{
+    private $dir;
+
+    /**
+     * @var FileResource[]
+     */
+    private $files;
+
+    public function __construct(string $dir)
+    {
+        $this->dir = $dir;
+
+        $this->files = $this->getFiles();
+    }
+
+    private function getFiles(): array
+    {
+        $files = array();
+
+        /** @var \SplFileInfo $file */
+        foreach (new \RecursiveDirectoryIterator($this->dir, \RecursiveDirectoryIterator::SKIP_DOTS) as $file) {
+            $path = $file->getRealPath();
+            $files[$path] = new FileResource($path);
+        }
+
+        return $files;
+    }
+
+    public function detectChanges(): array
+    {
+        $events = array();
+
+        $currentFiles = $this->getFiles();
+
+        // Check if any files has been added
+        foreach (array_keys($currentFiles) as $path) {
+            if (!isset($this->files[$path])) {
+                $this->files = $this->getFiles();
+
+                $events[] = new FileChangeEvent($path, FileChangeEvent::FILE_CREATED);
+            }
+        }
+
+        // Check if any files has been deleted
+        foreach (array_keys($this->files) as $file) {
+            if (!isset($currentFiles[$file])) {
+                $this->files = $this->getFiles();
+
+                $events[] = new FileChangeEvent($file, FileChangeEvent::FILE_DELETED);
+            }
+        }
+
+        // Check for any changes in files
+        foreach ($this->files as $file) {
+            if ($event = $file->detectChanges()) {
+                $events = array_merge($events, $event);
+            }
+        }
+
+        return $events;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/FileResource.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/FileResource.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource;
+
+use Symfony\Component\Filesystem\Watcher\FileChangeEvent;
+
+class FileResource implements ResourceInterface
+{
+    private $file;
+
+    private $lastModified;
+
+    public function __construct(string $file)
+    {
+        $this->file = $file;
+        $this->lastModified = filemtime($file);
+    }
+
+    private function isModified(): bool
+    {
+        clearstatcache(false, $this->file);
+
+        return $this->lastModified < filemtime($this->file);
+    }
+
+    private function updateModifiedTime(): void
+    {
+        $this->lastModified = filemtime($this->file);
+    }
+
+    public function detectChanges(): array
+    {
+        if ($this->isModified()) {
+            $this->updateModifiedTime();
+
+            return array(new FileChangeEvent($this->file, FileChangeEvent::FILE_CHANGED));
+        }
+
+        return array();
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/Locator/FileResourceLocator.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/Locator/FileResourceLocator.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource\Locator;
+
+use Symfony\Component\Filesystem\Watcher\Resource\ArrayResource;
+use Symfony\Component\Filesystem\Watcher\Resource\DirectoryResource;
+use Symfony\Component\Filesystem\Watcher\Resource\FileResource;
+use Symfony\Component\Filesystem\Watcher\Resource\ResourceInterface;
+use Symfony\Component\Finder\Finder;
+
+class FileResourceLocator implements LocatorInterface
+{
+    public function locate($path): ?ResourceInterface
+    {
+        if ($path instanceof Finder || $path instanceof \Iterator) {
+            $path = iterator_to_array($path);
+        }
+
+        if ($path instanceof \SplFileInfo) {
+            $path = $path->getRealPath();
+        }
+
+        if (\is_array($path)) {
+            return new ArrayResource(array_map(array($this, 'locate'), $path));
+        }
+
+        if (\is_string($path)) {
+            if (is_dir($path)) {
+                return new DirectoryResource($path);
+            }
+
+            $paths = glob($path, \defined('GLOB_BRACE') ? GLOB_BRACE : 0);
+
+            if (1 === \count($paths)) {
+                return new FileResource($paths[0]);
+            }
+
+            return new ArrayResource(array_map(function ($path) {
+                return new FileResource($path);
+            }, $paths));
+        }
+
+        return null;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/Locator/LocatorInterface.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/Locator/LocatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource\Locator;
+
+use Symfony\Component\Filesystem\Watcher\Resource\ResourceInterface;
+
+interface LocatorInterface
+{
+    public function locate($path): ?ResourceInterface;
+}

--- a/src/Symfony/Component/Filesystem/Watcher/Resource/ResourceInterface.php
+++ b/src/Symfony/Component/Filesystem/Watcher/Resource/ResourceInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher\Resource;
+
+interface ResourceInterface
+{
+    public function detectChanges(): array;
+}

--- a/src/Symfony/Component/Filesystem/Watcher/WatcherInterface.php
+++ b/src/Symfony/Component/Filesystem/Watcher/WatcherInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Watcher;
+
+interface WatcherInterface
+{
+    public function watch($path, callable $callback);
+}

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * The `FileDumper::setBackup()` method is deprecated and will be removed in 5.0.
  * The `TranslationWriter::disableBackup()` method is deprecated and will be removed in 5.0.
+ * Added `--watch` option to the `lint:xliff` command to watch the filesystem for changes and re-lint any changed files
 
 4.0.0
 -----

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+  * added `--watch` option to the `lint:yaml` command to watch the filesystem for changes and re-lint any changed files
+
 4.0.0
 -----
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | TDB

This PR actually has 2 parts:

* Add a `watch` method to the Filesystem component to monitor the filesystem for changes, and executing a callback function whenever a change is detected

The watch method can take any parameter and uses a resource locator to transform a path to a resource. The resource can then be monitored for any changes. When a directory is monitored, you can get changed events when a file in the directory changes, when a new file is created or when an existing file is deleted. It also tried to make usage of Inotify is the extension is installed.

Example usage:

```php
$fs = new Filesystem();

$fs->watch('/path/to/some/directory', function ($file, $event) {
    if ($event === FileChangeEvent::FILE_CREATED) {
        echo $file.' was created!';
    }
});
```

* Add a watch option to all the lint commands

When the `watch` option is used, the process will monitor the filesystem for any changes. When a change is detected, the changed file will be re-validated and the output printed to the console.