### PR TITLE
[FrameworkBundle] Add debug autoconfigure to the container debug command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -50,6 +50,9 @@ abstract class Descriptor implements DescriptorInterface
             case $object instanceof ParameterBag:
                 $this->describeContainerParameters($object, $options);
                 break;
+            case $object instanceof ContainerBuilder && isset($options['autoconfigure']) && true === $options['autoconfigure']:
+                $this->describeContainerAutoconfiguringTags($object, $options);
+                break;
             case $object instanceof ContainerBuilder && isset($options['group_by']) && 'tags' === $options['group_by']:
                 $this->describeContainerTags($object, $options);
                 break;
@@ -119,6 +122,11 @@ abstract class Descriptor implements DescriptorInterface
      * Describes container tags.
      */
     abstract protected function describeContainerTags(ContainerBuilder $builder, array $options = array());
+
+    /**
+     * Describes container autoconfiguring tags.
+     */
+    abstract protected function describeContainerAutoconfiguringTags(ContainerBuilder $builder, array $options = array());
 
     /**
      * Describes a container service by its name.
@@ -263,6 +271,28 @@ abstract class Descriptor implements DescriptorInterface
         }
 
         return $definitions;
+    }
+
+    /**
+     * @param ContainerBuilder $builder
+     *
+     * @return array
+     */
+    protected function getAutoconfiguredInstanceofByTag(ContainerBuilder $builder)
+    {
+        $autoconfiguredInstanceofByTag = array();
+
+        foreach ($builder->getAutoconfiguredInstanceof() as $key => $autoconfiguredInstanceof) {
+            foreach (array_keys($autoconfiguredInstanceof->getTags()) as $tag) {
+                if (!isset($autoconfiguredInstanceofByTag[$tag])) {
+                    $autoconfiguredInstanceofByTag[$tag] = array($key);
+                } else {
+                    $autoconfiguredInstanceofByTag[$tag][] = $key;
+                }
+            }
+        }
+
+        return $autoconfiguredInstanceofByTag;
     }
 
     protected function sortParameters(ParameterBag $parameters)

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -79,6 +79,22 @@ class JsonDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
+    protected function describeContainerAutoconfiguringTags(ContainerBuilder $builder, array $options = array())
+    {
+        $data = array();
+
+        $autoconfiguredInstanceofByTag = $this->getAutoconfiguredInstanceofByTag($builder);
+
+        foreach ($autoconfiguredInstanceofByTag as $tag => $autoconfiguredInstanceofList) {
+            $data[$tag] = $autoconfiguredInstanceofByTag[$tag];
+        }
+
+        $this->writeData($data, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function describeContainerService($service, array $options = array(), ContainerBuilder $builder = null)
     {
         if (!isset($options['id'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -97,6 +97,24 @@ class MarkdownDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
+    protected function describeContainerAutoconfiguringTags(ContainerBuilder $builder, array $options = array())
+    {
+        $this->write("Container autoconfiguring Tags\n==============================");
+
+        $autoconfiguredInstanceofByTag = $this->getAutoconfiguredInstanceofByTag($builder);
+
+        foreach ($autoconfiguredInstanceofByTag as $tag => $autoconfiguredInstanceofList) {
+            $this->write("\n\n".$tag."\n".str_repeat('-', strlen($tag)));
+            foreach ($autoconfiguredInstanceofList as $autoconfiguredInstanceof) {
+                $this->write("\n\n");
+                $this->write(sprintf('- %s', $autoconfiguredInstanceof));
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function describeContainerService($service, array $options = array(), ContainerBuilder $builder = null)
     {
         if (!isset($options['id'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -139,6 +139,21 @@ class TextDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
+    protected function describeContainerAutoconfiguringTags(ContainerBuilder $builder, array $options = array())
+    {
+        $options['output']->title('Symfony Container Autoconfiguring Tags');
+
+        $autoconfiguredInstanceofByTag = $this->getAutoconfiguredInstanceofByTag($builder);
+
+        foreach ($autoconfiguredInstanceofByTag as $tag => $autoconfiguredInstanceofList) {
+            $options['output']->section(sprintf('"%s" tag', $tag));
+            $options['output']->listing($autoconfiguredInstanceofList);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function describeContainerService($service, array $options = array(), ContainerBuilder $builder = null)
     {
         if (!isset($options['id'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -64,6 +64,14 @@ class XmlDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
+    protected function describeContainerAutoconfiguringTags(ContainerBuilder $builder, array $options = array())
+    {
+        $this->writeDocument($this->getContainerAutoconfiguringTagsDocument($builder));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function describeContainerService($service, array $options = array(), ContainerBuilder $builder = null)
     {
         if (!isset($options['id'])) {
@@ -141,7 +149,10 @@ class XmlDescriptor extends Descriptor
         $this->write($dom->saveXML());
     }
 
-    private function getRouteCollectionDocument(RouteCollection $routes): \DOMDocument
+    /**
+     * @return \DOMDocument
+     */
+    private function getRouteCollectionDocument(RouteCollection $routes)
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($routesXML = $dom->createElement('routes'));
@@ -243,6 +254,26 @@ class XmlDescriptor extends Descriptor
             foreach ($definitions as $serviceId => $definition) {
                 $definitionXML = $this->getContainerDefinitionDocument($definition, $serviceId, true);
                 $tagXML->appendChild($dom->importNode($definitionXML->childNodes->item(0), true));
+            }
+        }
+
+        return $dom;
+    }
+
+    private function getContainerAutoconfiguringTagsDocument(ContainerBuilder $builder): \DOMDocument
+    {
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->appendChild($containerXML = $dom->createElement('tags'));
+
+        $autoconfiguredInstanceofByTag = $this->getAutoconfiguredInstanceofByTag($builder);
+
+        foreach ($autoconfiguredInstanceofByTag as $tag => $autoconfiguredInstanceofList) {
+            $containerXML->appendChild($tagXML = $dom->createElement('tag'));
+            $tagXML->setAttribute('name', $tag);
+
+            foreach ($autoconfiguredInstanceofList as $autoconfiguredInstanceof) {
+                $tagXML->appendChild($autoconfiguredInstanceofXML = $dom->createElement('autoconfigured-instanceof'));
+                $autoconfiguredInstanceofXML->appendChild(new \DOMText($autoconfiguredInstanceof));
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -218,6 +218,7 @@ abstract class AbstractDescriptorTest extends TestCase
             'tag1' => array('show_private' => true, 'tag' => 'tag1'),
             'tags' => array('group_by' => 'tags', 'show_private' => true),
             'arguments' => array('show_private' => false, 'show_arguments' => true),
+            'autoconfigure' => array('autoconfigure' => true),
         );
 
         $data = array();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -92,6 +92,7 @@ class ObjectsProvider
         $builder1 = new ContainerBuilder();
         $builder1->setDefinitions(self::getContainerDefinitions());
         $builder1->setAliases(self::getContainerAliases());
+        $builder1->registerForAutoconfiguration(AutoconfiguringInterface::class)->addTag('autoconfiguring_interface_tag');
 
         return array('builder_1' => $builder1);
     }
@@ -195,4 +196,8 @@ class RouteStub extends Route
     {
         return new CompiledRoute('', '#PATH_REGEX#', array(), array(), '#HOST_REGEX#');
     }
+}
+
+interface AutoconfiguringInterface
+{
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_autoconfigure.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_autoconfigure.json
@@ -1,0 +1,5 @@
+{
+  "autoconfiguring_interface_tag": [
+    "Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\AutoconfiguringInterface"
+  ]
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_autoconfigure.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_autoconfigure.md
@@ -1,0 +1,7 @@
+Container autoconfiguring Tags
+==============================
+
+autoconfiguring_interface_tag
+-----------------------------
+
+- Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\AutoconfiguringInterface

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_autoconfigure.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_autoconfigure.txt
@@ -1,0 +1,7 @@
+[33mSymfony Container Autoconfiguring Tags[39m
+[33m======================================[39m
+
+[33m"autoconfiguring_interface_tag" tag[39m
+[33m-----------------------------------[39m
+
+ * Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\AutoconfiguringInterface

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_autoconfigure.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_autoconfigure.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tags>
+  <tag name="autoconfiguring_interface_tag">
+    <autoconfigured-instanceof>Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\AutoconfiguringInterface</autoconfigured-instanceof>
+  </tag>
+</tags>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes/no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26295    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR try to list the tags that are applied on certain classes through autoconfiguration

```
sf debug:container --autoconfigure
```

```
Symfony Container Autoconfiguring Tags
======================================

"console.command" tag
---------------------

 * Symfony\Component\Console\Command\Command

"config_cache.resource_checker" tag
-----------------------------------

 * Symfony\Component\Config\ResourceCheckerInterface

"container.env_var_processor" tag
---------------------------------

 * Symfony\Component\DependencyInjection\EnvVarProcessorInterface

"container.service_locator" tag
-------------------------------

 * Symfony\Component\DependencyInjection\ServiceLocator
```
