### PR TITLE
[SecurityBundle] Add missing argument to security.authentication.provider.simple

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimplePreAuthenticationFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimplePreAuthenticationFactory.php
@@ -49,6 +49,7 @@ class SimplePreAuthenticationFactory implements SecurityFactoryInterface
             ->replaceArgument(0, new Reference($config['authenticator']))
             ->replaceArgument(1, new Reference($userProvider))
             ->replaceArgument(2, $id)
+            ->replaceArgument(3, new Reference('security.user_checker.'.$id))
         ;
 
         // listener

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -236,6 +236,7 @@
             <argument /> <!-- Simple Authenticator -->
             <argument /> <!-- User Provider -->
             <argument /> <!-- Provider-shared Key -->
+            <argument>null</argument> <!-- UserChecker -->
         </service>
 
         <service id="security.authentication.provider.pre_authenticated" class="%security.authentication.provider.pre_authenticated.class%" abstract="true" public="false">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -101,6 +101,13 @@ abstract class CompleteConfigurationTest extends TestCase
                 'security.authentication.listener.anonymous.with_user_checker',
                 'security.access_listener',
             ),
+            array(
+                'security.channel_listener',
+                'security.context_listener.2',
+                'security.authentication.listener.simple_form.simple_auth',
+                'security.authentication.listener.anonymous.simple_auth',
+                'security.access_listener',
+            ),
         ), $listeners);
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -86,6 +86,11 @@ $container->loadFromExtension('security', array(
             'anonymous' => true,
             'http_basic' => true,
         ),
+        'simple_auth' => array(
+            'provider' => 'default',
+            'anonymous' => true,
+            'simple_form' => array('authenticator' => 'simple_authenticator'),
+        ),
     ),
 
     'access_control' => array(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -71,6 +71,11 @@
             <user-checker>app.user_checker</user-checker>
         </firewall>
 
+        <firewall name="simple_auth" provider="default">
+            <anonymous />
+            <simple-form authenticator="simple_authenticator" />
+        </firewall>
+
         <role id="ROLE_ADMIN">ROLE_USER</role>
         <role id="ROLE_SUPER_ADMIN">ROLE_USER,ROLE_ADMIN,ROLE_ALLOWED_TO_SWITCH</role>
         <role id="ROLE_REMOTE">ROLE_USER,ROLE_ADMIN</role>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -70,6 +70,11 @@ security:
             http_basic: ~
             user_checker: app.user_checker
 
+        simple_auth:
+            provider: default
+            anonymous: ~
+            simple_form: { authenticator: simple_authenticator }
+
     role_hierarchy:
         ROLE_ADMIN:       ROLE_USER
         ROLE_SUPER_ADMIN: [ROLE_USER, ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26753 
| License       | MIT
| Doc PR        | -

Created PR in relation to a conversation in [PR](https://github.com/symfony/symfony/pull/26762) #26762 
