### PR TITLE
[Workflow][Registry] Added a new 'all' method

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Added TransitionBlockers as a way to pass around reasons why exactly
    transitions can't be made.
  * Added a `MetadataStore`.
+ * Added Registry::all to return all the workflows associated with the specific subject
 
 4.0.0
 -----

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -11,7 +11,8 @@ CHANGELOG
  * Added TransitionBlockers as a way to pass around reasons why exactly
    transitions can't be made.
  * Added a `MetadataStore`.
- * Added Registry::all to return all the workflows associated with the specific subject
+ * Added `Registry::all` to return all the workflows associated with the
+   specific subject.
 
 4.0.0
 -----

--- a/src/Symfony/Component/Workflow/Registry.php
+++ b/src/Symfony/Component/Workflow/Registry.php
@@ -66,6 +66,23 @@ class Registry
         return $matched;
     }
 
+    /**
+     * @param object $subject
+     *
+     * @return Workflow[]
+     */
+    public function all($subject): array
+    {
+        $matched = array();
+        foreach ($this->workflows as list($workflow, $supportStrategy)) {
+            if ($supportStrategy->supports($workflow, $subject)) {
+                $matched[] = $workflow;
+            }
+        }
+
+        return $matched;
+    }
+
     private function supports(WorkflowInterface $workflow, $supportStrategy, $subject, $workflowName): bool
     {
         if (null !== $workflowName && $workflowName !== $workflow->getName()) {

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -81,6 +81,33 @@ class RegistryTest extends TestCase
         $this->assertSame('workflow1', $w1->getName());
     }
 
+    public function testAllWithOneMatchWithSuccess()
+    {
+        $workflows = $this->registry->all(new Subject1());
+        $this->assertInternalType('array', $workflows);
+        $this->assertCount(1, $workflows);
+        $this->assertInstanceOf(Workflow::class, $workflows[0]);
+        $this->assertSame('workflow1', $workflows[0]->getName());
+    }
+
+    public function testAllWithMultipleMatchWithSuccess()
+    {
+        $workflows = $this->registry->all(new Subject2());
+        $this->assertInternalType('array', $workflows);
+        $this->assertCount(2, $workflows);
+        $this->assertInstanceOf(Workflow::class, $workflows[0]);
+        $this->assertInstanceOf(Workflow::class, $workflows[1]);
+        $this->assertSame('workflow2', $workflows[0]->getName());
+        $this->assertSame('workflow3', $workflows[1]->getName());
+    }
+
+    public function testAllWithNoMatch()
+    {
+        $workflows = $this->registry->all(new \stdClass());
+        $this->assertInternalType('array', $workflows);
+        $this->assertCount(0, $workflows);
+    }
+
     /**
      * @group legacy
      */


### PR DESCRIPTION
[Workflow][Registry] Added the 'all' method which returns all the workflows associated to a specific object #26618

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26618
| License       | MIT
| Doc PR        | 

As explained in [26628](https://github.com/symfony/symfony/issues/26618#issuecomment-375624726)  I added the 'all' method which returns all the workflows associated to a specific object.
