### PR TITLE
[Form] Fix precision of MoneyToLocalizedStringTransformer's divisions on transform()

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -78,6 +78,16 @@ class MoneyToLocalizedStringTransformerTest extends TestCase
         $transformer = new MoneyToLocalizedStringTransformer(null, null, null, 100);
         IntlTestHelper::requireFullIntl($this, false);
         \Locale::setDefault('de_AT');
+
         $this->assertSame(3655, (int) $transformer->reverseTransform('36,55'));
+    }
+
+    public function testFloatToIntConversionMismatchOnTransform()
+    {
+        $transformer = new MoneyToLocalizedStringTransformer(null, null, MoneyToLocalizedStringTransformer::ROUND_DOWN, 100);
+        IntlTestHelper::requireFullIntl($this, false);
+        \Locale::setDefault('de_AT');
+
+        $this->assertSame('10,20', $transformer->transform(1020));
     }
 }

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -708,6 +708,7 @@ class NumberFormatter
         } elseif (isset(self::$customRoundingList[$roundingModeAttribute])) {
             $roundingCoef = pow(10, $precision);
             $value *= $roundingCoef;
+            $value = (float) (string) $value;
 
             switch ($roundingModeAttribute) {
                 case self::ROUND_CEILING:

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -428,6 +428,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
             // array(1.125, '1.13'),
             array(1.127, '1.13'),
             array(1.129, '1.13'),
+            array(1020 / 100, '10.20'),
         );
     }
 
@@ -451,6 +452,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
             array(1.125, '1.12'),
             array(1.127, '1.13'),
             array(1.129, '1.13'),
+            array(1020 / 100, '10.20'),
         );
     }
 
@@ -474,6 +476,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
             array(1.125, '1.12'),
             array(1.127, '1.13'),
             array(1.129, '1.13'),
+            array(1020 / 100, '10.20'),
         );
     }
 
@@ -498,6 +501,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
             array(-1.123, '-1.12'),
             array(-1.125, '-1.12'),
             array(-1.127, '-1.12'),
+            array(1020 / 100, '10.20'),
         );
     }
 
@@ -522,6 +526,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
             array(-1.123, '-1.13'),
             array(-1.125, '-1.13'),
             array(-1.127, '-1.13'),
+            array(1020 / 100, '10.20'),
         );
     }
 
@@ -546,6 +551,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
             array(-1.123, '-1.12'),
             array(-1.125, '-1.12'),
             array(-1.127, '-1.12'),
+            array(1020 / 100, '10.20'),
         );
     }
 
@@ -570,6 +576,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
             array(-1.123, '-1.13'),
             array(-1.125, '-1.13'),
             array(-1.127, '-1.13'),
+            array(1020 / 100, '10.20'),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        |

Related issue https://github.com/symfony/symfony/issues/21026.
Previous PR https://github.com/symfony/symfony/pull/24036.
Similar fix for `transform()` method.