### PR TITLE
[SecurityBundle] Deprecate switch_user.stateless config node

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -70,6 +70,7 @@ SecurityBundle
 --------------
 
  * The `logout_on_user_change` firewall option is deprecated.
+ * The `switch_user.stateless` firewall option is deprecated, use the `stateless` option instead.
  * The `SecurityUserValueResolver` class is deprecated, use
    `Symfony\Component\Security\Http\Controller\UserValueResolver` instead.
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -65,6 +65,7 @@ SecurityBundle
 --------------
 
  * The `logout_on_user_change` firewall option has been removed.
+ * The `switch_user.stateless` firewall option has been removed.
  * The `SecurityUserValueResolver` class has been removed.
 
 Translation

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -249,7 +249,10 @@ class MainConfiguration implements ConfigurationInterface
                     ->scalarNode('provider')->end()
                     ->scalarNode('parameter')->defaultValue('_switch_user')->end()
                     ->scalarNode('role')->defaultValue('ROLE_ALLOWED_TO_SWITCH')->end()
-                    ->booleanNode('stateless')->defaultValue(false)->end()
+                    ->booleanNode('stateless')
+                        ->setDeprecated('The "%path%.%node%" configuration key has been deprecated in Symfony 4.1.')
+                        ->defaultValue(false)
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -111,7 +111,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 array(
                     'parameter' => '_switch_user',
                     'role' => 'ROLE_ALLOWED_TO_SWITCH',
-                    'stateless' => true,
+                    'stateless' => false,
                 ),
             ),
             array(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -66,7 +66,7 @@ $container->loadFromExtension('security', array(
             'http_basic' => true,
             'form_login' => true,
             'anonymous' => true,
-            'switch_user' => array('stateless' => true),
+            'switch_user' => true,
             'x509' => true,
             'remote_user' => true,
             'logout' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/no_custom_user_checker.php
@@ -17,7 +17,7 @@ $container->loadFromExtension('security', array(
             'http_basic' => true,
             'form_login' => true,
             'anonymous' => true,
-            'switch_user' => array('stateless' => true),
+            'switch_user' => true,
             'x509' => true,
             'remote_user' => true,
             'logout' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -49,7 +49,7 @@
             <http-basic />
             <form-login />
             <anonymous />
-            <switch-user stateless="true" />
+            <switch-user />
             <x509 />
             <remote-user />
             <user-checker />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/no_custom_user_checker.xml
@@ -17,7 +17,7 @@
             <http-basic />
             <form-login />
             <anonymous />
-            <switch-user stateless="true" />
+            <switch-user />
             <x509 />
             <remote-user />
             <user-checker />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -49,7 +49,6 @@ security:
             form_login: true
             anonymous: true
             switch_user:
-                stateless: true
             x509: true
             remote_user: true
             logout: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/no_custom_user_checker.yml
@@ -12,8 +12,7 @@ security:
             http_basic: true
             form_login: true
             anonymous: true
-            switch_user:
-                stateless: true
+            switch_user: true
             x509: true
             remote_user: true
             logout: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -132,7 +132,7 @@ class SecurityExtensionTest extends TestCase
                 'some_firewall' => array(
                     'stateless' => true,
                     'http_basic' => null,
-                    'switch_user' => array('stateless' => false),
+                    'switch_user' => true,
                 ),
             ),
         ));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/switchuser_stateless.yml
@@ -9,6 +9,6 @@ security:
                     user_can_switch: { password: test, roles: [ROLE_USER, ROLE_ALLOWED_TO_SWITCH] }
     firewalls:
         main:
+            stateless: true
             switch_user:
                 parameter: X-Switch-User
-                stateless: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes 
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/issues/8447

unused since 4.0.