### PR TITLE
removed version in @final @internal for version < 4.0

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;
  *
  * @author Marco Pivetta <ocramius@gmail.com>
  *
- * @final since version 3.3
+ * @final
  */
 class ProxyDumper implements DumperInterface
 {

--- a/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
@@ -91,7 +91,7 @@ class RoutingExtension extends AbstractExtension
      *
      * @return array An array with the contexts the URL is safe
      *
-     * @final since version 3.4
+     * @final
      */
     public function isUrlGenerationSafe(Node $argsNode)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
@@ -22,7 +22,7 @@ use Symfony\Component\Routing\RouterInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class RouterCacheWarmer implements CacheWarmerInterface, ServiceSubscriberInterface
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  *
  * @author Roland Franssen <franssen.roland@gmail.com>
  *
- * @final since version 3.4
+ * @final
  */
 class AboutCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Gábor Egyed <gabor.egyed@gmail.com>
  *
- * @final since version 3.4
+ * @final
  */
 class AssetsInstallCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -29,7 +29,7 @@ use Symfony\Component\Finder\Finder;
  * @author Francis Besset <francis.besset@gmail.com>
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class CacheClearCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class CacheWarmupCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  *
- * @final since version 3.4
+ * @final
  */
 class ConfigDebugCommand extends AbstractConfigCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * @author Wouter J <waldio.webdesign@gmail.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  *
- * @final since version 3.4
+ * @final
  */
 class ConfigDumpReferenceCommand extends AbstractConfigCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -29,7 +29,7 @@ use Symfony\Component\Config\FileLocator;
  *
  * @author Ryan Weaver <ryan@thatsquality.com>
  *
- * @internal since version 3.4
+ * @internal
  */
 class ContainerDebugCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  *
  * @author Matthieu Auger <mail@matthieuauger.com>
  *
- * @final since version 3.4
+ * @final
  */
 class EventDispatcherDebugCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -29,7 +29,7 @@ use Symfony\Component\Routing\Route;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
  *
- * @final since version 3.4
+ * @final
  */
 class RouterDebugCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -26,7 +26,7 @@ use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class RouterMatchCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -33,7 +33,7 @@ use Symfony\Component\Translation\TranslatorInterface;
  *
  * @author Florian Voutzinos <florian@voutzinos.com>
  *
- * @final since version 3.4
+ * @final
  */
 class TranslationDebugCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -31,7 +31,7 @@ use Symfony\Component\Translation\Writer\TranslationWriterInterface;
  *
  * @author Michel Salib <michelsalib@hotmail.com>
  *
- * @final since version 3.4
+ * @final
  */
 class TranslationUpdateCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Workflow\Marking;
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  *
- * @final since version 3.4
+ * @final
  */
 class WorkflowDumpCommand extends Command
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/XliffLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/XliffLintCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Translation\Command\XliffLintCommand as BaseLintCommand;
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  *
- * @final since version 3.4
+ * @final
  */
 class XliffLintCommand extends BaseLintCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Yaml\Command\LintCommand as BaseLintCommand;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Robin Chalas <robin.chalas@gmail.com>
  *
- * @final since version 3.4
+ * @final
  */
 class YamlLintCommand extends BaseLintCommand
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -31,7 +31,7 @@ abstract class Controller implements ContainerAwareInterface
      *
      * @return mixed
      *
-     * @final since version 3.4
+     * @final
      */
     protected function getParameter(string $name)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -42,7 +42,7 @@ trait ControllerTrait
     /**
      * Returns true if the service id is defined.
      *
-     * @final since version 3.4
+     * @final
      */
     protected function has(string $id): bool
     {
@@ -54,7 +54,7 @@ trait ControllerTrait
      *
      * @return object The service
      *
-     * @final since version 3.4
+     * @final
      */
     protected function get(string $id)
     {
@@ -66,7 +66,7 @@ trait ControllerTrait
      *
      * @see UrlGeneratorInterface
      *
-     * @final since version 3.4
+     * @final
      */
     protected function generateUrl(string $route, array $parameters = array(), int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
@@ -78,7 +78,7 @@ trait ControllerTrait
      *
      * @param string $controller The controller name (a string like BlogBundle:Post:index)
      *
-     * @final since version 3.4
+     * @final
      */
     protected function forward(string $controller, array $path = array(), array $query = array()): Response
     {
@@ -93,7 +93,7 @@ trait ControllerTrait
     /**
      * Returns a RedirectResponse to the given URL.
      *
-     * @final since version 3.4
+     * @final
      */
     protected function redirect(string $url, int $status = 302): RedirectResponse
     {
@@ -103,7 +103,7 @@ trait ControllerTrait
     /**
      * Returns a RedirectResponse to the given route with the given parameters.
      *
-     * @final since version 3.4
+     * @final
      */
     protected function redirectToRoute(string $route, array $parameters = array(), int $status = 302): RedirectResponse
     {
@@ -113,7 +113,7 @@ trait ControllerTrait
     /**
      * Returns a JsonResponse that uses the serializer component if enabled, or json_encode.
      *
-     * @final since version 3.4
+     * @final
      */
     protected function json($data, int $status = 200, array $headers = array(), array $context = array()): JsonResponse
     {
@@ -133,7 +133,7 @@ trait ControllerTrait
      *
      * @param \SplFileInfo|string $file File object or path to file to be sent as response
      *
-     * @final since version 3.4
+     * @final
      */
     protected function file($file, string $fileName = null, string $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT): BinaryFileResponse
     {
@@ -148,7 +148,7 @@ trait ControllerTrait
      *
      * @throws \LogicException
      *
-     * @final since version 3.4
+     * @final
      */
     protected function addFlash(string $type, string $message)
     {
@@ -164,7 +164,7 @@ trait ControllerTrait
      *
      * @throws \LogicException
      *
-     * @final since version 3.4
+     * @final
      */
     protected function isGranted($attributes, $subject = null): bool
     {
@@ -181,7 +181,7 @@ trait ControllerTrait
      *
      * @throws AccessDeniedException
      *
-     * @final since version 3.4
+     * @final
      */
     protected function denyAccessUnlessGranted($attributes, $subject = null, string $message = 'Access Denied.')
     {
@@ -197,7 +197,7 @@ trait ControllerTrait
     /**
      * Returns a rendered view.
      *
-     * @final since version 3.4
+     * @final
      */
     protected function renderView(string $view, array $parameters = array()): string
     {
@@ -215,7 +215,7 @@ trait ControllerTrait
     /**
      * Renders a view.
      *
-     * @final since version 3.4
+     * @final
      */
     protected function render(string $view, array $parameters = array(), Response $response = null): Response
     {
@@ -239,7 +239,7 @@ trait ControllerTrait
     /**
      * Streams a view.
      *
-     * @final since version 3.4
+     * @final
      */
     protected function stream(string $view, array $parameters = array(), StreamedResponse $response = null): StreamedResponse
     {
@@ -275,7 +275,7 @@ trait ControllerTrait
      *
      *     throw $this->createNotFoundException('Page not found!');
      *
-     * @final since version 3.4
+     * @final
      */
     protected function createNotFoundException(string $message = 'Not Found', \Exception $previous = null): NotFoundHttpException
     {
@@ -291,7 +291,7 @@ trait ControllerTrait
      *
      * @throws \LogicException If the Security component is not available
      *
-     * @final since version 3.4
+     * @final
      */
     protected function createAccessDeniedException(string $message = 'Access Denied.', \Exception $previous = null): AccessDeniedException
     {
@@ -305,7 +305,7 @@ trait ControllerTrait
     /**
      * Creates and returns a Form instance from the type of the form.
      *
-     * @final since version 3.4
+     * @final
      */
     protected function createForm(string $type, $data = null, array $options = array()): FormInterface
     {
@@ -315,7 +315,7 @@ trait ControllerTrait
     /**
      * Creates and returns a form builder instance.
      *
-     * @final since version 3.4
+     * @final
      */
     protected function createFormBuilder($data = null, array $options = array()): FormBuilderInterface
     {
@@ -327,7 +327,7 @@ trait ControllerTrait
      *
      * @throws \LogicException If DoctrineBundle is not available
      *
-     * @final since version 3.4
+     * @final
      */
     protected function getDoctrine(): ManagerRegistry
     {
@@ -347,7 +347,7 @@ trait ControllerTrait
      *
      * @see TokenInterface::getUser()
      *
-     * @final since version 3.4
+     * @final
      */
     protected function getUser()
     {
@@ -373,7 +373,7 @@ trait ControllerTrait
      * @param string      $id    The id used when generating the token
      * @param string|null $token The actual token sent with the request that should be validated
      *
-     * @final since version 3.4
+     * @final
      */
     protected function isCsrfTokenValid(string $id, ?string $token): bool
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -22,7 +22,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class RedirectController
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -20,7 +20,7 @@ use Twig\Environment;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class TemplateController
 {

--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Security\Core\Encoder\SelfSaltingEncoderInterface;
  *
  * @author Sarah Khalil <mkhalil.sarah@gmail.com>
  *
- * @final since version 3.4
+ * @final
  */
 class UserPasswordEncoderCommand extends Command
 {

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -212,7 +212,7 @@ class DebugClassLoaderTest extends TestCase
 
         $xError = array(
             'type' => E_USER_DEPRECATED,
-            'message' => 'The "Symfony\Component\Debug\Tests\Fixtures\FinalClass" class is considered final since version 3.3. It may change without further notice as of its next major version. You should not extend it from "Test\Symfony\Component\Debug\Tests\ExtendsFinalClass".',
+            'message' => 'The "Symfony\Component\Debug\Tests\Fixtures\FinalClass" class is considered final. It may change without further notice as of its next major version. You should not extend it from "Test\Symfony\Component\Debug\Tests\ExtendsFinalClass".',
         );
 
         $this->assertSame($xError, $lastError);
@@ -234,7 +234,7 @@ class DebugClassLoaderTest extends TestCase
 
         $xError = array(
             'type' => E_USER_DEPRECATED,
-            'message' => 'The "Symfony\Component\Debug\Tests\Fixtures\FinalMethod::finalMethod()" method is considered final since version 3.3. It may change without further notice as of its next major version. You should not extend it from "Symfony\Component\Debug\Tests\Fixtures\ExtendedFinalMethod".',
+            'message' => 'The "Symfony\Component\Debug\Tests\Fixtures\FinalMethod::finalMethod()" method is considered final. It may change without further notice as of its next major version. You should not extend it from "Symfony\Component\Debug\Tests\Fixtures\ExtendedFinalMethod".',
         );
 
         $this->assertSame($xError, $lastError);
@@ -269,10 +269,10 @@ class DebugClassLoaderTest extends TestCase
         restore_error_handler();
 
         $this->assertSame($deprecations, array(
-            'The "Symfony\Component\Debug\Tests\Fixtures\InternalClass" class is considered internal since version 3.4. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternalsParent".',
+            'The "Symfony\Component\Debug\Tests\Fixtures\InternalClass" class is considered internal. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternalsParent".',
             'The "Symfony\Component\Debug\Tests\Fixtures\InternalInterface" interface is considered internal. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternalsParent".',
             'The "Symfony\Component\Debug\Tests\Fixtures\InternalTrait" trait is considered internal. It may change without further notice. You should not use it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
-            'The "Symfony\Component\Debug\Tests\Fixtures\InternalTrait2::internalMethod()" method is considered internal since version 3.4. It may change without further notice. You should not extend it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
+            'The "Symfony\Component\Debug\Tests\Fixtures\InternalTrait2::internalMethod()" method is considered internal. It may change without further notice. You should not extend it from "Test\Symfony\Component\Debug\Tests\ExtendsInternals".',
         ));
     }
 }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/AnnotatedClass.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/AnnotatedClass.php
@@ -5,7 +5,7 @@ namespace Symfony\Component\Debug\Tests\Fixtures;
 class AnnotatedClass
 {
     /**
-     * @deprecated since version 3.4.
+     * @deprecated
      */
     public function deprecatedMethod()
     {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/FinalClass.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/FinalClass.php
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Debug\Tests\Fixtures;
 
 /**
- * @final since version 3.3.
+ * @final
  */
 class FinalClass
 {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/FinalMethod.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/FinalMethod.php
@@ -5,7 +5,7 @@ namespace Symfony\Component\Debug\Tests\Fixtures;
 class FinalMethod
 {
     /**
-     * @final since version 3.3.
+     * @final
      */
     public function finalMethod()
     {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalClass.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalClass.php
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Debug\Tests\Fixtures;
 
 /**
- * @internal since version 3.4.
+ * @internal
  */
 class InternalClass
 {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait2.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/InternalTrait2.php
@@ -8,7 +8,7 @@ namespace Symfony\Component\Debug\Tests\Fixtures;
 trait InternalTrait2
 {
     /**
-     * @internal since version 3.4
+     * @internal
      */
     public function internalMethod()
     {

--- a/src/Symfony/Component/Debug/Tests/phpt/debug_class_loader.phpt
+++ b/src/Symfony/Component/Debug/Tests/phpt/debug_class_loader.phpt
@@ -23,4 +23,4 @@ class_exists(ExtendedFinalMethod::class);
 
 ?>
 --EXPECTF--
-The "Symfony\Component\Debug\Tests\Fixtures\FinalMethod::finalMethod()" method is considered final since version 3.3. It may change without further notice as of its next major version. You should not extend it from "Symfony\Component\Debug\Tests\Fixtures\ExtendedFinalMethod".
+The "Symfony\Component\Debug\Tests\Fixtures\FinalMethod::finalMethod()" method is considered final. It may change without further notice as of its next major version. You should not extend it from "Symfony\Component\Debug\Tests\Fixtures\ExtendedFinalMethod".

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  *
- * @final since version 3.4
+ * @final
  */
 class ServiceReferenceGraph
 {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1397,7 +1397,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @return array An array of Service conditionals
      *
-     * @internal since version 3.4
+     * @internal
      */
     public static function getServiceConditionals($value)
     {

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/NullDumper.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Definition;
  *
  * @author Marco Pivetta <ocramius@gmail.com>
  *
- * @final since version 3.3
+ * @final
  */
 class NullDumper implements DumperInterface
 {

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -412,7 +412,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setProtocolVersion(string $version)
     {
@@ -424,7 +424,7 @@ class Response
     /**
      * Gets the HTTP protocol version.
      *
-     * @final since version 3.2
+     * @final
      */
     public function getProtocolVersion(): string
     {
@@ -441,7 +441,7 @@ class Response
      *
      * @throws \InvalidArgumentException When the HTTP status code is not valid
      *
-     * @final since version 3.2
+     * @final
      */
     public function setStatusCode(int $code, $text = null)
     {
@@ -470,7 +470,7 @@ class Response
     /**
      * Retrieves the status code for the current web response.
      *
-     * @final since version 3.2
+     * @final
      */
     public function getStatusCode(): int
     {
@@ -482,7 +482,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setCharset(string $charset)
     {
@@ -494,7 +494,7 @@ class Response
     /**
      * Retrieves the response charset.
      *
-     * @final since version 3.2
+     * @final
      */
     public function getCharset(): ?string
     {
@@ -510,7 +510,7 @@ class Response
      * Responses with neither a freshness lifetime (Expires, max-age) nor cache
      * validator (Last-Modified, ETag) are considered uncacheable.
      *
-     * @final since version 3.3
+     * @final
      */
     public function isCacheable(): bool
     {
@@ -532,7 +532,7 @@ class Response
      * origin. A response is considered fresh when it includes a Cache-Control/max-age
      * indicator or Expires header and the calculated age is less than the freshness lifetime.
      *
-     * @final since version 3.3
+     * @final
      */
     public function isFresh(): bool
     {
@@ -543,7 +543,7 @@ class Response
      * Returns true if the response includes headers that can be used to validate
      * the response with the origin server using a conditional GET request.
      *
-     * @final since version 3.3
+     * @final
      */
     public function isValidateable(): bool
     {
@@ -557,7 +557,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setPrivate()
     {
@@ -574,7 +574,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setPublic()
     {
@@ -620,7 +620,7 @@ class Response
      * When present, the TTL of the response should not be overridden to be
      * greater than the value provided by the origin.
      *
-     * @final since version 3.3
+     * @final
      */
     public function mustRevalidate(): bool
     {
@@ -632,7 +632,7 @@ class Response
      *
      * @throws \RuntimeException When the header is not parseable
      *
-     * @final since version 3.2
+     * @final
      */
     public function getDate(): ?\DateTimeInterface
     {
@@ -644,7 +644,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setDate(\DateTimeInterface $date)
     {
@@ -661,7 +661,7 @@ class Response
     /**
      * Returns the age of the response in seconds.
      *
-     * @final since version 3.2
+     * @final
      */
     public function getAge(): int
     {
@@ -689,7 +689,7 @@ class Response
     /**
      * Returns the value of the Expires header as a DateTime instance.
      *
-     * @final since version 3.2
+     * @final
      */
     public function getExpires(): ?\DateTimeInterface
     {
@@ -708,7 +708,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setExpires(\DateTimeInterface $date = null)
     {
@@ -735,7 +735,7 @@ class Response
      * First, it checks for a s-maxage directive, then a max-age directive, and then it falls
      * back on an expires header. It returns null when no maximum age can be established.
      *
-     * @final since version 3.2
+     * @final
      */
     public function getMaxAge(): ?int
     {
@@ -761,7 +761,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setMaxAge(int $value)
     {
@@ -777,7 +777,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setSharedMaxAge(int $value)
     {
@@ -795,7 +795,7 @@ class Response
      * When the responses TTL is <= 0, the response may not be served from cache without first
      * revalidating with the origin.
      *
-     * @final since version 3.2
+     * @final
      */
     public function getTtl(): ?int
     {
@@ -811,7 +811,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setTtl(int $seconds)
     {
@@ -827,7 +827,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setClientTtl(int $seconds)
     {
@@ -841,7 +841,7 @@ class Response
      *
      * @throws \RuntimeException When the HTTP header is not parseable
      *
-     * @final since version 3.2
+     * @final
      */
     public function getLastModified(): ?\DateTimeInterface
     {
@@ -855,7 +855,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setLastModified(\DateTimeInterface $date = null)
     {
@@ -878,7 +878,7 @@ class Response
     /**
      * Returns the literal value of the ETag HTTP header.
      *
-     * @final since version 3.2
+     * @final
      */
     public function getEtag(): ?string
     {
@@ -893,7 +893,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setEtag(string $etag = null, bool $weak = false)
     {
@@ -919,7 +919,7 @@ class Response
      *
      * @throws \InvalidArgumentException
      *
-     * @final since version 3.3
+     * @final
      */
     public function setCache(array $options)
     {
@@ -976,7 +976,7 @@ class Response
      *
      * @see http://tools.ietf.org/html/rfc2616#section-10.3.5
      *
-     * @final since version 3.3
+     * @final
      */
     public function setNotModified()
     {
@@ -994,7 +994,7 @@ class Response
     /**
      * Returns true if the response includes a Vary header.
      *
-     * @final since version 3.2
+     * @final
      */
     public function hasVary(): bool
     {
@@ -1004,7 +1004,7 @@ class Response
     /**
      * Returns an array of header names given in the Vary header.
      *
-     * @final since version 3.2
+     * @final
      */
     public function getVary(): array
     {
@@ -1028,7 +1028,7 @@ class Response
      *
      * @return $this
      *
-     * @final since version 3.2
+     * @final
      */
     public function setVary($headers, bool $replace = true)
     {
@@ -1046,7 +1046,7 @@ class Response
      *
      * @return bool true if the Response validators match the Request, false otherwise
      *
-     * @final since version 3.3
+     * @final
      */
     public function isNotModified(Request $request): bool
     {
@@ -1078,7 +1078,7 @@ class Response
      *
      * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
      *
-     * @final since version 3.2
+     * @final
      */
     public function isInvalid(): bool
     {
@@ -1088,7 +1088,7 @@ class Response
     /**
      * Is response informative?
      *
-     * @final since version 3.3
+     * @final
      */
     public function isInformational(): bool
     {
@@ -1098,7 +1098,7 @@ class Response
     /**
      * Is response successful?
      *
-     * @final since version 3.2
+     * @final
      */
     public function isSuccessful(): bool
     {
@@ -1108,7 +1108,7 @@ class Response
     /**
      * Is the response a redirect?
      *
-     * @final since version 3.2
+     * @final
      */
     public function isRedirection(): bool
     {
@@ -1118,7 +1118,7 @@ class Response
     /**
      * Is there a client error?
      *
-     * @final since version 3.2
+     * @final
      */
     public function isClientError(): bool
     {
@@ -1128,7 +1128,7 @@ class Response
     /**
      * Was there a server side error?
      *
-     * @final since version 3.3
+     * @final
      */
     public function isServerError(): bool
     {
@@ -1138,7 +1138,7 @@ class Response
     /**
      * Is the response OK?
      *
-     * @final since version 3.2
+     * @final
      */
     public function isOk(): bool
     {
@@ -1148,7 +1148,7 @@ class Response
     /**
      * Is the response forbidden?
      *
-     * @final since version 3.2
+     * @final
      */
     public function isForbidden(): bool
     {
@@ -1158,7 +1158,7 @@ class Response
     /**
      * Is the response a not found error?
      *
-     * @final since version 3.2
+     * @final
      */
     public function isNotFound(): bool
     {
@@ -1168,7 +1168,7 @@ class Response
     /**
      * Is the response a redirect of some form?
      *
-     * @final since version 3.2
+     * @final
      */
     public function isRedirect(string $location = null): bool
     {
@@ -1178,7 +1178,7 @@ class Response
     /**
      * Is the response empty?
      *
-     * @final since version 3.2
+     * @final
      */
     public function isEmpty(): bool
     {
@@ -1190,7 +1190,7 @@ class Response
      *
      * Resulting level can be greater than target level if a non-removable buffer has been encountered.
      *
-     * @final since version 3.3
+     * @final
      */
     public static function closeOutputBuffers(int $targetLevel, bool $flush)
     {
@@ -1212,7 +1212,7 @@ class Response
      *
      * @see http://support.microsoft.com/kb/323308
      *
-     * @final since version 3.3
+     * @final
      */
     protected function ensureIEOverSSLCompatibility(Request $request)
     {

--- a/src/Symfony/Component/HttpKernel/CacheClearer/ChainCacheClearer.php
+++ b/src/Symfony/Component/HttpKernel/CacheClearer/ChainCacheClearer.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpKernel\CacheClearer;
  *
  * @author Dustin Dobervich <ddobervich@gmail.com>
  *
- * @final since version 3.4
+ * @final
  */
 class ChainCacheClearer implements CacheClearerInterface
 {

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpKernel\CacheWarmer;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class CacheWarmerAggregate implements CacheWarmerInterface
 {

--- a/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
@@ -18,7 +18,7 @@ use Psr\Container\ContainerInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.3
+ * @final
  */
 class SessionListener extends AbstractSessionListener
 {

--- a/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
@@ -18,7 +18,7 @@ use Psr\Container\ContainerInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.3
+ * @final
  */
 class TestSessionListener extends AbstractTestSessionListener
 {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -192,7 +192,7 @@ class Process implements \IteratorAggregate
      * @throws RuntimeException When process stopped after receiving signal
      * @throws LogicException   In case a callback is provided and output has been disabled
      *
-     * @final since version 3.3
+     * @final
      */
     public function run(callable $callback = null, array $env = array()): int
     {
@@ -214,7 +214,7 @@ class Process implements \IteratorAggregate
      *
      * @throws ProcessFailedException if the process didn't terminate successfully
      *
-     * @final since version 3.3
+     * @final
      */
     public function mustRun(callable $callback = null, array $env = array())
     {
@@ -335,7 +335,7 @@ class Process implements \IteratorAggregate
      *
      * @see start()
      *
-     * @final since version 3.3
+     * @final
      */
     public function restart(callable $callback = null, array $env = array())
     {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -25,7 +25,7 @@ use Symfony\Component\PropertyInfo\Util\PhpDocTypeHelper;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @final since version 3.3
+ * @final
  */
 class PhpDocExtractor implements PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface
 {

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -22,7 +22,7 @@ use Symfony\Component\PropertyInfo\Type;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @final since version 3.3
+ * @final
  */
 class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface
 {

--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @final since version 3.3
+ * @final
  */
 class SerializerExtractor implements PropertyListExtractorInterface
 {

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -18,7 +18,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @final since version 3.3
+ * @final
  */
 class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface
 {

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\PropertyInfo;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @final since version 3.3
+ * @final
  */
 class PropertyInfoExtractor implements PropertyInfoExtractorInterface
 {

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\PropertyInfo;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
- * @final since version 3.3
+ * @final
  */
 class Type
 {

--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
@@ -30,7 +30,7 @@ use Symfony\Component\Security\Http\SecurityEvents;
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
  *
- * @final since version 3.4
+ * @final
  */
 class GuardAuthenticatorHandler
 {

--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  *
- * @final since version 3.3.
+ * @final
  */
 class ChainDecoder implements ContextAwareDecoderInterface
 {

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  *
- * @final since version 3.3.
+ * @final
  */
 class ChainEncoder implements ContextAwareEncoderInterface
 {

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -22,7 +22,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @author Alexander M. Turek <me@derrabus.de>
  *
- * @final since version 3.3.
+ * @final
  */
 class ArrayDenormalizer implements ContextAwareDenormalizerInterface, SerializerAwareInterface
 {

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Yaml;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class Dumper
 {

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -19,7 +19,7 @@ use Symfony\Component\Yaml\Tag\TaggedValue;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class Parser
 {

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -18,7 +18,7 @@ use Symfony\Component\Yaml\Exception\ParseException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @final since version 3.4
+ * @final
  */
 class Yaml
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

On 4.0+, I think we can removed the "since version 3.x" from `@final` and `@internal` annotations. I've kept them for things that reference version 4.x.
