### PR TITLE
fix the handling of timestamp in the MongoDBSessionHandler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -141,7 +141,7 @@ class MongoDbSessionHandler extends AbstractSessionHandler
      */
     public function updateTimestamp($sessionId, $data)
     {
-        $expiry = $this->createDateTime(time() + (int) ini_get('session.gc_maxlifetime'));
+        $expiry = new \MongoDB\BSON\UTCDateTime((time() + (int) ini_get('session.gc_maxlifetime')) * 1000);
 
         if ($this->mongo instanceof \MongoDB\Client) {
             $methodName = 'updateOne';
@@ -154,34 +154,13 @@ class MongoDbSessionHandler extends AbstractSessionHandler
         $this->getCollection()->$methodName(
             array($this->options['id_field'] => $sessionId),
             array('$set' => array(
-                $this->options['time_field'] => $this->createDateTime(),
+                $this->options['time_field'] => new \MongoDB\BSON\UTCDateTime(),
                 $this->options['expiry_field'] => $expiry,
             )),
             $options
         );
 
         return true;
-    }
-
-    /**
-     * Create a date object using the class appropriate for the current mongo connection.
-     *
-     * Return an instance of a MongoDate or \MongoDB\BSON\UTCDateTime
-     *
-     * @param int $seconds An integer representing UTC seconds since Jan 1 1970.  Defaults to now.
-     *
-     * @return \MongoDate|\MongoDB\BSON\UTCDateTime
-     */
-    private function createDateTime($seconds = null)
-    {
-        if (null === $seconds) {
-            $seconds = time();
-        }
-        if ($this->mongo instanceof \MongoDB\Client) {
-            return new \MongoDB\BSON\UTCDateTime($seconds * 1000);
-        }
-
-        return new \MongoDate($seconds);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -182,7 +182,7 @@ class MongoDbSessionHandler extends AbstractSessionHandler
         }
         return new \MongoDate($seconds);
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -164,6 +164,26 @@ class MongoDbSessionHandler extends AbstractSessionHandler
     }
 
     /**
+     * Create a date object using the class appropriate for the current mongo connection.
+     *
+     * Return an instance of a MongoDate or \MongoDB\BSON\UTCDateTime
+     *
+     * @param int $seconds An integer representing UTC seconds since Jan 1 1970.  Defaults to now.
+     *
+     * @return \MongoDate|\MongoDB\BSON\UTCDateTime
+     */
+    private function createDateTime($seconds = null)
+    {
+        if (null === $seconds) {
+            $seconds = time();
+        }
+        if ($this->mongo instanceof \MongoDB\Client) {
+            return new \MongoDB\BSON\UTCDateTime($seconds * 1000);
+        }
+        return new \MongoDate($seconds);
+    }
+    
+    /**
      * {@inheritdoc}
      */
     protected function doRead($sessionId)

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -180,6 +180,7 @@ class MongoDbSessionHandler extends AbstractSessionHandler
         if ($this->mongo instanceof \MongoDB\Client) {
             return new \MongoDB\BSON\UTCDateTime($seconds * 1000);
         }
+
         return new \MongoDate($seconds);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT



in the process of upgrading from 3.4 to 4.0 we stumbled upon a issue with mongo session handler.

```
[05-Mar-2018 11:12:57 Europe/Vienna] PHP Fatal error:  Uncaught Error: Call to undefined method Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler::createDateTime() in /opt/APP/vendor/symfony/http-foundation/Session/Storage/Handler/MongoDbSessionHandler.php:144
Stack trace:
#0 [internal function]: Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler->updateTimestamp('96d983b59f8aef8...', 'user_obj|O:9:"k...')
#1 [internal function]: session_write_close()
#2 {main}
  thrown in /opt/APP/vendor/symfony/http-foundation/Session/Storage/Handler/MongoDbSessionHandler.php on line 144
```

this PR re-add's the method, that somehow got removed in 4.0 branch, whereas the interface forces to have the implemantation.


