### PR TITLE
[WebProfilerBundle] Tweak default route name

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -58,7 +58,7 @@
 
             <div class="sf-toolbar-info-piece">
                 <b>Route name</b>
-                <span>{{ collector.route|default('NONE') }}</span>
+                <span>{{ collector.route|default('n/a') }}</span>
             </div>
 
             <div class="sf-toolbar-info-piece">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes-ish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Use `n/a` instead of `NONE` which is consistent and less loud.

![image](https://user-images.githubusercontent.com/1047696/36351462-ae2da6ca-14aa-11e8-860c-6c583d721f3a.png)