### PR TITLE
[Filesystem] Add a failing test covering a bug in `Filesystem::mirror()`

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1078,7 +1078,7 @@ class FilesystemTest extends FilesystemTestCase
         $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
 
         // Mirror everything except `source2`
-        $iterator = new Finder;
+        $iterator = new Finder();
         $iterator->in($sourcePath)
             ->exclude('source2');
         $this->filesystem->mirror($sourcePath, $targetPath, $iterator);
@@ -1104,7 +1104,7 @@ class FilesystemTest extends FilesystemTestCase
         mkdir($targetPath.'target');
 
         // Mirror everything except `source2`
-        $iterator = new Finder;
+        $iterator = new Finder();
         $iterator->in($sourcePath)
             ->exclude('source2');
         $this->filesystem->mirror($sourcePath, $targetPath, $iterator, array('delete' => true));

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Filesystem\Tests;
 
+use Symfony\Component\Finder\Finder;
+
 /**
  * Test class for Filesystem.
  */
@@ -1063,6 +1065,27 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertTrue(is_dir($targetPath));
         $this->assertFileExists($targetPath.'source');
         $this->assertFileNotExists($targetPath.'target');
+    }
+
+    public function testMirrorWithIterator()
+    {
+        $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
+
+        mkdir($sourcePath);
+        mkdir($sourcePath.'source1');
+        mkdir($sourcePath.'source2');
+
+        $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
+
+        // Mirror everything except `source2`
+        $iterator = new Finder;
+        $iterator->in($sourcePath)
+            ->exclude('source2');
+        $this->filesystem->mirror($sourcePath, $targetPath, $iterator);
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertDirectoryExists($targetPath.'source1');
+        $this->assertDirectoryNotExists($targetPath.'source2');
     }
 
     /**

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1088,6 +1088,33 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertDirectoryNotExists($targetPath.'source2');
     }
 
+    public function testMirrorWithIteratorAndDeleteOption()
+    {
+        $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
+
+        mkdir($sourcePath);
+        mkdir($sourcePath.'source1');
+        mkdir($sourcePath.'source2');
+
+        // We use the `targettarget` name because we need a directory name with a different name to reproduce a bug
+        $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'targettarget'.DIRECTORY_SEPARATOR;
+
+        mkdir($targetPath);
+        mkdir($targetPath.'source1');
+        mkdir($targetPath.'target');
+
+        // Mirror everything except `source2`
+        $iterator = new Finder;
+        $iterator->in($sourcePath)
+            ->exclude('source2');
+        $this->filesystem->mirror($sourcePath, $targetPath, $iterator, array('delete' => true));
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertDirectoryExists($targetPath.'source1');
+        $this->assertDirectoryNotExists($targetPath.'source2');
+        $this->assertDirectoryNotExists($targetPath.'target');
+    }
+
     /**
      * @dataProvider providePathsForIsAbsolutePath
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | no    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none
| License       | MIT
| Doc PR        |

When calling `Filesystem::mirror()` with a `$iterator` parameter (to customize the list of files/folders to mirror), *and* when using the `delete` option on top of that, things break.

This new test covers the problem (but do not fix it). I have been scratching my head at it for an hour but I'm really having trouble with the implementation of `Filesystem::mirror()`.

I believe the bug was introduced following #23473, more specifically:

```diff
- $origin = str_replace($targetDir, $originDir, $file->getPathname());
+ $origin = $originDir.substr($file->getPathname(), $targetDirLen);
```

Here is my debug session right before the exception:

![capture d ecran 2018-03-04 a 20 25 29](https://user-images.githubusercontent.com/720328/36949547-3953a354-1fea-11e8-9ec1-4acf10d1c11c.png)

Here are the values of the variables:

```php
$originDir = '/tmp/source';
// I used a weird name on purpose so that it's longer than `source` to trigger the bug
$targetDir = '/tmp/targettarget';

// Here is the computed value of the file we are trying to delete:
$origin = '/tmp/sourcece1';
// it should be `/tmp/source/source1` instead if I understand correctly
```

I'm out of ideas for tonight sorry! I don't know if PR with failing tests are useful at all? I won't mind if you close it.