### PR TITLE
Fix false-positive deprecation notices for TranslationLoader and WriteCheckSessionHandler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -14,13 +14,16 @@ namespace Symfony\Bundle\FrameworkBundle\Translation;
 use Symfony\Component\Translation\Reader\TranslationReader;
 use Symfony\Component\Translation\MessageCatalogue;
 
-@trigger_error(sprintf('The class "%s" is deprecated since Symfony 3.4 and will be removed in 4.0. Use "%s" instead. ', TranslationLoader::class, TranslationReader::class), E_USER_DEPRECATED);
-
 /**
  * @deprecated since version 3.4 and will be removed in 4.0. Use Symfony\Component\Translation\Reader\TranslationReader instead
  */
 class TranslationLoader extends TranslationReader
 {
+    public function __construct()
+    {
+        @trigger_error(sprintf('The class "%s" is deprecated since Symfony 3.4 and will be removed in 4.0. Use "%s" instead. ', self::class, TranslationReader::class), E_USER_DEPRECATED);
+    }
+
     /**
      * Loads translation messages from a directory to the catalogue.
      *

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/WriteCheckSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/WriteCheckSessionHandler.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
-@trigger_error(sprintf('The %s class is deprecated since Symfony 3.4 and will be removed in 4.0. Implement `SessionUpdateTimestampHandlerInterface` or extend `AbstractSessionHandler` instead.', WriteCheckSessionHandler::class), E_USER_DEPRECATED);
-
 /**
  * Wraps another SessionHandlerInterface to only write the session when it has been modified.
  *
@@ -31,6 +29,8 @@ class WriteCheckSessionHandler implements \SessionHandlerInterface
 
     public function __construct(\SessionHandlerInterface $wrappedSessionHandler)
     {
+        @trigger_error(sprintf('The %s class is deprecated since Symfony 3.4 and will be removed in 4.0. Implement `SessionUpdateTimestampHandlerInterface` or extend `AbstractSessionHandler` instead.', self::class), E_USER_DEPRECATED);
+
         $this->wrappedSessionHandler = $wrappedSessionHandler;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25518 
| License       | MIT

Symfony 3.4 emits deprecation warnings for  `TranslationLoader` and `WriteCheckSessionHandler` as soon as these classes are loaded, yet at the same time these classes are part of the default services defined in Symfony 3.4, so if these classes are loaded during container compilation a deprecation warning is emitted, even if these classes are never actually used.

An example would be the following within a compiler pass:

    foreach ($containerBuilder->getDefinitions() as $definition) {
      if (is_subclass_of($definition->getClass(), SomeClass::class)) {
        $definition->addMethodCall('setSomething', [new Reference('someservice')]);
      }
    }

This will load both `TranslationLoader` and `WriteCheckSessionHandler` in order to check their definition.  No instance of the classes are ever used and the classes are not loaded after compilation ever, yet the deprecation notices are shown on every single page. More details are provided in issue #25518 .

By moving the deprecation notices to the class constructors false-positives are avoided while actual usage of the classes should still generate the deprecation warnings.