### PR TITLE
Use 3rd person verb form in command description

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolPruneCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolPruneCommand.php
@@ -44,7 +44,7 @@ final class CachePoolPruneCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Prune cache pools')
+            ->setDescription('Prunes cache pools')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command deletes all expired items from all pruneable pools.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The other commands have their descriptions written using the 3rd person singular form ([he/she] prunes) as opposed to the imperative form (prune). `cache:pool:prune` doesn't. This PR fixes that.

Admittedly, it is a tiny and rather unimportant change, but I just noticed it and thought it should be fixed.