### PR TITLE
[BrowserKit] Improves CookieJar::get

### DIFF
--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -47,13 +47,13 @@ class CookieJar
             foreach ($this->cookieJar as $cookieDomain => $pathCookies) {
                 if ($cookieDomain) {
                     $cookieDomain = '.'.ltrim($cookieDomain, '.');
-                    if ($cookieDomain != substr('.'.$domain, -strlen($cookieDomain))) {
+                    if ($cookieDomain !== substr('.'.$domain, -\strlen($cookieDomain))) {
                         continue;
                     }
                 }
 
                 foreach ($pathCookies as $cookiePath => $namedCookies) {
-                    if ($cookiePath != substr($path, 0, strlen($cookiePath))) {
+                    if (0 !== strpos($path, $cookiePath)) {
                         continue;
                     }
                     if (isset($namedCookies[$name])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      |no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

* change a call to `substr` + `strlen` to a single `strpos`