### PR TITLE
[Console] Use UTF-8 triangle for question prompt

### DIFF
--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -76,7 +76,7 @@ class SymfonyQuestionHelper extends QuestionHelper
             }
         }
 
-        $output->write(' ⏵ ');
+        $output->write(' ▸ ');
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -76,7 +76,7 @@ class SymfonyQuestionHelper extends QuestionHelper
             }
         }
 
-        $output->write(' > ');
+        $output->write(' ⏵ ');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Now inspired by #26698, this updates the prompt icon :) Havent looked at tests/windows yet... but i find it very pretty :}

Before

![image](https://user-images.githubusercontent.com/1047696/38145386-4c49a31e-3449-11e8-8555-d79faa8c6b79.png)

After

![image](https://user-images.githubusercontent.com/1047696/38145351-1895840c-3449-11e8-97cc-68e4b97080c9.png)

Move forward?

ref https://www.utf8icons.com/character/9205/black-medium-right-pointing-triangle