### PR TITLE
[BrowserKit] Fix cookie path handling when $domain is null

### DIFF
--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -43,32 +43,21 @@ class CookieJar
     {
         $this->flushExpiredCookies();
 
-        if (!empty($domain)) {
-            foreach ($this->cookieJar as $cookieDomain => $pathCookies) {
-                if ($cookieDomain) {
-                    $cookieDomain = '.'.ltrim($cookieDomain, '.');
-                    if ($cookieDomain !== substr('.'.$domain, -\strlen($cookieDomain))) {
-                        continue;
-                    }
-                }
-
-                foreach ($pathCookies as $cookiePath => $namedCookies) {
-                    if (0 !== strpos($path, $cookiePath)) {
-                        continue;
-                    }
-                    if (isset($namedCookies[$name])) {
-                        return $namedCookies[$name];
-                    }
+        foreach ($this->cookieJar as $cookieDomain => $pathCookies) {
+            if ($cookieDomain && $domain) {
+                $cookieDomain = '.'.ltrim($cookieDomain, '.');
+                if ($cookieDomain !== substr('.'.$domain, -\strlen($cookieDomain))) {
+                    continue;
                 }
             }
 
-            return;
-        }
-
-        // avoid relying on this behavior that is mainly here for BC reasons
-        foreach ($this->cookieJar as $cookies) {
-            if (isset($cookies[$path][$name])) {
-                return $cookies[$path][$name];
+            foreach ($pathCookies as $cookiePath => $namedCookies) {
+                if (0 !== strpos($path, $cookiePath)) {
+                    continue;
+                }
+                if (isset($namedCookies[$name])) {
+                    return $namedCookies[$name];
+                }
             }
         }
     }

--- a/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
@@ -237,6 +237,8 @@ class CookieJarTest extends TestCase
         $this->assertEquals($cookie1, $cookieJar->get('foo', '/test', 'example.com'));
         $this->assertEquals($cookie2, $cookieJar->get('foo1', '/', 'example.com'));
         $this->assertEquals($cookie2, $cookieJar->get('foo1', '/bar', 'example.com'));
+
+        $this->assertEquals($cookie2, $cookieJar->get('foo1', '/bar'));
     }
 
     public function testCookieWithWildcardDomain()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  |no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The bug is highlighted by the new test: there is an inconsistency in the path handling regarding if a domain is set or not. If it is set, and the cookie is set to a subpath of the passed path, the cookie is returned. However if no domain is set, it is not. This PR fixes this bug.