### PR TITLE
[Workflow] implemented TransitionException to be thrown instead of Logic exception

### DIFF
--- a/src/Symfony/Component/Workflow/Exception/TransitionException.php
+++ b/src/Symfony/Component/Workflow/Exception/TransitionException.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Exception;
+
+/**
+ * @author Andrew Tch <andrew.tchircoff@gmail.com>
+ */
+class TransitionException extends LogicException
+{
+    /**
+     * @var mixed
+     */
+    private $subject;
+
+    /**
+     * @var string
+     */
+    private $transitionName;
+
+    /**
+     * @var string
+     */
+    private $workflowName;
+
+    public function __construct($subject, $transitionName, $workflowName)
+    {
+        $this->subject = $subject;
+        $this->transitionName = $transitionName;
+        $this->workflowName = $workflowName;
+
+        parent::__construct(sprintf('Unable to apply transition "%s" for workflow "%s".', $this->transitionName, $this->workflowName));
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTransitionName()
+    {
+        return $this->transitionName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWorkflowName()
+    {
+        return $this->workflowName;
+    }
+}

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -15,6 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Workflow\Event\Event;
 use Symfony\Component\Workflow\Event\GuardEvent;
 use Symfony\Component\Workflow\Exception\LogicException;
+use Symfony\Component\Workflow\Exception\TransitionException;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 use Symfony\Component\Workflow\MarkingStore\MultipleStateMarkingStore;
 
@@ -138,7 +139,7 @@ class Workflow implements WorkflowInterface
         }
 
         if (!$applied) {
-            throw new LogicException(sprintf('Unable to apply transition "%s" for workflow "%s".', $transitionName, $this->name));
+            throw new TransitionException($subject, $transitionName, $this->name);
         }
 
         return $marking;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

Getting Logic exception from Workflow is somehow confusing - as there is no way to understand which transition triggered the exception, and there's no access to the subject being modified to format the exception in any other way.

Therefore, I've implemented TransitionException to be thrown at runtime (extending current LogicException to avoid BC). `getMessage` signature remains the same. All other exceptions are untouched (as they are tied to very logic of the workflow, and to to the subject).

See #26581