### PR TITLE
Revert "feature #24763 [Process] Allow writing portable "prepared" command lines (Simperfit)"

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1474,34 +1474,6 @@ EOTXT;
         yield array('éÉèÈàÀöä');
     }
 
-    public function testPreparedCommand()
-    {
-        $p = new Process(self::$phpBin.' -r \'print_r($argv);\' {{ abc }}DEF');
-        $p->run(null, array('abc' => 'A" B "C'));
-
-        $this->assertContains('A" B "CDEF', $p->getOutput());
-    }
-
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid command line "echo {{ abc }}": no value provided for placeholder "abc", did you mean "bcd"?
-     */
-    public function testPreparedCommandWithMissingValue()
-    {
-        $p = new Process('echo {{ abc }}');
-        $p->run(null, array('bcd' => 'BCD'));
-    }
-
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid command line "echo {{ abc }}": no values provided for any placeholders.
-     */
-    public function testPreparedCommandWithNoValues()
-    {
-        $p = new Process('echo {{ abc }}');
-        $p->run();
-    }
-
     public function testEnvArgument()
     {
         $env = array('FOO' => 'Foo', 'BAR' => 'Bar');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This reverts commit 136408937bc455df16931c541255220050cac97a, reversing
changes made to e043478ba5964718510bf32fdb043fac5a033059.

As discussed in #24763 and #26344

This doens't revert the possibility to use prepared command lines. They just won't be *portable* anymore, unless special care is taken by "userland".
Ie the placeholders need to be shell-dependent: use eg `echo "$FOO"` on *nix (the double quotes *are* important), and `echo !FOO!` on Windows (no double quotes there).