### PR TITLE
[VarDumper] Server dumper feature tweaks

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -63,7 +63,6 @@ class DumpDataCollectorTest extends TestCase
         // Server is up, server dumper is used
         $serverDumper = $this->getMockBuilder(ServerDumper::class)->disableOriginalConstructor()->getMock();
         $serverDumper->expects($this->once())->method('dump');
-        $serverDumper->method('isServerListening')->willReturn(true);
 
         $collector = new DumpDataCollector(null, null, null, null, $serverDumper);
         $collector->dump($data);

--- a/src/Symfony/Component/VarDumper/Dumper/ServerDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ServerDumper.php
@@ -97,17 +97,6 @@ class ServerDumper implements DataDumperInterface
         }
     }
 
-    public function isServerListening(): bool
-    {
-        set_error_handler(array(self::class, 'nullErrorHandler'));
-
-        try {
-            return $this->socket || $this->socket = $this->createSocket();
-        } finally {
-            restore_error_handler();
-        }
-    }
-
     private static function nullErrorHandler()
     {
         // noop

--- a/src/Symfony/Component/VarDumper/Resources/css/htmlDescriptor.css
+++ b/src/Symfony/Component/VarDumper/Resources/css/htmlDescriptor.css
@@ -2,6 +2,9 @@ body {
     display: flex;
     flex-direction: column-reverse;
     justify-content: flex-end;
+    max-width: 1140px;
+    margin: auto;
+    padding: 15px;
     word-wrap: break-word;
     background-color: #F9F9F9;
     color: #222;

--- a/src/Symfony/Component/VarDumper/Server/DumpServer.php
+++ b/src/Symfony/Component/VarDumper/Server/DumpServer.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\VarDumper\Server;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Cloner\Stub;
 
 /**
  * A server collecting Data clones sent by a ServerDumper.
@@ -51,7 +52,7 @@ class DumpServer
         }
 
         foreach ($this->getMessages() as $clientId => $message) {
-            $payload = @unserialize(base64_decode($message));
+            $payload = @unserialize(base64_decode($message), array('allowed_classes' => array(Data::class, Stub::class)));
 
             // Impossible to decode the message, give up.
             if (false === $payload) {

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ServerDumperTest.php
@@ -37,27 +37,6 @@ class ServerDumperTest extends TestCase
         $dumper->dump($data);
     }
 
-    public function testIsServerListening()
-    {
-        $dumper = new ServerDumper(self::VAR_DUMPER_SERVER);
-
-        $this->assertFalse($dumper->isServerListening());
-
-        $process = $this->getServerProcess();
-        $process->start(function ($type) use ($process) {
-            if (Process::ERR === $type) {
-                $process->stop();
-                $this->fail();
-            }
-        });
-
-        sleep(3);
-
-        $this->assertTrue($dumper->isServerListening());
-
-        $process->stop();
-    }
-
     public function testDump()
     {
         $wrappedDumper = $this->getMockBuilder(DataDumperInterface::class)->getMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This contains the following fixes & enhancements:

- Remove the `ServerDumper::isServerListening()` method which is not required anymore by core (forgotten on original PR after fixing reviews). Unless this is shown really useful for someone, we probably don't want to support it now that the core doesn't use it anymore. 
- Provide the unserialize `allowed_classes` option for security reasons
- Add ServerDumper HTML output max-width (value chosen based on bootstrap 4 container `max-width` for reference)