### PR TITLE
Do not normalize array keys in twig globals

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -76,6 +76,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('key')
                     ->example(array('foo' => '"@bar"', 'pi' => 3.14))
                     ->prototype('array')
+                        ->normalizeKeys(false)
                         ->beforeNormalization()
                             ->ifTrue(function ($v) { return is_string($v) && 0 === strpos($v, '@'); })
                             ->then(function ($v) {

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -41,4 +41,28 @@ class ConfigurationTest extends TestCase
 
         $this->assertFalse($config['strict_variables']);
     }
+
+    public function testGlobalsAreNotNormalized()
+    {
+        $input = array(
+            'globals' => array('some-global' => true),
+        );
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), array($input));
+
+        $this->assertSame(array('some-global' => array('value' => true)), $config['globals']);
+    }
+
+    public function testArrayKeysInGlobalsAreNotNormalized()
+    {
+        $input = array(
+            'globals' => array('global' => array('some-key' => 'some-value')),
+        );
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), array($input));
+
+        $this->assertSame(array('global' => array('value' => array('some-key' => 'some-value'))), $config['globals']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | rather no
| Tests pass?   | yes
| Fixed tickets | n.A.
| License       | MIT
| Doc PR        | n.A.

We should leave array keys in twig globals untouched.