### PR TITLE
[Messenger] Uses the `messenger.message_handler` tag instead of `message.handler`

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -31,7 +31,7 @@ class MessengerPass implements CompilerPassInterface
     private $messageHandlerResolverService;
     private $handlerTag;
 
-    public function __construct(string $messageBusService = 'message_bus', string $messageHandlerResolverService = 'messenger.handler_resolver', string $handlerTag = 'message_handler')
+    public function __construct(string $messageBusService = 'message_bus', string $messageHandlerResolverService = 'messenger.handler_resolver', string $handlerTag = 'messenger.message_handler')
     {
         $this->messageBusService = $messageBusService;
         $this->messageHandlerResolverService = $messageHandlerResolverService;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (technically, it's not even in 4.1)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT

After a few days using it, it feels weird to have the `messenger.receiver` and `messenger.sender` tags while the one for message handlers is `message_handler`. I believe that for consistency, this would make sense to rename this tag `messenger.message_handler`.

As we don't have tests for this pass yet (will be added in https://github.com/symfony/symfony/pull/26672) there is nothing else to change (but the documentation).