### PR TITLE
[Finder] Remove duplicate slashes in filenames

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -629,9 +629,9 @@ class Finder implements \IteratorAggregate, \Countable
 
         foreach ((array) $dirs as $dir) {
             if (is_dir($dir)) {
-                $resolvedDirs[] = $dir;
+                $resolvedDirs[] = $this->normalizeDir($dir);
             } elseif ($glob = glob($dir, (defined('GLOB_BRACE') ? GLOB_BRACE : 0) | GLOB_ONLYDIR)) {
-                $resolvedDirs = array_merge($resolvedDirs, $glob);
+                $resolvedDirs = array_merge($resolvedDirs, array_map(array($this, 'normalizeDir'), $glob));
             } else {
                 throw new \InvalidArgumentException(sprintf('The "%s" directory does not exist.', $dir));
             }
@@ -793,5 +793,17 @@ class Finder implements \IteratorAggregate, \Countable
 
             return $properties;
         }, $this->adapters);
+    }
+
+    /**
+     * Normalizes given directory names by removing trailing slashes.
+     *
+     * @param string $dir
+     *
+     * @return string
+     */
+    private function normalizeDir($dir)
+    {
+        return rtrim($dir, '/'.\DIRECTORY_SEPARATOR);
     }
 }

--- a/src/Symfony/Component/Finder/SplFileInfo.php
+++ b/src/Symfony/Component/Finder/SplFileInfo.php
@@ -28,7 +28,7 @@ class SplFileInfo extends \SplFileInfo
      */
     public function __construct($file, $relativePath, $relativePathname)
     {
-        parent::__construct(realpath($file) ?: $file);
+        parent::__construct($file);
         $this->relativePath = $relativePath;
         $this->relativePathname = $relativePathname;
     }

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilePathsIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilePathsIteratorTest.php
@@ -31,7 +31,7 @@ class FilePathsIteratorTest extends RealIteratorTestCase
 
     public function getSubPathData()
     {
-        $tmpDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'symfony_finder';
+        $tmpDir = sys_get_temp_dir().'/symfony_finder';
 
         return array(
             array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 up to 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26757
| License       | MIT

This PR takes another approach to fix in excess slashes in Finder than #26337
which does a simple rtrim instead of the breaking realpath.