### PR TITLE
Xml file loader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -347,7 +347,8 @@ class XmlFileLoader extends FileLoader
                 $domElement->parentNode->replaceChild($tmpDomElement, $domElement);
                 $tmpDomElement->setAttribute('id', $id);
             } else {
-                $domElement->parentNode->removeChild($domElement);
+                if (null !== $domElement->parentNode)
+                    $domElement->parentNode->removeChild($domElement);
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -347,8 +347,9 @@ class XmlFileLoader extends FileLoader
                 $domElement->parentNode->replaceChild($tmpDomElement, $domElement);
                 $tmpDomElement->setAttribute('id', $id);
             } else {
-                if (null !== $domElement->parentNode)
+                if (null !== $domElement->parentNode) {
                     $domElement->parentNode->removeChild($domElement);
+                }
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I'm using Symfony 2.8 and PHP Fatal error occurs very rarely when I do assetic:dump / cache:warmup as below.(also on Symfony 2.7)

`
PHP Fatal error:  Call to a member function removeChild() on null in .../symfony/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php on line 350 
`

It does occur very rarely. Also, after several retries, it works fine. 

The xml file which triggers error is as below(both version) and I didn't modify anything. 

https://github.com/symfony/swiftmailer-bundle/blob/v2.3.8/Resources/config/swiftmailer.xml
https://github.com/symfony/swiftmailer-bundle/blob/v2.6.7/Resources/config/swiftmailer.xml

Once more, error occurs so randomly. So, I can't be sure in what situation it occurs. But this modification does fix the problem and no side effect.