### PR TITLE
[HttpFoundation] Fix missing "throw" in JsonResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -148,6 +148,7 @@ class JsonResponse extends Response
                 if (\PHP_VERSION_ID < 50500 || !interface_exists('JsonSerializable', false)) {
                     restore_error_handler();
                 }
+                throw $e;
             } catch (\Exception $e) {
                 if (\PHP_VERSION_ID < 50500 || !interface_exists('JsonSerializable', false)) {
                     restore_error_handler();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
