### PR TITLE
[SecurityBundle] allow using custom function inside allow_if expressions

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -81,6 +81,7 @@ Security
    functionality, create a custom user-checker based on the
    `Symfony\Component\Security\Core\User\UserChecker`.
  * `AuthenticationUtils::getLastUsername()` now always returns a string.
+ * The `ExpressionVoter::addExpressionLanguageProvider()` method is deprecated. Register the provider directly on the injected ExpressionLanguage instance instead.
 
 SecurityBundle
 --------------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -76,6 +76,7 @@ Security
 
  * The `ContextListener::setLogoutOnUserChange()` method has been removed.
  * The `Symfony\Component\Security\Core\User\AdvancedUserInterface` has been removed.
+ * The `ExpressionVoter::addExpressionLanguageProvider()` method has been removed.
 
 SecurityBundle
 --------------

--- a/src/Symfony/Bundle/SecurityBundle/CacheWarmer/ExpressionCacheWarmer.php
+++ b/src/Symfony/Bundle/SecurityBundle/CacheWarmer/ExpressionCacheWarmer.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\CacheWarmer;
+
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
+
+class ExpressionCacheWarmer implements CacheWarmerInterface
+{
+    private $expressions;
+    private $expressionLanguage;
+
+    /**
+     * @param iterable|Expression[] $expressions
+     */
+    public function __construct(iterable $expressions, ExpressionLanguage $expressionLanguage)
+    {
+        $this->expressions = $expressions;
+        $this->expressionLanguage = $expressionLanguage;
+    }
+
+    public function isOptional()
+    {
+        return true;
+    }
+
+    public function warmUp($cacheDir)
+    {
+        foreach ($this->expressions as $expression) {
+            $this->expressionLanguage->parse($expression, array('token', 'user', 'object', 'subject', 'roles', 'request', 'trust_resolver'));
+        }
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -80,7 +80,9 @@
 
         <service id="security.user_checker" class="Symfony\Component\Security\Core\User\UserChecker" />
 
-        <service id="security.expression_language" class="Symfony\Component\Security\Core\Authorization\ExpressionLanguage" />
+        <service id="security.expression_language" class="Symfony\Component\Security\Core\Authorization\ExpressionLanguage">
+            <argument type="service" id="cache.security_expression_language"></argument>
+        </service>
 
         <service id="security.authentication_utils" class="Symfony\Component\Security\Http\Authentication\AuthenticationUtils" public="true">
             <argument type="service" id="request_stack" />
@@ -194,6 +196,18 @@
             <tag name="validator.constraint_validator" alias="security.validator.user_password" />
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.encoder_factory" />
+        </service>
+
+        <!-- Cache -->
+        <service id="cache.security_expression_language" parent="cache.system" public="false">
+            <tag name="cache.pool" />
+        </service>
+
+        <!-- Cache Warmers -->
+        <service id="security.cache_warmer.expression" class="Symfony\Bundle\SecurityBundle\CacheWarmer\ExpressionCacheWarmer">
+            <tag name="kernel.cache_warmer" />
+            <argument type="collection" /> <!-- expressions -->
+            <argument type="service" id="security.expression_language" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\CacheWarmer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\CacheWarmer\ExpressionCacheWarmer;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
+
+class ExpressionCacheWarmerTest extends TestCase
+{
+    public function testWarmUp()
+    {
+        $expressions = array(new Expression('A'), new Expression('B'));
+
+        $expressionLang = $this->createMock(ExpressionLanguage::class);
+        $expressionLang->expects($this->exactly(2))
+            ->method('parse')
+            ->withConsecutive(
+                array($expressions[0], array('token', 'user', 'object', 'subject', 'roles', 'request', 'trust_resolver')),
+                array($expressions[1], array('token', 'user', 'object', 'subject', 'roles', 'request', 'trust_resolver'))
+            );
+
+        (new ExpressionCacheWarmer($expressions, $expressionLang))->warmUp('');
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
@@ -37,8 +37,13 @@ class ExpressionVoter implements VoterInterface
         $this->roleHierarchy = $roleHierarchy;
     }
 
+    /**
+     * @deprecated since Symfony 4.1, register the provider directly on the injected ExpressionLanguage instance instead.
+     */
     public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
     {
+        @trigger_error(sprintf('The %s() method is deprecated since Symfony 4.1, register the provider directly on the injected ExpressionLanguage instance instead.', __METHOD__), E_USER_DEPRECATED);
+
         $this->expressionLanguage->registerProvider($provider);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | yes
| Tests pass?   | no  
| Fixed tickets | https://github.com/symfony/symfony/issues/23208
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/9552

This is a follow-up for https://github.com/symfony/symfony/pull/26263

As discussed there I propose to allow using custom functions as a new feature only and thus targeting `master` here.

If we agree to move forward with this there are some todos:
- [x] fix tests
- [x] add cache warmer for allow_if expressions
- [x] update documentation to mention this new feature
- [x] update UPGRADE files

ping @nicolas-grekas @stof 
