### PR TITLE
Improved the Ajax profiler panel when there are exceptions

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/ajax.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/ajax.html.twig
@@ -14,12 +14,12 @@
             <table class="sf-toolbar-ajax-requests">
                 <thead>
                     <tr>
+                        <th>Profile</th>
                         <th>Method</th>
                         <th>Type</th>
                         <th>Status</th>
                         <th>URL</th>
                         <th>Time</th>
-                        <th>Profile</th>
                     </tr>
                 </thead>
                 <tbody class="sf-toolbar-ajax-request-list"></tbody>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -132,6 +132,10 @@
             var row = document.createElement('tr');
             request.DOMNode = row;
 
+            var profilerCell = document.createElement('td');
+            profilerCell.textContent = 'n/a';
+            row.appendChild(profilerCell);
+
             var methodCell = document.createElement('td');
             methodCell.textContent = request.method;
             row.appendChild(methodCell);
@@ -164,10 +168,6 @@
             durationCell.textContent = 'n/a';
             row.appendChild(durationCell);
 
-            var profilerCell = document.createElement('td');
-            profilerCell.textContent = 'n/a';
-            row.appendChild(profilerCell);
-
             row.className = 'sf-ajax-request sf-ajax-request-loading';
             tbody.insertBefore(row, tbody.firstChild);
 
@@ -182,11 +182,11 @@
             pendingRequests--;
             var row = request.DOMNode;
             /* Unpack the children from the row */
-            var methodCell = row.children[0];
-            var statusCodeCell = row.children[2];
+            var profilerCell = row.children[0];
+            var methodCell = row.children[1];
+            var statusCodeCell = row.children[3];
             var statusCodeElem = statusCodeCell.children[0];
-            var durationCell = row.children[4];
-            var profilerCell = row.children[5];
+            var durationCell = row.children[5];
 
             if (request.error) {
                 row.className = 'sf-ajax-request sf-ajax-request-error';
@@ -217,7 +217,7 @@
             if (request.profilerUrl) {
                 profilerCell.textContent = '';
                 var profilerLink = document.createElement('a');
-                profilerLink.setAttribute('href', request.profilerUrl);
+                profilerLink.setAttribute('href', request.statusCode < 400 ? request.profilerUrl : request.profilerUrl + '?panel=exception');
                 profilerLink.textContent = request.profile;
                 profilerCell.appendChild(profilerLink);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26646
| License       | MIT
| Doc PR        | -

This makes the following changes in the Ajax panel:

* The `Profiler` column is now the first one.
* When the response status code is `400` or higher, the profiler link points to the exception panel instead of the default request/response panel

![ajax-panel](https://user-images.githubusercontent.com/73419/37874477-52cf3888-3030-11e8-8042-23351f2e7a0f.png)
