### PR TITLE
[Security] Add missing use for RoleInterface

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
+use Symfony\Component\Security\Core\Role\RoleInterface;
+
 /**
  * UsernamePasswordToken implements a username and password token.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Just a missing `use ...\RoleInterface` in the `UsernamePasswordToken` since 3.3.
