### PR TITLE
[RFC][FrameworkBundle] Add REPL command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ReplCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ReplCommand.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StreamableInputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @author Pierre du Plessus <pdples@gmail.com>
+ */
+final class ReplCommand extends Command
+{
+    protected static $defaultName = 'repl';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $inputStream = $input instanceof StreamableInputInterface ? ($input->getStream() ?: STDIN) : STDIN;
+        $application = $this->getApplication();
+        $io = new SymfonyStyle($input, $output);
+
+        $hasReadline = function_exists('readline');
+
+        if ($hasReadline) {
+            readline_completion_function(function () use ($application) {
+                return array_keys($application->all());
+            });
+        }
+
+        do {
+            if ($hasReadline) {
+                $text = readline('> ');
+            } else {
+                $output->write('> ');
+                $text = fgets($inputStream, 4096);
+            }
+
+            if (false === $text) {
+                throw new RuntimeException('Aborted');
+            }
+
+            $text = trim($text);
+
+            if ('exit' === strtolower($text)) {
+                break;
+            }
+
+            $parts = explode(' ', $text);
+
+            try {
+                if ($command = $this->isInternalCommand($parts[0])) {
+                    $command($output, implode(' ', array_splice($parts, 1)));
+                } elseif ($application->has($parts[0])) {
+                    $this->runCommand($output, $application, $parts);
+                } else {
+                    $io->error(sprintf('Command "%s" is not recognized', $parts[0]));
+                }
+            } catch (\Throwable $e) {
+                $application->renderException($e, $output);
+            }
+        } while (true);
+    }
+
+    protected function runCommand(OutputInterface $output, Application $application, array $parts): void
+    {
+        try {
+            $command = $application->find($parts[0]);
+            $input = new StringInput(implode(' ', $parts));
+            $input->setInteractive(false);
+
+            $command->run($input, $output);
+        } catch (\Throwable $e) {
+            $application->renderException($e, $output);
+        }
+    }
+
+    private function isInternalCommand($text): ?callable
+    {
+        switch (strtolower($text)) {
+            case 'describe':
+                return function (OutputInterface $output, $text) {
+                    if (!$text) {
+                        throw new InvalidArgumentException('You must pass a command name to get help information');
+                    }
+
+                    $command = $this->getApplication()->get($text);
+
+                    $helper = new DescriptorHelper();
+                    $helper->describe($output, $command);
+                };
+            case 'env':
+                return function (OutputInterface $output, $text) {
+                    if ($text) {
+                        $output->writeln(sprintf('%s=%s', $text, getenv($text)));
+                    } else {
+                        $table = new Table($output);
+
+                        foreach (getenv() as $key => $value) {
+                            $table->addRow(array($key, $value));
+                        }
+
+                        $table->render();
+                    }
+                };
+        }
+
+        return null;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -64,6 +64,10 @@
             <tag name="console.command" command="debug:event-dispatcher" />
         </service>
 
+        <service id="console.command.repl" class="Symfony\Bundle\FrameworkBundle\Command\ReplCommand">
+            <tag name="console.command" command="repl" />
+        </service>
+
         <service id="console.command.router_debug" class="Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand">
             <argument type="service" id="router" />
             <tag name="console.command" command="debug:router" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | TBD
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | TBD

I would like to get some feedback about a REPL command before I finish the implementation.

This adds a new `repl` command (`php bin/console repl`) command, which evaluates input given.
The input currently can be any existing command name, which will in turn run the command.
Example:

```
$ php bin/console repl
> lint:twig app
// Runs the 'lint:twig' command and print output
```

The benefit of a REPL command is that you can quickly run any command (without the need to type ./bin/console or use an alias), command auto-completion without the need of 3rd-party autocomplete tools, and additional functionality can be added for debugging etc.

The implementation is not ready and still requires some features (E.G history support), but I would like some feedback on the idea in general and what additional functionality should be added before I finish the implementation.

#### Examples of Things That Can Be Implemented

- Evaluate PHP code with default variables (E.G have `$container`, `$kernel` etc available which can be acted on - [Psysh](http://psysh.org/) can be re-used for advanced functionality, otherwise just support simple expressions based on pre-defined variables)
    - `> $container->has('some.service')`
- Simulate a web request to a route
    - `> request my_foo_route`
- Dispatch an event for testing/debugging
    - `> dispatch foo.event` 