### PR TITLE
[WebProfilerBundle] Live duration of AJAX request

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -168,6 +168,10 @@
             durationCell.textContent = 'n/a';
             row.appendChild(durationCell);
 
+            request.liveDurationHandle = setInterval(function() {
+                durationCell.textContent = (new Date() - request.start) + 'ms';
+            }, 100);
+
             row.className = 'sf-ajax-request sf-ajax-request-loading';
             tbody.insertBefore(row, tbody.firstChild);
 
@@ -176,6 +180,8 @@
 
         var finishAjaxRequest = function(index) {
             var request = requestStack[index];
+            clearInterval(request.liveDurationHandle);
+
             if (!request.DOMNode) {
                 return;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26645 
| License       | MIT
| Doc PR        | -

This will spit out current calculated AJAX request duration, before it finishes. Solves my DX issue about not knowing if request is still in progress.

![peek 2018-03-25 15-07](https://user-images.githubusercontent.com/496233/37875667-f45376a8-3042-11e8-87e5-24416b8ba670.gif)
