### PR TITLE
[DependencyInjection] fix regression when extending the Container class without a constructor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -981,9 +981,13 @@ EOF;
         if ($this->container->isCompiled()) {
             if (Container::class !== $baseClassWithNamespace) {
                 $r = $this->container->getReflectionClass($baseClassWithNamespace, false);
-
-                if (null !== $r && (null !== $constructor = $r->getConstructor()) && 0 === $constructor->getNumberOfRequiredParameters()) {
-                    $code .= "        parent::__construct();\n\n";
+                if (null !== $r
+                    && (null !== $constructor = $r->getConstructor())
+                    && 0 === $constructor->getNumberOfRequiredParameters()
+                    && Container::class !== $constructor->getDeclaringClass()->name
+                ) {
+                    $code .= "        parent::__construct();\n";
+                    $code .= "        \$this->parameterBag = null;\n\n";
                 }
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Container/NoConstructorContainer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Container/NoConstructorContainer.php
@@ -2,6 +2,8 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Container;
 
-class NoConstructorContainer
+use Symfony\Component\DependencyInjection\Container;
+
+class NoConstructorContainer extends Container
 {
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_constructor_without_arguments.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_constructor_without_arguments.php
@@ -24,6 +24,7 @@ class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tes
     public function __construct()
     {
         parent::__construct();
+        $this->parameterBag = null;
 
         $this->services = array();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_with_optional_constructor_arguments.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/custom_container_class_with_optional_constructor_arguments.php
@@ -24,6 +24,7 @@ class ProjectServiceContainer extends \Symfony\Component\DependencyInjection\Tes
     public function __construct()
     {
         parent::__construct();
+        $this->parameterBag = null;
 
         $this->services = array();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4+
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/26397
| License       | MIT
| Doc PR        | -

fix regression introduced in https://github.com/symfony/symfony/commit/c026ec63e33c696c422f3d72c99c8fe64f091376#diff-f7b23d463cba27ac5e4cb677f2be7623R985
