### PR TITLE
Update excluded_ajax_paths for sf4

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('toolbar')->defaultFalse()->end()
                 ->booleanNode('intercept_redirects')->defaultFalse()->end()
-                ->scalarNode('excluded_ajax_paths')->defaultValue('^/((?:index|app(_[\w]+)?)\.php/)?_wdt')->end()
+                ->scalarNode('excluded_ajax_paths')->defaultValue('^/((index|app(_[\w]+)?).php/)?_wdt')->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('toolbar')->defaultFalse()->end()
                 ->booleanNode('intercept_redirects')->defaultFalse()->end()
-                ->scalarNode('excluded_ajax_paths')->defaultValue('^/((index|app(_[\w]+)?).php/)?_wdt')->end()
+                ->scalarNode('excluded_ajax_paths')->defaultValue('^/((index|app(_[\w]+)?)\.php/)?_wdt')->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('toolbar')->defaultFalse()->end()
                 ->booleanNode('intercept_redirects')->defaultFalse()->end()
-                ->scalarNode('excluded_ajax_paths')->defaultValue('index.php?_wdt')->end()
+                ->scalarNode('excluded_ajax_paths')->defaultValue('^/((?:index|app(_[\w]+)?)\.php/)?_wdt')->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('toolbar')->defaultFalse()->end()
                 ->booleanNode('intercept_redirects')->defaultFalse()->end()
-                ->scalarNode('excluded_ajax_paths')->defaultValue('^/(app(_[\\w]+)?\\.php/)?_wdt')->end()
+                ->scalarNode('excluded_ajax_paths')->defaultValue('index.php?_wdt')->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -32,10 +32,10 @@ class ConfigurationTest extends TestCase
     public function getDebugModes()
     {
         return array(
-            array(array(), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?).php/)?_wdt')),
-            array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?).php/)?_wdt')),
-            array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?).php/)?_wdt')),
-            array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?).php/)?_wdt')),
+            array(array(), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt')),
+            array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt')),
+            array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt')),
+            array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?)\.php/)?_wdt')),
             array(array('excluded_ajax_paths' => 'test'), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => 'test')),
         );
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -32,10 +32,10 @@ class ConfigurationTest extends TestCase
     public function getDebugModes()
     {
         return array(
-            array(array(), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
+            array(array(), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((?:index|app(_[\w]+)?)\.php/)?_wdt')),
+            array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'excluded_ajax_paths' => '^/((?:index|app(_[\w]+)?)\.php/)?_wdt')),
+            array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((?:index|app(_[\w]+)?)\.php/)?_wdt')),
+            array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'excluded_ajax_paths' => '^/((?:index|app(_[\w]+)?)\.php/)?_wdt')),
             array(array('excluded_ajax_paths' => 'test'), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => 'test')),
         );
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -32,10 +32,10 @@ class ConfigurationTest extends TestCase
     public function getDebugModes()
     {
         return array(
-            array(array(), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((?:index|app(_[\w]+)?)\.php/)?_wdt')),
-            array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'excluded_ajax_paths' => '^/((?:index|app(_[\w]+)?)\.php/)?_wdt')),
-            array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((?:index|app(_[\w]+)?)\.php/)?_wdt')),
-            array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'excluded_ajax_paths' => '^/((?:index|app(_[\w]+)?)\.php/)?_wdt')),
+            array(array(), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?).php/)?_wdt')),
+            array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?).php/)?_wdt')),
+            array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?).php/)?_wdt')),
+            array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'excluded_ajax_paths' => '^/((index|app(_[\w]+)?).php/)?_wdt')),
             array(array('excluded_ajax_paths' => 'test'), array('intercept_redirects' => false, 'toolbar' => false, 'excluded_ajax_paths' => 'test')),
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25941 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/9267/files

This PR update `excluded_ajax_paths` from `vendor/symfony/web-profiler-bundle/DependencyInjection/Configuration.php` because
there is no  neither `app.php` nor `app_dev.php` in symfony 4
We also need update this [Documentation](https://symfony.com/doc/current/reference/configuration/web_profiler.html)
