### PR TITLE
[TwigBundle] document TwigRenderer BC break in UPGRADE-3.4

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -410,6 +410,14 @@ TwigBridge
 
  * deprecated the `Symfony\Bridge\Twig\Form\TwigRenderer` class, use the `FormRenderer`
    class from the Form component instead
+   
+    * the service `twig.form.renderer` is now an instance of `FormRenderer`. 
+      So you might have to adjust your type-hints to `FormRendererInterface` if you are still relying on 
+      the `TwigRendererInterface` which was deprecated in Symfony 3.2
+      
+    * retrieving the Renderer runtime from the twig environment via 
+      `$twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')` is not working anymore 
+       and should be replaced with `$twig->getRuntime('Symfony\Component\Form\FormRenderer')` instead
 
  * deprecated `Symfony\Bridge\Twig\Command\DebugCommand::set/getTwigEnvironment` and the ability
    to pass a command name as first argument


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | #24616, #25659
| License       | MIT
| Doc PR        | -

This is a follow up for https://github.com/symfony/symfony/pull/26553 as it seems impossible to fix the BC break in a clean way for everyone.

ping @nicolas-grekas @Tobion 