### PR TITLE
[WebProfilerBundle] Display the missing translation panel by default

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
@@ -45,13 +45,14 @@
                     var tabNavigation = document.createElement('ul');
                     tabNavigation.className = 'tab-navigation';
 
+                    var selectedTabId = 'tab-' + i + '-0'; /* select the first tab by default */
                     for (var j = 0; j < tabs.length; j++) {
                         var tabId = 'tab-' + i + '-' + j;
                         var tabTitle = tabs[j].querySelector('.tab-title').innerHTML;
 
                         var tabNavigationItem = document.createElement('li');
                         tabNavigationItem.setAttribute('data-tab-id', tabId);
-                        if (j == 0) { addClass(tabNavigationItem, 'active'); }
+                        if (hasClass(tabs[j], 'tab-active')) { selectedTabId = tabId; }
                         if (hasClass(tabs[j], 'disabled')) { addClass(tabNavigationItem, 'disabled'); }
                         tabNavigationItem.innerHTML = tabTitle;
                         tabNavigation.appendChild(tabNavigationItem);
@@ -61,6 +62,7 @@
                     }
 
                     tabGroups[i].insertBefore(tabNavigation, tabGroups[i].firstChild);
+                    addClass(document.querySelector('[data-tab-id="' + selectedTabId + '"]'), 'active');
                 }
 
                 /* display the active tab and add the 'click' event listeners */

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/base_js.html.twig
@@ -52,7 +52,7 @@
 
                         var tabNavigationItem = document.createElement('li');
                         tabNavigationItem.setAttribute('data-tab-id', tabId);
-                        if (hasClass(tabs[j], 'tab-active')) { selectedTabId = tabId; }
+                        if (hasClass(tabs[j], 'active')) { selectedTabId = tabId; }
                         if (hasClass(tabs[j], 'disabled')) { addClass(tabNavigationItem, 'disabled'); }
                         tabNavigationItem.innerHTML = tabTitle;
                         tabNavigation.appendChild(tabNavigationItem);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -117,7 +117,7 @@
     {% endfor %}
 
     <div class="sf-tabs">
-        <div class="tab {{ collector.countMissings == 0 ? 'tab-active' }}">
+        <div class="tab {{ collector.countMissings == 0 ? 'active' }}">
             <h3 class="tab-title">Defined <span class="badge">{{ collector.countDefines }}</span></h3>
 
             <div class="tab-content">
@@ -158,7 +158,7 @@
             </div>
         </div>
 
-        <div class="tab {{ collector.countMissings > 0 ? 'tab-active' }}">
+        <div class="tab {{ collector.countMissings > 0 ? 'active' }}">
             <h3 class="tab-title">Missing <span class="badge {{ collector.countMissings ? 'status-error' }}">{{ collector.countMissings }}</span></h3>
 
             <div class="tab-content">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/translation.html.twig
@@ -117,7 +117,7 @@
     {% endfor %}
 
     <div class="sf-tabs">
-        <div class="tab">
+        <div class="tab {{ collector.countMissings == 0 ? 'tab-active' }}">
             <h3 class="tab-title">Defined <span class="badge">{{ collector.countDefines }}</span></h3>
 
             <div class="tab-content">
@@ -158,7 +158,7 @@
             </div>
         </div>
 
-        <div class="tab">
+        <div class="tab {{ collector.countMissings > 0 ? 'tab-active' }}">
             <h3 class="tab-title">Missing <span class="badge {{ collector.countMissings ? 'status-error' }}">{{ collector.countMissings }}</span></h3>
 
             <div class="tab-content">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -413,7 +413,7 @@
 
                         var tabNavigationItem = document.createElement('li');
                         tabNavigationItem.setAttribute('data-tab-id', tabId);
-                        if (hasClass(tabs[j], 'tab-active')) { selectedTabId = tabId; }
+                        if (hasClass(tabs[j], 'active')) { selectedTabId = tabId; }
                         if (hasClass(tabs[j], 'disabled')) { addClass(tabNavigationItem, 'disabled'); }
                         tabNavigationItem.innerHTML = tabTitle;
                         tabNavigation.appendChild(tabNavigationItem);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -406,13 +406,14 @@
                     var tabNavigation = document.createElement('ul');
                     tabNavigation.className = 'tab-navigation';
 
+                    var selectedTabId = 'tab-' + i + '-0'; /* select the first tab by default */
                     for (var j = 0; j < tabs.length; j++) {
                         var tabId = 'tab-' + i + '-' + j;
                         var tabTitle = tabs[j].querySelector('.tab-title').innerHTML;
 
                         var tabNavigationItem = document.createElement('li');
                         tabNavigationItem.setAttribute('data-tab-id', tabId);
-                        if (j == 0) { addClass(tabNavigationItem, 'active'); }
+                        if (hasClass(tabs[j], 'tab-active')) { selectedTabId = tabId; }
                         if (hasClass(tabs[j], 'disabled')) { addClass(tabNavigationItem, 'disabled'); }
                         tabNavigationItem.innerHTML = tabTitle;
                         tabNavigation.appendChild(tabNavigationItem);
@@ -422,6 +423,7 @@
                     }
 
                     tabGroups[i].insertBefore(tabNavigation, tabGroups[i].firstChild);
+                    addClass(document.querySelector('[data-tab-id="' + selectedTabId + '"]'), 'active');
                 }
 
                 /* display the active tab and add the 'click' event listeners */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Display the "Missing Translations" panel by default ... except if there are no missing translations.