### PR TITLE
AllValidator should not throw when not traversable is passed

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -34,7 +34,7 @@ class AllValidator extends ConstraintValidator
         }
 
         if (!is_array($value) && !$value instanceof \Traversable) {
-            throw new UnexpectedTypeException($value, 'array or Traversable');
+            return;
         }
 
         $context = $this->context;

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -31,12 +31,9 @@ class AllValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
-    public function testThrowsExceptionIfNotTraversable()
+    public function testNotTraversableIsValid()
     {
-        $this->validator->validate('foo.barbar', new All(new Range(array('min' => 4))));
+        $this->assertNull($this->validator->validate('foo.barbar', new All(new Range(array('min' => 4)))));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | behavior change
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26463   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

The same way `AllValidator` does not throw for empty values, and the same way every other validator does not throw but skips or returns a violation instead - the `AllValidator` should return `null` in case if not an array or a traversable passed.