### PR TITLE
Fixes #26563 (open_basedir restriction in effect)

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -39,7 +39,7 @@ class PhpExecutableFinder
         $args = $includeArgs && $args ? ' '.implode(' ', $args) : '';
 
         // PHP_BINARY return the current sapi executable
-        if (PHP_BINARY && in_array(PHP_SAPI, array('cli', 'cli-server', 'phpdbg')) && is_file(PHP_BINARY)) {
+        if (PHP_BINARY && in_array(PHP_SAPI, array('cli', 'cli-server', 'phpdbg'))) {
             return PHP_BINARY.$args;
         }
 


### PR DESCRIPTION
If the open_basedir is set is_file(PHP_BINARY) is false.

| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes/
| New feature?  | no 
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed tickets | #26563
| License       | MIT
| Doc PR        | 

If we are using cli we already used the binary so there is no need to check if the file exists.
