### PR TITLE
[Security] Make security.providers optional

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -314,7 +314,6 @@ class MainConfiguration implements ConfigurationInterface
                         ),
                         'my_entity_provider' => array('entity' => array('class' => 'SecurityBundle:User', 'property' => 'username')),
                     ))
-                    ->isRequired()
                     ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')
                     ->prototype('array')

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -422,6 +422,9 @@ class SecurityExtension extends Extension
                         $userProvider = null;
                     } elseif ($defaultProvider) {
                         $userProvider = $defaultProvider;
+                    } elseif (empty($providerIds)) {
+                        $userProvider = sprintf('security.user.provider.missing.%s', $key);
+                        $container->setDefinition($userProvider, (new ChildDefinition('security.user.provider.missing'))->replaceArgument(0, $id));
                     } else {
                         throw new InvalidConfigurationException(sprintf('Not configuring explicitly the provider for the "%s" listener on "%s" firewall is ambiguous as there is more than one registered provider.', $key, $id));
                     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -166,6 +166,10 @@
         </service>
 
         <!-- Provisioning -->
+        <service id="security.user.provider.missing" class="Symfony\Component\Security\Core\User\MissingUserProvider" abstract="true">
+            <argument /> <!-- firewall -->
+        </service>
+
         <service id="security.user.provider.in_memory" class="Symfony\Component\Security\Core\User\InMemoryUserProvider" abstract="true" />
         <service id="security.user.provider.in_memory.user" class="Symfony\Component\Security\Core\User\User" abstract="true">
             <deprecated>The "%service_id%" service is deprecated since Symfony 4.1.</deprecated>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/MissingUserProviderBundle/MissingUserProviderBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/MissingUserProviderBundle/MissingUserProviderBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\MissingUserProviderBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class MissingUserProviderBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/MissingUserProviderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/MissingUserProviderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+class MissingUserProviderTest extends WebTestCase
+{
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage "default" firewall requires a user provider but none was defined.
+     */
+    public function testUserProviderIsNeeded()
+    {
+        $client = $this->createClient(array('test_case' => 'MissingUserProvider', 'root_config' => 'config.yml'));
+
+        $client->request('GET', '/', array(), array(), array(
+            'PHP_AUTH_USER' => 'username',
+            'PHP_AUTH_PW' => 'pa$$word',
+        ));
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/bundles.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\MissingUserProviderBundle\MissingUserProviderBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return array(
+    new FrameworkBundle(),
+    new SecurityBundle(),
+    new MissingUserProviderBundle(),
+);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/config.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+security:
+    firewalls:
+        default:
+            http_basic: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MissingUserProvider/routing.yml
@@ -1,0 +1,2 @@
+home:
+    path: /

--- a/src/Symfony/Component/Security/Core/User/MissingUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/MissingUserProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\User;
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * MissingUserProvider is a dummy user provider used to throw proper exception
+ * when a firewall requires a user provider but none was defined.
+ *
+ * @internal
+ */
+class MissingUserProvider implements UserProviderInterface
+{
+    /**
+     * @param string $firewall the firewall missing a provider
+     */
+    public function __construct(string $firewall)
+    {
+        throw new InvalidConfigurationException(sprintf('"%s" firewall requires a user provider but none was defined.', $firewall));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByUsername($username)
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(UserInterface $user)
+    {
+        throw new \BadMethodCallException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        throw new \BadMethodCallException();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21998
| License       | MIT

Don't really know if it's viable but I just hit #21998 so I would like to tackle this.