### PR TITLE
[RFC] [PropertyAccess] Allow using read and write access info for users

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -415,7 +415,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @return array
      */
-    private function getReadAccessInfo($class, $property)
+    public function getReadAccessInfo($class, $property)
     {
         $key = (false !== strpos($class, '@') ? rawurlencode($class) : $class).'..'.$property;
 
@@ -590,7 +590,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @param mixed $value
      */
-    private function getWriteAccessInfo(string $class, string $property, $value): array
+    public function getWriteAccessInfo(string $class, string $property, $value): array
     {
         $key = (false !== strpos($class, '@') ? rawurlencode($class) : $class).'..'.$property;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | yes  
| License       | MIT

Goal of this PR is to be able to retrieve more informations on the read / write acess info (accessor / mutator).

I have an use case where i need to get which accessor or mutator is used to read or write on a property for a specific class. My intent behind that is to generate the code instead of relying on the property acessor component, as i know that my schema will not change (or that the changes are never done on runtime and can be cached at each deployement). To be more clear this is something that i need to redo https://github.com/symfony/symfony/pull/17516 (but in a different way)

However there is other ways to do that and i am not sure that this change should be here, as there is some options:

### 1. Public methods

This is the changes that are here, also instead of returning an array this method could provide an object.
A new interface would be created (in order to have BC with the existing PropertyAcessorInterface)

### 2. Porting this code to the PropertyInfo component

Getting the accessor / mutator info on a property may be more suitable in the PropertyInfo component. So this code would be ported to the PropertyInfo component. Then a follow up PR could make PropertyAccess use the data from the PropertyInfo component (however it would induce a new required dependency for the PropertyAccess component)

### 3. Not wanted

Just close this PR then :)

PS: This is cleary not a finished PR and changes are only here to better describe my intent, i will do a new PR (or not) depending on the following discussion (as this is a RFC)