### PR TITLE
allow_extra_attributes does not throw an exception as documented

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -200,11 +200,17 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      * @param array         $context
      * @param bool          $attributesAsString If false, return an array of {@link AttributeMetadataInterface}
      *
+     * @throws \Symfony\Component\Serializer\Exception\LogicException if the 'allow_extra_attributes' context variable is false and no class metadata factory is provided
+     *
      * @return string[]|AttributeMetadataInterface[]|bool
      */
     protected function getAllowedAttributes($classOrObject, array $context, $attributesAsString = false)
     {
         if (!$this->classMetadataFactory) {
+            if (isset($context[static::ALLOW_EXTRA_ATTRIBUTES]) && !$context[static::ALLOW_EXTRA_ATTRIBUTES]) {
+                throw new LogicException(sprintf("A class metadata factory must be provided in the constructor when setting '%s' to false.", static::ALLOW_EXTRA_ATTRIBUTES));
+            }
+
             return false;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -52,7 +53,8 @@ class AbstractObjectNormalizerTest extends TestCase
      */
     public function testDenormalizeWithExtraAttributes()
     {
-        $normalizer = new AbstractObjectNormalizerDummy();
+        $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $normalizer = new AbstractObjectNormalizerDummy($factory);
         $normalizer->denormalize(
             array('fooFoo' => 'foo', 'fooBar' => 'bar'),
             __NAMESPACE__.'\Dummy',
@@ -143,6 +145,23 @@ class AbstractObjectNormalizerTest extends TestCase
         $denormalizer->setSerializer($serializer);
 
         return $denormalizer;
+    }
+
+    /**
+     * Test that additional attributes throw an exception if no metadata factory is specified.
+     *
+     * @see https://symfony.com/doc/current/components/serializer.html#deserializing-an-object
+     *
+     * @expectedException \Symfony\Component\Serializer\Exception\LogicException
+     * @expectedExceptionMessage A class metadata factory must be provided in the constructor when setting 'allow_extra_attributes' to false.
+     */
+    public function testExtraAttributesException()
+    {
+        $normalizer = new ObjectNormalizer();
+
+        $normalizer->denormalize(array(), \stdClass::class, 'xml', array(
+            'allow_extra_attributes' => false,
+        ));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

The example at [Deserializing an object](https://symfony.com/doc/current/components/serializer.html#deserializing-an-object) does not actually work. It looks like this is a bug and not a docs issue. https://github.com/symfony/symfony/issues/24783 reported the same bug, but it looks like the fix at https://github.com/symfony/symfony/pull/24816 isn't complete.

Here's a failing test that copies the existing example.