### PR TITLE
Improve the documentation of `Filesystem::mirror()`

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -524,13 +524,18 @@ class Filesystem
     /**
      * Mirrors a directory to another.
      *
+     * All files and directories in the origin directory will be copied into the target directory. By default:
+     *
+     * - existing files in the target directory will be overwritten, except if they are newer (see the `override` option)
+     * - files in the target directory that do not exist in the source directory will not be deleted (see the `delete` option)
+     *
      * @param string       $originDir The origin directory
      * @param string       $targetDir The target directory
-     * @param \Traversable $iterator  A Traversable instance
+     * @param \Traversable $iterator  Provide an iterator to filter which files in the origin directory will be copied.
      * @param array        $options   An array of boolean options
      *                                Valid options are:
-     *                                - $options['override'] Whether to override an existing file on copy or not (see copy())
-     *                                - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink())
+     *                                - $options['override'] If true, target files newer than origin files are overwritten (see copy(), defaults to false)
+     *                                - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink(), defaults to false)
      *                                - $options['delete'] Whether to delete files that are not in the source directory (defaults to false)
      *
      * @throws IOException When file type is unknown


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      |no
| New feature?  |no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    |no
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | ?
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I always end up reading the code of the method to understand what really happens with the default parameters. Hopefully this will clear things up for future me and others.