### PR TITLE
Default deleteFileAfterSend() to true

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -350,7 +350,7 @@ class BinaryFileResponse extends Response
      *
      * @return $this
      */
-    public function deleteFileAfterSend($shouldDelete)
+    public function deleteFileAfterSend($shouldDelete = true)
     {
         $this->deleteFileAfterSend = $shouldDelete;
 


### PR DESCRIPTION
This should default to true when called since there is only one option.

| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | N/A
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | 

<!--
* Defaults deleteFileAfterSend() to true
-->
