### PR TITLE
[Form][WCAG] Errors sign for people that do not see colors

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -244,7 +244,7 @@
         <div class="{% if form is not rootform %}invalid-feedback d-block{% else %}alert alert-danger{% endif %}">
             <ul class="list-unstyled mb-0">
                 {%- for error in errors -%}
-                    <li>&#x274C; {{ error.message }}</li>
+                    <li><span class="initialism form-error-icon badge badge-danger">{{ 'error'|trans }}</span> <span class="form-error-message">{{ error.message }}</span></li>
                 {%- endfor -%}
             </ul>
         </div>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -244,7 +244,7 @@
         <div class="{% if form is not rootform %}invalid-feedback d-block{% else %}alert alert-danger{% endif %}">
             <ul class="list-unstyled mb-0">
                 {%- for error in errors -%}
-                    <li>{{ error.message }}</li>
+                    <li>&#x274C; {{ error.message }}</li>
                 {%- endfor -%}
             </ul>
         </div>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -244,7 +244,7 @@
         <div class="{% if form is not rootform %}invalid-feedback d-block{% else %}alert alert-danger{% endif %}">
             <ul class="list-unstyled mb-0">
                 {%- for error in errors -%}
-                    <li><span class="initialism form-error-icon badge badge-danger">{{ 'error'|trans }}</span> <span class="form-error-message">{{ error.message }}</span></li>
+                    <li><span class="initialism form-error-icon badge badge-danger">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span></li>
                 {%- endfor -%}
             </ul>
         </div>

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
@@ -34,7 +34,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
         [
             ./div[
                 ./ul
-                    [./li[.="[trans]Error![/trans]"]]
+                    [./li[.="❌ [trans]Error![/trans]"]]
                     [count(./li)=1]
             ]
         ]

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
@@ -34,7 +34,10 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
         [
             ./div[
                 ./ul
-                    [./li[.="❌ [trans]Error![/trans]"]]
+                    [./li
+                        [./span[.="[trans]error[/trans]"]]
+                        [./span[.="[trans]Error![/trans]"]]
+                    ]
                     [count(./li)=1]
             ]
         ]

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
@@ -35,7 +35,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
             ./div[
                 ./ul
                     [./li
-                        [./span[.="[trans]error[/trans]"]]
+                        [./span[.="[trans]Error[/trans]"]]
                         [./span[.="[trans]Error![/trans]"]]
                     ]
                     [count(./li)=1]

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
@@ -34,7 +34,10 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         [
             ./div[
                 ./ul
-                    [./li[.="❌ [trans]Error![/trans]"]]
+                    [./li
+                        [./span[.="[trans]error[/trans]"]]
+                        [./span[.="[trans]Error![/trans]"]]
+                    ]
                     [count(./li)=1]
             ]
         ]
@@ -166,9 +169,12 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
             [@class="list-unstyled mb-0"]
             [
                 ./li
-                    [.="❌ [trans]Error 1[/trans]"]
+                    [./span[.="[trans]error[/trans]"]]
+                    [./span[.="[trans]Error 1[/trans]"]]
+                  
                 /following-sibling::li
-                    [.="❌ [trans]Error 2[/trans]"]
+                    [./span[.="[trans]error[/trans]"]]
+                    [./span[.="[trans]Error 2[/trans]"]]
             ]
             [count(./li)=2]
     ]

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
@@ -35,7 +35,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
             ./div[
                 ./ul
                     [./li
-                        [./span[.="[trans]error[/trans]"]]
+                        [./span[.="[trans]Error[/trans]"]]
                         [./span[.="[trans]Error![/trans]"]]
                     ]
                     [count(./li)=1]
@@ -169,11 +169,11 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
             [@class="list-unstyled mb-0"]
             [
                 ./li
-                    [./span[.="[trans]error[/trans]"]]
+                    [./span[.="[trans]Error[/trans]"]]
                     [./span[.="[trans]Error 1[/trans]"]]
                   
                 /following-sibling::li
-                    [./span[.="[trans]error[/trans]"]]
+                    [./span[.="[trans]Error[/trans]"]]
                     [./span[.="[trans]Error 2[/trans]"]]
             ]
             [count(./li)=2]

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
@@ -34,7 +34,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         [
             ./div[
                 ./ul
-                    [./li[.="[trans]Error![/trans]"]]
+                    [./li[.="❌ [trans]Error![/trans]"]]
                     [count(./li)=1]
             ]
         ]
@@ -166,9 +166,9 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
             [@class="list-unstyled mb-0"]
             [
                 ./li
-                    [.="[trans]Error 1[/trans]"]
+                    [.="❌ [trans]Error 1[/trans]"]
                 /following-sibling::li
-                    [.="[trans]Error 2[/trans]"]
+                    [.="❌ [trans]Error 2[/trans]"]
             ]
             [count(./li)=2]
     ]

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -41,7 +41,7 @@
         "symfony/doctrine-bridge": "<2.7",
         "symfony/framework-bundle": "<3.4",
         "symfony/http-kernel": "<3.3.5",
-        "symfony/twig-bridge": "<3.4"
+        "symfony/twig-bridge": "<3.4.5|<4.0.5,>=4.0"
     },
     "suggest": {
         "symfony/validator": "For form validation.",

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Невалиден бизнес идентификационен код (BIC).</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Грешка</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Tato hodnota není platný identifikační kód podniku (BIC).</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Chyba</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
@@ -242,6 +242,10 @@
                 <source>This value is not a valid ISSN.</source>
                 <target>Værdien er ikke en gyldig ISSN.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Fejl</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Dieser Wert ist kein gültiger BIC.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Fehler</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>This is not a valid Business Identifier Code (BIC).</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Error</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>No es un Código de Identificación Bancaria (BIC) válido.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Error</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
@@ -278,6 +278,10 @@
                 <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
                 <target>Balio hau ez litzateke {{ compared_value_type }} {{ compared_value }}-(r)en berbera izan behar.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Errore</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
@@ -222,6 +222,10 @@
                 <source>Unsupported card type or invalid card number.</source>
                 <target>Tätä korttityyppiä ei tueta tai korttinumero on virheellinen.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Virhe</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Ce n'est pas un code universel d'identification des banques (BIC) valide.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Erreur</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Ovo nije validan poslovni identifikacijski broj (BIC).</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Greška</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Érvénytelen nemzetközi bankazonosító kód (BIC/SWIFT).</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Hiba</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Questo valore non è un codice BIC valido.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Errore</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -302,6 +302,10 @@
                 <source>An empty file is not allowed.</source>
                 <target>Failas negali būti tuščias.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Klaida</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -310,6 +310,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Dit is geen geldige bedrijfsidentificatiecode (BIC/SWIFT).</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Fout</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Ta wartość nie jest poprawnym kodem BIC (Business Identifier Code).</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Błąd</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
@@ -302,6 +302,10 @@
                 <source>An empty file is not allowed.</source>
                 <target>Ficheiro vazio não é permitido.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Erro</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -278,6 +278,10 @@
                 <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
                 <target>Această valoare nu trebuie să fie identică cu {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Eroare</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -310,6 +310,10 @@
                 <source>This value does not match the expected {{ charset }} charset.</source>
                 <target>Значение не совпадает с ожидаемой {{ charset }} кодировкой.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Ошибка</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
@@ -314,6 +314,10 @@
                 <source>This is not a valid Business Identifier Code (BIC).</source>
                 <target>Detta är inte en giltig BIC-kod.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Fel</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -222,6 +222,10 @@
                 <source>Unsupported card type or invalid card number.</source>
                 <target>Desteklenmeyen kart tipi veya geçersiz kart numarası.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Hata</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
@@ -278,6 +278,10 @@
                 <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
                 <target>Значення не повинно бути ідентичним {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>Помилка</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -310,6 +310,10 @@
                 <source>This value does not match the expected {{ charset }} charset.</source>
                 <target>该值不符合 {{ charset }} 编码。</target>
             </trans-unit>
+            <trans-unit id="82">
+                <source>Error</source>
+                <target>错误</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

According to my friend and WCAG2 expect [Sandra](https://twitter.com/sandrability):

> The form errors is correctly encoded and works great. But visually they may be hard to see for people that do not see colors very well. Try to improve errors with an icon to make it more visual clear that an error has occurred. 


![screen shot 2018-02-26 at 17 42 01](https://user-images.githubusercontent.com/1275206/36802282-c81357c6-1cb4-11e8-843c-4592e3d597f9.png)
