### PR TITLE
[FrameworkBundle] Respect debug mode when warm up annotations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -36,7 +36,7 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
      * @param CacheItemPoolInterface $fallbackPool     The pool where runtime-discovered annotations are cached
      * @param bool                   $debug            Run in debug mode
      */
-    public function __construct(Reader $annotationReader, $phpArrayFile, CacheItemPoolInterface $fallbackPool, $excludeRegexp = null, $debug)
+    public function __construct(Reader $annotationReader, $phpArrayFile, CacheItemPoolInterface $fallbackPool, $excludeRegexp = null, $debug = false)
     {
         parent::__construct($phpArrayFile, $fallbackPool);
         $this->annotationReader = $annotationReader;

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -28,17 +28,20 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
 {
     private $annotationReader;
     private $excludeRegexp;
+    private $debug;
 
     /**
      * @param Reader                 $annotationReader
      * @param string                 $phpArrayFile     The PHP file where annotations are cached
      * @param CacheItemPoolInterface $fallbackPool     The pool where runtime-discovered annotations are cached
+     * @param bool                   $debug            Run in debug mode
      */
-    public function __construct(Reader $annotationReader, $phpArrayFile, CacheItemPoolInterface $fallbackPool, $excludeRegexp = null)
+    public function __construct(Reader $annotationReader, $phpArrayFile, CacheItemPoolInterface $fallbackPool, $excludeRegexp = null, $debug)
     {
         parent::__construct($phpArrayFile, $fallbackPool);
         $this->annotationReader = $annotationReader;
         $this->excludeRegexp = $excludeRegexp;
+        $this->debug = $debug;
     }
 
     /**
@@ -53,7 +56,7 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         }
 
         $annotatedClasses = include $annotatedClassPatterns;
-        $reader = new CachedReader($this->annotationReader, new DoctrineProvider($arrayAdapter));
+        $reader = new CachedReader($this->annotationReader, new DoctrineProvider($arrayAdapter), $this->debug);
 
         foreach ($annotatedClasses as $class) {
             if (null !== $this->excludeRegexp && preg_match($this->excludeRegexp, $class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -38,6 +38,7 @@
             <argument>%kernel.cache_dir%/annotations.php</argument>
             <argument type="service" id="cache.annotations" />
             <argument>#^Symfony\\(?:Component\\HttpKernel\\|Bundle\\FrameworkBundle\\Controller\\(?!AbstractController$|Controller$))#</argument>
+            <argument>%kernel.debug%</argument>
         </service>
 
         <service id="annotations.cache" class="Symfony\Component\Cache\DoctrineProvider">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -57,7 +57,7 @@ class AnnotationsCacheWarmerTest extends TestCase
         $readerMock->expects($this->exactly(0))->method('getPropertyAnnotations');
         $readerMock->expects($this->exactly(0))->method('getPropertyAnnotation');
         $reader = new CachedReader(
-            $readerMock,
+            $this->getReadOnlyReader(),
             new DoctrineProvider(new PhpArrayAdapter($cacheFile, new NullAdapter()))
         );
         $refClass = new \ReflectionClass($this);
@@ -82,16 +82,8 @@ class AnnotationsCacheWarmerTest extends TestCase
         $warmer->warmUp($this->cacheDir);
         $this->assertFileExists($cacheFile);
         // Assert cache is valid
-        /** @var Reader|\PHPUnit_Framework_MockObject_MockObject $readerMock */
-        $readerMock = $this->createMock(Reader::class);
-        $readerMock->expects($this->exactly(0))->method('getClassAnnotations');
-        $readerMock->expects($this->exactly(0))->method('getClassAnnotation');
-        $readerMock->expects($this->exactly(0))->method('getMethodAnnotations');
-        $readerMock->expects($this->exactly(0))->method('getMethodAnnotation');
-        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotations');
-        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotation');
         $reader = new CachedReader(
-            $readerMock,
+            $this->getReadOnlyReader(),
             new DoctrineProvider(new PhpArrayAdapter($cacheFile, new NullAdapter())),
             true
         );
@@ -99,5 +91,21 @@ class AnnotationsCacheWarmerTest extends TestCase
         $reader->getClassAnnotations($refClass);
         $reader->getMethodAnnotations($refClass->getMethod(__FUNCTION__));
         $reader->getPropertyAnnotations($refClass->getProperty('cacheDir'));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Reader
+     */
+    private function getReadOnlyReader()
+    {
+        $readerMock = $this->getMockBuilder(Reader::class)->getMock();
+        $readerMock->expects($this->exactly(0))->method('getClassAnnotations');
+        $readerMock->expects($this->exactly(0))->method('getClassAnnotation');
+        $readerMock->expects($this->exactly(0))->method('getMethodAnnotations');
+        $readerMock->expects($this->exactly(0))->method('getMethodAnnotation');
+        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotations');
+        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotation');
+
+        return $readerMock;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -48,14 +48,6 @@ class AnnotationsCacheWarmerTest extends TestCase
         $this->assertFileExists($cacheFile);
 
         // Assert cache is valid
-        /** @var Reader|\PHPUnit_Framework_MockObject_MockObject $readerMock */
-        $readerMock = $this->createMock(Reader::class);
-        $readerMock->expects($this->exactly(0))->method('getClassAnnotations');
-        $readerMock->expects($this->exactly(0))->method('getClassAnnotation');
-        $readerMock->expects($this->exactly(0))->method('getMethodAnnotations');
-        $readerMock->expects($this->exactly(0))->method('getMethodAnnotation');
-        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotations');
-        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotation');
         $reader = new CachedReader(
             $this->getReadOnlyReader(),
             new DoctrineProvider(new PhpArrayAdapter($cacheFile, new NullAdapter()))
@@ -98,7 +90,7 @@ class AnnotationsCacheWarmerTest extends TestCase
      */
     private function getReadOnlyReader()
     {
-        $readerMock = $this->getMockBuilder(Reader::class)->getMock();
+        $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')->getMock();
         $readerMock->expects($this->exactly(0))->method('getClassAnnotations');
         $readerMock->expects($this->exactly(0))->method('getClassAnnotation');
         $readerMock->expects($this->exactly(0))->method('getMethodAnnotations');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -19,7 +19,7 @@ class AnnotationsCacheWarmerTest extends TestCase
 
     protected function setUp()
     {
-        $this->cacheDir = sys_get_temp_dir() . '/' . uniqid();
+        $this->cacheDir = sys_get_temp_dir().'/'.uniqid();
         $fs = new Filesystem();
         $fs->mkdir($this->cacheDir);
         parent::setUp();
@@ -34,7 +34,7 @@ class AnnotationsCacheWarmerTest extends TestCase
 
     public function testAnnotationsCacheWarmerWithDebugDisabled()
     {
-        file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export([__CLASS__], true)));
+        file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export(array(__CLASS__), true)));
         $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
         $reader = new AnnotationReader();
         $fallbackPool = new ArrayAdapter();
@@ -68,7 +68,7 @@ class AnnotationsCacheWarmerTest extends TestCase
 
     public function testAnnotationsCacheWarmerWithDebugEnabled()
     {
-        file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export([__CLASS__], true)));
+        file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export(array(__CLASS__), true)));
         $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
         $reader = new AnnotationReader();
         $fallbackPool = new ArrayAdapter();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\Reader;
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\Cache\DoctrineProvider;
+use Symfony\Component\Filesystem\Filesystem;
+
+class AnnotationsCacheWarmerTest extends TestCase
+{
+    private $cacheDir;
+
+    protected function setUp()
+    {
+        $this->cacheDir = sys_get_temp_dir() . '/' . uniqid();
+        $fs = new Filesystem();
+        $fs->mkdir($this->cacheDir);
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        $fs = new Filesystem();
+        $fs->remove($this->cacheDir);
+        parent::tearDown();
+    }
+
+    public function testAnnotationsCacheWarmerWithDebugDisabled()
+    {
+        file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export([__CLASS__], true)));
+        $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
+        $reader = new AnnotationReader();
+        $fallbackPool = new ArrayAdapter();
+        $warmer = new AnnotationsCacheWarmer(
+            $reader,
+            $cacheFile,
+            $fallbackPool,
+            null
+        );
+        $warmer->warmUp($this->cacheDir);
+        $this->assertFileExists($cacheFile);
+
+        // Assert cache is valid
+        /** @var Reader|\PHPUnit_Framework_MockObject_MockObject $readerMock */
+        $readerMock = $this->createMock(Reader::class);
+        $readerMock->expects($this->exactly(0))->method('getClassAnnotations');
+        $readerMock->expects($this->exactly(0))->method('getClassAnnotation');
+        $readerMock->expects($this->exactly(0))->method('getMethodAnnotations');
+        $readerMock->expects($this->exactly(0))->method('getMethodAnnotation');
+        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotations');
+        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotation');
+        $reader = new CachedReader(
+            $readerMock,
+            new DoctrineProvider(new PhpArrayAdapter($cacheFile, new NullAdapter()))
+        );
+        $refClass = new \ReflectionClass($this);
+        $reader->getClassAnnotations($refClass);
+        $reader->getMethodAnnotations($refClass->getMethod(__FUNCTION__));
+        $reader->getPropertyAnnotations($refClass->getProperty('cacheDir'));
+    }
+
+    public function testAnnotationsCacheWarmerWithDebugEnabled()
+    {
+        file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export([__CLASS__], true)));
+        $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
+        $reader = new AnnotationReader();
+        $fallbackPool = new ArrayAdapter();
+        $warmer = new AnnotationsCacheWarmer(
+            $reader,
+            $cacheFile,
+            $fallbackPool,
+            null,
+            true
+        );
+        $warmer->warmUp($this->cacheDir);
+        $this->assertFileExists($cacheFile);
+        // Assert cache is valid
+        /** @var Reader|\PHPUnit_Framework_MockObject_MockObject $readerMock */
+        $readerMock = $this->createMock(Reader::class);
+        $readerMock->expects($this->exactly(0))->method('getClassAnnotations');
+        $readerMock->expects($this->exactly(0))->method('getClassAnnotation');
+        $readerMock->expects($this->exactly(0))->method('getMethodAnnotations');
+        $readerMock->expects($this->exactly(0))->method('getMethodAnnotation');
+        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotations');
+        $readerMock->expects($this->exactly(0))->method('getPropertyAnnotation');
+        $reader = new CachedReader(
+            $readerMock,
+            new DoctrineProvider(new PhpArrayAdapter($cacheFile, new NullAdapter())),
+            true
+        );
+        $refClass = new \ReflectionClass($this);
+        $reader->getClassAnnotations($refClass);
+        $reader->getMethodAnnotations($refClass->getMethod(__FUNCTION__));
+        $reader->getPropertyAnnotations($refClass->getProperty('cacheDir'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |


Propagate current debug mode to the annotations reader. Without thi, warmup is useless with debug mode, because timetsamps are not written to cache.