### PR TITLE
[Bridge\PhpUnit] Cannot autoload class "\Symfony\Bridge\PhpUnit\SymfonyTestsListener"

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CoverageListener.php
+++ b/src/Symfony/Bridge/PhpUnit/CoverageListener.php
@@ -18,3 +18,9 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
 } else {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\CoverageListenerForV7', 'Symfony\Bridge\PhpUnit\CoverageListener');
 }
+
+if (false) {
+    class CoverageListener
+    {
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -18,3 +18,9 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
 } else {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerForV7', 'Symfony\Bridge\PhpUnit\SymfonyTestsListener');
 }
+
+if (false) {
+    class SymfonyTestsListener
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26430
| License       | MIT
| Doc PR        | - <!-- required for new features -->

Allows composer to discover the class for autoloading when using `composer install --classmap-authoritative`