### PR TITLE
Support phpdbg SAPI in Debug::enable()

### DIFF
--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -1,11 +1,6 @@
 CHANGELOG
 =========
 
-2.7.1
------
-
-* fix support for PHPDBG SAPI in `Debug::enable()`
-
 2.7.0
 -----
 

--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.7.1
+-----
+
+* fix support for PHPDBG SAPI in `Debug::enable()`
+
 2.7.0
 -----
 

--- a/src/Symfony/Component/Debug/Debug.php
+++ b/src/Symfony/Component/Debug/Debug.php
@@ -45,7 +45,7 @@ class Debug
             error_reporting(-1);
         }
 
-        if ('cli' !== PHP_SAPI) {
+        if (!in_array(PHP_SAPI, array('cli', 'phpdbg'))) {
             ini_set('display_errors', 0);
             ExceptionHandler::register();
         } elseif ($displayErrors && (!ini_get('log_errors') || ini_get('error_log'))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

PHPDBG is a CLI PHP debugger which could be useful for debugging in development or for running PHPUnit tests with code coverage faster compared to XDebug.

It has CLI characteristics, but it runs as a different SAPI.