### PR TITLE
[Intl] Load locale aliases to support alias fallbacks

### DIFF
--- a/src/Symfony/Component/Intl/Intl.php
+++ b/src/Symfony/Component/Intl/Intl.php
@@ -15,6 +15,7 @@ use Symfony\Component\Intl\Data\Bundle\Reader\JsonBundleReader;
 use Symfony\Component\Intl\Data\Bundle\Reader\BufferedBundleReader;
 use Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReader;
 use Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReaderInterface;
+use Symfony\Component\Intl\Data\Provider\LocaleDataProvider;
 use Symfony\Component\Intl\Data\Provider\ScriptDataProvider;
 use Symfony\Component\Intl\ResourceBundle\CurrencyBundle;
 use Symfony\Component\Intl\ResourceBundle\CurrencyBundleInterface;
@@ -259,6 +260,11 @@ final class Intl
                 new JsonBundleReader(),
                 self::BUFFER_SIZE
             ));
+            $localeDataProvider = new LocaleDataProvider(
+                self::getDataDirectory().'/'.self::LOCALE_DIR,
+                self::$entryReader
+            );
+            self::$entryReader->setLocaleAliases($localeDataProvider->getAliases());
         }
 
         return self::$entryReader;

--- a/src/Symfony/Component/Intl/Tests/IntlTest.php
+++ b/src/Symfony/Component/Intl/Tests/IntlTest.php
@@ -61,7 +61,7 @@ class IntlTest extends TestCase
 
     public function testGetDataDirectoryReturnsThePathToIcuData()
     {
-        $this->assertDirectoryExists(Intl::getDataDirectory());
+        $this->assertTrue(is_dir(Intl::getDataDirectory()));
     }
 
     /**

--- a/src/Symfony/Component/Intl/Tests/IntlTest.php
+++ b/src/Symfony/Component/Intl/Tests/IntlTest.php
@@ -63,4 +63,22 @@ class IntlTest extends TestCase
     {
         $this->assertDirectoryExists(Intl::getDataDirectory());
     }
+
+    /**
+     * @requires extension intl
+     */
+    public function testLocaleAliasesAreLoaded()
+    {
+        \Locale::setDefault('zh_TW');
+        $countryNameZhTw = Intl::getRegionBundle()->getCountryName('AD');
+
+        \Locale::setDefault('zh_Hant_TW');
+        $countryNameHantZhTw = Intl::getRegionBundle()->getCountryName('AD');
+
+        \Locale::setDefault('zh');
+        $countryNameZh = Intl::getRegionBundle()->getCountryName('AD');
+
+        $this->assertSame($countryNameZhTw, $countryNameHantZhTw, 'zh_TW is an alias to zh_Hant_TW');
+        $this->assertNotSame($countryNameZh, $countryNameZhTw, 'zh_TW does not fall back to zh');
+    }
 }

--- a/src/Symfony/Component/Intl/Tests/IntlTest.php
+++ b/src/Symfony/Component/Intl/Tests/IntlTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Intl\Tests;
+
+use Symfony\Component\Intl\Intl;
+use PHPUnit\Framework\TestCase;
+
+class IntlTest extends TestCase
+{
+    /**
+     * @requires extension intl
+     */
+    public function testIsExtensionLoadedChecksIfIntlExtensionIsLoaded()
+    {
+        $this->assertTrue(Intl::isExtensionLoaded());
+    }
+
+    public function testGetCurrencyBundleCreatesTheCurrencyBundle()
+    {
+        $this->assertInstanceOf('Symfony\Component\Intl\ResourceBundle\CurrencyBundleInterface', Intl::getCurrencyBundle());
+    }
+
+    public function testGetLanguageBundleCreatesTheLanguageBundle()
+    {
+        $this->assertInstanceOf('Symfony\Component\Intl\ResourceBundle\LanguageBundleInterface', Intl::getLanguageBundle());
+    }
+
+    public function testGetLocaleBundleCreatesTheLocaleBundle()
+    {
+        $this->assertInstanceOf('Symfony\Component\Intl\ResourceBundle\LocaleBundleInterface', Intl::getLocaleBundle());
+    }
+
+    public function testGetRegionBundleCreatesTheRegionBundle()
+    {
+        $this->assertInstanceOf('Symfony\Component\Intl\ResourceBundle\LocaleBundleInterface', Intl::getLocaleBundle());
+    }
+
+    public function testGetIcuVersionReadsTheVersionOfInstalledIcuLibrary()
+    {
+        $this->assertStringMatchesFormat('%d.%d', Intl::getIcuVersion());
+    }
+
+    public function testGetIcuDataVersionReadsTheVersionOfInstalledIcuData()
+    {
+        $this->assertStringMatchesFormat('%d.%d', Intl::getIcuDataVersion());
+    }
+
+    public function testGetIcuStubVersionReadsTheVersionOfBundledStubs()
+    {
+        $this->assertStringMatchesFormat('%d.%d', Intl::getIcuStubVersion());
+    }
+
+    public function testGetDataDirectoryReturnsThePathToIcuData()
+    {
+        $this->assertDirectoryExists(Intl::getDataDirectory());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #21457
| License       | MIT
| Doc PR        | -

For example, `zh_TW` is an alias to `zh_Hant_TW`. Without aliases,` zh_TW` would fall back to `zh` (which is incorrect). With aliases loaded, `zh_TW` will fall back properly to `zh_Hant_TW`.

Judging by git history this has never worked. 

```php
\Locale::setDefault('zh'); dump(Intl::getRegionBundle()->getCountryName('AD'));
\Locale::setDefault('zh_TW'); dump(Intl::getRegionBundle()->getCountryName('AD'));
\Locale::setDefault('zh_Hant_TW'); dump(Intl::getRegionBundle()->getCountryName('AD'));
```

Before:

```
"安道尔"
"安道尔"
"安道爾"
```

After:

```
"安道尔"
"安道爾"
"安道爾"
```

All tests are passing, including those from the `intl-data` group.