### PR TITLE
[Form] block_name in createBuilder()

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -55,7 +55,13 @@ class FormFactory implements FormFactoryInterface
             throw new UnexpectedTypeException($type, 'string');
         }
 
-        return $this->createNamedBuilder($this->registry->getType($type)->getBlockPrefix(), $type, $data, $options);
+        if (array_key_exists('block_name', $options)) {
+            $name = $options['block_name'];
+        } else {
+            $name = $this->registry->getType($type)->getBlockPrefix();
+        }
+
+        return $this->createNamedBuilder($name, $type, $data, $options);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

I'm not sure but when I rename a form in my Controller with "block_name", example : 

```php
    $form = $this->createForm(UserStatusCommentType::class, $comment, [
        'block_name' => 'user_status_comment_' . $idStatus,
    ]);
```

`block_name` not override default block prefix (->getBlockPrefix() ).

Your documentation ( https://symfony.com/doc/current/reference/forms/types/form.html#block-name ) :

> Allows you to override the block name used to render the form type. Useful for example if you have multiple instances of the same form and you need to personalize the rendering of the forms individually.

Sorry for my bad english, I'm french