### PR TITLE
[WebProfilerBundle] Fix anchor CSS

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -259,6 +259,6 @@ class CodeExtension extends AbstractExtension
             $line .= '</span>';
         }
 
-        return $line;
+        return trim($line);
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
@@ -68,7 +68,7 @@ a.doc:hover {
 
 .anchor {
     position: relative;
-    display: block;
+    display: inline;
     top: -7em;
     visibility: hidden;
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
@@ -68,7 +68,7 @@ a.doc:hover {
 
 .anchor {
     position: relative;
-    display: inline;
+    display: inline-block;
     top: -7em;
     visibility: hidden;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Empty source lines overlap in `/_profiler/open?file=x`. AFAIK it's a regression after #23296, but it's the first time i noticed so maybe it's related to a chrome change in between. No real CSS expert.. but this seems to fix it.

Before:
![image](https://user-images.githubusercontent.com/1047696/36377240-ba3f897a-1576-11e8-8660-8b04a6f7bd76.png)

After:
![image](https://user-images.githubusercontent.com/1047696/36377574-f99bd73a-1577-11e8-913c-d4287d5115a2.png)

I can confirm both chrome and firefox render as shown in the after screenshot. Firefox worked before as well, chrome not.

cc @ogizanagi 