### PR TITLE
[Console] [DX] Fix command description/help display

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -140,6 +140,13 @@ class TextDescriptor extends Descriptor
         $command->getSynopsis(false);
         $command->mergeApplicationDefinition(false);
 
+        if ($description = $command->getDescription()) {
+            $this->writeText('<comment>Description:</comment>', $options);
+            $this->writeText("\n");
+            $this->writeText('  '.$description);
+            $this->writeText("\n\n");
+        }
+
         $this->writeText('<comment>Usage:</comment>', $options);
         foreach (array_merge(array($command->getSynopsis(true)), $command->getAliases(), $command->getUsages()) as $usage) {
             $this->writeText("\n");
@@ -154,7 +161,8 @@ class TextDescriptor extends Descriptor
             $this->writeText("\n");
         }
 
-        if ($help = $command->getProcessedHelp()) {
+        $help = $command->getProcessedHelp();
+        if ($help && $help !== $description) {
             $this->writeText("\n");
             $this->writeText('<comment>Help:</comment>', $options);
             $this->writeText("\n");

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -1,3 +1,6 @@
+Description:
+  Displays help for a command
+
 Usage:
   help [options] [--] [<command_name>]
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -1,3 +1,6 @@
+Description:
+  Lists commands
+
 Usage:
   list [options] [--] [<namespace>]
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.txt
@@ -1,3 +1,6 @@
+<comment>Description:</comment>
+  command 1 description
+
 <comment>Usage:</comment>
   descriptor:command1
   alias1

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
@@ -1,3 +1,6 @@
+<comment>Description:</comment>
+  command 2 description
+
 <comment>Usage:</comment>
   descriptor:command2 [options] [--] \<argument_name>
   descriptor:command2 -o|--option_name \<argument_name>

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_astext.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_astext.txt
@@ -1,3 +1,6 @@
+<comment>Description:</comment>
+  description
+
 <comment>Usage:</comment>
   namespace:name
   name

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_mbstring.txt
@@ -1,3 +1,6 @@
+<comment>Description:</comment>
+  command åèä description
+
 <comment>Usage:</comment>
   descriptor:åèä [options] [--] \<argument_åèä>
   descriptor:åèä -o|--option_name \<argument_name>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no   
| Deprecations? | no 
| Tests pass?   | yes  
| Fixed tickets | https://github.com/symfony/symfony/issues/26376
| License       | MIT
| Doc PR        | none

Hi,

Here is a fix for the issue https://github.com/symfony/symfony/issues/26376

I only patch the text descriptor, should I do it for others?
(I do not think so as the main and default one is text)

Thanks