### PR TITLE
[Console] Support binary / negatable options

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -949,8 +949,7 @@ class Application
             new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
             new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
-            new InputOption('--ansi', '', InputOption::VALUE_NONE, 'Force ANSI output'),
-            new InputOption('--no-ansi', '', InputOption::VALUE_NONE, 'Disable ANSI output'),
+            new InputOption('--ansi', '', InputOption::VALUE_BINARY, 'Force ANSI output', null),
             new InputOption('--no-interaction', '-n', InputOption::VALUE_NONE, 'Do not ask any interactive question'),
         ));
     }

--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -125,6 +125,7 @@ class JsonDescriptor extends Descriptor
             'accept_value' => $option->acceptValue(),
             'is_value_required' => $option->isValueRequired(),
             'is_multiple' => $option->isArray(),
+            'is_negatable' => $option->isNegatable(),
             'description' => preg_replace('/\s*[\r\n]\s*/', ' ', $option->getDescription()),
             'default' => INF === $option->getDefault() ? 'INF' : $option->getDefault(),
         );

--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -143,6 +143,9 @@ class JsonDescriptor extends Descriptor
 
         $inputOptions = array();
         foreach ($definition->getOptions() as $name => $option) {
+            if ($option->isHidden()) {
+                continue;
+            }
             $inputOptions[$name] = $this->getInputOptionData($option);
         }
 

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -105,6 +105,9 @@ class MarkdownDescriptor extends Descriptor
 
             $this->write('### Options');
             foreach ($definition->getOptions() as $option) {
+                if ($option->isHidden()) {
+                    continue;
+                }
                 $this->write("\n\n");
                 $this->write($this->describeInputOption($option));
             }

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -68,7 +68,8 @@ class MarkdownDescriptor extends Descriptor
      */
     protected function describeInputOption(InputOption $option, array $options = array())
     {
-        $name = '--'.$option->getName();
+        $negatable = $option->isNegatable() ? '[no-]' : '';
+        $name = '--'.$negatable.$option->getName();
         if ($option->getShortcut()) {
             $name .= '|-'.implode('|-', explode('|', $option->getShortcut())).'';
         }
@@ -79,6 +80,7 @@ class MarkdownDescriptor extends Descriptor
             .'* Accept value: '.($option->acceptValue() ? 'yes' : 'no')."\n"
             .'* Is value required: '.($option->isValueRequired() ? 'yes' : 'no')."\n"
             .'* Is multiple: '.($option->isArray() ? 'yes' : 'no')."\n"
+            .'* Is negatable: '.($option->isNegatable() ? 'yes' : 'no')."\n"
             .'* Default: `'.str_replace("\n", '', var_export($option->getDefault(), true)).'`'
         );
     }

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -56,10 +56,12 @@ class TextDescriptor extends Descriptor
      */
     protected function describeInputOption(InputOption $option, array $options = array())
     {
+        $default = '';
         if ($option->acceptValue() && null !== $option->getDefault() && (!is_array($option->getDefault()) || count($option->getDefault()))) {
             $default = sprintf('<comment> [default: %s]</comment>', $this->formatDefaultValue($option->getDefault()));
-        } else {
-            $default = '';
+        } elseif ($option->isNegatable() && (null !== $option->getDefault())) {
+            $negative_default = $option->getDefault() ? '' : 'no-';
+            $default = sprintf('<comment> [default: --%s%s]</comment>', $negative_default, $option->getName());
         }
 
         $value = '';
@@ -72,9 +74,10 @@ class TextDescriptor extends Descriptor
         }
 
         $totalWidth = isset($options['total_width']) ? $options['total_width'] : $this->calculateTotalWidthForOptions(array($option));
+        $negatable = $option->isNegatable() ? '[no-]' : '';
         $synopsis = sprintf('%s%s',
             $option->getShortcut() ? sprintf('-%s, ', $option->getShortcut()) : '    ',
-            sprintf('--%s%s', $option->getName(), $value)
+            sprintf('--%s%s%s', $negatable, $option->getName(), $value)
         );
 
         $spacingWidth = $totalWidth - Helper::strlen($synopsis);

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -120,6 +120,9 @@ class TextDescriptor extends Descriptor
 
             $this->writeText('<comment>Options:</comment>', $options);
             foreach ($definition->getOptions() as $option) {
+                if ($option->isHidden()) {
+                    continue;
+                }
                 if (strlen($option->getShortcut()) > 1) {
                     $laterOptions[] = $option;
                     continue;

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -41,7 +41,9 @@ class XmlDescriptor extends Descriptor
 
         $definitionXML->appendChild($optionsXML = $dom->createElement('options'));
         foreach ($definition->getOptions() as $option) {
-            $this->appendDocument($optionsXML, $this->getInputOptionDocument($option));
+            if (!$option->isHidden()) {
+                $this->appendDocument($optionsXML, $this->getInputOptionDocument($option));
+            }
         }
 
         return $dom;

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -225,6 +225,7 @@ class XmlDescriptor extends Descriptor
         $objectXML->setAttribute('accept_value', $option->acceptValue() ? 1 : 0);
         $objectXML->setAttribute('is_value_required', $option->isValueRequired() ? 1 : 0);
         $objectXML->setAttribute('is_multiple', $option->isArray() ? 1 : 0);
+        $objectXML->setAttribute('is_negatable', $option->isNegatable() ? 1 : 0);
         $objectXML->appendChild($descriptionXML = $dom->createElement('description'));
         $descriptionXML->appendChild($dom->createTextNode($option->getDescription()));
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -213,14 +213,7 @@ class ArgvInput extends Input
      */
     private function addLongOption($name, $value)
     {
-        if (!$this->definition->hasOption($name)) {
-            if ($this->addNegativeBinaryLongOption($name, $value)) {
-                return;
-            }
-            throw new RuntimeException(sprintf('The "--%s" option does not exist.', $name));
-        }
-
-        $option = $this->definition->getOption($name);
+        $option = $this->getOptionDefinition($name);
 
         if (null !== $value && !$option->acceptValue()) {
             throw new RuntimeException(sprintf('The "--%s" option does not accept a value.', $name));
@@ -237,51 +230,14 @@ class ArgvInput extends Input
             }
         }
 
-        if (null === $value) {
-            if ($option->isValueRequired()) {
-                throw new RuntimeException(sprintf('The "--%s" option requires a value.', $name));
-            }
-
-            if (!$option->isArray() && !$option->isValueOptional()) {
-                $value = true;
-            }
-        }
+        $name = $option->effectiveName();
+        $value = $option->checkValue($value);
 
         if ($option->isArray()) {
             $this->options[$name][] = $value;
         } else {
             $this->options[$name] = $value;
         }
-    }
-
-    /**
-     * Adds a long option value.
-     *
-     * @param string $name  The long option key
-     * @param mixed  $value The value for the option
-     *
-     * @return boolean if negative option was found and added
-     */
-    private function addNegativeBinaryLongOption($name, $value)
-    {
-        // Negative binary options always start with 'no-'.
-        if ('no-' != substr($name, 0, 3)) {
-            return false;
-        }
-        $binary_option_name = substr($name, 3);
-        if (!$this->definition->hasOption($binary_option_name)) {
-            return false;
-        }
-
-        $option = $this->definition->getOption($binary_option_name);
-        if (!$option->isNegatable()) {
-            return false;
-        }
-        if (null !== $value && !$option->acceptValue()) {
-            throw new RuntimeException(sprintf('The "--%s" option does not accept a value.', $name));
-        }
-        $this->options[$binary_option_name] = false;
-        return true;
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -168,23 +168,7 @@ class ArrayInput extends Input
      */
     private function addLongOption($name, $value)
     {
-        if (!$this->definition->hasOption($name)) {
-            throw new InvalidOptionException(sprintf('The "--%s" option does not exist.', $name));
-        }
-
-        $option = $this->definition->getOption($name);
-
-        if (null === $value) {
-            if ($option->isValueRequired()) {
-                throw new InvalidOptionException(sprintf('The "--%s" option requires a value.', $name));
-            }
-
-            if (!$option->isValueOptional()) {
-                $value = true;
-            }
-        }
-
-        $this->options[$name] = $value;
+        $this->setOption($name, $value);
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -146,11 +146,8 @@ abstract class Input implements InputInterface, StreamableInputInterface
      */
     public function getOption($name)
     {
-        if (!$this->definition->hasOption($name)) {
-            throw new InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
-        }
-
-        return array_key_exists($name, $this->options) ? $this->options[$name] : $this->definition->getOption($name)->getDefault();
+        $option = $this->getOptionDefinition($name);
+        return array_key_exists($name, $this->options) ? $this->options[$name] : $option->getDefault();
     }
 
     /**
@@ -158,11 +155,8 @@ abstract class Input implements InputInterface, StreamableInputInterface
      */
     public function setOption($name, $value)
     {
-        if (!$this->definition->hasOption($name)) {
-            throw new InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
-        }
-
-        $this->options[$name] = $value;
+        $option = $this->getOptionDefinition($name);
+        $this->options[$option->effectiveName()] = $option->checkValue($value);
     }
 
     /**
@@ -199,5 +193,21 @@ abstract class Input implements InputInterface, StreamableInputInterface
     public function getStream()
     {
         return $this->stream;
+    }
+
+    /**
+     * Look up the option definition for the given option name.
+     *
+     * @param string $name
+     *
+     * @return InputOption
+     */
+    protected function getOptionDefinition($name)
+    {
+        if (!$this->definition->hasOption($name)) {
+            throw new RuntimeException(sprintf('The "--%s" option does not exist.', $name));
+        }
+
+        return $this->definition->getOption($name);
     }
 }

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -228,6 +228,19 @@ class InputDefinition
      */
     public function addOption(InputOption $option)
     {
+        $this->doAddOption($option);
+
+        if ($option->isNegatable()) {
+            $negatedOption = new NegatedInputOption($option);
+            $this->doAddOption($negatedOption);
+        }
+    }
+
+    /**
+     * @throws LogicException When option given already exist
+     */
+    private function doAddOption(InputOption $option)
+    {
         if (isset($this->options[$option->getName()]) && !$option->equals($this->options[$option->getName()])) {
             throw new LogicException(sprintf('An option named "%s" already exists.', $option->getName()));
         }
@@ -324,7 +337,7 @@ class InputDefinition
     {
         $values = array();
         foreach ($this->options as $option) {
-            $values[$option->getName()] = $option->getDefault();
+            $values[$option->effectiveName()] = $option->getDefault();
         }
 
         return $values;
@@ -363,6 +376,9 @@ class InputDefinition
             $elements[] = '[options]';
         } elseif (!$short) {
             foreach ($this->getOptions() as $option) {
+                if ($option->isHidden()) {
+                    continue;
+                }
                 $value = '';
                 if ($option->acceptValue()) {
                     $value = sprintf(

--- a/src/Symfony/Component/Console/Input/NegatedInputOption.php
+++ b/src/Symfony/Component/Console/Input/NegatedInputOption.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Input;
+
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\LogicException;
+
+/**
+ * Represents a command line option.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class NegatedInputOption extends InputOption
+{
+    private $primaryOption;
+
+    const VALUE_NONE = 1;
+    const VALUE_REQUIRED = 2;
+    const VALUE_OPTIONAL = 4;
+    const VALUE_IS_ARRAY = 8;
+    const VALUE_NEGATABLE = 16;
+    const VALUE_HIDDEN = 32;
+    const VALUE_BINARY = (self::VALUE_NONE | self::VALUE_NEGATABLE);
+
+    private $name;
+    private $shortcut;
+    private $mode;
+    private $default;
+    private $description;
+
+    /**
+     * @param string       $name        The option name
+     * @param string|array $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param int          $mode        The option mode: One of the VALUE_* constants
+     * @param string       $description A description text
+     * @param mixed        $default     The default value (must be null for self::VALUE_NONE)
+     *
+     * @throws InvalidArgumentException If option mode is invalid or incompatible
+     */
+    public function __construct(InputOption $primaryOption)
+    {
+        $this->primaryOption = $primaryOption;
+
+        /* string $name, $shortcut = null, int $mode = null, string $description = '', $default = null */
+        $name = 'no-' . $primaryOption->getName();
+        $shortcut = null;
+        $mode = self::VALUE_HIDDEN;
+        $description = $primaryOption->getDescription();
+        $default = $this->negate($primaryOption->getDefault());
+
+        parent::__construct($name, $shortcut, $mode, $description, $default);
+    }
+
+    public function effectiveName()
+    {
+        return $this->primaryOption->getName();
+    }
+
+    /**
+     * Sets the default value.
+     *
+     * @param mixed $default The default value
+     *
+     * @throws LogicException When incorrect default value is given
+     */
+    public function setDefault($default = null)
+    {
+        $this->primaryOption->setDefault($this->negate($default));
+    }
+
+    /**
+     * Returns the default value.
+     *
+     * @return mixed The default value
+     */
+    public function getDefault()
+    {
+        return $this->negate($this->primaryOption->getDefault());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function checkValue($value)
+    {
+        return false;
+    }
+
+    /**
+     * Negate a value if it is provided.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private function negate($value)
+    {
+        if ($value === null) {
+            return $value;
+        }
+        return !$value;
+    }
+}


### PR DESCRIPTION
e.g. --foo and --no-foo.

Work-in-progress.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes (CHANGELOG.md updates needed)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no (Need updating; work-in-progress)
| Fixed tickets | #24314
| License       | MIT
| Doc PR        | Still needed (symfony/symfony-docs#...)

Hoping for some feedback here before updating tests and docs, so that I do not need to do that twice.

The implementation here is slightly more capable than the description in the original issue (#24314). Two new InputOption constants are added:

| Constant        | Description
| ------------- | ---
| VALUE_NEGATABLE | Option --foo may also be represented as --no-foo
| VALUE_BINARY | This is just VALUE_NEGATABLE | VALUE_NONE

This allows for flexible use of the negatable option.

- Default value may be `true`, `false` or `null` (the last differentiates between --foo, --no-foo, and no option specifice)
- Options with values may also be specified, e.g. `--browser=firefox` or `--no-browser` to clear, otherwise returns a default like `chrome`
- Options with values may also be required, e.g. `--foo=bar` or `--no-foo` are accepted, but `--foo` throws an exception

I can fine-tune this further if different behavior is desired.