### PR TITLE
Failed opening old class name from remember me cookie

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -104,7 +104,7 @@ class EntityUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        return $class === $this->getClass() || is_subclass_of($class, $this->getClass());
+        return $class === $this->getClass() || (class_exists($class, false) && is_subclass_of($class, $this->getClass()));
     }
 
     private function getObjectManager()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

When using remember me login, and user class is renamed, this error happens:

```
Compile Error: Symfony\Component\Debug\DebugClassLoader::loadClass(): Failed opening required 'OldUser.php' 
```

This is because remember me cookie remembered old user class FQCN, and trying to load it.