### PR TITLE
[FrameworkBundle] [Console][DX] add a warning when command is not found

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -65,6 +65,8 @@ class Application extends BaseApplication
 
         $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));
 
+        $this->registerCommands();
+
         if ($this->registrationErrors) {
             $this->renderRegistrationErrors($input, $output);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none
| License       | MIT
| Doc PR        |


This PR add DX on the the console `find()` and `get()` methods when a command is not found because it has not been registered properly.