### PR TITLE
Deterministic time in cache items for reproducible builds

### DIFF
--- a/src/Symfony/Component/Cache/Traits/FilesystemTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemTrait.php
@@ -36,9 +36,9 @@ trait FilesystemTrait
                 continue;
             }
 
-            if ($time >= (int) $expiresAt = fgets($h)) {
+            if (($expiresAt = (int) fgets($h)) && $time >= $expiresAt) {
                 fclose($h);
-                $pruned = isset($expiresAt[0]) && @unlink($file) && !file_exists($file) && $pruned;
+                $pruned = @unlink($file) && !file_exists($file) && $pruned;
             } else {
                 fclose($h);
             }
@@ -60,11 +60,9 @@ trait FilesystemTrait
             if (!file_exists($file) || !$h = @fopen($file, 'rb')) {
                 continue;
             }
-            if ($now >= (int) $expiresAt = fgets($h)) {
+            if (($expiresAt = (int) fgets($h)) && $now >= $expiresAt) {
                 fclose($h);
-                if (isset($expiresAt[0])) {
-                    @unlink($file);
-                }
+                @unlink($file);
             } else {
                 $i = rawurldecode(rtrim(fgets($h)));
                 $value = stream_get_contents($h);
@@ -94,7 +92,7 @@ trait FilesystemTrait
     protected function doSave(array $values, $lifetime)
     {
         $ok = true;
-        $expiresAt = time() + ($lifetime ?: 31557600); // 31557600s = 1 year
+        $expiresAt = $lifetime ? (time() + $lifetime) : 0;
 
         foreach ($values as $id => $value) {
             $ok = $this->write($this->getFile($id, true), $expiresAt."\n".rawurlencode($id)."\n".serialize($value), $expiresAt) && $ok;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Allows setting a deterministic time for cache entries. This can be used to seed builds with a deterministic timestamp for reproducibility. 

Parent issue is symfony/symfony#25958