### PR TITLE
[Routing] Redirect from trailing slash to no-slash when possible

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
@@ -180,12 +180,6 @@ class StaticPrefixCollection
                 break;
             }
         }
-        if (1 < $i && '/' === $prefix[$i - 1]) {
-            --$i;
-        }
-        if (null !== $staticLength && 1 < $staticLength && '/' === $prefix[$staticLength - 1]) {
-            --$staticLength;
-        }
 
         return array(substr($prefix, 0, $i), substr($prefix, 0, $staticLength ?? $i));
     }

--- a/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
@@ -25,22 +25,21 @@ abstract class RedirectableUrlMatcher extends UrlMatcher implements Redirectable
     public function match($pathinfo)
     {
         try {
-            $parameters = parent::match($pathinfo);
+            return parent::match($pathinfo);
         } catch (ResourceNotFoundException $e) {
-            if ('/' === substr($pathinfo, -1) || !in_array($this->context->getMethod(), array('HEAD', 'GET'))) {
+            if ('/' === $pathinfo || !\in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
                 throw $e;
             }
 
             try {
-                $parameters = parent::match($pathinfo.'/');
+                $pathinfo = '/' !== $pathinfo[-1] ? $pathinfo.'/' : substr($pathinfo, 0, -1);
+                $ret = parent::match($pathinfo);
 
-                return array_replace($parameters, $this->redirect($pathinfo.'/', isset($parameters['_route']) ? $parameters['_route'] : null));
+                return $this->redirect($pathinfo, $ret['_route'] ?? null) + $ret;
             } catch (ResourceNotFoundException $e2) {
                 throw $e;
             }
         }
-
-        return $parameters;
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher0.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher0.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
         $host = strtolower($context->getHost());
@@ -82,41 +81,41 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         .'|/([^/]++)(*:57)'
                         .'|head/([^/]++)(*:77)'
                     .')'
-                    .'|/test/([^/]++)(?'
-                        .'|/(*:103)'
+                    .'|/test/([^/]++)/(?'
+                        .'|(*:103)'
                     .')'
                     .'|/([\']+)(*:119)'
-                    .'|/a(?'
-                        .'|/b\'b/([^/]++)(?'
+                    .'|/a/(?'
+                        .'|b\'b/([^/]++)(?'
                             .'|(*:148)'
                             .'|(*:156)'
                         .')'
-                        .'|/(.*)(*:170)'
-                        .'|/b\'b/([^/]++)(?'
-                            .'|(*:194)'
-                            .'|(*:202)'
+                        .'|(.*)(*:169)'
+                        .'|b\'b/([^/]++)(?'
+                            .'|(*:192)'
+                            .'|(*:200)'
                         .')'
                     .')'
-                    .'|/multi/hello(?:/([^/]++))?(*:238)'
+                    .'|/multi/hello(?:/([^/]++))?(*:236)'
                     .'|/([^/]++)/b/([^/]++)(?'
-                        .'|(*:269)'
-                        .'|(*:277)'
+                        .'|(*:267)'
+                        .'|(*:275)'
                     .')'
-                    .'|/aba/([^/]++)(*:299)'
+                    .'|/aba/([^/]++)(*:297)'
                 .')|(?i:([^\\.]++)\\.example\\.com)(?'
                     .'|/route1(?'
-                        .'|3/([^/]++)(*:359)'
-                        .'|4/([^/]++)(*:377)'
+                        .'|3/([^/]++)(*:357)'
+                        .'|4/([^/]++)(*:375)'
                     .')'
                 .')|(?i:c\\.example\\.com)(?'
-                    .'|/route15/([^/]++)(*:427)'
+                    .'|/route15/([^/]++)(*:425)'
                 .')|[^/]*+(?'
-                    .'|/route16/([^/]++)(*:462)'
-                    .'|/a(?'
-                        .'|/a\\.\\.\\.(*:483)'
-                        .'|/b(?'
-                            .'|/([^/]++)(*:505)'
-                            .'|/c/([^/]++)(*:524)'
+                    .'|/route16/([^/]++)(*:460)'
+                    .'|/a/(?'
+                        .'|a\\.\\.\\.(*:481)'
+                        .'|b/(?'
+                            .'|([^/]++)(*:502)'
+                            .'|c/([^/]++)(*:520)'
                         .')'
                     .')'
                 .')'
@@ -130,10 +129,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         $matches = array('foo' => $matches[1] ?? null);
 
                         // baz4
-                        return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array());
+                        return $this->mergeDefaults(array('_route' => 'baz4') + $matches, array());
 
                         // baz5
-                        $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array());
+                        $ret = $this->mergeDefaults(array('_route' => 'baz5') + $matches, array());
                         if (!isset(($a = array('POST' => 0))[$requestMethod])) {
                             $allow += $a;
                             goto not_baz5;
@@ -143,7 +142,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         not_baz5:
 
                         // baz.baz6
-                        $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array());
+                        $ret = $this->mergeDefaults(array('_route' => 'baz.baz6') + $matches, array());
                         if (!isset(($a = array('PUT' => 0))[$requestMethod])) {
                             $allow += $a;
                             goto not_bazbaz6;
@@ -157,7 +156,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         $matches = array('foo' => $matches[1] ?? null);
 
                         // foo1
-                        $ret = $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array());
+                        $ret = $this->mergeDefaults(array('_route' => 'foo1') + $matches, array());
                         if (!isset(($a = array('PUT' => 0))[$requestMethod])) {
                             $allow += $a;
                             goto not_foo1;
@@ -167,18 +166,18 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         not_foo1:
 
                         break;
-                    case 194:
+                    case 192:
                         $matches = array('foo1' => $matches[1] ?? null);
 
                         // foo2
-                        return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array());
+                        return $this->mergeDefaults(array('_route' => 'foo2') + $matches, array());
 
                         break;
-                    case 269:
+                    case 267:
                         $matches = array('_locale' => $matches[1] ?? null, 'foo' => $matches[2] ?? null);
 
                         // foo3
-                        return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array());
+                        return $this->mergeDefaults(array('_route' => 'foo3') + $matches, array());
 
                         break;
                     default:
@@ -188,18 +187,18 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                             77 => array(array('_route' => 'barhead'), array('foo'), array('GET' => 0), null),
                             119 => array(array('_route' => 'quoter'), array('quoter'), null, null),
                             156 => array(array('_route' => 'bar1'), array('bar'), null, null),
-                            170 => array(array('_route' => 'overridden'), array('var'), null, null),
-                            202 => array(array('_route' => 'bar2'), array('bar1'), null, null),
-                            238 => array(array('_route' => 'helloWorld', 'who' => 'World!'), array('who'), null, null),
-                            277 => array(array('_route' => 'bar3'), array('_locale', 'bar'), null, null),
-                            299 => array(array('_route' => 'foo4'), array('foo'), null, null),
-                            359 => array(array('_route' => 'route13'), array('var1', 'name'), null, null),
-                            377 => array(array('_route' => 'route14', 'var1' => 'val'), array('var1', 'name'), null, null),
-                            427 => array(array('_route' => 'route15'), array('name'), null, null),
-                            462 => array(array('_route' => 'route16', 'var1' => 'val'), array('name'), null, null),
-                            483 => array(array('_route' => 'a'), array(), null, null),
-                            505 => array(array('_route' => 'b'), array('var'), null, null),
-                            524 => array(array('_route' => 'c'), array('var'), null, null),
+                            169 => array(array('_route' => 'overridden'), array('var'), null, null),
+                            200 => array(array('_route' => 'bar2'), array('bar1'), null, null),
+                            236 => array(array('_route' => 'helloWorld', 'who' => 'World!'), array('who'), null, null),
+                            275 => array(array('_route' => 'bar3'), array('_locale', 'bar'), null, null),
+                            297 => array(array('_route' => 'foo4'), array('foo'), null, null),
+                            357 => array(array('_route' => 'route13'), array('var1', 'name'), null, null),
+                            375 => array(array('_route' => 'route14', 'var1' => 'val'), array('var1', 'name'), null, null),
+                            425 => array(array('_route' => 'route15'), array('name'), null, null),
+                            460 => array(array('_route' => 'route16', 'var1' => 'val'), array('name'), null, null),
+                            481 => array(array('_route' => 'a'), array(), null, null),
+                            502 => array(array('_route' => 'b'), array('var'), null, null),
+                            520 => array(array('_route' => 'c'), array('var'), null, null),
                         );
 
                         list($ret, $vars, $requiredMethods, $requiredSchemes) = $routes[$m];
@@ -218,7 +217,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         return $ret;
                 }
 
-                if (524 === $m) {
+                if (520 === $m) {
                     break;
                 }
                 $regex = substr_replace($regex, 'F', $m - $offset, 1 + strlen($m));

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher10.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher10.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher11.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher11.php
@@ -15,11 +15,26 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $this->context = $context;
     }
 
-    public function match($rawPathinfo)
+    public function match($pathinfo)
+    {
+        $allow = array();
+        if ($ret = $this->doMatch($pathinfo, $allow)) {
+            return $ret;
+        }
+        if ('/' !== $pathinfo && in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
+            $pathinfo = '/' !== $pathinfo[-1] ? $pathinfo.'/' : substr($pathinfo, 0, -1);
+            if ($ret = $this->doMatch($pathinfo)) {
+                return $this->redirect($pathinfo, $ret['_route']) + $ret;
+            }
+        }
+
+        throw $allow ? new MethodNotAllowedException(array_keys($allow)) : new ResourceNotFoundException();
+    }
+
+    private function doMatch(string $rawPathinfo, array &$allow = array()): ?array
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
 
@@ -30,32 +45,34 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $matchedPathinfo = $pathinfo;
         $regexList = array(
             0 => '{^(?'
-                    .'|/(en|fr)(?'
-                        .'|/admin/post(?'
-                            .'|/?(*:34)'
-                            .'|/new(*:45)'
-                            .'|/(\\d+)(?'
-                                .'|(*:61)'
-                                .'|/edit(*:73)'
-                                .'|/delete(*:87)'
+                    .'|/(en|fr)/(?'
+                        .'|admin/post/(?'
+                            .'|(*:33)'
+                            .'|new(*:43)'
+                            .'|(\\d+)(?'
+                                .'|(*:58)'
+                                .'|/(?'
+                                    .'|edit(*:73)'
+                                    .'|delete(*:86)'
+                                .')'
                             .')'
                         .')'
-                        .'|/blog(?'
-                            .'|/?(*:106)'
-                            .'|/rss\\.xml(*:123)'
-                            .'|/p(?'
-                                .'|age/([^/]++)(*:148)'
-                                .'|osts/([^/]++)(*:169)'
+                        .'|blog/(?'
+                            .'|(*:104)'
+                            .'|rss\\.xml(*:120)'
+                            .'|p(?'
+                                .'|age/([^/]++)(*:144)'
+                                .'|osts/([^/]++)(*:165)'
                             .')'
-                            .'|/comments/(\\d+)/new(*:197)'
-                            .'|/search(*:212)'
+                            .'|comments/(\\d+)/new(*:192)'
+                            .'|search(*:206)'
                         .')'
-                        .'|/log(?'
-                            .'|in(*:230)'
-                            .'|out(*:241)'
+                        .'|log(?'
+                            .'|in(*:223)'
+                            .'|out(*:234)'
                         .')'
                     .')'
-                    .'|/(en|fr)?(*:260)'
+                    .'|/(en|fr)?(*:253)'
                 .')$}sD',
         );
 
@@ -64,20 +81,20 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                 switch ($m = (int) $matches['MARK']) {
                     default:
                         $routes = array(
-                            34 => array(array('_route' => 'a', '_locale' => 'en'), array('_locale'), null, null, true),
-                            45 => array(array('_route' => 'b', '_locale' => 'en'), array('_locale'), null, null),
-                            61 => array(array('_route' => 'c', '_locale' => 'en'), array('_locale', 'id'), null, null),
+                            33 => array(array('_route' => 'a', '_locale' => 'en'), array('_locale'), null, null),
+                            43 => array(array('_route' => 'b', '_locale' => 'en'), array('_locale'), null, null),
+                            58 => array(array('_route' => 'c', '_locale' => 'en'), array('_locale', 'id'), null, null),
                             73 => array(array('_route' => 'd', '_locale' => 'en'), array('_locale', 'id'), null, null),
-                            87 => array(array('_route' => 'e', '_locale' => 'en'), array('_locale', 'id'), null, null),
-                            106 => array(array('_route' => 'f', '_locale' => 'en'), array('_locale'), null, null, true),
-                            123 => array(array('_route' => 'g', '_locale' => 'en'), array('_locale'), null, null),
-                            148 => array(array('_route' => 'h', '_locale' => 'en'), array('_locale', 'page'), null, null),
-                            169 => array(array('_route' => 'i', '_locale' => 'en'), array('_locale', 'page'), null, null),
-                            197 => array(array('_route' => 'j', '_locale' => 'en'), array('_locale', 'id'), null, null),
-                            212 => array(array('_route' => 'k', '_locale' => 'en'), array('_locale'), null, null),
-                            230 => array(array('_route' => 'l', '_locale' => 'en'), array('_locale'), null, null),
-                            241 => array(array('_route' => 'm', '_locale' => 'en'), array('_locale'), null, null),
-                            260 => array(array('_route' => 'n', '_locale' => 'en'), array('_locale'), null, null),
+                            86 => array(array('_route' => 'e', '_locale' => 'en'), array('_locale', 'id'), null, null),
+                            104 => array(array('_route' => 'f', '_locale' => 'en'), array('_locale'), null, null),
+                            120 => array(array('_route' => 'g', '_locale' => 'en'), array('_locale'), null, null),
+                            144 => array(array('_route' => 'h', '_locale' => 'en'), array('_locale', 'page'), null, null),
+                            165 => array(array('_route' => 'i', '_locale' => 'en'), array('_locale', 'page'), null, null),
+                            192 => array(array('_route' => 'j', '_locale' => 'en'), array('_locale', 'id'), null, null),
+                            206 => array(array('_route' => 'k', '_locale' => 'en'), array('_locale'), null, null),
+                            223 => array(array('_route' => 'l', '_locale' => 'en'), array('_locale'), null, null),
+                            234 => array(array('_route' => 'm', '_locale' => 'en'), array('_locale'), null, null),
+                            253 => array(array('_route' => 'n', '_locale' => 'en'), array('_locale'), null, null),
                         );
 
                         list($ret, $vars, $requiredMethods, $requiredSchemes) = $routes[$m];
@@ -88,22 +105,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                             }
                         }
 
-                        if (empty($routes[$m][4]) || '/' === $pathinfo[-1]) {
-                            // no-op
-                        } elseif ('GET' !== $canonicalMethod) {
-                            $allow['GET'] = 'GET';
-                            break;
-                        } else {
-                            return array_replace($ret, $this->redirect($rawPathinfo.'/', $ret['_route']));
-                        }
-
                         if ($requiredSchemes && !isset($requiredSchemes[$context->getScheme()])) {
                             if ('GET' !== $canonicalMethod) {
                                 $allow['GET'] = 'GET';
                                 break;
                             }
 
-                            return array_replace($ret, $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)));
+                            return $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)) + $ret;
                         }
 
                         if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
@@ -114,7 +122,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                         return $ret;
                 }
 
-                if (260 === $m) {
+                if (253 === $m) {
                     break;
                 }
                 $regex = substr_replace($regex, 'F', $m - $offset, 1 + strlen($m));
@@ -122,6 +130,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             }
         }
 
-        throw $allow ? new MethodNotAllowedException(array_keys($allow)) : new ResourceNotFoundException();
+        return null;
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher12.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher12.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
 
@@ -30,19 +29,19 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $matchedPathinfo = $pathinfo;
         $regexList = array(
             0 => '{^(?'
-                    .'|/abc([^/]++)(?'
-                        .'|/1(?'
+                    .'|/abc([^/]++)/(?'
+                        .'|1(?'
                             .'|(*:27)'
                             .'|0(?'
                                 .'|(*:38)'
                                 .'|0(*:46)'
                             .')'
                         .')'
-                        .'|/2(?'
-                            .'|(*:60)'
+                        .'|2(?'
+                            .'|(*:59)'
                             .'|0(?'
-                                .'|(*:71)'
-                                .'|0(*:79)'
+                                .'|(*:70)'
+                                .'|0(*:78)'
                             .')'
                         .')'
                     .')'
@@ -57,9 +56,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                             27 => array(array('_route' => 'r1'), array('foo'), null, null),
                             38 => array(array('_route' => 'r10'), array('foo'), null, null),
                             46 => array(array('_route' => 'r100'), array('foo'), null, null),
-                            60 => array(array('_route' => 'r2'), array('foo'), null, null),
-                            71 => array(array('_route' => 'r20'), array('foo'), null, null),
-                            79 => array(array('_route' => 'r200'), array('foo'), null, null),
+                            59 => array(array('_route' => 'r2'), array('foo'), null, null),
+                            70 => array(array('_route' => 'r20'), array('foo'), null, null),
+                            78 => array(array('_route' => 'r200'), array('foo'), null, null),
                         );
 
                         list($ret, $vars, $requiredMethods, $requiredSchemes) = $routes[$m];
@@ -78,7 +77,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         return $ret;
                 }
 
-                if (79 === $m) {
+                if (78 === $m) {
                     break;
                 }
                 $regex = substr_replace($regex, 'F', $m - $offset, 1 + strlen($m));

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher13.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher13.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
         $host = strtolower($context->getHost());
@@ -46,10 +45,10 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         $matches = array('foo' => $matches[1] ?? null, 'foo' => $matches[2] ?? null);
 
                         // r1
-                        return $this->mergeDefaults(array_replace($matches, array('_route' => 'r1')), array());
+                        return $this->mergeDefaults(array('_route' => 'r1') + $matches, array());
 
                         // r2
-                        return $this->mergeDefaults(array_replace($matches, array('_route' => 'r2')), array());
+                        return $this->mergeDefaults(array('_route' => 'r2') + $matches, array());
 
                         break;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher6.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher6.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
 
@@ -56,17 +55,17 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $matchedPathinfo = $pathinfo;
         $regexList = array(
             0 => '{^(?'
-                    .'|/trailing/regex(?'
-                        .'|/no\\-methods/([^/]++)/(*:47)'
-                        .'|/get\\-method/([^/]++)/(*:76)'
-                        .'|/head\\-method/([^/]++)/(*:106)'
-                        .'|/post\\-method/([^/]++)/(*:137)'
+                    .'|/trailing/regex/(?'
+                        .'|no\\-methods/([^/]++)/(*:47)'
+                        .'|get\\-method/([^/]++)/(*:75)'
+                        .'|head\\-method/([^/]++)/(*:104)'
+                        .'|post\\-method/([^/]++)/(*:134)'
                     .')'
-                    .'|/not\\-trailing/regex(?'
-                        .'|/no\\-methods/([^/]++)(*:190)'
-                        .'|/get\\-method/([^/]++)(*:219)'
-                        .'|/head\\-method/([^/]++)(*:249)'
-                        .'|/post\\-method/([^/]++)(*:279)'
+                    .'|/not\\-trailing/regex/(?'
+                        .'|no\\-methods/([^/]++)(*:187)'
+                        .'|get\\-method/([^/]++)(*:215)'
+                        .'|head\\-method/([^/]++)(*:244)'
+                        .'|post\\-method/([^/]++)(*:273)'
                     .')'
                 .')$}sD',
         );
@@ -77,13 +76,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     default:
                         $routes = array(
                             47 => array(array('_route' => 'regex_trailing_slash_no_methods'), array('param'), null, null),
-                            76 => array(array('_route' => 'regex_trailing_slash_GET_method'), array('param'), array('GET' => 0), null),
-                            106 => array(array('_route' => 'regex_trailing_slash_HEAD_method'), array('param'), array('HEAD' => 0), null),
-                            137 => array(array('_route' => 'regex_trailing_slash_POST_method'), array('param'), array('POST' => 0), null),
-                            190 => array(array('_route' => 'regex_not_trailing_slash_no_methods'), array('param'), null, null),
-                            219 => array(array('_route' => 'regex_not_trailing_slash_GET_method'), array('param'), array('GET' => 0), null),
-                            249 => array(array('_route' => 'regex_not_trailing_slash_HEAD_method'), array('param'), array('HEAD' => 0), null),
-                            279 => array(array('_route' => 'regex_not_trailing_slash_POST_method'), array('param'), array('POST' => 0), null),
+                            75 => array(array('_route' => 'regex_trailing_slash_GET_method'), array('param'), array('GET' => 0), null),
+                            104 => array(array('_route' => 'regex_trailing_slash_HEAD_method'), array('param'), array('HEAD' => 0), null),
+                            134 => array(array('_route' => 'regex_trailing_slash_POST_method'), array('param'), array('POST' => 0), null),
+                            187 => array(array('_route' => 'regex_not_trailing_slash_no_methods'), array('param'), null, null),
+                            215 => array(array('_route' => 'regex_not_trailing_slash_GET_method'), array('param'), array('GET' => 0), null),
+                            244 => array(array('_route' => 'regex_not_trailing_slash_HEAD_method'), array('param'), array('HEAD' => 0), null),
+                            273 => array(array('_route' => 'regex_not_trailing_slash_POST_method'), array('param'), array('POST' => 0), null),
                         );
 
                         list($ret, $vars, $requiredMethods, $requiredSchemes) = $routes[$m];
@@ -102,7 +101,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                         return $ret;
                 }
 
-                if (279 === $m) {
+                if (273 === $m) {
                     break;
                 }
                 $regex = substr_replace($regex, 'F', $m - $offset, 1 + strlen($m));

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher7.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher7.php
@@ -15,11 +15,26 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $this->context = $context;
     }
 
-    public function match($rawPathinfo)
+    public function match($pathinfo)
+    {
+        $allow = array();
+        if ($ret = $this->doMatch($pathinfo, $allow)) {
+            return $ret;
+        }
+        if ('/' !== $pathinfo && in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
+            $pathinfo = '/' !== $pathinfo[-1] ? $pathinfo.'/' : substr($pathinfo, 0, -1);
+            if ($ret = $this->doMatch($pathinfo)) {
+                return $this->redirect($pathinfo, $ret['_route']) + $ret;
+            }
+        }
+
+        throw $allow ? new MethodNotAllowedException(array_keys($allow)) : new ResourceNotFoundException();
+    }
+
+    private function doMatch(string $rawPathinfo, array &$allow = array()): ?array
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
 
@@ -27,32 +42,23 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             $canonicalMethod = 'GET';
         }
 
-        switch ($trimmedPathinfo) {
+        switch ($pathinfo) {
             default:
                 $routes = array(
-                    '/trailing/simple/no-methods' => array(array('_route' => 'simple_trailing_slash_no_methods'), null, null, null, true),
-                    '/trailing/simple/get-method' => array(array('_route' => 'simple_trailing_slash_GET_method'), null, array('GET' => 0), null, true),
-                    '/trailing/simple/head-method' => array(array('_route' => 'simple_trailing_slash_HEAD_method'), null, array('HEAD' => 0), null, true),
-                    '/trailing/simple/post-method' => array(array('_route' => 'simple_trailing_slash_POST_method'), null, array('POST' => 0), null, true),
+                    '/trailing/simple/no-methods/' => array(array('_route' => 'simple_trailing_slash_no_methods'), null, null, null),
+                    '/trailing/simple/get-method/' => array(array('_route' => 'simple_trailing_slash_GET_method'), null, array('GET' => 0), null),
+                    '/trailing/simple/head-method/' => array(array('_route' => 'simple_trailing_slash_HEAD_method'), null, array('HEAD' => 0), null),
+                    '/trailing/simple/post-method/' => array(array('_route' => 'simple_trailing_slash_POST_method'), null, array('POST' => 0), null),
                     '/not-trailing/simple/no-methods' => array(array('_route' => 'simple_not_trailing_slash_no_methods'), null, null, null),
                     '/not-trailing/simple/get-method' => array(array('_route' => 'simple_not_trailing_slash_GET_method'), null, array('GET' => 0), null),
                     '/not-trailing/simple/head-method' => array(array('_route' => 'simple_not_trailing_slash_HEAD_method'), null, array('HEAD' => 0), null),
                     '/not-trailing/simple/post-method' => array(array('_route' => 'simple_not_trailing_slash_POST_method'), null, array('POST' => 0), null),
                 );
 
-                if (!isset($routes[$trimmedPathinfo])) {
+                if (!isset($routes[$pathinfo])) {
                     break;
                 }
-                list($ret, $requiredHost, $requiredMethods, $requiredSchemes) = $routes[$trimmedPathinfo];
-
-                if (empty($routes[$trimmedPathinfo][4]) || '/' === $pathinfo[-1]) {
-                    // no-op
-                } elseif ('GET' !== $canonicalMethod) {
-                    $allow['GET'] = 'GET';
-                    break;
-                } else {
-                    return array_replace($ret, $this->redirect($rawPathinfo.'/', $ret['_route']));
-                }
+                list($ret, $requiredHost, $requiredMethods, $requiredSchemes) = $routes[$pathinfo];
 
                 if ($requiredSchemes && !isset($requiredSchemes[$context->getScheme()])) {
                     if ('GET' !== $canonicalMethod) {
@@ -60,7 +66,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                         break;
                     }
 
-                    return array_replace($ret, $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)));
+                    return $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)) + $ret;
                 }
 
                 if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
@@ -74,17 +80,17 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $matchedPathinfo = $pathinfo;
         $regexList = array(
             0 => '{^(?'
-                    .'|/trailing/regex(?'
-                        .'|/no\\-methods/([^/]++)/?(*:48)'
-                        .'|/get\\-method/([^/]++)/?(*:78)'
-                        .'|/head\\-method/([^/]++)/(*:108)'
-                        .'|/post\\-method/([^/]++)/(*:139)'
+                    .'|/trailing/regex/(?'
+                        .'|no\\-methods/([^/]++)/(*:47)'
+                        .'|get\\-method/([^/]++)/(*:75)'
+                        .'|head\\-method/([^/]++)/(*:104)'
+                        .'|post\\-method/([^/]++)/(*:134)'
                     .')'
-                    .'|/not\\-trailing/regex(?'
-                        .'|/no\\-methods/([^/]++)(*:192)'
-                        .'|/get\\-method/([^/]++)(*:221)'
-                        .'|/head\\-method/([^/]++)(*:251)'
-                        .'|/post\\-method/([^/]++)(*:281)'
+                    .'|/not\\-trailing/regex/(?'
+                        .'|no\\-methods/([^/]++)(*:187)'
+                        .'|get\\-method/([^/]++)(*:215)'
+                        .'|head\\-method/([^/]++)(*:244)'
+                        .'|post\\-method/([^/]++)(*:273)'
                     .')'
                 .')$}sD',
         );
@@ -94,14 +100,14 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                 switch ($m = (int) $matches['MARK']) {
                     default:
                         $routes = array(
-                            48 => array(array('_route' => 'regex_trailing_slash_no_methods'), array('param'), null, null, true),
-                            78 => array(array('_route' => 'regex_trailing_slash_GET_method'), array('param'), array('GET' => 0), null, true),
-                            108 => array(array('_route' => 'regex_trailing_slash_HEAD_method'), array('param'), array('HEAD' => 0), null),
-                            139 => array(array('_route' => 'regex_trailing_slash_POST_method'), array('param'), array('POST' => 0), null),
-                            192 => array(array('_route' => 'regex_not_trailing_slash_no_methods'), array('param'), null, null),
-                            221 => array(array('_route' => 'regex_not_trailing_slash_GET_method'), array('param'), array('GET' => 0), null),
-                            251 => array(array('_route' => 'regex_not_trailing_slash_HEAD_method'), array('param'), array('HEAD' => 0), null),
-                            281 => array(array('_route' => 'regex_not_trailing_slash_POST_method'), array('param'), array('POST' => 0), null),
+                            47 => array(array('_route' => 'regex_trailing_slash_no_methods'), array('param'), null, null),
+                            75 => array(array('_route' => 'regex_trailing_slash_GET_method'), array('param'), array('GET' => 0), null),
+                            104 => array(array('_route' => 'regex_trailing_slash_HEAD_method'), array('param'), array('HEAD' => 0), null),
+                            134 => array(array('_route' => 'regex_trailing_slash_POST_method'), array('param'), array('POST' => 0), null),
+                            187 => array(array('_route' => 'regex_not_trailing_slash_no_methods'), array('param'), null, null),
+                            215 => array(array('_route' => 'regex_not_trailing_slash_GET_method'), array('param'), array('GET' => 0), null),
+                            244 => array(array('_route' => 'regex_not_trailing_slash_HEAD_method'), array('param'), array('HEAD' => 0), null),
+                            273 => array(array('_route' => 'regex_not_trailing_slash_POST_method'), array('param'), array('POST' => 0), null),
                         );
 
                         list($ret, $vars, $requiredMethods, $requiredSchemes) = $routes[$m];
@@ -112,22 +118,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                             }
                         }
 
-                        if (empty($routes[$m][4]) || '/' === $pathinfo[-1]) {
-                            // no-op
-                        } elseif ('GET' !== $canonicalMethod) {
-                            $allow['GET'] = 'GET';
-                            break;
-                        } else {
-                            return array_replace($ret, $this->redirect($rawPathinfo.'/', $ret['_route']));
-                        }
-
                         if ($requiredSchemes && !isset($requiredSchemes[$context->getScheme()])) {
                             if ('GET' !== $canonicalMethod) {
                                 $allow['GET'] = 'GET';
                                 break;
                             }
 
-                            return array_replace($ret, $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)));
+                            return $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)) + $ret;
                         }
 
                         if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
@@ -138,7 +135,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                         return $ret;
                 }
 
-                if (281 === $m) {
+                if (273 === $m) {
                     break;
                 }
                 $regex = substr_replace($regex, 'F', $m - $offset, 1 + strlen($m));
@@ -146,6 +143,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             }
         }
 
-        throw $allow ? new MethodNotAllowedException(array_keys($allow)) : new ResourceNotFoundException();
+        return null;
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher8.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher8.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher9.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher9.php
@@ -19,7 +19,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($rawPathinfo);
-        $trimmedPathinfo = rtrim($pathinfo, '/');
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
         $host = strtolower($context->getHost());
@@ -32,11 +31,11 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             case '/':
                 // a
                 if (preg_match('#^(?P<d>[^\\.]++)\\.e\\.c\\.b\\.a$#sDi', $host, $hostMatches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'a')), array());
+                    return $this->mergeDefaults(array('_route' => 'a') + $hostMatches, array());
                 }
                 // c
                 if (preg_match('#^(?P<e>[^\\.]++)\\.e\\.c\\.b\\.a$#sDi', $host, $hostMatches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'c')), array());
+                    return $this->mergeDefaults(array('_route' => 'c') + $hostMatches, array());
                 }
                 // b
                 if ('d.c.b.a' === $host) {

--- a/src/Symfony/Component/Routing/Tests/Matcher/DumpedRedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/DumpedRedirectableUrlMatcherTest.php
@@ -19,14 +19,6 @@ use Symfony\Component\Routing\RequestContext;
 
 class DumpedRedirectableUrlMatcherTest extends RedirectableUrlMatcherTest
 {
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\MethodNotAllowedException
-     */
-    public function testRedirectWhenNoSlashForNonSafeMethod()
-    {
-        parent::testRedirectWhenNoSlashForNonSafeMethod();
-    }
-
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)
     {
         static $i = 0;

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/StaticPrefixCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/StaticPrefixCollectionTest.php
@@ -48,7 +48,7 @@ EOF
                 ),
                 <<<EOF
 root
-/prefix/segment
+/prefix/segment/
 -> prefix_segment
 -> leading_segment
 EOF
@@ -61,7 +61,7 @@ EOF
                 ),
                 <<<EOF
 root
-/prefix/segment
+/prefix/segment/
 -> prefix_segment
 -> leading_segment
 EOF
@@ -75,7 +75,7 @@ EOF
                 ),
                 <<<EOF
 root
-/group
+/group/
 -> nested_segment
 -> some_segment
 -> other_segment
@@ -92,12 +92,12 @@ EOF
                     array('/group/ff/', 'ff'),
                 ),
                 <<<EOF
-/group
+/group/
 -> aa
 -> bb
 -> cc
 root
-/group
+/group/
 -> dd
 -> ee
 -> ff
@@ -118,17 +118,17 @@ EOF
                     array('/aaa/333/', 'third_aaa'),
                 ),
                 <<<EOF
-/aaa
+/aaa/
 -> first_aaa
 -> second_aaa
 -> third_aaa
-/prefixed
--> /prefixed/group
+/prefixed/
+-> /prefixed/group/
 -> -> aa
 -> -> bb
 -> -> cc
 -> root
--> /prefixed/group
+-> /prefixed/group/
 -> -> dd
 -> -> ee
 -> -> ff

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -27,6 +27,16 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $matcher->match('/foo');
     }
 
+    public function testRedirectWhenSlash()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo'));
+
+        $matcher = $this->getUrlMatcher($coll);
+        $matcher->expects($this->once())->method('redirect')->will($this->returnValue(array()));
+        $matcher->match('/foo/');
+    }
+
     /**
      * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26207
| License       | MIT
| Doc PR        | -

Implemented as suggest by @Tobion in https://github.com/symfony/symfony/pull/26059#issuecomment-365071281

When a route for `/foo` exists but the request is for `/foo/`, we now redirect.
(this complements the flipped side redirection, which already exists.)