### PR TITLE
[PHPunit] suite variable should be used

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV7.php
@@ -36,6 +36,6 @@ class CoverageListenerForV7 implements TestListener
 
     public function startTestSuite(TestSuite $suite): void
     {
-        $this->trait->startTest($test);
+        $this->trait->startTest($suite);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    
| Fixed tickets | 
| License       | MIT

If you using phpunit V7 with the CoverageListener you getting a error with `Undefined variable: test`