### PR TITLE
[Console] Fix unexpected character on Windows

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -520,9 +520,6 @@ class ProgressBar
                 // Move the cursor to the beginning of the line
                 $this->output->write("\x0D");
 
-                // Erase the line
-                $this->output->write("\x1B[2K");
-
                 // Erase previous lines
                 if ($this->formatLineCount > 0) {
                     $this->output->write(str_repeat("\x1B[1A\x1B[2K", $this->formatLineCount));

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -554,7 +554,7 @@ class ProgressBarTest extends TestCase
         $this->assertEquals(
             ">---------------------------\nfoobar".
             $this->generateOutput("=========>------------------\nfoobar").
-            "\x0D\x1B[2K\x1B[1A\x1B[2K".
+            "\x0D\x1B[1A\x1B[2K".
             $this->generateOutput("============================\nfoobar"),
             stream_get_contents($output->getStream())
         );
@@ -663,6 +663,6 @@ class ProgressBarTest extends TestCase
     {
         $count = substr_count($expected, "\n");
 
-        return "\x0D\x1B[2K".($count ? str_repeat("\x1B[1A\x1B[2K", $count) : '').$expected;
+        return "\x0D".($count ? str_repeat("\x1B[1A\x1B[2K", $count) : '').$expected;
     }
 }


### PR DESCRIPTION
Fix unexpected character on windows systems, fix https://github.com/symfony/symfony/issues/23920

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Fixed tickets | #23920   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This line cause an unexpected character on windows systems, and doesn't seems to be needed, because the progress line is already deleted (tested on MacOS 10.13.3, Windows 7 and Windows 10)