### PR TITLE
Transform both switchToXHR() and removeXhr() to xmlHttpRequest()

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -151,14 +151,15 @@ abstract class Client
         return isset($this->server[$key]) ? $this->server[$key] : $default;
     }
 
-    public function switchToXHR()
+    public function xmlHttpRequest(string $method, string $uri, array $parameters = array(), array $files = array(), array $server = array(), string $content = null, bool $changeHistory = true): Crawler
     {
         $this->setServerParameter('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest');
-    }
 
-    public function removeXHR()
-    {
-        unset($this->server['HTTP_X_REQUESTED_WITH']);
+        try {
+            return $this->request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
+        } finally {
+            unset($this->server['HTTP_X_REQUESTED_WITH']);
+        }
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -104,13 +104,11 @@ class ClientTest extends TestCase
         $this->assertNull($client->getRequest());
     }
 
-    public function testGetRequestWithXHR()
+    public function testXmlHttpRequest()
     {
         $client = new TestClient();
-        $client->switchToXHR();
-        $client->request('GET', 'http://example.com/', array(), array(), array(), null, true, true);
+        $client->xmlHttpRequest('GET', 'http://example.com/', array(), array(), array(), null, true);
         $this->assertEquals($client->getRequest()->getServer()['HTTP_X_REQUESTED_WITH'], 'XMLHttpRequest');
-        $client->removeXHR();
         $this->assertFalse($client->getServerParameter('HTTP_X_REQUESTED_WITH', false));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | Will do.


See https://github.com/symfony/symfony/pull/24778#issuecomment-369879079 for more information about this.

We are switching from a possible global estate change to just only one request affected.