### PR TITLE
Added support for name on the unit node

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * The `FileDumper::setBackup()` method is deprecated and will be removed in 5.0.
  * The `TranslationWriter::disableBackup()` method is deprecated and will be removed in 5.0.
- * The `XliffFileDumper` will write "name" on the "unit" node. 
+ * The `XliffFileDumper` will write "name" on the "unit" node when dumping XLIFF 2.0.
 
 4.0.0
 -----

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * The `FileDumper::setBackup()` method is deprecated and will be removed in 5.0.
  * The `TranslationWriter::disableBackup()` method is deprecated and will be removed in 5.0.
+ * The `XliffFileDumper` will write "name" on the "unit" node. 
 
 4.0.0
 -----

--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -146,6 +146,7 @@ class XliffFileDumper extends FileDumper
         foreach ($messages->all($domain) as $source => $target) {
             $translation = $dom->createElement('unit');
             $translation->setAttribute('id', strtr(substr(base64_encode(hash('sha256', $source, true)), 0, 7), '/+', '._'));
+            $translation->setAttribute('name', $source);
             $metadata = $messages->getMetadata($source, $domain);
 
             // Add notes section

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources-2.0-clean.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources-2.0-clean.xlf
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
   <file id="messages.en_US">
-    <unit id="LCa0a2j">
+    <unit id="LCa0a2j" name="foo">
       <segment>
         <source>foo</source>
         <target>bar</target>
       </segment>
     </unit>
-    <unit id="LHDhK3o">
+    <unit id="LHDhK3o" name="key">
       <segment>
         <source>key</source>
         <target order="1"></target>
       </segment>
     </unit>
-    <unit id="2DA_bnh">
+    <unit id="2DA_bnh" name="key.with.cdata">
       <segment>
         <source>key.with.cdata</source>
         <target><![CDATA[<source> & <target>]]></target>

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources-notes-meta.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources-notes-meta.xlf
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="fr-FR" trgLang="en-US">
   <file id="messages.en_US">
-    <unit id="LCa0a2j">
+    <unit id="LCa0a2j" name="foo">
       <notes>
         <note category="state">new</note>
         <note category="approved">true</note>
@@ -12,7 +12,7 @@
         <target>bar</target>
       </segment>
     </unit>
-    <unit id="uqWglk0">
+    <unit id="uqWglk0" name="baz">
       <notes>
         <note id="x">x_content</note>
         <note appliesTo="target" category="quality">Fuzzy</note>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25758
| License       | MIT
| Doc PR        | na

See [unit specification](http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html#unit) and [name specification](http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html#name)
