### PR TITLE
[Routing] Revert throwing 405 on missed slash/scheme redirections

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -264,7 +264,6 @@ EOF;
             if ('/' === substr(\$pathinfo, -1)) {
                 // no-op
             } elseif (!in_array(\$this->context->getMethod(), array('HEAD', 'GET'))) {
-                \$allow[] = 'GET';
                 goto $gotoname;
             } else {
                 return \$this->redirect(\$rawPathinfo.'/', '$name');
@@ -283,7 +282,6 @@ EOF;
             \$requiredSchemes = $schemes;
             if (!isset(\$requiredSchemes[\$this->context->getScheme()])) {
                 if (!in_array(\$this->context->getMethod(), array('HEAD', 'GET'))) {
-                    \$allow[] = 'GET';
                     goto $gotoname;
                 }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -69,7 +69,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     if ('/' === substr($pathinfo, -1)) {
                         // no-op
                     } elseif (!in_array($this->context->getMethod(), array('HEAD', 'GET'))) {
-                        $allow[] = 'GET';
                         goto not_baz3;
                     } else {
                         return $this->redirect($rawPathinfo.'/', 'baz3');
@@ -86,7 +85,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                 if ('/' === substr($pathinfo, -1)) {
                     // no-op
                 } elseif (!in_array($this->context->getMethod(), array('HEAD', 'GET'))) {
-                    $allow[] = 'GET';
                     goto not_baz4;
                 } else {
                     return $this->redirect($rawPathinfo.'/', 'baz4');
@@ -185,7 +183,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                 if ('/' === substr($pathinfo, -1)) {
                     // no-op
                 } elseif (!in_array($this->context->getMethod(), array('HEAD', 'GET'))) {
-                    $allow[] = 'GET';
                     goto not_hey;
                 } else {
                     return $this->redirect($rawPathinfo.'/', 'hey');
@@ -337,7 +334,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             $requiredSchemes = array (  'https' => 0,);
             if (!isset($requiredSchemes[$this->context->getScheme()])) {
                 if (!in_array($this->context->getMethod(), array('HEAD', 'GET'))) {
-                    $allow[] = 'GET';
                     goto not_secure;
                 }
 
@@ -353,7 +349,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             $requiredSchemes = array (  'http' => 0,);
             if (!isset($requiredSchemes[$this->context->getScheme()])) {
                 if (!in_array($this->context->getMethod(), array('HEAD', 'GET'))) {
-                    $allow[] = 'GET';
                     goto not_nonsecure;
                 }
 

--- a/src/Symfony/Component/Routing/Tests/Matcher/DumpedRedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/DumpedRedirectableUrlMatcherTest.php
@@ -19,14 +19,6 @@ use Symfony\Component\Routing\RequestContext;
 
 class DumpedRedirectableUrlMatcherTest extends RedirectableUrlMatcherTest
 {
-    /**
-     * @expectedException \Symfony\Component\Routing\Exception\MethodNotAllowedException
-     */
-    public function testRedirectWhenNoSlashForNonSafeMethod()
-    {
-        parent::testRedirectWhenNoSlashForNonSafeMethod();
-    }
-
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)
     {
         static $i = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | ye
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This partially reverts an unreleased behavior: throwing a 405 when a non-safe verb prevents a slash/scheme redirection.
While this was correct, we are removing it from master to remove some complexity from the implementation of dumped router.
Better not make anyone rely on such nitpicking details that have little to no use in practice.