### PR TITLE
[HttpFoundation] Adds getAcceptableFormats() method for Request

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.2.0
+-----
+
+ * added `getAcceptableFormats()` for reading acceptable formats based on Accept header
+
 4.1.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -171,6 +171,11 @@ class Request
     protected $format;
 
     /**
+     * @var array
+     */
+    private $acceptableFormats;
+
+    /**
      * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
      */
     protected $session;
@@ -263,6 +268,7 @@ class Request
         $this->charsets = null;
         $this->encodings = null;
         $this->acceptableContentTypes = null;
+        $this->acceptableFormats = null;
         $this->pathInfo = null;
         $this->requestUri = null;
         $this->baseUrl = null;
@@ -450,6 +456,7 @@ class Request
         $dup->charsets = null;
         $dup->encodings = null;
         $dup->acceptableContentTypes = null;
+        $dup->acceptableFormats = null;
         $dup->pathInfo = null;
         $dup->requestUri = null;
         $dup->baseUrl = null;
@@ -1353,6 +1360,18 @@ class Request
     public function getContentType()
     {
         return $this->getFormat($this->headers->get('CONTENT_TYPE'));
+    }
+
+    /**
+     * Gets the acceptable client formats associated with the request.
+     */
+    public function getAcceptableFormats(): array
+    {
+        if (null !== $this->acceptableFormats) {
+            return $this->acceptableFormats;
+        }
+
+        return $this->acceptableFormats = array_values(array_unique(array_filter(array_map(array($this, 'getFormat'), $this->getAcceptableContentTypes()))));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1427,6 +1427,16 @@ class RequestTest extends TestCase
         $this->assertEquals(array('application/vnd.wap.wmlscriptc', 'text/vnd.wap.wml', 'application/vnd.wap.xhtml+xml', 'application/xhtml+xml', 'text/html', 'multipart/mixed', '*/*'), $request->getAcceptableContentTypes());
     }
 
+    public function testGetAcceptableFormats()
+    {
+        $request = new Request();
+        $this->assertEquals(array(), $request->getAcceptableFormats());
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/html, application/xhtml+xml, application/xml;q=0.9, */*');
+        $this->assertEquals(array('html', 'xml'), $request->getAcceptableFormats());
+    }
+
     public function testGetLanguages()
     {
         $request = new Request();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21909
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Adds a new method `getAcceptableFormats()` for `Request`. This reads the content types in Accept header and maps them to formats already defined in `Request` class

In a request made by a browser, based on the default Accept header, the `getAcceptableFormats()` will return an array `['html', 'xml']`

In progress
- [x] gather feedback for my changes
- [x] submit changes to the documentation
