### PR TITLE
[FrameworkBundle] [SecurityBundle][WIP] Added LoginType

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Form/LoginType.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Form/LoginType.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Form;
+
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class LoginType extends AbstractType
+{
+    private $requestStack;
+    private $firewallMap;
+    private $authenticationUtils;
+    private $urlGenerator;
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(RequestStack $requestStack, FirewallMap $firewallMap, AuthenticationUtils $authenticationUtils, UrlGeneratorInterface $urlGenerator, TranslatorInterface $translator)
+    {
+        $this->requestStack = $requestStack;
+        $this->firewallMap = $firewallMap;
+        $this->authenticationUtils = $authenticationUtils;
+        $this->urlGenerator = $urlGenerator;
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $firewallConfig = $this->firewallMap->getFirewallConfig($this->requestStack->getCurrentRequest());
+        if (!$firewallConfig || !$firewallConfig->isSecurityEnabled()) {
+            throw new \LogicException('You cannot use LoginType if security is not enabled');
+        }
+
+        $firewallOptions = $firewallConfig->getOptions()['form_login'];
+
+        $builder
+            ->add($firewallOptions['username_parameter'], TextType::class, ['label' => 'label.username']) // Label should be configurable
+            ->add($firewallOptions['password_parameter'], PasswordType::class, ['label' => 'label.password']) // Label should be configurable
+            ->setAction($this->urlGenerator->generate($firewallOptions['check_path']))
+        ;
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use($firewallOptions) {
+            if ($error = $this->authenticationUtils->getLastAuthenticationError()) {
+                $event->getForm()->addError(new FormError(
+                    $this->translator->trans($error->getMessageKey(), $error->getMessageData(), 'security')
+                ));
+            }
+
+            $event->setData(array_replace((array) $event->getData(), [
+                $firewallOptions['username_parameter'] => $this->authenticationUtils->getLastUsername(),
+            ]));
+        });
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            ''
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return '';
+    }
+}
+

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -102,5 +102,16 @@
             <argument type="service" id="translator"/>
             <argument type="string">%validator.translation_domain%</argument>
         </service>
+
+        <!-- LoginType -->
+        <service id="form.type.login" class="Symfony\Bundle\FrameworkBundle\Form\LoginType">
+            <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />
+            <argument type="service" id="security.firewall.map" />
+            <argument type="service" id="Symfony\Component\Security\Http\Authentication\AuthenticationUtils" />
+            <argument type="service" id="Symfony\Component\Routing\Generator\UrlGeneratorInterface" />
+            <argument type="service" id="Symfony\Component\Translation\TranslatorInterface" />
+
+            <tag name="form.type" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -372,6 +372,7 @@ class SecurityExtension extends Extension
                 $key = str_replace('-', '_', $factory->getKey());
                 if (array_key_exists($key, $firewall)) {
                     $listenerKeys[] = $key;
+                    $options[$key] = $firewall[$key];
                 }
             }
         }
@@ -382,6 +383,7 @@ class SecurityExtension extends Extension
 
         $config->replaceArgument(10, $listenerKeys);
         $config->replaceArgument(11, isset($firewall['switch_user']) ? $firewall['switch_user'] : null);
+        $config->replaceArgument(12, $options ?? []);
 
         return array($matcher, $listeners, $exceptionListener);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -154,6 +154,7 @@
             <argument />                   <!-- access_denied_url -->
             <argument type="collection" /> <!-- listeners -->
             <argument />                   <!-- switch_user -->
+            <argument type="collection" /> <!-- options -->
         </service>
 
         <service id="security.logout_url_generator" class="Symfony\Component\Security\Http\Logout\LogoutUrlGenerator">

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -28,8 +28,9 @@ final class FirewallConfig
     private $accessDeniedUrl;
     private $listeners;
     private $switchUser;
+    private $options;
 
-    public function __construct(string $name, string $userChecker, string $requestMatcher = null, bool $securityEnabled = true, bool $stateless = false, string $provider = null, string $context = null, string $entryPoint = null, string $accessDeniedHandler = null, string $accessDeniedUrl = null, array $listeners = array(), $switchUser = null)
+    public function __construct(string $name, string $userChecker, string $requestMatcher = null, bool $securityEnabled = true, bool $stateless = false, string $provider = null, string $context = null, string $entryPoint = null, string $accessDeniedHandler = null, string $accessDeniedUrl = null, array $listeners = array(), $switchUser = null, array $options = [])
     {
         $this->name = $name;
         $this->userChecker = $userChecker;
@@ -43,6 +44,7 @@ final class FirewallConfig
         $this->accessDeniedUrl = $accessDeniedUrl;
         $this->listeners = $listeners;
         $this->switchUser = $switchUser;
+        $this->options = $options;
     }
 
     public function getName(): string
@@ -115,5 +117,10 @@ final class FirewallConfig
     public function getSwitchUser(): ?array
     {
         return $this->switchUser;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| License       | MIT
| Doc PR        | TODO

- [ ] update changelog
- [ ] update doc
- [ ] manage simple_form

Hello,

Here is a proposal to improve DX for the [login form](https://symfony.com/doc/current/security/form_login_setup.html) :

- Template file would use the `form` function
  - No need to bother with action, input name, translator
- Controller only requires to create a form 
  - No need to call the AuthenticationUtils anymore
- CSRF is rendered with the FormType
  - No need to take care of this in the template

I have a concrete (working) example with symfony-demo [here](https://github.com/B-Galati/demo/commit/8bb25da6800c618e6d9d08144d4c2a8948199884).

This PR is a POC/draft at the moment to concretely show what I would like to do. If the idea is accepted I will update the PR.

Let me know what you all think. Perhaps it is a terrible idea for some reasons :D

Note 1 : At the same time we could also add more information in the "Security Firewall" section of the profiler.
Note 2 : If someone have an idea to make the LoginType secure by default when the CSRF is loaded it would be amazing.
Note 3 : I took some ideas from \Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfFormLoginBundle\Form\UserLoginType