### PR TITLE
Improve the documentation of `Finder::exclude()`

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -386,6 +386,10 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Excludes directories.
      *
+     * Directories passed as argument must be relative to the ones defined with the `in()` method. For example:
+     *
+     *     $finder->in(__DIR__)->exclude('ruby');
+     *
      * @param string|array $dirs A directory path or an array of directories
      *
      * @return $this


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |
| License       | MIT
| Doc PR        |

Tried to do this and this didn't work:

```php
$iterator->in($sourcePath)
    ->exclude($sourcePath.'/foo');
```

I read on http://symfony.com/doc/current/components/finder.html that excluded directories need to be relative:

![capture d ecran 2018-03-04 a 16 10 31](https://user-images.githubusercontent.com/720328/36947055-28e47eda-1fc7-11e8-9475-399a3d853169.png)
