### PR TITLE
[TwigBridge] Apply some changes to support Bootstrap4-stable

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -217,7 +217,7 @@
 
         {{ widget|raw }}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-            {{ label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) -}}
+            {{- label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) -}}
             {{- form_errors(form) -}}
         </label>
     {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -3,11 +3,25 @@
 {# Widgets #}
 
 {% block money_widget -%}
-    {% if not valid %}
-        {% set group_class = ' form-control is-invalid' %}
-        {% set valid = true %}
-    {% endif %}
-    {{- parent() -}}
+    {%- set prepend = not (money_pattern starts with '{{') -%}
+    {%- set append = not (money_pattern ends with '}}') -%}
+    {%- if prepend or append -%}
+        <div class="input-group{{ group_class|default('') }}">
+            {%- if prepend -%}
+                <div class="input-group-prepend">
+                    <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+                </div>
+            {%- endif -%}
+            {{- block('form_widget_simple') -}}
+            {%- if append -%}
+                <div class="input-group-append">
+                    <span class="input-group-text">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
+                </div>
+            {%- endif -%}
+        </div>
+    {%- else -%}
+        {{- block('form_widget_simple') -}}
+    {%- endif -%}
 {%- endblock money_widget %}
 
 {% block datetime_widget -%}
@@ -39,7 +53,6 @@
         {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) -%}
         {% set valid = true %}
     {%- endif -%}
-
     {%- if widget == 'single_text' -%}
         {{- block('form_widget_simple') -}}
     {%- else -%}
@@ -80,7 +93,9 @@
     <div class="input-group{{ not valid ? ' form-control is-invalid' }}">
         {% set valid = true %}
         {{- block('form_widget_simple') -}}
-        <span class="input-group-addon">%</span>
+        <div class="input-group-append">
+            <span class="input-group-text">%</span>
+        </div>
     </div>
 {%- endblock percent_widget %}
 
@@ -93,7 +108,7 @@
 
 {%- block widget_attributes -%}
     {%- if not valid %}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) %}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' is-invalid')|trim}) %}
     {% endif -%}
     {{ parent() }}
 {%- endblock widget_attributes -%}
@@ -105,15 +120,14 @@
 
 {% block checkbox_widget -%}
     {%- set parent_label_class = parent_label_class|default(label_attr.class|default('')) -%}
-    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
-    {% if 'checkbox-inline' in parent_label_class %}
-        {{- form_label(form, null, { widget: parent() }) -}}
-    {% elseif 'form-check-inline' in parent_label_class %}
-        <div class="form-check{{ not valid ? ' form-control is-invalid' }} form-check-inline">
+    {%- if 'checkbox-custom' in parent_label_class -%}
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' custom-control-input')|trim}) -%}
+        <div class="custom-control custom-checkbox{{ 'checkbox-inline' in parent_label_class ? ' custom-control-inline' }}">
             {{- form_label(form, null, { widget: parent() }) -}}
         </div>
-    {% else -%}
-        <div class="form-check{{ not valid ? ' form-control is-invalid' }}">
+    {%- else -%}
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
+        <div class="form-check{{ 'checkbox-inline' in parent_label_class ? ' form-check-inline' }}">
             {{- form_label(form, null, { widget: parent() }) -}}
         </div>
     {%- endif -%}
@@ -121,18 +135,21 @@
 
 {% block radio_widget -%}
     {%- set parent_label_class = parent_label_class|default(label_attr.class|default('')) -%}
-    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
-    {%- if 'radio-inline' in parent_label_class -%}
-        {{- form_label(form, null, { widget: parent() }) -}}
+    {%- if 'radio-custom' in parent_label_class -%}
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' custom-control-input')|trim}) -%}
+        <div class="custom-control custom-radio{{ 'radio-inline' in parent_label_class ? ' custom-control-inline' }}">
+            {{- form_label(form, null, { widget: parent() }) -}}
+        </div>
     {%- else -%}
-        <div class="form-check{{ not valid ? ' form-control is-invalid' }}">
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
+        <div class="form-check{{ 'radio-inline' in parent_label_class ? ' form-check-inline' }}">
             {{- form_label(form, null, { widget: parent() }) -}}
         </div>
     {%- endif -%}
 {%- endblock radio_widget %}
 
 {% block choice_widget_expanded -%}
-    {% if '-inline' in label_attr.class|default('') -%}
+    <div {{ block('widget_container_attributes') }}>
         {%- for child in form %}
             {{- form_widget(child, {
                 parent_label_class: label_attr.class|default(''),
@@ -140,20 +157,7 @@
                 valid: valid,
             }) -}}
         {% endfor -%}
-    {%- else -%}
-        {%- if not valid -%}
-            {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) %}
-        {%- endif -%}
-        <div {{ block('widget_container_attributes') }}>
-            {%- for child in form %}
-                {{- form_widget(child, {
-                    parent_label_class: label_attr.class|default(''),
-                    translation_domain: choice_translation_domain,
-                    valid: true,
-                }) -}}
-            {% endfor -%}
-        </div>
-    {%- endif %}
+    </div>
 {%- endblock choice_widget_expanded %}
 
 {# Labels #}
@@ -162,7 +166,7 @@
     {% if label is not same as(false) -%}
         {%- if compound is defined and compound -%}
             {%- set element = 'legend' -%}
-            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' col-form-legend')|trim}) -%}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' col-form-label')|trim}) -%}
         {%- else -%}
             {%- set label_attr = label_attr|merge({for: id, class: (label_attr.class|default('') ~ ' form-control-label')|trim}) -%}
         {%- endif -%}
@@ -179,19 +183,26 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}{% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}</{{ element|default('label') }}>
+        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}{{- form_errors(form) -}}</{{ element|default('label') }}>
     {%- endif -%}
 {%- endblock form_label %}
 
 {% block checkbox_radio_label -%}
     {#- Do not display the label if widget is not defined in order to prevent double label rendering -#}
     {%- if widget is defined -%}
-        {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' form-check-label')|trim}) -%}
+        {%- if parent_label_class is defined and ('checkbox-custom' in parent_label_class or 'radio-custom' in parent_label_class) -%}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' custom-control-label')|trim}) -%}
+        {%- else %}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' form-check-label')|trim}) -%}
+        {%- endif %}
+        {%- if not compound -%}
+            {% set label_attr = label_attr|merge({'for': id}) %}
+        {%- endif -%}
         {%- if required -%}
             {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) -%}
         {%- endif -%}
         {%- if parent_label_class is defined -%}
-            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) -%}
+            {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|replace({'checkbox-inline': '', 'radio-inline': '', 'checkbox-custom': '', 'radio-custom': ''})|trim}) -%}
         {%- endif -%}
         {%- if label is not same as(false) and label is empty -%}
             {%- if label_format is not empty -%}
@@ -203,8 +214,11 @@
                 {%- set label = name|humanize -%}
             {%- endif -%}
         {%- endif -%}
+
+        {{ widget|raw }}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-            {{- widget|raw }} {{ label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) -}}
+            {{ label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) -}}
+            {{- form_errors(form) -}}
         </label>
     {%- endif -%}
 {%- endblock checkbox_radio_label %}
@@ -225,12 +239,12 @@
 
 {% block form_errors -%}
     {%- if errors|length > 0 -%}
-    <div class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %}">
-        <ul class="list-unstyled mb-0">
-            {%- for error in errors -%}
-                <li>{{ error.message }}</li>
-            {%- endfor -%}
-        </ul>
-    </div>
+        <div class="{% if form is not rootform %}invalid-feedback d-block{% else %}alert alert-danger{% endif %}">
+            <ul class="list-unstyled mb-0">
+                {%- for error in errors -%}
+                    <li>{{ error.message }}</li>
+                {%- endfor -%}
+            </ul>
+        </div>
     {%- endif %}
 {%- endblock form_errors %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
@@ -147,7 +147,7 @@
 
 {% block choice_label -%}
     {# remove the checkbox-inline and radio-inline class, it's only useful for embed labels #}
-    {%- set label_attr = label_attr|merge({class: label_attr.class|default('')|replace({'checkbox-inline': '', 'radio-inline': ''})|trim}) -%}
+    {%- set label_attr = label_attr|merge({class: label_attr.class|default('')|replace({'checkbox-inline': '', 'radio-inline': '', 'checkbox-custom': '', 'radio-custom': ''})|trim}) -%}
     {{- block('form_label') -}}
 {% endblock choice_label %}
 

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
         "symfony/asset": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
-        "symfony/form": "~3.4|~4.0",
+        "symfony/form": "^3.4.5|^4.0.5",
         "symfony/http-foundation": "^3.3.11|~4.0",
         "symfony/http-kernel": "~3.2|~4.0",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -41,7 +41,7 @@
         "symfony/workflow": "~3.3|~4.0"
     },
     "conflict": {
-        "symfony/form": "<3.4",
+        "symfony/form": "<3.4.5",
         "symfony/console": "<3.4"
     },
     "suggest": {

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
@@ -53,7 +53,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
 
         $this->assertMatchesXpath($html,
 '/legend
-    [@class="col-form-label col-sm-2 col-form-legend required"]
+    [@class="col-form-label col-sm-2 col-form-label required"]
     [.="[trans]Name[/trans]"]
 '
         );
@@ -144,7 +144,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
 
         $this->assertMatchesXpath($html,
 '/legend
-    [@class="col-sm-2 col-form-legend required"]
+    [@class="col-sm-2 col-form-label required"]
     [.="[trans]Custom label[/trans]"]
 '
         );

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
@@ -53,7 +53,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
         $this->assertMatchesXpath($html,
 '/legend
-    [@class="col-form-legend required"]
+    [@class="col-form-label required"]
     [.="[trans]Name[/trans]"]
 '
         );
@@ -144,7 +144,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
         $this->assertMatchesXpath($html,
 '/legend
-    [@class="col-form-legend required"]
+    [@class="col-form-label required"]
     [.="[trans]Custom label[/trans]"]
 '
         );
@@ -184,12 +184,10 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 '/div
     [@class="form-check"]
     [
-        ./label
-            [.=" [trans]Name[/trans]"]
+        ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class form-check-input"][@checked="checked"][@value="1"]
+        /following-sibling::label
+            [.="[trans]Name[/trans]"]
             [@class="form-check-label required"]
-            [
-                ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class form-check-input"][@checked="checked"][@value="1"]
-            ]
     ]
 '
         );
@@ -234,20 +232,16 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&A[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&B[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -263,11 +257,9 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 '/div
     [@class="form-check"]
     [
-        ./label
-            [.=" [trans]Name[/trans]"]
-            [
-                ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class form-check-input"][not(@checked)]
-            ]
+        ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class form-check-input"][not(@checked)]
+        /following-sibling::label
+            [.="[trans]Name[/trans]"]
     ]
 '
         );
@@ -283,11 +275,9 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 '/div
     [@class="form-check"]
     [
-        ./label
-            [.=" [trans]Name[/trans]"]
-            [
-                ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class form-check-input"][@value="foo&bar"]
-            ]
+        ./input[@type="checkbox"][@name="name"][@id="my&id"][@class="my&class form-check-input"][@value="foo&bar"]
+        /following-sibling::label
+            [.="[trans]Name[/trans]"]
     ]
 '
         );
@@ -307,20 +297,16 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&A[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&B[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -343,18 +329,14 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
+                /following-sibling::label
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -383,28 +365,22 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]label.&a[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
+                    [.="[trans]label.&a[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
+                /following-sibling::label
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]label.&c[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_2"][@value="&c"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_2"][@value="&c"][not(@checked)]
+                /following-sibling::label
+                    [.="[trans]label.&c[/trans]"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -429,18 +405,14 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
+                /following-sibling::label
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -463,20 +435,16 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" Choice&A"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
+                    [.="Choice&A"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" Choice&B"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)]
+                /following-sibling::label
+                    [.="Choice&B"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -499,20 +467,16 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&A[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&B[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)][@class="foo&bar form-check-input"]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)][@class="foo&bar form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -536,29 +500,23 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Test&Me[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_placeholder"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_placeholder"][not(@checked)]
+                /following-sibling::label
+                    [.="[trans]Test&Me[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&A[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@checked]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@checked]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&B[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][not(@checked)]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -583,29 +541,23 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" Placeholder&Not&Translated"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_placeholder"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_placeholder"][not(@checked)]
+                /following-sibling::label
+                    [.="Placeholder&Not&Translated"]
+            ]
+        /following-sibling::div
+            [@class="form-check"]
+            [  
+                ./input[@type="radio"][@name="name"][@id="name_0"][@checked]
+                /following-sibling::label
+                    [.="Choice&A"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" Choice&A"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@checked]
-                    ]
-            ]
-        /following-sibling::div
-            [@class="form-check"]
-            [
-                ./label
-                    [.=" Choice&B"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][not(@checked)]
+                /following-sibling::label
+                    [.="Choice&B"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -627,20 +579,16 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&A[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_0"][@checked]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@checked]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&B[/trans]"]
-                    [
-                        ./input[@type="radio"][@name="name"][@id="name_1"][not(@checked)]
-                    ]
+                ./input[@type="radio"][@name="name"][@id="name_1"][not(@checked)]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -663,29 +611,23 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&A[/trans]"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&B[/trans]"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&C[/trans]"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)]
+                /following-sibling::label
+                    [.="[trans]Choice&C[/trans]"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -708,18 +650,14 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][@value="&b"][not(@checked)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_1"][@value="&b"][not(@checked)]
+                /following-sibling::label
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -748,28 +686,22 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]label.&a[/trans]"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
+                    [.="[trans]label.&a[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][@value="&b"][not(@checked)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_1"][@value="&b"][not(@checked)]
+                /following-sibling::label
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]label.&c[/trans]"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@value="&c"][not(@checked)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@value="&c"][not(@checked)]
+                /following-sibling::label
+                    [.="[trans]label.&c[/trans]"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -794,18 +726,14 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@value="&a"][@checked]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@value="&a"][@checked]
+                /following-sibling::label
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][@value="&b"][not(@checked)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_1"][@value="&b"][not(@checked)]
+                /following-sibling::label
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -829,29 +757,23 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" Choice&A"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)]
+                /following-sibling::label
+                    [.="Choice&A"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" Choice&B"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)]
+                /following-sibling::label
+                    [.="Choice&B"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" Choice&C"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)]
+                /following-sibling::label
+                    [.="Choice&C"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -875,29 +797,23 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&A[/trans]"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&B[/trans]"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)][@class="foo&bar form-check-input"]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)][@class="foo&bar form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
             ]
         /following-sibling::div
             [@class="form-check"]
             [
-                ./label
-                    [.=" [trans]Choice&C[/trans]"]
-                    [
-                        ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)]
-                    ]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)]
+                /following-sibling::label
+                    [.="[trans]Choice&C[/trans]"]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
@@ -913,17 +829,15 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 '/div
     [@class="form-check"]
     [
-        ./label
+        ./input
+            [@id="my&id"]
+            [@type="radio"]
+            [@name="name"]
+            [@class="my&class form-check-input"]
+            [@checked="checked"]
+            [@value="1"]
+        /following-sibling::label
             [@class="form-check-label required"]
-            [
-                ./input
-                    [@id="my&id"]
-                    [@type="radio"]
-                    [@name="name"]
-                    [@class="my&class form-check-input"]
-                    [@checked="checked"]
-                    [@value="1"]
-            ]
     ]
 '
         );
@@ -937,16 +851,14 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 '/div
     [@class="form-check"]
     [
-        ./label
+        ./input
+            [@id="my&id"]
+            [@type="radio"]
+            [@name="name"]
+            [@class="my&class form-check-input"]
+            [not(@checked)]
+        /following-sibling::label
             [@class="form-check-label required"]
-            [
-                ./input
-                    [@id="my&id"]
-                    [@type="radio"]
-                    [@name="name"]
-                    [@class="my&class form-check-input"]
-                    [not(@checked)]
-            ]
     ]
 '
         );
@@ -962,16 +874,15 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 '/div
     [@class="form-check"]
     [
-        ./label
+        ./input
+            [@id="my&id"]
+            [@type="radio"]
+            [@name="name"]
+            [@class="my&class form-check-input"]
+            [@value="foo&bar"]
+        /following-sibling::label
             [@class="form-check-label required"]
-            [
-                ./input
-                    [@id="my&id"]
-                    [@type="radio"]
-                    [@name="name"]
-                    [@class="my&class form-check-input"]
-                    [@value="foo&bar"]
-            ]
+            [@for="my&id"]
     ]
 '
         );
@@ -996,6 +907,61 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         $this->assertWidgetMatchesXpath($form->createView(), array('attr' => array('class' => 'my&class form-control-file')),
 '/input
     [@type="file"]
+'
+        );
+    }
+
+    public function testMoney()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\MoneyType', 1234.56, array(
+            'currency' => 'EUR',
+        ));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+            '/div
+    [@class="input-group"]
+    [
+        ./div
+            [@class="input-group-prepend"]
+            [
+                ./span
+                    [@class="input-group-text"]
+                    [contains(.., "€")]
+            ]
+        /following-sibling::input
+            [@id="my&id"]
+            [@type="text"]
+            [@name="name"]
+            [@class="my&class form-control"]
+            [@value="1234.56"]
+    ]
+'
+        );
+    }
+
+    public function testPercent()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PercentType', 0.1);
+
+        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+            '/div
+    [@class="input-group"]
+    [
+        ./input
+            [@id="my&id"]
+            [@type="text"]
+            [@name="name"]
+            [@class="my&class form-control"]
+            [@value="10"]
+            /following-sibling::div
+                [@class="input-group-append"]
+                [
+                    ./span
+                    [@class="input-group-text"]
+                    [contains(.., "%")]
+                ]               
+                     
+    ]
 '
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25655 #25635 #24435
| License       | MIT
| Doc PR        | -

Follow up of https://github.com/symfony/symfony/pull/25715, see discussion there.

This fixes the following errors:
- Delete form-control-label, don't used in Bootstrap 4
- Replace col-form-legend by col-form-label
- Separate the label and input (before the input was in the label)
- Use form-check-inline to put radio and/or checkboxes inline
- Add support of custom form for radio and checkboxes
- Fix input-group: MoneyType (Issue #25655), PercentType
- Remove form-control duplication (Issue #25635)
- Fix Errors in label (#24435)