### PR TITLE
[Console] Improved rendering of optional arguments in command synopsis

### DIFF
--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -382,21 +382,21 @@ class InputDefinition
             $elements[] = '[--]';
         }
 
+        $tail = '';
         foreach ($this->getArguments() as $argument) {
             $element = '<'.$argument->getName().'>';
-            if (!$argument->isRequired()) {
-                $element = '['.$element.']';
-            } elseif ($argument->isArray()) {
-                $element = $element.' ('.$element.')';
-            }
-
             if ($argument->isArray()) {
                 $element .= '...';
+            }
+
+            if (!$argument->isRequired()) {
+                $element = '['.$element;
+                $tail .= ']';
             }
 
             $elements[] = $element;
         }
 
-        return implode(' ', $elements);
+        return implode(' ', $elements) . $tail;
     }
 }

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -397,6 +397,6 @@ class InputDefinition
             $elements[] = $element;
         }
 
-        return implode(' ', $elements) . $tail;
+        return implode(' ', $elements).$tail;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -374,8 +374,9 @@ class InputDefinitionTest extends TestCase
 
             array(new InputDefinition(array(new InputArgument('foo', InputArgument::REQUIRED))), '<foo>', 'puts arguments in angle brackets'),
             array(new InputDefinition(array(new InputArgument('foo'))), '[<foo>]', 'puts optional arguments in square brackets'),
-            array(new InputDefinition(array(new InputArgument('foo', InputArgument::IS_ARRAY))), '[<foo>]...', 'uses an ellipsis for array arguments'),
-            array(new InputDefinition(array(new InputArgument('foo', InputArgument::REQUIRED | InputArgument::IS_ARRAY))), '<foo> (<foo>)...', 'uses parenthesis and ellipsis for required array arguments'),
+            array(new InputDefinition(array(new InputArgument('foo'), new InputArgument('bar'))), '[<foo> [<bar>]]', 'chains optional arguments inside brackets'),
+            array(new InputDefinition(array(new InputArgument('foo', InputArgument::IS_ARRAY))), '[<foo>...]', 'uses an ellipsis for array arguments'),
+            array(new InputDefinition(array(new InputArgument('foo', InputArgument::REQUIRED | InputArgument::IS_ARRAY))), '<foo>...', 'uses an ellipsis for required array arguments'),
 
             array(new InputDefinition(array(new InputOption('foo'), new InputArgument('foo', InputArgument::REQUIRED))), '[--foo] [--] <foo>', 'puts [--] between options and arguments'),
         );


### PR DESCRIPTION
Current rendering:
```
  build [options] [--] [<file>] [<output-dir>] [<packages>]...
```
Fixed (and actually correct) rendering:
```
  build [options] [--] [<file> [<output-dir> [<packages>...]]]
```

Also dropped duplicating required array-type argument. There's just no need for that, it only confuses the reader.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes and no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | --
| License       | MIT
| Doc PR        | --

Optional arguments can not be independent, in general.  Neither the argument parser allows that.