### PR TITLE
Adding support to bind scalar values to controller arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -838,7 +838,7 @@ class Definition
     /**
      * Gets bindings.
      *
-     * @return array
+     * @return array|BoundArgument[]
      */
     public function getBindings()
     {

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -136,13 +136,16 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         $binding = $bindings[$bindingName];
 
                         list($bindingValue, $bindingId) = $binding->getValues();
+                        $binding->setValues(array($bindingValue, $bindingId, true));
 
                         if (!$bindingValue instanceof Reference) {
-                            continue;
+                            $args[$p->name] = new Reference('value.'.$container->hash($bindingValue));
+                            $container->register((string) $args[$p->name], 'mixed')
+                                ->setFactory('current')
+                                ->addArgument(array($bindingValue));
+                        } else {
+                            $args[$p->name] = $bindingValue;
                         }
-
-                        $binding->setValues(array($bindingValue, $bindingId, true));
-                        $args[$p->name] = $bindingValue;
 
                         continue;
                     } elseif (!$type || !$autowire) {

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -311,7 +311,7 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         return array(array(ControllerDummy::class), array('$bar'));
     }
 
-    public function testDoNotBindScalarValueToControllerArgument()
+    public function testBindScalarValueToControllerArgument()
     {
         $container = new ContainerBuilder();
         $resolver = $container->register('argument_resolver.service')->addArgument(array());
@@ -320,11 +320,24 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
             ->setBindings(array('$someArg' => '%foo%'))
             ->addTag('controller.service_arguments');
 
+        $container->setParameter('foo', 'foo_val');
+
         $pass = new RegisterControllerArgumentLocatorsPass();
         $pass->process($container);
 
         $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
-        $this->assertEmpty($locator);
+
+        $locator = $container->getDefinition((string) $locator['foo::fooAction']->getValues()[0]);
+
+        // assert the locator has a someArg key
+        $arguments = $locator->getArgument(0);
+        $this->assertArrayHasKey('someArg', $arguments);
+        $this->assertInstanceOf(ServiceClosureArgument::class, $arguments['someArg']);
+        // get the Reference that someArg points to
+        $reference = $arguments['someArg']->getValues()[0];
+        // make sure this service *does* exist and returns the correct value
+        $this->assertTrue($container->has((string) $reference));
+        $this->assertSame('foo_val', $container->get((string) $reference));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25960
| License       | MIT
| Doc PR        | symfony/symfony-docs#9477

Hi guys!

This fixes (I think) the last rough edge with autowiring & error messages. 100% credit to @nicolas-grekas for this implementation - he has generously allowed me to steal his code in return for writing the test. I did test this on a real project.

Cheers!