### PR TITLE
[DoctrineBridge] Don't rely on ClassMetadataInfo->hasField in DoctrineOrmTypeGuesser anymore

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -95,7 +95,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
         $classMetadata = $classMetadatas[0];
 
         // Check whether the field exists and is nullable or not
-        if ($classMetadata->hasField($property)) {
+        if (isset($classMetadata->fieldMappings[$property])) {
             if (!$classMetadata->isNullable($property) && Type::BOOLEAN !== $classMetadata->getTypeOfField($property)) {
                 return new ValueGuess(true, Guess::HIGH_CONFIDENCE);
             }
@@ -124,7 +124,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     public function guessMaxLength($class, $property)
     {
         $ret = $this->getMetadata($class);
-        if ($ret && $ret[0]->hasField($property) && !$ret[0]->hasAssociation($property)) {
+        if ($ret && isset($ret[0]->fieldMappings[$property]) && !$ret[0]->hasAssociation($property)) {
             $mapping = $ret[0]->getFieldMapping($property);
 
             if (isset($mapping['length'])) {
@@ -143,7 +143,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     public function guessPattern($class, $property)
     {
         $ret = $this->getMetadata($class);
-        if ($ret && $ret[0]->hasField($property) && !$ret[0]->hasAssociation($property)) {
+        if ($ret && isset($ret[0]->fieldMappings[$property]) && !$ret[0]->hasAssociation($property)) {
             if (in_array($ret[0]->getTypeOfField($property), array(Type::DECIMAL, Type::FLOAT))) {
                 return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
             }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
@@ -33,21 +33,20 @@ class DoctrineOrmTypeGuesserTest extends TestCase
 
         // Simple field, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(true));
+        $classMetadata->fieldMappings['field'] = true;
         $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(false));
 
         $return[] = array($classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE));
 
         // Simple field, nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(true));
+        $classMetadata->fieldMappings['field'] = true;
         $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(true));
 
         $return[] = array($classMetadata, new ValueGuess(false, Guess::MEDIUM_CONFIDENCE));
 
         // One-to-one, nullable (by default)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(false));
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
 
         $mapping = array('joinColumns' => array(array()));
@@ -57,7 +56,6 @@ class DoctrineOrmTypeGuesserTest extends TestCase
 
         // One-to-one, nullable (explicit)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(false));
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
 
         $mapping = array('joinColumns' => array(array('nullable' => true)));
@@ -67,7 +65,6 @@ class DoctrineOrmTypeGuesserTest extends TestCase
 
         // One-to-one, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(false));
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
 
         $mapping = array('joinColumns' => array(array('nullable' => false)));
@@ -77,7 +74,6 @@ class DoctrineOrmTypeGuesserTest extends TestCase
 
         // One-to-many, no clue
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(false));
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(false));
 
         $return[] = array($classMetadata, null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/26543
| License       | MIT
| Doc PR        | -

Discussion and explanations in the linked issue https://github.com/symfony/symfony/issues/26543