### PR TITLE
[Routing] support scheme requirement without redirectable dumped matcher

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
-use Symfony\Component\Routing\Route;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -27,38 +27,38 @@ abstract class RedirectableUrlMatcher extends UrlMatcher implements Redirectable
         try {
             return parent::match($pathinfo);
         } catch (ResourceNotFoundException $e) {
-            if ('/' === $pathinfo || !\in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
+            if (!\in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
                 throw $e;
             }
 
-            try {
-                $pathinfo = '/' !== $pathinfo[-1] ? $pathinfo.'/' : substr($pathinfo, 0, -1);
-                $ret = parent::match($pathinfo);
+            if ($this->allowSchemes) {
+                redirect_scheme:
+                $scheme = $this->context->getScheme();
+                $this->context->setScheme(current($this->allowSchemes));
+                try {
+                    $ret = parent::match($pathinfo);
 
-                return $this->redirect($pathinfo, $ret['_route'] ?? null) + $ret;
-            } catch (ResourceNotFoundException $e2) {
+                    return $this->redirect($pathinfo, $ret['_route'] ?? null, $this->context->getScheme()) + $ret;
+                } catch (ExceptionInterface $e2) {
+                    throw $e;
+                } finally {
+                    $this->context->setScheme($scheme);
+                }
+            } elseif ('/' === $pathinfo) {
                 throw $e;
+            } else {
+                try {
+                    $pathinfo = '/' !== $pathinfo[-1] ? $pathinfo.'/' : substr($pathinfo, 0, -1);
+                    $ret = parent::match($pathinfo);
+
+                    return $this->redirect($pathinfo, $ret['_route'] ?? null) + $ret;
+                } catch (ExceptionInterface $e2) {
+                    if ($this->allowSchemes) {
+                        goto redirect_scheme;
+                    }
+                    throw $e;
+                }
             }
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function handleRouteRequirements($pathinfo, $name, Route $route)
-    {
-        // expression condition
-        if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(), array('context' => $this->context, 'request' => $this->request ?: $this->createRequest($pathinfo)))) {
-            return array(self::REQUIREMENT_MISMATCH, null);
-        }
-
-        // check HTTP scheme requirement
-        $scheme = $this->context->getScheme();
-        $schemes = $route->getSchemes();
-        if ($schemes && !$route->hasScheme($scheme)) {
-            return array(self::ROUTE_MATCH, $this->redirect($pathinfo, $name, current($schemes)));
-        }
-
-        return array(self::REQUIREMENT_MATCH, null);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher0.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher0.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -64,8 +64,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     }
                 }
 
+                $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                 if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                    $allow += $requiredMethods;
+                    if ($hasRequiredScheme) {
+                        $allow += $requiredMethods;
+                    }
+                    break;
+                }
+                if (!$hasRequiredScheme) {
+                    $allowSchemes += $requiredSchemes;
                     break;
                 }
 
@@ -209,8 +216,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                             }
                         }
 
+                        $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                         if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                            $allow += $requiredMethods;
+                            if ($hasRequiredScheme) {
+                                $allow += $requiredMethods;
+                            }
+                            break;
+                        }
+                        if (!$hasRequiredScheme) {
+                            $allowSchemes += $requiredSchemes;
                             break;
                         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher10.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher10.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -2799,8 +2799,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                             }
                         }
 
+                        $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                         if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                            $allow += $requiredMethods;
+                            if ($hasRequiredScheme) {
+                                $allow += $requiredMethods;
+                            }
+                            break;
+                        }
+                        if (!$hasRequiredScheme) {
+                            $allowSchemes += $requiredSchemes;
                             break;
                         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher11.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher11.php
@@ -17,23 +17,42 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
     public function match($pathinfo)
     {
-        $allow = array();
-        if ($ret = $this->doMatch($pathinfo, $allow)) {
+        $allow = $allowSchemes = array();
+        if ($ret = $this->doMatch($pathinfo, $allow, $allowSchemes)) {
             return $ret;
         }
-        if ('/' !== $pathinfo && in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
+        if ($allow) {
+            throw new MethodNotAllowedException(array_keys($allow));
+        }
+        if (!in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
+            // no-op
+        } elseif ($allowSchemes) {
+            redirect_scheme:
+            $scheme = $this->context->getScheme();
+            $this->context->setScheme(key($allowSchemes));
+            try {
+                if ($ret = $this->doMatch($pathinfo)) {
+                    return $this->redirect($pathinfo, $ret['_route'], $this->context->getScheme()) + $ret;
+                }
+            } finally {
+                $this->context->setScheme($scheme);
+            }
+        } elseif ('/' !== $pathinfo) {
             $pathinfo = '/' !== $pathinfo[-1] ? $pathinfo.'/' : substr($pathinfo, 0, -1);
-            if ($ret = $this->doMatch($pathinfo)) {
+            if ($ret = $this->doMatch($pathinfo, $allow, $allowSchemes)) {
                 return $this->redirect($pathinfo, $ret['_route']) + $ret;
+            }
+            if ($allowSchemes) {
+                goto redirect_scheme;
             }
         }
 
-        throw $allow ? new MethodNotAllowedException(array_keys($allow)) : new ResourceNotFoundException();
+        throw new ResourceNotFoundException();
     }
 
-    private function doMatch(string $rawPathinfo, array &$allow = array()): ?array
+    private function doMatch(string $rawPathinfo, array &$allow = array(), array &$allowSchemes = array()): ?array
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -113,11 +132,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                             break;
                         }
                         if (!$hasRequiredScheme) {
-                            if ('GET' !== $canonicalMethod) {
-                                break;
-                            }
-
-                            return $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)) + $ret;
+                            $allowSchemes += $requiredSchemes;
+                            break;
                         }
 
                         return $ret;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher12.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher12.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -69,8 +69,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                             }
                         }
 
+                        $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                         if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                            $allow += $requiredMethods;
+                            if ($hasRequiredScheme) {
+                                $allow += $requiredMethods;
+                            }
+                            break;
+                        }
+                        if (!$hasRequiredScheme) {
+                            $allowSchemes += $requiredSchemes;
                             break;
                         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher13.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher13.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -43,8 +43,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                 }
                 list($ret, $requiredHost, $requiredMethods, $requiredSchemes) = $routes[$pathinfo];
 
+                $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                 if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                    $allow += $requiredMethods;
+                    if ($hasRequiredScheme) {
+                        $allow += $requiredMethods;
+                    }
+                    break;
+                }
+                if (!$hasRequiredScheme) {
+                    $allowSchemes += $requiredSchemes;
                     break;
                 }
 
@@ -74,8 +81,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                             }
                         }
 
+                        $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                         if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                            $allow += $requiredMethods;
+                            if ($hasRequiredScheme) {
+                                $allow += $requiredMethods;
+                            }
+                            break;
+                        }
+                        if (!$hasRequiredScheme) {
+                            $allowSchemes += $requiredSchemes;
                             break;
                         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher4.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -60,8 +60,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                 }
                 list($ret, $requiredHost, $requiredMethods, $requiredSchemes) = $routes[$pathinfo];
 
+                $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                 if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                    $allow += $requiredMethods;
+                    if ($hasRequiredScheme) {
+                        $allow += $requiredMethods;
+                    }
+                    break;
+                }
+                if (!$hasRequiredScheme) {
+                    $allowSchemes += $requiredSchemes;
                     break;
                 }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher5.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher5.php
@@ -17,23 +17,42 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
     public function match($pathinfo)
     {
-        $allow = array();
-        if ($ret = $this->doMatch($pathinfo, $allow)) {
+        $allow = $allowSchemes = array();
+        if ($ret = $this->doMatch($pathinfo, $allow, $allowSchemes)) {
             return $ret;
         }
-        if ('/' !== $pathinfo && in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
+        if ($allow) {
+            throw new MethodNotAllowedException(array_keys($allow));
+        }
+        if (!in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
+            // no-op
+        } elseif ($allowSchemes) {
+            redirect_scheme:
+            $scheme = $this->context->getScheme();
+            $this->context->setScheme(key($allowSchemes));
+            try {
+                if ($ret = $this->doMatch($pathinfo)) {
+                    return $this->redirect($pathinfo, $ret['_route'], $this->context->getScheme()) + $ret;
+                }
+            } finally {
+                $this->context->setScheme($scheme);
+            }
+        } elseif ('/' !== $pathinfo) {
             $pathinfo = '/' !== $pathinfo[-1] ? $pathinfo.'/' : substr($pathinfo, 0, -1);
-            if ($ret = $this->doMatch($pathinfo)) {
+            if ($ret = $this->doMatch($pathinfo, $allow, $allowSchemes)) {
                 return $this->redirect($pathinfo, $ret['_route']) + $ret;
+            }
+            if ($allowSchemes) {
+                goto redirect_scheme;
             }
         }
 
-        throw $allow ? new MethodNotAllowedException(array_keys($allow)) : new ResourceNotFoundException();
+        throw new ResourceNotFoundException();
     }
 
-    private function doMatch(string $rawPathinfo, array &$allow = array()): ?array
+    private function doMatch(string $rawPathinfo, array &$allow = array(), array &$allowSchemes = array()): ?array
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -72,11 +91,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     break;
                 }
                 if (!$hasRequiredScheme) {
-                    if ('GET' !== $canonicalMethod) {
-                        break;
-                    }
-
-                    return $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)) + $ret;
+                    $allowSchemes += $requiredSchemes;
+                    break;
                 }
 
                 return $ret;
@@ -115,11 +131,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                             break;
                         }
                         if (!$hasRequiredScheme) {
-                            if ('GET' !== $canonicalMethod) {
-                                break;
-                            }
-
-                            return $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)) + $ret;
+                            $allowSchemes += $requiredSchemes;
+                            break;
                         }
 
                         return $ret;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher6.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher6.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -44,8 +44,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                 }
                 list($ret, $requiredHost, $requiredMethods, $requiredSchemes) = $routes[$pathinfo];
 
+                $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                 if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                    $allow += $requiredMethods;
+                    if ($hasRequiredScheme) {
+                        $allow += $requiredMethods;
+                    }
+                    break;
+                }
+                if (!$hasRequiredScheme) {
+                    $allowSchemes += $requiredSchemes;
                     break;
                 }
 
@@ -93,8 +100,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                             }
                         }
 
+                        $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                         if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                            $allow += $requiredMethods;
+                            if ($hasRequiredScheme) {
+                                $allow += $requiredMethods;
+                            }
+                            break;
+                        }
+                        if (!$hasRequiredScheme) {
+                            $allowSchemes += $requiredSchemes;
                             break;
                         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher7.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher7.php
@@ -17,23 +17,42 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
     public function match($pathinfo)
     {
-        $allow = array();
-        if ($ret = $this->doMatch($pathinfo, $allow)) {
+        $allow = $allowSchemes = array();
+        if ($ret = $this->doMatch($pathinfo, $allow, $allowSchemes)) {
             return $ret;
         }
-        if ('/' !== $pathinfo && in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
+        if ($allow) {
+            throw new MethodNotAllowedException(array_keys($allow));
+        }
+        if (!in_array($this->context->getMethod(), array('HEAD', 'GET'), true)) {
+            // no-op
+        } elseif ($allowSchemes) {
+            redirect_scheme:
+            $scheme = $this->context->getScheme();
+            $this->context->setScheme(key($allowSchemes));
+            try {
+                if ($ret = $this->doMatch($pathinfo)) {
+                    return $this->redirect($pathinfo, $ret['_route'], $this->context->getScheme()) + $ret;
+                }
+            } finally {
+                $this->context->setScheme($scheme);
+            }
+        } elseif ('/' !== $pathinfo) {
             $pathinfo = '/' !== $pathinfo[-1] ? $pathinfo.'/' : substr($pathinfo, 0, -1);
-            if ($ret = $this->doMatch($pathinfo)) {
+            if ($ret = $this->doMatch($pathinfo, $allow, $allowSchemes)) {
                 return $this->redirect($pathinfo, $ret['_route']) + $ret;
+            }
+            if ($allowSchemes) {
+                goto redirect_scheme;
             }
         }
 
-        throw $allow ? new MethodNotAllowedException(array_keys($allow)) : new ResourceNotFoundException();
+        throw new ResourceNotFoundException();
     }
 
-    private function doMatch(string $rawPathinfo, array &$allow = array()): ?array
+    private function doMatch(string $rawPathinfo, array &$allow = array(), array &$allowSchemes = array()): ?array
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -68,11 +87,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     break;
                 }
                 if (!$hasRequiredScheme) {
-                    if ('GET' !== $canonicalMethod) {
-                        break;
-                    }
-
-                    return $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)) + $ret;
+                    $allowSchemes += $requiredSchemes;
+                    break;
                 }
 
                 return $ret;
@@ -127,11 +143,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                             break;
                         }
                         if (!$hasRequiredScheme) {
-                            if ('GET' !== $canonicalMethod) {
-                                break;
-                            }
-
-                            return $this->redirect($rawPathinfo, $ret['_route'], key($requiredSchemes)) + $ret;
+                            $allowSchemes += $requiredSchemes;
+                            break;
                         }
 
                         return $ret;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher8.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher8.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();
@@ -57,8 +57,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                             }
                         }
 
+                        $hasRequiredScheme = !$requiredSchemes || isset($requiredSchemes[$context->getScheme()]);
                         if ($requiredMethods && !isset($requiredMethods[$canonicalMethod]) && !isset($requiredMethods[$requestMethod])) {
-                            $allow += $requiredMethods;
+                            if ($hasRequiredScheme) {
+                                $allow += $requiredMethods;
+                            }
+                            break;
+                        }
+                        if (!$hasRequiredScheme) {
+                            $allowSchemes += $requiredSchemes;
                             break;
                         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher9.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher9.php
@@ -17,7 +17,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
     public function match($rawPathinfo)
     {
-        $allow = array();
+        $allow = $allowSchemes = array();
         $pathinfo = rawurldecode($rawPathinfo);
         $context = $this->context;
         $requestMethod = $canonicalMethod = $context->getMethod();

--- a/src/Symfony/Component/Routing/Tests/Matcher/DumpedUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/DumpedUrlMatcherTest.php
@@ -17,24 +17,6 @@ use Symfony\Component\Routing\RequestContext;
 
 class DumpedUrlMatcherTest extends UrlMatcherTest
 {
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The "schemes" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.
-     */
-    public function testSchemeRequirement()
-    {
-        parent::testSchemeRequirement();
-    }
-
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The "schemes" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.
-     */
-    public function testSchemeAndMethodMismatch()
-    {
-        parent::testSchemeRequirement();
-    }
-
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)
     {
         static $i = 0;

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -46,24 +46,6 @@ class PhpMatcherDumperTest extends TestCase
         @unlink($this->dumpPath);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
-    public function testDumpWhenSchemeIsUsedWithoutAProperDumper()
-    {
-        $collection = new RouteCollection();
-        $collection->add('secure', new Route(
-            '/secure',
-            array(),
-            array(),
-            array(),
-            '',
-            array('https')
-        ));
-        $dumper = new PhpMatcherDumper($collection);
-        $dumper->dump();
-    }
-
     public function testRedirectPreservesUrlEncoding()
     {
         $collection = new RouteCollection();

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Routing\RequestContext;
 
 class RedirectableUrlMatcherTest extends UrlMatcherTest
 {
-    public function testRedirectWhenNoSlash()
+    public function testMissingTrailingSlash()
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/'));
@@ -27,7 +27,7 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $matcher->match('/foo');
     }
 
-    public function testRedirectWhenSlash()
+    public function testExtraTrailingSlash()
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo'));
@@ -125,6 +125,16 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
         $matcher = $this->getUrlMatcher($coll, new RequestContext());
         $matcher->expects($this->once())->method('redirect')->with('/foo', 'foo', 'https')->willReturn(array());
         $this->assertSame(array('_route' => 'foo'), $matcher->match('/foo'));
+    }
+
+    public function testMissingTrailingSlashAndScheme()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', (new Route('/foo/'))->setSchemes(array('https')));
+
+        $matcher = $this->getUrlMatcher($coll);
+        $matcher->expects($this->once())->method('redirect')->with('/foo/', 'foo', 'https')->will($this->returnValue(array()));
+        $matcher->match('/foo');
     }
 
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -328,12 +328,87 @@ class UrlMatcherTest extends TestCase
     /**
      * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
      */
+    public function testMissingTrailingSlash()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo/'));
+
+        $matcher = $this->getUrlMatcher($coll);
+        $matcher->match('/foo');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     */
+    public function testExtraTrailingSlash()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo'));
+
+        $matcher = $this->getUrlMatcher($coll);
+        $matcher->match('/foo/');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     */
+    public function testMissingTrailingSlashForNonSafeMethod()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo/'));
+
+        $context = new RequestContext();
+        $context->setMethod('POST');
+        $matcher = $this->getUrlMatcher($coll, $context);
+        $matcher->match('/foo');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     */
+    public function testExtraTrailingSlashForNonSafeMethod()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo'));
+
+        $context = new RequestContext();
+        $context->setMethod('POST');
+        $matcher = $this->getUrlMatcher($coll, $context);
+        $matcher->match('/foo/');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     */
     public function testSchemeRequirement()
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array(), array(), '', array('https')));
         $matcher = $this->getUrlMatcher($coll);
         $matcher->match('/foo');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     */
+    public function testSchemeRequirementForNonSafeMethod()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo', array(), array(), array(), '', array('https')));
+
+        $context = new RequestContext();
+        $context->setMethod('POST');
+        $matcher = $this->getUrlMatcher($coll, $context);
+        $matcher->match('/foo');
+    }
+
+    public function testSamePathWithDifferentScheme()
+    {
+        $coll = new RouteCollection();
+        $coll->add('https_route', new Route('/', array(), array(), array(), '', array('https')));
+        $coll->add('http_route', new Route('/', array(), array(), array(), '', array('http')));
+        $matcher = $this->getUrlMatcher($coll);
+        $this->assertEquals(array('_route' => 'http_route'), $matcher->match('/'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no     
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        |

The scheme handling was just redirecting immediately without testing the other routes at all for potential matches. This can cause Problems when you try to have different routes/controllers for the same path but different schemes. See added test.

```php
        $coll = new RouteCollection();
        $coll->add('https_route', new Route('/', array(), array(), array(), '', array('https')));
        $coll->add('http_route', new Route('/', array(), array(), array(), '', array('http')));
        $matcher = $this->getUrlMatcher($coll);
        $this->assertEquals(array('_route' => 'http_route'), $matcher->match('/'));
```

Instead of matching the right route, it would redirect immediatly as soon as it hits the first route.
This does not make sense and is not consistent with the other logic. Redirection should only happen when nothing matches. While fixing this I could also remove the limitation

> throw new \LogicException('The "schemes" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.');

If redirection is not possible, the wrong scheme will just not match the route. This is the same as already implemented by UrlMatcher (not RedirecableUrlMatcher). If redirection is supported, it will redirect to the first supported scheme if no other route matches. This makes the implementation similar to redirection for trailing slash and handling not allowed methods.

Also previously, the scheme redirection was done for non-safe verbs which shouldn't happen as well, ref. #25962
