### PR TITLE
Add ControllerTrait::createNamedFormBuilder method

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Added option in workflow dump command to label graph with a custom label
  * Using a `RouterInterface` that does not implement the `WarmableInterface` is deprecated and will not be supported in Symfony 5.0.
  * The `RequestDataCollector` class has been deprecated and will be removed in Symfony 5.0. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
+ * Added the `ControllerTrait::createNamedFormBuilder` shortcut method. 
 
 4.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -322,6 +322,16 @@ trait ControllerTrait
     }
 
     /**
+     * Creates and returns a named form builder instance.
+     *
+     * @final
+     */
+    protected function createNamedFormBuilder(string $name, $data = null, array $options = array()): FormBuilderInterface
+    {
+        return $this->container->get('form.factory')->createNamedBuilder($name, FormType::class, $data, $options);
+    }
+
+    /**
      * Shortcut to return the Doctrine Registry service.
      *
      * @throws \LogicException If DoctrineBundle is not available

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -516,6 +518,22 @@ abstract class ControllerTraitTest extends TestCase
         $this->assertEquals($formBuilder, $controller->createFormBuilder('foo'));
     }
 
+    public function testCreateNamedFormBuilder()
+    {
+        $formBuilder = $this->getMockBuilder(FormBuilderInterface::class)->getMock();
+
+        $formFactory = $this->getMockBuilder(FormFactoryInterface::class)->getMock();
+        $formFactory->expects($this->once())->method('createNamedBuilder')->willReturn($formBuilder);
+
+        $container = new Container();
+        $container->set('form.factory', $formFactory);
+
+        $controller = $this->createController();
+        $controller->setContainer($container);
+
+        $this->assertEquals($formBuilder, $controller->createNamedFormBuilder('foo'));
+    }
+
     public function testGetDoctrine()
     {
         $doctrine = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')->getMock();
@@ -551,6 +569,7 @@ trait TestControllerTrait
         createAccessDeniedException as public;
         createForm as public;
         createFormBuilder as public;
+        createNamedFormBuilder as public;
         getDoctrine as public;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

A long time ago, you merged #2936 to allow empty root form name with the builder.

The issue is, if we want to do that from the controller, we can't use `createFormBuilder` because it will create a named form with the form type block prefix.

So we currently have to use the FactoryService.

This PR adds a `createNamedFormBuilder` to allows empty root form name builder with simplicity.