### PR TITLE
[VarDumper][PhpUnitBridge] VarDumperServerListener

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/VarDumperServerListenerForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/VarDumperServerListenerForV5.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @internal
+ */
+class VarDumperServerListenerForV5 extends \PHPUnit_Framework_BaseTestListener implements ContextProviderInterface
+{
+    private $trait;
+
+    public function __construct(string $host = null)
+    {
+        $this->trait = new VarDumperServerListenerTrait($host);
+    }
+
+    public function startTest(\PHPUnit_Framework_Test $test)
+    {
+        $this->trait->startTest($test);
+    }
+
+    public function getContext(): ?array
+    {
+        $this->trait->getContext();
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Legacy/VarDumperServerListenerForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/VarDumperServerListenerForV6.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+use PHPUnit\Framework\BaseTestListener;
+use PHPUnit\Framework\Test;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @internal
+ */
+class VarDumperServerListenerForV6 extends BaseTestListener implements ContextProviderInterface
+{
+    private $trait;
+
+    public function __construct(string $host = null)
+    {
+        $this->trait = new VarDumperServerListenerTrait($host);
+    }
+
+    public function startTest(Test $test)
+    {
+        $this->trait->startTest($test);
+    }
+
+    public function getContext(): ?array
+    {
+        $this->trait->getContext();
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Legacy/VarDumperServerListenerForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/VarDumperServerListenerForV7.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
+use PHPUnit\Framework\TestSuite;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @internal
+ */
+class VarDumperServerListenerForV7 implements TestListener, ContextProviderInterface
+{
+    use TestListenerDefaultImplementation;
+
+    private $trait;
+
+    public function __construct(string $host = null)
+    {
+        $this->trait = new VarDumperServerListenerTrait($host);
+    }
+
+    public function startTestSuite(TestSuite $suite): void
+    {
+        $this->trait->startTest($suite);
+    }
+
+    public function getContext(): ?array
+    {
+        $this->trait->getContext();
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Legacy/VarDumperServerListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/VarDumperServerListenerTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\VarDumperServerListener;
+use Symfony\Component\VarDumper\Dumper\ServerDumper;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @internal
+ */
+class VarDumperServerListenerTrait
+{
+    /** @var TestCase|null */
+    private $currentTestCase;
+
+    public function __construct(string $host = null)
+    {
+        if (!class_exists(ServerDumper::class)) {
+            throw new \LogicException(sprintf('The "%s" class is required for using the "%s" listener. Install "symfony/var-dumper" version 4.1 or above.', ServerDumper::class, VarDumperServerListener::class));
+        }
+
+        ServerDumper::register($host, true, array('phpunit' => $this));
+    }
+
+    public function startTest($test)
+    {
+        if (!$test instanceof TestCase) {
+            $this->currentTestCase = null;
+
+            return;
+        }
+
+        $this->currentTestCase = $test;
+    }
+
+    public function getContext(): ?array
+    {
+        if (!$this->currentTestCase) {
+            return null;
+        }
+
+        return array(
+            'identifier' => spl_object_hash($this->currentTestCase),
+            'test_class' => \get_class($this->currentTestCase),
+            'test_case' => $this->currentTestCase->getName(),
+        );
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/VarDumperServerListener.php
+++ b/src/Symfony/Bridge/PhpUnit/VarDumperServerListener.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit;
+
+if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
+    class_alias('Symfony\Bridge\PhpUnit\Legacy\VarDumperServerListenerForV5', 'Symfony\Bridge\PhpUnit\VarDumperServerListener');
+} elseif (version_compare(\PHPUnit\Runner\Version::id(), '7.0.0', '<')) {
+    class_alias('Symfony\Bridge\PhpUnit\Legacy\VarDumperServerListenerForV6', 'Symfony\Bridge\PhpUnit\VarDumperServerListener');
+} else {
+    class_alias('Symfony\Bridge\PhpUnit\Legacy\VarDumperServerListenerForV7', 'Symfony\Bridge\PhpUnit\VarDumperServerListener');
+}
+
+if (false) {
+    class VarDumperServerListener
+    {
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -22,6 +22,7 @@
     },
     "suggest": {
         "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader",
+        "symfony/var-dumper": "To use the VarDumperServerListener",
         "ext-zip": "Zip support is required when using bin/simple-phpunit"
     },
     "conflict": {

--- a/src/Symfony/Component/VarDumper/Command/Descriptor/CliDescriptor.php
+++ b/src/Symfony/Component/VarDumper/Command/Descriptor/CliDescriptor.php
@@ -43,7 +43,11 @@ class CliDescriptor implements DumpDescriptorInterface
         $this->lastIdentifier = $clientId;
 
         $section = "Received from client #$clientId";
-        if (isset($context['request'])) {
+        if (isset($context['phpunit'])) {
+            $phpunit = $context['phpunit'];
+            $this->lastIdentifier = $phpunit['identifier'];
+            $section = sprintf('%s::%s', $phpunit['test_class'], $phpunit['test_case']);
+        } elseif (isset($context['request'])) {
             $request = $context['request'];
             $this->lastIdentifier = $request['identifier'];
             $section = sprintf('%s %s', $request['method'], $request['uri']);

--- a/src/Symfony/Component/VarDumper/Command/Descriptor/HtmlDescriptor.php
+++ b/src/Symfony/Component/VarDumper/Command/Descriptor/HtmlDescriptor.php
@@ -42,7 +42,11 @@ class HtmlDescriptor implements DumpDescriptorInterface
         }
 
         $title = '-';
-        if (isset($context['request'])) {
+        if (isset($context['phpunit'])) {
+            $phpunit = $context['phpunit'];
+            $title = '<code>PhpUnit</code>'.sprintf('%s::%s', $phpunit['test_class'], $phpunit['test_case']);
+            $dedupIdentifier = $phpunit['identifier'];
+        } elseif (isset($context['request'])) {
             $request = $context['request'];
             $title = sprintf('<code>%s</code> <a href="%s">%s</a>', $request['method'], $uri = $request['uri'], $uri);
             $dedupIdentifier = $request['identifier'];

--- a/src/Symfony/Component/VarDumper/Dumper/ServerDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ServerDumper.php
@@ -11,8 +11,16 @@
 
 namespace Symfony\Component\VarDumper\Dumper;
 
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\CliContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\RequestContextProvider;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
+use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * ServerDumper forwards serialized Data clones to a server.
@@ -40,6 +48,42 @@ class ServerDumper implements DataDumperInterface
         $this->host = $host;
         $this->wrappedDumper = $wrappedDumper;
         $this->contextProviders = $contextProviders;
+    }
+
+    /**
+     * @final
+     */
+    public static function getDefaultContextProviders(Request $request = null, string $projectDir = null): array
+    {
+        $contextProviders = array();
+
+        if ('cli' !== PHP_SAPI && ($request || class_exists(Request::class))) {
+            $requestStack = new RequestStack();
+            $requestStack->push($request ?? Request::createFromGlobals());
+            $contextProviders['request'] = new RequestContextProvider($requestStack);
+        }
+
+        $fileLinkFormatter = class_exists(FileLinkFormatter::class) ? new FileLinkFormatter(null, $requestStack ?? null, $projectDir) : null;
+
+        return $contextProviders + array(
+            'cli' => new CliContextProvider(),
+            'source' => new SourceContextProvider(null, $projectDir, $fileLinkFormatter),
+        );
+    }
+
+    /**
+     * @final
+     */
+    public static function register(string $host = null, bool $lock = false, array $contextProviders = array()): ?callable
+    {
+        $contextProviders += self::getDefaultContextProviders();
+        $host = $host ?? $_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912';
+        $cloner = new VarCloner();
+        $dumper = new self($host, VarDumper::getDefaultDumper(), $contextProviders);
+
+        return VarDumper::setHandler(function ($var) use ($dumper, $cloner) {
+            $dumper->dump($cloner->cloneVar($var));
+        }, $lock);
     }
 
     public function getContextProviders(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Based on previous PR (https://github.com/symfony/symfony/pull/26695) about easy server dumper as main handler registration.

Keeping exploring different usages for the server dumper feature, this provides a PhpUnit listener you can configure to automatically register the server dumper (allowing to get better context about dumps, cli & html format & avoid mixing the test suite output with wild cli dumps).

<details>

<summary>Considering the following changes in the symfony-demo</summary>

```diff
diff --git a/phpunit.xml.dist b/phpunit.xml.dist
index d545bf4..90e9a18 100644
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,5 +34,6 @@
         <!-- it begins a database transaction before every testcase and rolls it back after
              the test finished, so tests can manipulate the database without affecting other tests -->
         <listener class="\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitListener" />
+        <listener class="\Symfony\Bridge\PhpUnit\VarDumperServerListener" />
     </listeners>
 </phpunit>
diff --git a/src/Controller/BlogController.php b/src/Controller/BlogController.php
index e3e30aa..e2f4633 100644
--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -50,6 +50,7 @@ class BlogController extends AbstractController
      */
     public function index(int $page, string $_format, PostRepository $posts): Response
     {
+        dump(__METHOD__);
         $latestPosts = $posts->findLatest($page);

         // Every template name also has two extensions that specify the format and
diff --git a/tests/Controller/BlogControllerTest.php b/tests/Controller/BlogControllerTest.php
index 822cd43..04d5e1c 100644
--- a/tests/Controller/BlogControllerTest.php
+++ b/tests/Controller/BlogControllerTest.php
@@ -28,14 +28,19 @@ class BlogControllerTest extends WebTestCase
 {
     public function testIndex()
     {
+        dump('Start '.__METHOD__);
         $client = static::createClient();
         $crawler = $client->request('GET', '/en/blog/');

+        dump('After request '.__METHOD__);
+
         $this->assertCount(
             Post::NUM_ITEMS,
             $crawler->filter('article.post'),
             'The homepage displays the right number of posts.'
         );
+
+        dump('End '.__METHOD__);
     }

     public function testRss()
```

</details>

running `vendor/bin/simple-phpunit --filter=BlogControllerTest::testIndex` and with server up will generate:

|CLI|HTML|
|--|--|
|![capture d ecran 2018-03-28 a 14 50 39](https://user-images.githubusercontent.com/2211145/38029918-6ed11812-3297-11e8-89f7-cc22b522b111.png)|![capture d ecran 2018-03-28 a 14 49 17](https://user-images.githubusercontent.com/2211145/38029855-462feb90-3297-11e8-928a-92cb52de796d.png) (_Note: the HTML output shows most recent dumps first)_|

giving proper context about the test case in dedicated output instead of this mess:

```sh
PHPUnit 6.5.7 by Sebastian Bergmann and contributors.

Testing Project Test Suite
"Start App\Tests\Controller\BlogControllerTest::testIndex"
"App\Controller\BlogController::index"
"After request App\Tests\Controller\BlogControllerTest::testIndex"
"End App\Tests\Controller\BlogControllerTest::testIndex"
.                                                                   1 / 1 (100%)

Time: 267 ms, Memory: 24.00MB
```

(of course the output is quite simple here)

However, by setting the `debug.dump_destination: ` on test env too, and by not locking the handler from the PhpUnit listener, you'll get better context about the controller's dump:

![capture d ecran 2018-03-28 a 14 56 06](https://user-images.githubusercontent.com/2211145/38030245-55b7b07e-3298-11e8-8364-b34a10e1bc38.png)

but right after the request is executed, the server dumper in use still is the one registered by the `DebugBundle`, so we're now loosing the PhpUnit context.
So, right now, I don't know how to get the best of both worlds. https://github.com/ogizanagi/symfony/commit/23a80bbdbe179daa020d5ebac1d4613b19d42875 is an attempt to this, but is not bullet-proof.

Any feedback welcome.