### PR TITLE
[FrameworkBundle][Cache] cache pool namespace in FrameworkBundle Configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -586,6 +586,7 @@ class Configuration implements ConfigurationInterface
                                         ->info('The service name to use as provider when the specified adapter needs one.')
                                     ->end()
                                     ->scalarNode('clearer')->end()
+                                    ->scalarNode('namespace')->end()
                                 ->end()
                             ->end()
                             ->validate()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not checked ...
| Fixed tickets | no
| License       | MIT
| Doc PR        | no ...

First of all - sorry. This is my first PR.

Every cache pool has namespace, it is generated by \Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolPass::getNamespace
So. The problem is, that it is not possible to set namespace for cache pool in framework configuration.
For expample like this:
framework:
    cache:
        pools:
            cache.foo:
                adapter:      cache.adapter.redis
                provider:     snc_redis.system
                public:         false
                namespace: foonamespace

Now 'namespace' node doesn't take place in \Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration::addCacheSection
BUT here \Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CachePoolPass::process there is some code 
if (!isset($tags[0]['namespace'])) {
    $tags[0]['namespace'] = $this->getNamespace($seed, $id);
}
that tells us that 'namespace' can be set from tag options, which are set by values from configuration here \Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension::registerCacheConfiguration
This PR fix it with 1 line of code and shouln't break anything

Some words about PR.
Maybe this is feature.
I know that cache features came with version 3.1, so i created branch from not last commit in branch 3.1 but which is also in master.
I'm not good with tests but i suppose some fixtures should be changed FrameworkBundle/Tests/DependencyInjection/Fixtures
Also there must be Doc PR to https://symfony.com/doc/master/reference/configuration/framework.html#pools

I will appreciate any help or recomendations with this PR