### PR TITLE
[HttpKernel] Allow generators in registerBundle

### DIFF
--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -27,7 +27,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Returns an array of bundles to register.
      *
-     * @return BundleInterface[] An array of bundle instances
+     * @return iterable|BundleInterface[] An iterable of bundle instances
      */
     public function registerBundles();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Flex recipe [utilizes generator in Kernel.php](https://github.com/symfony/recipes/blob/a067bebf03a2b244cdf82dd4e3eff52de5320ac2/symfony/framework-bundle/3.3/src/Kernel.php#L33). This needs to be explicitly allowed in interface.