### PR TITLE
Remove if (false) class_alias workarounds

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CoverageListener.php
+++ b/src/Symfony/Bridge/PhpUnit/CoverageListener.php
@@ -18,9 +18,3 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
 } else {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\CoverageListenerForV7', 'Symfony\Bridge\PhpUnit\CoverageListener');
 }
-
-if (false) {
-    class CoverageListener
-    {
-    }
-}

--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -18,9 +18,3 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
 } else {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerForV7', 'Symfony\Bridge\PhpUnit\SymfonyTestsListener');
 }
-
-if (false) {
-    class SymfonyTestsListener
-    {
-    }
-}

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -14,16 +14,3 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 @trigger_error('The '.__NAMESPACE__.'\ResolveDefinitionTemplatesPass class is deprecated since Symfony 3.4 and will be removed in 4.0. Use the ResolveChildDefinitionsPass class instead.', E_USER_DEPRECATED);
 
 class_exists(ResolveChildDefinitionsPass::class);
-
-if (false) {
-    /**
-     * This definition decorates another definition.
-     *
-     * @author Johannes M. Schmitt <schmittjoh@gmail.com>
-     *
-     * @deprecated The ResolveDefinitionTemplatesPass class is deprecated since version 3.4 and will be removed in 4.0. Use the ResolveChildDefinitionsPass class instead.
-     */
-    class ResolveDefinitionTemplatesPass extends AbstractRecursivePass
-    {
-    }
-}

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -14,16 +14,3 @@ namespace Symfony\Component\DependencyInjection;
 @trigger_error('The '.__NAMESPACE__.'\DefinitionDecorator class is deprecated since Symfony 3.3 and will be removed in 4.0. Use the Symfony\Component\DependencyInjection\ChildDefinition class instead.', E_USER_DEPRECATED);
 
 class_exists(ChildDefinition::class);
-
-if (false) {
-    /**
-     * This definition decorates another definition.
-     *
-     * @author Johannes M. Schmitt <schmittjoh@gmail.com>
-     *
-     * @deprecated The DefinitionDecorator class is deprecated since version 3.3 and will be removed in 4.0. Use the Symfony\Component\DependencyInjection\ChildDefinition class instead.
-     */
-    class DefinitionDecorator extends Definition
-    {
-    }
-}

--- a/src/Symfony/Component/Security/Core/Authorization/DebugAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/DebugAccessDecisionManager.php
@@ -11,26 +11,4 @@
 
 namespace Symfony\Component\Security\Core\Authorization;
 
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-
 class_exists(TraceableAccessDecisionManager::class);
-
-if (false) {
-    /**
-     * This is a placeholder for the old class, that got renamed; this is not a BC break since the class is internal, this
-     * placeholder is here just to help backward compatibility with older SecurityBundle versions.
-     *
-     * @deprecated The DebugAccessDecisionManager class has been renamed and is deprecated since version 3.3 and will be removed in 4.0. Use the TraceableAccessDecisionManager class instead.
-     *
-     * @internal
-     */
-    class DebugAccessDecisionManager implements AccessDecisionManagerInterface
-    {
-        /**
-         * {@inheritdoc}
-         */
-        public function decide(TokenInterface $token, array $attributes, $object = null)
-        {
-        }
-    }
-}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

There is no longer need to encourage this workaround for IDE. It has been [fixed in PhpStorm 2018.1](https://youtrack.jetbrains.com/issue/WI-33814)! I've tested it, works great.

Branches 2.7 and 2.8 are free from this practice, hence submitting against 3.4