### PR TITLE
Readd 'form_label_errors' block to disable errors on form labels

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -203,7 +203,7 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}{{- form_errors(form) -}}</{{ element|default('label') }}>
+        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}{% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}</{{ element|default('label') }}>
     {%- endif -%}
 {%- endblock form_label %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -108,9 +108,9 @@
                     var rows = document.createDocumentFragment();
 
                     if (requestStack.length) {
-                        var nbOfAjaxRequest = tbodies.rows.length;
+                        var nbOfAjaxRequest = tbody.rows.length;
                         if (nbOfAjaxRequest >= 100) {
-                            tbodies.deleteRow(nbOfAjaxRequest - 1);
+                            tbody.deleteRow(nbOfAjaxRequest - 1);
                         }
 
                         for (var i = 0; i < requestStack.length; i++) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

Re-added **form_label_errors** block on bootstrap 4 form themes.
You can disable errors shown on form labels by simply extend bootstrap4 layout and empty **form_label_errors** block. See below:
```
{% use "bootstrap_4_layout.html.twig" %}

{# Disable errors shown on form labels #}
{% block form_label_errors %}{% endblock form_label_errors %}
```
Block previously removed [here](https://github.com/symfony/symfony/commit/b375957c8b6c6496e2b450b4b66cc29099d0c0c6#diff-62cb2a10f5a37db0e87e3bd81609b17dR186) by @nicolas-grekas.
cc @Nyholm 