### PR TITLE
Drastically improved debug:autowiring + new autowiring info system

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -15,6 +15,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Debug\AutowiringInfoManager;
+use Symfony\Component\DependencyInjection\Debug\AutowiringTypeInfo;
 
 /**
  * A console command for autowiring information.
@@ -26,6 +28,15 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class DebugAutowiringCommand extends ContainerDebugCommand
 {
     protected static $defaultName = 'debug:autowiring';
+
+    private $autowiringInfoManager;
+
+    public function __construct(AutowiringInfoManager $autowiringInfoManager = null)
+    {
+        $this->autowiringInfoManager = $autowiringInfoManager;
+
+        parent::__construct();
+    }
 
     /**
      * {@inheritdoc}
@@ -78,24 +89,92 @@ EOF
 
         asort($serviceIds);
 
-        $io->title('Autowirable Services');
         $io->text('The following classes & interfaces can be used as type-hints when autowiring:');
         if ($search) {
             $io->text(sprintf('(only showing classes/interfaces matching <comment>%s</comment>)', $search));
         }
         $io->newLine();
-        $tableRows = array();
+
+        $keyServices = array();
+        $otherServices = array();
         $hasAlias = array();
         foreach ($serviceIds as $serviceId) {
-            if ($builder->hasAlias($serviceId)) {
-                $tableRows[] = array(sprintf('<fg=cyan>%s</fg=cyan>', $serviceId));
-                $tableRows[] = array(sprintf('    alias to %s', $builder->getAlias($serviceId)));
-                $hasAlias[(string) $builder->getAlias($serviceId)] = true;
-            } else {
-                $tableRows[$serviceId] = array(sprintf('<fg=cyan>%s</fg=cyan>', $serviceId));
+            if (null !== $this->autowiringInfoManager && $autowiringInfo = $this->autowiringInfoManager->getInfo($serviceId)) {
+                $keyServices[] = array(
+                    'info' => $autowiringInfo,
+                    'alias' => $builder->has($serviceId) ? $builder->getAlias($serviceId) : null,
+                );
+
+                continue;
             }
+
+            if ($builder->hasAlias($serviceId)) {
+                $hasAlias[(string) $builder->getAlias($serviceId)] = true;
+            }
+
+            $otherServices[$serviceId] = array(
+                'type' => $serviceId,
+                'alias' => $builder->hasAlias($serviceId) ? $builder->getAlias($serviceId) : null,
+            );
+        }
+        $otherServices = array_diff_key($otherServices, $hasAlias);
+
+        usort($keyServices, function ($a, $b) {
+            if ($a['info']->getPriority() === $b['info']->getPriority()) {
+                return 0;
+            }
+
+            return $a['info']->getPriority() > $b['info']->getPriority() ? -1 : 1;
+        });
+
+        $this->printKeyServices($keyServices, $io);
+
+        $this->printOtherServices($otherServices, $io);
+    }
+
+    private function printOtherServices(array $otherServices, SymfonyStyle $io)
+    {
+        if (empty($otherServices)) {
+            return;
         }
 
-        $io->table(array(), array_diff_key($tableRows, $hasAlias));
+        // not necessary to print if this is the only list
+        if (null !== $this->autowiringInfoManager) {
+            $io->title('Other Services');
+        }
+
+        foreach ($otherServices as $serviceData) {
+            $io->writeln(sprintf('<fg=cyan>%s</fg=cyan>', $serviceData['type']));
+            if ($alias = $serviceData['alias']) {
+                $io->writeln(sprintf('    alias to %s', $alias));
+            }
+        }
+    }
+
+    private function printKeyServices(array $keyServices, SymfonyStyle $io)
+    {
+        if (empty($keyServices)) {
+            return;
+        }
+
+        $io->title('Key Services');
+        foreach ($keyServices as $serviceData) {
+            /** @var AutowiringTypeInfo $info */
+            $info = $serviceData['info'];
+
+            $nameLine = sprintf('<comment>%s</comment>', $info->getName());
+            if ($info->getDescription()) {
+                $nameLine .= sprintf(' (%s)', $info->getDescription());
+            }
+            $io->writeln($nameLine);
+
+            $io->writeln(sprintf('    Type: <fg=cyan>%s</fg=cyan>', $info->getType()));
+
+            if ($serviceData['alias']) {
+                $io->writeln(sprintf('    Alias to the %s service', $serviceData['alias']));
+            }
+
+            $io->writeln('');
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AutowireDebugInfoPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AutowireDebugInfoPass.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Looks for & processes debug.autowiring_info_provider tags.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class AutowireDebugInfoPass implements CompilerPassInterface
+{
+    const AUTOWIRING_INFO_PROVIDER_TAG = 'debug.autowiring_info_provider';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasDefinition('debug.autowiring_info_manager')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('debug.autowiring_info_manager');
+
+        $references = array();
+        foreach ($container->findTaggedServiceIds(self::AUTOWIRING_INFO_PROVIDER_TAG, true) as $serviceId => $attributes) {
+            $references[] = new Reference($serviceId);
+        }
+
+        $definition->replaceArgument(0, $references);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkAutowiringInfoProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkAutowiringInfoProvider.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
+
+use Doctrine\Common\Annotations\Reader;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\DependencyInjection\Debug\AutowiringInfoProviderInterface;
+use Symfony\Component\DependencyInjection\Debug\AutowiringTypeInfo;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Workflow\Registry;
+
+/**
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+final class FrameworkAutowiringInfoProvider implements AutowiringInfoProviderInterface
+{
+    public function getTypeInfos(): array
+    {
+        return array(
+            AutowiringTypeInfo::create(CacheItemPoolInterface::class, 'Cache', 10)
+                ->setDescription('general-purpose service for caching things'),
+
+            AutowiringTypeInfo::create(CacheInterface::class, 'Simple Cache', 10)
+                ->setDescription('simpler cache, but less features'),
+
+            AutowiringTypeInfo::create(RouterInterface::class, 'Router', 10)
+                ->setDescription('used to generate URLs'),
+
+            AutowiringTypeInfo::create(EventDispatcherInterface::class, 'Event Dispatcher')
+                ->setDescription('used to dispatch custom events'),
+
+            AutowiringTypeInfo::create(Reader::class, 'Annotation Reader', -10),
+
+            AutowiringTypeInfo::create(ParameterBagInterface::class, 'Parameter Bag')
+                ->setDescription('access service parameters'),
+
+            AutowiringTypeInfo::create(Filesystem::class, 'Filesystem')
+                ->setDescription('helper for filesystem actions'),
+
+            AutowiringTypeInfo::create(RequestStack::class, 'Request Stack')
+                ->setDescription('access the Request object'),
+
+            AutowiringTypeInfo::create(SessionInterface::class, 'Session'),
+
+            AutowiringTypeInfo::create(FlashBagInterface::class, 'Flash Bag')
+                ->setDescription('use to set temporary success/failure messages'),
+
+            AutowiringTypeInfo::create(KernelInterface::class, 'Kernel'),
+
+            AutowiringTypeInfo::create(Stopwatch::class, 'Stopwatch')
+                ->setDescription('use to add custom timings to profiler'),
+
+            AutowiringTypeInfo::create(Packages::class, 'Asset Packages')
+                ->setDescription('use to generate URLs to assets'),
+
+            AutowiringTypeInfo::create(FormFactoryInterface::class, 'Form Factory')
+                ->setDescription('use to create form objects'),
+
+            AutowiringTypeInfo::create(ValidatorInterface::class, 'Validator')
+                ->setDescription('use to validate data against some constraints'),
+
+            AutowiringTypeInfo::create(TranslatorInterface::class, 'Translator'),
+
+            AutowiringTypeInfo::create(PropertyAccessorInterface::class, 'Property Accessor')
+                ->setDescription('use to read dynamic keys from some data'),
+
+            AutowiringTypeInfo::create(CsrfTokenManagerInterface::class, 'CSRF Token Manager')
+                ->setDescription('generate and check CSRF tokens'),
+
+            AutowiringTypeInfo::create(SerializerInterface::class, 'Serializer')
+                ->setDescription('use to serialize data to JSON, XML, etc'),
+
+            AutowiringTypeInfo::create(Registry::class, 'Workflow')
+                ->setDescription('use to fetch workflows'),
+
+            AutowiringTypeInfo::create(Registry::class, 'Workflow')
+                ->setDescription('use to fetch workflows'),
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AutowireDebugInfoPass;
 use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
@@ -33,6 +34,7 @@ use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Debug\AutowiringInfoProviderInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -330,6 +332,8 @@ class FrameworkExtension extends Extension
             ->addTag('validator.constraint_validator');
         $container->registerForAutoconfiguration(ObjectInitializerInterface::class)
             ->addTag('validator.initializer');
+        $container->registerForAutoconfiguration(AutowiringInfoProviderInterface::class)
+            ->addTag(AutowireDebugInfoPass::AUTOWIRING_INFO_PROVIDER_TAG);
 
         if (!$container->getParameter('kernel.debug')) {
             // remove tagged iterator argument for resource checkers

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle;
 
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddAnnotationsCachedReaderPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddDebugLogProcessorPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AutowireDebugInfoPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CacheCollectorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolClearerPass;
@@ -120,6 +121,7 @@ class FrameworkBundle extends Bundle
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_BEFORE_REMOVING, -255);
             $container->addCompilerPass(new CacheCollectorPass(), PassConfig::TYPE_BEFORE_REMOVING);
+            $container->addCompilerPass(new AutowireDebugInfoPass());
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -56,6 +56,7 @@
         </service>
 
         <service id="console.command.debug_autowiring" class="Symfony\Bundle\FrameworkBundle\Command\DebugAutowiringCommand">
+            <argument type="service" id="debug.autowiring_info_manager" on-invalid="ignore" />
             <tag name="console.command" command="debug:autowiring" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -23,5 +23,13 @@
             <argument type="service" id="debug.argument_resolver.inner" />
             <argument type="service" id="debug.stopwatch" />
         </service>
+
+        <service id="debug.autowiring_info_manager" class="Symfony\Component\DependencyInjection\Debug\AutowiringInfoManager">
+            <argument /> <!-- argument info providers -->
+        </service>
+
+        <service id="debug.autowiring.framework_autowiring_info_provider" class="Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkAutowiringInfoProvider">
+            <tag name="debug.autowiring_info_provider" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -31,6 +31,7 @@ class DebugAutowiringCommandTest extends WebTestCase
 
         $this->assertContains('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
         $this->assertContains('alias to http_kernel', $tester->getDisplay());
+        $this->assertContains('Simple Cache', $tester->getDisplay(), 'Key services are displayed');
     }
 
     public function testSearchArgument()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityAutowiringInfoProvider.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityAutowiringInfoProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Debug\AutowiringInfoProviderInterface;
+use Symfony\Component\DependencyInjection\Debug\AutowiringTypeInfo;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
+
+/**
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+final class SecurityAutowiringInfoProvider implements AutowiringInfoProviderInterface
+{
+    public function getTypeInfos(): array
+    {
+        return array(
+            AutowiringTypeInfo::create(GuardAuthenticatorHandler::class, 'Guard Auth Handler')
+                ->setDescription('use to manually authenticate with Guard'),
+
+            AutowiringTypeInfo::create(Security::class, 'Security')
+                ->setDescription('use to check access & get the current User'),
+
+            AutowiringTypeInfo::create(UserPasswordEncoderInterface::class, 'Password Encoder')
+                ->setDescription('use to encode passwords & check them'),
+        );
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_debug.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_debug.xml
@@ -19,5 +19,9 @@
         </service>
 
         <service id="security.firewall" alias="debug.security.firewall" />
+
+        <service id="debug.autowiring.security_autowiring_info_provider" class="Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityAutowiringInfoProvider">
+            <tag name="debug.autowiring_info_provider" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigAutowiringInfoProvider.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigAutowiringInfoProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Debug\AutowiringInfoProviderInterface;
+use Symfony\Component\DependencyInjection\Debug\AutowiringTypeInfo;
+use Twig\Environment;
+
+/**
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+final class TwigAutowiringInfoProvider implements AutowiringInfoProviderInterface
+{
+    public function getTypeInfos(): array
+    {
+        return array(
+            AutowiringTypeInfo::create(Environment::class, 'Twig Templating')
+                ->setDescription('use to render templates'),
+        );
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -153,5 +153,9 @@
         <service id="twig.runtime_loader" class="Twig\RuntimeLoader\ContainerRuntimeLoader">
             <argument /> <!-- runtime locator -->
         </service>
+
+        <service id="debug.autowiring.twig_autowiring_info_provider" class="Symfony\Bundle\TwigBundle\DependencyInjection\TwigAutowiringInfoProvider">
+            <tag name="debug.autowiring_info_provider" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Debug/AutowiringInfoManager.php
+++ b/src/Symfony/Component/DependencyInjection/Debug/AutowiringInfoManager.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Debug;
+
+/**
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+final class AutowiringInfoManager
+{
+    /**
+     * @var AutowiringInfoProviderInterface[]
+     */
+    private $autowiringInfoProviders;
+
+    private $typeInfos = null;
+
+    public function __construct(array $autowiringInfoProviders)
+    {
+        $this->autowiringInfoProviders = $autowiringInfoProviders;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return AutowiringTypeInfo|null
+     */
+    public function getInfo(string $type)
+    {
+        if (null === $this->typeInfos) {
+            $this->populateTypesInfo();
+        }
+
+        return isset($this->typeInfos[$type]) ? $this->typeInfos[$type] : null;
+    }
+
+    private function populateTypesInfo()
+    {
+        $typeInfos = array();
+        foreach ($this->autowiringInfoProviders as $provider) {
+            foreach ($provider->getTypeInfos() as $typeInfo) {
+                $typeInfos[$typeInfo->getType()] = $typeInfo;
+            }
+        }
+
+        $this->typeInfos = $typeInfos;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Debug/AutowiringInfoProviderInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Debug/AutowiringInfoProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Debug;
+
+/**
+ * Interface for classes that can provide info about the purpose of service classes/interfaces.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+interface AutowiringInfoProviderInterface
+{
+    /**
+     * Returns information about autowiring types.
+     *
+     * @return array|AutowiringTypeInfo[]
+     */
+    public function getTypeInfos(): array;
+}

--- a/src/Symfony/Component/DependencyInjection/Debug/AutowiringTypeInfo.php
+++ b/src/Symfony/Component/DependencyInjection/Debug/AutowiringTypeInfo.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Debug;
+
+/**
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+final class AutowiringTypeInfo
+{
+    private $type;
+
+    private $name;
+
+    private $priority;
+
+    private $description = '';
+
+    public function __construct(string $type, string $name, int $priority = 0)
+    {
+        $this->type = $type;
+        $this->name = $name;
+        $this->priority = $priority;
+    }
+
+    /**
+     * @param string $type     The class/interface for the type
+     * @param string $name     A very short name to describe this (e.g. Logger or Annotation Reader)
+     * @param int    $priority A priority for how important this service is
+     *
+     * @return static
+     */
+    public static function create(string $type, string $name, int $priority = 0)
+    {
+        return new static($type, $name, $priority);
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Debug/AutowiringInfoManagerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Debug/AutowiringInfoManagerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Debug\AutowiringInfoManager;
+use Symfony\Component\DependencyInjection\Debug\AutowiringInfoProviderInterface;
+use Symfony\Component\DependencyInjection\Debug\AutowiringTypeInfo;
+
+class AutowiringInfoManagerTest extends TestCase
+{
+    public function testGetInfo()
+    {
+        $infoFoo = AutowiringTypeInfo::create('FooInterface', 'Foo');
+        $infoBar = AutowiringTypeInfo::create('BarInterface', 'Bar');
+        $infoBaz = AutowiringTypeInfo::create('BazInterface', 'Baz');
+
+        $provider1 = $this->createMock(AutowiringInfoProviderInterface::class);
+        $provider1->expects($this->once())
+            ->method('getTypeInfos')
+            ->willReturn(array($infoFoo, $infoBar));
+
+        $provider2 = $this->createMock(AutowiringInfoProviderInterface::class);
+        $provider2->expects($this->once())
+            ->method('getTypeInfos')
+            ->willReturn(array($infoBaz));
+
+        $manager = new AutowiringInfoManager(array($provider1, $provider2));
+        $this->assertSame($infoFoo, $manager->getInfo('FooInterface'));
+        $this->assertSame($infoBar, $manager->getInfo('BarInterface'));
+        $this->assertSame($infoBaz, $manager->getInfo('BazInterface'));
+        $this->assertNull($manager->getInfo('InventedClass'));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Debug/AutowiringTypeInfoTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Debug/AutowiringTypeInfoTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Debug\AutowiringTypeInfo;
+
+class AutowiringTypeInfoTest extends TestCase
+{
+    public function testBasicFunctionality()
+    {
+        $info = AutowiringTypeInfo::create('Foo\\CoolStuffType', 'Cool Stuff');
+        $this->assertSame($info->getType(), 'Foo\\CoolStuffType');
+        $this->assertSame($info->getName(), 'Cool Stuff');
+        $this->assertSame(0, $info->getPriority());
+        $this->assertSame('', $info->getDescription());
+
+        $info = AutowiringTypeInfo::create('Foo\\CoolStuffType', 'Cool Stuff', 10)
+            ->setDescription('Some really cool stuff');
+
+        $this->assertSame(10, $info->getPriority());
+        $this->assertSame('Some really cool stuff', $info->getDescription());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#9247

Hey guys!

This PR makes debug:autowiring WAY more useful :). See screenshot at the bottom.

It's now human-focused: you look for the *problem* you need to solve (Cache, Logger, etc).

Note: if there are *multiple* types for the same thing - e.g. `Twig\Environment` &
`Twig_Environment` - then by convention, we'll choose one to "recommend" and only
add info about it. The other will still appear at the bottom of the list.

Behind the scenes, this introduces a new mini-system where bundles can tell the
core the *purpose* of the classes/interfaces that they expose. I didn't include
this at the container level (e.g. in Definition), because I think that's overkill:
this is just a nice decoration around the system. The system is also NOT included
when `kernel.debug = false`, so there's *zero* prod overhead. The `debug:autowiring`
command still works in this situation, but falls back to its original "one big list".

Cheers!

<img width="343" alt="screen shot 2018-02-11 at 2 57 53 pm" src="https://user-images.githubusercontent.com/121003/36078339-c7df06c6-0f42-11e8-9ab0-25dfd6874786.png">
