### PR TITLE
[Security] Check provider return value in ChainProvider loadUserByUse…

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/ChainUserProviderTest.php
@@ -65,6 +65,31 @@ class ChainUserProviderTest extends TestCase
         $provider->loadUserByUsername('foo');
     }
 
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\LogicException
+     */
+    public function testLoadUserByUsernameWithNullUserThrowsLogicException()
+    {
+        $provider1 = $this->getProvider();
+        $provider1
+            ->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with($this->equalTo('foo'))
+            ->will($this->throwException(new UsernameNotFoundException('not found')))
+        ;
+
+        $provider2 = $this->getProvider();
+        $provider2
+            ->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with($this->equalTo('foo'))
+            ->will($this->returnValue(null))
+        ;
+
+        $provider = new ChainUserProvider(array($provider1, $provider2));
+        $provider->loadUserByUsername('foo');
+    }
+
     public function testRefreshUser()
     {
         $provider1 = $this->getProvider();

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\User;
 
+use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
@@ -53,7 +54,13 @@ class ChainUserProvider implements UserProviderInterface
     {
         foreach ($this->providers as $provider) {
             try {
-                return $provider->loadUserByUsername($username);
+                $user = $provider->loadUserByUsername($username);
+
+                if (!$user instanceof UserInterface) {
+                    throw new LogicException(sprintf('%s should return an object implementing UserInterface or throw UsernameNotFoundException. "%s" given.', get_class($provider), is_object($user) ? get_class($user) : gettype($user)));
+                }
+
+                return $user;
             } catch (UsernameNotFoundException $e) {
                 // try next one
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | unsure
| Deprecations? | no
| Tests pass?   | yes   
| License       | MIT

The Chain  provider does not check for a valid UserInterface Object, I think this should throw an exception if the object is not implementing UserInterface
