### PR TITLE
[Console] Added environment variable for console color setting

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -13,11 +13,6 @@
             <tag name="monolog.logger" channel="console" />
         </service>
 
-        <service id="console.color_listener" class="Symfony\Component\Console\EventListener\CommandColorListener">
-            <tag name="kernel.event_subscriber" />
-            <argument>SYM_COLOR</argument>
-        </service>
-
         <service id="console.command.about" class="Symfony\Bundle\FrameworkBundle\Command\AboutCommand">
             <tag name="console.command" command="about" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -13,6 +13,11 @@
             <tag name="monolog.logger" channel="console" />
         </service>
 
+        <service id="console.color_listener" class="Symfony\Component\Console\EventListener\CommandColorListener">
+            <tag name="kernel.event_subscriber" />
+            <argument>SYM_COLOR</argument>
+        </service>
+
         <service id="console.command.about" class="Symfony\Bundle\FrameworkBundle\Command\AboutCommand">
             <tag name="console.command" command="about" />
         </service>

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added option to run suggested command if command is not found and only 1 alternative is available
  * added option to modify console output and print multiple modifiable sections
+ * added option to use an environment variable to control color formatting
 
 4.0.0
 -----

--- a/src/Symfony/Component/Console/EventListener/CommandColorListener.php
+++ b/src/Symfony/Component/Console/EventListener/CommandColorListener.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Symfony\Component\Console\EventListener;
+
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Adds support for an environment variable to enable/disable colors
+ *
+ * Example use case:
+ *     Running commands from crontab, rather than adding '--no-asci' to all
+ *     entries, adds an environment variable
+ */
+class CommandColorListener implements EventSubscriberInterface
+{
+    /**
+     * @var string
+     */
+    protected $varName = null;
+
+    /**
+     * @param string $varName
+     */
+    public function __construct(string $varName)
+    {
+        $this->varName = $varName;
+    }
+
+    /**
+     * Sets the decorated output option when an environment variable is set
+     *
+     * @param ConsoleCommandEvent $event
+     */
+    public function onConsoleCommand(ConsoleCommandEvent $event)
+    {
+        $color = strtolower(getenv($this->varName, true) ?: getenv($this->varName));
+
+        if (empty($color)) {
+            return;
+        }
+
+        $event->getOutput()->setDecorated(in_array($color, ['true', 'y', 'yes']));
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ConsoleEvents::COMMAND => array('onConsoleCommand', 0),
+        ];
+    }
+}

--- a/src/Symfony/Component/Console/EventListener/CommandColorListener.php
+++ b/src/Symfony/Component/Console/EventListener/CommandColorListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Console\EventListener;
 
 use Symfony\Component\Console\Event\ConsoleCommandEvent;

--- a/src/Symfony/Component/Console/EventListener/CommandColorListener.php
+++ b/src/Symfony/Component/Console/EventListener/CommandColorListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\EventListener;
 
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**

--- a/src/Symfony/Component/Console/EventListener/CommandColorListener.php
+++ b/src/Symfony/Component/Console/EventListener/CommandColorListener.php
@@ -50,7 +50,7 @@ class CommandColorListener implements EventSubscriberInterface
             return;
         }
 
-        $event->getOutput()->setDecorated(in_array($color, array('true', 'y', 'yes')));
+        $event->getOutput()->setDecorated(in_array($color, array('true', 'y', 'yes', '1')));
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/Console/EventListener/CommandColorListener.php
+++ b/src/Symfony/Component/Console/EventListener/CommandColorListener.php
@@ -3,11 +3,10 @@
 namespace Symfony\Component\Console\EventListener;
 
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Adds support for an environment variable to enable/disable colors
+ * Adds support for an environment variable to enable/disable colors.
  *
  * Example use case:
  *     Running commands from crontab, rather than adding '--no-asci' to all
@@ -29,7 +28,7 @@ class CommandColorListener implements EventSubscriberInterface
     }
 
     /**
-     * Sets the decorated output option when an environment variable is set
+     * Sets the decorated output option when an environment variable is set.
      *
      * @param ConsoleCommandEvent $event
      */
@@ -41,13 +40,13 @@ class CommandColorListener implements EventSubscriberInterface
             return;
         }
 
-        $event->getOutput()->setDecorated(in_array($color, ['true', 'y', 'yes']));
+        $event->getOutput()->setDecorated(in_array($color, array('true', 'y', 'yes')));
     }
 
     public static function getSubscribedEvents()
     {
-        return [
+        return array(
             ConsoleEvents::COMMAND => array('onConsoleCommand', 0),
-        ];
+        );
     }
 }

--- a/src/Symfony/Component/Console/Tests/EventListener/CommandColorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/CommandColorListenerTest.php
@@ -53,41 +53,41 @@ class CommandColorListenerTest extends TestCase
         $this->fixture->onConsoleCommand(
             $this->createConfiguredMock(
                 ConsoleCommandEvent::class,
-                [
+                array(
                     'getOutput' => $output,
-                ]
+                )
             )
         );
     }
 
     public function sampleValueList()
     {
-        return [
-            [
+        return array(
+            array(
                 'TRUE',
                 true,
-            ],
-            [
+            ),
+            array(
                 'y',
                 true,
-            ],
-            [
+            ),
+            array(
                 'yes',
                 true,
-            ],
-            [
+            ),
+            array(
                 'n',
                 false,
-            ],
-            [
+            ),
+            array(
                 'false',
                 false,
-            ],
-            [
+            ),
+            array(
                 uniqid(),
                 false,
-            ],
-        ];
+            ),
+        );
     }
 
     public function testNotSet()
@@ -100,9 +100,9 @@ class CommandColorListenerTest extends TestCase
         $this->fixture->onConsoleCommand(
             $this->createConfiguredMock(
                 ConsoleCommandEvent::class,
-                [
+                array(
                     'getOutput' => $output,
-                ]
+                )
             )
         );
     }
@@ -110,11 +110,10 @@ class CommandColorListenerTest extends TestCase
     public function testGetSubscribedEvents()
     {
         $this->assertEquals(
-            [
+            array(
                 ConsoleEvents::COMMAND => array('onConsoleCommand', 0),
-            ],
+            ),
             CommandColorListener::getSubscribedEvents()
         );
     }
-
 }

--- a/src/Symfony/Component/Console/Tests/EventListener/CommandColorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/CommandColorListenerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Symfony\Component\Console\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\EventListener\CommandColorListener;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CommandColorListenerTest extends TestCase
+{
+    /**
+     * @var CommandColorListener
+     */
+    protected $fixture = null;
+
+    /**
+     * @var string
+     */
+    protected static $varName = null;
+
+    public static function setUpBeforeClass()
+    {
+        do {
+            self::$varName = uniqid('CommandColorListener');
+        } while (!empty(getenv(self::$varName)));
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->fixture = new CommandColorListener(self::$varName);
+    }
+
+    protected function tearDown()
+    {
+        if (!empty(self::$varName)) {
+            putenv(self::$varName.'=');
+        }
+    }
+
+    /**
+     * @dataProvider sampleValueList
+     */
+    public function testSetDecorated($set, $expected)
+    {
+        putenv(self::$varName.'='.$set);
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects($this->once())->method('setDecorated')->with($expected);
+
+        $this->fixture->onConsoleCommand(
+            $this->createConfiguredMock(
+                ConsoleCommandEvent::class,
+                [
+                    'getOutput' => $output,
+                ]
+            )
+        );
+    }
+
+    public function sampleValueList()
+    {
+        return [
+            [
+                'TRUE',
+                true,
+            ],
+            [
+                'y',
+                true,
+            ],
+            [
+                'yes',
+                true,
+            ],
+            [
+                'n',
+                false,
+            ],
+            [
+                'false',
+                false,
+            ],
+            [
+                uniqid(),
+                false,
+            ],
+        ];
+    }
+
+    public function testNotSet()
+    {
+        putenv(self::$varName.'=');
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects($this->never())->method('setDecorated');
+
+        $this->fixture->onConsoleCommand(
+            $this->createConfiguredMock(
+                ConsoleCommandEvent::class,
+                [
+                    'getOutput' => $output,
+                ]
+            )
+        );
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $this->assertEquals(
+            [
+                ConsoleEvents::COMMAND => array('onConsoleCommand', 0),
+            ],
+            CommandColorListener::getSubscribedEvents()
+        );
+    }
+
+}

--- a/src/Symfony/Component/Console/Tests/EventListener/CommandColorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/CommandColorListenerTest.php
@@ -3,8 +3,9 @@
 namespace Symfony\Component\Console\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\EventListener\CommandColorListener;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CommandColorListenerTest extends TestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | TBD 

- [x] Verify tests passed

Added allowing using an environment variable to set the console color setting, superseding auto detection. Symfony 2.7 was colorless when run from cron on Amazon Linux. Symfony 3.4 was colorful in the same context.


Add something like the following to the configuration:
```xml
        <service id="console.color_listener" class="Symfony\Component\Console\EventListener\CommandColorListener">
            <tag name="kernel.event_subscriber" />
            <argument>CONSOLE_COLORS</argument>
        </service>
```

```sh
# Disable color, ignoring auto-detection
export CONSOLE_COLORS=false
# Enable color, ignoring auto-detection
export CONSOLE_COLORS=true
```

Or at the top of crontab:
```
CONSOLE_COLORS=false
```