### PR TITLE
[Routing] Fixed the importing of files using glob patterns that match multiple resources

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RoutingConfigurator.php
@@ -39,9 +39,17 @@ class RoutingConfigurator
     final public function import($resource, $type = null, $ignoreErrors = false)
     {
         $this->loader->setCurrentDir(dirname($this->path));
-        $subCollection = $this->loader->import($resource, $type, $ignoreErrors, $this->file);
+        $imported = $this->loader->import($resource, $type, $ignoreErrors, $this->file);
+        if (!is_array($imported)) {
+            return new ImportConfigurator($this->collection, $imported);
+        }
 
-        return new ImportConfigurator($this->collection, $subCollection);
+        $mergedCollection = new RouteCollection();
+        foreach ($imported as $subCollection) {
+            $mergedCollection->addCollection($subCollection);
+        }
+
+        return new ImportConfigurator($this->collection, $mergedCollection);
     }
 
     /**

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -146,26 +146,33 @@ class XmlFileLoader extends FileLoader
 
         $this->setCurrentDir(dirname($path));
 
-        $subCollection = $this->import($resource, ('' !== $type ? $type : null), false, $file);
-        /* @var $subCollection RouteCollection */
-        $subCollection->addPrefix($prefix);
-        if (null !== $host) {
-            $subCollection->setHost($host);
-        }
-        if (null !== $condition) {
-            $subCollection->setCondition($condition);
-        }
-        if (null !== $schemes) {
-            $subCollection->setSchemes($schemes);
-        }
-        if (null !== $methods) {
-            $subCollection->setMethods($methods);
-        }
-        $subCollection->addDefaults($defaults);
-        $subCollection->addRequirements($requirements);
-        $subCollection->addOptions($options);
+        $imported = $this->import($resource, ('' !== $type ? $type : null), false, $file);
 
-        $collection->addCollection($subCollection);
+        if (!is_array($imported)) {
+            $imported = array($imported);
+        }
+
+        foreach ($imported as $subCollection) {
+            /* @var $subCollection RouteCollection */
+            $subCollection->addPrefix($prefix);
+            if (null !== $host) {
+                $subCollection->setHost($host);
+            }
+            if (null !== $condition) {
+                $subCollection->setCondition($condition);
+            }
+            if (null !== $schemes) {
+                $subCollection->setSchemes($schemes);
+            }
+            if (null !== $methods) {
+                $subCollection->setMethods($methods);
+            }
+            $subCollection->addDefaults($defaults);
+            $subCollection->addRequirements($requirements);
+            $subCollection->addOptions($options);
+
+            $collection->addCollection($subCollection);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -158,26 +158,33 @@ class YamlFileLoader extends FileLoader
 
         $this->setCurrentDir(dirname($path));
 
-        $subCollection = $this->import($config['resource'], $type, false, $file);
-        /* @var $subCollection RouteCollection */
-        $subCollection->addPrefix($prefix);
-        if (null !== $host) {
-            $subCollection->setHost($host);
-        }
-        if (null !== $condition) {
-            $subCollection->setCondition($condition);
-        }
-        if (null !== $schemes) {
-            $subCollection->setSchemes($schemes);
-        }
-        if (null !== $methods) {
-            $subCollection->setMethods($methods);
-        }
-        $subCollection->addDefaults($defaults);
-        $subCollection->addRequirements($requirements);
-        $subCollection->addOptions($options);
+        $imported = $this->import($config['resource'], $type, false, $file);
 
-        $collection->addCollection($subCollection);
+        if (!is_array($imported)) {
+            $imported = array($imported);
+        }
+
+        foreach ($imported as $subCollection) {
+            /* @var $subCollection RouteCollection */
+            $subCollection->addPrefix($prefix);
+            if (null !== $host) {
+                $subCollection->setHost($host);
+            }
+            if (null !== $condition) {
+                $subCollection->setCondition($condition);
+            }
+            if (null !== $schemes) {
+                $subCollection->setSchemes($schemes);
+            }
+            if (null !== $methods) {
+                $subCollection->setMethods($methods);
+            }
+            $subCollection->addDefaults($defaults);
+            $subCollection->addRequirements($requirements);
+            $subCollection->addOptions($options);
+
+            $collection->addCollection($subCollection);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/bar.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/bar.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="bar_route" path="/bar" controller="AppBundle:Bar:view" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/bar.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/bar.yml
@@ -1,0 +1,4 @@
+bar_route:
+    path: /bar
+    defaults:
+        _controller: AppBundle:Bar:view

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/baz.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/baz.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="baz_route" path="/baz" controller="AppBundle:Baz:view" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/baz.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/baz.yml
@@ -1,0 +1,4 @@
+baz_route:
+    path: /baz
+    defaults:
+        _controller: AppBundle:Baz:view

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/import_multiple.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/import_multiple.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import resource="ba?.xml" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/import_multiple.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/import_multiple.yml
@@ -1,0 +1,2 @@
+_static:
+    resource: ba?.yml

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/import_single.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/import_single.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import resource="b?r.xml" />
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/import_single.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/import_single.yml
@@ -1,0 +1,2 @@
+_static:
+    resource: b?r.yml

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    return $routes->import('php_dsl_ba?.php');
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl_bar.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl_bar.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $collection = $routes->collection();
+
+    $collection->add('bar_route', '/bar')
+        ->defaults(['_controller' => 'AppBundle:Bar:view']);
+
+    return $collection;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl_bar.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl_bar.php
@@ -6,7 +6,7 @@ return function (RoutingConfigurator $routes) {
     $collection = $routes->collection();
 
     $collection->add('bar_route', '/bar')
-        ->defaults(['_controller' => 'AppBundle:Bar:view']);
+        ->defaults(array('_controller' => 'AppBundle:Bar:view'));
 
     return $collection;
 };

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl_baz.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl_baz.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $collection = $routes->collection();
+
+    $collection->add('baz_route', '/baz')
+        ->defaults(['_controller' => 'AppBundle:Baz:view']);
+
+    return $collection;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl_baz.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/glob/php_dsl_baz.php
@@ -6,7 +6,7 @@ return function (RoutingConfigurator $routes) {
     $collection = $routes->collection();
 
     $collection->add('baz_route', '/baz')
-        ->defaults(['_controller' => 'AppBundle:Baz:view']);
+        ->defaults(array('_controller' => 'AppBundle:Baz:view'));
 
     return $collection;
 };

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -117,4 +117,17 @@ class PhpFileLoaderTest extends TestCase
 
         $this->assertEquals($expectedCollection, $routeCollection);
     }
+
+    public function testRoutingConfiguratorCanImportGlobPatterns()
+    {
+        $locator = new FileLocator(array(__DIR__.'/../Fixtures/glob'));
+        $loader = new PhpFileLoader($locator);
+        $routeCollection = $loader->load('php_dsl.php');
+
+        $route = $routeCollection->get('bar_route');
+        $this->assertSame('AppBundle:Bar:view', $route->getDefault('_controller'));
+
+        $route = $routeCollection->get('baz_route');
+        $this->assertSame('AppBundle:Baz:view', $route->getDefault('_controller'));
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -361,4 +361,25 @@ class XmlFileLoaderTest extends TestCase
         $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/controller')));
         $loader->load('import_override_defaults.xml');
     }
+
+    public function testImportRouteWithGlobMatchingSingleFile()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/glob')));
+        $routeCollection = $loader->load('import_single.xml');
+
+        $route = $routeCollection->get('bar_route');
+        $this->assertSame('AppBundle:Bar:view', $route->getDefault('_controller'));
+    }
+
+    public function testImportRouteWithGlobMatchingMultipleFiles()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/glob')));
+        $routeCollection = $loader->load('import_multiple.xml');
+
+        $route = $routeCollection->get('bar_route');
+        $this->assertSame('AppBundle:Bar:view', $route->getDefault('_controller'));
+
+        $route = $routeCollection->get('baz_route');
+        $this->assertSame('AppBundle:Baz:view', $route->getDefault('_controller'));
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -182,4 +182,25 @@ class YamlFileLoaderTest extends TestCase
         $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/controller')));
         $loader->load('import_override_defaults.yml');
     }
+
+    public function testImportRouteWithGlobMatchingSingleFile()
+    {
+        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/glob')));
+        $routeCollection = $loader->load('import_single.yml');
+
+        $route = $routeCollection->get('bar_route');
+        $this->assertSame('AppBundle:Bar:view', $route->getDefault('_controller'));
+    }
+
+    public function testImportRouteWithGlobMatchingMultipleFiles()
+    {
+        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures/glob')));
+        $routeCollection = $loader->load('import_multiple.yml');
+
+        $route = $routeCollection->get('bar_route');
+        $this->assertSame('AppBundle:Bar:view', $route->getDefault('_controller'));
+
+        $route = $routeCollection->get('baz_route');
+        $this->assertSame('AppBundle:Baz:view', $route->getDefault('_controller'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22160
| License       | MIT
| Doc PR        | n/a

This fixes the import of resources specified using glob patterns in `XmlFileLoader` and `YamlFileLoader`.

@nicolas-grekas This supersedes #25633 that's been in limbo since December despite your comments, so I decided to take care of it as I need this to work. I took care of the two loaders that are affected, and added tests.