### PR TITLE
[Console] add ClassName on help output

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -158,7 +158,8 @@ class JsonDescriptor extends Descriptor
 
         return array(
             'name' => $command->getName(),
-            'usage' => array_merge(array($command->getSynopsis()), $command->getUsages(), $command->getAliases()),
+            'usage' => \array_merge(array($command->getSynopsis()), $command->getUsages(), $command->getAliases()),
+            'classname' => \get_class($command),
             'description' => $command->getDescription(),
             'help' => $command->getProcessedHelp(),
             'definition' => $this->getInputDefinitionData($command->getNativeDefinition()),

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -132,6 +132,10 @@ class MarkdownDescriptor extends Descriptor
             $this->write($help);
         }
 
+        $this->write("\n\n");
+        $this->write('### ClassName'."\n\n"
+            .\get_class($command));
+
         if ($command->getNativeDefinition()) {
             $this->write("\n\n");
             $this->describeInputDefinition($command->getNativeDefinition());

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -147,6 +147,12 @@ class TextDescriptor extends Descriptor
         }
         $this->writeText("\n");
 
+        $this->writeText("\n");
+        $this->writeText('<comment>ClassName:</comment>', $options);
+        $this->writeText("\n");
+        $this->writeText('  '.\get_class($command), $options);
+        $this->writeText("\n");
+
         $definition = $command->getNativeDefinition();
         if ($definition->getOptions() || $definition->getArguments()) {
             $this->writeText("\n");

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -68,6 +68,9 @@ class XmlDescriptor extends Descriptor
             $usagesXML->appendChild($dom->createElement('usage', $usage));
         }
 
+        $commandXML->appendChild($classNameXML = $dom->createElement('classname'));
+        $classNameXML->appendChild($dom->createTextNode(str_replace("\n", "\n ", \get_class($command))));
+
         $commandXML->appendChild($descriptionXML = $dom->createElement('description'));
         $descriptionXML->appendChild($dom->createTextNode(str_replace("\n", "\n ", $command->getDescription())));
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -6,6 +6,7 @@
             "usage": [
                 "help [--format FORMAT] [--raw] [--] [<command_name>]"
             ],
+            "classname": "Symfony\\Component\\Console\\Command\\HelpCommand",
             "description": "Displays help for a command",
             "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>php app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
             "definition": {
@@ -109,6 +110,7 @@
             "usage": [
                 "list [--raw] [--format FORMAT] [--] [<namespace>]"
             ],
+            "classname": "Symfony\\Component\\Console\\Command\\ListCommand",
             "description": "Lists commands",
             "help": "The <info>list<\/info> command lists all commands:\n\n  <info>php app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>php app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>php app\/console list --raw<\/info>",
             "definition": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
@@ -23,6 +23,10 @@ You can also output the help in other formats by using the --format option:
 
 To display the list of available commands, please use the list command.
 
+### ClassName
+
+Symfony\Component\Console\Command\HelpCommand
+
 ### Arguments
 
 #### `command_name`
@@ -140,6 +144,10 @@ You can also output the information in other formats by using the --format optio
 It's also possible to get raw list of commands (useful for embedding command runner):
 
   php app/console list --raw
+
+### ClassName
+
+Symfony\Component\Console\Command\ListCommand
 
 ### Arguments
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -5,6 +5,7 @@
       <usages>
         <usage>help [--format FORMAT] [--raw] [--] [&lt;command_name&gt;]</usage>
       </usages>
+      <classname>Symfony\Component\Console\Command\HelpCommand</classname>
       <description>Displays help for a command</description>
       <help>The &lt;info&gt;help&lt;/info&gt; command displays help for a given command:
  
@@ -60,6 +61,7 @@
       <usages>
         <usage>list [--raw] [--format FORMAT] [--] [&lt;namespace&gt;]</usage>
       </usages>
+      <classname>Symfony\Component\Console\Command\ListCommand</classname>
       <description>Lists commands</description>
       <help>The &lt;info&gt;list&lt;/info&gt; command lists all commands:
  

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -10,6 +10,7 @@
             "usage": [
                 "help [--format FORMAT] [--raw] [--] [<command_name>]"
             ],
+            "classname": "Symfony\\Component\\Console\\Command\\HelpCommand",
             "description": "Displays help for a command",
             "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>php app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
             "definition": {
@@ -114,6 +115,7 @@
                 "list [--raw] [--format FORMAT] [--] [<namespace>]"
             ],
             "description": "Lists commands",
+            "classname": "Symfony\\Component\\Console\\Command\\ListCommand",
             "help": "The <info>list<\/info> command lists all commands:\n\n  <info>php app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>php app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>php app\/console list --raw<\/info>",
             "definition": {
                 "arguments": {
@@ -155,6 +157,7 @@
                 "alias1",
                 "alias2"
             ],
+            "classname": "Symfony\\Component\\Console\\Tests\\Fixtures\\DescriptorCommand1",
             "description": "command 1 description",
             "help": "command 1 help",
             "definition": {
@@ -234,6 +237,7 @@
                 "descriptor:command2 -o|--option_name <argument_name>",
                 "descriptor:command2 <argument_name>"
             ],
+            "classname": "Symfony\\Component\\Console\\Tests\\Fixtures\\DescriptorCommand2",
             "description": "command 2 description",
             "help": "command 2 help",
             "definition": {
@@ -328,6 +332,7 @@
             "usage": [
                 "descriptor:command3"
             ],
+            "classname": "Symfony\\Component\\Console\\Tests\\Fixtures\\DescriptorCommand3",
             "description": "command 3 description",
             "help": "command 3 help",
             "definition": {
@@ -407,6 +412,7 @@
                 "descriptor:alias_command4",
                 "command4:descriptor"
             ],
+            "classname": "Symfony\\Component\\Console\\Tests\\Fixtures\\DescriptorCommand4",
             "description": null,
             "help": "",
             "definition": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -36,6 +36,10 @@ You can also output the help in other formats by using the --format option:
 
 To display the list of available commands, please use the list command.
 
+### ClassName
+
+Symfony\Component\Console\Command\HelpCommand
+
 ### Arguments
 
 #### `command_name`
@@ -154,6 +158,10 @@ It's also possible to get raw list of commands (useful for embedding command run
 
   php app/console list --raw
 
+### ClassName
+
+Symfony\Component\Console\Command\ListCommand
+
 ### Arguments
 
 #### `namespace`
@@ -196,6 +204,10 @@ command 1 description
 * `alias2`
 
 command 1 help
+
+### ClassName
+
+Symfony\Component\Console\Tests\Fixtures\DescriptorCommand1
 
 ### Options
 
@@ -274,6 +286,10 @@ command 2 description
 * `descriptor:command2 <argument_name>`
 
 command 2 help
+
+### ClassName
+
+Symfony\Component\Console\Tests\Fixtures\DescriptorCommand2
 
 ### Arguments
 
@@ -364,6 +380,10 @@ Do not ask any interactive question
 * `descriptor:alias_command4`
 * `command4:descriptor`
 
+
+### ClassName
+
+Symfony\Component\Console\Tests\Fixtures\DescriptorCommand4
 
 ### Options
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -5,6 +5,7 @@
       <usages>
         <usage>help [--format FORMAT] [--raw] [--] [&lt;command_name&gt;]</usage>
       </usages>
+      <classname>Symfony\Component\Console\Command\HelpCommand</classname>
       <description>Displays help for a command</description>
       <help>The &lt;info&gt;help&lt;/info&gt; command displays help for a given command:
  
@@ -60,6 +61,7 @@
       <usages>
         <usage>list [--raw] [--format FORMAT] [--] [&lt;namespace&gt;]</usage>
       </usages>
+      <classname>Symfony\Component\Console\Command\ListCommand</classname>
       <description>Lists commands</description>
       <help>The &lt;info&gt;list&lt;/info&gt; command lists all commands:
  
@@ -100,6 +102,7 @@
         <usage>alias1</usage>
         <usage>alias2</usage>
       </usages>
+      <classname>Symfony\Component\Console\Tests\Fixtures\DescriptorCommand1</classname>
       <description>command 1 description</description>
       <help>command 1 help</help>
       <arguments/>
@@ -133,6 +136,7 @@
         <usage>descriptor:command2 -o|--option_name &lt;argument_name&gt;</usage>
         <usage>descriptor:command2 &lt;argument_name&gt;</usage>
       </usages>
+      <classname>Symfony\Component\Console\Tests\Fixtures\DescriptorCommand2</classname>
       <description>command 2 description</description>
       <help>command 2 help</help>
       <arguments>
@@ -172,6 +176,7 @@
       <usages>
         <usage>descriptor:command3</usage>
       </usages>
+      <classname>Symfony\Component\Console\Tests\Fixtures\DescriptorCommand3</classname>
       <description>command 3 description</description>
       <help>command 3 help</help>
       <arguments/>
@@ -205,6 +210,7 @@
         <usage>descriptor:alias_command4</usage>
         <usage>command4:descriptor</usage>
       </usages>
+      <classname>Symfony\Component\Console\Tests\Fixtures\DescriptorCommand4</classname>
       <description></description>
       <help></help>
       <arguments/>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
@@ -27,6 +27,10 @@ You can also output the help in other formats by using the --format option:
 
 To display the list of available commands, please use the list command.
 
+### ClassName
+
+Symfony\Component\Console\Command\HelpCommand
+
 ### Arguments
 
 #### `command_name`
@@ -145,6 +149,10 @@ It's also possible to get raw list of commands (useful for embedding command run
 
   php app/console list --raw
 
+### ClassName
+
+Symfony\Component\Console\Command\ListCommand
+
 ### Arguments
 
 #### `namespace`
@@ -187,6 +195,10 @@ command åèä description
 * `descriptor:åèä <argument_name>`
 
 command åèä help
+
+### ClassName
+
+Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString
 
 ### Arguments
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -1,6 +1,9 @@
 Usage:
   list [options] [--] [<namespace>]
 
+ClassName:
+  Symfony\Component\Console\Command\ListCommand
+
 Arguments:
   namespace            The namespace name
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -1,6 +1,9 @@
 Usage:
   list [options] [--] [<namespace>]
 
+ClassName:
+  Symfony\Component\Console\Command\ListCommand
+
 Arguments:
   namespace            The namespace name
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.json
@@ -6,6 +6,7 @@
         "alias1",
         "alias2"
     ],
+    "classname": "Symfony\\Component\\Console\\Tests\\Fixtures\\DescriptorCommand1",
     "description": "command 1 description",
     "help": "command 1 help",
     "definition": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.md
@@ -10,3 +10,7 @@ command 1 description
 * `alias2`
 
 command 1 help
+
+### ClassName
+
+Symfony\Component\Console\Tests\Fixtures\DescriptorCommand1

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.txt
@@ -3,5 +3,8 @@
   alias1
   alias2
 
+<comment>ClassName:</comment>
+  Symfony\Component\Console\Tests\Fixtures\DescriptorCommand1
+
 <comment>Help:</comment>
   command 1 help

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.xml
@@ -5,6 +5,7 @@
     <usage>alias1</usage>
     <usage>alias2</usage>
   </usages>
+  <classname>Symfony\Component\Console\Tests\Fixtures\DescriptorCommand1</classname>
   <description>command 1 description</description>
   <help>command 1 help</help>
   <arguments/>

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.json
@@ -6,6 +6,7 @@
         "descriptor:command2 -o|--option_name <argument_name>",
         "descriptor:command2 <argument_name>"
     ],
+    "classname": "Symfony\\Component\\Console\\Tests\\Fixtures\\DescriptorCommand2",
     "description": "command 2 description",
     "help": "command 2 help",
     "definition": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.md
@@ -11,6 +11,10 @@ command 2 description
 
 command 2 help
 
+### ClassName
+
+Symfony\Component\Console\Tests\Fixtures\DescriptorCommand2
+
 ### Arguments
 
 #### `argument_name`

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
@@ -3,6 +3,9 @@
   descriptor:command2 -o|--option_name \<argument_name>
   descriptor:command2 \<argument_name>
 
+<comment>ClassName:</comment>
+  Symfony\Component\Console\Tests\Fixtures\DescriptorCommand2
+
 <comment>Arguments:</comment>
   <info>argument_name</info>      
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.xml
@@ -5,6 +5,7 @@
     <usage>descriptor:command2 -o|--option_name &lt;argument_name&gt;</usage>
     <usage>descriptor:command2 &lt;argument_name&gt;</usage>
   </usages>
+  <classname>Symfony\Component\Console\Tests\Fixtures\DescriptorCommand2</classname>
   <description>command 2 description</description>
   <help>command 2 help</help>
   <arguments>

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.md
@@ -11,6 +11,10 @@ command åèä description
 
 command åèä help
 
+### ClassName
+
+Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString
+
 ### Arguments
 
 #### `argument_åèä`

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
@@ -3,6 +3,9 @@
   descriptor:åèä -o|--option_name \<argument_name>
   descriptor:åèä \<argument_name>
 
+<comment>ClassName:</comment>
+  Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString
+
 <comment>Arguments:</comment>
   <info>argument_åèä</info>   
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes
| Fixed tickets | #26034 
| License       | MIT
| Doc PR        | todo if pr validated

I'm adding the class name output to the help command in order to be able to know what class it is, and can be helpful to debug or to add feature.
