### PR TITLE
Require ctype explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=5.3.9",
         "ext-xml": "*",
+        "ext-ctype": "*",
         "doctrine/common": "~2.4",
         "paragonie/random_compat": "~1.0",
         "symfony/polyfill-apcu": "~1.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 up to 4.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

```
PHP Fatal error:  Uncaught Error: Call to undefined function Symfony\Component\Yaml\ctype_digit() in /var/www/html/application/vendor/symfony/symfony/src/Symfony/Component/Yaml/Inline.php:538
```

There is no ctype extension when installing php on Alpine linux using packages
https://pkgs.alpinelinux.org/packages?name=php7&branch=v3.7&repo=community