### PR TITLE
[HttpKernel] Correctly merging cache directives in HttpCache/ResponseCacheStrategy

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
@@ -5,10 +5,6 @@
  *
  * (c) Fabien Potencier <fabien@symfony.com>
  *
- * This code is partially based on the Rack-Cache library by Ryan Tomayko,
- * which is released under the MIT license.
- * (based on commit 02d2b48d75bcb63cf1c0c7149c077ad256542801)
- *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -28,30 +24,69 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ResponseCacheStrategy implements ResponseCacheStrategyInterface
 {
-    private $cacheable = true;
+    /**
+     * Cache-Control headers that are sent to the final response if they appear in ANY of the responses.
+     */
+    private static $overrideDirectives = ['private', 'no-cache', 'no-store', 'no-transform', 'must-revalidate', 'proxy-revalidate'];
+
+    /**
+     * Cache-Control headers that are sent to the final response if they appear in ALL of the responses.
+     */
+    private static $inheritDirectives = ['public', 'immutable'];
+
     private $embeddedResponses = 0;
-    private $ttls = [];
-    private $maxAges = [];
     private $isNotCacheableResponseEmbedded = false;
+    private $age = 0;
+    private $flagDirectives = [
+        'no-cache' => null,
+        'no-store' => null,
+        'no-transform' => null,
+        'must-revalidate' => null,
+        'proxy-revalidate' => null,
+        'public' => null,
+        'private' => null,
+        'immutable' => null,
+    ];
+    private $ageDirectives = [
+        'max-age' => null,
+        's-maxage' => null,
+        'expires' => null,
+    ];
 
     /**
      * {@inheritdoc}
      */
     public function add(Response $response)
     {
-        if (!$response->isFresh() || !$response->isCacheable()) {
-            $this->cacheable = false;
-        } else {
-            $maxAge = $response->getMaxAge();
-            $this->ttls[] = $response->getTtl();
-            $this->maxAges[] = $maxAge;
+        ++$this->embeddedResponses;
 
-            if (null === $maxAge) {
-                $this->isNotCacheableResponseEmbedded = true;
+        foreach (self::$overrideDirectives as $directive) {
+            if ($response->headers->hasCacheControlDirective($directive)) {
+                $this->flagDirectives[$directive] = true;
             }
         }
 
-        ++$this->embeddedResponses;
+        foreach (self::$inheritDirectives as $directive) {
+            if (false !== $this->flagDirectives[$directive]) {
+                $this->flagDirectives[$directive] = $response->headers->hasCacheControlDirective($directive);
+            }
+        }
+
+        $age = $response->getAge();
+        $this->age = max($this->age, $age);
+
+        if ($this->willMakeFinalResponseUncacheable($response)) {
+            $this->isNotCacheableResponseEmbedded = true;
+
+            return;
+        }
+
+        $this->storeRelativeAgeDirective('max-age', $response->headers->getCacheControlDirective('max-age'), $age);
+        $this->storeRelativeAgeDirective('s-maxage', $response->headers->getCacheControlDirective('s-maxage') ?: $response->headers->getCacheControlDirective('max-age'), $age);
+
+        $expires = $response->getExpires();
+        $expires = null !== $expires ? $expires->format('U') - $response->getDate()->format('U') : null;
+        $this->storeRelativeAgeDirective('expires', $expires >= 0 ? $expires : null, 0);
     }
 
     /**
@@ -64,33 +99,124 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
             return;
         }
 
-        // Remove validation related headers in order to avoid browsers using
-        // their own cache, because some of the response content comes from
-        // at least one embedded response (which likely has a different caching strategy).
-        if ($response->isValidateable()) {
-            $response->setEtag(null);
-            $response->setLastModified(null);
-        }
+        // Remove validation related headers of the master response,
+        // because some of the response content comes from at least
+        // one embedded response (which likely has a different caching strategy).
+        $response->setEtag(null);
+        $response->setLastModified(null);
 
-        if (!$response->isFresh() || !$response->isCacheable()) {
-            $this->cacheable = false;
-        }
+        $this->add($response);
 
-        if (!$this->cacheable) {
-            $response->headers->set('Cache-Control', 'no-cache, must-revalidate');
+        $response->headers->set('Age', $this->age);
+
+        if ($this->isNotCacheableResponseEmbedded) {
+            $response->setExpires($response->getDate());
+
+            if ($this->flagDirectives['no-store']) {
+                $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');
+            } else {
+                $response->headers->set('Cache-Control', 'no-cache, must-revalidate');
+            }
 
             return;
         }
 
-        $this->ttls[] = $response->getTtl();
-        $this->maxAges[] = $response->getMaxAge();
+        $flags = array_filter($this->flagDirectives);
 
-        if ($this->isNotCacheableResponseEmbedded) {
-            $response->headers->removeCacheControlDirective('s-maxage');
-        } elseif (null !== $maxAge = min($this->maxAges)) {
-            $response->setSharedMaxAge($maxAge);
-            $response->headers->set('Age', $maxAge - min($this->ttls));
+        if (isset($flags['must-revalidate'])) {
+            $flags['no-cache'] = true;
         }
-        $response->setMaxAge(0);
+
+        $response->headers->set('Cache-Control', implode(', ', array_keys($flags)));
+
+        $maxAge = null;
+        $sMaxage = null;
+
+        if (\is_numeric($this->ageDirectives['max-age'])) {
+            $maxAge = $this->ageDirectives['max-age'] + $this->age;
+            $response->headers->addCacheControlDirective('max-age', $maxAge);
+        }
+
+        if (\is_numeric($this->ageDirectives['s-maxage'])) {
+            $sMaxage = $this->ageDirectives['s-maxage'] + $this->age;
+
+            if ($maxAge !== $sMaxage) {
+                $response->headers->addCacheControlDirective('s-maxage', $sMaxage);
+            }
+        }
+
+        if (\is_numeric($this->ageDirectives['expires'])) {
+            $date = clone $response->getDate();
+            $date->modify('+'.($this->ageDirectives['expires'] + $this->age).' seconds');
+            $response->setExpires($date);
+        }
+    }
+
+    /**
+     * RFC2616, Section 13.4.
+     *
+     * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.4
+     *
+     * @return bool
+     */
+    private function willMakeFinalResponseUncacheable(Response $response)
+    {
+        // RFC2616: A response received with a status code of 200, 203, 300, 301 or 410
+        // MAY be stored by a cache […] unless a cache-control directive prohibits caching.
+        if ($response->headers->hasCacheControlDirective('no-cache')
+            || $response->headers->getCacheControlDirective('no-store')
+        ) {
+            return true;
+        }
+
+        // Last-Modified and Etag headers cannot be merged, they render the response uncacheable
+        // by default (except if the response also has max-age etc.).
+        if (\in_array($response->getStatusCode(), [200, 203, 300, 301, 410])
+            && null === $response->getLastModified()
+            && null === $response->getEtag()
+        ) {
+            return false;
+        }
+
+        // RFC2616: A response received with any other status code (e.g. status codes 302 and 307)
+        // MUST NOT be returned in a reply to a subsequent request unless there are
+        // cache-control directives or another header(s) that explicitly allow it.
+        $cacheControl = ['max-age', 's-maxage', 'must-revalidate', 'proxy-revalidate', 'public', 'private'];
+        foreach ($cacheControl as $key) {
+            if ($response->headers->hasCacheControlDirective($key)) {
+                return false;
+            }
+        }
+
+        if ($response->headers->has('Expires')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Store lowest max-age/s-maxage/expires for the final response.
+     *
+     * The response might have been stored in cache a while ago. To keep things comparable,
+     * we have to subtract the age so that the value is normalized for an age of 0.
+     *
+     * If the value is lower than the currently stored value, we update the value, to keep a rolling
+     * minimal value of each instruction. If the value is NULL, the directive will not be set on the final response.
+     *
+     * @param string   $directive
+     * @param int|null $value
+     * @param int      $age
+     */
+    private function storeRelativeAgeDirective($directive, $value, $age)
+    {
+        if (null === $value) {
+            $this->ageDirectives[$directive] = false;
+        }
+
+        if (false !== $this->ageDirectives[$directive]) {
+            $value = $value - $age;
+            $this->ageDirectives[$directive] = null !== $this->ageDirectives[$directive] ? min($this->ageDirectives[$directive], $value) : $value;
+        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
@@ -237,4 +237,233 @@ class ResponseCacheStrategyTest extends TestCase
         $this->assertSame('60', $masterResponse->headers->getCacheControlDirective('s-maxage'));
         $this->assertFalse($masterResponse->isValidateable());
     }
+
+    /**
+     * @dataProvider cacheControlMergingProvider
+     */
+    public function testCacheControlMerging(array $expects, array $master, array $surrogates)
+    {
+        $cacheStrategy = new ResponseCacheStrategy();
+        $buildResponse = function ($config) {
+            $response = new Response();
+
+            foreach ($config as $key => $value) {
+                switch ($key) {
+                    case 'age':
+                        $response->headers->set('Age', $value);
+                        break;
+
+                    case 'expires':
+                        $expires = clone $response->getDate();
+                        $expires->modify('+'.$value.' seconds');
+                        $response->setExpires($expires);
+                        break;
+
+                    case 'max-age':
+                        $response->setMaxAge($value);
+                        break;
+
+                    case 's-maxage':
+                        $response->setSharedMaxAge($value);
+                        break;
+
+                    case 'private':
+                        $response->setPrivate();
+                        break;
+
+                    case 'public':
+                        $response->setPublic();
+                        break;
+
+                    default:
+                        $response->headers->addCacheControlDirective($key, $value);
+                }
+            }
+
+            return $response;
+        };
+
+        foreach ($surrogates as $config) {
+            $cacheStrategy->add($buildResponse($config));
+        }
+
+        $response = $buildResponse($master);
+        $cacheStrategy->update($response);
+
+        foreach ($expects as $key => $value) {
+            if ('expires' === $key) {
+                $this->assertSame($value, $response->getExpires()->format('U') - $response->getDate()->format('U'));
+            } elseif ('age' === $key) {
+                $this->assertSame($value, $response->getAge());
+            } elseif (true === $value) {
+                $this->assertTrue($response->headers->hasCacheControlDirective($key), sprintf('Cache-Control header must have "%s" flag', $key));
+            } elseif (false === $value) {
+                $this->assertFalse(
+                    $response->headers->hasCacheControlDirective($key),
+                    sprintf('Cache-Control header must NOT have "%s" flag', $key)
+                );
+            } else {
+                $this->assertSame($value, $response->headers->getCacheControlDirective($key), sprintf('Cache-Control flag "%s" should be "%s"', $key, $value));
+            }
+        }
+    }
+
+    public function cacheControlMergingProvider()
+    {
+        yield 'result is public if all responses are public' => [
+            ['private' => false, 'public' => true],
+            ['public' => true],
+            [
+                ['public' => true],
+            ],
+        ];
+
+        yield 'result is private by default' => [
+            ['private' => true, 'public' => false],
+            ['public' => true],
+            [
+                [],
+            ],
+        ];
+
+        yield 'combines public and private responses' => [
+            ['must-revalidate' => false, 'private' => true, 'public' => false],
+            ['public' => true],
+            [
+                ['private' => true],
+            ],
+        ];
+
+        yield 'inherits no-cache from surrogates' => [
+            ['no-cache' => true, 'public' => false],
+            ['public' => true],
+            [
+                ['no-cache' => true],
+            ],
+        ];
+
+        yield 'inherits no-store from surrogate' => [
+            ['no-store' => true, 'public' => false],
+            ['public' => true],
+            [
+                ['no-store' => true],
+            ],
+        ];
+
+        yield 'resolve to lowest possible max-age' => [
+            ['public' => false, 'private' => true, 's-maxage' => false, 'max-age' => '60'],
+            ['public' => true, 'max-age' => 3600],
+            [
+                ['private' => true, 'max-age' => 60],
+            ],
+        ];
+
+        yield 'resolves multiple max-age' => [
+            ['public' => false, 'private' => true, 's-maxage' => false, 'max-age' => '60'],
+            ['private' => true, 'max-age' => 100],
+            [
+                ['private' => true, 'max-age' => 3600],
+                ['public' => true, 'max-age' => 60, 's-maxage' => 60],
+                ['private' => true, 'max-age' => 60],
+            ],
+        ];
+
+        yield 'merge max-age and s-maxage' => [
+            ['public' => true, 's-maxage' => '60', 'max-age' => null],
+            ['public' => true, 's-maxage' => 3600],
+            [
+                ['public' => true, 'max-age' => 60],
+            ],
+        ];
+
+        yield 'result is private when combining private responses' => [
+            ['no-cache' => false, 'must-revalidate' => false, 'private' => true],
+            ['s-maxage' => 60, 'private' => true],
+            [
+                ['s-maxage' => 60, 'private' => true],
+            ],
+        ];
+
+        yield 'result can have s-maxage and max-age' => [
+            ['public' => true, 'private' => false, 's-maxage' => '60', 'max-age' => '30'],
+            ['s-maxage' => 100, 'max-age' => 2000],
+            [
+                ['s-maxage' => 1000, 'max-age' => 30],
+                ['s-maxage' => 500, 'max-age' => 500],
+                ['s-maxage' => 60, 'max-age' => 1000],
+            ],
+        ];
+
+        yield 'does not set headers without value' => [
+            ['max-age' => null, 's-maxage' => null, 'public' => null],
+            ['private' => true],
+            [
+                ['private' => true],
+            ],
+        ];
+
+        yield 'max-age 0 is sent to the client' => [
+            ['private' => true, 'max-age' => '0'],
+            ['max-age' => 0, 'private' => true],
+            [
+                ['max-age' => 60, 'private' => true],
+            ],
+        ];
+
+        yield 'max-age is relative to age' => [
+            ['max-age' => '240', 'age' => 60],
+            ['max-age' => 180],
+            [
+                ['max-age' => 600, 'age' => 60],
+            ],
+        ];
+
+        yield 'retains lowest age of all responses' => [
+            ['max-age' => '160', 'age' => 60],
+            ['max-age' => 600, 'age' => 60],
+            [
+                ['max-age' => 120, 'age' => 20],
+            ],
+        ];
+
+        yield 'max-age can be less than age, essentially expiring the response' => [
+            ['age' => 120, 'max-age' => '90'],
+            ['max-age' => 90, 'age' => 120],
+            [
+                ['max-age' => 120, 'age' => 60],
+            ],
+        ];
+
+        yield 'max-age is 0 regardless of age' => [
+            ['max-age' => '0'],
+            ['max-age' => 60],
+            [
+                ['max-age' => 0, 'age' => 60],
+            ],
+        ];
+
+        yield 'max-age is not negative' => [
+            ['max-age' => '0'],
+            ['max-age' => 0],
+            [
+                ['max-age' => 0, 'age' => 60],
+            ],
+        ];
+
+        yield 'calculates lowest Expires header' => [
+            ['expires' => 60],
+            ['expires' => 60],
+            [
+                ['expires' => 120],
+            ],
+        ];
+
+        yield 'calculates Expires header relative to age' => [
+            ['expires' => 210, 'age' => 120],
+            ['expires' => 90],
+            [
+                ['expires' => 600, 'age' => '120'],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26245, #26352, #28872
| License       | MIT
| Doc PR        | -

This PR is a first draft to fix the incorrect merging of private and other cache-related headers that are not meant for the shared cache but the browser (see mentioned issues).

The existing implementation of `HttpFoundation\Response` is very much tailored to the `HttpCache`, for example `isCacheable` returns `false` if the response is `private`, which is not true for a browser cache. That is why my implementation does not longer use much of the response methods. They are however still used by the `HttpCache` and we should keep them as-is. FYI, the `ResponseCacheStrategy` does **not** affect the stored data of `HttpCache` but is only applied to the result of multiple merged subrequests/ESI responses.

I did read up a lot on RFC2616 as a reference. [Section 13.4](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.4) gives an overall view of when a response MAY be cached. [Section 14.9.1](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1) has more insight into the `Cache-Control` directives. 

Here's a summary of the relevant information I applied to the implementation:

 - > Unless specifically constrained by a cache-control (section 14.9) directive, a caching system MAY always store a successful response (see section 13.8) as a cache entry, MAY return it without validation if it is fresh, and MAY return it after successful validation.

    A response without cache control headers is totally fine, and it's up to the cache (shared or private) to decide what to do with it. That is why the implementation does not longer set `no-cache` if no `Cache-Control` headers are present.

 - > A response received with a status code of 200, 203, 206, 300, 301 or 410 MAY be stored […] unless a cache-control directive prohibits caching.

    > A response received with any other status code (e.g. status codes 302 and 307) MUST NOT be returned […] unless there are cache-control directives or another header(s) that explicitly allow it.

    This is what `ResponseCacheStrategy::isUncacheable` implements to decide whether a response is not cacheable at all. It differs from `Response::isCacheable` which only returns true if there are actual `Cache-Control` headers.

 - > [Section 13.2.3](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.2.3): When a response is generated from a cache entry, the cache MUST include a single Age header field in the response with a value equal to the cache entry's current_age.

    That's why the implementation **always** adds the `Age` header. It takes the oldest age of any of the responses as common denominator for the content.

 - > [Section 14.9.3](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.3): If a response includes an s-maxage directive, then for a shared cache (but not for a private cache), the maximum age specified by this directive overrides the maximum age specified by either the max-age directive or the Expires header.

    This effectively means that `max-age`, `s-maxage` and `Expires` must all be kept on the response. My implementation assumes that we can only do that if they exist in **all** of the responses, and then takes the lowest value of any of them. Be aware the implementation might look confusing at first. Due to the fact that the `Age` header might come from another subresponse than the lowest expiration value, the values are stored relative to the current response date and then re-calculated based on the age header.


The Symfony implementation did not and still does not implement the full RFC. As an example, some of the `Cache-Control` headers (like `private` and `no-cache`) MAY actually have a string value, but the implementation only supports boolean. Also, [Custom `Cache-Control` headers](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.6) are currently not merged into the final response.


**ToDo/Questions:**

 1. [Section 13.5.2](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.2) specifies that we must add a [`Warning 214 Transformation applied`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.46) if we modify the response headers.

 2. Should we add an `Expires` headers based on `max-age` if none is explicitly set in the responses? This would essentially provide the same information as `max-age` but with support for HTTP/1.0 proxies/clients.

 3. I'm not sure about the implemented handling of the `private` directive. The directive is currently only added to the final response if it is present in all of the subresponses. This can effectively result in no cache-control directive, which does not tell a shared cache that the response must not be cached. However, adding a `private` might also tell a browser to actually cache it, even though non of the other responses asked for that.

 4. > [Section 14.9.2](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.2): The purpose of the `no-store` directive is to prevent the inadvertent release or retention of sensitive information […]. The `no-store` directive applies to the entire message, and MAY be sent either in a response or in a request. If sent in a request, a cache MUST NOT store any part of either this request or any response to it. If sent in a response, a cache MUST NOT store any part of either this response or the request that elicited it.

    I have not (yet) validated whether the `HttpCache` implementation respects any of this.

 5. As far as I understand, the current implementation of [`ResponseHeaderBag::computeCacheControlValue`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php#L313) is incorrect. `no-cache` means a response [must not be cached by a shared or private cache](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1), which overrides `private` automatically.

 5. The unit tests are still very limited and I want to add plenty more to test and sort-of describe the implementation or assumptions on the RFC.

/cc @nicolas-grekas 

#SymfonyConHackday2018