### PR TITLE
[Config] ReflectionClassResource check abstract class

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -155,12 +155,16 @@ class ReflectionClassResource implements SelfCheckingResourceInterface, \Seriali
             }
         }
 
-        if ($class->isSubclassOf(EventSubscriberInterface::class)) {
+        if ($class->isAbstract() || $class->isInterface() || $class->isTrait()) {
+            return;
+        }
+
+        if (interface_exists(EventSubscriberInterface::class, false) && $class->isSubclassOf(EventSubscriberInterface::class)) {
             yield EventSubscriberInterface::class;
             yield print_r(\call_user_func(array($class->name, 'getSubscribedEvents')), true);
         }
 
-        if ($class->isSubclassOf(ServiceSubscriberInterface::class)) {
+        if (interface_exists(ServiceSubscriberInterface::class, false) && $class->isSubclassOf(ServiceSubscriberInterface::class)) {
             yield ServiceSubscriberInterface::class;
             yield print_r(\call_user_func(array($class->name, 'getSubscribedServices')), true);
         }


### PR DESCRIPTION
generate Signature
update hash methods `ServiceSubscriberInterface::getSubscribedServices` and `EventSubscriberInterface::getSubscribedEvents` if the class is not abstract

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26459, #26501
| License       | MIT