### PR TITLE
Release v2.7.42

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,30 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.42 (2018-02-28)
+
+ * bug #26338 [Debug] Keep previous errors of Error instances (Philipp91)
+ * bug #26312 [Routing] Don't throw 405 when scheme requirement doesn't match (nicolas-grekas)
+ * bug #26298 Fix ArrayInput::toString() for InputArgument::IS_ARRAY args (maximium)
+ * bug #25557 [WebProfilerBundle] add a way to limit ajax request (Simperfit)
+ * bug #26228 [HttpFoundation] Fix missing "throw" in JsonResponse (nicolas-grekas)
+ * bug #26211 [Console] Suppress warning from sapi_windows_vt100_support (adawolfa)
+ * bug #26156 Fixes #26136: Avoid emitting warning in hasParameterOption() (greg-1-anderson)
+ * bug #26183 [DI] Add null check for removeChild (changmin.keum)
+ * bug #26159 created validator.tl.xlf for Form/Translations (ergiegonzaga)
+ * bug #26100 [Routing] Throw 405 instead of 404 when redirect is not possible (nicolas-grekas)
+ * bug #26040 [Process] Check PHP_BINDIR before $PATH in PhpExecutableFinder (nicolas-grekas)
+ * bug #26012 Exit as late as possible (greg0ire)
+ * bug #25893 [Console] Fix hasParameterOption / getParameterOption when used with multiple flags (greg-1-anderson)
+ * bug #25940 [Form] keep the context when validating forms (xabbuh)
+ * bug #25373 Use the PCRE_DOLLAR_ENDONLY modifier in route regexes (mpdude)
+ * bug #26010 [CssSelector] For AND operator, the left operand should have parentheses, not only right operand (Arnaud CHASSEUX)
+ * bug #25971 [Debug] Fix bad registration of exception handler, leading to mem leak (nicolas-grekas)
+ * bug #25962 [Routing] Fix trailing slash redirection for non-safe verbs (nicolas-grekas)
+ * bug #25948 [Form] Fixed empty data on expanded ChoiceType and FileType (HeahDude)
+ * bug #25972 support sapi_windows_vt100_support for php 7.2+ (jhdxr)
+ * bug #25744 [TwigBridge] Allow label translation to be safe (MatTheCat)
+
 * 2.7.41 (2018-01-29)
 
  * bug #25922 [HttpFoundation] Use the correct syntax for session gc based on Pdo driver (tanasecosminromeo)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,31 +12,31 @@ Symfony is the result of the work of many people who made the code better
  - Christophe Coevoet (stof)
  - Jordi Boggiano (seldaek)
  - Victor Berchet (victor)
- - Johannes S (johannes)
  - Kévin Dunglas (dunglas)
+ - Johannes S (johannes)
  - Jakub Zalas (jakubzalas)
- - Kris Wallsmith (kriswallsmith)
  - Robin Chalas (chalas_r)
+ - Kris Wallsmith (kriswallsmith)
  - Ryan Weaver (weaverryan)
  - Javier Eguiluz (javier.eguiluz)
  - Maxime Steinhausser (ogizanagi)
  - Hugo Hamon (hhamon)
- - Abdellatif Ait boudad (aitboudad)
  - Grégoire Pineau (lyrixx)
+ - Abdellatif Ait boudad (aitboudad)
  - Romain Neutron (romain)
  - Pascal Borreli (pborreli)
  - Wouter De Jong (wouterj)
  - Joseph Bielawski (stloyd)
  - Karma Dordrak (drak)
- - Lukas Kahwe Smith (lsmith)
  - Roland Franssen (ro0)
+ - Lukas Kahwe Smith (lsmith)
  - Martin Hasoň (hason)
  - Jeremy Mikola (jmikola)
  - Jean-François Simon (jfsimon)
  - Benjamin Eberlei (beberlei)
  - Igor Wiedler (igorw)
- - Eriksen Costa (eriksencosta)
  - Jules Pietri (heah)
+ - Eriksen Costa (eriksencosta)
  - Guilhem Niot (energetick)
  - Sarah Khalil (saro0h)
  - Jonathan Wage (jwage)
@@ -45,28 +45,28 @@ Symfony is the result of the work of many people who made the code better
  - William Durand (couac)
  - ornicar
  - Francis Besset (francisbesset)
- - stealth35 ‏ (stealth35)
- - Alexander Mols (asm89)
  - Iltar van der Berg (kjarli)
+ - stealth35 ‏ (stealth35)
+ - Hamza Amrouche (simperfit)
+ - Alexander Mols (asm89)
  - Yonel Ceruto (yonelceruto)
  - Bulat Shakirzyanov (avalanche123)
  - Peter Rehm (rpet)
  - Saša Stamenković (umpirsky)
+ - Matthias Pigulla (mpdude)
  - Henrik Bjørnskov (henrikbjorn)
  - Miha Vrhovnik
- - Matthias Pigulla (mpdude)
  - Diego Saint Esteben (dii3g0)
  - Dany Maillard (maidmaid)
- - Konstantin Kudryashov (everzet)
- - Amrouche Hamza (simperfit)
- - Kevin Bond (kbond)
  - Pierre du Plessis (pierredup)
+ - Konstantin Kudryashov (everzet)
+ - Kevin Bond (kbond)
  - Bilal Amarni (bamarni)
- - Florin Patan (florinpatan)
+ - Alexander M. Turek (derrabus)
  - Jérémy DERUSSÉ (jderusse)
+ - Florin Patan (florinpatan)
  - Samuel ROZE (sroze)
  - Gábor Egyed (1ed)
- - Alexander M. Turek (derrabus)
  - Michel Weimerskirch (mweimerskirch)
  - Andrej Hudec (pulzarraider)
  - Eric Clemmons (ericclemmons)
@@ -75,39 +75,40 @@ Symfony is the result of the work of many people who made the code better
  - Titouan Galopin (tgalopin)
  - Konstantin Myakshin (koc)
  - Christian Raue
+ - Tobias Nyholm (tobias)
  - Arnout Boks (aboks)
  - Deni
  - Henrik Westphal (snc)
  - Dariusz Górecki (canni)
- - Issei Murasawa (issei_m)
  - Douglas Greenshields (shieldo)
- - Tobias Nyholm (tobias)
+ - Issei Murasawa (issei_m)
  - Lee McDermott
  - Brandon Turner
  - Luis Cordova (cordoval)
  - Graham Campbell (graham)
  - Daniel Holmes (dholmes)
+ - Dariusz Ruminski
  - Toni Uebernickel (havvg)
  - Bart van den Burg (burgov)
  - Jordan Alliot (jalliot)
  - Jérôme Tamarelle (gromnan)
  - John Wards (johnwards)
- - Dariusz Ruminski
  - Fran Moreno (franmomu)
  - Antoine Hérault (herzult)
  - Paráda József (paradajozsef)
+ - David Maicher (dmaicher)
  - Arnaud Le Blanc (arnaud-lb)
  - Maxime STEINHAUSSER
+ - Vladimir Reznichenko (kalessil)
  - Michal Piotrowski (eventhorizon)
  - Tim Nagel (merk)
- - David Maicher (dmaicher)
- - Vladimir Reznichenko (kalessil)
  - Brice BERNARD (brikou)
  - Baptiste Clavié (talus)
  - marc.weistroff
  - lenar
  - Alexander Schwenn (xelaris)
  - Włodzimierz Gajda (gajdaw)
+ - Grégoire Paris (greg0ire)
  - Jacob Dreesen (jdreesen)
  - Florian Voutzinos (florianv)
  - Colin Frei
@@ -117,7 +118,6 @@ Symfony is the result of the work of many people who made the code better
  - Peter Kokot (maastermedia)
  - David Buchmann (dbu)
  - excelwebzone
- - Grégoire Paris (greg0ire)
  - Fabien Pennequin (fabienpennequin)
  - Gordon Franke (gimler)
  - Eric GELOEN (gelo)
@@ -129,15 +129,18 @@ Symfony is the result of the work of many people who made the code better
  - Sebastiaan Stok (sstok)
  - Stefano Sala (stefano.sala)
  - Evgeniy (ewgraf)
+ - Lars Strojny (lstrojny)
+ - Alex Pott
+ - Javier Spagnoletti (phansys)
  - Vincent AUBERT (vincent)
  - Juti Noppornpitak (shiroyuki)
  - Tigran Azatyan (tigranazatyan)
  - Sebastian Hörl (blogsh)
  - Daniel Gomes (danielcsgomes)
  - Hidenori Goto (hidenorigoto)
- - Alex Pott
  - Guilherme Blanco (guilhermeblanco)
  - Pablo Godel (pgodel)
+ - Jérôme Vasseur (jvasseur)
  - Jérémie Augustin (jaugustin)
  - Andréia Bohner (andreia)
  - Julien Falque (julienfalque)
@@ -146,20 +149,18 @@ Symfony is the result of the work of many people who made the code better
  - jwdeitch
  - Mikael Pajunen
  - Joel Wurtz (brouznouf)
- - Jérôme Vasseur (jvasseur)
  - Chris Wilkinson (thewilkybarkid)
  - Oleg Voronkovich
  - Philipp Wahala (hifi)
  - Vyacheslav Pavlov
  - Richard van Laak (rvanlaak)
- - Javier Spagnoletti (phansys)
  - Richard Shank (iampersistent)
  - Thomas Rabaix (rande)
  - Rouven Weßling (realityking)
  - Teoh Han Hui (teohhanhui)
+ - Valentin Udaltsov (vudaltsov)
  - Clemens Tolboom
  - Helmer Aaviksoo
- - Lars Strojny (lstrojny)
  - Hiromi Hishida (77web)
  - Matthieu Ouellette-Vachon (maoueh)
  - Michał Pipa (michal.pipa)
@@ -170,11 +171,11 @@ Symfony is the result of the work of many people who made the code better
  - GDIBass
  - jeremyFreeAgent (Jérémy Romey) (jeremyfreeagent)
  - James Halsall (jaitsu)
+ - Gabriel Caruso
  - Warnar Boekkooi (boekkooi)
  - Dmitrii Chekaliuk (lazyhammer)
  - Clément JOBEILI (dator)
  - Daniel Espendiller
- - Valentin Udaltsov (vudaltsov)
  - Possum
  - Dorian Villet (gnutix)
  - Sergey Linnik (linniksa)
@@ -182,6 +183,7 @@ Symfony is the result of the work of many people who made the code better
  - Mario A. Alvarez Garcia (nomack84)
  - Dennis Benkert (denderello)
  - SpacePossum
+ - Matthieu Napoli (mnapoli)
  - Benjamin Dulau (dbenjamin)
  - Mathieu Lemoine (lemoinem)
  - Christian Schmidt
@@ -192,6 +194,7 @@ Symfony is the result of the work of many people who made the code better
  - bronze1man
  - sun (sun)
  - Larry Garfield (crell)
+ - Gabriel Ostrolucký
  - Martin Schuhfuß (usefulthink)
  - apetitpa
  - Matthieu Bontemps (mbontemps)
@@ -216,10 +219,10 @@ Symfony is the result of the work of many people who made the code better
  - Niels Keurentjes (curry684)
  - Eugene Wissner
  - Julien Brochet (mewt)
- - Gabriel Ostrolucký
  - Tristan Darricau (nicofuma)
  - Michaël Perrin (michael.perrin)
  - Marcel Beerta (mazen)
+ - gadelat (gadelat)
  - Loïc Faugeron
  - Jannik Zschiesche (apfelbox)
  - Hidde Wieringa (hiddewie)
@@ -229,6 +232,7 @@ Symfony is the result of the work of many people who made the code better
  - Lorenz Schori
  - Sébastien Lavoie (lavoiesl)
  - Gregor Harlan (gharlan)
+ - Dariusz
  - Francois Zaninotto
  - Alexander Kotynia (olden)
  - Daniel Tschinder
@@ -244,6 +248,7 @@ Symfony is the result of the work of many people who made the code better
  - Xavier Perez
  - Arjen Brouwer (arjenjb)
  - Katsuhiro OGAWA
+ - Thomas Calvet (fancyweb)
  - Patrick McDougle (patrick-mcdougle)
  - Alif Rachmawadi
  - Alessandro Chitolina
@@ -263,9 +268,9 @@ Symfony is the result of the work of many people who made the code better
  - Nikolay Labinskiy (e-moe)
  - Leo Feyer
  - Chekote
- - gadelat (gadelat)
  - Thomas Adam
  - Albert Casademont (acasademont)
+ - Viktor Bocharskyi (bocharsky_bw)
  - Jhonny Lidfors (jhonne)
  - Diego Agulló (aeoris)
  - Andreas Schempp (aschempp)
@@ -276,10 +281,8 @@ Symfony is the result of the work of many people who made the code better
  - Nikita Konstantinov
  - Wodor Wodorski
  - Oskar Stark (oskarstark)
- - Dariusz
  - Thomas Lallement (raziel057)
  - Giorgio Premi
- - Matthieu Napoli (mnapoli)
  - Beau Simensen (simensen)
  - Michael Hirschler (mvhirsch)
  - Robert Kiss (kepten)
@@ -296,7 +299,6 @@ Symfony is the result of the work of many people who made the code better
  - Christian Schmidt
  - Yanick Witschi (toflar)
  - Edi Modrić (emodric)
- - Thomas Calvet (fancyweb)
  - Chad Sikorra (chadsikorra)
  - Chris Smith (cs278)
  - Florian Klein (docteurklein)
@@ -315,7 +317,6 @@ Symfony is the result of the work of many people who made the code better
  - Baptiste Lafontaine
  - François Pluchino (francoispluchino)
  - Aurelijus Valeiša (aurelijus)
- - Victor Bocharsky (bocharsky_bw)
  - Jan Decavele (jandc)
  - Gustavo Piltcher
  - Stepan Tanasiychuk (stfalcon)
@@ -418,7 +419,6 @@ Symfony is the result of the work of many people who made the code better
  - Jan Schumann
  - Niklas Fiekas
  - Markus Bachmann (baachi)
- - Gabriel Caruso
  - lancergr
  - Mihai Stancu
  - Olivier Dolbeau (odolbeau)
@@ -467,6 +467,7 @@ Symfony is the result of the work of many people who made the code better
  - Gladhon
  - Sebastian Bergmann
  - Miroslav Sustek
+ - Sullivan SENECHAL (soullivaneuh)
  - Pablo Díez (pablodip)
  - Martin Hujer (martinhujer)
  - Kevin McBride
@@ -499,6 +500,7 @@ Symfony is the result of the work of many people who made the code better
  - Arjen van der Meijden
  - Michele Locati
  - Dariusz Ruminski
+ - Mathieu Lechat
  - Erik Trapman (eriktrapman)
  - De Cock Xavier (xdecock)
  - Almog Baku (almogbaku)
@@ -554,6 +556,7 @@ Symfony is the result of the work of many people who made the code better
  - Jean-Christophe Cuvelier [Artack]
  - alcaeus
  - vitaliytv
+ - Dalibor Karlović (dkarlovi)
  - Sebastian Blum
  - aubx
  - Marvin Butkereit
@@ -609,6 +612,7 @@ Symfony is the result of the work of many people who made the code better
  - Ivo Bathke (ivoba)
  - Strate
  - Anton A. Sumin
+ - Israel J. Carberry
  - Miquel Rodríguez Telep (mrtorrent)
  - Sergey Kolodyazhnyy (skolodyazhnyy)
  - umpirski
@@ -649,9 +653,9 @@ Symfony is the result of the work of many people who made the code better
  - Tiago Brito (blackmx)
  - Richard van den Brand (ricbra)
  - develop
+ - Greg Anderson
  - VJ
  - Delf Tonder (leberknecht)
- - Sullivan SENECHAL (soullivaneuh)
  - Mark Sonnabaum
  - Richard Quadling
  - jochenvdv
@@ -720,7 +724,6 @@ Symfony is the result of the work of many people who made the code better
  - Nikita Nefedov (nikita2206)
  - cgonzalez
  - Ben
- - Mathieu Lechat
  - Vincent Composieux (eko)
  - Jayson Xu (superjavason)
  - Christopher Hertel (chertel)
@@ -802,6 +805,7 @@ Symfony is the result of the work of many people who made the code better
  - Thibault Duplessis
  - Marc Abramowitz
  - Martijn Evers
+ - Tony Tran
  - Jacques Moati
  - Balazs Csaba (balazscsaba2006)
  - Douglas Reith (douglas_reith)
@@ -812,6 +816,7 @@ Symfony is the result of the work of many people who made the code better
  - Michael Roterman (wtfzdotnet)
  - Arno Geurts
  - Adán Lobato (adanlobato)
+ - Ian Jenkins (jenkoian)
  - Matthew Davis (mdavis1982)
  - Maks
  - Antoine LA
@@ -834,6 +839,7 @@ Symfony is the result of the work of many people who made the code better
  - Rootie
  - Raul Fraile (raulfraile)
  - sensio
+ - Sebastien Morel (plopix)
  - Patrick Kaufmann
  - Piotr Stankowski
  - Reece Fowell (reecefowell)
@@ -846,6 +852,7 @@ Symfony is the result of the work of many people who made the code better
  - Christian Jul Jensen
  - Alexandre GESLIN (alexandregeslin)
  - The Whole Life to Learn
+ - ergiegonzaga
  - Farhad Safarov
  - Liverbool (liverbool)
  - Sam Malone
@@ -877,6 +884,7 @@ Symfony is the result of the work of many people who made the code better
  - Danilo Silva
  - Arnaud PETITPAS (apetitpa)
  - Zachary Tong (polyfractal)
+ - Ashura
  - Hryhorii Hrebiniuk
  - Dennis Fridrich (dfridrich)
  - hamza
@@ -896,11 +904,11 @@ Symfony is the result of the work of many people who made the code better
  - Wojciech Sznapka
  - Gavin Staniforth
  - Ariel J. Birnbaum
+ - Mathieu Santostefano
  - Arjan Keeman
  - Máximo Cuadros (mcuadros)
  - tamirvs
  - julien.galenski
- - Israel J. Carberry
  - Bob van de Vijver
  - Christian Neff
  - Oliver Hoff
@@ -923,6 +931,7 @@ Symfony is the result of the work of many people who made the code better
  - Antanas Arvasevicius
  - Maximilian Berghoff (electricmaxxx)
  - nacho
+ - Mathieu Piot
  - Piotr Antosik (antek88)
  - Artem Lopata
  - Sergey Novikov (s12v)
@@ -964,6 +973,7 @@ Symfony is the result of the work of many people who made the code better
  - DerManoMann
  - Olaf Klischat
  - orlovv
+ - Peter Smeets (darkspartan)
  - Haralan Dobrev (hkdobrev)
  - Jhonny Lidfors (jhonny)
  - Julien Bianchi (jubianchi)
@@ -1010,6 +1020,7 @@ Symfony is the result of the work of many people who made the code better
  - fduch (fduch)
  - Rhodri Pugh (rodnaph)
  - David de Boer (ddeboer)
+ - Ryan Rogers
  - Klaus Purer
  - arnaud (arnooo999)
  - Gilles Doge (gido)
@@ -1020,6 +1031,7 @@ Symfony is the result of the work of many people who made the code better
  - Brooks Boyd
  - Roger Webb
  - Dmitriy Simushev
+ - Pawel Smolinski
  - pkowalczyk
  - Max Voloshin (maxvoloshin)
  - Nicolas Fabre (nfabre)
@@ -1033,6 +1045,7 @@ Symfony is the result of the work of many people who made the code better
  - Felicitus
  - Krzysztof Przybyszewski
  - Paul Matthews
+ - Jakub Kisielewski
  - Vacheslav Silyutin
  - Juan Traverso
  - Alain Flaus (halundra)
@@ -1047,7 +1060,7 @@ Symfony is the result of the work of many people who made the code better
  - Marco
  - Marc Torres
  - Alberto Aldegheri
- - Dalibor Karlović
+ - Dmitri Petmanson
  - heccjj
  - Alexandre Melard
  - Jay Klehr
@@ -1089,6 +1102,7 @@ Symfony is the result of the work of many people who made the code better
  - Pierre Tachoire (krichprollsch)
  - Marc J. Schmidt (marcjs)
  - Marco Jantke
+ - Remon van de Kamp
  - Saem Ghani
  - Clément LEFEBVRE
  - Conrad Kleinespel
@@ -1173,7 +1187,9 @@ Symfony is the result of the work of many people who made the code better
  - Mathieu Morlon
  - Daniel Tschinder
  - Alexander Schranz
+ - Arnaud CHASSEUX
  - Rafał Muszyński (rafmus90)
+ - Sébastien Decrême (sebdec)
  - Timothy Anido (xanido)
  - Mara Blaga
  - Rick Prent
@@ -1184,6 +1200,7 @@ Symfony is the result of the work of many people who made the code better
  - Jon Gotlin (jongotlin)
  - Michael Dowling (mtdowling)
  - Karlos Presumido (oneko)
+ - Thomas Counsell
  - BilgeXA
  - r1pp3rj4ck
  - Robert Queck
@@ -1197,6 +1214,7 @@ Symfony is the result of the work of many people who made the code better
  - rkerner
  - Alex Silcock
  - Qingshan Luo
+ - Ergie Gonzaga
  - Matthew J Mucklo
  - fdgdfg (psampaz)
  - Stéphane Seng
@@ -1217,6 +1235,7 @@ Symfony is the result of the work of many people who made the code better
  - Patrik Gmitter (patie)
  - Jonathan Gough
  - Benjamin Bender
+ - Jared Farrish
  - Konrad Mohrfeldt
  - Lance Chen
  - Andrew (drew)
@@ -1302,6 +1321,7 @@ Symfony is the result of the work of many people who made the code better
  - Waqas Ahmed
  - Luis Muñoz
  - Matthew Donadio
+ - Houziaux mike
  - Andreas
  - Thomas Chmielowiec
  - shdev
@@ -1329,6 +1349,7 @@ Symfony is the result of the work of many people who made the code better
  - loru88
  - Romain Dorgueil
  - Christopher Parotat
+ - 蝦米
  - Grayson Koonce (breerly)
  - Indra Gunawan (indragunawan)
  - Karim Cassam Chenaï (ka)
@@ -1376,6 +1397,7 @@ Symfony is the result of the work of many people who made the code better
  - Artem Lopata (bumz)
  - Nicole Cordes
  - Roman Orlov
+ - andrey1s
  - VolCh
  - Alexey Popkov
  - Gijs Kunze
@@ -1416,6 +1438,7 @@ Symfony is the result of the work of many people who made the code better
  - Tischoi
  - J Bruni
  - Alexey Prilipko
+ - Dmitriy Fedorenko
  - vlakoff
  - bertillon
  - Bertalan Attila
@@ -1447,6 +1470,7 @@ Symfony is the result of the work of many people who made the code better
  - David Zuelke
  - Oleg Andreyev
  - Pierre Rineau
+ - Maxim Lovchikov
  - adenkejawen
  - Ari Pringle (apringle)
  - Dan Ordille (dordille)
@@ -1463,6 +1487,7 @@ Symfony is the result of the work of many people who made the code better
  - Matt Lehner
  - Hein Zaw Htet™
  - Ruben Kruiswijk
+ - Cosmin-Romeo TANASE
  - Michael J
  - Joseph Maarek
  - Alexander Menk
@@ -1488,6 +1513,7 @@ Symfony is the result of the work of many people who made the code better
  - Even André Fiskvik
  - Arjan Keeman
  - Erik van Wingerden
+ - Valouleloup
  - Dane Powell
  - Gerrit Drost
  - Linnaea Von Lavia
@@ -1517,14 +1543,15 @@ Symfony is the result of the work of many people who made the code better
  - David Joos (djoos)
  - Denis Klementjev (dklementjev)
  - Tomáš Polívka (draczris)
+ - Dennis Smink (dsmink)
  - Franz Liedke (franzliedke)
+ - Gaylord Poillon (gaylord_p)
  - Christophe BECKER (goabonga)
  - gondo (gondo)
  - Gusakov Nikita (hell0w0rd)
  - Osman Üngür (import)
  - Javier Núñez Berrocoso (javiernuber)
  - Jelle Bekker (jbekker)
- - Ian Jenkins (jenkoian)
  - Giovanni Albero (johntree)
  - Jorge Martin (jorgemartind)
  - Joeri Verdeyen (jverdeyen)
@@ -1536,6 +1563,7 @@ Symfony is the result of the work of many people who made the code better
  - Muriel (metalmumu)
  - Michael Pohlers (mick_the_big)
  - mlpo (mlpo)
+ - Marek Šimeček (mssimi)
  - Cayetano Soriano Gallego (neoshadybeat)
  - Ondrej Machulda (ondram)
  - Pablo Monterde Perez (plebs)
@@ -1650,6 +1678,7 @@ Symfony is the result of the work of many people who made the code better
  - fmarchalemisys
  - mieszko4
  - Steve Preston
+ - Kevin Frantz
  - Neophy7e
  - bokonet
  - Arrilot
@@ -1659,9 +1688,11 @@ Symfony is the result of the work of many people who made the code better
  - djama
  - Michael Gwynne
  - Eduardo Conceição
+ - changmin.keum
  - Jon Cave
  - Sébastien HOUZE
  - Abdulkadir N. A.
+ - Adam Klvač
  - Yevgen Kovalienia
  - Lebnik
  - Shude
@@ -1697,6 +1728,7 @@ Symfony is the result of the work of many people who made the code better
  - Oncle Tom
  - Sam Anthony
  - Christian Stocker
+ - Oussama Elgoumri
  - Dawid Nowak
  - Lesnykh Ilia
  - darnel
@@ -1754,6 +1786,7 @@ Symfony is the result of the work of many people who made the code better
  - joris de wit (jdewit)
  - Jérémy CROMBEZ (jeremy)
  - Jose Manuel Gonzalez (jgonzalez)
+ - Joachim Krempel (jkrempel)
  - Jorge Maiden (jorgemaiden)
  - Justin Rainbow (jrainbow)
  - Juan Luis (juanlugb)
@@ -1764,6 +1797,7 @@ Symfony is the result of the work of many people who made the code better
  - Krzysztof Menżyk (krymen)
  - samuel laulhau (lalop)
  - Laurent Bachelier (laurentb)
+ - Luís Cobucci (lcobucci)
  - Florent Viel (luxifer)
  - Matthieu Mota (matthieumota)
  - Matthieu Moquet (mattketmo)
@@ -1788,6 +1822,7 @@ Symfony is the result of the work of many people who made the code better
  - Phil Taylor (prazgod)
  - Brayden Williams (redstar504)
  - Rich Sage (richsage)
+ - Rokas Mikalkėnas (rokasm)
  - Bart Ruysseveldt (ruyss)
  - Sascha Dens (saschadens)
  - scourgen hung (scourgen)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.42-DEV';
+    const VERSION = '2.7.42';
     const VERSION_ID = 20742;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 42;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.7.41...v2.7.42)

 * bug #26338 [Debug] Keep previous errors of Error instances (@Philipp91)
 * bug #26312 [Routing] Don't throw 405 when scheme requirement doesn't match (@nicolas-grekas)
 * bug #26298 Fix ArrayInput::toString() for InputArgument::IS_ARRAY args (@maximium)
 * bug #25557 [WebProfilerBundle] add a way to limit ajax request (@Simperfit)
 * bug #26228 [HttpFoundation] Fix missing "throw" in JsonResponse (@nicolas-grekas)
 * bug #26211 [Console] Suppress warning from sapi_windows_vt100_support (@adawolfa)
 * bug #26156 Fixes #26136: Avoid emitting warning in hasParameterOption() (@greg-1-anderson)
 * bug #26183 [DI] Add null check for removeChild (@changmin.keum)
 * bug #26159 created validator.tl.xlf for Form/Translations (@ergiegonzaga)
 * bug #26100 [Routing] Throw 405 instead of 404 when redirect is not possible (@nicolas-grekas)
 * bug #26040 [Process] Check PHP_BINDIR before $PATH in PhpExecutableFinder (@nicolas-grekas)
 * bug #26012 Exit as late as possible (@greg0ire)
 * bug #25893 [Console] Fix hasParameterOption / getParameterOption when used with multiple flags (@greg-1-anderson)
 * bug #25940 [Form] keep the context when validating forms (@xabbuh)
 * bug #25373 Use the PCRE_DOLLAR_ENDONLY modifier in route regexes (@mpdude)
 * bug #26010 [CssSelector] For AND operator, the left operand should have parentheses, not only right operand (@Arnaud CHASSEUX)
 * bug #25971 [Debug] Fix bad registration of exception handler, leading to mem leak (@nicolas-grekas)
 * bug #25962 [Routing] Fix trailing slash redirection for non-safe verbs (@nicolas-grekas)
 * bug #25948 [Form] Fixed empty data on expanded ChoiceType and FileType (@HeahDude)
 * bug #25972 support sapi_windows_vt100_support for php 7.2+ (@jhdxr)
 * bug #25744 [TwigBridge] Allow label translation to be safe (@MatTheCat)
