### PR TITLE
[Ldap] cast to string when checking empty passwords

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
@@ -84,7 +84,7 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
         $username = $token->getUsername();
         $password = $token->getCredentials();
 
-        if (empty($password)) {
+        if ('' === (string) $password) {
             throw new BadCredentialsException('The presented password must not be empty.');
         }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
@@ -84,7 +84,7 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
         $username = $token->getUsername();
         $password = $token->getCredentials();
 
-        if ('' === $password) {
+        if (empty($password)) {
             throw new BadCredentialsException('The presented password must not be empty.');
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
@@ -47,6 +47,23 @@ class LdapBindAuthenticationProviderTest extends TestCase
 
     /**
      * @expectedException        \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     * @expectedExceptionMessage The presented password must not be empty.
+     */
+    public function testNullPasswordShouldThrowAnException()
+    {
+        $userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();
+        $ldap = $this->getMockBuilder('Symfony\Component\Ldap\LdapClientInterface')->getMock();
+        $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
+
+        $provider = new LdapBindAuthenticationProvider($userProvider, $userChecker, 'key', $ldap);
+        $reflection = new \ReflectionMethod($provider, 'checkAuthentication');
+        $reflection->setAccessible(true);
+
+        $reflection->invoke($provider, new User('foo', null), new UsernamePasswordToken('foo', null, 'key'));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\Security\Core\Exception\BadCredentialsException
      * @expectedExceptionMessage The presented password is invalid.
      */
     public function testBindFailureShouldThrowAnException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 2.7 up to 4.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26525  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Quick fix condition that solved the issue. 
-->
