### PR TITLE
Add UsernameNotFoundException declaration to refreshUser().

### DIFF
--- a/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
@@ -57,7 +57,7 @@ interface UserProviderInterface
      *
      * @return UserInterface
      *
-     * @throws UnsupportedUserException if the user is not supported
+     * @throws UnsupportedUserException  if the user is not supported
      * @throws UsernameNotFoundException if the user is not found
      */
     public function refreshUser(UserInterface $user);

--- a/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
@@ -58,6 +58,7 @@ interface UserProviderInterface
      * @return UserInterface
      *
      * @throws UnsupportedUserException if the user is not supported
+     * @throws UsernameNotFoundException if the user is not found
      */
     public function refreshUser(UserInterface $user);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | maybe
| New feature?  | maybe
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Symfony\Component\Security\Core\User\UserProviderInterface::refreshUser() does not declare that implementations may throw a UsernameNotFoundException, although a) it makes sense, as the user could have been deleted since the last load, and b) the ContextListener already handles the UsernameNotFoundException. So it looks like someone thought of this, but simply forgot the annotation.

Unsure if this is a bugfix or a feature, but as it doesn't change executed code, master should be soon enough.