### PR TITLE
[FrameworkBundle] use templates/ instead of views/

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
@@ -43,8 +43,15 @@ class TemplateReference extends BaseTemplateReference
         $controller = str_replace('\\', '/', $this->get('controller'));
 
         $path = (empty($controller) ? '' : $controller.'/').$this->get('name').'.'.$this->get('format').'.'.$this->get('engine');
+        if (empty($this->parameters['bundle'])) {
+            if (file_exists('views/')) {
+                return  'views/'.$path;
+            }
 
-        return empty($this->parameters['bundle']) ? 'views/'.$path : '@'.$this->get('bundle').'/Resources/views/'.$path;
+            return  '../templates/'.$path;
+        }
+
+        return '@'.$this->get('bundle').'/Resources/views/'.$path;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/templates/fragment.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/templates/fragment.html.php
@@ -1,0 +1,14 @@
+<?php echo $this->get('actions')->render($this->get('actions')->controller('TestBundle:Fragment:inlined', array(
+            'options' => array(
+                'bar' => $bar,
+                'eleven' => 11,
+            ),
+        )));
+?>--<?php
+        echo $this->get('actions')->render($this->get('actions')->controller('TestBundle:Fragment:customformat', array('_format' => 'html')));
+?>--<?php
+        echo $this->get('actions')->render($this->get('actions')->controller('TestBundle:Fragment:customlocale', array('_locale' => 'es')));
+?>--<?php
+        $app->getRequest()->setLocale('fr');
+        echo $this->get('actions')->render($this->get('actions')->controller('TestBundle:Fragment:forwardlocale'));
+?>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -62,15 +62,15 @@ class TemplateNameParserTest extends TestCase
             array('FooBundle:Post:index.xml.php', 'FooBundle:Post:index.xml.php', '@FooBundle/Resources/views/Post/index.xml.php', new TemplateReference('FooBundle', 'Post', 'index', 'xml', 'php')),
             array('SensioFooBundle:Post:index.html.php', 'SensioFooBundle:Post:index.html.php', '@SensioFooBundle/Resources/views/Post/index.html.php', new TemplateReference('SensioFooBundle', 'Post', 'index', 'html', 'php')),
             array('SensioCmsFooBundle:Post:index.html.php', 'SensioCmsFooBundle:Post:index.html.php', '@SensioCmsFooBundle/Resources/views/Post/index.html.php', new TemplateReference('SensioCmsFooBundle', 'Post', 'index', 'html', 'php')),
-            array(':Post:index.html.php', ':Post:index.html.php', 'views/Post/index.html.php', new TemplateReference('', 'Post', 'index', 'html', 'php')),
-            array('::index.html.php', '::index.html.php', 'views/index.html.php', new TemplateReference('', '', 'index', 'html', 'php')),
-            array('index.html.php', '::index.html.php', 'views/index.html.php', new TemplateReference('', '', 'index', 'html', 'php')),
+            array(':Post:index.html.php', ':Post:index.html.php', '../templates/Post/index.html.php', new TemplateReference('', 'Post', 'index', 'html', 'php')),
+            array('::index.html.php', '::index.html.php', '../templates/index.html.php', new TemplateReference('', '', 'index', 'html', 'php')),
+            array('index.html.php', '::index.html.php', '../templates/index.html.php', new TemplateReference('', '', 'index', 'html', 'php')),
             array('FooBundle:Post:foo.bar.index.html.php', 'FooBundle:Post:foo.bar.index.html.php', '@FooBundle/Resources/views/Post/foo.bar.index.html.php', new TemplateReference('FooBundle', 'Post', 'foo.bar.index', 'html', 'php')),
             array('@FooBundle/Resources/views/layout.html.twig', '@FooBundle/Resources/views/layout.html.twig', '@FooBundle/Resources/views/layout.html.twig', new BaseTemplateReference('@FooBundle/Resources/views/layout.html.twig', 'twig')),
             array('@FooBundle/Foo/layout.html.twig', '@FooBundle/Foo/layout.html.twig', '@FooBundle/Foo/layout.html.twig', new BaseTemplateReference('@FooBundle/Foo/layout.html.twig', 'twig')),
             array('name.twig', 'name.twig', 'name.twig', new BaseTemplateReference('name.twig', 'twig')),
             array('name', 'name', 'name', new BaseTemplateReference('name')),
-            array('default/index.html.php', '::default/index.html.php', 'views/default/index.html.php', new TemplateReference(null, null, 'default/index', 'html', 'php')),
+            array('default/index.html.php', '::default/index.html.php', '../templates/default/index.html.php', new TemplateReference(null, null, 'default/index', 'html', 'php')),
         );
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateTest.php
@@ -29,8 +29,8 @@ class TemplateTest extends TestCase
         return array(
             array(new TemplateReference('FooBundle', 'Post', 'index', 'html', 'php'), '@FooBundle/Resources/views/Post/index.html.php'),
             array(new TemplateReference('FooBundle', '', 'index', 'html', 'twig'), '@FooBundle/Resources/views/index.html.twig'),
-            array(new TemplateReference('', 'Post', 'index', 'html', 'php'), 'views/Post/index.html.php'),
-            array(new TemplateReference('', '', 'index', 'html', 'php'), 'views/index.html.php'),
+            array(new TemplateReference('', 'Post', 'index', 'html', 'php'), '../templates/Post/index.html.php'),
+            array(new TemplateReference('', '', 'index', 'html', 'php'), '../templates/index.html.php'),
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | no
| Fixed tickets | #26192
| License       | MIT
| Doc PR        |

Should we provide something in order to have `views` working with symfony >= 4.0?