### PR TITLE
add container.autowiring.strict_mode to 3.4 docs

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -56,6 +56,15 @@ DependencyInjection
            autowire: true
     ```
 
+ * Autowiring services based on the types they implement is deprecated and will not be supported anymore in Symfony 4.0
+   where it will only match an alias or a service id that matches then given FQCN. You can opt in the behavior of Symfony
+   4 by the enabling the `container.autowiring.strict_mode` parameter:
+
+   ```yml
+   parameters:
+       container.autowiring.strict_mode: true
+   ```
+
  * Top-level anonymous services in XML are deprecated and will throw an exception in Symfony 4.0.
 
  * Case insensitivity of parameter names is deprecated and will be removed in 4.0.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

#26251 was a nice step, but IMO we need to add some docs to the 3.4 upgrade docs too as this is where people are probably looking first.