### PR TITLE
[TwigBridge] fix BC break caused by using FormRenderer instead of TwigRenderer

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/form.xml
@@ -18,7 +18,14 @@
             <argument type="service" id="twig" />
         </service>
 
-        <service id="twig.form.renderer" class="Symfony\Component\Form\FormRenderer">
+        <service id="twig.form.renderer" class="Symfony\Bridge\Twig\Form\TwigRenderer">
+            <argument type="service" id="twig.form.engine" />
+            <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
+            <tag name="twig.runtime" />
+        </service>
+
+        <!-- used to allow forward-compatibility when retrieving non-deprecated "FormRenderer" twig runtime by FQCN -->
+        <service id="twig.form.renderer.non_deprecated" class="Symfony\Component\Form\FormRenderer">
             <argument type="service" id="twig.form.engine" />
             <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
             <tag name="twig.runtime" />

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -270,9 +270,11 @@ class TwigExtensionTest extends TestCase
 
         $loader = $container->getDefinition('twig.runtime_loader');
         $args = $container->getDefinition((string) $loader->getArgument(0))->getArgument(0);
+        $this->assertArrayHasKey('Symfony\Bridge\Twig\Form\TwigRenderer', $args);
         $this->assertArrayHasKey('Symfony\Component\Form\FormRenderer', $args);
         $this->assertArrayHasKey('FooClass', $args);
-        $this->assertEquals('twig.form.renderer', $args['Symfony\Component\Form\FormRenderer']->getValues()[0]);
+        $this->assertEquals('twig.form.renderer', $args['Symfony\Bridge\Twig\Form\TwigRenderer']->getValues()[0]);
+        $this->assertEquals('twig.form.renderer.non_deprecated', $args['Symfony\Component\Form\FormRenderer']->getValues()[0]);
         $this->assertEquals('foo', $args['FooClass']->getValues()[0]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #24616, #25659
| License       | MIT
| Doc PR        | -

In https://github.com/symfony/symfony/commit/6ea71cb2ccc205294798d809e2ee295cfd9a0b5f#diff-5eb0532c96734f6e23428e921225b2f0R21 the `TwigRenderer` service was replaced with `FormRenderer`.

This caused 2 BC breaks:

- people that were injecting `twig.form.renderer` **and** coding against the interface `TwigRendererInterface` suddenly received an error because the new `FormRenderer` does not implement this interface.
- also retrieving the twig runtime for the old  FQCN is not working anymore and causes a `Twig_Error_Runtime` exception

This PR reverts the class change for the service `twig.form.renderer`. This should be safe to revert because the old `TwigRendererInterface` extends `FormRendererInterface` and `TwigRenderer` extends `FormRenderer`. So all people that adapted to the BC break and changed the expected interface/class should still be fine.

Additionally because some people already adjusted to the second BC break when retrieving the runtime (see for example https://github.com/sonata-project/SonataAdminBundle/issues/4758) we add the new non-deprecated `FormRenderer` as a runtime as well.

So both of these work on 3.4 then:

```php
$twig->getRuntime(TwigRenderer::class)
$twig->getRuntime(FormRenderer::class)
```

WDYT? Did I forget something? 
