### PR TITLE
[Filesystem] Fix mirroring a directory with a relative path and a custom iterator

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -572,6 +572,10 @@ class Filesystem
         }
 
         foreach ($iterator as $file) {
+            if (false === strpos($file->getPath(), $originDir)) {
+                throw new IOException(sprintf('Unable to mirror "%s" directory. If the origin directory is relative, try using "realpath" before calling the mirror method.', $originDir), 0, null, $originDir);
+            }
+
             $target = $targetDir.substr($file->getPathname(), $originDirLen);
 
             if ($copyOnWindows) {

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1332,6 +1332,46 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileNotExists($targetPath.'target');
     }
 
+    public function testMirrorWithCustomIterator()
+    {
+        $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
+        mkdir($sourcePath);
+
+        $file = $sourcePath.DIRECTORY_SEPARATOR.'file';
+        file_put_contents($file, 'FILE');
+
+        $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
+
+        $splFile = new \SplFileInfo($file);
+        $iterator = new \ArrayObject(array($splFile));
+
+        $this->filesystem->mirror($sourcePath, $targetPath, $iterator);
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertFileEquals($file, $targetPath.DIRECTORY_SEPARATOR.'file');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Filesystem\Exception\IOException
+     * @expectedExceptionMessageRegExp /Unable to mirror "(.*)" directory/
+     */
+    public function testMirrorWithCustomIteratorWithRelativePath()
+    {
+        $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
+        $realSourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
+        mkdir($realSourcePath);
+
+        $file = $realSourcePath.'file';
+        file_put_contents($file, 'FILE');
+
+        $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
+
+        $splFile = new \SplFileInfo($file);
+        $iterator = new \ArrayObject(array($splFile));
+
+        $this->filesystem->mirror($sourcePath, $targetPath, $iterator);
+    }
+
     /**
      * @dataProvider providePathsForIsAbsolutePath
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8 up to 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The Filesystem::mirror method with a Finder iterator doesn't work if the origin directory is relative. 

This is a case where it won't work:

```
$dir = '/data/../data/';

$finder = (new Finder())->in($dir)->getIterator();

(new Filesystem())->mirror($dir, '/tmp', $finder);
```

The finder will return file objects like this :
```
SplFileInfo {
    pathname: "/data/file.tmp"
    ...
}
```

But the following line will fail because because the `$file->getPathname()` and the `$originDir` are differents.
```
$target = $targetDir.substr($file->getPathname(), $originDirLen);

// $file->getPathname() = '/data/file.tmp'
// $originDirLen = strlen('/data/../data/') = 14
// $target = '/tmp' instead of '/tpm/file.tpm'
```

In some case, it's even worse. If the filename length is bigger than the `$originDirLen`, the target file will be a file with a completely wrong name:
```
// $file->getPathname() = '/data/file123456789.tmp'
// $originDirLen = strlen('/data/../data/') = 14
// $target = '/tmp/56789.tmp' instead of '/tpm/file123456789.tmp'
```

I fixed this on my side by using the realpath function everytime i'm calling the mirror method, but i doubt this is the desired behavior.