### PR TITLE
[HttpFoundation] Allow query params to be formated with a preservered order

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -616,14 +616,15 @@ class Request
     /**
      * Normalizes a query string.
      *
-     * It builds a normalized query string, where keys/value pairs are alphabetized,
+     * It builds a normalized query string, where keys/value pairs are alphabetized (by default),
      * have consistent escaping and unneeded delimiters are removed.
      *
-     * @param string $qs Query string
+     * @param string $qs            Query string
+     * @param bool   $preserveOrder Flag to preserve the querystring from being alphabetically ordered
      *
      * @return string A normalized query string for the Request
      */
-    public static function normalizeQueryString($qs)
+    public static function normalizeQueryString($qs, bool $preserveOrder = false)
     {
         if ('' == $qs) {
             return '';
@@ -651,7 +652,9 @@ class Request
             $order[] = urldecode($keyValuePair[0]);
         }
 
-        array_multisort($order, SORT_ASC, $parts);
+        if (true !== $preserveOrder) {
+            array_multisort($order, SORT_ASC, $parts);
+        }
 
         return implode('&', $parts);
     }
@@ -1103,13 +1106,15 @@ class Request
      * Generates the normalized query string for the Request.
      *
      * It builds a normalized query string, where keys/value pairs are alphabetized
-     * and have consistent escaping.
+     * (by default) and have consistent escaping.
+     *
+     * @param bool $preserveOrder Flag to preserve the querystring from being alphabetically ordered
      *
      * @return string|null A normalized query string for the Request
      */
-    public function getQueryString()
+    public function getQueryString(bool $preserveOrder = false)
     {
-        $qs = static::normalizeQueryString($this->server->get('QUERY_STRING'));
+        $qs = static::normalizeQueryString($this->server->get('QUERY_STRING'), $preserveOrder);
 
         return '' === $qs ? null : $qs;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR aimed to allow using the queryString normalization without reordering the parameters name.
It can be specifically usefull in the context of building API and parsing urls like `/foo?order[baz]=asc&order[bar]=asc`. In this case, in order to apply an order condition on a query where preserving the order of the parameter matters like `ORDER BY baz ASC, bar ASC` for example , it would be nice to have this possibility.
