### PR TITLE
Retro-fit proxy code to make it deterministic for older proxy manager implementations

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -61,6 +61,14 @@ class ProxyDumperTest extends TestCase
         );
     }
 
+    public function testDeterministicProxyCode()
+    {
+        $definition = new Definition(__CLASS__);
+        $definition->setLazy(true);
+
+        $this->assertSame($this->dumper->getProxyCode($definition), $this->dumper->getProxyCode($definition));
+    }
+
     public function testGetProxyFactoryCode()
     {
         $definition = new Definition(__CLASS__);


### PR DESCRIPTION
Follow up on https://github.com/symfony/symfony/issues/25958#issuecomment-365543535

ProxyManager >= 7.2 already implements a deterministic identifier naming strategy which is critical for reproducible builds (https://github.com/symfony/symfony/issues/25958).  but versions below that don’t. This is what this PR fixes. Here is more context: https://github.com/Ocramius/ProxyManager/pull/411

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
