### PR TITLE
[Config] Handle nullable node name + fix inheritdocs

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -150,9 +150,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     }
 
     /**
-     * Sets the node Name.
-     *
-     * @param string $name The node's name
+     * {@inheritdoc}
      */
     public function setName($name)
     {
@@ -160,9 +158,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     }
 
     /**
-     * Checks if the node has a default value.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasDefaultValue()
     {
@@ -170,11 +166,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     }
 
     /**
-     * Retrieves the default value.
-     *
-     * @return array The default value
-     *
-     * @throws \RuntimeException if the node has no default value
+     * {@inheritdoc}
      */
     public function getDefaultValue()
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -170,9 +170,7 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Checks if this node is required.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isRequired()
     {
@@ -180,9 +178,7 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Returns the name of this node.
-     *
-     * @return string The Node's name
+     * {@inheritdoc}
      */
     public function getName()
     {
@@ -190,13 +186,11 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Retrieves the path of this node.
-     *
-     * @return string The Node's path
+     * {@inheritdoc}
      */
     public function getPath()
     {
-        $path = $this->name;
+        $path = null === $this->name ? '' : $this->name;
 
         if (null !== $this->parent) {
             $path = $this->parent->getPath().'.'.$path;
@@ -206,14 +200,7 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Merges two values together.
-     *
-     * @param mixed $leftSide
-     * @param mixed $rightSide
-     *
-     * @return mixed The merged value
-     *
-     * @throws ForbiddenOverwriteException
+     * {@inheritdoc}
      */
     final public function merge($leftSide, $rightSide)
     {
@@ -233,11 +220,7 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Normalizes a value, applying all normalization closures.
-     *
-     * @param mixed $value Value to normalize
-     *
-     * @return mixed The normalized value
+     * {@inheritdoc}
      */
     final public function normalize($value)
     {
@@ -285,14 +268,7 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Finalizes a value, applying all finalization closures.
-     *
-     * @param mixed $value The value to finalize
-     *
-     * @return mixed The finalized value
-     *
-     * @throws Exception
-     * @throws InvalidConfigurationException
+     * {@inheritdoc}
      */
     final public function finalize($value)
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -40,7 +40,7 @@ abstract class BaseNode implements NodeInterface
      */
     public function __construct($name, NodeInterface $parent = null)
     {
-        if (null !== $name && false !== strpos($name, '.')) {
+        if (false !== strpos($name = (string) $name, '.')) {
             throw new \InvalidArgumentException('The name must not contain ".".');
         }
 
@@ -182,7 +182,7 @@ abstract class BaseNode implements NodeInterface
      */
     public function getName()
     {
-        return null === $this->name ? '' : $this->name;
+        return $this->name;
     }
 
     /**
@@ -190,7 +190,7 @@ abstract class BaseNode implements NodeInterface
      */
     public function getPath()
     {
-        $path = null === $this->name ? '' : $this->name;
+        $path = $this->name;
 
         if (null !== $this->parent) {
             $path = $this->parent->getPath().'.'.$path;

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -40,7 +40,7 @@ abstract class BaseNode implements NodeInterface
      */
     public function __construct($name, NodeInterface $parent = null)
     {
-        if (false !== strpos($name, '.')) {
+        if (null !== $name && false !== strpos($name, '.')) {
             throw new \InvalidArgumentException('The name must not contain ".".');
         }
 
@@ -186,7 +186,7 @@ abstract class BaseNode implements NodeInterface
      */
     public function getName()
     {
-        return $this->name;
+        return null === $this->name ? '' : $this->name;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -47,7 +47,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     }
 
     /**
-     * Sets a custom children builder.
+     * {@inheritdoc}
      */
     public function setBuilder(NodeBuilder $builder)
     {
@@ -55,9 +55,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     }
 
     /**
-     * Returns a builder to add children nodes.
-     *
-     * @return NodeBuilder
+     * {@inheritdoc}
      */
     public function children()
     {
@@ -306,17 +304,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     }
 
     /**
-     * Appends a node definition.
-     *
-     *     $node = new ArrayNodeDefinition()
-     *         ->children()
-     *             ->scalarNode('foo')->end()
-     *             ->scalarNode('baz')->end()
-     *         ->end()
-     *         ->append($this->getBarNodeDefinition())
-     *     ;
-     *
-     * @return $this
+     * {@inheritdoc}
      */
     public function append(NodeDefinition $node)
     {

--- a/src/Symfony/Component/Config/Definition/Builder/ParentNodeDefinitionInterface.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ParentNodeDefinitionInterface.php
@@ -18,9 +18,32 @@ namespace Symfony\Component\Config\Definition\Builder;
  */
 interface ParentNodeDefinitionInterface
 {
+    /**
+     * Returns a builder to add children nodes.
+     *
+     * @return NodeBuilder
+     */
     public function children();
 
+    /**
+     * Appends a node definition.
+     *
+     * Usage:
+     *
+     *     $node = $parentNode
+     *         ->children()
+     *             ->scalarNode('foo')->end()
+     *             ->scalarNode('baz')->end()
+     *             ->append($this->getBarNodeDefinition())
+     *         ->end()
+     *     ;
+     *
+     * @return $this
+     */
     public function append(NodeDefinition $node);
 
+    /**
+     * Sets a custom children builder.
+     */
     public function setBuilder(NodeBuilder $builder);
 }

--- a/src/Symfony/Component/Config/Definition/NodeInterface.php
+++ b/src/Symfony/Component/Config/Definition/NodeInterface.php
@@ -65,7 +65,7 @@ interface NodeInterface
     /**
      * Normalizes a value.
      *
-     * @param mixed $value Value to normalize
+     * @param mixed $value The value to normalize
      *
      * @return mixed The normalized value
      *

--- a/src/Symfony/Component/Config/Definition/NodeInterface.php
+++ b/src/Symfony/Component/Config/Definition/NodeInterface.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Config\Definition;
 
+use Symfony\Component\Config\Definition\Exception\Exception;
+use Symfony\Component\Config\Definition\Exception\ForbiddenOverwriteException;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
 /**
  * Common Interface among all nodes.
  *
@@ -59,9 +63,9 @@ interface NodeInterface
     public function getDefaultValue();
 
     /**
-     * Normalizes the supplied value.
+     * Normalizes a value.
      *
-     * @param mixed $value The value to normalize
+     * @param mixed $value Value to normalize
      *
      * @return mixed The normalized value
      */
@@ -73,7 +77,9 @@ interface NodeInterface
      * @param mixed $leftSide
      * @param mixed $rightSide
      *
-     * @return mixed The merged values
+     * @return mixed The merged value
+     *
+     * @throws ForbiddenOverwriteException
      */
     public function merge($leftSide, $rightSide);
 
@@ -83,6 +89,9 @@ interface NodeInterface
      * @param mixed $value The value to finalize
      *
      * @return mixed The finalized value
+     *
+     * @throws Exception
+     * @throws InvalidConfigurationException
      */
     public function finalize($value);
 }

--- a/src/Symfony/Component/Config/Definition/NodeInterface.php
+++ b/src/Symfony/Component/Config/Definition/NodeInterface.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Config\Definition;
 
-use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Config\Definition\Exception\ForbiddenOverwriteException;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 
 /**
  * Common Interface among all nodes.
@@ -68,6 +68,8 @@ interface NodeInterface
      * @param mixed $value Value to normalize
      *
      * @return mixed The normalized value
+     *
+     * @throws InvalidTypeException if the value type is invalid
      */
     public function normalize($value);
 
@@ -79,7 +81,8 @@ interface NodeInterface
      *
      * @return mixed The merged value
      *
-     * @throws ForbiddenOverwriteException
+     * @throws ForbiddenOverwriteException if the configuration path cannot be overwritten
+     * @throws InvalidTypeException        if the value type is invalid
      */
     public function merge($leftSide, $rightSide);
 
@@ -90,8 +93,8 @@ interface NodeInterface
      *
      * @return mixed The finalized value
      *
-     * @throws Exception
-     * @throws InvalidConfigurationException
+     * @throws InvalidTypeException          if the value type is invalid
+     * @throws InvalidConfigurationException if the value is invalid configuration
      */
     public function finalize($value);
 }

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -102,9 +102,7 @@ class PrototypedArrayNode extends ArrayNode
     }
 
     /**
-     * Checks if the node has a default value.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasDefaultValue()
     {
@@ -126,12 +124,10 @@ class PrototypedArrayNode extends ArrayNode
     }
 
     /**
-     * Retrieves the default value.
+     * {@inheritdoc}
      *
      * The default value could be either explicited or derived from the prototype
      * default value.
-     *
-     * @return array The default value
      */
     public function getDefaultValue()
     {

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -27,9 +27,6 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
     protected $defaultValue;
     protected $allowEmptyValue = true;
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDefaultValue($value)
     {
         $this->defaultValueSet = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no-ish
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Small split from #26297 that can be merged until master/4.1. Whereas the doc fixes only apply until 3.4, hence the split.

Small change regarding `getName/Path()` for not returning a `null` value anymore which violates `NodeInterface::getName/Path()`

Remainng issue left at 

https://github.com/symfony/symfony/blob/cd5f4105a43208632c8b62fd75b4dad53dcd8a41/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php#L381-L383

which i tend to leave untouched across all branches for now.