### PR TITLE
[Console] Fix docblock of DescriptorInterface::describe

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/DescriptorInterface.php
+++ b/src/Symfony/Component/Console/Descriptor/DescriptorInterface.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 interface DescriptorInterface
 {
     /**
-     * Describes an InputArgument instance.
+     * Describes an object if supported.
      *
      * @param OutputInterface $output
      * @param object          $object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes?

This might be the smallest commit ever, but I came across this docblock which seems to be incorrectly copied from https://github.com/symfony/symfony/blob/7101893b51cf6d6e2a9bc131eadefa0a02151d11/src/Symfony/Component/Console/Descriptor/Descriptor.php#L74 and it threw me off guard for a moment when I read it.

I can see more improvements being made (like mentioning the `InvalidArgumentException`) but I didn't want to overdo it.