### PR TITLE
[Debug] Keep previous errors of Error instances

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FatalThrowableError.php
+++ b/src/Symfony/Component/Debug/Exception/FatalThrowableError.php
@@ -37,7 +37,8 @@ class FatalThrowableError extends FatalErrorException
             $e->getCode(),
             $severity,
             $e->getFile(),
-            $e->getLine()
+            $e->getLine(),
+            $e->getPrevious()
         );
 
         $this->setTrace($e->getTrace());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 (I have tested against 4.0, but I guess it applies to all the older versions too)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | --
| License       | MIT

Passing on the previous exception gives developers better debugging information. In particular, if you throw an uncaught `new \Error("Something", 0, new \Exception("Inner exception"))` or sth. like that today, you will not see the "Inner exception" text (which may be more helpful than the outer error) in the HTTP debug response. Converting exceptions into errors this way is a common pattern when an exception raised in a sub-routine cannot reasonably occur for a specific caller situation, so there it becomes an `AssertionError` instead.
