### PR TITLE
[PropertyAccessor] add getType to receive the type hinting from method

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -82,6 +82,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @param string|PropertyPathInterface $propertyPath
      *
      * @return null|string
+     *
      * @throws \ReflectionException
      */
     public function getType(&$objectOrArray, $propertyPath): ? string
@@ -92,9 +93,9 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         $propertyPath = $this->getPropertyPath($propertyPath);
 
-        $zval = [
+        $zval = array(
             self::VALUE => $objectOrArray,
-        ];
+        );
 
         for ($i = 0; $i < $propertyPath->getLength(); ++$i) {
             $property = $propertyPath->getElement($i);
@@ -106,7 +107,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                     throw new UnexpectedTypeException($zval[self::VALUE], $propertyPath, $i + 1);
                 }
 
-                $access = $this->getWriteAccessInfo(get_class($zval[self::VALUE]), $property, []);
+                $access = $this->getWriteAccessInfo(get_class($zval[self::VALUE]), $property, array());
 
                 if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
                     $reflMethod = new \ReflectionMethod(get_class($zval[self::VALUE]), $access[self::ACCESS_NAME]);
@@ -115,6 +116,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                         return $reflMethod->getParameters()[0]->getType()->getName();
                     }
                 }
+
                 return null;
             }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -78,6 +78,30 @@ class PropertyAccessor implements PropertyAccessorInterface
     }
 
     /**
+	 * @param $objectOrArray
+	 * @param $propertyPath
+	 *
+	 * @return null|string
+	 * @throws \ReflectionException
+	 */
+	public function getType(&$objectOrArray, $propertyPath): ? string
+	{
+		$propertyPath = $this->getPropertyPath($propertyPath);
+		$property  = $propertyPath->getElement($propertyPath->getLength() - 1);
+		$access = $this->getWriteAccessInfo(get_class($objectOrArray), $property, []);
+
+		if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
+            $reflMethod = new \ReflectionMethod(get_class($objectOrArray), $access[self::ACCESS_NAME]);
+			
+			if ($reflMethod->getNumberOfParameters() == 1) {
+				return $reflMethod->getParameters()[0]->getType()->getName();
+			}
+		}
+
+		return null;
+	}
+    
+    /**
      * {@inheritdoc}
      */
     public function getValue($objectOrArray, $propertyPath)

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -77,29 +77,33 @@ class PropertyAccessor implements PropertyAccessorInterface
         $this->cacheItemPool = $cacheItemPool instanceof NullAdapter ? null : $cacheItemPool; // Replace the NullAdapter by the null value
     }
 
-    /**
-	 * @param $objectOrArray
-	 * @param $propertyPath
-	 *
-	 * @return null|string
-	 * @throws \ReflectionException
-	 */
-	public function getType(&$objectOrArray, $propertyPath): ? string
-	{
-		$propertyPath = $this->getPropertyPath($propertyPath);
-		$property  = $propertyPath->getElement($propertyPath->getLength() - 1);
-		$access = $this->getWriteAccessInfo(get_class($objectOrArray), $property, []);
+   /**
+     * @param $objectOrArray
+     * @param $propertyPath
+     *
+     * @return null|string
+     * @throws \ReflectionException
+     */
+    public function getType(&$objectOrArray, $propertyPath): ? string
+    {
+        if (!is_object($objectOrArray)) {
+            throw new UnexpectedTypeException($objectOrArray, $propertyPath, 0);
+        }
 
-		if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
+        $propertyPath = $this->getPropertyPath($propertyPath);
+        $property = $propertyPath->getElement($propertyPath->getLength() - 1);
+        $access = $this->getWriteAccessInfo(get_class($objectOrArray), $property, []);
+
+        if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
             $reflMethod = new \ReflectionMethod(get_class($objectOrArray), $access[self::ACCESS_NAME]);
-			
-			if ($reflMethod->getNumberOfParameters() == 1) {
-				return $reflMethod->getParameters()[0]->getType()->getName();
-			}
-		}
 
-		return null;
-	}
+            if ($reflMethod->getNumberOfParameters() == 1) {
+                return $reflMethod->getParameters()[0]->getType()->getName();
+            }
+        }
+
+        return null;
+    }
     
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Some time you need to know the type hinting type before we use setValue (maybe to change the type of data).

| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   |
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When i use PropertyAccessor, often I must handle Type Error Expected. To avoid this, on many place I must write \Reflect.... I think we missing getType (and also hasValue) method for easy use. All important method are private. So i can not simply extend the class.