### PR TITLE
[Form] fixed ignored scale parameter for IntegerType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
@@ -22,17 +22,21 @@ class IntegerToLocalizedStringTransformer extends NumberToLocalizedStringTransfo
     /**
      * Constructs a transformer.
      *
-     * @param int  $scale        Unused
+     * @param int  $scale        Number of decimals
      * @param bool $grouping     Whether thousands should be grouped
      * @param int  $roundingMode One of the ROUND_ constants in this class
      */
     public function __construct($scale = 0, $grouping = false, $roundingMode = self::ROUND_DOWN)
     {
+        if (null === $scale) {
+            $scale = 0;
+        }
+
         if (null === $roundingMode) {
             $roundingMode = self::ROUND_DOWN;
         }
 
-        parent::__construct(0, $grouping, $roundingMode);
+        parent::__construct($scale, $grouping, $roundingMode);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -34,6 +34,14 @@ class IntegerTypeTest extends BaseTypeTest
         $this->assertSame('1', $form->getViewData());
     }
 
+    public function testRoundingWithScale()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array('scale' => 2));
+        $form->setData('12345.67890');
+
+        $this->assertSame('12345.67', $form->createView()->vars['value']);
+    }
+
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
         parent::testSubmitNull($expected, $norm, '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7  <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26734   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR is fixing the issue of the **scale** parameter that is ignored for _integer_ form field type.
One unit test has been added to illustrate the resolution of the issue.

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->