### PR TITLE
Fix typo in test method name

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -229,7 +229,7 @@ class AbstractTokenTest extends TestCase
      *
      * @dataProvider getUserChangesAdvancedUser
      */
-    public function testSetUserSetsAuthenticatedToFalseWhenUserChangesdvancedUser($firstUser, $secondUser)
+    public function testSetUserSetsAuthenticatedToFalseWhenUserChangesAdvancedUser($firstUser, $secondUser)
     {
         $token = $this->getToken();
         $token->setAuthenticated(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This fixes a small typo spotted in #23508 (see https://github.com/symfony/symfony/pull/23508/files/8456f3b32ce6ec394fb27b9fc9a2989ed54862b1#r171488418)