### PR TITLE
[FrameworkBundle] Add support to 307/308 HTTP status codes in RedirectController

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Added option in workflow dump command to label graph with a custom label
  * Using a `RouterInterface` that does not implement the `WarmableInterface` is deprecated and will not be supported in Symfony 5.0.
  * The `RequestDataCollector` class has been deprecated and will be removed in Symfony 5.0. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
+ * The `RedirectController` class allows for 307/308 HTTP status codes
 
 4.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -72,7 +72,6 @@ class RedirectController
         if ($keepRequestMethod) {
             $statusCode = $permanent ? Response::HTTP_PERMANENTLY_REDIRECT : Response::HTTP_TEMPORARY_REDIRECT;
         } else {
-            @trigger_error('Since next major release redirect action will be made with 307/308 HTTP status codes', \E_USER_DEPRECATED);
             $statusCode = $permanent ? Response::HTTP_MOVED_PERMANENTLY : Response::HTTP_FOUND;
         }
 
@@ -107,7 +106,6 @@ class RedirectController
         if ($keepRequestMethod) {
             $statusCode = $permanent ? Response::HTTP_PERMANENTLY_REDIRECT : Response::HTTP_TEMPORARY_REDIRECT;
         } else {
-            @trigger_error('Since next major release redirect action will be made with 307/308 HTTP status codes', \E_USER_DEPRECATED);
             $statusCode = $permanent ? Response::HTTP_MOVED_PERMANENTLY : Response::HTTP_FOUND;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -57,7 +57,7 @@ class RedirectController
     public function redirectAction(Request $request, string $route, bool $permanent = false, $ignoreAttributes = false, bool $keepRequestMethod = false): Response
     {
         if ('' == $route) {
-            throw new HttpException($permanent ? Response::HTTP_GONE : Response::HTTP_NOT_FOUND);
+            throw new HttpException($permanent ? 410 : 404);
         }
 
         $attributes = array();
@@ -70,9 +70,9 @@ class RedirectController
         }
 
         if ($keepRequestMethod) {
-            $statusCode = $permanent ? Response::HTTP_PERMANENTLY_REDIRECT : Response::HTTP_TEMPORARY_REDIRECT;
+            $statusCode = $permanent ? 308 : 307;
         } else {
-            $statusCode = $permanent ? Response::HTTP_MOVED_PERMANENTLY : Response::HTTP_FOUND;
+            $statusCode = $permanent ? 301 : 302;
         }
 
         return new RedirectResponse($this->router->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL), $statusCode);
@@ -100,13 +100,13 @@ class RedirectController
     public function urlRedirectAction(Request $request, string $path, bool $permanent = false, string $scheme = null, int $httpPort = null, int $httpsPort = null, bool $keepRequestMethod = false): Response
     {
         if ('' == $path) {
-            throw new HttpException($permanent ? Response::HTTP_GONE : Response::HTTP_NOT_FOUND);
+            throw new HttpException($permanent ? 410 : 404);
         }
 
         if ($keepRequestMethod) {
-            $statusCode = $permanent ? Response::HTTP_PERMANENTLY_REDIRECT : Response::HTTP_TEMPORARY_REDIRECT;
+            $statusCode = $permanent ? 308 : 307;
         } else {
-            $statusCode = $permanent ? Response::HTTP_MOVED_PERMANENTLY : Response::HTTP_FOUND;
+            $statusCode = $permanent ? 301 : 302;
         }
 
         // redirect if the path is a full URL

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -46,29 +46,37 @@ class RedirectController
      * In case the route name is empty, the status code will be 404 when permanent is false
      * and 410 otherwise.
      *
-     * @param Request    $request          The request instance
-     * @param string     $route            The route name to redirect to
-     * @param bool       $permanent        Whether the redirection is permanent
-     * @param bool|array $ignoreAttributes Whether to ignore attributes or an array of attributes to ignore
+     * @param Request    $request           The request instance
+     * @param string     $route             The route name to redirect to
+     * @param bool       $permanent         Whether the redirection is permanent
+     * @param bool|array $ignoreAttributes  Whether to ignore attributes or an array of attributes to ignore
+     * @param bool       $keepRequestMethod Wheter redirect action should keep HTTP request method
      *
      * @throws HttpException In case the route name is empty
      */
-    public function redirectAction(Request $request, string $route, bool $permanent = false, $ignoreAttributes = false): Response
+    public function redirectAction(Request $request, string $route, bool $permanent = false, $ignoreAttributes = false, bool $keepRequestMethod = false): Response
     {
         if ('' == $route) {
-            throw new HttpException($permanent ? 410 : 404);
+            throw new HttpException($permanent ? Response::HTTP_GONE : Response::HTTP_NOT_FOUND);
         }
 
         $attributes = array();
         if (false === $ignoreAttributes || is_array($ignoreAttributes)) {
             $attributes = $request->attributes->get('_route_params');
-            unset($attributes['route'], $attributes['permanent'], $attributes['ignoreAttributes']);
+            unset($attributes['route'], $attributes['permanent'], $attributes['ignoreAttributes'], $attributes['keepRequestMethod']);
             if ($ignoreAttributes) {
                 $attributes = array_diff_key($attributes, array_flip($ignoreAttributes));
             }
         }
 
-        return new RedirectResponse($this->router->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL), $permanent ? 301 : 302);
+        if ($keepRequestMethod) {
+            $statusCode = $permanent ? Response::HTTP_PERMANENTLY_REDIRECT : Response::HTTP_TEMPORARY_REDIRECT;
+        } else {
+            @trigger_error('Since next major release redirect action will be made with 307/308 HTTP status codes', \E_USER_DEPRECATED);
+            $statusCode = $permanent ? Response::HTTP_MOVED_PERMANENTLY : Response::HTTP_FOUND;
+        }
+
+        return new RedirectResponse($this->router->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL), $statusCode);
     }
 
     /**
@@ -80,22 +88,28 @@ class RedirectController
      * In case the path is empty, the status code will be 404 when permanent is false
      * and 410 otherwise.
      *
-     * @param Request     $request   The request instance
-     * @param string      $path      The absolute path or URL to redirect to
-     * @param bool        $permanent Whether the redirect is permanent or not
-     * @param string|null $scheme    The URL scheme (null to keep the current one)
-     * @param int|null    $httpPort  The HTTP port (null to keep the current one for the same scheme or the default configured port)
-     * @param int|null    $httpsPort The HTTPS port (null to keep the current one for the same scheme or the default configured port)
+     * @param Request     $request           The request instance
+     * @param string      $path              The absolute path or URL to redirect to
+     * @param bool        $permanent         Whether the redirect is permanent or not
+     * @param string|null $scheme            The URL scheme (null to keep the current one)
+     * @param int|null    $httpPort          The HTTP port (null to keep the current one for the same scheme or the default configured port)
+     * @param int|null    $httpsPort         The HTTPS port (null to keep the current one for the same scheme or the default configured port)
+     * @param bool        $keepRequestMethod Wheter redirect action should keep HTTP request method
      *
      * @throws HttpException In case the path is empty
      */
-    public function urlRedirectAction(Request $request, string $path, bool $permanent = false, string $scheme = null, int $httpPort = null, int $httpsPort = null): Response
+    public function urlRedirectAction(Request $request, string $path, bool $permanent = false, string $scheme = null, int $httpPort = null, int $httpsPort = null, bool $keepRequestMethod = false): Response
     {
         if ('' == $path) {
-            throw new HttpException($permanent ? 410 : 404);
+            throw new HttpException($permanent ? Response::HTTP_GONE : Response::HTTP_NOT_FOUND);
         }
 
-        $statusCode = $permanent ? 301 : 302;
+        if ($keepRequestMethod) {
+            $statusCode = $permanent ? Response::HTTP_PERMANENTLY_REDIRECT : Response::HTTP_TEMPORARY_REDIRECT;
+        } else {
+            @trigger_error('Since next major release redirect action will be made with 307/308 HTTP status codes', \E_USER_DEPRECATED);
+            $statusCode = $permanent ? Response::HTTP_MOVED_PERMANENTLY : Response::HTTP_FOUND;
+        }
 
         // redirect if the path is a full URL
         if (parse_url($path, PHP_URL_SCHEME)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -62,7 +62,7 @@ class RedirectControllerTest extends TestCase
                 'permanent' => $permanent,
                 'additional-parameter' => 'value',
                 'ignoreAttributes' => $ignoreAttributes,
-                'keepRequestMethod' => $keepRequestMethod
+                'keepRequestMethod' => $keepRequestMethod,
             ),
         );
 
@@ -85,16 +85,16 @@ class RedirectControllerTest extends TestCase
 
     public function provider()
     {
-        return [
-            [true, false, false, Response::HTTP_MOVED_PERMANENTLY, ['additional-parameter' => 'value']],
-            [false, false, false, Response::HTTP_FOUND, ['additional-parameter' => 'value']],
-            [false, false, true, Response::HTTP_FOUND, []],
-            [false, false, ['additional-parameter'], Response::HTTP_FOUND, []],
-            [true, true, false, Response::HTTP_PERMANENTLY_REDIRECT, ['additional-parameter' => 'value']],
-            [false, true, false, Response::HTTP_TEMPORARY_REDIRECT, ['additional-parameter' => 'value']],
-            [false, true, true, Response::HTTP_TEMPORARY_REDIRECT, []],
-            [false, true, ['additional-parameter'], Response::HTTP_TEMPORARY_REDIRECT, []],
-        ];
+        return array(
+            array(true, false, false, Response::HTTP_MOVED_PERMANENTLY, array('additional-parameter' => 'value')),
+            array(false, false, false, Response::HTTP_FOUND, array('additional-parameter' => 'value')),
+            array(false, false, true, Response::HTTP_FOUND, array()),
+            array(false, false, array('additional-parameter'), Response::HTTP_FOUND, array()),
+            array(true, true, false, Response::HTTP_PERMANENTLY_REDIRECT, array('additional-parameter' => 'value')),
+            array(false, true, false, Response::HTTP_TEMPORARY_REDIRECT, array('additional-parameter' => 'value')),
+            array(false, true, true, Response::HTTP_TEMPORARY_REDIRECT, array()),
+            array(false, true, array('additional-parameter'), Response::HTTP_TEMPORARY_REDIRECT, array()),
+        );
     }
 
     public function testEmptyPath()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -33,14 +33,14 @@ class RedirectControllerTest extends TestCase
             $controller->redirectAction($request, '', true);
             $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
         } catch (HttpException $e) {
-            $this->assertSame(Response::HTTP_GONE, $e->getStatusCode());
+            $this->assertSame(410, $e->getStatusCode());
         }
 
         try {
             $controller->redirectAction($request, '', false);
             $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
         } catch (HttpException $e) {
-            $this->assertSame(Response::HTTP_NOT_FOUND, $e->getStatusCode());
+            $this->assertSame(404, $e->getStatusCode());
         }
     }
 
@@ -86,14 +86,14 @@ class RedirectControllerTest extends TestCase
     public function provider()
     {
         return array(
-            array(true, false, false, Response::HTTP_MOVED_PERMANENTLY, array('additional-parameter' => 'value')),
-            array(false, false, false, Response::HTTP_FOUND, array('additional-parameter' => 'value')),
-            array(false, false, true, Response::HTTP_FOUND, array()),
-            array(false, false, array('additional-parameter'), Response::HTTP_FOUND, array()),
-            array(true, true, false, Response::HTTP_PERMANENTLY_REDIRECT, array('additional-parameter' => 'value')),
-            array(false, true, false, Response::HTTP_TEMPORARY_REDIRECT, array('additional-parameter' => 'value')),
-            array(false, true, true, Response::HTTP_TEMPORARY_REDIRECT, array()),
-            array(false, true, array('additional-parameter'), Response::HTTP_TEMPORARY_REDIRECT, array()),
+            array(true, false, false, 301, array('additional-parameter' => 'value')),
+            array(false, false, false, 302, array('additional-parameter' => 'value')),
+            array(false, false, true, 302, array()),
+            array(false, false, array('additional-parameter'), 302, array()),
+            array(true, true, false, 308, array('additional-parameter' => 'value')),
+            array(false, true, false, 307, array('additional-parameter' => 'value')),
+            array(false, true, true, 307, array()),
+            array(false, true, array('additional-parameter'), 307, array()),
         );
     }
 
@@ -106,14 +106,14 @@ class RedirectControllerTest extends TestCase
             $controller->urlRedirectAction($request, '', true);
             $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
         } catch (HttpException $e) {
-            $this->assertSame(Response::HTTP_GONE, $e->getStatusCode());
+            $this->assertSame(410, $e->getStatusCode());
         }
 
         try {
             $controller->urlRedirectAction($request, '', false);
             $this->fail('Expected Symfony\Component\HttpKernel\Exception\HttpException to be thrown');
         } catch (HttpException $e) {
-            $this->assertSame(Response::HTTP_NOT_FOUND, $e->getStatusCode());
+            $this->assertSame(404, $e->getStatusCode());
         }
     }
 
@@ -124,7 +124,7 @@ class RedirectControllerTest extends TestCase
         $returnResponse = $controller->urlRedirectAction($request, 'http://foo.bar/');
 
         $this->assertRedirectUrl($returnResponse, 'http://foo.bar/');
-        $this->assertEquals(Response::HTTP_FOUND, $returnResponse->getStatusCode());
+        $this->assertEquals(302, $returnResponse->getStatusCode());
     }
 
     public function testFullURLWithMethodKeep()
@@ -134,7 +134,7 @@ class RedirectControllerTest extends TestCase
         $returnResponse = $controller->urlRedirectAction($request, 'http://foo.bar/', false, null, null, null, true);
 
         $this->assertRedirectUrl($returnResponse, 'http://foo.bar/');
-        $this->assertEquals(Response::HTTP_TEMPORARY_REDIRECT, $returnResponse->getStatusCode());
+        $this->assertEquals(307, $returnResponse->getStatusCode());
     }
 
     public function testUrlRedirectDefaultPorts()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  #26171
| License       | MIT
| Doc PR        | 

With this PR `RedirectController` will allow to create redirections with use of 307/308 HTTP status codes together with 301/302. Related RFC documents:
* https://tools.ietf.org/html/rfc7231
* https://tools.ietf.org/html/rfc7538
