### PR TITLE
[Process] Make prepared command lines opt-in

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -269,7 +269,8 @@ class Process implements \IteratorAggregate
                 // exec is mandatory to deal with sending a signal to the process
                 $commandline = 'exec '.$commandline;
             }
-        } else {
+        } elseif ('!' === substr($commandline = trim($commandline), 0, 1)) {
+            $commandline = ltrim(substr($commandline, 1));
             $commandline = $this->replacePlaceholders($commandline, $env);
         }
 
@@ -1554,7 +1555,11 @@ class Process implements \IteratorAggregate
 
     private function replacePlaceholders(string $commandline, array $env)
     {
-        $pattern = '\\' === DIRECTORY_SEPARATOR ? '!%s!' : '${%s}';
+        if (false !== strpos($commandline, '"')) {
+            throw new InvalidArgumentException(sprintf('Double quotes are invalid in prepared command line: !%s', $commandline));
+        }
+
+        $pattern = '\\' === DIRECTORY_SEPARATOR ? '!%s!' : '"$%s"';
 
         return preg_replace_callback('/\{\{ ?([_a-zA-Z0-9]++) ?\}\}/', function ($m) use ($pattern, $commandline, $env) {
             if (!isset($env[$m[1]]) || false === $env[$m[1]]) {

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1380,13 +1380,13 @@ class ProcessTest extends TestCase
 
     public function testSetBadEnv()
     {
-        $process = $this->getProcess('echo hello');
+        $process = $this->getProcess('echo {{ hello }}');
         $process->setEnv(array('bad%%' => '123'));
         $process->inheritEnvironmentVariables(true);
 
         $process->run();
 
-        $this->assertSame('hello'.PHP_EOL, $process->getOutput());
+        $this->assertSame('{{ hello }}'.PHP_EOL, $process->getOutput());
         $this->assertSame('', $process->getErrorOutput());
     }
 
@@ -1476,7 +1476,7 @@ EOTXT;
 
     public function testPreparedCommand()
     {
-        $p = new Process('echo {{ abc }}DEF');
+        $p = new Process('!echo {{ abc }}DEF');
         $p->run(null, array('abc' => 'ABC'));
 
         $this->assertSame('ABCDEF', rtrim($p->getOutput()));
@@ -1488,7 +1488,7 @@ EOTXT;
      */
     public function testPreparedCommandWithMissingValue()
     {
-        $p = new Process('echo {{ abc }}');
+        $p = new Process('!echo {{ abc }}');
         $p->run(null, array('bcd' => 'BCD'));
     }
 
@@ -1498,7 +1498,17 @@ EOTXT;
      */
     public function testPreparedCommandWithNoValues()
     {
-        $p = new Process('echo {{ abc }}');
+        $p = new Process('!echo {{ abc }}');
+        $p->run();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Double quotes are invalid in prepared command line: !echo "{{ abc }}"
+     */
+    public function testPreparedCommandWithDoubleQuote()
+    {
+        $p = new Process('!echo "{{ abc }}"');
         $p->run();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As discussed in #24763, prepared command lines should be opt-in.
Here is the way to opt-in: just prefix your command lines with a `!` and this will make `{{ FOO }}` placeholders replaceable by values provided to either the constructor or the `run()` method.

e.g. `(new Process('!echo {{ FOO }}'))->run(null, array('FOO' => 123));`

Btw, this should be the recommended way to run any command line IMHO.