### PR TITLE
[Messenger] Mention the interface is a marker

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/MessageHandlerInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/MessageHandlerInterface.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Messenger\Handler;
 
 /**
- * Handlers can implement this interface.
+ * Marker interface for message handlers.
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/26685#discussion_r179029460
| License       | MIT
| Doc PR        | ø

Replace the interface's description to explicit it is a marker. Sentence based on [other](https://github.com/symfony/symfony/blob/5129c4cf7e294b1a5ea30d6fec6e89b75396dcd2/src/Symfony/Component/Security/Guard/Token/GuardTokenInterface.php#L17) [examples](https://github.com/symfony/symfony/blob/c88158a6da6474c5e52deaa7c77210689308d37e/src/Symfony/Component/Security/Core/Encoder/SelfSaltingEncoderInterface.php#L15) [in](https://github.com/symfony/symfony/blob/9fda6d3ee3ea7f32a00a13508f9748df01c2ecc7/src/Symfony/Component/PropertyAccess/Exception/ExceptionInterface.php#L15) [the](https://github.com/symfony/symfony/blob/9fda6d3ee3ea7f32a00a13508f9748df01c2ecc7/src/Symfony/Component/Process/Exception/ExceptionInterface.php#L15) [codebase](https://github.com/symfony/symfony/blob/9fda6d3ee3ea7f32a00a13508f9748df01c2ecc7/src/Symfony/Component/OptionsResolver/Exception/ExceptionInterface.php#L15).

cc @weaverryan @nicolas-grekas 