### PR TITLE
[HttpFoundation] Support samesite cookies in response

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -338,10 +338,11 @@ class Response
 
         // cookies
         foreach ($this->headers->getCookies() as $cookie) {
+            $path = $cookie->getPath().(null !== $cookie->getSameSite() ? ('; samesite='.$cookie->getSameSite()) : '');
             if ($cookie->isRaw()) {
-                setrawcookie($cookie->getName(), $cookie->getValue(), $cookie->getExpiresTime(), $cookie->getPath(), $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly());
+                setrawcookie($cookie->getName(), $cookie->getValue(), $cookie->getExpiresTime(), $path, $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly());
             } else {
-                setcookie($cookie->getName(), $cookie->getValue(), $cookie->getExpiresTime(), $cookie->getPath(), $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly());
+                setcookie($cookie->getName(), $cookie->getValue(), $cookie->getExpiresTime(), $path, $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly());
             }
         }
 

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -210,7 +210,7 @@ class ResponseHeaderBag extends HeaderBag
      *
      * @param string $format
      *
-     * @return array
+     * @return Cookie[]
      *
      * @throws \InvalidArgumentException When the $format is invalid
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/server.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/server.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation\Tests;
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Response;
+
+require_once __DIR__.'/../../../../../../vendor/autoload.php';
+
+$uri = $_SERVER['REQUEST_URI'];
+
+switch ($uri) {
+    case '/ping':
+        $response = new Response('pong');
+        break;
+
+    case '/cookie/samesite-lax':
+        $response = new Response($uri);
+        $response->headers->setCookie(new Cookie('SF', 'V', 0, '/cookie', 'example.org', true, true, false, Cookie::SAMESITE_LAX));
+        break;
+
+    case '/cookie/samesite-strict':
+        $response = new Response($uri);
+        $response->headers->setCookie(new Cookie('SF', 'V', 0, null, null, true, true, false, Cookie::SAMESITE_STRICT));
+        break;
+
+    default:
+        $response = new Response('', Response::HTTP_NOT_IMPLEMENTED);
+        break;
+}
+
+$response->send();

--- a/src/Symfony/Component/HttpFoundation/Tests/HttpFoundationIntegrationTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HttpFoundationIntegrationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class HttpFoundationIntegrationTest extends TestCase
+{
+    private $host = 'localhost:55876';
+
+    /** @var Process */
+    private $process;
+
+    protected function setUp()
+    {
+        $this->startServer();
+    }
+
+    protected function tearDown()
+    {
+        $this->stopServer();
+    }
+
+    public function testLaxSameSiteCookieIsProperlySent()
+    {
+        $cookieHeader = array_filter(
+            get_headers('http://'.$this->host.'/cookie/samesite-lax'),
+            function ($header) {
+                return 0 === strpos($header, 'Set-Cookie: ');
+            }
+        );
+
+        self::assertCount(1, $cookieHeader);
+        self::assertSame(
+            'Set-Cookie: SF=V; path=/cookie; samesite=lax; domain=example.org; secure; HttpOnly',
+            current($cookieHeader)
+        );
+    }
+
+    public function testStrictSameSiteCookieIsProperlySent()
+    {
+        $cookieHeader = array_filter(
+            get_headers('http://'.$this->host.'/cookie/samesite-strict'),
+            function ($header) {
+                return 0 === strpos($header, 'Set-Cookie: ');
+            }
+        );
+
+        self::assertCount(1, $cookieHeader);
+        self::assertSame(
+            'Set-Cookie: SF=V; path=/; samesite=strict; secure; HttpOnly',
+            current($cookieHeader)
+        );
+    }
+
+    private function startServer()
+    {
+        $this->process = new Process('php -S '.$this->host.' '.__DIR__.'/Fixtures/server.php&>/dev/null');
+        $this->process->start();
+
+        $count = 0;
+        do {
+            $result = @file_get_contents('http://'.$this->host.'/ping');
+            usleep(100);
+        } while ('pong' !== $result && ++$count < 10);
+    }
+
+    private function stopServer()
+    {
+        $this->process->stop();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25344
| License       | MIT
| Doc PR        | n.A.

This hack adds support for samesite cookies in `Response::sendHeaders()`. One can misuse the path parameter to set the samesite attribute nevertheless.