### PR TITLE
[MonologBridge] Allow to change level format in ConsoleFormatter

### DIFF
--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -60,6 +60,7 @@ class ConsoleFormatter implements FormatterInterface
             'date_format' => self::SIMPLE_DATE,
             'colors' => true,
             'multiline' => false,
+            'level_name_format' => '%-9s',
         ), $options);
 
         if (class_exists(VarCloner::class)) {
@@ -119,7 +120,7 @@ class ConsoleFormatter implements FormatterInterface
         $formatted = strtr($this->options['format'], array(
             '%datetime%' => $record['datetime']->format($this->options['date_format']),
             '%start_tag%' => sprintf('<%s>', $levelColor),
-            '%level_name%' => sprintf('%-9s', $record['level_name']),
+            '%level_name%' => sprintf($this->options['level_name_format'], $record['level_name']),
             '%end_tag%' => '</>',
             '%channel%' => $record['channel'],
             '%message%' => $this->replacePlaceHolder($record)['message'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I want to use this format `%datetime% <comment>[%level_name%]</comment> %start_tag%%message%%end_tag%`, but ConsoleFormatter formats in a way message looks like this:

![screenshot from 2018-02-19 01-54-21](https://user-images.githubusercontent.com/496233/36359102-d6c20e4c-1517-11e8-9988-8a49efc4cacb.png)

As you see, unnecessary padding looks like anomaly here and there is currently no way to remove it without making own formatter.

This option allows me to replace default padding format with `%s`.