### PR TITLE
[Config] Introduce BuilderAwareInterface

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/BuilderAwareInterface.php
+++ b/src/Symfony/Component/Config/Definition/Builder/BuilderAwareInterface.php
@@ -12,13 +12,14 @@
 namespace Symfony\Component\Config\Definition\Builder;
 
 /**
- * An interface that must be implemented by nodes which can have children.
+ * An interface that can be implemented by nodes which built other nodes.
  *
- * @author Victor Berchet <victor@suumit.com>
+ * @author Roland Franssen <franssen.roland@gmail.com>
  */
-interface ParentNodeDefinitionInterface extends BuilderAwareInterface
+interface BuilderAwareInterface
 {
-    public function children();
-
-    public function append(NodeDefinition $node);
+    /**
+     * Sets a custom children builder.
+     */
+    public function setBuilder(NodeBuilder $builder);
 }

--- a/src/Symfony/Component/Config/Definition/Builder/BuilderAwareInterface.php
+++ b/src/Symfony/Component/Config/Definition/Builder/BuilderAwareInterface.php
@@ -18,8 +18,5 @@ namespace Symfony\Component\Config\Definition\Builder;
  */
 interface BuilderAwareInterface
 {
-    /**
-     * Sets a custom children builder.
-     */
     public function setBuilder(NodeBuilder $builder);
 }

--- a/src/Symfony/Component/Config/Definition/Builder/BuilderAwareInterface.php
+++ b/src/Symfony/Component/Config/Definition/Builder/BuilderAwareInterface.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Config\Definition\Builder;
 
 /**
- * An interface that can be implemented by nodes which built other nodes.
+ * An interface that can be implemented by nodes which build other nodes.
  *
  * @author Roland Franssen <franssen.roland@gmail.com>
  */

--- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -186,7 +186,7 @@ class NodeBuilder implements NodeParentInterface
      */
     public function append(NodeDefinition $node)
     {
-        if ($node instanceof ParentNodeDefinitionInterface) {
+        if ($node instanceof BuilderAwareInterface) {
             $builder = clone $this;
             $builder->setParent(null);
             $node->setBuilder($builder);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Split `ParentNodeDefinitionInterface` into `BuilderAwareInterface`.

Use case is custom node definition  (extended from VariableNodeDef) with a corresponding prototyped array node.

To set the actual prototype i need the builder at definition level, provided by `ParentNodeDefinitionInterface`. However i don't implement `children()` + `append()`, i solely need the builder scope.

To go after #26297 