### PR TITLE
[PropertyInfo] Types should not be extracted from private constructor

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -207,13 +207,9 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return null;
         }
 
-        if (!$reflectionClass->isInstantiable()) {
-            return null;
-        }
-
         $constructor = $reflectionClass->getConstructor();
 
-        if (!$constructor) {
+        if (!$constructor || !$constructor->isPublic()) {
             return null;
         }
 

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -207,6 +207,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return null;
         }
 
+        if (!$reflectionClass->isInstantiable()) {
+            return null;
+        }
+
         $constructor = $reflectionClass->getConstructor();
 
         if (!$constructor) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
@@ -207,6 +207,13 @@ class ReflectionExtractorTest extends TestCase
         $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyChild3', $property, array()));
     }
 
+    public function testExtractPhp71WithPrivateConstructor()
+    {
+        $property = 'string';
+        $type = null;
+        $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\PrivateConstructor', $property, array()));
+    }
+
     /**
      * @dataProvider getReadableProperties
      */

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PrivateConstructor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/PrivateConstructor.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class PrivateConstructor
+{
+    private $string;
+
+    private function __construct(string $string)
+    {
+        $this->string = $string;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Since #25605, types are now extracted from constructors. But, IMO, types should not be extracted when constructor is private.

cc @lyrixx