### PR TITLE
[HttpKernel] Send new session cookie from AbstractTestSessionListener after session invalidation

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
@@ -29,6 +29,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 abstract class AbstractTestSessionListener implements EventSubscriberInterface
 {
+    private $sessionId;
+
     public function onKernelRequest(GetResponseEvent $event)
     {
         if (!$event->isMasterRequest()) {
@@ -44,7 +46,8 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
         $cookies = $event->getRequest()->cookies;
 
         if ($cookies->has($session->getName())) {
-            $session->setId($cookies->get($session->getName()));
+            $this->sessionId = $cookies->get($session->getName());
+            $session->setId($this->sessionId);
         }
     }
 
@@ -66,9 +69,10 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
             $session->save();
         }
 
-        if ($session instanceof Session ? !$session->isEmpty() : $wasStarted) {
+        if ($session instanceof Session ? !$session->isEmpty() || $session->getId() !== $this->sessionId : $wasStarted) {
             $params = session_get_cookie_params();
             $event->getResponse()->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
+            $this->sessionId = $session->getId();
         }
     }
 


### PR DESCRIPTION
When we call `\Symfony\Component\HttpFoundation\Session\Session::invalidate` the session will be emptied and given a new ID, however, since it is empty this `AbstractTestSessionListener` will not send a new cookie to the user, so the user is not caught up to the latest session ID and will re-generate a session with the old session ID on a new visit.
Thus, we the sessionID has changed during a request we must always send a new cookie with the new sessionID, even though the session is empty.

This behaviour is also what is shown in production (non-test) mode.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

