### PR TITLE
Replace private static vars with private consts where appropriate

### DIFF
--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -30,7 +30,7 @@ class ConsoleFormatter implements FormatterInterface
     const SIMPLE_FORMAT = "%datetime% %start_tag%%level_name%%end_tag% <comment>[%channel%]</> %message%%context%%extra%\n";
     const SIMPLE_DATE = 'H:i:s';
 
-    private static $levelColorMap = array(
+    private const LEVEL_COLOR_MAP = array(
         Logger::DEBUG => 'fg=white',
         Logger::INFO => 'fg=green',
         Logger::NOTICE => 'fg=blue',
@@ -99,7 +99,7 @@ class ConsoleFormatter implements FormatterInterface
     {
         $record = $this->replacePlaceHolder($record);
 
-        $levelColor = self::$levelColorMap[$record['level']];
+        $levelColor = self::LEVEL_COLOR_MAP[$record['level']];
 
         if ($this->options['multiline']) {
             $separator = "\n";

--- a/src/Symfony/Bridge/PhpUnit/DnsMock.php
+++ b/src/Symfony/Bridge/PhpUnit/DnsMock.php
@@ -17,7 +17,7 @@ namespace Symfony\Bridge\PhpUnit;
 class DnsMock
 {
     private static $hosts = array();
-    private static $dnsTypes = array(
+    private const DNS_TYPES = array(
         'A' => DNS_A,
         'MX' => DNS_MX,
         'NS' => DNS_NS,
@@ -54,7 +54,7 @@ class DnsMock
                 if ($record['type'] === $type) {
                     return true;
                 }
-                if ('ANY' === $type && isset(self::$dnsTypes[$record['type']]) && 'HINFO' !== $record['type']) {
+                if ('ANY' === $type && isset(self::DNS_TYPES[$record['type']]) && 'HINFO' !== $record['type']) {
                     return true;
                 }
             }
@@ -152,7 +152,7 @@ class DnsMock
             $records = array();
 
             foreach (self::$hosts[$hostname] as $record) {
-                if (isset(self::$dnsTypes[$record['type']]) && (self::$dnsTypes[$record['type']] & $type)) {
+                if (isset(self::DNS_TYPES[$record['type']]) && (self::DNS_TYPES[$record['type']] & $type)) {
                     $records[] = array_merge(array('host' => $hostname, 'class' => 'IN', 'ttl' => 1, 'type' => $record['type']), $record);
                 }
             }

--- a/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationDefaultDomainNodeVisitorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationDefaultDomainNodeVisitorTest.php
@@ -20,8 +20,8 @@ use Twig\Node\Node;
 
 class TranslationDefaultDomainNodeVisitorTest extends TestCase
 {
-    private static $message = 'message';
-    private static $domain = 'domain';
+    private const MESSAGE = 'message';
+    private const DOMAIN = 'domain';
 
     /** @dataProvider getDefaultDomainAssignmentTestData */
     public function testDefaultDomainAssignment(Node $node)
@@ -30,7 +30,7 @@ class TranslationDefaultDomainNodeVisitorTest extends TestCase
         $visitor = new TranslationDefaultDomainNodeVisitor();
 
         // visit trans_default_domain tag
-        $defaultDomain = TwigNodeProvider::getTransDefaultDomainTag(self::$domain);
+        $defaultDomain = TwigNodeProvider::getTransDefaultDomainTag(self::DOMAIN);
         $visitor->enterNode($defaultDomain, $env);
         $visitor->leaveNode($defaultDomain, $env);
 
@@ -46,7 +46,7 @@ class TranslationDefaultDomainNodeVisitorTest extends TestCase
         $visitor->enterNode($node, $env);
         $visitor->leaveNode($node, $env);
 
-        $this->assertEquals(array(array(self::$message, self::$domain)), $visitor->getMessages());
+        $this->assertEquals(array(array(self::MESSAGE, self::DOMAIN)), $visitor->getMessages());
     }
 
     /** @dataProvider getDefaultDomainAssignmentTestData */
@@ -72,20 +72,20 @@ class TranslationDefaultDomainNodeVisitorTest extends TestCase
         $visitor->enterNode($node, $env);
         $visitor->leaveNode($node, $env);
 
-        $this->assertEquals(array(array(self::$message, null)), $visitor->getMessages());
+        $this->assertEquals(array(array(self::MESSAGE, null)), $visitor->getMessages());
     }
 
     public function getDefaultDomainAssignmentTestData()
     {
         return array(
-            array(TwigNodeProvider::getTransFilter(self::$message)),
-            array(TwigNodeProvider::getTransChoiceFilter(self::$message)),
-            array(TwigNodeProvider::getTransTag(self::$message)),
+            array(TwigNodeProvider::getTransFilter(self::MESSAGE)),
+            array(TwigNodeProvider::getTransChoiceFilter(self::MESSAGE)),
+            array(TwigNodeProvider::getTransTag(self::MESSAGE)),
             // with named arguments
-            array(TwigNodeProvider::getTransFilter(self::$message, null, array(
+            array(TwigNodeProvider::getTransFilter(self::MESSAGE, null, array(
                 'arguments' => new ArrayExpression(array(), 0),
             ))),
-            array(TwigNodeProvider::getTransChoiceFilter(self::$message), null, array(
+            array(TwigNodeProvider::getTransChoiceFilter(self::MESSAGE), null, array(
                 'arguments' => new ArrayExpression(array(), 0),
             )),
         );

--- a/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
+++ b/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
@@ -18,7 +18,7 @@ use Twig\Error\SyntaxError;
  */
 class UndefinedCallableHandler
 {
-    private static $filterComponents = array(
+    private const FILTER_COMPONENTS = array(
         'humanize' => 'form',
         'trans' => 'translation',
         'transchoice' => 'translation',
@@ -26,7 +26,7 @@ class UndefinedCallableHandler
         'yaml_dump' => 'yaml',
     );
 
-    private static $functionComponents = array(
+    private const FUNCTION_COMPONENTS = array(
         'asset' => 'asset',
         'asset_version' => 'asset',
         'dump' => 'debug-bundle',
@@ -57,20 +57,20 @@ class UndefinedCallableHandler
 
     public static function onUndefinedFilter($name)
     {
-        if (!isset(self::$filterComponents[$name])) {
+        if (!isset(self::FILTER_COMPONENTS[$name])) {
             return false;
         }
 
         // Twig will append the source context to the message, so that it will end up being like "[...] Unknown filter "%s" in foo.html.twig on line 123."
-        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown filter "%s".', self::$filterComponents[$name], $name));
+        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown filter "%s".', self::FILTER_COMPONENTS[$name], $name));
     }
 
     public static function onUndefinedFunction($name)
     {
-        if (!isset(self::$functionComponents[$name])) {
+        if (!isset(self::FUNCTION_COMPONENTS[$name])) {
             return false;
         }
 
-        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown function "%s".', self::$functionComponents[$name], $name));
+        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown function "%s".', self::FUNCTION_COMPONENTS[$name], $name));
     }
 }

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerLogCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
  */
 class ServerLogCommand extends Command
 {
-    private static $bgColor = array('black', 'blue', 'cyan', 'green', 'magenta', 'red', 'white', 'yellow');
+    private const BG_COLOR = array('black', 'blue', 'cyan', 'green', 'magenta', 'red', 'white', 'yellow');
 
     private $el;
     private $handler;
@@ -145,7 +145,7 @@ EOF
             if (isset($record['log_id'])) {
                 $clientId = unpack('H*', $record['log_id'])[1];
             }
-            $logBlock = sprintf('<bg=%s> </>', self::$bgColor[$clientId % 8]);
+            $logBlock = sprintf('<bg=%s> </>', self::BG_COLOR[$clientId % 8]);
             $output->write($logBlock);
         }
 

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -22,7 +22,7 @@ class Cookie
      * Handles dates as defined by RFC 2616 section 3.3.1, and also some other
      * non-standard, but common formats.
      */
-    private static $dateFormats = array(
+    private const DATE_FORMATS = array(
         'D, d M Y H:i:s T',
         'D, d-M-y H:i:s T',
         'D, d-M-Y H:i:s T',
@@ -87,7 +87,7 @@ class Cookie
 
         if (null !== $this->expires) {
             $dateTime = \DateTime::createFromFormat('U', $this->expires, new \DateTimeZone('GMT'));
-            $cookie .= '; expires='.str_replace('+0000', '', $dateTime->format(self::$dateFormats[0]));
+            $cookie .= '; expires='.str_replace('+0000', '', $dateTime->format(self::DATE_FORMATS[0]));
         }
 
         if ('' !== $this->domain) {
@@ -197,7 +197,7 @@ class Cookie
             $dateValue = substr($dateValue, 1, -1);
         }
 
-        foreach (self::$dateFormats as $dateFormat) {
+        foreach (self::DATE_FORMATS as $dateFormat) {
             if (false !== $date = \DateTime::createFromFormat($dateFormat, $dateValue, new \DateTimeZone('GMT'))) {
                 return $date->format('U');
             }

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
  */
 class OutputFormatterStyle implements OutputFormatterStyleInterface
 {
-    private static $availableForegroundColors = array(
+    private const AVAILABLE_FOREGROUND_COLORS = array(
         'black' => array('set' => 30, 'unset' => 39),
         'red' => array('set' => 31, 'unset' => 39),
         'green' => array('set' => 32, 'unset' => 39),
@@ -31,7 +31,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         'white' => array('set' => 37, 'unset' => 39),
         'default' => array('set' => 39, 'unset' => 39),
     );
-    private static $availableBackgroundColors = array(
+    private const AVAILABLE_BACKGROUND_COLORS = array(
         'black' => array('set' => 40, 'unset' => 49),
         'red' => array('set' => 41, 'unset' => 49),
         'green' => array('set' => 42, 'unset' => 49),
@@ -42,7 +42,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         'white' => array('set' => 47, 'unset' => 49),
         'default' => array('set' => 49, 'unset' => 49),
     );
-    private static $availableOptions = array(
+    private const AVAILABLE_OPTIONS = array(
         'bold' => array('set' => 1, 'unset' => 22),
         'underscore' => array('set' => 4, 'unset' => 24),
         'blink' => array('set' => 5, 'unset' => 25),
@@ -89,15 +89,15 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
             return;
         }
 
-        if (!isset(static::$availableForegroundColors[$color])) {
+        if (!isset(static::AVAILABLE_FOREGROUND_COLORS[$color])) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid foreground color specified: "%s". Expected one of (%s)',
                 $color,
-                implode(', ', array_keys(static::$availableForegroundColors))
+                implode(', ', array_keys(static::AVAILABLE_FOREGROUND_COLORS))
             ));
         }
 
-        $this->foreground = static::$availableForegroundColors[$color];
+        $this->foreground = static::AVAILABLE_FOREGROUND_COLORS[$color];
     }
 
     /**
@@ -115,15 +115,15 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
             return;
         }
 
-        if (!isset(static::$availableBackgroundColors[$color])) {
+        if (!isset(static::AVAILABLE_BACKGROUND_COLORS[$color])) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid background color specified: "%s". Expected one of (%s)',
                 $color,
-                implode(', ', array_keys(static::$availableBackgroundColors))
+                implode(', ', array_keys(static::AVAILABLE_BACKGROUND_COLORS))
             ));
         }
 
-        $this->background = static::$availableBackgroundColors[$color];
+        $this->background = static::AVAILABLE_BACKGROUND_COLORS[$color];
     }
 
     /**
@@ -135,16 +135,16 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
      */
     public function setOption($option)
     {
-        if (!isset(static::$availableOptions[$option])) {
+        if (!isset(static::AVAILABLE_OPTIONS[$option])) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid option specified: "%s". Expected one of (%s)',
                 $option,
-                implode(', ', array_keys(static::$availableOptions))
+                implode(', ', array_keys(static::AVAILABLE_OPTIONS))
             ));
         }
 
-        if (!in_array(static::$availableOptions[$option], $this->options)) {
-            $this->options[] = static::$availableOptions[$option];
+        if (!in_array(static::AVAILABLE_OPTIONS[$option], $this->options)) {
+            $this->options[] = static::AVAILABLE_OPTIONS[$option];
         }
     }
 
@@ -157,15 +157,15 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
      */
     public function unsetOption($option)
     {
-        if (!isset(static::$availableOptions[$option])) {
+        if (!isset(static::AVAILABLE_OPTIONS[$option])) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid option specified: "%s". Expected one of (%s)',
                 $option,
-                implode(', ', array_keys(static::$availableOptions))
+                implode(', ', array_keys(static::AVAILABLE_OPTIONS))
             ));
         }
 
-        $pos = array_search(static::$availableOptions[$option], $this->options);
+        $pos = array_search(static::AVAILABLE_OPTIONS[$option], $this->options);
         if (false !== $pos) {
             unset($this->options[$pos]);
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
@@ -27,7 +27,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterEnvVarProcessorsPass implements CompilerPassInterface
 {
-    private static $allowedTypes = array('array', 'bool', 'float', 'int', 'string');
+    private const ALLOWED_TYPES = array('array', 'bool', 'float', 'int', 'string');
 
     public function process(ContainerBuilder $container)
     {
@@ -68,8 +68,8 @@ class RegisterEnvVarProcessorsPass implements CompilerPassInterface
         $types = explode('|', $types);
 
         foreach ($types as $type) {
-            if (!in_array($type, self::$allowedTypes)) {
-                throw new InvalidArgumentException(sprintf('Invalid type "%s" returned by "%s::getProvidedTypes()", expected one of "%s".', $type, $class, implode('", "', self::$allowedTypes)));
+            if (!in_array($type, self::ALLOWED_TYPES)) {
+                throw new InvalidArgumentException(sprintf('Invalid type "%s" returned by "%s::getProvidedTypes()", expected one of "%s".', $type, $class, implode('", "', self::ALLOWED_TYPES)));
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -47,7 +47,7 @@ class Definition
 
     protected $arguments = array();
 
-    private static $defaultDeprecationTemplate = 'The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.';
+    private const DEFAULT_DEPRECATION_TEMPLATE = 'The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.';
 
     /**
      * @param string|null $class     The service class
@@ -769,7 +769,7 @@ class Definition
      */
     public function getDeprecationMessage($id)
     {
-        return str_replace('%service_id%', $id, $this->deprecationTemplate ?: self::$defaultDeprecationTemplate);
+        return str_replace('%service_id%', $id, $this->deprecationTemplate ?: self::DEFAULT_DEPRECATION_TEMPLATE);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -36,7 +36,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
  */
 class YamlFileLoader extends FileLoader
 {
-    private static $serviceKeywords = array(
+    private const SERVICE_KEYWORDS = array(
         'alias' => 'alias',
         'parent' => 'parent',
         'class' => 'class',
@@ -61,7 +61,7 @@ class YamlFileLoader extends FileLoader
         'bind' => 'bind',
     );
 
-    private static $prototypeKeywords = array(
+    private const PROTOTYPE_KEYWORDS = array(
         'resource' => 'resource',
         'namespace' => 'namespace',
         'exclude' => 'exclude',
@@ -82,7 +82,7 @@ class YamlFileLoader extends FileLoader
         'bind' => 'bind',
     );
 
-    private static $instanceofKeywords = array(
+    private const INSTANCEOF_KEYWORDS = array(
         'shared' => 'shared',
         'lazy' => 'lazy',
         'public' => 'public',
@@ -93,7 +93,7 @@ class YamlFileLoader extends FileLoader
         'autowire' => 'autowire',
     );
 
-    private static $defaultsKeywords = array(
+    private const DEFAULTS_KEYWORDS = array(
         'public' => 'public',
         'tags' => 'tags',
         'autowire' => 'autowire',
@@ -243,8 +243,8 @@ class YamlFileLoader extends FileLoader
         }
 
         foreach ($defaults as $key => $default) {
-            if (!isset(self::$defaultsKeywords[$key])) {
-                throw new InvalidArgumentException(sprintf('The configuration key "%s" cannot be used to define a default value in "%s". Allowed keys are "%s".', $key, $file, implode('", "', self::$defaultsKeywords)));
+            if (!isset(self::DEFAULTS_KEYWORDS[$key])) {
+                throw new InvalidArgumentException(sprintf('The configuration key "%s" cannot be used to define a default value in "%s". Allowed keys are "%s".', $key, $file, implode('", "', self::DEFAULTS_KEYWORDS)));
             }
         }
 
@@ -786,11 +786,11 @@ class YamlFileLoader extends FileLoader
     private function checkDefinition($id, array $definition, $file)
     {
         if ($this->isLoadingInstanceof) {
-            $keywords = self::$instanceofKeywords;
+            $keywords = self::INSTANCEOF_KEYWORDS;
         } elseif ($throw = (isset($definition['resource']) || isset($definition['namespace']))) {
-            $keywords = self::$prototypeKeywords;
+            $keywords = self::PROTOTYPE_KEYWORDS;
         } else {
-            $keywords = self::$serviceKeywords;
+            $keywords = self::SERVICE_KEYWORDS;
         }
 
         foreach ($definition as $key => $value) {

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -20,13 +20,13 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  */
 class BinaryNode extends Node
 {
-    private static $operators = array(
+    private const OPERATORS = array(
         '~' => '.',
         'and' => '&&',
         'or' => '||',
     );
 
-    private static $functions = array(
+    private const FUNCTIONS = array(
         '**' => 'pow',
         '..' => 'range',
         'in' => 'in_array',
@@ -57,9 +57,9 @@ class BinaryNode extends Node
             return;
         }
 
-        if (isset(self::$functions[$operator])) {
+        if (isset(self::FUNCTIONS[$operator])) {
             $compiler
-                ->raw(sprintf('%s(', self::$functions[$operator]))
+                ->raw(sprintf('%s(', self::FUNCTIONS[$operator]))
                 ->compile($this->nodes['left'])
                 ->raw(', ')
                 ->compile($this->nodes['right'])
@@ -69,8 +69,8 @@ class BinaryNode extends Node
             return;
         }
 
-        if (isset(self::$operators[$operator])) {
-            $operator = self::$operators[$operator];
+        if (isset(self::OPERATORS[$operator])) {
+            $operator = self::OPERATORS[$operator];
         }
 
         $compiler
@@ -89,13 +89,13 @@ class BinaryNode extends Node
         $operator = $this->attributes['operator'];
         $left = $this->nodes['left']->evaluate($functions, $values);
 
-        if (isset(self::$functions[$operator])) {
+        if (isset(self::FUNCTIONS[$operator])) {
             $right = $this->nodes['right']->evaluate($functions, $values);
 
             if ('not in' === $operator) {
                 return !in_array($left, $right);
             }
-            $f = self::$functions[$operator];
+            $f = self::FUNCTIONS[$operator];
 
             return $f($left, $right);
         }

--- a/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
@@ -20,7 +20,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  */
 class UnaryNode extends Node
 {
-    private static $operators = array(
+    private const OPERATORS = array(
         '!' => '!',
         'not' => '!',
         '+' => '+',
@@ -39,7 +39,7 @@ class UnaryNode extends Node
     {
         $compiler
             ->raw('(')
-            ->raw(self::$operators[$this->attributes['operator']])
+            ->raw(self::OPERATORS[$this->attributes['operator']])
             ->compile($this->nodes['node'])
             ->raw(')')
         ;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
@@ -30,7 +30,7 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
     const SECONDS = 'seconds';
     const INVERT = 'invert';
 
-    private static $availableFields = array(
+    private const AVAILABLE_FIELDS = array(
         self::YEARS => 'y',
         self::MONTHS => 'm',
         self::DAYS => 'd',
@@ -85,7 +85,7 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($dateInterval, '\DateInterval');
         }
         $result = array();
-        foreach (self::$availableFields as $field => $char) {
+        foreach (self::AVAILABLE_FIELDS as $field => $char) {
             $result[$field] = $dateInterval->format('%'.($this->pad ? strtoupper($char) : $char));
         }
         if (in_array('weeks', $this->fields, true)) {
@@ -134,7 +134,7 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
         if (isset($value['invert']) && !is_bool($value['invert'])) {
             throw new TransformationFailedException('The value of "invert" must be boolean');
         }
-        foreach (self::$availableFields as $field => $char) {
+        foreach (self::AVAILABLE_FIELDS as $field => $char) {
             if ('invert' !== $field && isset($value[$field]) && !ctype_digit((string) $value[$field])) {
                 throw new TransformationFailedException(sprintf('This amount of "%s" is invalid', $field));
             }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
@@ -37,7 +37,7 @@ class DateIntervalType extends AbstractType
         'minutes',
         'seconds',
     );
-    private static $widgets = array(
+    private const WIDGETS = array(
         'text' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         'integer' => 'Symfony\Component\Form\Extension\Core\Type\IntegerType',
         'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
@@ -120,7 +120,7 @@ class DateIntervalType extends AbstractType
             }
             foreach ($this->timeParts as $part) {
                 if ($options['with_'.$part]) {
-                    $childForm = $builder->create($part, self::$widgets[$options['widget']], $childOptions[$part]);
+                    $childForm = $builder->create($part, self::WIDGETS[$options['widget']], $childOptions[$part]);
                     if ('integer' === $options['widget']) {
                         $childForm->addModelTransformer(
                             new ReversedTransformer(

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -57,7 +57,7 @@ class DateTimeType extends AbstractType
      */
     const HTML5_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZZZZ";
 
-    private static $acceptedFormats = array(
+    private const ACCEPTED_FORMATS = array(
         \IntlDateFormatter::FULL,
         \IntlDateFormatter::LONG,
         \IntlDateFormatter::MEDIUM,
@@ -88,7 +88,7 @@ class DateTimeType extends AbstractType
         $calendar = \IntlDateFormatter::GREGORIAN;
         $pattern = is_string($options['format']) ? $options['format'] : null;
 
-        if (!in_array($dateFormat, self::$acceptedFormats, true)) {
+        if (!in_array($dateFormat, self::ACCEPTED_FORMATS, true)) {
             throw new InvalidOptionsException('The "date_format" option must be one of the IntlDateFormatter constants (FULL, LONG, MEDIUM, SHORT) or a string representing a custom format.');
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -30,14 +30,14 @@ class DateType extends AbstractType
     const DEFAULT_FORMAT = \IntlDateFormatter::MEDIUM;
     const HTML5_FORMAT = 'yyyy-MM-dd';
 
-    private static $acceptedFormats = array(
+    private const ACCEPTED_FORMATS = array(
         \IntlDateFormatter::FULL,
         \IntlDateFormatter::LONG,
         \IntlDateFormatter::MEDIUM,
         \IntlDateFormatter::SHORT,
     );
 
-    private static $widgets = array(
+    private const WIDGETS = array(
         'text' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
     );
@@ -52,7 +52,7 @@ class DateType extends AbstractType
         $calendar = \IntlDateFormatter::GREGORIAN;
         $pattern = is_string($options['format']) ? $options['format'] : null;
 
-        if (!in_array($dateFormat, self::$acceptedFormats, true)) {
+        if (!in_array($dateFormat, self::ACCEPTED_FORMATS, true)) {
             throw new InvalidOptionsException('The "format" option must be one of the IntlDateFormatter constants (FULL, LONG, MEDIUM, SHORT) or a string representing a custom format.');
         }
 
@@ -114,9 +114,9 @@ class DateType extends AbstractType
             }
 
             $builder
-                ->add('year', self::$widgets[$options['widget']], $yearOptions)
-                ->add('month', self::$widgets[$options['widget']], $monthOptions)
-                ->add('day', self::$widgets[$options['widget']], $dayOptions)
+                ->add('year', self::WIDGETS[$options['widget']], $yearOptions)
+                ->add('month', self::WIDGETS[$options['widget']], $monthOptions)
+                ->add('day', self::WIDGETS[$options['widget']], $dayOptions)
                 ->addViewTransformer(new DateTimeToArrayTransformer(
                     $options['model_timezone'], $options['view_timezone'], array('year', 'month', 'day')
                 ))

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -28,7 +28,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TimeType extends AbstractType
 {
-    private static $widgets = array(
+    private const WIDGETS = array(
         'text' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         'choice' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
     );
@@ -121,14 +121,14 @@ class TimeType extends AbstractType
                 }
             }
 
-            $builder->add('hour', self::$widgets[$options['widget']], $hourOptions);
+            $builder->add('hour', self::WIDGETS[$options['widget']], $hourOptions);
 
             if ($options['with_minutes']) {
-                $builder->add('minute', self::$widgets[$options['widget']], $minuteOptions);
+                $builder->add('minute', self::WIDGETS[$options['widget']], $minuteOptions);
             }
 
             if ($options['with_seconds']) {
-                $builder->add('second', self::$widgets[$options['widget']], $secondOptions);
+                $builder->add('second', self::WIDGETS[$options['widget']], $secondOptions);
             }
 
             $builder->addViewTransformer(new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts, 'text' === $options['widget']));

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -39,7 +39,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @var array
      */
-    private static $allowedMethods = array(
+    private const ALLOWED_METHODS = array(
         'GET',
         'PUT',
         'POST',
@@ -790,11 +790,11 @@ class FormConfigBuilder implements FormConfigBuilderInterface
 
         $upperCaseMethod = strtoupper($method);
 
-        if (!in_array($upperCaseMethod, self::$allowedMethods)) {
+        if (!in_array($upperCaseMethod, self::ALLOWED_METHODS)) {
             throw new InvalidArgumentException(sprintf(
                 'The form method is "%s", but should be one of "%s".',
                 $method,
-                implode('", "', self::$allowedMethods)
+                implode('", "', self::ALLOWED_METHODS)
             ));
         }
 

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -26,7 +26,7 @@ class NativeRequestHandler implements RequestHandlerInterface
     /**
      * The allowed keys of the $_FILES array.
      */
-    private static $fileKeys = array(
+    private const FILE_KEYS = array(
         'error',
         'name',
         'size',
@@ -173,12 +173,12 @@ class NativeRequestHandler implements RequestHandlerInterface
         $keys = array_keys($data);
         sort($keys);
 
-        if (self::$fileKeys !== $keys || !isset($data['name']) || !is_array($data['name'])) {
+        if (self::FILE_KEYS !== $keys || !isset($data['name']) || !is_array($data['name'])) {
             return $data;
         }
 
         $files = $data;
-        foreach (self::$fileKeys as $k) {
+        foreach (self::FILE_KEYS as $k) {
             unset($files[$k]);
         }
 
@@ -211,7 +211,7 @@ class NativeRequestHandler implements RequestHandlerInterface
         $keys = array_keys($data);
         sort($keys);
 
-        if (self::$fileKeys === $keys) {
+        if (self::FILE_KEYS === $keys) {
             if (UPLOAD_ERR_NO_FILE === $data['error']) {
                 return;
             }

--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  */
 class FileBag extends ParameterBag
 {
-    private static $fileKeys = array('error', 'name', 'size', 'tmp_name', 'type');
+    private const FILE_KEYS = array('error', 'name', 'size', 'tmp_name', 'type');
 
     /**
      * @param array $parameters An array of HTTP files
@@ -80,7 +80,7 @@ class FileBag extends ParameterBag
             $keys = array_keys($file);
             sort($keys);
 
-            if ($keys == self::$fileKeys) {
+            if (self::FILE_KEYS == $keys) {
                 if (UPLOAD_ERR_NO_FILE == $file['error']) {
                     $file = null;
                 } else {
@@ -120,12 +120,12 @@ class FileBag extends ParameterBag
         $keys = array_keys($data);
         sort($keys);
 
-        if (self::$fileKeys != $keys || !isset($data['name']) || !is_array($data['name'])) {
+        if (self::FILE_KEYS != $keys || !isset($data['name']) || !is_array($data['name'])) {
             return $data;
         }
 
         $files = $data;
-        foreach (self::$fileKeys as $k) {
+        foreach (self::FILE_KEYS as $k) {
             unset($files[$k]);
         }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -197,7 +197,7 @@ class Request
 
     private static $trustedHeaderSet = -1;
 
-    private static $forwardedParams = array(
+    private const FORWARDED_PARAMS = array(
         self::HEADER_X_FORWARDED_FOR => 'for',
         self::HEADER_X_FORWARDED_HOST => 'host',
         self::HEADER_X_FORWARDED_PROTO => 'proto',
@@ -213,7 +213,7 @@ class Request
      * The other headers are non-standard, but widely used
      * by popular reverse proxies (like Apache mod_proxy or Amazon EC2).
      */
-    private static $trustedHeaders = array(
+    private const TRUSTED_HEADERS = array(
         self::HEADER_FORWARDED => 'FORWARDED',
         self::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
         self::HEADER_X_FORWARDED_HOST => 'X_FORWARDED_HOST',
@@ -1953,15 +1953,15 @@ class Request
         $clientValues = array();
         $forwardedValues = array();
 
-        if ((self::$trustedHeaderSet & $type) && $this->headers->has(self::$trustedHeaders[$type])) {
-            foreach (explode(',', $this->headers->get(self::$trustedHeaders[$type])) as $v) {
+        if ((self::$trustedHeaderSet & $type) && $this->headers->has(self::TRUSTED_HEADERS[$type])) {
+            foreach (explode(',', $this->headers->get(self::TRUSTED_HEADERS[$type])) as $v) {
                 $clientValues[] = (self::HEADER_X_FORWARDED_PORT === $type ? '0.0.0.0:' : '').trim($v);
             }
         }
 
-        if ((self::$trustedHeaderSet & self::HEADER_FORWARDED) && $this->headers->has(self::$trustedHeaders[self::HEADER_FORWARDED])) {
-            $forwardedValues = $this->headers->get(self::$trustedHeaders[self::HEADER_FORWARDED]);
-            $forwardedValues = preg_match_all(sprintf('{(?:%s)=(?:"?\[?)([a-zA-Z0-9\.:_\-/]*+)}', self::$forwardedParams[$type]), $forwardedValues, $matches) ? $matches[1] : array();
+        if ((self::$trustedHeaderSet & self::HEADER_FORWARDED) && $this->headers->has(self::TRUSTED_HEADERS[self::HEADER_FORWARDED])) {
+            $forwardedValues = $this->headers->get(self::TRUSTED_HEADERS[self::HEADER_FORWARDED]);
+            $forwardedValues = preg_match_all(sprintf('{(?:%s)=(?:"?\[?)([a-zA-Z0-9\.:_\-/]*+)}', self::FORWARDED_PARAMS[$type]), $forwardedValues, $matches) ? $matches[1] : array();
         }
 
         if (null !== $ip) {
@@ -1982,7 +1982,7 @@ class Request
         }
         $this->isForwardedValid = false;
 
-        throw new ConflictingHeadersException(sprintf('The request has both a trusted "%s" header and a trusted "%s" header, conflicting with each other. You should either configure your proxy to remove one of them, or configure your project to distrust the offending one.', self::$trustedHeaders[self::HEADER_FORWARDED], self::$trustedHeaders[$type]));
+        throw new ConflictingHeadersException(sprintf('The request has both a trusted "%s" header and a trusted "%s" header, conflicting with each other. You should either configure your proxy to remove one of them, or configure your project to distrust the offending one.', self::TRUSTED_HEADERS[self::HEADER_FORWARDED], self::TRUSTED_HEADERS[$type]));
     }
 
     private function normalizeAndFilterClientIps(array $clientIps, $ip)

--- a/src/Symfony/Component/HttpKernel/Log/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Log/Logger.php
@@ -22,7 +22,7 @@ use Psr\Log\LogLevel;
  */
 class Logger extends AbstractLogger
 {
-    private static $levels = array(
+    private const LEVELS = array(
         LogLevel::DEBUG => 0,
         LogLevel::INFO => 1,
         LogLevel::NOTICE => 2,
@@ -52,11 +52,11 @@ class Logger extends AbstractLogger
             }
         }
 
-        if (!isset(self::$levels[$minLevel])) {
+        if (!isset(self::LEVELS[$minLevel])) {
             throw new InvalidArgumentException(sprintf('The log level "%s" does not exist.', $minLevel));
         }
 
-        $this->minLevelIndex = self::$levels[$minLevel];
+        $this->minLevelIndex = self::LEVELS[$minLevel];
         $this->formatter = $formatter ?: array($this, 'format');
         if (false === $this->handle = is_resource($output) ? $output : @fopen($output, 'a')) {
             throw new InvalidArgumentException(sprintf('Unable to open "%s".', $output));
@@ -68,11 +68,11 @@ class Logger extends AbstractLogger
      */
     public function log($level, $message, array $context = array())
     {
-        if (!isset(self::$levels[$level])) {
+        if (!isset(self::LEVELS[$level])) {
             throw new InvalidArgumentException(sprintf('The log level "%s" does not exist.', $level));
         }
 
-        if (self::$levels[$level] < $this->minLevelIndex) {
+        if (self::LEVELS[$level] < $this->minLevelIndex) {
             return;
         }
 

--- a/src/Symfony/Component/Inflector/Inflector.php
+++ b/src/Symfony/Component/Inflector/Inflector.php
@@ -27,7 +27,7 @@ final class Inflector
      *
      * @see http://english-zone.com/spelling/plurals.html
      */
-    private static $pluralMap = array(
+    private const PLURAL_MAP = array(
         // First entry: plural suffix, reversed
         // Second entry: length of plural suffix
         // Third entry: Whether the suffix may succeed a vocal
@@ -169,7 +169,7 @@ final class Inflector
         // The inner loop $j iterates over the characters of the plural suffix
         // in the plural table to compare them with the characters of the actual
         // given plural suffix
-        foreach (self::$pluralMap as $map) {
+        foreach (self::PLURAL_MAP as $map) {
             $suffix = $map[0];
             $suffixLength = $map[1];
             $j = 0;

--- a/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
@@ -42,7 +42,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
     /**
      * Monetary units excluded from generation.
      */
-    private static $blacklist = array(
+    private const BLACKLIST = array(
         self::UNKNOWN_CURRENCY_ID => true,
         self::EUROPEAN_COMPOSITE_UNIT_ID => true,
         self::EUROPEAN_MONETARY_UNIT_ID => true,
@@ -155,7 +155,7 @@ class CurrencyDataGenerator extends AbstractDataGenerator
         $symbolNamePairs = iterator_to_array($rootBundle['Currencies']);
 
         // Remove unwanted currencies
-        $symbolNamePairs = array_diff_key($symbolNamePairs, self::$blacklist);
+        $symbolNamePairs = array_diff_key($symbolNamePairs, self::BLACKLIST);
 
         return $symbolNamePairs;
     }

--- a/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
@@ -29,7 +29,7 @@ class LanguageDataGenerator extends AbstractDataGenerator
     /**
      * Source: http://www-01.sil.org/iso639-3/codes.asp.
      */
-    private static $preferredAlpha2ToAlpha3Mapping = array(
+    private const PREFERRED_ALPHA2_TO_ALPHA3_MAPPING = array(
         'ak' => 'aka',
         'ar' => 'ara',
         'ay' => 'aym',
@@ -172,18 +172,18 @@ class LanguageDataGenerator extends AbstractDataGenerator
         foreach ($aliases as $alias => $language) {
             $language = $language['replacement'];
             if (2 === strlen($language) && 3 === strlen($alias)) {
-                if (isset(self::$preferredAlpha2ToAlpha3Mapping[$language])) {
+                if (isset(self::PREFERRED_ALPHA2_TO_ALPHA3_MAPPING[$language])) {
                     // Validate to prevent typos
-                    if (!isset($aliases[self::$preferredAlpha2ToAlpha3Mapping[$language]])) {
+                    if (!isset($aliases[self::PREFERRED_ALPHA2_TO_ALPHA3_MAPPING[$language]])) {
                         throw new RuntimeException(
                             'The statically set three-letter mapping '.
-                            self::$preferredAlpha2ToAlpha3Mapping[$language].' '.
+                            self::PREFERRED_ALPHA2_TO_ALPHA3_MAPPING[$language].' '.
                             'for the language code '.$language.' seems to be '.
                             'invalid. Typo?'
                         );
                     }
 
-                    $alpha3 = self::$preferredAlpha2ToAlpha3Mapping[$language];
+                    $alpha3 = self::PREFERRED_ALPHA2_TO_ALPHA3_MAPPING[$language];
                     $alpha2 = $aliases[$alpha3]['replacement'];
 
                     if ($language !== $alpha2) {
@@ -199,7 +199,7 @@ class LanguageDataGenerator extends AbstractDataGenerator
                     throw new RuntimeException(
                         'Multiple three-letter mappings exist for the language '.
                         'code '.$language.'. Please add one of them to the '.
-                        'property $preferredAlpha2ToAlpha3Mapping.'
+                        'constant PREFERRED_ALPHA2_TO_ALPHA3_MAPPING.'
                     );
                 } else {
                     $alpha2ToAlpha3[$language] = $alias;

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -38,7 +38,7 @@ class RegionDataGenerator extends AbstractDataGenerator
     /**
      * Regions excluded from generation.
      */
-    private static $blacklist = array(
+    private const BLACKLIST = array(
         self::UNKNOWN_REGION_ID => true,
         // Look like countries, but are sub-continents
         self::OUTLYING_OCEANIA_REGION_ID => true,
@@ -135,7 +135,7 @@ class RegionDataGenerator extends AbstractDataGenerator
         $regionNames = array();
 
         foreach ($unfilteredRegionNames as $region => $regionName) {
-            if (isset(self::$blacklist[$region])) {
+            if (isset(self::BLACKLIST[$region])) {
                 continue;
             }
 

--- a/src/Symfony/Component/Intl/Globals/IntlGlobals.php
+++ b/src/Symfony/Component/Intl/Globals/IntlGlobals.php
@@ -38,7 +38,7 @@ abstract class IntlGlobals
     /**
      * All known error codes.
      */
-    private static $errorCodes = array(
+    private const ERROR_CODES = array(
         self::U_ZERO_ERROR => 'U_ZERO_ERROR',
         self::U_ILLEGAL_ARGUMENT_ERROR => 'U_ILLEGAL_ARGUMENT_ERROR',
         self::U_PARSE_ERROR => 'U_PARSE_ERROR',
@@ -63,7 +63,7 @@ abstract class IntlGlobals
      */
     public static function isFailure($errorCode)
     {
-        return isset(self::$errorCodes[$errorCode])
+        return isset(self::ERROR_CODES[$errorCode])
             && $errorCode > self::U_ZERO_ERROR;
     }
 
@@ -100,8 +100,8 @@ abstract class IntlGlobals
      */
     public static function getErrorName($code)
     {
-        if (isset(self::$errorCodes[$code])) {
-            return self::$errorCodes[$code];
+        if (isset(self::ERROR_CODES[$code])) {
+            return self::ERROR_CODES[$code];
         }
 
         return '[BOGUS UErrorCode]';
@@ -117,11 +117,11 @@ abstract class IntlGlobals
      */
     public static function setError($code, $message = '')
     {
-        if (!isset(self::$errorCodes[$code])) {
+        if (!isset(self::ERROR_CODES[$code])) {
             throw new \InvalidArgumentException(sprintf('No such error code: "%s"', $code));
         }
 
-        self::$errorMessage = $message ? sprintf('%s: %s', $message, self::$errorCodes[$code]) : self::$errorCodes[$code];
+        self::$errorMessage = $message ? sprintf('%s: %s', $message, self::ERROR_CODES[$code]) : self::ERROR_CODES[$code];
         self::$errorCode = $code;
     }
 }

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -165,7 +165,7 @@ class NumberFormatter
     /**
      * The supported styles to the constructor $styles argument.
      */
-    private static $supportedStyles = array(
+    private const SUPPORTED_STYLES = array(
         'CURRENCY' => self::CURRENCY,
         'DECIMAL' => self::DECIMAL,
     );
@@ -173,7 +173,7 @@ class NumberFormatter
     /**
      * Supported attributes to the setAttribute() $attr argument.
      */
-    private static $supportedAttributes = array(
+    private const SUPPORTED_ATTRIBUTES = array(
         'FRACTION_DIGITS' => self::FRACTION_DIGITS,
         'GROUPING_USED' => self::GROUPING_USED,
         'ROUNDING_MODE' => self::ROUNDING_MODE,
@@ -184,7 +184,7 @@ class NumberFormatter
      * NumberFormatter::ROUNDING_MODE. NumberFormatter::ROUND_DOWN
      * and NumberFormatter::ROUND_UP does not have a PHP only equivalent.
      */
-    private static $roundingModes = array(
+    private const ROUNDING_MODES = array(
         'ROUND_HALFEVEN' => self::ROUND_HALFEVEN,
         'ROUND_HALFDOWN' => self::ROUND_HALFDOWN,
         'ROUND_HALFUP' => self::ROUND_HALFUP,
@@ -200,7 +200,7 @@ class NumberFormatter
      *
      * @see http://www.php.net/manual/en/function.round.php
      */
-    private static $phpRoundingMap = array(
+    private const PHP_ROUNDING_MAP = array(
         self::ROUND_HALFDOWN => \PHP_ROUND_HALF_DOWN,
         self::ROUND_HALFEVEN => \PHP_ROUND_HALF_EVEN,
         self::ROUND_HALFUP => \PHP_ROUND_HALF_UP,
@@ -211,7 +211,7 @@ class NumberFormatter
      * PHP's round() function, but there's an equivalent. Keys are rounding
      * modes, values does not matter.
      */
-    private static $customRoundingList = array(
+    private const CUSTOM_ROUNDING_LIST = array(
         self::ROUND_CEILING => true,
         self::ROUND_FLOOR => true,
         self::ROUND_DOWN => true,
@@ -221,21 +221,21 @@ class NumberFormatter
     /**
      * The maximum value of the integer type in 32 bit platforms.
      */
-    private static $int32Max = 2147483647;
+    private const INT_32_MAX = 2147483647;
 
     /**
      * The maximum value of the integer type in 64 bit platforms.
      *
      * @var int|float
      */
-    private static $int64Max = 9223372036854775807;
+    private const INT_64_MAX = 9223372036854775807;
 
-    private static $enSymbols = array(
+    private const EN_SYMBOLS = array(
         self::DECIMAL => array('.', ',', ';', '%', '0', '#', '-', '+', '¤', '¤¤', '.', 'E', '‰', '*', '∞', 'NaN', '@', ','),
         self::CURRENCY => array('.', ',', ';', '%', '0', '#', '-', '+', '¤', '¤¤', '.', 'E', '‰', '*', '∞', 'NaN', '@', ','),
     );
 
-    private static $enTextAttributes = array(
+    private const EN_TEXT_ATTRIBUTES = array(
         self::DECIMAL => array('', '', '-', '', ' ', '', ''),
         self::CURRENCY => array('¤', '', '-¤', '', ' ', ''),
     );
@@ -263,8 +263,8 @@ class NumberFormatter
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');
         }
 
-        if (!in_array($style, self::$supportedStyles)) {
-            $message = sprintf('The available styles are: %s.', implode(', ', array_keys(self::$supportedStyles)));
+        if (!in_array($style, self::SUPPORTED_STYLES)) {
+            $message = sprintf('The available styles are: %s.', implode(', ', array_keys(self::SUPPORTED_STYLES)));
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'style', $style, $message);
         }
 
@@ -462,7 +462,7 @@ class NumberFormatter
      */
     public function getSymbol($attr)
     {
-        return array_key_exists($this->style, self::$enSymbols) && array_key_exists($attr, self::$enSymbols[$this->style]) ? self::$enSymbols[$this->style][$attr] : false;
+        return array_key_exists($this->style, self::EN_SYMBOLS) && array_key_exists($attr, self::EN_SYMBOLS[$this->style]) ? self::EN_SYMBOLS[$this->style][$attr] : false;
     }
 
     /**
@@ -476,7 +476,7 @@ class NumberFormatter
      */
     public function getTextAttribute($attr)
     {
-        return array_key_exists($this->style, self::$enTextAttributes) && array_key_exists($attr, self::$enTextAttributes[$this->style]) ? self::$enTextAttributes[$this->style][$attr] : false;
+        return array_key_exists($this->style, self::EN_TEXT_ATTRIBUTES) && array_key_exists($attr, self::EN_TEXT_ATTRIBUTES[$this->style]) ? self::EN_TEXT_ATTRIBUTES[$this->style][$attr] : false;
     }
 
     /**
@@ -564,29 +564,29 @@ class NumberFormatter
      */
     public function setAttribute($attr, $value)
     {
-        if (!in_array($attr, self::$supportedAttributes)) {
+        if (!in_array($attr, self::SUPPORTED_ATTRIBUTES)) {
             $message = sprintf(
                 'The available attributes are: %s',
-                implode(', ', array_keys(self::$supportedAttributes))
+                implode(', ', array_keys(self::SUPPORTED_ATTRIBUTES))
             );
 
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'attr', $value, $message);
         }
 
-        if (self::$supportedAttributes['ROUNDING_MODE'] == $attr && $this->isInvalidRoundingMode($value)) {
+        if (self::SUPPORTED_ATTRIBUTES['ROUNDING_MODE'] == $attr && $this->isInvalidRoundingMode($value)) {
             $message = sprintf(
                 'The supported values for ROUNDING_MODE are: %s',
-                implode(', ', array_keys(self::$roundingModes))
+                implode(', ', array_keys(self::ROUNDING_MODES))
             );
 
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'attr', $value, $message);
         }
 
-        if (self::$supportedAttributes['GROUPING_USED'] == $attr) {
+        if (self::SUPPORTED_ATTRIBUTES['GROUPING_USED'] == $attr) {
             $value = $this->normalizeGroupingUsedValue($value);
         }
 
-        if (self::$supportedAttributes['FRACTION_DIGITS'] == $attr) {
+        if (self::SUPPORTED_ATTRIBUTES['FRACTION_DIGITS'] == $attr) {
             $value = $this->normalizeFractionDigitsValue($value);
         }
 
@@ -705,9 +705,9 @@ class NumberFormatter
         $precision = $this->getUninitializedPrecision($value, $precision);
 
         $roundingModeAttribute = $this->getAttribute(self::ROUNDING_MODE);
-        if (isset(self::$phpRoundingMap[$roundingModeAttribute])) {
-            $value = round($value, $precision, self::$phpRoundingMap[$roundingModeAttribute]);
-        } elseif (isset(self::$customRoundingList[$roundingModeAttribute])) {
+        if (isset(self::PHP_ROUNDING_MAP[$roundingModeAttribute])) {
+            $value = round($value, $precision, self::PHP_ROUNDING_MAP[$roundingModeAttribute]);
+        } elseif (isset(self::CUSTOM_ROUNDING_LIST[$roundingModeAttribute])) {
             $roundingCoef = pow(10, $precision);
             $value *= $roundingCoef;
 
@@ -813,7 +813,7 @@ class NumberFormatter
      */
     private function getInt32Value($value)
     {
-        if ($value > self::$int32Max || $value < -self::$int32Max - 1) {
+        if ($value > self::INT_32_MAX || $value < -self::INT_32_MAX - 1) {
             return false;
         }
 
@@ -829,11 +829,11 @@ class NumberFormatter
      */
     private function getInt64Value($value)
     {
-        if ($value > self::$int64Max || $value < -self::$int64Max - 1) {
+        if ($value > self::INT_64_MAX || $value < -self::INT_64_MAX - 1) {
             return false;
         }
 
-        if (PHP_INT_SIZE !== 8 && ($value > self::$int32Max || $value < -self::$int32Max - 1)) {
+        if (PHP_INT_SIZE !== 8 && ($value > self::INT_32_MAX || $value < -self::INT_32_MAX - 1)) {
             return (float) $value;
         }
 
@@ -849,7 +849,7 @@ class NumberFormatter
      */
     private function isInvalidRoundingMode($value)
     {
-        if (in_array($value, self::$roundingModes, true)) {
+        if (in_array($value, self::ROUNDING_MODES, true)) {
             return false;
         }
 

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -32,7 +32,7 @@ class BundleEntryReaderTest extends TestCase
      */
     private $readerImpl;
 
-    private static $data = array(
+    private const DATA = array(
         'Entries' => array(
             'Foo' => 'Bar',
             'Bar' => 'Baz',
@@ -41,7 +41,7 @@ class BundleEntryReaderTest extends TestCase
         'Version' => '2.0',
     );
 
-    private static $fallbackData = array(
+    private const FALLBACK_DATA = array(
         'Entries' => array(
             'Foo' => 'Foo',
             'Bam' => 'Lah',
@@ -50,7 +50,7 @@ class BundleEntryReaderTest extends TestCase
         'Version' => '1.0',
     );
 
-    private static $mergedData = array(
+    private const MERGED_DATA = array(
         // no recursive merging -> too complicated
         'Entries' => array(
             'Foo' => 'Bar',
@@ -72,9 +72,9 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$data));
+            ->will($this->returnValue(self::DATA));
 
-        $this->assertSame(self::$data, $this->reader->read(self::RES_DIR, 'root'));
+        $this->assertSame(self::DATA, $this->reader->read(self::RES_DIR, 'root'));
     }
 
     public function testReadEntireDataFileIfNoIndicesGiven()
@@ -82,14 +82,14 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(self::$data));
+            ->will($this->returnValue(self::DATA));
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$fallbackData));
+            ->will($this->returnValue(self::FALLBACK_DATA));
 
-        $this->assertSame(self::$mergedData, $this->reader->readEntry(self::RES_DIR, 'en', array()));
+        $this->assertSame(self::MERGED_DATA, $this->reader->readEntry(self::RES_DIR, 'en', array()));
     }
 
     public function testReadExistingEntry()
@@ -97,7 +97,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$data));
+            ->will($this->returnValue(self::DATA));
 
         $this->assertSame('Bar', $this->reader->readEntry(self::RES_DIR, 'root', array('Entries', 'Foo')));
     }
@@ -110,7 +110,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'root')
-            ->will($this->returnValue(self::$data));
+            ->will($this->returnValue(self::DATA));
 
         $this->reader->readEntry(self::RES_DIR, 'root', array('Entries', 'NonExisting'));
     }
@@ -120,12 +120,12 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(0))
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(self::$data));
+            ->will($this->returnValue(self::DATA));
 
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(self::$fallbackData));
+            ->will($this->returnValue(self::FALLBACK_DATA));
 
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Entries', 'Bam')));
     }
@@ -138,7 +138,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->once())
             ->method('read')
             ->with(self::RES_DIR, 'en_GB')
-            ->will($this->returnValue(self::$data));
+            ->will($this->returnValue(self::DATA));
 
         $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Entries', 'Bam'), false);
     }
@@ -153,7 +153,7 @@ class BundleEntryReaderTest extends TestCase
         $this->readerImpl->expects($this->at(1))
             ->method('read')
             ->with(self::RES_DIR, 'en')
-            ->will($this->returnValue(self::$fallbackData));
+            ->will($this->returnValue(self::FALLBACK_DATA));
 
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', array('Entries', 'Bam')));
     }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
@@ -26,7 +26,7 @@ abstract class AbstractDataProviderTest extends TestCase
     // not loaded, because it is NOT possible to skip the execution of data
     // providers.
 
-    private static $locales = array(
+    private const LOCALES = array(
         'af',
         'af_NA',
         'af_ZA',
@@ -625,7 +625,7 @@ abstract class AbstractDataProviderTest extends TestCase
         'zu_ZA',
     );
 
-    private static $localeAliases = array(
+    private const LOCALE_ALIASES = array(
         'az_AZ' => 'az_Latn_AZ',
         'bs_BA' => 'bs_Latn_BA',
         'en_NH' => 'en_VU',
@@ -700,12 +700,12 @@ abstract class AbstractDataProviderTest extends TestCase
 
     protected function getLocales()
     {
-        return self::$locales;
+        return self::LOCALES;
     }
 
     protected function getLocaleAliases()
     {
-        return self::$localeAliases;
+        return self::LOCALE_ALIASES;
     }
 
     protected function getRootLocales()

--- a/src/Symfony/Component/Ldap/Ldap.php
+++ b/src/Symfony/Component/Ldap/Ldap.php
@@ -21,7 +21,7 @@ final class Ldap implements LdapInterface
 {
     private $adapter;
 
-    private static $adapterMap = array(
+    private const ADAPTER_MAP = array(
         'ext_ldap' => 'Symfony\Component\Ldap\Adapter\ExtLdap\Adapter',
     );
 
@@ -72,15 +72,15 @@ final class Ldap implements LdapInterface
      */
     public static function create($adapter, array $config = array()): Ldap
     {
-        if (!isset(self::$adapterMap[$adapter])) {
+        if (!isset(self::ADAPTER_MAP[$adapter])) {
             throw new DriverNotFoundException(sprintf(
                 'Adapter "%s" not found. You should use one of: %s',
                 $adapter,
-                implode(', ', self::$adapterMap)
+                implode(', ', self::ADAPTER_MAP)
             ));
         }
 
-        $class = self::$adapterMap[$adapter];
+        $class = self::ADAPTER_MAP[$adapter];
 
         return new self(new $class($config));
     }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -85,7 +85,7 @@ class OptionsResolver implements Options
      */
     private $locked = false;
 
-    private static $typeAliases = array(
+    private const TYPE_ALIASES = array(
         'boolean' => 'bool',
         'integer' => 'int',
         'double' => 'float',
@@ -777,7 +777,7 @@ class OptionsResolver implements Options
             $invalidTypes = array();
 
             foreach ($this->allowedTypes[$option] as $type) {
-                $type = isset(self::$typeAliases[$type]) ? self::$typeAliases[$type] : $type;
+                $type = isset(self::TYPE_ALIASES[$type]) ? self::TYPE_ALIASES[$type] : $type;
 
                 if ($valid = $this->verifyTypes($type, $value, $invalidTypes)) {
                     break;

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -64,7 +64,7 @@ class PropertyAccessor implements PropertyAccessorInterface
 
     private $readPropertyCache = array();
     private $writePropertyCache = array();
-    private static $resultProto = array(self::VALUE => null);
+    private const RESULT_PROTO = array(self::VALUE => null);
 
     /**
      * Should not be used by application code. Use
@@ -336,7 +336,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             throw new NoSuchIndexException(sprintf('Cannot read index "%s" from object of type "%s" because it doesn\'t implement \ArrayAccess.', $index, get_class($zval[self::VALUE])));
         }
 
-        $result = self::$resultProto;
+        $result = self::RESULT_PROTO;
 
         if (isset($zval[self::VALUE][$index])) {
             $result[self::VALUE] = $zval[self::VALUE][$index];
@@ -369,7 +369,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             throw new NoSuchPropertyException(sprintf('Cannot read property "%s" from an array. Maybe you intended to write the property path as "[%1$s]" instead.', $property));
         }
 
-        $result = self::$resultProto;
+        $result = self::RESULT_PROTO;
         $object = $zval[self::VALUE];
         $access = $this->getReadAccessInfo(get_class($object), $property);
 

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -27,7 +27,7 @@ use Symfony\Component\Config\Loader\FileLoader;
  */
 class YamlFileLoader extends FileLoader
 {
-    private static $availableKeys = array(
+    private const AVAILABLE_KEYS = array(
         'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix',
     );
     private $yamlParser;
@@ -192,10 +192,10 @@ class YamlFileLoader extends FileLoader
         if (!is_array($config)) {
             throw new \InvalidArgumentException(sprintf('The definition of "%s" in "%s" must be a YAML array.', $name, $path));
         }
-        if ($extraKeys = array_diff(array_keys($config), self::$availableKeys)) {
+        if ($extraKeys = array_diff(array_keys($config), self::AVAILABLE_KEYS)) {
             throw new \InvalidArgumentException(sprintf(
                 'The routing file "%s" contains unsupported keys for "%s": "%s". Expected one of: "%s".',
-                $path, $name, implode('", "', $extraKeys), implode('", "', self::$availableKeys)
+                $path, $name, implode('", "', $extraKeys), implode('", "', self::AVAILABLE_KEYS)
             ));
         }
         if (isset($config['resource']) && isset($config['path'])) {

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
  */
 class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface
 {
-    private static $supportedTypes = array(
+    private const SUPPORTED_TYPES = array(
         \SplFileInfo::class => true,
         \SplFileObject::class => true,
         File::class => true,
@@ -116,7 +116,7 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface
      */
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return isset(self::$supportedTypes[$type]);
+        return isset(self::SUPPORTED_TYPES[$type]);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -28,7 +28,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
     private $format;
     private $timezone;
 
-    private static $supportedTypes = array(
+    private const SUPPORTED_TYPES = array(
         \DateTimeInterface::class => true,
         \DateTimeImmutable::class => true,
         \DateTime::class => true,
@@ -113,7 +113,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
      */
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return isset(self::$supportedTypes[$type]);
+        return isset(self::SUPPORTED_TYPES[$type]);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -512,7 +512,7 @@ class PropertyCamelizedDummy
 
 class StaticPropertyDummy
 {
-    private static $property = 'value';
+    private const PROPERTY = 'value';
 }
 
 class PropertyParentDummy

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -33,7 +33,7 @@ class EmailValidator extends ConstraintValidator
      */
     const PATTERN_LOOSE = '/^.+\@\S+\.\S+$/';
 
-    private static $emailPatterns = array(
+    private const EMAIL_PATTERNS = array(
         Email::VALIDATION_MODE_LOOSE => self::PATTERN_LOOSE,
         Email::VALIDATION_MODE_HTML5 => self::PATTERN_HTML5,
     );
@@ -120,7 +120,7 @@ class EmailValidator extends ConstraintValidator
 
                 return;
             }
-        } elseif (!preg_match(self::$emailPatterns[$constraint->mode], $value)) {
+        } elseif (!preg_match(self::EMAIL_PATTERNS[$constraint->mode], $value)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Email::INVALID_FORMAT_ERROR)

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -27,7 +27,7 @@ class FileValidator extends ConstraintValidator
     const KIB_BYTES = 1024;
     const MIB_BYTES = 1048576;
 
-    private static $suffices = array(
+    private const SUFFICES = array(
         1 => 'bytes',
         self::KB_BYTES => 'kB',
         self::MB_BYTES => 'MB',
@@ -233,6 +233,6 @@ class FileValidator extends ConstraintValidator
             $sizeAsString = (string) round($size / $coef, 2);
         }
 
-        return array($sizeAsString, $limitAsString, self::$suffices[$coef]);
+        return array($sizeAsString, $limitAsString, self::SUFFICES[$coef]);
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -35,7 +35,7 @@ class IbanValidator extends ConstraintValidator
      *
      * @see https://www.swift.com/sites/default/files/resources/iban_registry.pdf
      */
-    private static $formats = array(
+    private const FORMATS = array(
         'AD' => 'AD\d{2}\d{4}\d{4}[\dA-Z]{12}', // Andorra
         'AE' => 'AE\d{2}\d{3}\d{16}', // United Arab Emirates
         'AL' => 'AL\d{2}\d{8}[\dA-Z]{16}', // Albania
@@ -180,7 +180,7 @@ class IbanValidator extends ConstraintValidator
         }
 
         // ...have a format available
-        if (!array_key_exists($countryCode, self::$formats)) {
+        if (!array_key_exists($countryCode, self::FORMATS)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Iban::NOT_SUPPORTED_COUNTRY_CODE_ERROR)
@@ -190,7 +190,7 @@ class IbanValidator extends ConstraintValidator
         }
 
         // ...and have a valid format
-        if (!preg_match('/^'.self::$formats[$countryCode].'$/', $canonicalized)
+        if (!preg_match('/^'.self::FORMATS[$countryCode].'$/', $canonicalized)
         ) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))

--- a/src/Symfony/Component/VarDumper/Caster/AmqpCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/AmqpCaster.php
@@ -20,7 +20,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class AmqpCaster
 {
-    private static $flags = array(
+    private const FLAGS = array(
         AMQP_DURABLE => 'AMQP_DURABLE',
         AMQP_PASSIVE => 'AMQP_PASSIVE',
         AMQP_EXCLUSIVE => 'AMQP_EXCLUSIVE',
@@ -37,7 +37,7 @@ class AmqpCaster
         AMQP_REQUEUE => 'AMQP_REQUEUE',
     );
 
-    private static $exchangeTypes = array(
+    private const EXCHANGE_TYPES = array(
         AMQP_EX_TYPE_DIRECT => 'AMQP_EX_TYPE_DIRECT',
         AMQP_EX_TYPE_FANOUT => 'AMQP_EX_TYPE_FANOUT',
         AMQP_EX_TYPE_TOPIC => 'AMQP_EX_TYPE_TOPIC',
@@ -131,7 +131,7 @@ class AmqpCaster
             $prefix.'flags' => self::extractFlags($c->getFlags()),
         );
 
-        $type = isset(self::$exchangeTypes[$c->getType()]) ? new ConstStub(self::$exchangeTypes[$c->getType()], $c->getType()) : $c->getType();
+        $type = isset(self::EXCHANGE_TYPES[$c->getType()]) ? new ConstStub(self::EXCHANGE_TYPES[$c->getType()], $c->getType()) : $c->getType();
 
         // Recent version of the extension already expose private properties
         if (isset($a["\x00AMQPExchange\x00name"])) {
@@ -195,7 +195,7 @@ class AmqpCaster
     {
         $flagsArray = array();
 
-        foreach (self::$flags as $value => $name) {
+        foreach (self::FLAGS as $value => $name) {
             if ($flags & $value) {
                 $flagsArray[] = $name;
             }

--- a/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
@@ -20,7 +20,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class DOMCaster
 {
-    private static $errorCodes = array(
+    private const ERROR_CODES = array(
         DOM_PHP_ERR => 'DOM_PHP_ERR',
         DOM_INDEX_SIZE_ERR => 'DOM_INDEX_SIZE_ERR',
         DOMSTRING_SIZE_ERR => 'DOMSTRING_SIZE_ERR',
@@ -40,7 +40,7 @@ class DOMCaster
         DOM_VALIDATION_ERR => 'DOM_VALIDATION_ERR',
     );
 
-    private static $nodeTypes = array(
+    private const NODE_TYPES = array(
         XML_ELEMENT_NODE => 'XML_ELEMENT_NODE',
         XML_ATTRIBUTE_NODE => 'XML_ATTRIBUTE_NODE',
         XML_TEXT_NODE => 'XML_TEXT_NODE',
@@ -64,8 +64,8 @@ class DOMCaster
     public static function castException(\DOMException $e, array $a, Stub $stub, $isNested)
     {
         $k = Caster::PREFIX_PROTECTED.'code';
-        if (isset($a[$k], self::$errorCodes[$a[$k]])) {
-            $a[$k] = new ConstStub(self::$errorCodes[$a[$k]], $a[$k]);
+        if (isset($a[$k], self::ERROR_CODES[$a[$k]])) {
+            $a[$k] = new ConstStub(self::ERROR_CODES[$a[$k]], $a[$k]);
         }
 
         return $a;
@@ -95,7 +95,7 @@ class DOMCaster
         $a += array(
             'nodeName' => $dom->nodeName,
             'nodeValue' => new CutStub($dom->nodeValue),
-            'nodeType' => new ConstStub(self::$nodeTypes[$dom->nodeType], $dom->nodeType),
+            'nodeType' => new ConstStub(self::NODE_TYPES[$dom->nodeType], $dom->nodeType),
             'parentNode' => new CutStub($dom->parentNode),
             'childNodes' => $dom->childNodes,
             'firstChild' => new CutStub($dom->firstChild),
@@ -119,7 +119,7 @@ class DOMCaster
         $a += array(
             'nodeName' => $dom->nodeName,
             'nodeValue' => new CutStub($dom->nodeValue),
-            'nodeType' => new ConstStub(self::$nodeTypes[$dom->nodeType], $dom->nodeType),
+            'nodeType' => new ConstStub(self::NODE_TYPES[$dom->nodeType], $dom->nodeType),
             'prefix' => $dom->prefix,
             'localName' => $dom->localName,
             'namespaceURI' => $dom->namespaceURI,

--- a/src/Symfony/Component/VarDumper/Caster/PdoCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/PdoCaster.php
@@ -20,7 +20,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class PdoCaster
 {
-    private static $pdoAttributes = array(
+    private const PDO_ATTRIBUTES = array(
         'CASE' => array(
             \PDO::CASE_LOWER => 'LOWER',
             \PDO::CASE_NATURAL => 'NATURAL',
@@ -63,7 +63,7 @@ class PdoCaster
         $errmode = $c->getAttribute(\PDO::ATTR_ERRMODE);
         $c->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
-        foreach (self::$pdoAttributes as $k => $v) {
+        foreach (self::PDO_ATTRIBUTES as $k => $v) {
             if (!isset($k[0])) {
                 $k = $v;
                 $v = array();

--- a/src/Symfony/Component/VarDumper/Caster/PgSqlCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/PgSqlCaster.php
@@ -20,7 +20,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class PgSqlCaster
 {
-    private static $paramCodes = array(
+    private const PARAM_CODES = array(
         'server_encoding',
         'client_encoding',
         'is_superuser',
@@ -33,7 +33,7 @@ class PgSqlCaster
         'standard_conforming_strings',
     );
 
-    private static $transactionStatus = array(
+    private const TRANSACTION_STATUS = array(
         PGSQL_TRANSACTION_IDLE => 'PGSQL_TRANSACTION_IDLE',
         PGSQL_TRANSACTION_ACTIVE => 'PGSQL_TRANSACTION_ACTIVE',
         PGSQL_TRANSACTION_INTRANS => 'PGSQL_TRANSACTION_INTRANS',
@@ -41,7 +41,7 @@ class PgSqlCaster
         PGSQL_TRANSACTION_UNKNOWN => 'PGSQL_TRANSACTION_UNKNOWN',
     );
 
-    private static $resultStatus = array(
+    private const RESULT_STATUS = array(
         PGSQL_EMPTY_QUERY => 'PGSQL_EMPTY_QUERY',
         PGSQL_COMMAND_OK => 'PGSQL_COMMAND_OK',
         PGSQL_TUPLES_OK => 'PGSQL_TUPLES_OK',
@@ -52,7 +52,7 @@ class PgSqlCaster
         PGSQL_FATAL_ERROR => 'PGSQL_FATAL_ERROR',
     );
 
-    private static $diagCodes = array(
+    private const DIAG_CODES = array(
         'severity' => PGSQL_DIAG_SEVERITY,
         'sqlstate' => PGSQL_DIAG_SQLSTATE,
         'message' => PGSQL_DIAG_MESSAGE_PRIMARY,
@@ -81,8 +81,8 @@ class PgSqlCaster
         $a['busy'] = pg_connection_busy($link);
 
         $a['transaction'] = pg_transaction_status($link);
-        if (isset(self::$transactionStatus[$a['transaction']])) {
-            $a['transaction'] = new ConstStub(self::$transactionStatus[$a['transaction']], $a['transaction']);
+        if (isset(self::TRANSACTION_STATUS[$a['transaction']])) {
+            $a['transaction'] = new ConstStub(self::TRANSACTION_STATUS[$a['transaction']], $a['transaction']);
         }
 
         $a['pid'] = pg_get_pid($link);
@@ -94,7 +94,7 @@ class PgSqlCaster
         $a['options'] = pg_options($link);
         $a['version'] = pg_version($link);
 
-        foreach (self::$paramCodes as $v) {
+        foreach (self::PARAM_CODES as $v) {
             if (false !== $s = pg_parameter_status($link, $v)) {
                 $a['param'][$v] = $s;
             }
@@ -110,13 +110,13 @@ class PgSqlCaster
     {
         $a['num rows'] = pg_num_rows($result);
         $a['status'] = pg_result_status($result);
-        if (isset(self::$resultStatus[$a['status']])) {
-            $a['status'] = new ConstStub(self::$resultStatus[$a['status']], $a['status']);
+        if (isset(self::RESULT_STATUS[$a['status']])) {
+            $a['status'] = new ConstStub(self::RESULT_STATUS[$a['status']], $a['status']);
         }
         $a['command-completion tag'] = pg_result_status($result, PGSQL_STATUS_STRING);
 
         if (-1 === $a['num rows']) {
-            foreach (self::$diagCodes as $k => $v) {
+            foreach (self::DIAG_CODES as $k => $v) {
                 $a['error'][$k] = pg_result_error_field($result, $v);
             }
         }

--- a/src/Symfony/Component/VarDumper/Caster/RedisCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/RedisCaster.php
@@ -20,7 +20,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class RedisCaster
 {
-    private static $serializer = array(
+    private const SERIALIZER = array(
         \Redis::SERIALIZER_NONE => 'NONE',
         \Redis::SERIALIZER_PHP => 'PHP',
         2 => 'IGBINARY', // Optional Redis::SERIALIZER_IGBINARY
@@ -49,7 +49,7 @@ class RedisCaster
             $prefix.'persistentId' => $c->getPersistentID(),
             $prefix.'options' => new EnumStub(array(
                 'READ_TIMEOUT' => $c->getOption(\Redis::OPT_READ_TIMEOUT),
-                'SERIALIZER' => isset(self::$serializer[$ser]) ? new ConstStub(self::$serializer[$ser], $ser) : $ser,
+                'SERIALIZER' => isset(self::SERIALIZER[$ser]) ? new ConstStub(self::SERIALIZER[$ser], $ser) : $ser,
                 'PREFIX' => $c->getOption(\Redis::OPT_PREFIX),
                 'SCAN' => new ConstStub($retry ? 'RETRY' : 'NORETRY', $retry),
             )),

--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -20,7 +20,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class ReflectionCaster
 {
-    private static $extraMap = array(
+    private const EXTRA_MAP = array(
         'docComment' => 'getDocComment',
         'extension' => 'getExtensionName',
         'isDisabled' => 'isDisabled',
@@ -303,7 +303,7 @@ class ReflectionCaster
             $x['line'] = $c->getStartLine().' to '.$c->getEndLine();
         }
 
-        self::addMap($x, $c, self::$extraMap, '');
+        self::addMap($x, $c, self::EXTRA_MAP, '');
 
         if ($x) {
             $a[Caster::PREFIX_VIRTUAL.'extra'] = new EnumStub($x);

--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -20,7 +20,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class SplCaster
 {
-    private static $splFileObjectFlags = array(
+    private const SPL_FILE_OBJECT_FLAGS = array(
         \SplFileObject::DROP_NEW_LINE => 'DROP_NEW_LINE',
         \SplFileObject::READ_AHEAD => 'READ_AHEAD',
         \SplFileObject::SKIP_EMPTY => 'SKIP_EMPTY',
@@ -155,7 +155,7 @@ class SplCaster
 
         if (isset($a[$prefix.'flags'])) {
             $flagsArray = array();
-            foreach (self::$splFileObjectFlags as $value => $name) {
+            foreach (self::SPL_FILE_OBJECT_FLAGS as $value => $name) {
                 if ($a[$prefix.'flags'] & $value) {
                     $flagsArray[] = $name;
                 }

--- a/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
@@ -16,7 +16,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
 
 class SymfonyCaster
 {
-    private static $requestGetters = array(
+    private const REQUEST_GETTERS = array(
         'pathInfo' => 'getPathInfo',
         'requestUri' => 'getRequestUri',
         'baseUrl' => 'getBaseUrl',
@@ -29,7 +29,7 @@ class SymfonyCaster
     {
         $clone = null;
 
-        foreach (self::$requestGetters as $prop => $getter) {
+        foreach (self::REQUEST_GETTERS as $prop => $getter) {
             if (null === $a[Caster::PREFIX_PROTECTED.$prop]) {
                 if (null === $clone) {
                     $clone = clone $request;

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -19,7 +19,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class XmlReaderCaster
 {
-    private static $nodeTypes = array(
+    private const NODE_TYPES = array(
         \XMLReader::NONE => 'NONE',
         \XMLReader::ELEMENT => 'ELEMENT',
         \XMLReader::ATTRIBUTE => 'ATTRIBUTE',
@@ -46,7 +46,7 @@ class XmlReaderCaster
         $info = array(
             'localName' => $reader->localName,
             'prefix' => $reader->prefix,
-            'nodeType' => new ConstStub(self::$nodeTypes[$reader->nodeType], $reader->nodeType),
+            'nodeType' => new ConstStub(self::NODE_TYPES[$reader->nodeType], $reader->nodeType),
             'depth' => $reader->depth,
             'isDefault' => $reader->isDefault,
             'isEmptyElement' => \XMLReader::NONE === $reader->nodeType ? null : $reader->isEmptyElement,

--- a/src/Symfony/Component/VarDumper/Caster/XmlResourceCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlResourceCaster.php
@@ -20,7 +20,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class XmlResourceCaster
 {
-    private static $xmlErrors = array(
+    private const XML_ERRORS = array(
         XML_ERROR_NONE => 'XML_ERROR_NONE',
         XML_ERROR_NO_MEMORY => 'XML_ERROR_NO_MEMORY',
         XML_ERROR_SYNTAX => 'XML_ERROR_SYNTAX',
@@ -52,8 +52,8 @@ class XmlResourceCaster
         $a['current_line_number'] = xml_get_current_line_number($h);
         $a['error_code'] = xml_get_error_code($h);
 
-        if (isset(self::$xmlErrors[$a['error_code']])) {
-            $a['error_code'] = new ConstStub(self::$xmlErrors[$a['error_code']], $a['error_code']);
+        if (isset(self::XML_ERRORS[$a['error_code']])) {
+            $a['error_code'] = new ConstStub(self::XML_ERRORS[$a['error_code']], $a['error_code']);
         }
 
         return $a;

--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -28,14 +28,14 @@ class Escaper
     // first to ensure proper escaping because str_replace operates iteratively
     // on the input arrays. This ordering of the characters avoids the use of strtr,
     // which performs more slowly.
-    private static $escapees = array('\\', '\\\\', '\\"', '"',
+    private const ESCAPEES = array('\\', '\\\\', '\\"', '"',
                                      "\x00",  "\x01",  "\x02",  "\x03",  "\x04",  "\x05",  "\x06",  "\x07",
                                      "\x08",  "\x09",  "\x0a",  "\x0b",  "\x0c",  "\x0d",  "\x0e",  "\x0f",
                                      "\x10",  "\x11",  "\x12",  "\x13",  "\x14",  "\x15",  "\x16",  "\x17",
                                      "\x18",  "\x19",  "\x1a",  "\x1b",  "\x1c",  "\x1d",  "\x1e",  "\x1f",
                                      "\xc2\x85", "\xc2\xa0", "\xe2\x80\xa8", "\xe2\x80\xa9",
                                );
-    private static $escaped = array('\\\\', '\\"', '\\\\', '\\"',
+    private const ESCAPED = array('\\\\', '\\"', '\\\\', '\\"',
                                      '\\0',   '\\x01', '\\x02', '\\x03', '\\x04', '\\x05', '\\x06', '\\a',
                                      '\\b',   '\\t',   '\\n',   '\\v',   '\\f',   '\\r',   '\\x0e', '\\x0f',
                                      '\\x10', '\\x11', '\\x12', '\\x13', '\\x14', '\\x15', '\\x16', '\\x17',
@@ -64,7 +64,7 @@ class Escaper
      */
     public static function escapeWithDoubleQuotes(string $value): string
     {
-        return sprintf('"%s"', str_replace(self::$escapees, self::$escaped, $value));
+        return sprintf('"%s"', str_replace(self::ESCAPEES, self::ESCAPED, $value));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Hello again, this is a new take on https://github.com/symfony/symfony/pull/26511 which got closed.
This could be accepted for the 4.1 version and added to the roadmap.

As proposed, I refactored the entire repo instead of just a single component.

One problem I have is the `Symfony\Component\Debug\DebugClassLoader` ([api docs](https://api.symfony.com/master/Symfony/Component/Debug/DebugClassLoader.html)). There are 3 private static properties that hold empty arrays:

- `$final`
- `$internal`
- `$deprecated`

None of these seem to be reassigned/pushed into anywhere in the file. Perhaps I am missing something? Why have an empty array as a constant in the source code? So far, I left it as it was.

Thank you for your help and feedback. :)