### PR TITLE
[Security][Profiler] Display the original expression in 'Access decision log'

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -317,7 +317,14 @@
                         </td>
                         <td>
                             {% if decision.attributes|length == 1 %}
-                                {{ decision.attributes|first }}
+                                {% set attribute = decision.attributes|first %}
+                                {% if attribute.expression is defined %}
+                                    Expression: <pre><code>{{ attribute.expression }}</code></pre>
+                                {% elseif attribute.type == 'string' %}
+                                    {{ attribute }}
+                                {% else %}
+                                     {{ profiler_dump(attribute) }}
+                                {% endif %}
                             {% else %}
                                 {{ profiler_dump(decision.attributes) }}
                             {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24127
| License       | MIT
| Doc PR        |

---

before:

![screenshot at 2018-02-22 18-22-28](https://user-images.githubusercontent.com/408368/36553752-798001ba-17fd-11e8-9539-254a25a01e60.png)


after:

![after](https://user-images.githubusercontent.com/408368/36553856-b7449fe2-17fd-11e8-94cb-ddaf4f033511.png)



