### PR TITLE
[FrameworkBundle] Silence "Failed to remove directory" on cache:clear

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -156,7 +156,9 @@ EOF
         try {
             $fs->remove($oldCacheDir);
         } catch (IOException $e) {
-            $io->warning($e->getMessage());
+            if ($output->isVerbose()) {
+                $io->warning($e->getMessage());
+            }
         }
 
         if ($output->isVerbose()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2600
| License       | MIT
| Doc PR        | -

Let's improve the experience of ppl (see old linked issue). This warning is just noise to most.