### PR TITLE
[HttpKernel] Make ServiceValueResolver work if controller namespace starts with a backslash in routing

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -39,9 +39,15 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
 
         if (\is_array($controller) && \is_callable($controller, true) && \is_string($controller[0])) {
             $controller = $controller[0].'::'.$controller[1];
+        } elseif (!\is_string($controller) || '' === $controller) {
+            return false;
         }
 
-        return \is_string($controller) && $this->container->has($controller) && $this->container->get($controller)->has($argument->getName());
+        if ('\\' === $controller[0]) {
+            $controller = ltrim($controller, '\\');
+        }
+
+        return $this->container->has($controller) && $this->container->get($controller)->has($argument->getName());
     }
 
     /**
@@ -51,6 +57,10 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
     {
         if (\is_array($controller = $request->attributes->get('_controller'))) {
             $controller = $controller[0].'::'.$controller[1];
+        }
+
+        if ('\\' === $controller[0]) {
+            $controller = ltrim($controller, '\\');
         }
 
         yield $this->container->get($controller)->get($argument->getName());

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
@@ -47,6 +47,25 @@ class ServiceValueResolverTest extends TestCase
         $this->assertYieldEquals(array(new DummyService()), $resolver->resolve($request, $argument));
     }
 
+    public function testExistingControllerWithATrailingBackSlash()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator(array(
+            'App\\Controller\\Mine::method' => function () {
+                return new ServiceLocator(array(
+                    'dummy' => function () {
+                        return new DummyService();
+                    },
+                ));
+            },
+        )));
+
+        $request = $this->requestWithAttributes(array('_controller' => '\\App\\Controller\\Mine::method'));
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+
+        $this->assertTrue($resolver->supports($request, $argument));
+        $this->assertYieldEquals(array(new DummyService()), $resolver->resolve($request, $argument));
+    }
+
     public function testControllerNameIsAnArray()
     {
         $resolver = new ServiceValueResolver(new ServiceLocator(array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26772
| License       | MIT


Hi folks,

This PR fixes https://github.com/symfony/symfony/issues/26772: 
>Controller "App\Controllers\Foo" requires that you provide a value for the "$foo" argument. Either the argument is nullable and no null value has been provided, no default value has been provided or because there is a non optional argument after this one.

Thank you for your work!

PS: This is my first (of many planned!) PR to Symfony, so please let me know if I did something wrong.
