### PR TITLE
[Messenger] Make NoHandlerForMessageException a logic exception

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/NoHandlerForMessageException.php
+++ b/src/Symfony/Component/Messenger/Exception/NoHandlerForMessageException.php
@@ -14,6 +14,6 @@ namespace Symfony\Component\Messenger\Exception;
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-class NoHandlerForMessageException extends \RuntimeException implements ExceptionInterface
+class NoHandlerForMessageException extends \LogicException implements ExceptionInterface
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://github.com/symfony/symfony/pull/26648#discussion_r178049882   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

To me, a missing handler for a message is a program logic exception (or misconfiguration). Even if it's only detected at runtime here. 
It's the same as `ServiceNotFoundException` which even is an `\InvalidArgumentException`. Could eventually also be the case here.