### PR TITLE
Fixes #26136: Avoid emitting warning in hasParameterOption()

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -283,7 +283,7 @@ class ArgvInput extends Input
                 //   For long options, test for '--option=' at beginning
                 //   For short options, test for '-o' at beginning
                 $leading = 0 === strpos($value, '--') ? $value.'=' : $value;
-                if ($token === $value || !empty($leading) && 0 === strpos($token, $leading)) {
+                if ($token === $value || '' !== $leading && 0 === strpos($token, $leading)) {
                     return true;
                 }
             }
@@ -311,7 +311,7 @@ class ArgvInput extends Input
                 //   For long options, test for '--option=' at beginning
                 //   For short options, test for '-o' at beginning
                 $leading = 0 === strpos($value, '--') ? $value.'=' : $value;
-                if (!empty($leading) && 0 === strpos($token, $leading)) {
+                if ('' !== $leading && 0 === strpos($token, $leading)) {
                     return substr($token, strlen($leading));
                 }
             }

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -283,7 +283,7 @@ class ArgvInput extends Input
                 //   For long options, test for '--option=' at beginning
                 //   For short options, test for '-o' at beginning
                 $leading = 0 === strpos($value, '--') ? $value.'=' : $value;
-                if ($token === $value || 0 === strpos($token, $leading)) {
+                if ($token === $value || !empty($leading) && 0 === strpos($token, $leading)) {
                     return true;
                 }
             }
@@ -311,7 +311,7 @@ class ArgvInput extends Input
                 //   For long options, test for '--option=' at beginning
                 //   For short options, test for '-o' at beginning
                 $leading = 0 === strpos($value, '--') ? $value.'=' : $value;
-                if (0 === strpos($token, $leading)) {
+                if (!empty($leading) && 0 === strpos($token, $leading)) {
                     return substr($token, strlen($leading));
                 }
             }

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -337,6 +337,21 @@ class ArgvInputTest extends TestCase
         $this->assertFalse($input->hasParameterOption('-fh'), '->hasParameterOption() returns true if the given short option is in the raw input');
     }
 
+    public function testNoWarningOnInvalidParameterOption()
+    {
+        $input = new ArgvInput(array('cli.php', '-edev'));
+
+        // Control.
+        $this->assertTrue($input->hasParameterOption(array('-e', '')));
+        // No warning is thrown if https://github.com/symfony/symfony/pull/26156 is fixed
+        $this->assertFalse($input->hasParameterOption(array('-m', '')));
+
+        // Control.
+        $this->assertEquals('dev', $input->getParameterOption(array('-e', '')));
+        // No warning is thrown if https://github.com/symfony/symfony/pull/26156 is fixed
+        $this->assertEquals('', $input->getParameterOption(array('-m', '')));
+    }
+
     public function testToString()
     {
         $input = new ArgvInput(array('cli.php', '-f', 'foo'));

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -349,7 +349,7 @@ class ArgvInputTest extends TestCase
         // Control.
         $this->assertEquals('dev', $input->getParameterOption(array('-e', '')));
         // No warning is thrown if https://github.com/symfony/symfony/pull/26156 is fixed
-        $this->assertEquals('', $input->getParameterOption(array('-m', '')));
+        $this->assertFalse($input->getParameterOption(array('-m', '')));
     }
 
     public function testToString()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26136
| License       | MIT
| Doc PR        | n/a

When hasParameterOption / getParameterOption is passed invalid parameters, a warning may be emitted. While the root cause of the warning is an invalid parameter supplied by the caller, earlier versions of Symfony accepted these parameters, which were effectively ignored.

In the context of these methods, what I mean by "invalid parameter" is an empty string, which is the correct datatype, but is not ever a useful thing to provide to these methods. Since empty strings here did not cause a problem in previous versions, and since Symfony is used by all sorts of projects for all sorts of purposes, it seems best to continue to be flexible about the parameters accepted by Symfony APIs.
