### PR TITLE
[Routing] Fix same-prefix aggregation

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -98,23 +98,25 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         .')'
                     .')'
                     .'|/multi/hello(?:/([^/]++))?(*:238)'
-                    .'|/([^/]++)/b/([^/]++)(*:266)'
-                    .'|/([^/]++)/b/([^/]++)(*:294)'
-                    .'|/aba/([^/]++)(*:315)'
+                    .'|/([^/]++)/b/([^/]++)(?'
+                        .'|(*:269)'
+                        .'|(*:277)'
+                    .')'
+                    .'|/aba/([^/]++)(*:299)'
                 .')|(?i:([^\\.]++)\\.example\\.com)(?'
                     .'|/route1(?'
-                        .'|3/([^/]++)(*:375)'
-                        .'|4/([^/]++)(*:393)'
+                        .'|3/([^/]++)(*:359)'
+                        .'|4/([^/]++)(*:377)'
                     .')'
                 .')|(?i:c\\.example\\.com)(?'
-                    .'|/route15/([^/]++)(*:443)'
+                    .'|/route15/([^/]++)(*:427)'
                 .')|[^/]*+(?'
-                    .'|/route16/([^/]++)(*:478)'
+                    .'|/route16/([^/]++)(*:462)'
                     .'|/a(?'
-                        .'|/a\\.\\.\\.(*:499)'
+                        .'|/a\\.\\.\\.(*:483)'
                         .'|/b(?'
-                            .'|/([^/]++)(*:521)'
-                            .'|/c/([^/]++)(*:540)'
+                            .'|/([^/]++)(*:505)'
+                            .'|/c/([^/]++)(*:524)'
                         .')'
                     .')'
                 .')'
@@ -172,7 +174,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array());
 
                         break;
-                    case 266:
+                    case 269:
                         $matches = array('_locale' => $matches[1] ?? null, 'foo' => $matches[2] ?? null);
 
                         // foo3
@@ -189,15 +191,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                             170 => array(array('_route' => 'overridden'), array('var'), null, null),
                             202 => array(array('_route' => 'bar2'), array('bar1'), null, null),
                             238 => array(array('_route' => 'helloWorld', 'who' => 'World!'), array('who'), null, null),
-                            294 => array(array('_route' => 'bar3'), array('_locale', 'bar'), null, null),
-                            315 => array(array('_route' => 'foo4'), array('foo'), null, null),
-                            375 => array(array('_route' => 'route13'), array('var1', 'name'), null, null),
-                            393 => array(array('_route' => 'route14', 'var1' => 'val'), array('var1', 'name'), null, null),
-                            443 => array(array('_route' => 'route15'), array('name'), null, null),
-                            478 => array(array('_route' => 'route16', 'var1' => 'val'), array('name'), null, null),
-                            499 => array(array('_route' => 'a'), array(), null, null),
-                            521 => array(array('_route' => 'b'), array('var'), null, null),
-                            540 => array(array('_route' => 'c'), array('var'), null, null),
+                            277 => array(array('_route' => 'bar3'), array('_locale', 'bar'), null, null),
+                            299 => array(array('_route' => 'foo4'), array('foo'), null, null),
+                            359 => array(array('_route' => 'route13'), array('var1', 'name'), null, null),
+                            377 => array(array('_route' => 'route14', 'var1' => 'val'), array('var1', 'name'), null, null),
+                            427 => array(array('_route' => 'route15'), array('name'), null, null),
+                            462 => array(array('_route' => 'route16', 'var1' => 'val'), array('name'), null, null),
+                            483 => array(array('_route' => 'a'), array(), null, null),
+                            505 => array(array('_route' => 'b'), array('var'), null, null),
+                            524 => array(array('_route' => 'c'), array('var'), null, null),
                         );
 
                         list($ret, $vars, $requiredMethods, $requiredSchemes) = $routes[$m];
@@ -216,7 +218,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         return $ret;
                 }
 
-                if (540 === $m) {
+                if (524 === $m) {
                     break;
                 }
                 $regex = substr_replace($regex, 'F', $m - $offset, 1 + strlen($m));

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher11.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher11.php
@@ -1,0 +1,127 @@
+<?php
+
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * This class has been auto-generated
+ * by the Symfony Routing Component.
+ */
+class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\RedirectableUrlMatcher
+{
+    public function __construct(RequestContext $context)
+    {
+        $this->context = $context;
+    }
+
+    public function match($rawPathinfo)
+    {
+        $allow = array();
+        $pathinfo = rawurldecode($rawPathinfo);
+        $trimmedPathinfo = rtrim($pathinfo, '/');
+        $context = $this->context;
+        $requestMethod = $canonicalMethod = $context->getMethod();
+
+        if ('HEAD' === $requestMethod) {
+            $canonicalMethod = 'GET';
+        }
+
+        $matchedPathinfo = $pathinfo;
+        $regexList = array(
+            0 => '{^(?'
+                    .'|/(en|fr)(?'
+                        .'|/admin/post(?'
+                            .'|/?(*:34)'
+                            .'|/new(*:45)'
+                            .'|/(\\d+)(?'
+                                .'|(*:61)'
+                                .'|/edit(*:73)'
+                                .'|/delete(*:87)'
+                            .')'
+                        .')'
+                        .'|/blog(?'
+                            .'|/?(*:106)'
+                            .'|/rss\\.xml(*:123)'
+                            .'|/p(?'
+                                .'|age/([^/]++)(*:148)'
+                                .'|osts/([^/]++)(*:169)'
+                            .')'
+                            .'|/comments/(\\d+)/new(*:197)'
+                            .'|/search(*:212)'
+                        .')'
+                        .'|/log(?'
+                            .'|in(*:230)'
+                            .'|out(*:241)'
+                        .')'
+                    .')'
+                    .'|/(en|fr)?(*:260)'
+                .')$}sD',
+        );
+
+        foreach ($regexList as $offset => $regex) {
+            while (preg_match($regex, $matchedPathinfo, $matches)) {
+                switch ($m = (int) $matches['MARK']) {
+                    default:
+                        $routes = array(
+                            34 => array(array('_route' => 'a', '_locale' => 'en'), array('_locale'), null, null, true),
+                            45 => array(array('_route' => 'b', '_locale' => 'en'), array('_locale'), null, null),
+                            61 => array(array('_route' => 'c', '_locale' => 'en'), array('_locale', 'id'), null, null),
+                            73 => array(array('_route' => 'd', '_locale' => 'en'), array('_locale', 'id'), null, null),
+                            87 => array(array('_route' => 'e', '_locale' => 'en'), array('_locale', 'id'), null, null),
+                            106 => array(array('_route' => 'f', '_locale' => 'en'), array('_locale'), null, null, true),
+                            123 => array(array('_route' => 'g', '_locale' => 'en'), array('_locale'), null, null),
+                            148 => array(array('_route' => 'h', '_locale' => 'en'), array('_locale', 'page'), null, null),
+                            169 => array(array('_route' => 'i', '_locale' => 'en'), array('_locale', 'page'), null, null),
+                            197 => array(array('_route' => 'j', '_locale' => 'en'), array('_locale', 'id'), null, null),
+                            212 => array(array('_route' => 'k', '_locale' => 'en'), array('_locale'), null, null),
+                            230 => array(array('_route' => 'l', '_locale' => 'en'), array('_locale'), null, null),
+                            241 => array(array('_route' => 'm', '_locale' => 'en'), array('_locale'), null, null),
+                            260 => array(array('_route' => 'n', '_locale' => 'en'), array('_locale'), null, null),
+                        );
+
+                        list($ret, $vars, $requiredMethods, $requiredSchemes) = $routes[$m];
+
+                        foreach ($vars as $i => $v) {
+                            if (isset($matches[1 + $i])) {
+                                $ret[$v] = $matches[1 + $i];
+                            }
+                        }
+
+                        if (empty($routes[$m][4]) || '/' === $pathinfo[-1]) {
+                            // no-op
+                        } elseif ('GET' !== $canonicalMethod) {
+                            $allow['GET'] = 'GET';
+                            break;
+                        } else {
+                            return array_replace($ret, $this->redirect($rawPathinfo.'/', $ret['_route']));
+                        }
+
+                        if ($requiredSchemes && !isset($requiredSchemes[$context->getScheme()])) {
+                            if ('GET' !== $canonicalMethod) {
+                                $allow['GET'] = 'GET';
+                                break;
+                            }
+
+                            return array_replace($ret, $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)));
+                        }
+
+                        if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
+                            $allow += $requiredMethods;
+                            break;
+                        }
+
+                        return $ret;
+                }
+
+                if (260 === $m) {
+                    break;
+                }
+                $regex = substr_replace($regex, 'F', $m - $offset, 1 + strlen($m));
+                $offset += strlen($m);
+            }
+        }
+
+        throw $allow ? new MethodNotAllowedException(array_keys($allow)) : new ResourceNotFoundException();
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -118,23 +118,25 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                         .')'
                     .')'
                     .'|/multi/hello(?:/([^/]++))?(*:239)'
-                    .'|/([^/]++)/b/([^/]++)(*:267)'
-                    .'|/([^/]++)/b/([^/]++)(*:295)'
-                    .'|/aba/([^/]++)(*:316)'
+                    .'|/([^/]++)/b/([^/]++)(?'
+                        .'|(*:270)'
+                        .'|(*:278)'
+                    .')'
+                    .'|/aba/([^/]++)(*:300)'
                 .')|(?i:([^\\.]++)\\.example\\.com)(?'
                     .'|/route1(?'
-                        .'|3/([^/]++)(*:376)'
-                        .'|4/([^/]++)(*:394)'
+                        .'|3/([^/]++)(*:360)'
+                        .'|4/([^/]++)(*:378)'
                     .')'
                 .')|(?i:c\\.example\\.com)(?'
-                    .'|/route15/([^/]++)(*:444)'
+                    .'|/route15/([^/]++)(*:428)'
                 .')|[^/]*+(?'
-                    .'|/route16/([^/]++)(*:479)'
+                    .'|/route16/([^/]++)(*:463)'
                     .'|/a(?'
-                        .'|/a\\.\\.\\.(*:500)'
+                        .'|/a\\.\\.\\.(*:484)'
                         .'|/b(?'
-                            .'|/([^/]++)(*:522)'
-                            .'|/c/([^/]++)(*:541)'
+                            .'|/([^/]++)(*:506)'
+                            .'|/c/([^/]++)(*:525)'
                         .')'
                     .')'
                 .')'
@@ -207,7 +209,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                         return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array());
 
                         break;
-                    case 267:
+                    case 270:
                         $matches = array('_locale' => $matches[1] ?? null, 'foo' => $matches[2] ?? null);
 
                         // foo3
@@ -224,15 +226,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                             171 => array(array('_route' => 'overridden'), array('var'), null, null),
                             203 => array(array('_route' => 'bar2'), array('bar1'), null, null),
                             239 => array(array('_route' => 'helloWorld', 'who' => 'World!'), array('who'), null, null),
-                            295 => array(array('_route' => 'bar3'), array('_locale', 'bar'), null, null),
-                            316 => array(array('_route' => 'foo4'), array('foo'), null, null),
-                            376 => array(array('_route' => 'route13'), array('var1', 'name'), null, null),
-                            394 => array(array('_route' => 'route14', 'var1' => 'val'), array('var1', 'name'), null, null),
-                            444 => array(array('_route' => 'route15'), array('name'), null, null),
-                            479 => array(array('_route' => 'route16', 'var1' => 'val'), array('name'), null, null),
-                            500 => array(array('_route' => 'a'), array(), null, null),
-                            522 => array(array('_route' => 'b'), array('var'), null, null),
-                            541 => array(array('_route' => 'c'), array('var'), null, null),
+                            278 => array(array('_route' => 'bar3'), array('_locale', 'bar'), null, null),
+                            300 => array(array('_route' => 'foo4'), array('foo'), null, null),
+                            360 => array(array('_route' => 'route13'), array('var1', 'name'), null, null),
+                            378 => array(array('_route' => 'route14', 'var1' => 'val'), array('var1', 'name'), null, null),
+                            428 => array(array('_route' => 'route15'), array('name'), null, null),
+                            463 => array(array('_route' => 'route16', 'var1' => 'val'), array('name'), null, null),
+                            484 => array(array('_route' => 'a'), array(), null, null),
+                            506 => array(array('_route' => 'b'), array('var'), null, null),
+                            525 => array(array('_route' => 'c'), array('var'), null, null),
                         );
 
                         list($ret, $vars, $requiredMethods, $requiredSchemes) = $routes[$m];
@@ -260,7 +262,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                         return $ret;
                 }
 
-                if (541 === $m) {
+                if (525 === $m) {
                     break;
                 }
                 $regex = substr_replace($regex, 'F', $m - $offset, 1 + strlen($m));

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -438,6 +438,26 @@ class PhpMatcherDumperTest extends TestCase
             $chunkedCollection->add('_'.$i, new Route('/'.$h.'/{a}/{b}/{c}/'.$h));
         }
 
+        /* test case 11 */
+        $demoCollection = new RouteCollection();
+        $demoCollection->add('a', new Route('/admin/post/'));
+        $demoCollection->add('b', new Route('/admin/post/new'));
+        $demoCollection->add('c', (new Route('/admin/post/{id}'))->setRequirements(array('id' => '\d+')));
+        $demoCollection->add('d', (new Route('/admin/post/{id}/edit'))->setRequirements(array('id' => '\d+')));
+        $demoCollection->add('e', (new Route('/admin/post/{id}/delete'))->setRequirements(array('id' => '\d+')));
+        $demoCollection->add('f', new Route('/blog/'));
+        $demoCollection->add('g', new Route('/blog/rss.xml'));
+        $demoCollection->add('h', (new Route('/blog/page/{page}'))->setRequirements(array('id' => '\d+')));
+        $demoCollection->add('i', (new Route('/blog/posts/{page}'))->setRequirements(array('id' => '\d+')));
+        $demoCollection->add('j', (new Route('/blog/comments/{id}/new'))->setRequirements(array('id' => '\d+')));
+        $demoCollection->add('k', new Route('/blog/search'));
+        $demoCollection->add('l', new Route('/login'));
+        $demoCollection->add('m', new Route('/logout'));
+        $demoCollection->addPrefix('/{_locale}');
+        $demoCollection->add('n', new Route('/{_locale}'));
+        $demoCollection->addRequirements(array('_locale' => 'en|fr'));
+        $demoCollection->addDefaults(array('_locale' => 'en'));
+
         return array(
            array(new RouteCollection(), 'url_matcher0.php', array()),
            array($collection, 'url_matcher1.php', array()),
@@ -450,6 +470,7 @@ class PhpMatcherDumperTest extends TestCase
            array($unicodeCollection, 'url_matcher8.php', array()),
            array($hostTreeCollection, 'url_matcher9.php', array()),
            array($chunkedCollection, 'url_matcher10.php', array()),
+           array($demoCollection, 'url_matcher11.php', array('base_class' => 'Symfony\Component\Routing\Tests\Fixtures\RedirectableUrlMatcher')),
         );
     }
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/StaticPrefixCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/StaticPrefixCollectionTest.php
@@ -86,7 +86,7 @@ EOF
                     array('/group/aa/', 'aa'),
                     array('/group/bb/', 'bb'),
                     array('/group/cc/', 'cc'),
-                    array('/', 'root'),
+                    array('/(.*)', 'root'),
                     array('/group/dd/', 'dd'),
                     array('/group/ee/', 'ee'),
                     array('/group/ff/', 'ff'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Follows #26059 and #26169.

The blog post on http://symfony.com/blog/new-in-symfony-4-1-fastest-php-router made me review the aggregation logic, and discover issues.

So now, instead of this:
```
        .'|/(en|fr)/admin/post/?(*:82)'
        .'|/(en|fr)/admin/post/new(*:166)'
        .'|/(en|fr)/admin/post/(\\d+)(*:253)'
        .'|/(en|fr)/admin/post/(\\d+)/edit(*:345)'
        .'|/(en|fr)/admin/post/(\\d+)/delete(*:442)'
        .'|/(en|fr)/blog/?(*:519)'
        .'|/(en|fr)/blog/rss\\.xml(*:603)'
        .'|/(en|fr)/blog/page/([^/]++)(*:694)'
        .'|/(en|fr)/blog/posts/([^/]++)(*:784)'
        .'|/(en|fr)/blog/comment/(\d+)/new(*:880)'
        .'|/(en|fr)/blog/search(*:962)'
        .'|/(en|fr)/login(*:1038)'
        .'|/(en|fr)/logout(*:1116)'
        .'|/(en|fr)?(*:1188)'
```

we generate this:
```
        .'|/(en|fr)(?'
            .'|/admin/post(?'
                .'|/?(*:34)'
                .'|/new(*:45)'
                .'|/(\\d+)(?'
                    .'|(*:61)'
                    .'|/edit(*:73)'
                    .'|/delete(*:87)'
                .')'
            .')'
            .'|/blog(?'
                .'|/?(*:106)'
                .'|/rss\\.xml(*:123)'
                .'|/p(?'
                    .'|age/([^/]++)(*:148)'
                    .'|osts/([^/]++)(*:169)'
                .')'
                .'|/comments/(\\d+)/new(*:197)'
                .'|/search(*:212)'
            .')'
            .'|/log(?'
                .'|in(*:230)'
                .'|out(*:241)'
            .')'
        .')'
        .'|/(en|fr)?(*:260)' 
```

This is not only another perf fix, but a real bug fix, as I found ordering issues.