### PR TITLE
[FrameworkBundle] Fix validation configuration default test case

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -259,7 +259,7 @@ class ConfigurationTest extends TestCase
                         'entity_manager_name' => null,
                     ),
                     'validation' => array(
-                        'enabled' => false,
+                        'enabled' => !class_exists(FullStack::class),
                     ),
                 ),
             ),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT

This test case wasn't updated after a change in the PR to automatically enable the validation middleware based on the interface.