### PR TITLE
Release v2.8.36

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,10 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.36 (2018-03-05)
+
+ * bug #26368 [WebProfilerBundle] Fix Debug toolbar breaks app (xkobal)
+
 * 2.8.35 (2018-03-01)
 
  * bug #26338 [Debug] Keep previous errors of Error instances (Philipp91)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.36-DEV';
+    const VERSION = '2.8.36';
     const VERSION_ID = 20836;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
     const RELEASE_VERSION = 36;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';
     const END_OF_LIFE = '11/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v2.8.35...v2.8.36)

 * bug #26368 [WebProfilerBundle] Fix Debug toolbar breaks app (@xkobal)
