### PR TITLE
[Security] Add Callable voter

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/CallableVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/CallableVoter.php
@@ -39,13 +39,13 @@ class CallableVoter implements VoterInterface
         $result = ($this->callable)($token, $subject, $attributes);
 
         if (false === $result) {
-            return Voter::ACCESS_DENIED;
+            return VoterInterface::ACCESS_DENIED;
         }
 
         if (true === $result) {
-            return Voter::ACCESS_GRANTED;
+            return VoterInterface::ACCESS_GRANTED;
         }
 
-        return Voter::ACCESS_ABSTAIN;
+        return VoterInterface::ACCESS_ABSTAIN;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/CallableVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/CallableVoter.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * CallableVoter delegate vote to the callable.
+ *
+ * Callable received the token, the subject and the attributes
+ * This callable must return true, false, mixed to respectively
+ * ACCESS_GRANTED, ACCESS_DENIED, or ACCESS_ABSTAIN.
+ *
+ * @author Anthony Moutte <instabledesign@gmail.com>
+ */
+class CallableVoter implements VoterInterface
+{
+    private $callable;
+
+    public function __construct(callable $callable)
+    {
+        $this->callable = $callable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function vote(TokenInterface $token, $subject, array $attributes)
+    {
+        $result = ($this->callable)($token, $subject, $attributes);
+
+        if (false === $result) {
+            return Voter::ACCESS_DENIED;
+        }
+
+        if (true === $result) {
+            return Voter::ACCESS_GRANTED;
+        }
+
+        return Voter::ACCESS_ABSTAIN;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/CallableVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/CallableVoterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\CallableVoter;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class CallableVoterTest extends TestCase
+{
+    /**
+     * @dataProvider getVoteTests
+     */
+    public function testVote($callable, $expected)
+    {
+        $voter = new CallableVoter($callable);
+        $tokenMock = $this->getMockBuilder(TokenInterface::class)->getMock();
+
+        $this->assertSame($expected, $voter->vote($tokenMock, null, array()));
+    }
+
+    public function getVoteTests()
+    {
+        return array(
+            array(
+                function () {
+                    return true;
+                },
+                Voter::ACCESS_GRANTED,
+            ),
+            array(
+                array(
+                    new class() {
+                        public function get()
+                        {
+                            return true;
+                        }
+                    },
+                    'get',
+                ),
+                Voter::ACCESS_GRANTED,
+            ),
+            array(
+                new class() {
+                    public function __invoke()
+                    {
+                        return true;
+                    }
+                },
+                Voter::ACCESS_GRANTED,
+            ),
+            array(
+                function () {
+                    return false;
+                },
+                Voter::ACCESS_DENIED,
+            ),
+            array(
+                array(
+                    new class() {
+                        public function get()
+                        {
+                            return false;
+                        }
+                    },
+                    'get',
+                ),
+                Voter::ACCESS_DENIED,
+            ),
+            array(
+                new class() {
+                    public function __invoke()
+                    {
+                        return false;
+                    }
+                },
+                Voter::ACCESS_DENIED,
+            ),
+            array(
+                function () {
+                    return null;
+                },
+                Voter::ACCESS_ABSTAIN,
+            ),
+            array(
+                array(
+                    new class() {
+                        public function get()
+                        {
+                            return null;
+                        }
+                    },
+                    'get',
+                ),
+                Voter::ACCESS_ABSTAIN,
+            ),
+            array(
+                new class() {
+                    public function __invoke()
+                    {
+                        return null;
+                    }
+                },
+                Voter::ACCESS_ABSTAIN,
+            ),
+        );
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/CallableVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/CallableVoterTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\CallableVoter;
-use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class CallableVoterTest extends TestCase
 {
@@ -36,7 +36,7 @@ class CallableVoterTest extends TestCase
                 function () {
                     return true;
                 },
-                Voter::ACCESS_GRANTED,
+                VoterInterface::ACCESS_GRANTED,
             ),
             array(
                 array(
@@ -48,7 +48,7 @@ class CallableVoterTest extends TestCase
                     },
                     'get',
                 ),
-                Voter::ACCESS_GRANTED,
+                VoterInterface::ACCESS_GRANTED,
             ),
             array(
                 new class() {
@@ -57,13 +57,13 @@ class CallableVoterTest extends TestCase
                         return true;
                     }
                 },
-                Voter::ACCESS_GRANTED,
+                VoterInterface::ACCESS_GRANTED,
             ),
             array(
                 function () {
                     return false;
                 },
-                Voter::ACCESS_DENIED,
+                VoterInterface::ACCESS_DENIED,
             ),
             array(
                 array(
@@ -75,7 +75,7 @@ class CallableVoterTest extends TestCase
                     },
                     'get',
                 ),
-                Voter::ACCESS_DENIED,
+                VoterInterface::ACCESS_DENIED,
             ),
             array(
                 new class() {
@@ -84,13 +84,13 @@ class CallableVoterTest extends TestCase
                         return false;
                     }
                 },
-                Voter::ACCESS_DENIED,
+                VoterInterface::ACCESS_DENIED,
             ),
             array(
                 function () {
                     return null;
                 },
-                Voter::ACCESS_ABSTAIN,
+                VoterInterface::ACCESS_ABSTAIN,
             ),
             array(
                 array(
@@ -102,7 +102,7 @@ class CallableVoterTest extends TestCase
                     },
                     'get',
                 ),
-                Voter::ACCESS_ABSTAIN,
+                VoterInterface::ACCESS_ABSTAIN,
             ),
             array(
                 new class() {
@@ -111,7 +111,7 @@ class CallableVoterTest extends TestCase
                         return null;
                     }
                 },
-                Voter::ACCESS_ABSTAIN,
+                VoterInterface::ACCESS_ABSTAIN,
             ),
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Simple implementation of a CallableVoter.

The `callable` must return true, false, mixed to respectively grant, denied, abstain.

It allow this multiple syntax use

```php
use Symfony\Component\Security\Core\Authorization\Voter\CallableVoter;

new CallableVoter(
    function () {
        return true;
    }
);

new CallableVoter(
    [
        new class()
        {
            public function get()
            {
                return true;
            }
        },
        'get',
    ]
);

new CallableVoter(
    new class()
    {
        public function __invoke()
        {
            return true;
        }
    }
);
```

What did you think about such addition?
Feel free to comment or close it.