### PR TITLE
Make sure form errors is valid HTML

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -261,12 +261,12 @@
 
 {% block form_errors -%}
     {%- if errors|length > 0 -%}
-        <div class="{% if form is not rootform %}invalid-feedback d-block{% else %}alert alert-danger{% endif %}">
-            <ul class="list-unstyled mb-0">
-                {%- for error in errors -%}
-                    <li><span class="initialism form-error-icon badge badge-danger">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span></li>
-                {%- endfor -%}
-            </ul>
-        </div>
+        <span class="{% if form is not rootform %}invalid-feedback d-block{% else %}alert alert-danger{% endif %}">
+            {%- for error in errors -%}
+                <span class="mb-0 d-block">
+                    <span class="initialism form-error-icon badge badge-danger">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span>
+                </span>
+            {%- endfor -%}
+        </span>
     {%- endif %}
 {%- endblock form_errors %}

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
@@ -32,14 +32,12 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
     [
         ./label[@for="name"]
         [
-            ./div[
-                ./ul
-                    [./li
-                        [./span[.="[trans]Error[/trans]"]]
-                        [./span[.="[trans]Error![/trans]"]]
-                    ]
-                    [count(./li)=1]
-            ]
+            ./span[@class="alert alert-danger"]
+                [./span[@class="mb-0 d-block"]
+                    [./span[.="[trans]Error[/trans]"]]
+                    [./span[.="[trans]Error![/trans]"]]
+                ]
+                [count(./span)=1]
         ]
         /following-sibling::div[./input[@id="name"]]
     ]

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
@@ -32,14 +32,12 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
     [
         ./label[@for="name"]
         [
-            ./div[
-                ./ul
-                    [./li
-                        [./span[.="[trans]Error[/trans]"]]
-                        [./span[.="[trans]Error![/trans]"]]
-                    ]
-                    [count(./li)=1]
-            ]
+            ./span[@class="alert alert-danger"]
+                [./span[@class="mb-0 d-block"]
+                    [./span[.="[trans]Error[/trans]"]]
+                    [./span[.="[trans]Error![/trans]"]]
+                ]
+                [count(./span)=1]
         ]
         /following-sibling::input[@id="name"]
     ]
@@ -162,22 +160,18 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         $html = $this->renderErrors($view);
 
         $this->assertMatchesXpath($html,
-'/div
+'/span
     [@class="alert alert-danger"]
     [
-        ./ul
-            [@class="list-unstyled mb-0"]
-            [
-                ./li
-                    [./span[.="[trans]Error[/trans]"]]
-                    [./span[.="[trans]Error 1[/trans]"]]
-                  
-                /following-sibling::li
-                    [./span[.="[trans]Error[/trans]"]]
-                    [./span[.="[trans]Error 2[/trans]"]]
-            ]
-            [count(./li)=2]
+        ./span[@class="mb-0 d-block"]
+            [./span[.="[trans]Error[/trans]"]]
+            [./span[.="[trans]Error 1[/trans]"]]
+          
+        /following-sibling::span[@class="mb-0 d-block"]
+            [./span[.="[trans]Error[/trans]"]]
+            [./span[.="[trans]Error 2[/trans]"]]    
     ]
+    [count(./span)=2]
 '
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #26461
| License       | MIT
| Doc PR        | 

Using `<div>` and `<ul>` in a `<label>` is not valid HTML. This PR uses `<span>`s instead and some Bootstrap 4 classes to make it look just like before. 


