### PR TITLE
[Form] allow additional http methods in form configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -29,7 +29,6 @@
         <!-- FormFactory -->
         <service id="form.factory" class="Symfony\Component\Form\FormFactory" public="true">
             <argument type="service" id="form.registry" />
-            <argument type="service" id="form.resolved_type_factory" />
         </service>
         <service id="Symfony\Component\Form\FormFactoryInterface" alias="form.factory" />
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * deprecated calling `FormRenderer::searchAndRenderBlock` for fields which were already rendered
  * added a cause when a CSRF error has occurred
  * deprecated the `scale` option of the `IntegerType`
+ * removed restriction on allowed HTTP methods
 
 4.1.0
 -----

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -35,19 +35,6 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     private static $nativeRequestHandler;
 
     /**
-     * The accepted request methods.
-     *
-     * @var array
-     */
-    private static $allowedMethods = array(
-        'GET',
-        'PUT',
-        'POST',
-        'DELETE',
-        'PATCH',
-    );
-
-    /**
      * @var bool
      */
     protected $locked = false;
@@ -788,13 +775,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
             throw new BadMethodCallException('The config builder cannot be modified anymore.');
         }
 
-        $upperCaseMethod = strtoupper($method);
-
-        if (!\in_array($upperCaseMethod, self::$allowedMethods)) {
-            throw new InvalidArgumentException(sprintf('The form method is "%s", but should be one of "%s".', $method, implode('", "', self::$allowedMethods)));
-        }
-
-        $this->method = $upperCaseMethod;
+        $this->method = strtoupper($method);
 
         return $this;
     }

--- a/src/Symfony/Component/Form/Tests/FormConfigTest.php
+++ b/src/Symfony/Component/Form/Tests/FormConfigTest.php
@@ -138,14 +138,6 @@ class FormConfigTest extends TestCase
         self::assertSame('PATCH', $formConfigBuilder->getMethod());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     */
-    public function testSetMethodDoesNotAllowOtherValues()
-    {
-        $this->getConfigBuilder()->setMethod('foo');
-    }
-
     private function getConfigBuilder($name = 'name')
     {
         $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26287
| License       | MIT
| Doc PR        | TBD

In order to allow HTTP methods other than GET, PUT, POST, DELETE and PATCH, the `allowed_methods` option under `framework.form` configuration has been added.
This configuration option adds the specified methods to the `FormConfigBuilder` whitelist, allowing that methods be used in form configuration via `setMethod` or the `method` option.

The use-case, that has been discussed in #26287, required the usage of custom HTTP method for describing a resource in an API application.
