### PR TITLE
[WebProfilerBundle]  Display the Missing translations tab by default if there are missing translations

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -95,7 +95,7 @@
     {% endfor %}
 
     <div class="sf-tabs">
-        <div class="tab">
+        <div class="tab {{ collector.countMissings == 0 ? 'tab-active' }}">
             <h3 class="tab-title">Defined <span class="badge">{{ messages_defined|length }}</span></h3>
 
             <div class="tab-content">
@@ -132,7 +132,7 @@
             </div>
         </div>
 
-        <div class="tab">
+        <div class="tab {{ collector.countMissings > 0 ? 'tab-active' }}">
             <h3 class="tab-title">Missing <span class="badge">{{ messages_missing|length }}</span></h3>
 
             <div class="tab-content">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -338,13 +338,14 @@
                     var tabNavigation = document.createElement('ul');
                     tabNavigation.className = 'tab-navigation';
 
+                    var selectedTabId = 'tab-' + i + '-0'; /* select the first tab by default */
                     for (var j = 0; j < tabs.length; j++) {
                         var tabId = 'tab-' + i + '-' + j;
                         var tabTitle = tabs[j].querySelector('.tab-title').innerHTML;
 
                         var tabNavigationItem = document.createElement('li');
                         tabNavigationItem.setAttribute('data-tab-id', tabId);
-                        if (j == 0) { Sfjs.addClass(tabNavigationItem, 'active'); }
+                        if (hasClass(tabs[j], 'tab-active')) { selectedTabId = tabId; }
                         if (Sfjs.hasClass(tabs[j], 'disabled')) { Sfjs.addClass(tabNavigationItem, 'disabled'); }
                         tabNavigationItem.innerHTML = tabTitle;
                         tabNavigation.appendChild(tabNavigationItem);
@@ -354,6 +355,7 @@
                     }
 
                     tabGroups[i].insertBefore(tabNavigation, tabGroups[i].firstChild);
+                    addClass(document.querySelector('[data-tab-id="' + selectedTabId + '"]'), 'active');
                 }
 
                 /* display the active tab and add the 'click' event listeners */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Some of you may consider this a new feature instead of a bug, but I thought this was a bug because the new behavior should be the behavior of this panel since day one.

The idea is to display the "Missing translations" tab selected by default ... but only when there are missing translations. Otherwise, keep displaying the "Defined translations" tab.