### PR TITLE
[Yaml] Fix regression when trying to parse multiline

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -402,7 +402,7 @@ class Parser
                     throw new ParseException('Multiple documents are not supported.', $this->currentLineNb + 1, $this->currentLine, $this->filename);
                 }
 
-                if (isset($this->currentLine[1]) && '?' === $this->currentLine[0] && ' ' === $this->currentLine[1]) {
+                if ($deprecatedUsage = (isset($this->currentLine[1]) && '?' === $this->currentLine[0] && ' ' === $this->currentLine[1])) {
                     @trigger_error($this->getDeprecationMessage('Starting an unquoted string with a question mark followed by a space is deprecated since Symfony 3.3 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.'), E_USER_DEPRECATED);
                 }
 
@@ -427,6 +427,10 @@ class Parser
                     $value = '';
 
                     foreach ($this->lines as $line) {
+                        // If the indentation is not consistent at offset 0, it is to be considered as a ParseError
+                        if (0 === $this->offset && !$deprecatedUsage && isset($line[0]) && ' ' === $line[0]) {
+                            throw new ParseException('Unable to parse.', $this->getRealCurrentLineNb() + 1, $this->currentLine, $this->filename);
+                        }
                         if ('' === trim($line)) {
                             $value .= "\n";
                         } elseif (!$previousLineWasNewline && !$previousLineWasTerminatedWithBackslash) {

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -812,6 +812,41 @@ EOT;
         $this->assertSame($expected, $this->parser->parse($yaml));
     }
 
+    public function getParseExceptionNotAffectedMultiLineStringLastResortParsing()
+    {
+        $tests = array();
+
+        $yaml = <<<'EOT'
+a
+    b:
+EOT;
+        $tests['parse error on first line'] = array($yaml);
+
+        $yaml = <<<'EOT'
+a
+
+b
+    c:
+EOT;
+        $tests['parse error due to inconsistent indentation'] = array($yaml);
+
+        $yaml = <<<'EOT'
+ &  *  !  |  >  '  "  %  @  ` #, { asd a;sdasd }-@^qw3
+EOT;
+        $tests['symfony/symfony/issues/22967#issuecomment-322067742'] = array($yaml);
+
+        return $tests;
+    }
+
+    /**
+     * @dataProvider getParseExceptionNotAffectedMultiLineStringLastResortParsing
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function testParseExceptionNotAffectedByMultiLineStringLastResortParsing($yaml)
+    {
+        $this->parser->parse($yaml);
+    }
+
     public function testMultiLineStringLastResortParsing()
     {
         $yaml = <<<'EOT'
@@ -822,6 +857,17 @@ test:
 EOT;
         $expected = array(
             'test' => 'You can have things that don\'t look like strings here true yes you can',
+        );
+
+        $this->assertSame($expected, $this->parser->parse($yaml));
+
+        $yaml = <<<'EOT'
+a:
+    b
+       c
+EOT;
+        $expected = array(
+            'a' => 'b c',
         );
 
         $this->assertSame($expected, $this->parser->parse($yaml));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  #22967
| License       | MIT
| Doc PR        | 

I think this is the lower impacted branch, it fixes a regression added in the last releases campain some days ago.

As discused on Slack @xabbuh 