### PR TITLE
is_executable warning exception

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -65,7 +65,7 @@ class PhpExecutableFinder
             }
         }
 
-        if (is_executable($php = PHP_BINDIR.('\\' === DIRECTORY_SEPARATOR ? '\\php.exe' : '/php'))) {
+        if (@is_executable($php = PHP_BINDIR.('\\' === DIRECTORY_SEPARATOR ? '\\php.exe' : '/php'))) {
             return $php;
         }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

is_executable warning exception
The @ gets rid of the warning when this command fails. `is_executable(): open_basedir restriction in effect`

![e_warning](https://user-images.githubusercontent.com/14247909/37216359-d4432fc2-23cf-11e8-9f81-b2535a4f5f71.png)

