### PR TITLE
[Validator] Improvement: provide file basename for constr. violation messages in FileValidator.

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -138,10 +138,12 @@ class FileValidator extends ConstraintValidator
         }
 
         $sizeInBytes = filesize($path);
+        $basename = $value instanceof UploadedFile ? $value->getClientOriginalName() : basename($path);
 
         if (0 === $sizeInBytes) {
             $this->context->buildViolation($constraint->disallowEmptyMessage)
                 ->setParameter('{{ file }}', $this->formatValue($path))
+                ->setParameter('{{ name }}', $this->formatValue($basename))
                 ->setCode(File::EMPTY_ERROR)
                 ->addViolation();
 
@@ -158,6 +160,7 @@ class FileValidator extends ConstraintValidator
                     ->setParameter('{{ size }}', $sizeAsString)
                     ->setParameter('{{ limit }}', $limitAsString)
                     ->setParameter('{{ suffix }}', $suffix)
+                    ->setParameter('{{ name }}', $this->formatValue($basename))
                     ->setCode(File::TOO_LARGE_ERROR)
                     ->addViolation();
 
@@ -189,6 +192,7 @@ class FileValidator extends ConstraintValidator
                 ->setParameter('{{ file }}', $this->formatValue($path))
                 ->setParameter('{{ type }}', $this->formatValue($mime))
                 ->setParameter('{{ types }}', $this->formatValues($mimeTypes))
+                ->setParameter('{{ name }}', $this->formatValue($basename))
                 ->setCode(File::INVALID_MIME_TYPE_ERROR)
                 ->addViolation();
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -176,6 +176,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ size }}', $sizeAsString)
             ->setParameter('{{ suffix }}', $suffix)
             ->setParameter('{{ file }}', '"'.$this->path.'"')
+            ->setParameter('{{ name }}', '"'.basename($this->path).'"')
             ->setCode(File::TOO_LARGE_ERROR)
             ->assertRaised();
     }
@@ -278,6 +279,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ size }}', $sizeAsString)
             ->setParameter('{{ suffix }}', $suffix)
             ->setParameter('{{ file }}', '"'.$this->path.'"')
+            ->setParameter('{{ name }}', '"'.basename($this->path).'"')
             ->setCode(File::TOO_LARGE_ERROR)
             ->assertRaised();
     }
@@ -356,6 +358,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ type }}', '"application/pdf"')
             ->setParameter('{{ types }}', '"image/png", "image/jpg"')
             ->setParameter('{{ file }}', '"'.$this->path.'"')
+            ->setParameter('{{ name }}', '"'.basename($this->path).'"')
             ->setCode(File::INVALID_MIME_TYPE_ERROR)
             ->assertRaised();
     }
@@ -386,6 +389,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ type }}', '"application/pdf"')
             ->setParameter('{{ types }}', '"image/*", "image/jpg"')
             ->setParameter('{{ file }}', '"'.$this->path.'"')
+            ->setParameter('{{ name }}', '"'.basename($this->path).'"')
             ->setCode(File::INVALID_MIME_TYPE_ERROR)
             ->assertRaised();
     }
@@ -402,6 +406,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ file }}', '"'.$this->path.'"')
+            ->setParameter('{{ name }}', '"'.basename($this->path).'"')
             ->setCode(File::EMPTY_ERROR)
             ->assertRaised();
     }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | N/A

`\Symfony\Component\Validator\Constraints\FileValidator` provides absolute path to file on server when user, per example, uploads empty file, too large file, of wrong mime type, etc...

Absolute path to file on server does not have value to the end user, on top of that, exposing it can be a security issue - end user should not be aware of server filesystem.

Basename of file, however, has value (per example: MyAwesomeSheet.xlsx, MyCV.doc, etc..) - if something is wrong with file upload (size, mime, etc...).

If basename is exposed, we can construct messages like: "Your file 'MyCV.doc' is not allowed for upload due to....whatever"...

This PR provides basename of file so end user of `\Symfony\Component\Validator\Constraints\FileValidator` can construct error messages of higher value for end user.