### PR TITLE
[WIP] [Debug] Avoid fatal handler loops

### DIFF
--- a/src/Symfony/Component/Debug/Tests/phpt/avoid_loop_with_exception_handler.phpt
+++ b/src/Symfony/Component/Debug/Tests/phpt/avoid_loop_with_exception_handler.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Test that, when handling a fatal, we don't create a loop with a third party exception handler installed after ours
+--FILE--
+<?php
+
+namespace Symfony\Component\Debug;
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/vendor/autoload.php';
+
+class ThirdPartyExceptionHandler
+{
+    private static $prevErrorHandler;
+    private static $prevExceptionHandler;
+    
+    public static function register()
+    {
+        static::$prevErrorHandler = set_error_handler([__CLASS__, 'handleError']);
+        static::$prevExceptionHandler = set_exception_handler([__CLASS__, 'handleException']);
+    }
+
+    public static function handleError($e)
+    {
+        echo 'Third party error handler' . PHP_EOL;
+        echo 'Calling previous handler: ' . get_class(static::$prevErrorHandler[0]) . PHP_EOL;
+        return call_user_func(static::$prevErrorHandler, $e);
+    }
+
+    public static function handleException($e)
+    {
+        echo 'Third party exception handler' . PHP_EOL;
+        echo 'Calling previous handler: ' . get_class(static::$prevExceptionHandler[0]) . PHP_EOL;
+        return call_user_func(static::$prevExceptionHandler, $e);
+    }
+}
+
+ErrorHandler::register();
+ThirdPartyExceptionHandler::register();
+ini_set('display_errors', 1);
+
+$a = null;
+require 'inexistent_file.php';
+?>
+--EXPECTF--
+Third party error handler
+Calling previous handler: Symfony\Component\Debug\ErrorHandler
+Third party exception handler
+Calling previous handler: Symfony\Component\Debug\ErrorHandler
+Uncaught Exception: foo
+Fatal error: Uncaught %s
+Stack trace:
+%a


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #26438
| License       | MIT

This PR starts to try and solve #26438. For now it's just a WIP with the reproducing test case.

The bug is present when:
 * a third party error handler (like Sentry) is installed
 * a fatal in thrown under PHP 7

The third party error/exception handlers remember the previous handler, and call them when their work is finished. But Symfony's handler has this piece of code: https://github.com/symfony/symfony/blob/874d4d659774d7bab90538072c83ed532dd17dc5/src/Symfony/Component/Debug/ErrorHandler.php#L616-L635

Citing @alcohol from #26438:

>  it looks like it is trying to find itself (or an instance of) in the stack of exception handlers that may or may not have been registered. It does this by restoring previous error handlers, and looking at what gets restored. Once it finds itself (or there simply arent any), it "restores" the previous stack of error handlers by reassigning them in order, and proceeds to the setExceptionHandler step, where the $handler should be an instance of itself, and $h is whatever what was last added to the stack of error handlers.

This operation creates a loop because the handler is altering the order of exception handlers, generating a loop: Symfony's handler is normally registered first by the FrameworkBundle, so it's putting himself as the last one registered with that.

Pinging @nicolas-grekas since he seems to have wrote a great part of the ErrorHandler.