### PR TITLE
[WebProfilerBundle] limit ajax request to 100 and remove the last one

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -122,6 +122,11 @@
                 return;
             }
 
+            var nbOfAjaxRequest = tbody.rows.count();
+            if (nbOfAjaxRequest >= 100) {
+                tbody.deleteRow(nbOfAjaxRequest - 1);
+            }
+
             var request = requestStack[index];
             pendingRequests++;
             var row = document.createElement('tr');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none fix merge
| License       | MIT


Merging back the bugfix to 3.4.