### PR TITLE
Revert "[Workflow] Added the symfony/phpunit-bridge"

### DIFF
--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -28,7 +28,6 @@
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/event-dispatcher": "~3.4|~4.0",
         "symfony/expression-language": "~3.4|~4.0",
-        "symfony/phpunit-bridge": "~3.4|~4.0",
         "symfony/security-core": "~3.4|~4.0",
         "symfony/validator": "~3.4|~4.0"
     },
@@ -36,9 +35,6 @@
         "psr-4": { "Symfony\\Component\\Workflow\\": "" }
     },
     "minimum-stability": "dev",
-    "config": {
-        "sort-packages": true
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.1-dev"

--- a/src/Symfony/Component/Workflow/phpunit.xml.dist
+++ b/src/Symfony/Component/Workflow/phpunit.xml.dist
@@ -27,8 +27,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\CoverageListener"></listener>
-    </listeners>
 </phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |


---

This PR revert #26090. I chatted with @stof and @nicolas-grekas and for now they think the best is to revert this PR.

---

About the previous PR: I made that in ordre to increase the quality via the code coverage of the component.

One thing to know: If the listener is defined in the phpunit.xml.dist the classe has to exist.
If not, phpunit fails.

So if we add the listener in the component, then the deps should be here.

Anyway, people seems to agree that is a bad idea to add the bridge in each component.

So what could we do to enable this listener everywhere in ordre to increase the right computing of the code covarage?