### PR TITLE
[Twig Bridge] Added country extension on twig-bridge

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CountryExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CountryExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * Provides translate country in ISO 3166-1 alpha 2 to country name.
+ *
+ * @author Rafael Mello <merorafael@gmail.com>
+ */
+class CountryExtension extends AbstractExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            new TwigFilter('country', array($this, 'getCountryName')),
+        );
+    }
+
+    /**
+     * Return the country name using the Locale class.
+     *
+     * @param string      $isoCode Country ISO 3166-1 alpha 2 code
+     * @param null|string $locale  Locale code
+     *
+     * @return null|string Country name
+     */
+    public function getCountryName($isoCode, $locale = null)
+    {
+        if ($isoCode === null) {
+            return;
+        }
+        if ($locale) {
+            \Locale::setDefault($locale);
+        }
+
+        return Intl::getRegionBundle()->getCountryName($isoCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'country_extension';
+    }
+}

--- a/src/Symfony/Bridge/Twig/Extension/CountryExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CountryExtension.php
@@ -1,12 +1,22 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\Twig\Extension;
 
+use Symfony\Component\Intl\Intl;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 /**
- * Provides translate country in ISO 3166-1 alpha 2 to country name.
+ * Translate country code in the ISO 3166-1 alpha 2 pattern to country name.
  *
  * @author Rafael Mello <merorafael@gmail.com>
  */
@@ -32,7 +42,7 @@ class CountryExtension extends AbstractExtension
      */
     public function getCountryName($isoCode, $locale = null)
     {
-        if ($isoCode === null) {
+        if (null === $isoCode) {
             return;
         }
         if ($locale) {

--- a/src/Symfony/Bridge/Twig/Tests/Extension/CountryExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/CountryExtensionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\CountryExtension;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader as TwigArrayLoader;
+
+class CountryExtensionTest extends TestCase
+{
+    protected function getTemplate($template)
+    {
+        if (is_array($template)) {
+            $loader = new TwigArrayLoader($template);
+        } else {
+            $loader = new TwigArrayLoader(array('index' => $template));
+        }
+
+        $twig = new Environment($loader, array('debug' => true, 'cache' => false));
+        $twig->addExtension(new CountryExtension());
+
+        return $twig->loadTemplate('index');
+    }
+
+    public static function dataProvider()
+    {
+        return [
+            ['US', 'United States'],
+            ['ES', 'Spain'],
+            ['PT', 'Portugal'],
+            ['BR', 'Brazil'],
+        ];
+    }
+
+    public function testEmptyCountryIso()
+    {
+        $output = $this->getTemplate("{{ ''|country }}")->render([]);
+        $this->assertEmpty($output);
+    }
+
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testGetCountryName($countryIso, $expected)
+    {
+        $output = $this->getTemplate("{{ '$countryIso'|country }}")->render([]);
+        $this->assertEquals($expected, $output);
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/CountryExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/CountryExtensionTest.php
@@ -25,27 +25,26 @@ class CountryExtensionTest extends TestCase
 
     public static function dataProvider()
     {
-        return [
-            ['US', 'United States'],
-            ['ES', 'Spain'],
-            ['PT', 'Portugal'],
-            ['BR', 'Brazil'],
-        ];
+        return array(
+            array('US', 'United States'),
+            array('ES', 'Spain'),
+            array('PT', 'Portugal'),
+            array('BR', 'Brazil'),
+        );
     }
 
     public function testEmptyCountryIso()
     {
-        $output = $this->getTemplate("{{ ''|country }}")->render([]);
+        $output = $this->getTemplate("{{ ''|country }}")->render(array());
         $this->assertEmpty($output);
     }
-
 
     /**
      * @dataProvider dataProvider
      */
     public function testGetCountryName($countryIso, $expected)
     {
-        $output = $this->getTemplate("{{ '$countryIso'|country }}")->render([]);
+        $output = $this->getTemplate("{{ '$countryIso'|country }}")->render(array());
         $this->assertEquals($expected, $output);
     }
 }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -38,7 +38,8 @@
         "symfony/var-dumper": "~3.4|~4.0",
         "symfony/expression-language": "~3.4|~4.0",
         "symfony/web-link": "~3.4|~4.0",
-        "symfony/workflow": "~3.4|~4.0"
+        "symfony/workflow": "~3.4|~4.0",
+        "symfony/intl": "~3.4|~4.0"
     },
     "conflict": {
         "symfony/form": "<3.4.5|<4.0.5,>=4.0",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "twig/twig": "^1.35|^2.4.4"
+        "twig/twig": "^1.35|^2.4.4",
+        "symfony/intl": "~3.4|~4.0"
     },
     "require-dev": {
         "symfony/asset": "~3.4|~4.0",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -17,8 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "twig/twig": "^1.35|^2.4.4",
-        "symfony/intl": "~3.4|~4.0"
+        "twig/twig": "^1.35|^2.4.4"
     },
     "require-dev": {
         "symfony/asset": "~3.4|~4.0",
@@ -58,7 +57,8 @@
         "symfony/stopwatch": "For using the StopwatchExtension",
         "symfony/var-dumper": "For using the DumpExtension",
         "symfony/expression-language": "For using the ExpressionExtension",
-        "symfony/web-link": "For using the WebLinkExtension"
+        "symfony/web-link": "For using the WebLinkExtension",
+        "symfony/intl": "For using the CountryExtension"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\Twig\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hello everybody,

I created an Twig extension for translate from country code in ISO 3166-1 alpha 2(pattern used on symfony-form CountryType) to country name. I did not find the documentation related to twig-bridge to send the PR, where should I commit?

Thanks,
Rafael Mello
