### PR TITLE
[Form] ability to set rounding strategy for MoneyType

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `input=datetime_immutable` to DateType, TimeType, DateTimeType
+ * added `rounding_mode` option to MoneyType
 
 4.0.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
@@ -31,7 +32,7 @@ class MoneyType extends AbstractType
             ->addViewTransformer(new MoneyToLocalizedStringTransformer(
                 $options['scale'],
                 $options['grouping'],
-                null,
+                $options['rounding_mode'],
                 $options['divisor']
             ))
         ;
@@ -53,9 +54,20 @@ class MoneyType extends AbstractType
         $resolver->setDefaults(array(
             'scale' => 2,
             'grouping' => false,
+            'rounding_mode' => NumberToLocalizedStringTransformer::ROUND_HALF_UP,
             'divisor' => 1,
             'currency' => 'EUR',
             'compound' => false,
+        ));
+
+        $resolver->setAllowedValues('rounding_mode', array(
+            NumberToLocalizedStringTransformer::ROUND_FLOOR,
+            NumberToLocalizedStringTransformer::ROUND_DOWN,
+            NumberToLocalizedStringTransformer::ROUND_HALF_DOWN,
+            NumberToLocalizedStringTransformer::ROUND_HALF_EVEN,
+            NumberToLocalizedStringTransformer::ROUND_HALF_UP,
+            NumberToLocalizedStringTransformer::ROUND_UP,
+            NumberToLocalizedStringTransformer::ROUND_CEILING,
         ));
 
         $resolver->setAllowedTypes('scale', 'int');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -70,4 +70,20 @@ class MoneyTypeTest extends BaseTypeTest
 
         $this->assertSame('{{ widget }}', $view->vars['money_pattern']);
     }
+
+    public function testDefaultFormattingWithDefaultRounding()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array('scale' => 0));
+        $form->setData('12345.54321');
+
+        $this->assertSame('12346', $form->createView()->vars['value']);
+    }
+
+    public function testDefaultFormattingWithSpecifiedRounding()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array('scale' => 0, 'rounding_mode' => \NumberFormatter::ROUND_DOWN));
+        $form->setData('12345.54321');
+
+        $this->assertSame('12345', $form->createView()->vars['value']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/9543

Added `rounding_mode` to the `MoneyType` to be possible to change rounding strategy for money values. For now it's just `ROUND_HALF_UP` but it's good to have `ROUND_DOWN` as well. E.g. to transform `15.999` to `15.99` instead of `15.1`.
