### PR TITLE
[FrameworkBundle] show the unregistered command warning at the end of the list command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Console;
 
+use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
@@ -79,11 +80,23 @@ class Application extends BaseApplication
      */
     protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
     {
-        if ($this->registrationErrors) {
-            $this->renderRegistrationErrors($input, $output);
+        if (!$command instanceof ListCommand) {
+            if ($this->registrationErrors) {
+                $this->renderRegistrationErrors($input, $output);
+                $this->registrationErrors = array();
+            }
+
+            return parent::doRunCommand($command, $input, $output);
         }
 
-        return parent::doRunCommand($command, $input, $output);
+        $returnCode = parent::doRunCommand($command, $input, $output);
+
+        if ($this->registrationErrors) {
+            $this->renderRegistrationErrors($input, $output);
+            $this->registrationErrors = array();
+        }
+
+        return $returnCode;
     }
 
     /**
@@ -192,7 +205,5 @@ class Application extends BaseApplication
         foreach ($this->registrationErrors as $error) {
             $this->doRenderException($error, $output);
         }
-
-        $this->registrationErrors = array();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | yes   <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no   <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26203  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | I don't think we need one.

This PR modify the warning error when you have unregistered command on the list command, it shows it at the end.