### PR TITLE
[Messenger] Fix messenger profiler name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/MessengerDataCollector.php
@@ -34,7 +34,7 @@ class MessengerDataCollector extends DataCollector implements MiddlewareInterfac
      */
     public function getName()
     {
-        return 'messages';
+        return 'messenger';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26674
| License       | MIT
| Doc PR        | ø

In #26674, the profiler name was not renamed properly, which means it wasn't displayed anymore.