### PR TITLE
Added .gitattributes files to root and all components

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+* text=auto
+/.github         export-ignore
+/.composer       export-ignore
+.editorconfig    export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.php_cs.dist     export-ignore
+.travis.yml      export-ignore
+appveyor.yml     export-ignore
+CHANGELOG-4.0.md export-ignore
+CONTRIBUTING.md  export-ignore
+CONTRIBUTORS.md  export-ignore
+link             export-ignore
+phpunit          export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore
+UPGRADE-4.0.md   export-ignore

--- a/src/Symfony/Component/Asset/.gitattributes
+++ b/src/Symfony/Component/Asset/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/BrowserKit/.gitattributes
+++ b/src/Symfony/Component/BrowserKit/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Cache/.gitattributes
+++ b/src/Symfony/Component/Cache/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Config/.gitattributes
+++ b/src/Symfony/Component/Config/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Console/.gitattributes
+++ b/src/Symfony/Component/Console/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/CssSelector/.gitattributes
+++ b/src/Symfony/Component/CssSelector/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Debug/.gitattributes
+++ b/src/Symfony/Component/Debug/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/DependencyInjection/.gitattributes
+++ b/src/Symfony/Component/DependencyInjection/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/DomCrawler/.gitattributes
+++ b/src/Symfony/Component/DomCrawler/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Dotenv/.gitattributes
+++ b/src/Symfony/Component/Dotenv/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/EventDispatcher/.gitattributes
+++ b/src/Symfony/Component/EventDispatcher/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/ExpressionLanguage/.gitattributes
+++ b/src/Symfony/Component/ExpressionLanguage/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Filesystem/.gitattributes
+++ b/src/Symfony/Component/Filesystem/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Finder/.gitattributes
+++ b/src/Symfony/Component/Finder/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Form/.gitattributes
+++ b/src/Symfony/Component/Form/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/HttpFoundation/.gitattributes
+++ b/src/Symfony/Component/HttpFoundation/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/HttpKernel/.gitattributes
+++ b/src/Symfony/Component/HttpKernel/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Inflector/.gitattributes
+++ b/src/Symfony/Component/Inflector/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Intl/.gitattributes
+++ b/src/Symfony/Component/Intl/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Ldap/.gitattributes
+++ b/src/Symfony/Component/Ldap/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Lock/.gitattributes
+++ b/src/Symfony/Component/Lock/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/OptionsResolver/.gitattributes
+++ b/src/Symfony/Component/OptionsResolver/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Process/.gitattributes
+++ b/src/Symfony/Component/Process/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/PropertyAccess/.gitattributes
+++ b/src/Symfony/Component/PropertyAccess/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/PropertyInfo/.gitattributes
+++ b/src/Symfony/Component/PropertyInfo/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Routing/.gitattributes
+++ b/src/Symfony/Component/Routing/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Security/.gitattributes
+++ b/src/Symfony/Component/Security/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Serializer/.gitattributes
+++ b/src/Symfony/Component/Serializer/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Stopwatch/.gitattributes
+++ b/src/Symfony/Component/Stopwatch/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Templating/.gitattributes
+++ b/src/Symfony/Component/Templating/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Translation/.gitattributes
+++ b/src/Symfony/Component/Translation/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Validator/.gitattributes
+++ b/src/Symfony/Component/Validator/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/VarDumper/.gitattributes
+++ b/src/Symfony/Component/VarDumper/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/WebLink/.gitattributes
+++ b/src/Symfony/Component/WebLink/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Workflow/.gitattributes
+++ b/src/Symfony/Component/Workflow/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore

--- a/src/Symfony/Component/Yaml/.gitattributes
+++ b/src/Symfony/Component/Yaml/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/Tests           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0 <!-- see below -->
| Bug fix?      | no
| New feature?  | not realy <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a <!-- required for new features -->

This change adds `.gitattributes` files in all components.

The `.gitattributes` file allows you to configure several things, but the most important thing related to composer is the ability to not include certain files and folders into your release. In short, this should slightly reduce the size of symfony component packages by excluding few files from them.