### PR TITLE
[Routing] Allow defining and reusing subroutines

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
@@ -51,4 +51,11 @@ class RoutingConfigurator
     {
         return new CollectionConfigurator($this->collection, $name);
     }
+
+    final public function subroutine(string $name, string $pattern): self
+    {
+        $this->collection->setSubroutine($name, $pattern);
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -83,6 +83,9 @@ class XmlFileLoader extends FileLoader
             case 'import':
                 $this->parseImport($collection, $node, $path, $file);
                 break;
+            case 'subroutine':
+                $collection->setSubroutine($node->getAttribute('id'), $node->getAttribute('pattern'));
+                break;
             default:
                 throw new \InvalidArgumentException(sprintf('Unknown tag "%s" used in file "%s". Expected "route" or "import".', $node->localName, $path));
         }

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -78,6 +78,12 @@ class YamlFileLoader extends FileLoader
         }
 
         foreach ($parsedConfig as $name => $config) {
+            if ('_subroutines' === $name && \is_array($config) && !isset($config['resource']) && !isset($config['path'])) {
+                foreach ($config as $name => $pattern) {
+                    $collection->setSubroutine($name, $pattern);
+                }
+                continue;
+            }
             $this->validate($config, $name, $path);
 
             if (isset($config['resource'])) {

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -21,6 +21,7 @@
     <xsd:choice minOccurs="0" maxOccurs="unbounded">
       <xsd:element name="import" type="import" />
       <xsd:element name="route" type="route" />
+      <xsd:element name="subroutine" type="subroutine" />
     </xsd:choice>
   </xsd:complexType>
 
@@ -67,6 +68,11 @@
     <xsd:attribute name="schemes" type="xsd:string" />
     <xsd:attribute name="methods" type="xsd:string" />
     <xsd:attribute name="controller" type="xsd:string" />
+  </xsd:complexType>
+
+  <xsd:complexType name="subroutine">
+    <xsd:attribute name="id" type="xsd:string" use="required" />
+    <xsd:attribute name="pattern" type="xsd:string" use="required" />
   </xsd:complexType>
 
   <xsd:complexType name="default" mixed="true">

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -404,6 +404,11 @@ EOF;
                 $code .= "\n                .')'";
                 $state->regex .= ')';
             }
+            foreach ($this->getRoutes()->getSubroutines() as $name => $rx) {
+                $rx = sprintf('(?(DEFINE)(?P<%s>%s))', $name, $rx);
+                $code .= "\n                .'{$rx}'";
+                $state->regex .= $rx;
+            }
             $rx = ")$}{$modifiers}";
             $code .= "\n                .'{$rx}',";
             $state->regex .= $rx;

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -35,6 +35,11 @@ class RouteCollection implements \IteratorAggregate, \Countable
      */
     private $resources = array();
 
+    /**
+     * @var array
+     */
+    private $subroutines = array();
+
     public function __clone()
     {
         foreach ($this->routes as $name => $route) {
@@ -128,6 +133,10 @@ class RouteCollection implements \IteratorAggregate, \Countable
 
         foreach ($collection->getResources() as $resource) {
             $this->addResource($resource);
+        }
+
+        foreach ($collection->getSubroutines() as $name => $pattern) {
+            $this->setSubroutine($name, $pattern);
         }
     }
 
@@ -290,5 +299,24 @@ class RouteCollection implements \IteratorAggregate, \Countable
         if (!isset($this->resources[$key])) {
             $this->resources[$key] = $resource;
         }
+    }
+
+    /**
+     * Sets a subroutine that can be reused in requirements.
+     */
+    public function setSubroutine(string $name, string $pattern)
+    {
+        if (\strlen($name) > RouteCompiler::VARIABLE_MAXIMUM_LENGTH) {
+            throw new \DomainException(sprintf('Subroutine name "%s" cannot be longer than %s characters. Please use a shorter name for pattern "%s".', $name, RouteCompiler::VARIABLE_MAXIMUM_LENGTH, $pattern));
+        }
+        $this->subroutines[$name] = $pattern;
+    }
+
+    /**
+     * Returns the defined subroutines.
+     */
+    public function getSubroutines(): array
+    {
+        return $this->subroutines;
     }
 }

--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -37,6 +37,7 @@ class RouteCollectionBuilder
     private $schemes;
     private $methods;
     private $resources = array();
+    private $subroutines = array();
 
     public function __construct(LoaderInterface $loader = null)
     {
@@ -75,6 +76,10 @@ class RouteCollectionBuilder
 
             foreach ($collection->getResources() as $resource) {
                 $builder->addResource($resource);
+            }
+
+            foreach ($collection->getSubroutines() as $name => $pattern) {
+                $builder->setSubroutine($name, $pattern);
             }
         }
 
@@ -263,6 +268,22 @@ class RouteCollectionBuilder
     }
 
     /**
+     * Sets a subroutine that can be reused in requirements.
+     */
+    public function setSubroutine(string $name, string $pattern)
+    {
+        $this->subroutines[$name] = $pattern;
+    }
+
+    /**
+     * Returns the defined subroutines.
+     */
+    public function getSubroutines()
+    {
+        return $this->subroutines;
+    }
+
+    /**
      * Creates the final RouteCollection and returns it.
      *
      * @return RouteCollection
@@ -319,6 +340,10 @@ class RouteCollectionBuilder
 
         foreach ($this->resources as $resource) {
             $routeCollection->addResource($resource);
+        }
+
+        foreach ($this->subroutines as $name => $pattern) {
+            $routeCollection->setSubroutine($name, $pattern);
         }
 
         return $routeCollection;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/controller/routing.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/controller/routing.xml
@@ -4,6 +4,8 @@
     xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
+    <subroutine id="number" pattern="\d" />
+
     <route id="app_homepage" path="/" controller="AppBundle:Homepage:show" />
 
     <route id="app_blog" path="/blog">

--- a/src/Symfony/Component/Routing/Tests/Fixtures/controller/routing.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/controller/routing.yml
@@ -1,3 +1,6 @@
+_subroutines:
+    number: \d
+
 app_homepage:
     path: /
     controller: AppBundle:Homepage:show

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl.php
@@ -3,6 +3,8 @@
 namespace Symfony\Component\Routing\Loader\Configurator;
 
 return function (RoutingConfigurator $routes) {
+    $routes->subroutine('number', '\d');
+
     $routes
         ->collection()
         ->add('foo', '/foo')

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -113,6 +113,7 @@ class PhpFileLoaderTest extends TestCase
             ->setMethods(array('GET'))
             ->setDefaults(array('id' => 0))
         );
+        $expectedCollection->setSubroutine('number', '\d');
 
         $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl_sub.php')));
         $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl.php')));

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -411,4 +411,12 @@ class XmlFileLoaderTest extends TestCase
         $this->assertNotNull($routeCollection->get('api_app_blog'));
         $this->assertEquals('/api/blog', $routeCollection->get('api_app_blog')->getPath());
     }
+
+    public function testSubroutine()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/controller')));
+        $routeCollection = $loader->load('routing.xml');
+
+        $this->assertSame(array('number' => '\d'), $routeCollection->getSubroutines());
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -275,4 +275,12 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals('DefaultController::defaultAction', $routes->get('home.nl')->getDefault('_controller'));
         $this->assertEquals('DefaultController::defaultAction', $routes->get('not_localized')->getDefault('_controller'));
     }
+
+    public function testSubroutine()
+    {
+        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/controller')));
+        $routeCollection = $loader->load('routing.yml');
+
+        $this->assertSame(array('number' => '\d'), $routeCollection->getSubroutines());
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -596,6 +596,16 @@ class UrlMatcherTest extends TestCase
         $this->assertEquals(array('_route' => 'a', 'a' => 'a', 'b' => 'b'), $matcher->match('/a/b'));
     }
 
+    public function testSubroutine()
+    {
+        $coll = new RouteCollection();
+        $coll->setSubroutine('date', '\d{4}-\d{2}-\d{2}');
+        $coll->add('a', new Route('/{a}', array(), array('a' => '(?&date)')));
+
+        $matcher = $this->getUrlMatcher($coll);
+        $this->assertEquals(array('_route' => 'a', 'a' => '2018-03-14'), $matcher->match('/2018-03-14'));
+    }
+
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)
     {
         return new UrlMatcher($routes, $context ?: new RequestContext());

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
@@ -361,4 +361,13 @@ class RouteCollectionBuilderTest extends TestCase
         $this->assertEquals('/other/a', $routes['a']->getPath());
         $this->assertEquals('/other/b', $routes['b']->getPath());
     }
+
+    public function testSubroutine()
+    {
+        $routeCollectionBuilder = new RouteCollectionBuilder(new YamlFileLoader(new FileLocator(array(__DIR__.'/Fixtures/controller'))));
+        $routeCollectionBuilder->import('routing.yml');
+        $routeCollection = $routeCollectionBuilder->build();
+
+        $this->assertSame(array('number' => '\d'), $routeCollection->getSubroutines());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26524
| License       | MIT
| Doc PR        | -

Tested locally:
- config/routes/annotations.yaml:
```
_subroutines:
    yyyy_mm_dd: \d{4}-\d{2}-\d{2}
```
- src/Controller/HelloController.php
```
class HelloController extends Controller
{
    /**
     * @Route("/hello/{date<(?&yyyy_mm_dd)>}", name="hello")
     */
```

It works well :)

Here are the remaining steps:
- [ ] agree on vocabulary
- [x] add tests
- [x] implement in `XmlFileLoader`
- [x] implement in `RoutingConfigurator`
- [x] handle in `UrlMatcher`
- [x] add docblocks
