### PR TITLE
[VarDumper] Easy server dumper registration

### DIFF
--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\VarDumper;
 
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
 // Load the global dump() function
@@ -29,7 +30,7 @@ class VarDumper
     {
         if (null === self::$handler) {
             $cloner = new VarCloner();
-            $dumper = \in_array(PHP_SAPI, array('cli', 'phpdbg'), true) ? new CliDumper() : new HtmlDumper();
+            $dumper = self::getDefaultDumper();
             self::$handler = function ($var) use ($cloner, $dumper) {
                 $dumper->dump($cloner->cloneVar($var));
             };
@@ -38,11 +39,22 @@ class VarDumper
         return call_user_func(self::$handler, $var);
     }
 
+    /**
+     * @final since 4.1
+     */
     public static function setHandler(callable $callable = null)
     {
         $prevHandler = self::$handler;
         self::$handler = $callable;
 
         return $prevHandler;
+    }
+
+    /**
+     * @final
+     */
+    public static function getDefaultDumper(): DataDumperInterface
+    {
+        return \in_array(PHP_SAPI, array('cli', 'phpdbg'), true) ? new CliDumper() : new HtmlDumper();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Following #26654, this is another step aiming to ease usage of the server dumper feature in any situation.

The new `ServerDumper::register()` method allows to easily configure & set the ServerDumper as main handler in one line.

The new `$lock` flag might not be the ideal solution, but is answering issues when registering the server dumper as main handler but being overwritten by another process (like in tests for instance. PR acting as a real use-case incoming => https://github.com/symfony/symfony/pull/26696). 
Anyway, I'm open to any suggestion :)