### PR TITLE
[Routing][WIP] Add priorities to routing component

### DIFF
--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -86,20 +86,23 @@ class RouteCollectionTest extends TestCase
     {
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo'));
+        $collection->add('prio', new Route('/prio'));
 
         $collection1 = new RouteCollection();
         $collection1->add('bar', $bar = new Route('/bar'));
         $collection1->add('foo', $foo = new Route('/foo-new'));
+        $collection1->addWithPriority('prio', $prio = new Route('/prio-new'), 100);
 
         $collection2 = new RouteCollection();
         $collection2->add('grandchild', $grandchild = new Route('/grandchild'));
+        $collection2->addWithPriority('first', $first = new Route('/grandchild'), 200);
 
         $collection1->addCollection($collection2);
         $collection->addCollection($collection1);
         $collection->add('last', $last = new Route('/last'));
 
-        $this->assertSame(array('bar' => $bar, 'foo' => $foo, 'grandchild' => $grandchild, 'last' => $last), $collection->all(),
-            '->addCollection() imports routes of another collection, overrides if necessary and adds them at the end');
+        $this->assertSame(array('first' => $first, 'prio' => $prio, 'bar' => $bar, 'foo' => $foo, 'grandchild' => $grandchild, 'last' => $last), $collection->all(),
+            '->addCollection() imports routes of another collection, overrides if necessary and adds them at the end of their priority');
     }
 
     public function testAddCollectionWithResources()
@@ -316,5 +319,27 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($apiFoo, $collection->get('api_api_foo'));
         $this->assertNull($collection->get('foo'));
         $this->assertNull($collection->get('bar'));
+    }
+
+    public function testAddWithNumericName()
+    {
+        $collection = new RouteCollection();
+        $collection->add(100, new Route('/foo'));
+
+        $this->assertSame([100], array_keys($collection->all()));
+    }
+
+    public function testAddWithPriority()
+    {
+        $collection = new RouteCollection();
+        $collection->addWithPriority('foo', $foo = new Route('/foo'), 0);
+        $collection->addWithPriority('bar', $bar = new Route('/bar'), 1);
+
+        $expected = [
+            'bar' => $bar,
+            'foo' => $foo,
+        ];
+
+        $this->assertSame($expected, $collection->all());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | None yet

When using the Route annotation, route ordering is unpredictable, and if you need a route in one controller to be first/last (e.g. as a catch-all route), you can't reliably achieve this. Instead you have to resort to using one of the other configuration formats.

In order to remedy this, I'd like to propose the addition of *priority* to the routing system. I suppose that makes the route collection a priority ordered dictionary, instead of just an ordered dictionary. When adding a route to a route collection, you can optionally specify a priority (the default is 0). Routes with higher priority are sorted before routes with lower priority. Routes with the same priority are still sorted by when they were added to the collection.

Adding a collection to your route collection respects priority, and if the added collection contains a route with the same name, but a higher/lower priority, the order will be updated accordingly (same priority still means they are added last).

*This PR is not done, I still need to add priority to loader(s), I do however want feedback on this early.*