### PR TITLE
[DI] Allow autoconfigured calls in PHP

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -207,6 +207,16 @@ class IntegrationTest extends TestCase
             'child_service',
             'child_service_expected',
         );
+
+        $container = new ContainerBuilder();
+        $container->registerForAutoconfiguration(IntegrationTestStub::class)
+            ->addMethodCall('setSunshine', array('supernova'));
+        yield array(
+            'instanceof_and_calls',
+            'main_service',
+            'main_service_expected',
+            $container,
+        );
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -200,16 +200,22 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Autoconfigured instanceof for type "PHPUnit\Framework\TestCase" defines method calls but these are not supported and should be removed.
+     * Test that autoconfigured calls are handled gracefully.
      */
-    public function testProcessThrowsExceptionForAutoconfiguredCalls()
+    public function testProcessForAutoconfiguredCalls()
     {
         $container = new ContainerBuilder();
-        $container->registerForAutoconfiguration(parent::class)
-            ->addMethodCall('setFoo');
+        $container->registerForAutoconfiguration(parent::class)->addMethodCall('setLogger');
+
+        $def = $container->register('foo', self::class)->setAutoconfigured(true);
+        $this->assertFalse($def->hasMethodCall('setLogger'), 'Definition shouldn\'t have method call yet.');
 
         (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertTrue(
+            $container->findDefinition('foo')->hasMethodCall('setLogger'),
+            'Definition should have "setLogger" method call.'
+        );
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -209,7 +209,7 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $expected = array(
             array('setFoo', array(
                 'plain_value',
-                '%some_parameter%'
+                '%some_parameter%',
             )),
             array('callBar', array()),
             array('isBaz', array()),

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/instanceof_and_calls/expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/instanceof_and_calls/expected.yml
@@ -1,0 +1,10 @@
+services:
+    # main_service should look like this in the end
+    main_service_expected:
+        class: Symfony\Component\DependencyInjection\Tests\Compiler\IntegrationTestStub
+        public: true
+        autoconfigure: true
+        calls:
+            - [setSunshine, [supernova]]
+            - [setSunshine, [warm]]
+

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/instanceof_and_calls/main.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/instanceof_and_calls/main.yml
@@ -1,0 +1,9 @@
+services:
+    _instanceof:
+        Symfony\Component\DependencyInjection\Tests\Compiler\IntegrationTestStubParent:
+            calls:
+                - [setSunshine, [warm]]
+    main_service:
+        class: Symfony\Component\DependencyInjection\Tests\Compiler\IntegrationTestStub
+        autoconfigure: true
+        public: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    |no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Allow to auto-configured method calls like:
```php
$container->registerForAutoconfiguration(LoggerAwareInterface::class)->addMethodCall('setLogger', array(new Reference(LoggerInterface::class)));
```
