### PR TITLE
[Serializer.encoder] Added yml in format

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -22,7 +22,7 @@ use Symfony\Component\Yaml\Parser;
  */
 class YamlEncoder implements EncoderInterface, DecoderInterface
 {
-    const FORMAT = 'yaml';
+    const FORMAT = array('yaml', 'yml');
 
     private $dumper;
     private $parser;
@@ -54,7 +54,7 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
      */
     public function supportsEncoding($format)
     {
-        return self::FORMAT === $format;
+        return in_array($format, self::FORMAT);
     }
 
     /**
@@ -72,6 +72,6 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
      */
     public function supportsDecoding($format)
     {
-        return self::FORMAT === $format;
+        return in_array($format, self::FORMAT);
     }
 }

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -22,7 +22,12 @@ use Symfony\Component\Yaml\Parser;
  */
 class YamlEncoder implements EncoderInterface, DecoderInterface
 {
-    const FORMAT = array('yaml', 'yml');
+    /**
+     *@deprecated 4.1.0 Should no longer used by external code and not recommended.
+     */
+    const FORMAT = 'yaml';
+
+    private const FORMATS = array('yaml', 'yml');
 
     private $dumper;
     private $parser;
@@ -54,7 +59,7 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
      */
     public function supportsEncoding($format)
     {
-        return in_array($format, self::FORMAT);
+        return in_array(strtolower($format), self::FORMATS, true);
     }
 
     /**
@@ -72,6 +77,6 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
      */
     public function supportsDecoding($format)
     {
-        return in_array($format, self::FORMAT);
+        return in_array(strtolower($format), self::FORMATS, true);
     }
 }


### PR DESCRIPTION
Added yml format in valid list

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

Added yml as valid format to be able to use converter with .yml file without addind a custom converter in services

example :
https://github.com/FroggDev/Symfony_phpunit_advanced/blob/master/src/Serializer/YamlEncoder.php
https://github.com/FroggDev/Symfony_phpunit_advanced/blob/master/src/Exporter/ExportContact.php

an export of contact.yml require a custom YamlEncoder added in services.yaml
(another solution is to add a test if ext=yml then ext=yaml but it is really not a clean solution)