### PR TITLE
[HttpKernel] don't try to wire Request argument with controller.service_arguments

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\LazyProxy\ProxyHelper;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\TypedReference;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Creates the service-locators required by ServiceValueResolver.
@@ -145,6 +146,10 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
 
                         continue;
                     } elseif (!$type || !$autowire) {
+                        continue;
+                    }
+
+                    if (Request::class === $type) {
                         continue;
                     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

This does not make sense as Request is not a service and it's already handled by RequestValueResolver.
Also it produces alot of logging messages like the following whenever you only use the Request class in an action but no other service.

> Cannot autowire service "service_locator.IXu0y5S": it references class "Symfony\Component\HttpFoundation\Request" but no such service exists. It cannot be auto-registered because it is from a different root namespace.

> Removing service-argument resolver for controller "App\Controller\MyController:myAction": no corresponding services exist for the referenced types.