### PR TITLE
[Lock] Add a TTL to refresh lock

### DIFF
--- a/src/Symfony/Component/Lock/LockInterface.php
+++ b/src/Symfony/Component/Lock/LockInterface.php
@@ -38,10 +38,12 @@ interface LockInterface
     /**
      * Increase the duration of an acquired lock.
      *
+     * @param float|null $ttl Maximum expected lock duration in seconds
+     *
      * @throws LockConflictedException If the lock is acquired by someone else
      * @throws LockAcquiringException  If the lock can not be refreshed
      */
-    public function refresh();
+    public function refresh(/* $ttl = null */);
 
     /**
      * Returns whether or not the lock is acquired.

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -97,6 +97,20 @@ class LockTest extends TestCase
         $lock->refresh();
     }
 
+    public function testRefreshCustom()
+    {
+        $key = new Key(uniqid(__METHOD__, true));
+        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $lock = new Lock($key, $store, 10);
+
+        $store
+            ->expects($this->once())
+            ->method('putOffExpiration')
+            ->with($key, 20);
+
+        $lock->refresh(20);
+    }
+
     public function testIsAquired()
     {
         $key = new Key(uniqid(__METHOD__, true));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | see LockInterface's comment
| Tests pass?   | yes
| Fixed tickets | NA
| License       | MIT
| Doc PR        | NA

Using remote locks in long processes needs to defines a fined grain refresh TTL. For instance, when looping over a long list of jobs we can extends the live of the lock by few seconds before processing each item.
But when the the jobs is splitted and each part to take the same time, we can not define the best TTL

Exemple

```php
$lock->acquire();

$this->2minutesJob();

$lock->refresh();
$this->5minutesJob();

$lock->refresh();
$this->1minutesJob();
```

The purpose of this PR is to be able to override the default TTL

```php
$lock->acquire();

$lock->refresh(120);
$this->2minutesJob();

$lock->refresh(300);
$this->5minutesJob();

$lock->refresh(60);
$this->1minutesJob();
```