### PR TITLE
[PhpUnitBridge] Ability to use different composer.json file

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -26,8 +26,10 @@ if (PHP_VERSION_ID >= 70200) {
     $PHPUNIT_VERSION = '4.8';
 }
 
+COMPOSER_FILE_NAME = getenv('COMPOSER_FILE_NAME') ? : 'composer.json';
+
 $root = __DIR__;
-while (!file_exists($root.'/composer.json') || file_exists($root.'/DeprecationErrorHandler.php')) {
+while (!file_exists($root.'/'.$COMPOSER_FILE_NAME) || file_exists($root.'/DeprecationErrorHandler.php')) {
     if ($root === dirname($root)) {
         break;
     }

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -26,10 +26,13 @@ if (PHP_VERSION_ID >= 70200) {
     $PHPUNIT_VERSION = '4.8';
 }
 
-COMPOSER_FILE_NAME = getenv('COMPOSER_FILE_NAME') ? : 'composer.json';
+if ('composer.json' !== $COMPOSER_JSON = getenv('COMPOSER') ?: 'composer.json') {
+    putenv('COMPOSER=composer.json');
+    $_SERVER['COMPOSER'] = $_ENV['COMPOSER'] = 'composer.json';
+}
 
 $root = __DIR__;
-while (!file_exists($root.'/'.$COMPOSER_FILE_NAME) || file_exists($root.'/DeprecationErrorHandler.php')) {
+while (!file_exists($root.'/'.$COMPOSER_JSON) || file_exists($root.'/DeprecationErrorHandler.php')) {
     if ($root === dirname($root)) {
         break;
     }


### PR DESCRIPTION
Hi, I have a project where I use a different composer.json via environment variable. Look [here](https://getcomposer.org/doc/03-cli.md#composer). Because of this, $root gets set to "/" and everything fails.

Hope this helps.

| Q             | A
| ------------- | ---
| Branch?       | master for features / 2.7 up to 4.0 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | yes
| Tests pass?   | I'll add if this is useful.
| Fixed tickets | 
| License       | MIT
| Doc PR        | symfony/symfony-docs

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
