### PR TITLE
[Security] register custom providers on ExpressionLanguage directly

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
@@ -36,10 +36,10 @@ class AddExpressionLanguageProvidersPass implements CompilerPassInterface
         }
 
         // security
-        if ($container->has('security.access.expression_voter')) {
-            $definition = $container->findDefinition('security.access.expression_voter');
+        if ($container->has('security.expression_language')) {
+            $definition = $container->findDefinition('security.expression_language');
             foreach ($container->findTaggedServiceIds('security.expression_language_provider', true) as $id => $attributes) {
-                $definition->addMethodCall('addExpressionLanguageProvider', array(new Reference($id)));
+                $definition->addMethodCall('registerProvider', array(new Reference($id)));
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
@@ -24,7 +24,7 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition = new Definition('\stdClass');
         $definition->addTag('routing.expression_language_provider');
         $container->setDefinition('some_routing_provider', $definition->setPublic(true));
 
@@ -43,7 +43,7 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition = new Definition('\stdClass');
         $definition->addTag('routing.expression_language_provider');
         $container->setDefinition('some_routing_provider', $definition->setPublic(true));
 
@@ -63,17 +63,16 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition = new Definition('\stdClass');
         $definition->addTag('security.expression_language_provider');
         $container->setDefinition('some_security_provider', $definition->setPublic(true));
 
-        $container->register('security.access.expression_voter', '\stdClass')->setPublic(true);
+        $container->register('security.expression_language', '\stdClass')->setPublic(true);
         $container->compile();
 
-        $router = $container->getDefinition('security.access.expression_voter');
-        $calls = $router->getMethodCalls();
+        $calls = $container->getDefinition('security.expression_language')->getMethodCalls();
         $this->assertCount(1, $calls);
-        $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);
+        $this->assertEquals('registerProvider', $calls[0][0]);
         $this->assertEquals(new Reference('some_security_provider'), $calls[0][1][0]);
     }
 
@@ -82,22 +81,17 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\TestProvider');
+        $definition = new Definition('\stdClass');
         $definition->addTag('security.expression_language_provider');
         $container->setDefinition('some_security_provider', $definition->setPublic(true));
 
-        $container->register('my_security.access.expression_voter', '\stdClass')->setPublic(true);
-        $container->setAlias('security.access.expression_voter', 'my_security.access.expression_voter');
+        $container->register('my_security.expression_language', '\stdClass')->setPublic(true);
+        $container->setAlias('security.expression_language', 'my_security.expression_language');
         $container->compile();
 
-        $router = $container->getDefinition('my_security.access.expression_voter');
-        $calls = $router->getMethodCalls();
+        $calls = $container->getDefinition('my_security.expression_language')->getMethodCalls();
         $this->assertCount(1, $calls);
-        $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);
+        $this->assertEquals('registerProvider', $calls[0][0]);
         $this->assertEquals(new Reference('some_security_provider'), $calls[0][1][0]);
     }
-}
-
-class TestProvider
-{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no  
| Deprecations? | no 
| Tests pass?   | yes  
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is a fix on 3.4 related to https://github.com/symfony/symfony/pull/26660.

See the comment from @stof here: https://github.com/symfony/symfony/pull/26660#discussion_r177410230

- fixes a bug where custom providers would not be registered when retrieving the `security.expression_language` instance without the `ExpressionVoter` being instantiated.
- avoids deprecations on 3.4 when using the 4.1 patch in https://github.com/symfony/symfony/pull/26660
