### PR TITLE
Make deprecation notices less verbose

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -5,48 +5,46 @@ Config
 ------
 
  * Implementing `ParentNodeDefinitionInterface` without the `getChildNodeDefinitions()` method
-   is deprecated and will be unsupported in 5.0.
+   is deprecated.
 
 EventDispatcher
 ---------------
 
- * The `TraceableEventDispatcherInterface` has been deprecated and will be removed in 5.0.
+ * The `TraceableEventDispatcherInterface` has been deprecated.
 
 FrameworkBundle
 ---------------
 
- * A `RouterInterface` that does not implement the `WarmableInterface` is deprecated and will not be supported in Symfony 5.0.
- * The `RequestDataCollector` class has been deprecated and will be removed in Symfony 5.0. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
+ * A `RouterInterface` that does not implement the `WarmableInterface` is deprecated.
+ * The `RequestDataCollector` class has been deprecated. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
 
 HttpFoundation
 --------------
 
- * Passing the file size to the constructor of the `UploadedFile` class is deprecated and won't be
-   supported anymore in 5.0.
+ * Passing the file size to the constructor of the `UploadedFile` class is deprecated.
 
  * The `getClientSize()` method of the `UploadedFile` class is deprecated. Use `getSize()` instead.
 
 Security
 --------
 
- * The `ContextListener::setLogoutOnUserChange()` method is deprecated and will be removed in 5.0.
+ * The `ContextListener::setLogoutOnUserChange()` method is deprecated.
  * Using the `AdvancedUserInterface` is now deprecated. To use the existing
    functionality, create a custom user-checker based on the
-   `Symfony\Component\Security\Core\User\UserChecker`. This functionality will
-   be removed in Symfony 5.0.
+   `Symfony\Component\Security\Core\User\UserChecker`.
 
 SecurityBundle
 --------------
 
- * The `logout_on_user_change` firewall option is deprecated and will be removed in 5.0.
- * The `SecurityUserValueResolver` class is deprecated and will be removed in 5.0, use
+ * The `logout_on_user_change` firewall option is deprecated.
+ * The `SecurityUserValueResolver` class is deprecated, use
    `Symfony\Component\Security\Http\Controller\UserValueResolver` instead.
 
 Translation
 -----------
 
- * The `FileDumper::setBackup()` method is deprecated and will be removed in 5.0.
- * The `TranslationWriter::disableBackup()` method is deprecated and will be removed in 5.0.
+ * The `FileDumper::setBackup()` method is deprecated.
+ * The `TranslationWriter::disableBackup()` method is deprecated.
 
 TwigBundle
 ----------
@@ -56,9 +54,9 @@ TwigBundle
 Validator
 --------
 
- * The `Email::__construct()` 'strict' property is deprecated and will be removed in 5.0. Use 'mode'=>"strict" instead.
- * Calling `EmailValidator::__construct()` method with a boolean parameter is deprecated and will be removed in 5.0, use `EmailValidator("strict")` instead.
- * Deprecated the `checkDNS` and `dnsMessage` options of the `Url` constraint. They will be removed in 5.0.
+ * The `Email::__construct()` 'strict' property is deprecated. Use 'mode'=>"strict" instead.
+ * Calling `EmailValidator::__construct()` method with a boolean parameter is deprecated, use `EmailValidator("strict")` instead.
+ * Deprecated the `checkDNS` and `dnsMessage` options of the `Url` constraint.
 
 Workflow
 --------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,8 +8,8 @@ CHANGELOG
  * Added a new `parameter_bag` service with related autowiring aliases to access parameters as-a-service
  * Allowed the `Router` to work with any PSR-11 container
  * Added option in workflow dump command to label graph with a custom label
- * Using a `RouterInterface` that does not implement the `WarmableInterface` is deprecated and will not be supported in Symfony 5.0.
- * The `RequestDataCollector` class has been deprecated and will be removed in Symfony 5.0. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
+ * Using a `RouterInterface` that does not implement the `WarmableInterface` is deprecated.
+ * The `RequestDataCollector` class has been deprecated. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
  * The `RedirectController` class allows for 307/308 HTTP status codes
 
 4.0.0

--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/RequestDataCollector.php
@@ -13,14 +13,14 @@ namespace Symfony\Bundle\FrameworkBundle\DataCollector;
 
 use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector as BaseRequestDataCollector;
 
-@trigger_error(sprintf('The "%s" class is deprecated since version 4.1 and will be removed in Symfony 5.0. Use %s instead.', RequestDataCollector::class, BaseRequestDataCollector::class), E_USER_DEPRECATED);
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.1. Use %s instead.', RequestDataCollector::class, BaseRequestDataCollector::class), E_USER_DEPRECATED);
 
 /**
  * RequestDataCollector.
  *
  * @author Jules Pietri <jusles@heahprod.com>
  *
- * @deprecated since version 4.1, to be removed in Symfony 5.0
+ * @deprecated since Symfony 4.1
  */
 class RequestDataCollector extends BaseRequestDataCollector
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -70,7 +70,7 @@
         </service>
 
         <service id="session.save_listener" class="Symfony\Component\HttpKernel\EventListener\SaveSessionListener">
-            <deprecated>The "%service_id%" service is deprecated since Symfony 4.1 and will be removed in 5.0. Use the "session_listener" service instead.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since Symfony 4.1. Use the "session_listener" service instead.</deprecated>
         </service>
 
         <!-- for BC -->

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 4.1.0
 -----
 
- * The `logout_on_user_change` firewall option is deprecated and will be removed in 5.0.
+ * The `logout_on_user_change` firewall option is deprecated.
  * deprecated `SecurityUserValueResolver`, use
    `Symfony\Component\Security\Http\Controller\UserValueResolver` instead.
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -200,7 +200,7 @@ class MainConfiguration implements ConfigurationInterface
             ->booleanNode('logout_on_user_change')
                 ->defaultTrue()
                 ->info('When true, it will trigger a logout for the user if something has changed. Note: No-Op option since 4.0. Will always be true.')
-                ->setDeprecated('The "%path%.%node%" configuration key has been deprecated in Symfony 4.1 and will be removed in 5.0.')
+                ->setDeprecated('The "%path%.%node%" configuration key has been deprecated in Symfony 4.1.')
             ->end()
             ->arrayNode('logout')
                 ->treatTrueLike(array())

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -165,7 +165,7 @@
         <!-- Provisioning -->
         <service id="security.user.provider.in_memory" class="Symfony\Component\Security\Core\User\InMemoryUserProvider" abstract="true" />
         <service id="security.user.provider.in_memory.user" class="Symfony\Component\Security\Core\User\User" abstract="true">
-            <deprecated>The "%service_id%" service is deprecated since Symfony 4.1 and will be removed in 5.0.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since Symfony 4.1.</deprecated>
         </service>
 
         <service id="security.user.provider.ldap" class="Symfony\Component\Security\Core\User\LdapUserProvider" abstract="true">

--- a/src/Symfony/Bundle/SecurityBundle/SecurityUserValueResolver.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityUserValueResolver.php
@@ -19,14 +19,14 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.1 and will be removed in 5.0, use "%s" instead.', SecurityUserValueResolver::class, UserValueResolver::class), E_USER_DEPRECATED);
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.1, use "%s" instead.', SecurityUserValueResolver::class, UserValueResolver::class), E_USER_DEPRECATED);
 
 /**
  * Supports the argument type of {@see UserInterface}.
  *
  * @author Iltar van der Berg <kjarli@gmail.com>
  *
- * @deprecated since Symfony 4.1, to be removed in 5.0. Use {@link UserValueResolver} instead
+ * @deprecated since Symfony 4.1, use {@link UserValueResolver} instead
  */
 final class SecurityUserValueResolver implements ArgumentValueResolverInterface
 {

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -364,7 +364,7 @@ abstract class NodeDefinition implements NodeParentInterface
                     $child->setPathSeparator($separator);
                 }
             } else {
-                @trigger_error('Passing a ParentNodeDefinitionInterface without getChildNodeDefinitions() is deprecated since version 4.1 and will be removed in 5.0.', E_USER_DEPRECATED);
+                @trigger_error('Passing a ParentNodeDefinitionInterface without getChildNodeDefinitions() is deprecated since Symfony 4.1.', E_USER_DEPRECATED);
             }
         }
 

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * added support for invokable event listeners tagged with `kernel.event_listener` by default 
  * The `TraceableEventDispatcher::getOrphanedEvents()` method has been added.
- * The `TraceableEventDispatcherInterface` has been deprecated and will be removed in 5.0.
+ * The `TraceableEventDispatcherInterface` has been deprecated.
 
 4.0.0
 -----

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\EventDispatcher\Debug;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @deprecated since version 4.1, will be removed in 5.0.
+ * @deprecated since version 4.1
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,15 +4,12 @@ CHANGELOG
 4.1.0
 -----
 
- * Passing the file size to the constructor of the `UploadedFile` class is deprecated and won't be
-   supported anymore in 5.0.
-
+ * Passing the file size to the constructor of the `UploadedFile` class is deprecated.
  * The `getClientSize()` method of the `UploadedFile` class is deprecated. Use `getSize()` instead.
  * added `RedisSessionHandler` to use Redis as a session storage
-
-* The `get()` method of the `AcceptHeader` class now takes into account the
-  `*` and `*/*` default values (if they are present in the Accept HTTP header)
-  when looking for items.
+ * The `get()` method of the `AcceptHeader` class now takes into account the
+   `*` and `*/*` default values (if they are present in the Accept HTTP header)
+   when looking for items.
 
 4.0.0
 -----

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -59,7 +59,7 @@ class UploadedFile extends File
         $this->mimeType = $mimeType ?: 'application/octet-stream';
 
         if (4 < func_num_args() ? !is_bool($test) : null !== $error && @filesize($path) === $error) {
-            @trigger_error(sprintf('Passing a size as 4th argument to the constructor of "%s" is deprecated since Symfony 4.1 and will be unsupported in 5.0.', __CLASS__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Passing a size as 4th argument to the constructor of "%s" is deprecated since Symfony 4.1.', __CLASS__), E_USER_DEPRECATED);
             $error = $test;
             $test = 5 < func_num_args() ? func_get_arg(5) : false;
         }
@@ -145,13 +145,13 @@ class UploadedFile extends File
      * It is extracted from the request from which the file has been uploaded.
      * Then it should not be considered as a safe value.
      *
-     * @deprecated since 4.1 will be removed in 5.0 use getSize() instead.
+     * @deprecated since 4.1, use getSize() instead.
      *
      * @return int|null The file sizes
      */
     public function getClientSize()
     {
-        @trigger_error(sprintf('"%s" is deprecated since Symfony 4.1 and will be removed in 5.0. Use getSize() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('"%s" is deprecated since Symfony 4.1. Use getSize() instead.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->getSize();
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -195,7 +195,7 @@ class UploadedFileTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a size as 4th argument to the constructor of "Symfony\Component\HttpFoundation\File\UploadedFile" is deprecated since Symfony 4.1 and will be unsupported in 5.0.
+     * @expectedDeprecation Passing a size as 4th argument to the constructor of "Symfony\Component\HttpFoundation\File\UploadedFile" is deprecated since Symfony 4.1.
      */
     public function testConstructDeprecatedSize()
     {
@@ -213,7 +213,7 @@ class UploadedFileTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a size as 4th argument to the constructor of "Symfony\Component\HttpFoundation\File\UploadedFile" is deprecated since Symfony 4.1 and will be unsupported in 5.0.
+     * @expectedDeprecation Passing a size as 4th argument to the constructor of "Symfony\Component\HttpFoundation\File\UploadedFile" is deprecated since Symfony 4.1.
      */
     public function testConstructDeprecatedSizeWhenPassingOnlyThe4Needed()
     {

--- a/src/Symfony/Component/HttpKernel/EventListener/SaveSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SaveSessionListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.1 and will be removed in 5.0. Use AbstractSessionListener instead.', SaveSessionListener::class), E_USER_DEPRECATED);
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.1, use AbstractSessionListener instead.', SaveSessionListener::class), E_USER_DEPRECATED);
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * @author Tobias Schultze <http://tobion.de>
  *
- * @deprecated since Symfony 4.1, to be removed in 5.0. Use AbstractSessionListener instead.
+ * @deprecated since Symfony 4.1, use AbstractSessionListener instead
  */
 class SaveSessionListener implements EventSubscriberInterface
 {

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,12 +4,11 @@ CHANGELOG
 4.1.0
 -----
 
- * The `ContextListener::setLogoutOnUserChange()` method is deprecated and will be removed in 5.0.
+ * The `ContextListener::setLogoutOnUserChange()` method is deprecated.
  * added `UserValueResolver`.
  * Using the AdvancedUserInterface is now deprecated. To use the existing
    functionality, create a custom user-checker based on the
-   `Symfony\Component\Security\Core\User\UserChecker`. This functionality will
-   be removed in Symfony 5.0.
+   `Symfony\Component\Security\Core\User\UserChecker`.
 
 4.0.0
 -----

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -261,7 +261,7 @@ abstract class AbstractToken implements TokenInterface
         }
 
         if ($this->user instanceof AdvancedUserInterface && $user instanceof AdvancedUserInterface) {
-            @trigger_error(sprintf('Checking for the AdvancedUserInterface in %s has been deprecated in 4.1 and will be removed in 5.0. Implement the %s to check if the user has been changed,', __METHOD__, EquatableInterface::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Checking for the AdvancedUserInterface in %s has been deprecated in 4.1. Implement the %s to check if the user has been changed,', __METHOD__, EquatableInterface::class), E_USER_DEPRECATED);
             if ($this->user->isAccountNonExpired() !== $user->isAccountNonExpired()) {
                 return true;
             }
@@ -278,7 +278,7 @@ abstract class AbstractToken implements TokenInterface
                 return true;
             }
         } elseif ($this->user instanceof AdvancedUserInterface xor $user instanceof AdvancedUserInterface) {
-            @trigger_error(sprintf('Checking for the AdvancedUserInterface in %s has been deprecated in 4.1 and will be removed in 5.0. Implement the %s to check if the user has been changed,', __METHOD__, EquatableInterface::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Checking for the AdvancedUserInterface in %s has been deprecated in 4.1. Implement the %s to check if the user has been changed,', __METHOD__, EquatableInterface::class), E_USER_DEPRECATED);
 
             return true;
         }

--- a/src/Symfony/Component/Security/Core/Tests/User/UserCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/UserCheckerTest.php
@@ -32,7 +32,7 @@ class UserCheckerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPostAuth with an AdvancedUserInterface is deprecated as of 4.1 and will be removed in 5.0. Create a custom user checker if you wish to keep this functionality.
+     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPostAuth with an AdvancedUserInterface is deprecated since Symfony 4.1. Create a custom user checker if you wish to keep this functionality.
      */
     public function testCheckPostAuthPassAdvancedUser()
     {
@@ -55,7 +55,7 @@ class UserCheckerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPostAuth with an AdvancedUserInterface is deprecated as of 4.1 and will be removed in 5.0. Create a custom user checker if you wish to keep this functionality.
+     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPostAuth with an AdvancedUserInterface is deprecated since Symfony 4.1. Create a custom user checker if you wish to keep this functionality.
      * @expectedException \Symfony\Component\Security\Core\Exception\CredentialsExpiredException
      */
     public function testCheckPostAuthCredentialsExpiredAdvancedUser()
@@ -70,7 +70,7 @@ class UserCheckerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPreAuth with an AdvancedUserInterface is deprecated as of 4.1 and will be removed in 5.0. Create a custom user checker if you wish to keep this functionality.
+     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPreAuth with an AdvancedUserInterface is deprecated since Symfony 4.1. Create a custom user checker if you wish to keep this functionality.
      */
     public function testCheckPreAuthPassAdvancedUser()
     {
@@ -95,7 +95,7 @@ class UserCheckerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPreAuth with an AdvancedUserInterface is deprecated as of 4.1 and will be removed in 5.0. Create a custom user checker if you wish to keep this functionality.
+     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPreAuth with an AdvancedUserInterface is deprecated since Symfony 4.1. Create a custom user checker if you wish to keep this functionality.
      * @expectedException \Symfony\Component\Security\Core\Exception\LockedException
      */
     public function testCheckPreAuthAccountLockedAdvancedUser()
@@ -119,7 +119,7 @@ class UserCheckerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPreAuth with an AdvancedUserInterface is deprecated as of 4.1 and will be removed in 5.0. Create a custom user checker if you wish to keep this functionality.
+     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPreAuth with an AdvancedUserInterface is deprecated since Symfony 4.1. Create a custom user checker if you wish to keep this functionality.
      * @expectedException \Symfony\Component\Security\Core\Exception\DisabledException
      */
     public function testCheckPreAuthDisabledAdvancedUser()
@@ -144,7 +144,7 @@ class UserCheckerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPreAuth with an AdvancedUserInterface is deprecated as of 4.1 and will be removed in 5.0. Create a custom user checker if you wish to keep this functionality.
+     * @expectedDeprecation Calling Symfony\Component\Security\Core\User\UserChecker::checkPreAuth with an AdvancedUserInterface is deprecated since Symfony 4.1. Create a custom user checker if you wish to keep this functionality.
      * @expectedException \Symfony\Component\Security\Core\Exception\AccountExpiredException
      */
     public function testCheckPreAuthAccountExpiredAdvancedUser()

--- a/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
@@ -32,7 +32,7 @@ use Symfony\Component\Security\Core\Exception\DisabledException;
  *
  * @see UserInterface
  * @see AccountStatusException
- * @deprecated since version 4.1, will be removed in 5.0.
+ * @deprecated since version 4.1
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Component/Security/Core/User/UserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/UserChecker.php
@@ -33,7 +33,7 @@ class UserChecker implements UserCheckerInterface
         }
 
         if ($user instanceof AdvancedUserInterface && !$user instanceof User) {
-            @trigger_error(sprintf('Calling %s with an AdvancedUserInterface is deprecated as of 4.1 and will be removed in 5.0. Create a custom user checker if you wish to keep this functionality.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling %s with an AdvancedUserInterface is deprecated since Symfony 4.1. Create a custom user checker if you wish to keep this functionality.', __METHOD__), E_USER_DEPRECATED);
         }
 
         if (!$user->isAccountNonLocked()) {
@@ -65,7 +65,7 @@ class UserChecker implements UserCheckerInterface
         }
 
         if ($user instanceof AdvancedUserInterface && !$user instanceof User) {
-            @trigger_error(sprintf('Calling %s with an AdvancedUserInterface is deprecated as of 4.1 and will be removed in 5.0. Create a custom user checker if you wish to keep this functionality.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling %s with an AdvancedUserInterface is deprecated since Symfony 4.1. Create a custom user checker if you wish to keep this functionality.', __METHOD__), E_USER_DEPRECATED);
         }
 
         if (!$user->isCredentialsNonExpired()) {

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -67,11 +67,11 @@ class ContextListener implements ListenerInterface
      *
      * @param bool $logoutOnUserChange
      *
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     public function setLogoutOnUserChange($logoutOnUserChange)
     {
-        @trigger_error(sprintf('The %s() method is deprecated since Symfony 4.1 and will be removed in 5.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since Symfony 4.1.', __METHOD__), E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -4,8 +4,8 @@ CHANGELOG
 4.1.0
 -----
 
- * The `FileDumper::setBackup()` method is deprecated and will be removed in 5.0.
- * The `TranslationWriter::disableBackup()` method is deprecated and will be removed in 5.0.
+ * The `FileDumper::setBackup()` method is deprecated.
+ * The `TranslationWriter::disableBackup()` method is deprecated.
  * The `XliffFileDumper` will write "name" on the "unit" node when dumping XLIFF 2.0.
 
 4.0.0

--- a/src/Symfony/Component/Translation/Dumper/FileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/FileDumper.php
@@ -47,11 +47,11 @@ abstract class FileDumper implements DumperInterface
      *
      * @param bool
      *
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     public function setBackup($backup)
     {
-        @trigger_error(sprintf('The %s() method is deprecated since Symfony 4.1 and will be removed in 5.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since Symfony 4.1.', __METHOD__), E_USER_DEPRECATED);
 
         if (false !== $backup) {
             throw new \LogicException('The backup feature is no longer supported.');

--- a/src/Symfony/Component/Translation/Writer/TranslationWriter.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriter.php
@@ -39,11 +39,11 @@ class TranslationWriter implements TranslationWriterInterface
     /**
      * Disables dumper backup.
      *
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     public function disableBackup()
     {
-        @trigger_error(sprintf('The %s() method is deprecated since Symfony 4.1 and will be removed in 5.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since Symfony 4.1.', __METHOD__), E_USER_DEPRECATED);
 
         foreach ($this->dumpers as $dumper) {
             if (method_exists($dumper, 'setBackup')) {

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 4.1.0
 -----
 
- * Deprecated the `checkDNS` and `dnsMessage` options of the `Url` constraint. They will be removed in 5.0.
+ * Deprecated the `checkDNS` and `dnsMessage` options of the `Url` constraint.
  * added a `values` option to the `Expression` constraint
 
 4.0.0

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -51,7 +51,7 @@ class Email extends Constraint
     public $checkHost = false;
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0. Set mode to "strict" instead.
+     * @deprecated since Symfony 4.1. Set mode to "strict" instead.
      */
     public $strict;
     public $mode;
@@ -59,7 +59,7 @@ class Email extends Constraint
     public function __construct($options = null)
     {
         if (is_array($options) && array_key_exists('strict', $options)) {
-            @trigger_error(sprintf('The "strict" property is deprecated since Symfony 4.1 and will be removed in 5.0. Use "mode"=>"%s" instead.', self::VALIDATION_MODE_STRICT), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "strict" property is deprecated since Symfony 4.1. Use "mode"=>"%s" instead.', self::VALIDATION_MODE_STRICT), E_USER_DEPRECATED);
         }
 
         if (is_array($options) && array_key_exists('mode', $options) && !in_array($options['mode'], self::$validationModes, true)) {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -49,7 +49,7 @@ class EmailValidator extends ConstraintValidator
     public function __construct($defaultMode = Email::VALIDATION_MODE_LOOSE)
     {
         if (is_bool($defaultMode)) {
-            @trigger_error(sprintf('Calling `new %s(%s)` is deprecated since Symfony 4.1 and will be removed in 5.0, use `new %s("%s")` instead.', self::class, $defaultMode ? 'true' : 'false', self::class, $defaultMode ? Email::VALIDATION_MODE_STRICT : Email::VALIDATION_MODE_LOOSE), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling `new %s(%s)` is deprecated since Symfony 4.1, use `new %s("%s")` instead.', self::class, $defaultMode ? 'true' : 'false', self::class, $defaultMode ? Email::VALIDATION_MODE_STRICT : Email::VALIDATION_MODE_LOOSE), E_USER_DEPRECATED);
 
             $defaultMode = $defaultMode ? Email::VALIDATION_MODE_STRICT : Email::VALIDATION_MODE_LOOSE;
         }
@@ -81,7 +81,7 @@ class EmailValidator extends ConstraintValidator
         $value = (string) $value;
 
         if (null !== $constraint->strict) {
-            @trigger_error(sprintf('The %s::$strict property is deprecated since Symfony 4.1 and will be removed in 5.0. Use %s::mode="%s" instead.', Email::class, Email::class, Email::VALIDATION_MODE_STRICT), E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s::$strict property is deprecated since Symfony 4.1. Use %s::mode="%s" instead.', Email::class, Email::class, Email::VALIDATION_MODE_STRICT), E_USER_DEPRECATED);
 
             if ($constraint->strict) {
                 $constraint->mode = Email::VALIDATION_MODE_STRICT;

--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -22,67 +22,67 @@ use Symfony\Component\Validator\Constraint;
 class Url extends Constraint
 {
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_ANY = 'ANY';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_NONE = false;
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_A = 'A';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_A6 = 'A6';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_AAAA = 'AAAA';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_CNAME = 'CNAME';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_MX = 'MX';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_NAPTR = 'NAPTR';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_NS = 'NS';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_PTR = 'PTR';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_SOA = 'SOA';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_SRV = 'SRV';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     const CHECK_DNS_TYPE_TXT = 'TXT';
 
@@ -95,13 +95,13 @@ class Url extends Constraint
     public $message = 'This value is not a valid URL.';
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     public $dnsMessage = 'The host could not be resolved.';
     public $protocols = array('http', 'https');
 
     /**
-     * @deprecated since Symfony 4.1, to be removed in 5.0
+     * @deprecated since Symfony 4.1
      */
     public $checkDNS = self::CHECK_DNS_TYPE_NONE;
     public $relativeProtocol = false;
@@ -110,10 +110,10 @@ class Url extends Constraint
     {
         if (is_array($options)) {
             if (array_key_exists('checkDNS', $options)) {
-                @trigger_error(sprintf('The "checkDNS" option in "%s" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.', self::class), E_USER_DEPRECATED);
+                @trigger_error(sprintf('The "checkDNS" option in "%s" is deprecated since Symfony 4.1. Its false-positive rate is too high to be relied upon.', self::class), E_USER_DEPRECATED);
             }
             if (array_key_exists('dnsMessage', $options)) {
-                @trigger_error(sprintf('The "dnsMessage" option in "%s" is deprecated since Symfony 4.1 and will be removed in 5.0.', self::class), E_USER_DEPRECATED);
+                @trigger_error(sprintf('The "dnsMessage" option in "%s" is deprecated since Symfony 4.1.', self::class), E_USER_DEPRECATED);
             }
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Constraints\Email;
 class EmailTest extends TestCase
 {
     /**
-     * @expectedDeprecation The "strict" property is deprecated since Symfony 4.1 and will be removed in 5.0. Use "mode"=>"strict" instead.
+     * @expectedDeprecation The "strict" property is deprecated since Symfony 4.1. Use "mode"=>"strict" instead.
      * @group legacy
      */
     public function testLegacyConstructorStrict()

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -27,7 +27,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @expectedDeprecation Calling `new Symfony\Component\Validator\Constraints\EmailValidator(true)` is deprecated since Symfony 4.1 and will be removed in 5.0, use `new Symfony\Component\Validator\Constraints\EmailValidator("strict")` instead.
+     * @expectedDeprecation Calling `new Symfony\Component\Validator\Constraints\EmailValidator(true)` is deprecated since Symfony 4.1, use `new Symfony\Component\Validator\Constraints\EmailValidator("strict")` instead.
      * @group legacy
      */
     public function testLegacyValidatorConstructorStrict()
@@ -226,8 +226,8 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @expectedDeprecation The "strict" property is deprecated since Symfony 4.1 and will be removed in 5.0. Use "mode"=>"strict" instead.
-     * @expectedDeprecation The Symfony\Component\Validator\Constraints\Email::$strict property is deprecated since Symfony 4.1 and will be removed in 5.0. Use Symfony\Component\Validator\Constraints\Email::mode="strict" instead.
+     * @expectedDeprecation The "strict" property is deprecated since Symfony 4.1. Use "mode"=>"strict" instead.
+     * @expectedDeprecation The Symfony\Component\Validator\Constraints\Email::$strict property is deprecated since Symfony 4.1. Use Symfony\Component\Validator\Constraints\Email::mode="strict" instead.
      * @group legacy
      */
     public function testStrict()

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -265,7 +265,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
      * @dataProvider getCheckDns
      * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
      * @group legacy
-     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.
+     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1. Its false-positive rate is too high to be relied upon.
      */
     public function testCheckDns($violation)
     {
@@ -297,7 +297,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
      * @dataProvider getCheckDnsTypes
      * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
      * @group legacy
-     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.
+     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1. Its false-positive rate is too high to be relied upon.
      */
     public function testCheckDnsByType($type)
     {
@@ -335,8 +335,8 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
      * @expectedException \Symfony\Component\Validator\Exception\InvalidOptionsException
      * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
      * @group legacy
-     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.
-     * @expectedDeprecation The "dnsMessage" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0.
+     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1. Its false-positive rate is too high to be relied upon.
+     * @expectedDeprecation The "dnsMessage" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1.
      */
     public function testCheckDnsWithInvalidType()
     {
@@ -352,7 +352,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1 and will be removed in 5.0. Its false-positive rate is too high to be relied upon.
+     * @expectedDeprecation The "checkDNS" option in "Symfony\Component\Validator\Constraints\Url" is deprecated since Symfony 4.1. Its false-positive rate is too high to be relied upon.
      */
     public function testCheckDnsOptionIsDeprecated()
     {

--- a/src/Symfony/Component/Workflow/Registry.php
+++ b/src/Symfony/Component/Workflow/Registry.php
@@ -27,7 +27,7 @@ class Registry
      * @param Workflow                 $workflow
      * @param SupportStrategyInterface $supportStrategy
      *
-     * @deprecated since Symfony 4.1, to be removed in 5.0. Use addWorkflow() instead.
+     * @deprecated since Symfony 4.1, use addWorkflow() instead
      */
     public function add(Workflow $workflow, $supportStrategy)
     {

--- a/src/Symfony/Component/Workflow/SupportStrategy/ClassInstanceSupportStrategy.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/ClassInstanceSupportStrategy.php
@@ -18,7 +18,7 @@ use Symfony\Component\Workflow\Workflow;
 /**
  * @author Andreas Kleemann <akleemann@inviqa.com>
  *
- * @deprecated since Symfony 4.1, to be removed in 5.0. Use InstanceOfSupportStrategy instead
+ * @deprecated since Symfony 4.1, use InstanceOfSupportStrategy instead
  */
 final class ClassInstanceSupportStrategy implements SupportStrategyInterface
 {

--- a/src/Symfony/Component/Workflow/SupportStrategy/SupportStrategyInterface.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/SupportStrategyInterface.php
@@ -16,7 +16,7 @@ use Symfony\Component\Workflow\Workflow;
 /**
  * @author Andreas Kleemann <akleemann@inviqa.com>
  *
- * @deprecated since Symfony 4.1, to be removed in 5.0. Use WorkflowSupportStrategyInterface instead
+ * @deprecated since Symfony 4.1, use WorkflowSupportStrategyInterface instead
  */
 interface SupportStrategyInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I think there is no need to say that deprecated features will be removed in the next major version. That makes messages more verbose for no real reasons.
