### PR TITLE
[FrameworkBundle] fix lowest supported Serializer version

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -67,7 +67,7 @@
         "symfony/console": "<3.4",
         "symfony/form": "<3.4",
         "symfony/property-info": "<3.4",
-        "symfony/serializer": "<3.4",
+        "symfony/serializer": "<4.1",
         "symfony/stopwatch": "<3.4",
         "symfony/translation": "<3.4",
         "symfony/validator": "<4.1",

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -214,7 +214,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     abstract protected function getAttributeValue($object, $attribute, $format = null, array $context = array());
 
     /**
-     * Sets an handler function that will be called when the max depth is reached.
+     * Sets a handler function that will be called when the max depth is reached.
      */
     public function setMaxDepthHandler(?callable $handler): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The `AbstractObjectNormalizer::setMaxDepthHandler()` method does not
exist before `symfony/serializer` 4.1.