### PR TITLE
[Routing]  Implement i18n routing

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -22,6 +22,7 @@ namespace Symfony\Component\Routing\Annotation;
 class Route
 {
     private $path;
+    private $locales = array();
     private $name;
     private $requirements = array();
     private $options = array();
@@ -38,9 +39,18 @@ class Route
      */
     public function __construct(array $data)
     {
+        if (isset($data['locales'])) {
+            throw new \BadMethodCallException(sprintf('Unknown property "locales" on annotation "%s".', get_class($this)));
+        }
+
         if (isset($data['value'])) {
-            $data['path'] = $data['value'];
+            $data[is_array($data['value']) ? 'locales' : 'path'] = $data['value'];
             unset($data['value']);
+        }
+
+        if (isset($data['path']) && is_array($data['path'])) {
+            $data['locales'] = $data['path'];
+            unset($data['path']);
         }
 
         foreach ($data as $key => $value) {
@@ -60,6 +70,16 @@ class Route
     public function getPath()
     {
         return $this->path;
+    }
+
+    public function setLocales(array $locales)
+    {
+        $this->locales = $locales;
+    }
+
+    public function getLocales(): array
+    {
+        return $this->locales;
     }
 
     public function setHost($pattern)

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -54,11 +54,13 @@ use Psr\Log\LoggerInterface;
 class {$options['class']} extends {$options['base_class']}
 {
     private static \$declaredRoutes;
+    private \$defaultLocale;
 
-    public function __construct(RequestContext \$context, LoggerInterface \$logger = null)
+    public function __construct(RequestContext \$context, LoggerInterface \$logger = null, string \$defaultLocale = null)
     {
         \$this->context = \$context;
         \$this->logger = \$logger;
+        \$this->defaultLocale = \$defaultLocale;
         if (null === self::\$declaredRoutes) {
             self::\$declaredRoutes = {$this->generateDeclaredRoutes()};
         }
@@ -107,7 +109,14 @@ EOF;
         return <<<'EOF'
     public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
-        if (!isset(self::$declaredRoutes[$name])) {
+        $locale = $parameters['_locale']
+            ?? $this->context->getParameter('_locale')
+            ?: $this->defaultLocale;
+
+        if (null !== $locale && isset(self::$declaredRoutes[$name.'.'.$locale])) {
+            unset($parameters['_locale']);
+            $name = $name.'.'.$locale;
+        } elseif (!isset(self::$declaredRoutes[$name])) {
             throw new RouteNotFoundException(sprintf('Unable to generate a URL for the named route "%s" as such route does not exist.', $name));
         }
 

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -113,9 +113,9 @@ EOF;
             ?? $this->context->getParameter('_locale')
             ?: $this->defaultLocale;
 
-        if (null !== $locale && isset(self::$declaredRoutes[$name.'.'.$locale])) {
+        if (null !== $locale && (self::$declaredRoutes[$name.'.'.$locale][1]['_canonical_route'] ?? null) === $name) {
             unset($parameters['_locale']);
-            $name = $name.'.'.$locale;
+            $name .= '.'.$locale;
         } elseif (!isset(self::$declaredRoutes[$name])) {
             throw new RouteNotFoundException(sprintf('Unable to generate a URL for the named route "%s" as such route does not exist.', $name));
         }

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -37,6 +37,8 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
 
     protected $logger;
 
+    private $defaultLocale;
+
     /**
      * This array defines the characters (besides alphanumeric ones) that will not be percent-encoded in the path segment of the generated URL.
      *
@@ -65,11 +67,12 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         '%7C' => '|',
     );
 
-    public function __construct(RouteCollection $routes, RequestContext $context, LoggerInterface $logger = null)
+    public function __construct(RouteCollection $routes, RequestContext $context, LoggerInterface $logger = null, string $defaultLocale = null)
     {
         $this->routes = $routes;
         $this->context = $context;
         $this->logger = $logger;
+        $this->defaultLocale = $defaultLocale;
     }
 
     /**
@@ -109,7 +112,13 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
      */
     public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
-        if (null === $route = $this->routes->get($name)) {
+        $locale = $parameters['_locale']
+            ?? $this->context->getParameter('_locale')
+            ?: $this->defaultLocale;
+
+        if (null !== $locale && null !== $route = $this->routes->get($name.'.'.$locale)) {
+            unset($parameters['_locale']);
+        } elseif (null === $route = $this->routes->get($name)) {
             throw new RouteNotFoundException(sprintf('Unable to generate a URL for the named route "%s" as such route does not exist.', $name));
         }
 

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -116,7 +116,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
             ?? $this->context->getParameter('_locale')
             ?: $this->defaultLocale;
 
-        if (null !== $locale && null !== $route = $this->routes->get($name.'.'.$locale)) {
+        if (null !== $locale && null !== ($route = $this->routes->get($name.'.'.$locale)) && $route->getDefault('_canonical_route') === $name) {
             unset($parameters['_locale']);
         } elseif (null === $route = $this->routes->get($name)) {
             throw new RouteNotFoundException(sprintf('Unable to generate a URL for the named route "%s" as such route does not exist.', $name));

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -200,6 +200,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
             $this->configureRoute($route, $class, $method, $annot);
             if (0 !== $locale) {
                 $route->setDefault('_locale', $locale);
+                $route->setDefault('_canonical_route', $name);
                 $collection->add($name.'.'.$locale, $route);
             } else {
                 $collection->add($name, $route);

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -24,30 +24,25 @@ class CollectionConfigurator
 
     private $parent;
     private $parentConfigurator;
+    private $parentPrefixes;
 
-    public function __construct(RouteCollection $parent, string $name, self $parentConfigurator = null)
+    public function __construct(RouteCollection $parent, string $name, self $parentConfigurator = null, array $parentPrefixes = null)
     {
         $this->parent = $parent;
         $this->name = $name;
         $this->collection = new RouteCollection();
         $this->route = new Route('');
         $this->parentConfigurator = $parentConfigurator; // for GC control
+        $this->parentPrefixes = $parentPrefixes;
     }
 
     public function __destruct()
     {
-        $this->collection->addPrefix(rtrim($this->route->getPath(), '/'));
+        if (null === $this->prefixes) {
+            $this->collection->addPrefix($this->route->getPath());
+        }
+
         $this->parent->addCollection($this->collection);
-    }
-
-    /**
-     * Adds a route.
-     */
-    final public function add(string $name, string $path): RouteConfigurator
-    {
-        $this->collection->add($this->name.$name, $route = clone $this->route);
-
-        return new RouteConfigurator($this->collection, $route->setPath($path), $this->name, $this);
     }
 
     /**
@@ -57,18 +52,44 @@ class CollectionConfigurator
      */
     final public function collection($name = '')
     {
-        return new self($this->collection, $this->name.$name, $this);
+        return new self($this->collection, $this->name.$name, $this, $this->prefixes);
     }
 
     /**
      * Sets the prefix to add to the path of all child routes.
      *
+     * @param string|array $prefix the prefix, or the localized prefixes
+     *
      * @return $this
      */
-    final public function prefix(string $prefix)
+    final public function prefix($prefix)
     {
-        $this->route->setPath($prefix);
+        if (\is_array($prefix)) {
+            if (null === $this->parentPrefixes) {
+                // no-op
+            } elseif ($missing = array_diff_key($this->parentPrefixes, $prefix)) {
+                throw new \LogicException(sprintf('Collection "%s" is missing prefixes for locale(s) "%s".', $this->name, implode('", "', array_keys($missing))));
+            } else {
+                foreach ($prefix as $locale => $localePrefix) {
+                    if (!isset($this->parentPrefixes[$locale])) {
+                        throw new \LogicException(sprintf('Collection "%s" with locale "%s" is missing a corresponding prefix in its parent collection.', $this->name, $locale));
+                    }
+
+                    $prefix[$locale] = $this->parentPrefixes[$locale].$localePrefix;
+                }
+            }
+            $this->prefixes = $prefix;
+            $this->route->setPath('/');
+        } else {
+            $this->prefixes = null;
+            $this->route->setPath($prefix);
+        }
 
         return $this;
+    }
+
+    private function createRoute($path): Route
+    {
+        return (clone $this->route)->setPath($path);
     }
 }

--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
@@ -36,11 +36,35 @@ class ImportConfigurator
     /**
      * Sets the prefix to add to the path of all child routes.
      *
+     * @param string|array $prefix the prefix, or the localized prefixes
+     *
      * @return $this
      */
-    final public function prefix(string $prefix)
+    final public function prefix($prefix)
     {
-        $this->route->addPrefix($prefix);
+        if (!\is_array($prefix)) {
+            $this->route->addPrefix($prefix);
+        } else {
+            foreach ($prefix as $locale => $localePrefix) {
+                $prefix[$locale] = trim(trim($localePrefix), '/');
+            }
+            foreach ($this->route->all() as $name => $route) {
+                if (null === $locale = $route->getDefault('_locale')) {
+                    $this->route->remove($name);
+                    foreach ($prefix as $locale => $localePrefix) {
+                        $localizedRoute = clone $route;
+                        $localizedRoute->setDefault('_locale', $locale);
+                        $localizedRoute->setPath($localePrefix.$route->getPath());
+                        $this->route->add($name.'.'.$locale, $localizedRoute);
+                    }
+                } elseif (!isset($prefix[$locale])) {
+                    throw new \InvalidArgumentException(sprintf('Route "%s" with locale "%s" is missing a corresponding prefix in its parent collection.', $name, $locale));
+                } else {
+                    $route->setPath($prefix[$locale].$route->getPath());
+                    $this->route->add($name, $route);
+                }
+            }
+        }
 
         return $this;
     }

--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
@@ -54,6 +54,7 @@ class ImportConfigurator
                     foreach ($prefix as $locale => $localePrefix) {
                         $localizedRoute = clone $route;
                         $localizedRoute->setDefault('_locale', $locale);
+                        $localizedRoute->setDefault('_canonical_route', $name);
                         $localizedRoute->setPath($localePrefix.$route->getPath());
                         $this->route->add($name.'.'.$locale, $localizedRoute);
                     }

--- a/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Routing\Loader\Configurator;
 
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -24,11 +23,12 @@ class RouteConfigurator
 
     private $parentConfigurator;
 
-    public function __construct(RouteCollection $collection, Route $route, string $name = '', CollectionConfigurator $parentConfigurator = null)
+    public function __construct(RouteCollection $collection, $route, string $name = '', CollectionConfigurator $parentConfigurator = null, array $prefixes = null)
     {
         $this->collection = $collection;
         $this->route = $route;
         $this->name = $name;
         $this->parentConfigurator = $parentConfigurator; // for GC control
+        $this->prefixes = $prefixes;
     }
 }

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/AddTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/AddTrait.php
@@ -67,6 +67,7 @@ trait AddTrait
             $routes->add($name.'.'.$locale, $route = $this->createRoute($path));
             $this->collection->add($this->name.$name.'.'.$locale, $route);
             $route->setDefault('_locale', $locale);
+            $route->setDefault('_canonical_route', $this->name.$name);
         }
 
         return new RouteConfigurator($this->collection, $routes, $this->name, $parentConfigurator, $this->prefixes);

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/AddTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/AddTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Loader\Configurator\Traits;
 
+use Symfony\Component\Routing\Loader\Configurator\CollectionConfigurator;
 use Symfony\Component\Routing\Loader\Configurator\RouteConfigurator;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -24,22 +25,65 @@ trait AddTrait
 
     private $name = '';
 
+    private $prefixes;
+
     /**
      * Adds a route.
+     *
+     * @param string|array $path the path, or the localized paths of the route
      */
-    final public function add(string $name, string $path): RouteConfigurator
+    final public function add(string $name, $path): RouteConfigurator
     {
-        $parentConfigurator = $this instanceof RouteConfigurator ? $this->parentConfigurator : null;
-        $this->collection->add($this->name.$name, $route = new Route($path));
+        $paths = array();
+        $parentConfigurator = $this instanceof CollectionConfigurator ? $this : ($this instanceof RouteConfigurator ? $this->parentConfigurator : null);
 
-        return new RouteConfigurator($this->collection, $route, '', $parentConfigurator);
+        if (\is_array($path)) {
+            if (null === $this->prefixes) {
+                $paths = $path;
+            } elseif ($missing = array_diff_key($this->prefixes, $path)) {
+                throw new \LogicException(sprintf('Route "%s" is missing routes for locale(s) "%s".', $name, implode('", "', array_keys($missing))));
+            } else {
+                foreach ($path as $locale => $localePath) {
+                    if (!isset($this->prefixes[$locale])) {
+                        throw new \LogicException(sprintf('Route "%s" with locale "%s" is missing a corresponding prefix in its parent collection.', $name, $locale));
+                    }
+
+                    $paths[$locale] = $this->prefixes[$locale].$localePath;
+                }
+            }
+        } elseif (null !== $this->prefixes) {
+            foreach ($this->prefixes as $locale => $prefix) {
+                $paths[$locale] = $prefix.$path;
+            }
+        } else {
+            $this->collection->add($this->name.$name, $route = $this->createRoute($path));
+
+            return new RouteConfigurator($this->collection, $route, $this->name, $parentConfigurator, $this->prefixes);
+        }
+
+        $routes = new RouteCollection();
+
+        foreach ($paths as $locale => $path) {
+            $routes->add($name.'.'.$locale, $route = $this->createRoute($path));
+            $this->collection->add($this->name.$name.'.'.$locale, $route);
+            $route->setDefault('_locale', $locale);
+        }
+
+        return new RouteConfigurator($this->collection, $routes, $this->name, $parentConfigurator, $this->prefixes);
     }
 
     /**
      * Adds a route.
+     *
+     * @param string|array $path the path, or the localized paths of the route
      */
-    final public function __invoke(string $name, string $path): RouteConfigurator
+    final public function __invoke(string $name, $path): RouteConfigurator
     {
         return $this->add($name, $path);
+    }
+
+    private function createRoute($path): Route
+    {
+        return new Route($path);
     }
 }

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -130,9 +130,9 @@ class XmlFileLoader extends FileLoader
         } else {
             foreach ($paths as $locale => $p) {
                 $defaults['_locale'] = $locale;
-                $routeName = $id.'.'.$locale;
+                $defaults['_canonical_route'] = $id;
                 $route = new Route($p, $defaults, $requirements, $options, $node->getAttribute('host'), $schemes, $methods, $condition);
-                $collection->add($routeName, $route);
+                $collection->add($id.'.'.$locale, $route);
             }
         }
     }
@@ -183,6 +183,7 @@ class XmlFileLoader extends FileLoader
                         $localizedRoute = clone $route;
                         $localizedRoute->setPath($localePrefix.$route->getPath());
                         $localizedRoute->setDefault('_locale', $locale);
+                        $localizedRoute->setDefault('_canonical_route', $name);
                         $subCollection->add($name.'.'.$locale, $localizedRoute);
                     }
                 } elseif (!isset($prefixes[$locale])) {

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -120,9 +120,19 @@ class YamlFileLoader extends FileLoader
             $defaults['_controller'] = $config['controller'];
         }
 
-        $route = new Route($config['path'], $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
+        if (is_array($config['path'])) {
+            $route = new Route('', $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
 
-        $collection->add($name, $route);
+            foreach ($config['path'] as $locale => $path) {
+                $localizedRoute = clone $route;
+                $localizedRoute->setDefault('_locale', $locale);
+                $localizedRoute->setPath($path);
+                $collection->add($name.'.'.$locale, $localizedRoute);
+            }
+        } else {
+            $route = new Route($config['path'], $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
+            $collection->add($name, $route);
+        }
     }
 
     /**
@@ -151,9 +161,33 @@ class YamlFileLoader extends FileLoader
 
         $this->setCurrentDir(dirname($path));
 
+        /** @var RouteCollection $subCollection */
         $subCollection = $this->import($config['resource'], $type, false, $file);
-        /* @var $subCollection RouteCollection */
-        $subCollection->addPrefix($prefix);
+
+        if (!\is_array($prefix)) {
+            $subCollection->addPrefix($prefix);
+        } else {
+            foreach ($prefix as $locale => $localePrefix) {
+                $prefix[$locale] = trim(trim($localePrefix), '/');
+            }
+            foreach ($subCollection->all() as $name => $route) {
+                if (null === $locale = $route->getDefault('_locale')) {
+                    $subCollection->remove($name);
+                    foreach ($prefix as $locale => $localePrefix) {
+                        $localizedRoute = clone $route;
+                        $localizedRoute->setDefault('_locale', $locale);
+                        $localizedRoute->setPath($localePrefix.$route->getPath());
+                        $subCollection->add($name.'.'.$locale, $localizedRoute);
+                    }
+                } elseif (!isset($prefix[$locale])) {
+                    throw new \InvalidArgumentException(sprintf('Route "%s" with locale "%s" is missing a corresponding prefix when imported in "%s".', $name, $locale, $file));
+                } else {
+                    $route->setPath($prefix[$locale].$route->getPath());
+                    $subCollection->add($name, $route);
+                }
+            }
+        }
+
         if (null !== $host) {
             $subCollection->setHost($host);
         }

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -126,6 +126,7 @@ class YamlFileLoader extends FileLoader
             foreach ($config['path'] as $locale => $path) {
                 $localizedRoute = clone $route;
                 $localizedRoute->setDefault('_locale', $locale);
+                $localizedRoute->setDefault('_canonical_route', $name);
                 $localizedRoute->setPath($path);
                 $collection->add($name.'.'.$locale, $localizedRoute);
             }
@@ -176,6 +177,7 @@ class YamlFileLoader extends FileLoader
                     foreach ($prefix as $locale => $localePrefix) {
                         $localizedRoute = clone $route;
                         $localizedRoute->setDefault('_locale', $locale);
+                        $localizedRoute->setDefault('_canonical_route', $name);
                         $localizedRoute->setPath($localePrefix.$route->getPath());
                         $subCollection->add($name.'.'.$locale, $localizedRoute);
                     }

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -24,6 +24,14 @@
     </xsd:choice>
   </xsd:complexType>
 
+  <xsd:complexType name="localised-path">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="locale" type="xsd:string" use="required" />
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
   <xsd:group name="configs">
     <xsd:choice>
       <xsd:element name="default" nillable="true" type="default" />
@@ -34,10 +42,12 @@
   </xsd:group>
 
   <xsd:complexType name="route">
-    <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
-
+    <xsd:sequence>
+      <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="path" type="localised-path" minOccurs="0" maxOccurs="unbounded" />
+    </xsd:sequence>
     <xsd:attribute name="id" type="xsd:string" use="required" />
-    <xsd:attribute name="path" type="xsd:string" use="required" />
+    <xsd:attribute name="path" type="xsd:string" />
     <xsd:attribute name="host" type="xsd:string" />
     <xsd:attribute name="schemes" type="xsd:string" />
     <xsd:attribute name="methods" type="xsd:string" />
@@ -45,8 +55,10 @@
   </xsd:complexType>
 
   <xsd:complexType name="import">
-    <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
-
+    <xsd:sequence maxOccurs="unbounded" minOccurs="0">
+      <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="prefix" type="localised-path" minOccurs="0" maxOccurs="unbounded" />
+    </xsd:sequence>
     <xsd:attribute name="resource" type="xsd:string" use="required" />
     <xsd:attribute name="type" type="xsd:string" />
     <xsd:attribute name="prefix" type="xsd:string" />

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -256,10 +256,15 @@ EOF
                 }
 
                 if (!$route->getCondition()) {
+                    $defaults = $route->getDefaults();
+                    if (isset($defaults['_canonical_route'])) {
+                        $name = $defaults['_canonical_route'];
+                        unset($defaults['_canonical_route']);
+                    }
                     $default .= sprintf(
                         "%s => array(%s, %s, %s, %s),\n",
                         self::export($url),
-                        self::export(array('_route' => $name) + $route->getDefaults()),
+                        self::export(array('_route' => $name) + $defaults),
                         self::export(!$route->compile()->getHostVariables() ? $route->getHost() : $route->compile()->getHostRegex() ?: null),
                         self::export(array_flip($route->getMethods()) ?: null),
                         self::export(array_flip($route->getSchemes()) ?: null)
@@ -490,10 +495,15 @@ EOF;
 
             if (!$route->getCondition() && (!is_array($next = $routes[1 + $i] ?? null) || $regex !== $next[1])) {
                 $prevRegex = null;
+                $defaults = $route->getDefaults();
+                if (isset($defaults['_canonical_route'])) {
+                    $name = $defaults['_canonical_route'];
+                    unset($defaults['_canonical_route']);
+                }
                 $state->default .= sprintf(
                     "%s => array(%s, %s, %s, %s),\n",
                     $state->mark,
-                    self::export(array('_route' => $name) + $route->getDefaults()),
+                    self::export(array('_route' => $name) + $defaults),
                     self::export($vars),
                     self::export(array_flip($route->getMethods()) ?: null),
                     self::export(array_flip($route->getSchemes()) ?: null)
@@ -619,6 +629,11 @@ EOF;
 
         // the offset where the return value is appended below, with indendation
         $retOffset = 12 + strlen($code);
+        $defaults = $route->getDefaults();
+        if (isset($defaults['_canonical_route'])) {
+            $name = $defaults['_canonical_route'];
+            unset($defaults['_canonical_route']);
+        }
 
         // optimize parameters array
         if ($matches || $hostMatches) {
@@ -633,10 +648,10 @@ EOF;
             $code .= sprintf(
                 "            \$ret = \$this->mergeDefaults(%s, %s);\n",
                 implode(' + ', $vars),
-                self::export($route->getDefaults())
+                self::export($defaults)
             );
-        } elseif ($route->getDefaults()) {
-            $code .= sprintf("            \$ret = %s;\n", self::export(array_replace($route->getDefaults(), array('_route' => $name))));
+        } elseif ($defaults) {
+            $code .= sprintf("            \$ret = %s;\n", self::export(array('_route' => $name) + $defaults));
         } else {
             $code .= sprintf("            \$ret = array('_route' => '%s');\n", $name);
         }

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -194,9 +194,14 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
      */
     protected function getAttributes(Route $route, $name, array $attributes)
     {
+        $defaults = $route->getDefaults();
+        if (isset($defaults['_canonical_route'])) {
+            $name = $defaults['_canonical_route'];
+            unset($defaults['_canonical_route']);
+        }
         $attributes['_route'] = $name;
 
-        return $this->mergeDefaults($attributes, $route->getDefaults());
+        return $this->mergeDefaults($attributes, $defaults);
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
@@ -25,6 +25,14 @@ class RouteTest extends TestCase
     }
 
     /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testTryingToSetLocalesDirectly()
+    {
+        $route = new Route(array('locales' => array('nl' => 'bar')));
+    }
+
+    /**
      * @dataProvider getValidParameters
      */
     public function testRouteParameters($parameter, $value, $getter)
@@ -45,6 +53,7 @@ class RouteTest extends TestCase
             array('methods', array('GET', 'POST'), 'getMethods'),
             array('host', '{locale}.example.com', 'getHost'),
             array('condition', 'context.getMethod() == "GET"', 'getCondition'),
+            array('value', array('nl' => '/hier', 'en' => '/here'), 'getLocales'),
         );
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/AbstractClassController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/AbstractClassController.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+abstract class AbstractClassController
+{
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/ActionPathController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/ActionPathController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class ActionPathController
+{
+    /**
+     * @Route("/path", name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/DefaultValueController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/DefaultValueController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class DefaultValueController
+{
+    /**
+     * @Route("/{default}/path", name="action")
+     */
+    public function action($default = 'value')
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/ExplicitLocalizedActionPathController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/ExplicitLocalizedActionPathController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class ExplicitLocalizedActionPathController
+{
+    /**
+     * @Route(path={"en": "/path", "nl": "/pad"}, name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/here", name="lol")
+ */
+class InvokableController
+{
+    public function __invoke()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableLocalizedController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableLocalizedController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route(path={"nl": "/hier", "en": "/here"}, name="action")
+ */
+class InvokableLocalizedController
+{
+    public function __invoke()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedActionPathController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedActionPathController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class LocalizedActionPathController
+{
+    /**
+     * @Route(path={"en": "/path", "nl": "/pad"}, name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedMethodActionControllers.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedMethodActionControllers.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route(path={"en": "/the/path", "nl": "/het/pad"})
+ */
+class LocalizedMethodActionControllers
+{
+    /**
+     * @Route(name="post", methods={"POST"})
+     */
+    public function post()
+    {
+    }
+
+    /**
+     * @Route(name="put", methods={"PUT"})
+     */
+    public function put()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedPrefixLocalizedActionController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedPrefixLocalizedActionController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route(path={"nl": "/nl", "en": "/en"})
+ */
+class LocalizedPrefixLocalizedActionController
+{
+    /**
+     * @Route(path={"nl": "/actie", "en": "/action"}, name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedPrefixMissingLocaleActionController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedPrefixMissingLocaleActionController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route(path={"nl": "/nl"})
+ */
+class LocalizedPrefixMissingLocaleActionController
+{
+    /**
+     * @Route(path={"nl": "/actie", "en": "/action"}, name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedPrefixMissingRouteLocaleActionController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedPrefixMissingRouteLocaleActionController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route(path={"nl": "/nl", "en": "/en"})
+ */
+class LocalizedPrefixMissingRouteLocaleActionController
+{
+    /**
+     * @Route(path={"nl": "/actie"}, name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedPrefixWithRouteWithoutLocale.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/LocalizedPrefixWithRouteWithoutLocale.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route(path={"en": "/en", "nl": "/nl"})
+ */
+class LocalizedPrefixWithRouteWithoutLocale
+{
+    /**
+     * @Route("/suffix", name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/MethodActionControllers.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/MethodActionControllers.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/the/path")
+ */
+class MethodActionControllers
+{
+    /**
+     * @Route(name="post", methods={"POST"})
+     */
+    public function post()
+    {
+    }
+
+    /**
+     * @Route(name="put", methods={"PUT"})
+     */
+    public function put()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/MissingRouteNameController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/MissingRouteNameController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class MissingRouteNameController
+{
+    /**
+     * @Route("/path")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/NothingButNameController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/NothingButNameController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class NothingButNameController
+{
+    /**
+     * @Route(name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/PrefixedActionLocalizedRouteController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/PrefixedActionLocalizedRouteController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/prefix")
+ */
+class PrefixedActionLocalizedRouteController
+{
+    /**
+     * @Route(path={"en": "/path", "nl": "/pad"}, name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/PrefixedActionPathController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/PrefixedActionPathController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/prefix", host="frankdejonge.nl", condition="lol=fun")
+ */
+class PrefixedActionPathController
+{
+    /**
+     * @Route("/path", name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/RouteWithPrefixController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/RouteWithPrefixController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/prefix")
+ */
+class RouteWithPrefixController
+{
+    /**
+     * @Route("/path", name="action")
+     */
+    public function action()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localised.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localised.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="localised">
+        <default key="_controller">MyBundle:Blog:show</default>
+        <path locale="en">/path</path>
+        <path locale="fr">/route</path>
+    </route>
+
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-locale-but-not-localized.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-locale-but-not-localized.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="imported" path="/suffix">
+        <default key="_controller">MyBundle:Blog:show</default>
+    </route>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-locale-but-not-localized.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-locale-but-not-localized.yml
@@ -1,0 +1,4 @@
+---
+imported:
+    controller: ImportedController::someAction
+    path: /imported

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-locale.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-locale.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="imported">
+        <default key="_controller">MyBundle:Blog:show</default>
+        <path locale="en">/suffix</path>
+        <path locale="fr">/le-suffix</path>
+    </route>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-locale.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/imported-with-locale.yml
@@ -1,0 +1,6 @@
+---
+imported:
+    controller: ImportedController::someAction
+    path:
+        nl: /voorbeeld
+        en: /example

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-controller-default.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-controller-default.yml
@@ -1,0 +1,5 @@
+---
+i_need:
+    defaults:
+        _controller: DefaultController::defaultAction
+    resource: ./localized-route.yml

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-locale-imports-non-localized-route.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-locale-imports-non-localized-route.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+    <import resource="./imported-with-locale-but-not-localized.xml">
+        <prefix locale="fr">/le-prefix</prefix>
+        <prefix locale="en">/the-prefix</prefix>
+    </import>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-locale-imports-non-localized-route.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-locale-imports-non-localized-route.yml
@@ -1,0 +1,6 @@
+---
+i_need:
+    resource: ./imported-with-locale-but-not-localized.yml
+    prefix:
+        nl: /nl
+        en: /en

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-locale.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-locale.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+    <import resource="./imported-with-locale.xml">
+        <prefix locale="fr">/le-prefix</prefix>
+        <prefix locale="en">/the-prefix</prefix>
+    </import>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-locale.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/importer-with-locale.yml
@@ -1,0 +1,6 @@
+---
+i_need:
+    resource: ./imported-with-locale.yml
+    prefix:
+        nl: /nl
+        en: /en

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/importing-localized-route.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/importing-localized-route.yml
@@ -1,0 +1,3 @@
+---
+i_need:
+    resource: ./localized-route.yml

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/localized-route.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/localized-route.yml
@@ -1,0 +1,9 @@
+---
+home:
+    path:
+        nl: /nl
+        en: /en
+
+not_localized:
+    controller: HomeController::otherAction
+    path: /here

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/missing-locale-in-importer.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/missing-locale-in-importer.yml
@@ -1,0 +1,5 @@
+---
+importing_with_missing_prefix:
+    resource: ./localized-route.yml
+    prefix:
+    nl: /prefix

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/not-localized.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/not-localized.yml
@@ -1,0 +1,4 @@
+---
+not_localized:
+    controller: string
+    path: /here

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/officially_formatted_locales.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/officially_formatted_locales.yml
@@ -1,0 +1,7 @@
+---
+official:
+    controller: HomeController::someAction
+    path:
+        fr.UTF-8: /omelette-au-fromage
+        pt-PT: /eu-não-sou-espanhol
+        pt_BR: /churrasco

--- a/src/Symfony/Component/Routing/Tests/Fixtures/localized/route-without-path-or-locales.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/localized/route-without-path-or-locales.yml
@@ -1,0 +1,3 @@
+---
+routename:
+    controller: Here::here

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_i18n.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_i18n.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes
+        ->collection()
+        ->prefix(array('en' => '/glish'))
+        ->add('foo', '/foo')
+        ->add('bar', array('en' => '/bar'));
+
+    $routes
+        ->add('baz', array('en' => '/baz'));
+
+    $routes->import('php_dsl_sub_i18n.php')
+        ->prefix(array('fr' => '/ench'));
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_sub_i18n.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl_sub_i18n.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $add = $routes->collection('c_')
+        ->prefix('pub');
+
+    $add('foo', array('fr' => '/foo'));
+    $add('bar', array('fr' => '/bar'));
+};

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -86,8 +86,8 @@ class PhpGeneratorDumperTest extends TestCase
 
     public function testDumpWithLocalizedRoutes()
     {
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en'));
-        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test'));
 
         $code = $this->generatorDumper->dump([
             'class' => 'LocalizedProjectUrlGenerator',

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -84,6 +84,33 @@ class PhpGeneratorDumperTest extends TestCase
         $this->assertEquals('/app.php/testing2', $relativeUrlWithoutParameter);
     }
 
+    public function testDumpWithLocalizedRoutes()
+    {
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl'));
+
+        $code = $this->generatorDumper->dump([
+            'class' => 'LocalizedProjectUrlGenerator',
+        ]);
+        file_put_contents($this->testTmpFilepath, $code);
+        include $this->testTmpFilepath;
+
+        $context = new RequestContext('/app.php');
+        $projectUrlGenerator = new \LocalizedProjectUrlGenerator($context, null, 'en');
+
+        $urlWithDefaultLocale = $projectUrlGenerator->generate('test');
+        $urlWithSpecifiedLocale = $projectUrlGenerator->generate('test', ['_locale' => 'nl']);
+        $context->setParameter('_locale', 'en');
+        $urlWithEnglishContext = $projectUrlGenerator->generate('test');
+        $context->setParameter('_locale', 'nl');
+        $urlWithDutchContext = $projectUrlGenerator->generate('test');
+
+        $this->assertEquals('/app.php/testing/is/fun', $urlWithDefaultLocale);
+        $this->assertEquals('/app.php/testen/is/leuk', $urlWithSpecifiedLocale);
+        $this->assertEquals('/app.php/testing/is/fun', $urlWithEnglishContext);
+        $this->assertEquals('/app.php/testen/is/leuk', $urlWithDutchContext);
+    }
+
     public function testDumpWithTooManyRoutes()
     {
         $this->routeCollection->add('Test', new Route('/testing/{foo}'));

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -11,35 +11,44 @@
 
 namespace Symfony\Component\Routing\Tests\Loader;
 
-use Symfony\Component\Routing\Annotation\Route;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\AbstractClassController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\ActionPathController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\DefaultValueController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\ExplicitLocalizedActionPathController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\InvokableController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\InvokableLocalizedController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\LocalizedActionPathController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\LocalizedMethodActionControllers;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\LocalizedPrefixLocalizedActionController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\LocalizedPrefixMissingLocaleActionController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\LocalizedPrefixMissingRouteLocaleActionController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\LocalizedPrefixWithRouteWithoutLocale;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\MethodActionControllers;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\MissingRouteNameController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\NothingButNameController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\PrefixedActionLocalizedRouteController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\PrefixedActionPathController;
+use Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures\RouteWithPrefixController;
 
-class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
+class AnnotationClassLoaderTest extends TestCase
 {
-    protected $loader;
-    private $reader;
+    /**
+     * @var AnnotationClassLoader
+     */
+    private $loader;
 
     protected function setUp()
     {
-        parent::setUp();
-
-        $this->reader = $this->getReader();
-        $this->loader = $this->getClassLoader($this->reader);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testLoadMissingClass()
-    {
-        $this->loader->load('MissingClass');
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testLoadAbstractClass()
-    {
-        $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\AbstractClass');
+        $reader = new AnnotationReader();
+        $this->loader = new class($reader) extends AnnotationClassLoader {
+            protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot) {}
+        };
+        AnnotationRegistry::registerLoader('class_exists');
     }
 
     /**
@@ -69,187 +78,144 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->assertFalse($this->loader->supports('class', 'foo'), '->supports() checks the resource type if specified');
     }
 
-    public function getLoadTests()
+    public function testSimplePathRoute()
     {
-        return array(
-            array(
-                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('name' => 'route1', 'path' => '/path'),
-                array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
-            ),
-            array(
-                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('defaults' => array('arg2' => 'foo'), 'requirements' => array('arg3' => '\w+')),
-                array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
-            ),
-            array(
-                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('options' => array('foo' => 'bar')),
-                array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
-            ),
-            array(
-                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('schemes' => array('https'), 'methods' => array('GET')),
-                array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
-            ),
-            array(
-                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
-                array('condition' => 'context.getMethod() == "GET"'),
-                array('arg2' => 'defaultValue2', 'arg3' => 'defaultValue3'),
-            ),
-        );
+        $routes = $this->loader->load(ActionPathController::class);
+        $this->assertCount(1, $routes);
+        $this->assertEquals('/path', $routes->get('action')->getPath());
     }
 
-    /**
-     * @dataProvider getLoadTests
-     */
-    public function testLoad($className, $routeData = array(), $methodArgs = array())
+    public function testInvokableControllerLoader()
     {
-        $routeData = array_replace(array(
-            'name' => 'route',
-            'path' => '/',
-            'requirements' => array(),
-            'options' => array(),
-            'defaults' => array(),
-            'schemes' => array(),
-            'methods' => array(),
-            'condition' => '',
-        ), $routeData);
-
-        $this->reader
-            ->expects($this->once())
-            ->method('getMethodAnnotations')
-            ->will($this->returnValue(array($this->getAnnotatedRoute($routeData))))
-        ;
-
-        $routeCollection = $this->loader->load($className);
-        $route = $routeCollection->get($routeData['name']);
-
-        $this->assertSame($routeData['path'], $route->getPath(), '->load preserves path annotation');
-        $this->assertCount(
-            count($routeData['requirements']),
-            array_intersect_assoc($routeData['requirements'], $route->getRequirements()),
-            '->load preserves requirements annotation'
-        );
-        $this->assertCount(
-            count($routeData['options']),
-            array_intersect_assoc($routeData['options'], $route->getOptions()),
-            '->load preserves options annotation'
-        );
-        $this->assertCount(
-            count($routeData['defaults']),
-            $route->getDefaults(),
-            '->load preserves defaults annotation'
-        );
-        $this->assertEquals($routeData['schemes'], $route->getSchemes(), '->load preserves schemes annotation');
-        $this->assertEquals($routeData['methods'], $route->getMethods(), '->load preserves methods annotation');
-        $this->assertSame($routeData['condition'], $route->getCondition(), '->load preserves condition annotation');
+        $routes = $this->loader->load(InvokableController::class);
+        $this->assertCount(1, $routes);
+        $this->assertEquals('/here', $routes->get('lol')->getPath());
     }
 
-    public function testClassRouteLoad()
+    public function testInvokableLocalizedControllerLoading()
     {
-        $classRouteData = array(
-            'name' => 'prefix_',
-            'path' => '/prefix',
-            'schemes' => array('https'),
-            'methods' => array('GET'),
-        );
-
-        $methodRouteData = array(
-            'name' => 'route1',
-            'path' => '/path',
-            'schemes' => array('http'),
-            'methods' => array('POST', 'PUT'),
-        );
-
-        $this->reader
-            ->expects($this->once())
-            ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
-        ;
-        $this->reader
-            ->expects($this->once())
-            ->method('getMethodAnnotations')
-            ->will($this->returnValue(array($this->getAnnotatedRoute($methodRouteData))))
-        ;
-
-        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass');
-        $route = $routeCollection->get($classRouteData['name'].$methodRouteData['name']);
-
-        $this->assertSame($classRouteData['path'].$methodRouteData['path'], $route->getPath(), '->load concatenates class and method route path');
-        $this->assertEquals(array_merge($classRouteData['schemes'], $methodRouteData['schemes']), $route->getSchemes(), '->load merges class and method route schemes');
-        $this->assertEquals(array_merge($classRouteData['methods'], $methodRouteData['methods']), $route->getMethods(), '->load merges class and method route methods');
+        $routes = $this->loader->load(InvokableLocalizedController::class);
+        $this->assertCount(2, $routes);
+        $this->assertEquals('/here', $routes->get('action.en')->getPath());
+        $this->assertEquals('/hier', $routes->get('action.nl')->getPath());
     }
 
-    public function testInvokableClassRouteLoad()
+    public function testLocalizedPathRoutes()
     {
-        $classRouteData = array(
-            'name' => 'route1',
-            'path' => '/',
-            'schemes' => array('https'),
-            'methods' => array('GET'),
-        );
-
-        $this->reader
-            ->expects($this->exactly(2))
-            ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
-        ;
-        $this->reader
-            ->expects($this->once())
-            ->method('getMethodAnnotations')
-            ->will($this->returnValue(array()))
-        ;
-
-        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass');
-        $route = $routeCollection->get($classRouteData['name']);
-
-        $this->assertSame($classRouteData['path'], $route->getPath(), '->load preserves class route path');
-        $this->assertEquals(array_merge($classRouteData['schemes'], $classRouteData['schemes']), $route->getSchemes(), '->load preserves class route schemes');
-        $this->assertEquals(array_merge($classRouteData['methods'], $classRouteData['methods']), $route->getMethods(), '->load preserves class route methods');
+        $routes = $this->loader->load(LocalizedActionPathController::class);
+        $this->assertCount(2, $routes);
+        $this->assertEquals('/path', $routes->get('action.en')->getPath());
+        $this->assertEquals('/pad', $routes->get('action.nl')->getPath());
     }
 
-    public function testInvokableClassWithMethodRouteLoad()
+    public function testLocalizedPathRoutesWithExplicitPathPropety()
     {
-        $classRouteData = array(
-            'name' => 'route1',
-            'path' => '/prefix',
-            'schemes' => array('https'),
-            'methods' => array('GET'),
-        );
-
-        $methodRouteData = array(
-            'name' => 'route2',
-            'path' => '/path',
-            'schemes' => array('http'),
-            'methods' => array('POST', 'PUT'),
-        );
-
-        $this->reader
-            ->expects($this->once())
-            ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
-        ;
-        $this->reader
-            ->expects($this->once())
-            ->method('getMethodAnnotations')
-            ->will($this->returnValue(array($this->getAnnotatedRoute($methodRouteData))))
-        ;
-
-        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass');
-        $route = $routeCollection->get($classRouteData['name']);
-
-        $this->assertNull($route, '->load ignores class route');
-
-        $route = $routeCollection->get($classRouteData['name'].$methodRouteData['name']);
-
-        $this->assertSame($classRouteData['path'].$methodRouteData['path'], $route->getPath(), '->load concatenates class and method route path');
-        $this->assertEquals(array_merge($classRouteData['schemes'], $methodRouteData['schemes']), $route->getSchemes(), '->load merges class and method route schemes');
-        $this->assertEquals(array_merge($classRouteData['methods'], $methodRouteData['methods']), $route->getMethods(), '->load merges class and method route methods');
+        $routes = $this->loader->load(ExplicitLocalizedActionPathController::class);
+        $this->assertCount(2, $routes);
+        $this->assertEquals('/path', $routes->get('action.en')->getPath());
+        $this->assertEquals('/pad', $routes->get('action.nl')->getPath());
     }
 
-    private function getAnnotatedRoute($data)
+    public function testDefaultValuesForMethods()
     {
-        return new Route($data);
+        $routes = $this->loader->load(DefaultValueController::class);
+        $this->assertCount(1, $routes);
+        $this->assertEquals('/{default}/path', $routes->get('action')->getPath());
+        $this->assertEquals('value', $routes->get('action')->getDefault('default'));
+    }
+
+    public function testMethodActionControllers()
+    {
+        $routes = $this->loader->load(MethodActionControllers::class);
+        $this->assertCount(2, $routes);
+        $this->assertEquals('/the/path', $routes->get('put')->getPath());
+        $this->assertEquals('/the/path', $routes->get('post')->getPath());
+    }
+
+    public function testLocalizedMethodActionControllers()
+    {
+        $routes = $this->loader->load(LocalizedMethodActionControllers::class);
+        $this->assertCount(4, $routes);
+        $this->assertEquals('/the/path', $routes->get('put.en')->getPath());
+        $this->assertEquals('/the/path', $routes->get('post.en')->getPath());
+    }
+
+    public function testRouteWithPathWithPrefix()
+    {
+        $routes = $this->loader->load(PrefixedActionPathController::class);
+        $this->assertCount(1, $routes);
+        $route = $routes->get('action');
+        $this->assertEquals('/prefix/path', $route->getPath());
+        $this->assertEquals('lol=fun', $route->getCondition());
+        $this->assertEquals('frankdejonge.nl', $route->getHost());
+    }
+
+    public function testLocalizedRouteWithPathWithPrefix()
+    {
+        $routes = $this->loader->load(PrefixedActionLocalizedRouteController::class);
+        $this->assertCount(2, $routes);
+        $this->assertEquals('/prefix/path', $routes->get('action.en')->getPath());
+        $this->assertEquals('/prefix/pad', $routes->get('action.nl')->getPath());
+    }
+
+    public function testLocalizedPrefixLocalizedRoute()
+    {
+        $routes = $this->loader->load(LocalizedPrefixLocalizedActionController::class);
+        $this->assertCount(2, $routes);
+        $this->assertEquals('/nl/actie', $routes->get('action.nl')->getPath());
+        $this->assertEquals('/en/action', $routes->get('action.en')->getPath());
+    }
+
+    public function testMissingPrefixLocale()
+    {
+        $this->expectException(\LogicException::class);
+        $this->loader->load(LocalizedPrefixMissingLocaleActionController::class);
+    }
+
+    public function testMissingRouteLocale()
+    {
+        $this->expectException(\LogicException::class);
+        $this->loader->load(LocalizedPrefixMissingRouteLocaleActionController::class);
+    }
+
+    public function testRouteWithoutName()
+    {
+        $routes = $this->loader->load(MissingRouteNameController::class)->all();
+        $this->assertCount(1, $routes);
+        $this->assertEquals('/path', reset($routes)->getPath());
+    }
+
+    public function testNothingButName()
+    {
+        $routes = $this->loader->load(NothingButNameController::class)->all();
+        $this->assertCount(1, $routes);
+        $this->assertEquals('/', reset($routes)->getPath());
+    }
+
+    public function testNonExistingClass()
+    {
+        $this->expectException(\LogicException::class);
+        $this->loader->load('ClassThatDoesNotExist');
+    }
+
+    public function testLoadingAbstractClass()
+    {
+        $this->expectException(\LogicException::class);
+        $this->loader->load(AbstractClassController::class);
+    }
+
+    public function testLocalizedPrefixWithoutRouteLocale()
+    {
+        $routes = $this->loader->load(LocalizedPrefixWithRouteWithoutLocale::class);
+        $this->assertCount(2, $routes);
+        $this->assertEquals('/en/suffix', $routes->get('action.en')->getPath());
+        $this->assertEquals('/nl/suffix', $routes->get('action.nl')->getPath());
+    }
+
+    public function testLoadingRouteWithPrefix()
+    {
+        $routes = $this->loader->load(RouteWithPrefixController::class);
+        $this->assertCount(1, $routes);
+        $this->assertEquals('/prefix/path', $routes->get('action')->getPath());
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/FileLocatorStub.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/FileLocatorStub.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Loader;
+
+use Symfony\Component\Config\FileLocatorInterface;
+
+class FileLocatorStub implements FileLocatorInterface
+{
+    public function locate($name, $currentPath = null, $first = true)
+    {
+        if (0 === strpos($name, 'http')) {
+            return $name;
+        }
+
+        return rtrim($currentPath, '/').'/'.$name;
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -126,11 +126,11 @@ class PhpFileLoaderTest extends TestCase
 
         $expectedCollection = new RouteCollection();
 
-        $expectedCollection->add('foo.en', (new Route('/glish/foo'))->setDefaults(array('_locale' => 'en')));
-        $expectedCollection->add('bar.en', (new Route('/glish/bar'))->setDefaults(array('_locale' => 'en')));
-        $expectedCollection->add('baz.en', (new Route('/baz'))->setDefaults(array('_locale' => 'en')));
-        $expectedCollection->add('c_foo.fr', (new Route('/ench/pub/foo'))->setDefaults(array('_locale' => 'fr')));
-        $expectedCollection->add('c_bar.fr', (new Route('/ench/pub/bar'))->setDefaults(array('_locale' => 'fr')));
+        $expectedCollection->add('foo.en', (new Route('/glish/foo'))->setDefaults(array('_locale' => 'en', '_canonical_route' => 'foo')));
+        $expectedCollection->add('bar.en', (new Route('/glish/bar'))->setDefaults(array('_locale' => 'en', '_canonical_route' => 'bar')));
+        $expectedCollection->add('baz.en', (new Route('/baz'))->setDefaults(array('_locale' => 'en', '_canonical_route' => 'baz')));
+        $expectedCollection->add('c_foo.fr', (new Route('/ench/pub/foo'))->setDefaults(array('_locale' => 'fr', '_canonical_route' => 'c_foo')));
+        $expectedCollection->add('c_bar.fr', (new Route('/ench/pub/bar'))->setDefaults(array('_locale' => 'fr', '_canonical_route' => 'c_bar')));
 
         $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl_sub_i18n.php')));
         $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl_i18n.php')));

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -117,4 +117,24 @@ class PhpFileLoaderTest extends TestCase
 
         $this->assertEquals($expectedCollection, $routeCollection);
     }
+
+    public function testRoutingI18nConfigurator()
+    {
+        $locator = new FileLocator(array(__DIR__.'/../Fixtures'));
+        $loader = new PhpFileLoader($locator);
+        $routeCollection = $loader->load('php_dsl_i18n.php');
+
+        $expectedCollection = new RouteCollection();
+
+        $expectedCollection->add('foo.en', (new Route('/glish/foo'))->setDefaults(array('_locale' => 'en')));
+        $expectedCollection->add('bar.en', (new Route('/glish/bar'))->setDefaults(array('_locale' => 'en')));
+        $expectedCollection->add('baz.en', (new Route('/baz'))->setDefaults(array('_locale' => 'en')));
+        $expectedCollection->add('c_foo.fr', (new Route('/ench/pub/foo'))->setDefaults(array('_locale' => 'fr')));
+        $expectedCollection->add('c_bar.fr', (new Route('/ench/pub/bar'))->setDefaults(array('_locale' => 'fr')));
+
+        $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl_sub_i18n.php')));
+        $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl_i18n.php')));
+
+        $this->assertEquals($expectedCollection, $routeCollection);
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -83,6 +83,45 @@ class XmlFileLoaderTest extends TestCase
         }
     }
 
+    public function testLoadLocalized()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $routeCollection = $loader->load('localised.xml');
+        $routes = $routeCollection->all();
+
+        $this->assertCount(2, $routes, 'Two routes are loaded');
+        $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
+
+        $this->assertEquals('/route', $routeCollection->get('localised.fr')->getPath());
+        $this->assertEquals('/path', $routeCollection->get('localised.en')->getPath());
+    }
+
+    public function testLocalisedImports()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/localized')));
+        $routeCollection = $loader->load('importer-with-locale.xml');
+        $routes = $routeCollection->all();
+
+        $this->assertCount(2, $routes, 'Two routes are loaded');
+        $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
+
+        $this->assertEquals('/le-prefix/le-suffix', $routeCollection->get('imported.fr')->getPath());
+        $this->assertEquals('/the-prefix/suffix', $routeCollection->get('imported.en')->getPath());
+    }
+
+    public function testLocalisedImportsOfNotLocalizedRoutes()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/localized')));
+        $routeCollection = $loader->load('importer-with-locale-imports-non-localized-route.xml');
+        $routes = $routeCollection->all();
+
+        $this->assertCount(2, $routes, 'Two routes are loaded');
+        $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
+
+        $this->assertEquals('/le-prefix/suffix', $routeCollection->get('imported.fr')->getPath());
+        $this->assertEquals('/the-prefix/suffix', $routeCollection->get('imported.en')->getPath());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @dataProvider getPathsToInvalidFiles


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

This PR introduces support for I18N routing into core. This is a port from a bundle I've made recently, now merged into the default implementation. While it's ok to have this as a bundle, it was suggested by @nicolas-grekas to create a PR for this so it can be included into the core.

## New usages

### YAML

```yaml
contact:
    controller: ContactController::formAction
    path:
        en: /send-us-an-email
        nl: /stuur-ons-een-email
```

Will be effectively the same as declaring:

```yaml
contact.en:
    controller: ContactController::formAction
    path: /send-us-an-email
    defaults:
        _locale: en

contact.nl:
    controller: ContactController::formAction
    path: /stuur-ons-een-email
    defaults:
        _locale: nl
```

### Annotation usage:

```php
<?php

use Symfony\Component\Routing\Annotation\Route;

class ContactController
{
    /**
     * @Route({"en": "/send-us-an-email", "nl": "/stuur-ons-een-email"}, name="contact") 
     */
    public function formAction()
    {
        
    }
}

/** 
 * @Route("/contact") 
 */
class PrefixedContactController
{
    /**
     * @Route({"en": "/send-us-an-email", "nl": "/stuur-ons-een-email"}, name="contact") 
     */
    public function formAction()
    {
        
    }
}
```

### Route generation

```php
<?php
/** @var UrlGeneratorInterface $urlGenerator */
$urlWithCurrentLocale = $urlGenerator->generate('contact');
$urlWithSpecifiedLocale = $urlGenerator->generate('contact', ['_locale' => 'nl']);
```

Route generation is based on your request locale. When not available it falls back on a configured default. This way of route generation means you have a "route locale switcher" out of the box, but generate the current route with another locale for most cases.

## Advantages

Having i18n routes defined like this has some advantages:

* Less error prone.
* No need to keep `requirements` or `defaults` in sync with other definitions.
* No need to `{_locale}` in the path (bad for route matching performance).
* Better developer experience.


### Next steps

I've ported all the things the bundle supported, before moving on I'd like to discuss this first in order not to waste our collective time. This initial PR should give a clear enough picture to see what/how/why this is done.

If and when accepted I/we can move forward to implement the XML loader and @nicolas-grekas mentioned there should be a `Configurator` implemented for this as well. He opted to help with this (for which I'm very thankful).

- [x] Yaml Loader
- [x] Annotation Loader
- [x] XML Loader
- [x] PHP Loader?
- [ ] Documentation