### PR TITLE
[PhpUnitBridge] Search for SYMFONY_PHPUNIT_REMOVE env var in phpunit.xml then phpunit.xml.dist

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.1.0
+-----
+
+ * Search for `SYMFONY_PHPUNIT_REMOVE` env var in `phpunit.xml` then
+   `phpunit.xml.dist`
+
 4.0.0
 -----
 

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -53,6 +53,21 @@ $COMPOSER = file_exists($COMPOSER = $oldPwd.'/composer.phar') || ($COMPOSER = rt
 
 if (false === $SYMFONY_PHPUNIT_REMOVE = getenv('SYMFONY_PHPUNIT_REMOVE')) {
     $SYMFONY_PHPUNIT_REMOVE = 'phpspec/prophecy symfony/yaml';
+
+    $phpunitConfigFilename = null;
+    if (file_exists('phpunit.xml')) {
+        $phpunitConfigFilename = 'phpunit.xml';
+    } elseif (file_exists('phpunit.xml.dist')) {
+        $phpunitConfigFilename = 'phpunit.xml.dist';
+    }
+    if ($phpunitConfigFilename) {
+        $xml = new DomDocument();
+        $xml->load($phpunitConfigFilename);
+        $var = (new DOMXpath($xml))->query('//php/env[@name="SYMFONY_PHPUNIT_REMOVE"]')[0];
+        if ($var) {
+            $SYMFONY_PHPUNIT_REMOVE = $var->getAttribute('value');
+        }
+    }
 }
 
 if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__FILE__)."\n".$SYMFONY_PHPUNIT_REMOVE !== @file_get_contents("$PHPUNIT_DIR/.$PHPUNIT_VERSION.md5")) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

---

using the env var could be a bit annoying + not everyone may know this. So adding it to the `phpunit.xml.dist` file make sens IHMO