### PR TITLE
[BrowserKit] fixed BC Break for HTTP_HOST header

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -259,11 +259,17 @@ abstract class Client
             ++$this->redirectCount;
         }
 
+        $originalUri = $uri;
+
         $uri = $this->getAbsoluteUri($uri);
 
         $server = array_merge($this->server, $server);
 
-        if (isset($server['HTTPS'])) {
+        if (!empty($server['HTTP_HOST']) && null === parse_url($originalUri, PHP_URL_HOST)) {
+            $uri = preg_replace('{^(https?\://)'.preg_quote($this->extractHost($uri)).'}', '${1}'.$server['HTTP_HOST'], $uri);
+        }
+
+        if (isset($server['HTTPS']) && null === parse_url($originalUri, PHP_URL_SCHEME)) {
             $uri = preg_replace('{^'.parse_url($uri, PHP_URL_SCHEME).'}', $server['HTTPS'] ? 'https' : 'http', $uri);
         }
 

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -622,7 +622,7 @@ class ClientTest extends TestCase
         $this->assertEquals('', $client->getServerParameter('HTTP_HOST'));
         $this->assertEquals('Symfony2 BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
 
-        $this->assertEquals('http://www.example.com/https/www.example.com', $client->getRequest()->getUri());
+        $this->assertEquals('https://www.example.com/https/www.example.com', $client->getRequest()->getUri());
 
         $server = $client->getRequest()->getServer();
 
@@ -636,7 +636,24 @@ class ClientTest extends TestCase
         $this->assertEquals('new-server-key-value', $server['NEW_SERVER_KEY']);
 
         $this->assertArrayHasKey('HTTPS', $server);
-        $this->assertFalse($server['HTTPS']);
+        $this->assertTrue($server['HTTPS']);
+    }
+
+    public function testRequestWithRelativeUri()
+    {
+        $client = new TestClient();
+
+        $client->request('GET', '/', array(), array(), array(
+            'HTTP_HOST' => 'testhost',
+            'HTTPS' => true,
+        ));
+        $this->assertEquals('https://testhost/', $client->getRequest()->getUri());
+
+        $client->request('GET', 'https://www.example.com/', array(), array(), array(
+            'HTTP_HOST' => 'testhost',
+            'HTTPS' => false,
+        ));
+        $this->assertEquals('https://www.example.com/', $client->getRequest()->getUri());
     }
 
     public function testInternalRequest()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7, 2.8, 3.x, 4.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #22933
| License       | MIT
| Doc PR        | n/a

The situation well described in the original issue. I will add only:

- #10549 - makes server parameters to take precedence over URI.
- #16265 - partially revererts  #10549. Makes server parameters do not affect URI. But this is only true for `Client::request()`. It is still possible to set host for URI by `Client::setServerParameters()` when URI is realative (see examples below).

I propose a compromise solution: add to HTTP_HOST header power to override URI when it is relative.

Proposed solution:
- if the request URI is relative, then use the HTTP_HOST header passed to Client::request() to generate an absolute URI
- if the request URI is absolute, then ignore the HTTP_HOST header (as it now works)
- do the same with HTTPS server parameter

Profit:
- fix BC Break
- the documentation will be correct
  - http://symfony.com/doc/2.8/routing/hostname_pattern.html#testing-your-controllers
  - https://symfony.com/doc/2.8/testing.html#testing-configuration

Before:

```
$client->setServerParameters(['HTTP_HOST' => 'example.com']);
$client->request('GET', '/');
$this->assertEquals('http://example.com/', $client->getRequest()->getUri());

$client->request('GET', '/', [], [], ['HTTP_HOST' => 'example.com']);
$this->assertEquals('http://localhost/', $client->getRequest()->getUri());
```

Fixed (see last line):

```
$client->setServerParameters(['HTTP_HOST' => 'example.com']);
$client->request('GET', '/');
$this->assertEquals('http://example.com/', $client->getRequest()->getUri());

$client->request('GET', '/', [], [], ['HTTP_HOST' => 'example.com']);
$this->assertEquals('http://example.com/', $client->getRequest()->getUri());
```