### PR TITLE
[SecurityBundle] fix tests when libsodium is not installed

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -86,7 +86,8 @@ class UserPasswordEncoderCommandTest extends WebTestCase
         $this->assertContains('Password encoding succeeded', $output);
 
         $encoder = new Argon2iPasswordEncoder();
-        preg_match('#  Encoded password\s+(\$argon2id?\$[\w\d,=\$+\/]+={0,2})\s+#', $output, $matches);
+        $prefix = \extension_loaded('libsodium') ? '\$argon2id' : '\$argon2i';
+        preg_match("#  Encoded password\s+($prefix\\$[\w\d,=\\$+\/]+={0,2})\s+#", $output, $matches);
         $hash = $matches[1];
         $this->assertTrue($encoder->isPasswordValid($hash, 'password', null));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

#26057 updated a test to handle libsodium when the lib is installed.
When it's not installed, the checks of `Argon2iPasswordEncoder::isSupported()` still returns `true` if `sodium_crypto_pwhash_str()` exists and in this case the password value displayed by the command `security:encode-password` contains `$argon2i` instead of `$argon2id` so `preg_match()` returns `false`, a notice is emit (_Undefined offset: 1_) and the test fails.