### PR TITLE
[WebProfilerBundle] fix wrong variable for profiler counting ajax requests

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -110,7 +110,7 @@
                     if (requestStack.length) {
                         var nbOfAjaxRequest = tbody.rows.length;
                         if (nbOfAjaxRequest >= 100) {
-                            tbodies.deleteRow(nbOfAjaxRequest - 1);
+                            tbody.deleteRow(nbOfAjaxRequest - 1);
                         }
 
                         for (var i = 0; i < requestStack.length; i++) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -108,7 +108,7 @@
                     var rows = document.createDocumentFragment();
 
                     if (requestStack.length) {
-                        var nbOfAjaxRequest = tbodies.rows.length;
+                        var nbOfAjaxRequest = tbody.rows.length;
                         if (nbOfAjaxRequest >= 100) {
                             tbodies.deleteRow(nbOfAjaxRequest - 1);
                         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  2.7 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     
| Deprecations? | no
| Tests pass?   | yes    
| Fixed tickets | #26364 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

Symfony WebProfiler base js change variable tbodies to tbody for counting Ajax Requests.
