### PR TITLE
Release v4.0.6

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -7,6 +7,15 @@ in 4.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.0.0...v4.0.1
 
+* 4.0.6 (2018-03-05)
+
+ * bug #26393  [DI] Skip resource tracking if disabled (chalasr)
+ * bug #26403 fix the handling of timestamp in the MongoDBSessionHandler (hjanuschka)
+ * bug #26355 [DI] Fix missing "id" normalization when dumping the container (nicolas-grekas)
+ * bug #26368 [WebProfilerBundle] Fix Debug toolbar breaks app (xkobal)
+ * bug #26369 Use fill instead of style for svg colors (rpkamp)
+ * bug #26358 [FrameworkBundle] Silence "Failed to remove directory" on cache:clear (nicolas-grekas)
+
 * 4.0.5 (2018-03-01)
 
  * bug #26327 [Form][WCAG] Errors sign for people that do not see colors (Nyholm)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -63,12 +63,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '4.0.6-DEV';
+    const VERSION = '4.0.6';
     const VERSION_ID = 40006;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 0;
     const RELEASE_VERSION = 6;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '07/2018';
     const END_OF_LIFE = '01/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v4.0.5...v4.0.6)

 * bug #26393  [DI] Skip resource tracking if disabled (@chalasr)
 * bug #26403 fix the handling of timestamp in the MongoDBSessionHandler (@hjanuschka)
 * bug #26355 [DI] Fix missing "id" normalization when dumping the container (@nicolas-grekas)
 * bug #26368 [WebProfilerBundle] Fix Debug toolbar breaks app (@xkobal)
 * bug #26369 Use fill instead of style for svg colors (@rpkamp)
 * bug #26358 [FrameworkBundle] Silence "Failed to remove directory" on cache:clear (@nicolas-grekas)
