### PR TITLE
[Form][WCAG] Add hidden labels on date and time fields

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
@@ -40,6 +40,16 @@
         <div {{ block('widget_container_attributes') }}>
             {{- form_errors(form.date) -}}
             {{- form_errors(form.time) -}}
+
+            <div style="display:none">
+                {%- if form.date.year is defined %}{{ form_label(form.date.year) }}{% endif -%}
+                {%- if form.date.month is defined %}{{ form_label(form.date.month) }}{% endif -%}
+                {%- if form.date.day is defined %}{{ form_label(form.date.day) }}{% endif -%}
+                {%- if form.time.hour is defined %}{{ form_label(form.time.hour) }}{% endif -%}
+                {%- if form.time.minute is defined %}{{ form_label(form.time.minute) }}{% endif -%}
+                {%- if form.time.second is defined %}{{ form_label(form.time.second) }}{% endif -%}
+            </div>
+
             {{- form_widget(form.date, { datetime: true } ) -}}
             {{- form_widget(form.time, { datetime: true } ) -}}
         </div>
@@ -54,6 +64,12 @@
         {%- if datetime is not defined or not datetime -%}
             <div {{ block('widget_container_attributes') -}}>
         {%- endif %}
+            <div style="display:none">
+                {{ form_label(form.year) }}
+                {{ form_label(form.month) }}
+                {{ form_label(form.day) }}
+            </div>
+
             {{- date_pattern|replace({
                 '{{ year }}': form_widget(form.year),
                 '{{ month }}': form_widget(form.month),
@@ -73,7 +89,10 @@
         {%- if datetime is not defined or false == datetime -%}
             <div {{ block('widget_container_attributes') -}}>
         {%- endif -%}
-        {{- form_widget(form.hour) }}{% if with_minutes %}:{{ form_widget(form.minute) }}{% endif %}{% if with_seconds %}:{{ form_widget(form.second) }}{% endif %}
+        <div style="display:none">{{ form_label(form.hour) }}</div>
+        {{- form_widget(form.hour) -}}
+        {%- if with_minutes -%}:<div style="display:none">{{ form_label(form.minute) }}</div>{{ form_widget(form.minute) }}{%- endif -%}
+        {%- if with_seconds -%}:<div style="display:none">{{ form_label(form.second) }}</div>{{ form_widget(form.second) }}{%- endif -%}
         {%- if datetime is not defined or false == datetime -%}
             </div>
         {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_base_layout.html.twig
@@ -41,7 +41,7 @@
             {{- form_errors(form.date) -}}
             {{- form_errors(form.time) -}}
 
-            <div style="display:none">
+            <div class="sr-only">
                 {%- if form.date.year is defined %}{{ form_label(form.date.year) }}{% endif -%}
                 {%- if form.date.month is defined %}{{ form_label(form.date.month) }}{% endif -%}
                 {%- if form.date.day is defined %}{{ form_label(form.date.day) }}{% endif -%}
@@ -64,7 +64,7 @@
         {%- if datetime is not defined or not datetime -%}
             <div {{ block('widget_container_attributes') -}}>
         {%- endif %}
-            <div style="display:none">
+            <div class="sr-only">
                 {{ form_label(form.year) }}
                 {{ form_label(form.month) }}
                 {{ form_label(form.day) }}
@@ -89,10 +89,10 @@
         {%- if datetime is not defined or false == datetime -%}
             <div {{ block('widget_container_attributes') -}}>
         {%- endif -%}
-        <div style="display:none">{{ form_label(form.hour) }}</div>
+        <div class="sr-only">{{ form_label(form.hour) }}</div>
         {{- form_widget(form.hour) -}}
-        {%- if with_minutes -%}:<div style="display:none">{{ form_label(form.minute) }}</div>{{ form_widget(form.minute) }}{%- endif -%}
-        {%- if with_seconds -%}:<div style="display:none">{{ form_label(form.second) }}</div>{{ form_widget(form.second) }}{%- endif -%}
+        {%- if with_minutes -%}:<div class="sr-only">{{ form_label(form.minute) }}</div>{{ form_widget(form.minute) }}{%- endif -%}
+        {%- if with_seconds -%}:<div class="sr-only">{{ form_label(form.second) }}</div>{{ form_widget(form.second) }}{%- endif -%}
         {%- if datetime is not defined or false == datetime -%}
             </div>
         {%- endif -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

According to my friend and WCAG2 expect [Sandra](https://twitter.com/sandrability):

> "Guidance texts" (my translation) on DateType and DateTimeType etc are missing. It is great that they are grouped with a "fieldset" but it will be more clear if there was a label on each select. Especially since different countries have different time and date formats. The time form is read like "00 00" and you have no idea if it is seconds, minutes or hours. You may do "guidance texts" visually hidden if you do not want to change the looks of the form. But since "month" is shorten to "Jan" instead of "January" you may want to have clear and visual guidance texts. 

