### PR TITLE
[HttpFoundation] Replace private static variable with private constan…

### DIFF
--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  */
 class FileBag extends ParameterBag
 {
-    private static $fileKeys = array('error', 'name', 'size', 'tmp_name', 'type');
+    private const FILE_KEYS = array('error', 'name', 'size', 'tmp_name', 'type');
 
     /**
      * @param array $parameters An array of HTTP files
@@ -80,7 +80,7 @@ class FileBag extends ParameterBag
             $keys = array_keys($file);
             sort($keys);
 
-            if ($keys == self::$fileKeys) {
+            if (self::FILE_KEYS == $keys) {
                 if (UPLOAD_ERR_NO_FILE == $file['error']) {
                     $file = null;
                 } else {
@@ -120,12 +120,12 @@ class FileBag extends ParameterBag
         $keys = array_keys($data);
         sort($keys);
 
-        if (self::$fileKeys != $keys || !isset($data['name']) || !is_array($data['name'])) {
+        if (self::FILE_KEYS != $keys || !isset($data['name']) || !is_array($data['name'])) {
             return $data;
         }
 
         $files = $data;
-        foreach (self::$fileKeys as $k) {
+        foreach (self::FILE_KEYS as $k) {
             unset($files[$k]);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hi. I am completely new so sorry for any inconvenience I might have caused.

Now that private constants are allowed since PHP 7.1, I thought they might be better suited for the job of storing an array of file keys.

If you disagree, feel free to close the PR. In such case, I would like to learn why you consider private static variables a better solution.

Thank you very much for your replies and feedback.