### PR TITLE
[Finder] Fixed leading/trailing / in filename

### DIFF
--- a/src/Symfony/Component/Finder/SplFileInfo.php
+++ b/src/Symfony/Component/Finder/SplFileInfo.php
@@ -28,7 +28,7 @@ class SplFileInfo extends \SplFileInfo
      */
     public function __construct($file, $relativePath, $relativePathname)
     {
-        parent::__construct($file);
+        parent::__construct(realpath($file) ?: $file);
         $this->relativePath = $relativePath;
         $this->relativePathname = $relativePathname;
     }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -48,6 +48,20 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php', 'test.py', 'foo bar')), $finder->in(self::$tmpDir)->getIterator());
     }
 
+    public function testRemoveTrailingSlash()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test cannot be run on Windows.');
+        }
+
+        $finder = $this->buildFinder();
+
+        $expected = $this->toAbsolute(array('foo/bar.tmp', 'test.php', 'test.py', 'foo bar'));
+        $in = '//'.realpath(self::$tmpDir).'//';
+
+        $this->assertIterator($expected, $finder->in($in)->files()->getIterator());
+    }
+
     public function testDepth()
     {
         $finder = $this->buildFinder();
@@ -504,8 +518,8 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder->in($locations)->depth('< 10')->name('*.neon');
 
         $expected = array(
-            __DIR__.'/Fixtures/one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'c.neon',
-            __DIR__.'/Fixtures/one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'d.neon',
+            __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'c.neon',
+            __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'d.neon',
         );
 
         $this->assertIterator($expected, $finder);

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilePathsIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilePathsIteratorTest.php
@@ -31,7 +31,7 @@ class FilePathsIteratorTest extends RealIteratorTestCase
 
     public function getSubPathData()
     {
-        $tmpDir = sys_get_temp_dir().'/symfony_finder';
+        $tmpDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'symfony_finder';
 
         return array(
             array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

---

Without this patch, we go this:

```
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => '/tmp/symfony_finder/foo bar'
-    1 => '/tmp/symfony_finder/foo/bar.tmp'
-    2 => '/tmp/symfony_finder/test.php'
-    3 => '/tmp/symfony_finder/test.py'
+    0 => '///tmp/symfony_finder///foo bar'
+    1 => '///tmp/symfony_finder///foo/bar.tmp'
+    2 => '///tmp/symfony_finder///test.php'
+    3 => '///tmp/symfony_finder///test.py'
 )
```