### PR TITLE
Make ProgressBar::setMaxSteps public

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -295,6 +295,13 @@ final class ProgressBar
         }
     }
 
+    public function setMaxSteps(int $max)
+    {
+        $this->format = null;
+        $this->max = max(0, $max);
+        $this->stepWidth = $this->max ? Helper::strlen((string) $this->max) : 4;
+    }
+
     /**
      * Finishes the progress output.
      */
@@ -360,12 +367,6 @@ final class ProgressBar
         }
 
         $this->formatLineCount = substr_count($this->format, "\n");
-    }
-
-    private function setMaxSteps(int $max)
-    {
-        $this->max = max(0, $max);
-        $this->stepWidth = $this->max ? Helper::strlen((string) $this->max) : 4;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -592,6 +592,29 @@ class ProgressBarTest extends TestCase
         );
     }
 
+    public function testSettingMaxStepsDuringProgressing()
+    {
+        $output = $this->getOutputStream();
+        $bar = new ProgressBar($output);
+        $bar->start();
+        $bar->setProgress(2);
+        $bar->setMaxSteps(10);
+        $bar->setProgress(5);
+        $bar->setMaxSteps(100);
+        $bar->setProgress(10);
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            rtrim('    0 [>---------------------------]').
+            rtrim($this->generateOutput('    2 [-->-------------------------]')).
+            rtrim($this->generateOutput('  5/10 [==============>-------------]  50%')).
+            rtrim($this->generateOutput('  10/100 [==>-------------------------]  10%')).
+            rtrim($this->generateOutput(' 100/100 [============================] 100%')),
+            stream_get_contents($output->getStream())
+        );
+    }
+
     public function testWithSmallScreen()
     {
         $output = $this->getOutputStream();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24100
| License       | MIT
| Doc PR        | -

This is useful in cases when target of tracking changes its size during progress advancement. My exact use case is showing progress of file upload for file which is still being downloading.