### PR TITLE
[DI] Allow to merge imported parameters that are arrays

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -814,6 +814,7 @@ class YamlFileLoader extends FileLoader
      *
      * @param mixed $left
      * @param mixed $right
+     *
      * @return mixed[]|string
      */
     private function merge($left, $right)
@@ -829,8 +830,9 @@ class YamlFileLoader extends FileLoader
                     $right[$key] = $val;
                 }
             }
+
             return $right;
-        } elseif ($left === null && is_array($right)) {
+        } elseif (null === $left && is_array($right)) {
             return $right;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -809,7 +809,7 @@ class YamlFileLoader extends FileLoader
     /**
      * Merges configurations. Left has higher priority than right one.
      *
-     * @autor David Grudl (https://davidgrudl.com)
+     * @author David Grudl (https://davidgrudl.com)
      * @source https://github.com/nette/di/blob/8eb90721a131262f17663e50aee0032a62d0ef08/src/DI/Config/Helpers.php#L31
      *
      * @param mixed $left

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/parameters-with-import.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/parameters-with-import.yml
@@ -1,0 +1,5 @@
+imports:
+    - { resource: 'parameters.yml' }
+
+parameters:
+    key: new_value

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/parameters.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/parameters.yml
@@ -1,0 +1,2 @@
+parameters:
+    key: old_value

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -739,6 +739,15 @@ class YamlFileLoaderTest extends TestCase
         ), array_map(function ($v) { return $v->getValues()[0]; }, $definition->getBindings()));
     }
 
+    public function testParameters()
+    {
+        $containerBuilder = new ContainerBuilder();
+        $loader = new YamlFileLoader($containerBuilder, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('parameters.yml');
+
+        $this->assertSame('old_value', $containerBuilder->getParameter('key'));
+    }
+
     public function testMergeParametersFromImports()
     {
         $containerBuilder = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -738,4 +738,13 @@ class YamlFileLoaderTest extends TestCase
             '$factory' => 'factory',
         ), array_map(function ($v) { return $v->getValues()[0]; }, $definition->getBindings()));
     }
+
+    public function testMergeParametersFromImports()
+    {
+        $containerBuilder = new ContainerBuilder();
+        $loader = new YamlFileLoader($containerBuilder, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('parameters-with-import.yml');
+
+        $this->assertSame('new_value', $containerBuilder->getParameter('key'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes 
| License       | MIT

**There is no way to use parameters from the parent config at the moment.** They're only removed.

It caused many troubles that are described in these issues:

- https://github.com/Symplify/Symplify/issues/719
- https://github.com/Symplify/Symplify/issues/736
- https://github.com/Symplify/Symplify/issues/696

I see 2 possible solutions to this.

## 1. Merge parameters (BC break)

### Example of Current State

`parent-config.yml`

```yaml
parameters:
    key: old_value
    another_key:
       - skip_this
```

`config.yml`

```yaml
imports:
    - { resource: 'parent-config.yml' }

paramters:
    key: new_value
    another_key:
       - skip_that_too
```


### Result

```yaml
parameters:
    key: new_value
    another_key:
       - skip_that_too
```

### Expected Result with this PR

```yaml
parameters:
    key: new_value
    another_key:
       - skip_this
       - skip_that_too
```

This PR changed this behaviour. It merges parameters deep and combines them together.

At the moment the only workaround is to use reflection and [call many private methods](https://github.com/Symplify/Symplify/blob/efe794cb99f5fe0955213a00423acd4ae1176096/packages/EasyCodingStandard/src/Yaml/CheckerTolerantYamlFileLoader.php#L58-L101).

```php
use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;

class ArrayParametersYamlFileLoader extends YamlFileLoader
{
   // ...

    /**
     * Same as parent, just merging parameters instead overriding them
     *
     * @see https://github.com/Symplify/Symplify/pull/697
     *
     * @param mixed $resource
     * @param string|null $type
     */
    public function load($resource, $type = null): void
    {
        $path = $this->locator->locate($resource);
        $content = $this->loadFile($path);
        $this->container->fileExists($path);
        // empty file
        if ($content === null) {
            return;
        }
        // imports
        // $this->parseImports($content, $path);
        $this->privatesCaller->callPrivateMethod($this, 'parseImports', $content, $path);
        // parameters
        if (isset($content[self::PARAMETERS_KEY])) {
            $this->ensureParametersIsArray($content, $path);
            foreach ($content[self::PARAMETERS_KEY] as $key => $value) {
                // $this->resolveServices($value, $path, true),
                $resolvedValue = $this->privatesCaller->callPrivateMethod(
                    $this,
                    'resolveServices',
                    $value,
                    $path,
                    true
                );
                // only this section is different
                if ($this->container->hasParameter($key)) {
                    $newValue = $this->parametersMerger->merge(
                        $resolvedValue,
                        $this->container->getParameter($key)
                    );
                    $this->container->setParameter($key, $newValue);
                       $resolvedValue,
                        $this->container->getParameter($key)
                    );
                    $this->container->setParameter($key, $newValue);
                } else {
                    $this->container->setParameter($key, $resolvedValue);
                }
            }
        }
        // extensions
        // $this->loadFromExtensions($content);
        $this->privatesCaller->callPrivateMethod($this, 'loadFromExtensions', $content);
        // services - not accessible, private parent properties, luckily not needed
        // $this->anonymousServicesCount = 0;
        // $this->anonymousServicesSuffix = ContainerBuilder::hash($path);
        $this->setCurrentDir(dirname($path));
        try {
            // $this->parseDefinitions($content, $path);
            $this->privatesCaller->callPrivateMethod($this, 'parseDefinitions', $content, $path);
        } finally {
            $this->instanceof = [];
        }
    }

}
```

Or is there any other way to solve this?

## 2 Adding new `protected` method might also help

```php
protected function addParameter($key, $value)
{
    // do merge or override
}
```
