### PR TITLE
[Console] fix a bug when the style commands is too big

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -397,7 +397,12 @@ class SymfonyStyle extends OutputStyle
                 $message = OutputFormatter::escape($message);
             }
 
-            $lines = array_merge($lines, explode(PHP_EOL, wordwrap($message, $this->lineLength - $prefixLength - $indentLength, PHP_EOL, true)));
+            $length = $this->lineLength;
+            if (preg_match('(<\/.+>)', $message, $match)) {
+                $length += \strlen($match[0]); // this counts the number of character in order to be sure that it's not at the end of the line
+            }
+
+            $lines = array_merge($lines, explode(PHP_EOL, wordwrap($message, $length - $prefixLength - $indentLength, PHP_EOL, true)));
 
             if (count($messages) > 1 && $key < count($messages) - 1) {
                 $lines[] = '';
@@ -417,7 +422,7 @@ class SymfonyStyle extends OutputStyle
             }
 
             $line = $prefix.$line;
-            $line .= str_repeat(' ', $this->lineLength - Helper::strlenWithoutDecoration($this->getFormatter(), $line));
+            $line .= \str_repeat(' ', $length - Helper::strlenWithoutDecoration($this->getFormatter(), $line));
 
             if ($style) {
                 $line = sprintf('<%s>%s</>', $style, $line);

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_18.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_18.php
@@ -1,0 +1,17 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+// ensure that nested tags have no effect on the color of the '//' prefix
+return function (InputInterface $input, OutputInterface $output) {
+    $output->setDecorated(true);
+    $output = new SymfonyStyle($input, $output);
+    $output->comment(
+        sprintf(
+            'Loading the configuration file "<comment>%s</comment>".',
+            '/var/www/deploy/current/test/production/219099923320/feature-test-config/config/packages/alice.yml'
+        )
+    );
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
@@ -1,7 +1,6 @@
 
-[39;49m // [39;49mLorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et             [39m
-[39;49m // [39;49m[33mdolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea       [39m
-[39;49m // [39;49m[33mcommodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla     [39m
-[39;49m // [39;49m[33mpariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim            
-[39;49m // [39;49mid est laborum                                                                                                      
+[39;49m // [39;49mLorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna          [39m
+[39;49m // [39;49m[33maliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute [39m
+[39;49m // [39;49m[33mirure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.[39m Excepteur sint occaecat          
+[39;49m // [39;49mcupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum                                         
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_18.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_18.txt
@@ -1,0 +1,4 @@
+
+[39;49m // [39;49mLoading the configuration file                                                                                                
+[39;49m // [39;49m"[33m/var/www/deploy/current/test/production/219099923320/feature-test-config/config/packages/alice.yml[39m".                         
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26293 <!-- #-prefixed issue number(s), if any -->
| License       | MIT


I need to finish my test but wanted to know the first output on this and maybe if there is a better way to do it.

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
