### PR TITLE
[HttpKernel] Catch HttpExceptions when templating is not installed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -67,6 +67,15 @@
             <argument type="service" id="router" on-invalid="ignore" />
         </service>
 
+        <service id="http_exception_listener" class="Symfony\Component\HttpKernel\EventListener\ExceptionListener">
+            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-256"/>
+            <tag name="monolog.logger" channel="request" />
+            <argument>null</argument>
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument>%kernel.debug%</argument>
+            <argument>%kernel.charset%</argument>
+        </service>
+
         <service id="validate_request_listener" class="Symfony\Component\HttpKernel\EventListener\ValidateRequestListener">
             <tag name="kernel.event_subscriber" />
         </service>

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -12,9 +12,11 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Debug\ExceptionHandler;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -33,12 +35,14 @@ class ExceptionListener implements EventSubscriberInterface
     protected $controller;
     protected $logger;
     protected $debug;
+    private $charset;
 
-    public function __construct($controller, LoggerInterface $logger = null, $debug = false)
+    public function __construct($controller, LoggerInterface $logger = null, $debug = false, $charset = null)
     {
         $this->controller = $controller;
         $this->logger = $logger;
         $this->debug = $debug;
+        $this->charset = $charset;
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
@@ -117,8 +121,12 @@ class ExceptionListener implements EventSubscriberInterface
     protected function duplicateRequest(\Exception $exception, Request $request)
     {
         $attributes = array(
-            '_controller' => $this->controller,
-            'exception' => FlattenException::create($exception),
+            'exception' => $exception = FlattenException::create($exception),
+            '_controller' => $this->controller ?: function () use ($exception) {
+                $handler = new ExceptionHandler($this->debug, $this->charset);
+
+                return new Response($handler->getHtml($exception), $exception->getStatusCode(), $exception->getHeaders());
+            },
             'logger' => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
         );
         $request = $request->duplicate(null, null, $attributes);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -151,6 +151,23 @@ class ExceptionListenerTest extends TestCase
         $this->assertFalse($response->headers->has('content-security-policy'), 'CSP header has been removed');
         $this->assertFalse($dispatcher->hasListeners(KernelEvents::RESPONSE), 'CSP removal listener has been removed');
     }
+
+    public function testNullController()
+    {
+        $listener = new ExceptionListener(null);
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
+        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
+            $controller = $request->attributes->get('_controller');
+
+            return $controller();
+        }));
+        $request = Request::create('/');
+        $event = new GetResponseForExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, new \Exception('foo'));
+
+        $listener->onKernelException($event);
+
+        $this->assertContains('Whoops, looks like something went wrong.', $event->getResponse()->getContent());
+    }
 }
 
 class TestLogger extends Logger implements DebugLoggerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ?
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | #25844
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

- [x] Test manually
- [x] Check for BC breaks
- [x] Needs tests

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Replace this comment by a description of what your PR is solving.
-->
