### PR TITLE
[HttpFoundation] deprecate call to Request::getSession() when Request::hasSession() returns false

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -55,8 +55,8 @@ HttpFoundation
 --------------
 
  * Passing the file size to the constructor of the `UploadedFile` class is deprecated.
-
  * The `getClientSize()` method of the `UploadedFile` class is deprecated. Use `getSize()` instead.
+ * Deprecated `Symfony\Component\HttpFoundation\Request::getSession()` when no session has been set. Use `Symfony\Component\HttpFoundation\Request::hasSession()` instead.
 
 Security
 --------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -54,6 +54,7 @@ HttpFoundation
 
  * The `$size` argument of the `UploadedFile` constructor has been removed.
  * The `getClientSize()` method of the `UploadedFile` class has been removed.
+ * The `getSession()` method of the `Request` class throws an exception when session is null.
 
 Security
 --------

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -129,9 +129,7 @@ class ProfilerController
             throw new NotFoundHttpException('The profiler must be enabled.');
         }
 
-        $session = $request->getSession();
-
-        if (null !== $session && $session->isStarted() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
+        if ($request->hasSession() && ($session = $request->getSession()) && $session->isStarted() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
             // keep current flashes for one more request if using AutoExpireFlashBag
             $session->getFlashBag()->setAll($session->getFlashBag()->peekAll());
         }

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * The `get()` method of the `AcceptHeader` class now takes into account the
    `*` and `*/*` default values (if they are present in the Accept HTTP header)
    when looking for items.
+ * deprecated `Request::getSession()` when no session has been set. Use `Request::hasSession()` instead.
 
 4.0.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -725,6 +725,11 @@ class Request
             $this->setSession($session = $session());
         }
 
+        if (null === $session) {
+            @trigger_error(sprintf('Calling "%s()" when no session has been set is deprecated since Symfony 4.1 and will throw an exception in 5.0. Use "hasSession()" instead.', __METHOD__), E_USER_DEPRECATED);
+            // throw new \BadMethodCallException('Session has not been set');
+        }
+
         return $session;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1491,6 +1491,15 @@ class RequestTest extends TestCase
         $this->assertObjectHasAttribute('attributeName', $session);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Calling "Symfony\Component\HttpFoundation\Request::getSession()" when no session has been set is deprecated since Symfony 4.1 and will throw an exception in 5.0. Use "hasSession()" instead.
+     */
+    public function testGetSessionNullable()
+    {
+        (new Request())->getSession();
+    }
+
     public function testHasPreviousSession()
     {
         $request = new Request();

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
@@ -28,6 +28,10 @@ final class SessionValueResolver implements ArgumentValueResolverInterface
      */
     public function supports(Request $request, ArgumentMetadata $argument)
     {
+        if (!$request->hasSession()) {
+            return false;
+        }
+
         $type = $argument->getType();
         if (SessionInterface::class !== $type && !is_subclass_of($type, SessionInterface::class)) {
             return false;

--- a/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Guard\Authenticator;
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,7 +41,7 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        if ($request->getSession() instanceof SessionInterface) {
+        if ($request->hasSession()) {
             $request->getSession()->set(Security::AUTHENTICATION_ERROR, $exception);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #26539
| License       | MIT
