### PR TITLE
[Messenger] Add a `MessageHandlerInterface` (multiple messages + auto-configuration)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -60,6 +60,7 @@ use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\Store\StoreFactory;
 use Symfony\Component\Lock\StoreInterface;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\Transport\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\SenderInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -347,6 +348,8 @@ class FrameworkExtension extends Extension
             ->addTag('messenger.receiver');
         $container->registerForAutoconfiguration(SenderInterface::class)
             ->addTag('messenger.sender');
+        $container->registerForAutoconfiguration(MessageHandlerInterface::class)
+            ->addTag('messenger.message_handler');
 
         if (!$container->getParameter('kernel.debug')) {
             // remove tagged iterator argument for resource checkers

--- a/src/Symfony/Component/Messenger/Handler/MessageHandlerInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/MessageHandlerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+/**
+ * Handlers can implement this interface.
+ *
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ */
+interface MessageHandlerInterface
+{
+}

--- a/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+/**
+ * Handlers can implement this interface to handle multiple messages.
+ *
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ */
+interface MessageSubscriberInterface extends MessageHandlerInterface
+{
+    /**
+     * Return a list of messages to be handled.
+     *
+     * It returns a list of messages like in the following example:
+     *
+     *     return [MyMessage::class];
+     *
+     * It can also change the priority per classes.
+     *
+     *     return [
+     *         [FirstMessage::class, 0],
+     *         [SecondMessage::class, -10],
+     *     ];
+     *
+     * The `__invoke` method of the handler will be called as usual with the message to handle.
+     *
+     * @return array
+     */
+    public static function getHandledMessages(): array;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

Based on @chalasr's PR: https://github.com/symfony/symfony/pull/26672.

This reduces the hassle of registering handlers: it allows the auto-configuration with a new interface `HandlerInterface`. At the same time, it allows a handler to handle multiple messages.