### PR TITLE
Fix undiscoverablility of SymfonyTestsListenerForV7

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerForV7.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bridge\PhpUnit;
+namespace Symfony\Bridge\PhpUnit\Legacy;
 
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `3.4@dev` (and `4@dev`)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

As class is in wrong namespace, it's not discoverable by autoloader and during execution of aliasing we face following crash:
```
ker@dus:~/github/PHP-CS-Fixer λ vendor/bin/phpunit 
Class 'Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerForV7' not found
```


