### PR TITLE
[HttpFoundation] Add x-zip-compressed to MimeTypeExtensionGuesser.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeExtensionGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeExtensionGuesser.php
@@ -599,6 +599,7 @@ class MimeTypeExtensionGuesser implements ExtensionGuesserInterface
         'application/x-xliff+xml' => 'xlf',
         'application/x-xpinstall' => 'xpi',
         'application/x-xz' => 'xz',
+        'application/x-zip-compressed' => 'zip',
         'application/x-zmachine' => 'z1',
         'application/xaml+xml' => 'xaml',
         'application/xcap-diff+xml' => 'xdf',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | yes (kinda)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Zip files uploaded on Windows often have a mime type of `x-zip-compressed`. This patch adds support for this mime type to `MimeTypeExtensionGuesser`.

The mime type seems to be a valid mime type for zip files according to http://filext.com/file-extension/ZIP
