### PR TITLE
[SecurityBundle] Added an alias from RoleHierarchyInterface to security.role_hierarchy

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -96,6 +96,7 @@
         <service id="security.role_hierarchy" class="Symfony\Component\Security\Core\Role\RoleHierarchy">
             <argument>%security.role_hierarchy.roles%</argument>
         </service>
+        <service id="Symfony\Component\Security\Core\Role\RoleHierarchyInterface" alias="security.role_hierarchy" />
 
 
         <!-- Security Voters -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | I don't know
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

It's needed for autowirering

---

Note: I'm not sure if this is a bug fix or a new feature.