### PR TITLE
[Messenger] Remove the default transport if no `serializer` service

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -51,6 +51,12 @@ class MessengerPass implements CompilerPassInterface
             $container->removeDefinition('messenger.middleware.debug.logging');
         }
 
+        if (!$container->has('serializer')) {
+            $container->removeDefinition('messenger.transport.serialize_message_with_type_in_headers');
+            $container->removeAlias('messenger.transport.default_encoder');
+            $container->removeAlias('messenger.transport.default_decoder');
+        }
+
         $this->registerReceivers($container);
         $this->registerHandlers($container);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT

If the `serializer` service does not exist, we remove the default transport services as they rely on it.