### PR TITLE
Add hint in Github pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 | Bug fix?      | yes/no
 | New feature?  | yes/no <!-- don't forget to update src/**/CHANGELOG.md files -->
 | BC breaks?    | no     <!-- see https://symfony.com/bc -->
-| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md files -->
+| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
 | Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
 | Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
 | License       | MIT


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

I added a deprecation in the code base but I forgot to update the CHANGELOG.md file of the component although I double checked the pull request template of this case.

It's trivial but I think it can be a way to save some time for next distracted contributors :)