### PR TITLE
Display the request information in the exception page

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -66,6 +66,7 @@ class ExceptionController
                 'status_text' => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
                 'exception' => $exception,
                 'logger' => $logger,
+                'request_data' => $this->getRequestData($request),
                 'currentContent' => $currentContent,
             )
         ), 200, array('Content-Type' => $request->getMimeType($request->getRequestFormat()) ?: 'text/html'));
@@ -140,5 +141,25 @@ class ExceptionController
         }
 
         return false;
+    }
+
+    private function getRequestData(Request $request)
+    {
+        $data = array();
+
+        $data['headers'] = $request->headers->all();
+        $data['cookies'] = $request->cookies->all();
+        $data['get'] = $request->query->all();
+        $data['post'] = $request->request->all();
+        $data['server'] = $request->server->all();
+
+        $curlCommand = array('curl', '--compressed');
+        foreach ($request->headers->all() as $headerName => $headerValue) {
+            $curlCommand[] = sprintf('-H "%s: %s"', $headerName, addslashes($headerValue[0]));
+        }
+        $curlCommand[] = $request->getUri();
+        $data['as_curl_command'] = implode(" \\\n  ", $curlCommand);
+
+        return $data;
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
@@ -1,3 +1,23 @@
+{% macro table(labels, rows) %}
+    <table>
+    <thead>
+        <tr>
+            <th scope="col" class="key">{{ labels[0] ?? 'Key' }}</th>
+            <th scope="col">{{ labels[1] ?? 'Value' }}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for key in rows|keys|sort %}
+            <tr>
+                <th scope="row">{{ key }}</th>
+                <td>{{ rows[key] is iterable ? rows[key]|join('<br>') : rows[key] }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endmacro %}
+{% import _self as macros %}
+
 <div class="exception-summary {{ exception.message is empty ? 'exception-without-message' }}">
     <div class="exception-metadata">
         <div class="container">
@@ -72,6 +92,37 @@
             </div>
         </div>
         {% endif %}
+
+        <div class="tab">
+            <h3 class="tab-title">Request</h3>
+
+            <div class="tab-content">
+                <h3>Request as cURL command</h3>
+                <div class="highlight-terminal">
+                    <pre>{{ request_data.as_curl_command }}</pre>
+                </div>
+
+                <h3>Request Headers</h3>
+                {{ macros.table(['HTTP Header', 'Value'], request_data.headers) }}
+
+                {% if request_data.cookies is not empty %}
+                <h3>Request Cookies</h3>
+                {{ macros.table(['Name', 'Value'], request_data.cookies) }}
+                {% endif %}
+
+                {% if request_data.get is not empty %}
+                <h3>GET parameters</h3>
+                {{ macros.table(['Name', 'Value'], request_data.get) }}
+                {% endif %}
+
+                {% if request_data.post is not empty %}
+                <h3>POST parameters</h3>
+                {{ macros.table(['Name', 'Value'], request_data.post) }}
+                {% endif %}
+
+                <h3>Server parameters</h3>
+                {{ macros.table(['Name', 'Value'], request_data.server) }}
+        </div>
 
         <div class="tab">
             <h3 class="tab-title">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26186
| License       | MIT
| Doc PR        | -

This is a proof of concept. Code and design is not final. This is how it'd look:

![request-panel](https://user-images.githubusercontent.com/73419/37954962-8a2d68b8-31a7-11e8-81a7-87fa14d6346b.png)

Should we continue with this proposal or should we reject it? This new "Request" tab wouldn't replace "Request/Response" panel from the profiler. Here we don't display for example the request attributes (because they are complex and require VarDumper to work).