### PR TITLE
[HttpCache] Unlink tmp file on error

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -387,16 +387,22 @@ class Store implements StoreInterface
 
             $tmpFile = tempnam(dirname($path), basename($path));
             if (false === $fp = @fopen($tmpFile, 'wb')) {
+                @unlink($tmpFile);
+
                 return false;
             }
             @fwrite($fp, $data);
             @fclose($fp);
 
             if ($data != file_get_contents($tmpFile)) {
+                @unlink($tmpFile);
+
                 return false;
             }
 
             if (false === @rename($tmpFile, $path)) {
+                @unlink($tmpFile);
+
                 return false;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  2.7 up to 4.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  |no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #22719   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        |
<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

The tempnam function creates a unique temporary file for each call to a page to be cached, and if the temporary folder passed as an argument is not writable, tempnam will use /tmp.

_Note: If PHP cannot create a file in the specified dir parameter, it falls back on the system default. On NTFS this also happens if the specified dir contains more than 65534 files.
http://php.net/manual/en/function.tempnam.php_

Therefore, as soon as the HttpCache cache is no longer writable, the /tmp fills up fairly quickly, tempnam being called on every page (since no page cache) and creating a new unique file in /tmp.

See https://github.com/symfony/symfony/issues/22719
