### PR TITLE
[Console] Fix check of color support on Windows

### DIFF
--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -81,17 +81,26 @@ class StreamOutput extends Output
      *
      * Colorization is disabled if not supported by the stream:
      *
-     *  -  Windows != 10.0.10586 without Ansicon, ConEmu or Mintty
+     *  -  the stream is redirected (eg php file.php >log)
+     *  -  Windows without VT100 support, Ansicon, ConEmu, Mintty
      *  -  non tty consoles
      *
      * @return bool true if the stream supports colorization, false otherwise
      */
     protected function hasColorSupport()
     {
+        if (function_exists('stream_isatty') && !@stream_isatty($this->stream)) {
+            return false;
+        }
         if (DIRECTORY_SEPARATOR === '\\') {
+            if (function_exists('sapi_windows_vt100_support')) {
+                $vt100Enabled = @sapi_windows_vt100_support($this->stream);
+            } else {
+                $vt100Enabled = '10.0.10586' === PHP_WINDOWS_VERSION_MAJOR.'.'.PHP_WINDOWS_VERSION_MINOR.'.'.PHP_WINDOWS_VERSION_BUILD;
+            }
+
             return
-                function_exists('sapi_windows_vt100_support') && @sapi_windows_vt100_support($this->stream)
-                || '10.0.10586' === PHP_WINDOWS_VERSION_MAJOR.'.'.PHP_WINDOWS_VERSION_MINOR.'.'.PHP_WINDOWS_VERSION_BUILD
+                $vt100Enabled
                 || false !== getenv('ANSICON')
                 || 'ON' === getenv('ConEmuANSI')
                 || 'xterm' === getenv('TERM');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

If the stream is redirected, `StreamOutput::hasColorSupport()` returns `false` on POSIX systems.
On Windows, this is not always true. Before PHP 7.2 we can't say if the stream is redirected, but since PHP 7.2 we have the `stream_isatty` function that works on Windows too: let's use it.

Sure, `sapi_windows_vt100_support` should return `false` if the stream is redirected, but it's in `or` with the other conditions, so the logic was flawed.