### PR TITLE
[HttpFoundation] Don't reorder nested query string keys

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -660,6 +660,7 @@ class Request
 
         $parts = array();
         $order = array();
+        $index = 0;
 
         foreach (explode('&', $qs) as $param) {
             if ('' === $param || '=' === $param[0]) {
@@ -670,14 +671,13 @@ class Request
             }
 
             $keyValuePair = explode('=', $param, 2);
+            $key = urldecode($keyValuePair[0]);
 
             // GET parameters, that are submitted from a HTML form, encode spaces as "+" by default (as defined in enctype application/x-www-form-urlencoded).
             // PHP also converts "+" to spaces when filling the global _GET or when using the function parse_str. This is why we use urldecode and then normalize to
             // RFC 3986 with rawurlencode.
-            $parts[] = isset($keyValuePair[1]) ?
-                rawurlencode(urldecode($keyValuePair[0])).'='.rawurlencode(urldecode($keyValuePair[1])) :
-                rawurlencode(urldecode($keyValuePair[0]));
-            $order[] = urldecode($keyValuePair[0]);
+            $parts[] = rawurlencode($key).(isset($keyValuePair[1]) ? '='.rawurlencode(urldecode($keyValuePair[1])) : '');
+            $order[] = false !== ($i = strpos($key, '[')) ? substr_replace($key, pack('N', ++$index), 1 + $i) : $key;
         }
 
         array_multisort($order, SORT_ASC, $parts);

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -658,6 +658,10 @@ class RequestTest extends TestCase
             // Ignore pairs with empty key, even if there was a value, e.g. "=value", as such nameless values cannot be retrieved anyway.
             // PHP also does not include them when building _GET.
             array('foo=bar&=a=b&=x=y', 'foo=bar', 'removes params with empty key'),
+
+            // Don't reorder nested query string keys
+            array('foo[]=Z&foo[]=A', 'foo%5B%5D=Z&foo%5B%5D=A', 'keeps values order'),
+            array('foo[Z]=B&foo[A]=B', 'foo%5BZ%5D=B&foo%5BA%5D=B', 'keeps keys order'),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | api-platform/core#1710
| License       | MIT
| Doc PR        | -

Normalization shouldn't apply to recursive structures.
Replaces #26202