### PR TITLE
[HttpKernel] Be smarter when merging cache directives in HttpCache/ResponseCacheStrategy

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
@@ -219,4 +219,24 @@ class ResponseCacheStrategyTest extends TestCase
         $this->assertSame('60', $masterResponse->headers->getCacheControlDirective('s-maxage'));
         $this->assertFalse($masterResponse->isValidateable());
     }
+
+    public function testResponseIsPrivateWhenCombiningPrivateResponses()
+    {
+        $cacheStrategy = new ResponseCacheStrategy();
+
+        $masterResponse = new Response();
+        $masterResponse->setSharedMaxAge(60);
+        $masterResponse->setPrivate();
+
+        $embeddedResponse = new Response();
+        $embeddedResponse->setSharedMaxAge(60);
+        $embeddedResponse->setPrivate();
+
+        $cacheStrategy->add($embeddedResponse);
+        $cacheStrategy->update($masterResponse);
+
+        $this->assertFalse($masterResponse->headers->hasCacheControlDirective('no-cache'));
+        $this->assertFalse($masterResponse->headers->hasCacheControlDirective('must-revalidate'));
+        $this->assertTrue($masterResponse->headers->hasCacheControlDirective('private'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26245
| License       | MIT
| Doc PR        | -

Allows a better default behavior now that we fixed session handling and thus made cache-control stricter.