### PR TITLE
[HttpKernel] Revert collect extension information as late as possible

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -790,6 +790,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         foreach ($this->bundles as $bundle) {
             if ($extension = $bundle->getContainerExtension()) {
                 $container->registerExtension($extension);
+                $extensions[] = $extension->getAlias();
             }
 
             if ($this->debug) {
@@ -802,10 +803,6 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         }
 
         $this->build($container);
-
-        foreach ($container->getExtensions() as $extension) {
-            $extensions[] = $extension->getAlias();
-        }
 
         // ensure these extensions are implicitly loaded
         $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass($extensions));


### PR DESCRIPTION
This reverts https://github.com/symfony/symfony/pull/25914 which introduced BC break during minor version upgrade. All credits goes to @ManInTheBox who located it. It was a real pain to hunt down.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26512
| License       | MIT
