### PR TITLE
More compact display of vendor code in exception pages

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/trace.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/trace.html.twig
@@ -1,10 +1,10 @@
-<div class="trace-line-header break-long-words {{ trace.file|default(false) ? 'sf-toggle' }}" data-toggle-selector="#trace-html-{{ prefix }}-{{ i }}" data-toggle-initial="{{ _display_code_snippet ? 'display' }}">
+<div class="trace-line-header break-long-words {{ trace.file|default(false) ? 'sf-toggle' }}" data-toggle-selector="#trace-html-{{ prefix }}-{{ i }}" data-toggle-initial="{{ style == 'expanded' ? 'display' }}">
     {% if trace.file|default(false) %}
         <span class="icon icon-close">{{ include('@Twig/images/icon-minus-square.svg') }}</span>
         <span class="icon icon-open">{{ include('@Twig/images/icon-plus-square.svg') }}</span>
     {% endif %}
 
-    {% if trace.function %}
+    {% if style != 'compact' and trace.function %}
         <span class="trace-class">{{ trace.class|abbr_class }}</span>{% if trace.type is not empty %}<span class="trace-type">{{ trace.type }}</span>{% endif %}<span class="trace-method">{{ trace.function }}</span><span class="trace-arguments">({{ trace.args|format_args }})</span>
     {% endif %}
 
@@ -17,6 +17,7 @@
         <span class="block trace-file-path">
             in
             <a href="{{ file_link }}">{{ file_path_parts[:-1]|join(constant('DIRECTORY_SEPARATOR')) }}{{ constant('DIRECTORY_SEPARATOR') }}<strong>{{ file_path_parts|last }}</strong></a>
+            {%- if style == 'compact' and trace.function %}<span class="trace-type">{{ trace.type }}</span><span class="trace-method">{{ trace.function }}</span>{% endif %}
             (line {{ line_number }})
         </span>
     {% endif %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.html.twig
@@ -3,28 +3,34 @@
         <div class="trace-head">
             <span class="sf-toggle" data-toggle-selector="#trace-html-{{ index }}" data-toggle-initial="{{ expand ? 'display' }}">
                 <h3 class="trace-class">
+                    <span class="icon icon-close">{{ include('@Twig/images/icon-minus-square-o.svg') }}</span>
+                    <span class="icon icon-open">{{ include('@Twig/images/icon-plus-square-o.svg') }}</span>
+
                     <span class="trace-namespace">
                         {{ exception.class|split('\\')|slice(0, -1)|join('\\') }}
                         {{- exception.class|split('\\')|length > 1 ? '\\' }}
                     </span>
                     {{ exception.class|split('\\')|last }}
-
-                    <span class="icon icon-close">{{ include('@Twig/images/icon-minus-square-o.svg') }}</span>
-                    <span class="icon icon-open">{{ include('@Twig/images/icon-plus-square-o.svg') }}</span>
                 </h3>
 
                 {% if exception.message is not empty and index > 1 %}
                     <p class="break-long-words trace-message">{{ exception.message }}</p>
                 {% endif %}
             </span>
+
+            <form class="trace-toggle-vendors">
+                <input id="trace-html-{{ index }}-toggle-vendors" type="checkbox" checked aria-label="Toggle traces from vendors" onchange="var vendorTraces = document.querySelectorAll('#trace-html-{{ index }} .trace-from-vendor'); for (var i = 0; i < vendorTraces.length; i++) { vendorTraces[i].style.display = this.checked ? 'none' : 'block'; };" />
+                <label for="trace-html-{{ index }}-toggle-vendors">Hide vendors</label>
+            </form>
         </div>
 
         <div id="trace-html-{{ index }}" class="sf-toggle-content">
         {% set _is_first_user_code = true %}
         {% for i, trace in exception.trace %}
-            {% set _display_code_snippet = _is_first_user_code and ('/vendor/' not in trace.file) and ('/var/cache/' not in trace.file) and (trace.file is not empty) %}
+            {% set _is_vendor_trace = trace.file is not empty and ('/vendor/' in trace.file or '/var/cache/' in trace.file) %}
+            {% set _display_code_snippet = _is_first_user_code and not _is_vendor_trace %}
             {% if _display_code_snippet %}{% set _is_first_user_code = false %}{% endif %}
-            <div class="trace-line">
+            <div class="trace-line {{ _is_vendor_trace ? 'trace-from-vendor' }}">
                 {{ include('@Twig/Exception/trace.html.twig', { prefix: index, i: i, trace: trace, _display_code_snippet: _display_code_snippet }, with_context = false) }}
             </div>
         {% endfor %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/traces.html.twig
@@ -17,11 +17,6 @@
                     <p class="break-long-words trace-message">{{ exception.message }}</p>
                 {% endif %}
             </span>
-
-            <form class="trace-toggle-vendors">
-                <input id="trace-html-{{ index }}-toggle-vendors" type="checkbox" checked aria-label="Toggle traces from vendors" onchange="var vendorTraces = document.querySelectorAll('#trace-html-{{ index }} .trace-from-vendor'); for (var i = 0; i < vendorTraces.length; i++) { vendorTraces[i].style.display = this.checked ? 'none' : 'block'; };" />
-                <label for="trace-html-{{ index }}-toggle-vendors">Hide vendors</label>
-            </form>
         </div>
 
         <div id="trace-html-{{ index }}" class="sf-toggle-content">
@@ -31,7 +26,7 @@
             {% set _display_code_snippet = _is_first_user_code and not _is_vendor_trace %}
             {% if _display_code_snippet %}{% set _is_first_user_code = false %}{% endif %}
             <div class="trace-line {{ _is_vendor_trace ? 'trace-from-vendor' }}">
-                {{ include('@Twig/Exception/trace.html.twig', { prefix: index, i: i, trace: trace, _display_code_snippet: _display_code_snippet }, with_context = false) }}
+                {{ include('@Twig/Exception/trace.html.twig', { prefix: index, i: i, trace: trace, style: _is_vendor_trace ? 'compact' : _display_code_snippet ? 'expanded' }, with_context = false) }}
             </div>
         {% endfor %}
         </div>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
@@ -90,18 +90,22 @@ header .container { display: flex; justify-content: space-between; }
 .exception-illustration { flex-basis: 111px; flex-shrink: 0; height: 66px; margin-left: 15px; opacity: .7; }
 
 .trace + .trace { margin-top: 30px; }
-.trace-head { background-color: #e0e0e0; padding: 10px; }
-.trace-head .trace-class { color: #222; font-size: 18px; font-weight: bold; line-height: 1.3; margin: 0; position: relative; }
+.trace-head { background-color: #e0e0e0; padding: 10px; position: relative; }
+.trace-head .trace-class { color: #222; font-size: 18px; font-weight: bold; line-height: 1.3; margin: 0; padding-left: 28px; position: relative; }
 .trace-head .trace-namespace { color: #999; display: block; font-size: 13px; }
-.trace-head .icon { position: absolute; right: 0; top: 0; }
+.trace-head .icon { position: absolute; left: -3px; top: 0; }
 .trace-head .icon svg { height: 24px; width: 24px; }
 
-.trace-details { background: #FFF; border: 1px solid #E0E0E0; box-shadow: 0px 0px 1px rgba(128, 128, 128, .2); margin: 1em 0; }
+.trace-details { background: #FFF; border: 1px solid #E0E0E0; box-shadow: 0px 0px 1px rgba(128, 128, 128, .2); margin: 1em 0; table-layout: fixed; }
 
 .trace-message { font-size: 14px; font-weight: normal; margin: .5em 0 0; }
-.trace-details { table-layout: fixed; }
+
+.trace-toggle-vendors { position: absolute; top: 10px; right: 10px; }
+.trace-toggle-vendors label { cursor: pointer; margin-left: 2px; }
+
 .trace-line { position: relative; padding-top: 8px; padding-bottom: 8px; }
 .trace-line:hover { background: #F5F5F5; }
+.trace-line.trace-from-vendor { display: none; }
 .trace-line a { color: #222; }
 .trace-line .icon { opacity: .4; position: absolute; left: 10px; top: 11px; }
 .trace-line .icon svg { height: 16px; width: 16px; }

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/exception.css.twig
@@ -91,21 +91,18 @@ header .container { display: flex; justify-content: space-between; }
 
 .trace + .trace { margin-top: 30px; }
 .trace-head { background-color: #e0e0e0; padding: 10px; position: relative; }
-.trace-head .trace-class { color: #222; font-size: 18px; font-weight: bold; line-height: 1.3; margin: 0; padding-left: 28px; position: relative; }
+.trace-head .trace-class { color: #222; font-size: 18px; font-weight: bold; line-height: 1.3; margin: 0; position: relative; }
 .trace-head .trace-namespace { color: #999; display: block; font-size: 13px; }
-.trace-head .icon { position: absolute; left: -3px; top: 0; }
+.trace-head .icon { position: absolute; right: 0; top: 0; }
 .trace-head .icon svg { height: 24px; width: 24px; }
 
 .trace-details { background: #FFF; border: 1px solid #E0E0E0; box-shadow: 0px 0px 1px rgba(128, 128, 128, .2); margin: 1em 0; table-layout: fixed; }
 
 .trace-message { font-size: 14px; font-weight: normal; margin: .5em 0 0; }
 
-.trace-toggle-vendors { position: absolute; top: 10px; right: 10px; }
-.trace-toggle-vendors label { cursor: pointer; margin-left: 2px; }
-
 .trace-line { position: relative; padding-top: 8px; padding-bottom: 8px; }
+.trace-line + .trace-line { border-top: 1px solid #e0e0e0; }
 .trace-line:hover { background: #F5F5F5; }
-.trace-line.trace-from-vendor { display: none; }
 .trace-line a { color: #222; }
 .trace-line .icon { opacity: .4; position: absolute; left: 10px; top: 11px; }
 .trace-line .icon svg { height: 16px; width: 16px; }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23144
| License       | MIT
| Doc PR        | -

I like the general idea proposed in #23152 ... but I don't like the implementation ... so this PR is an alternative implementation.

**UPDATE**: the proposed feature has been completely redesigned. See https://github.com/symfony/symfony/pull/26671#issuecomment-376157869

~~The idea is to **hide by default all information that comes from "vendors"** (`vendor/` or `var/cache/` dir) because that code is out of your reach and you can't change it to fix your error.~~

~~In practice, each exception trace now would display a `Hide vendors` option enabled by default:~~

<details>
<summary>Click here to view the outdated images</summary>

![hide-vendors](https://user-images.githubusercontent.com/73419/37895113-a9d942bc-30e0-11e8-9ff4-191dcb057d60.png)

It works like a toggle ... and it's compatible with the overall toggle of each trace header:

![hide-vendors](https://user-images.githubusercontent.com/73419/37895137-b9e8d406-30e0-11e8-82bd-5729d32aaa63.gif)

When exceptions are complex, the amount of noise removed is massive:

## Before

![before](https://user-images.githubusercontent.com/73419/37895233-f9170eea-30e0-11e8-8c21-c514007d44d2.png)

## After

![after](https://user-images.githubusercontent.com/73419/37895240-fc2e50c0-30e0-11e8-9e5a-b7a73ba57b47.png)

</details>