### PR TITLE
[Messenger] Add debug:messenger CLI command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -277,6 +277,7 @@ class FrameworkExtension extends Extension
             $this->registerMessengerConfiguration($config['messenger'], $container, $loader, $config['serializer'], $config['validation']);
         } else {
             $container->removeDefinition('console.command.messenger_consume_messages');
+            $container->removeDefinition('console.command.messenger_debug');
         }
 
         if ($this->isConfigEnabled($container, $config['web_link'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -77,7 +77,7 @@
             <tag name="console.command" command="messenger:consume-messages" />
         </service>
 
-        <service id="console.command.messenger_debug" class="Symfony\Component\Messenger\Command\MessengerDebugCommand">
+        <service id="console.command.messenger_debug" class="Symfony\Component\Messenger\Command\DebugCommand">
             <argument type="collection" /> <!-- Message to handlers mapping -->
             <tag name="console.command" command="debug:messenger" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -77,6 +77,11 @@
             <tag name="console.command" command="messenger:consume-messages" />
         </service>
 
+        <service id="console.command.messenger_debug" class="Symfony\Component\Messenger\Command\MessengerDebugCommand">
+            <argument type="collection" /> <!-- Message to handlers mapping -->
+            <tag name="console.command" command="debug:messenger" />
+        </service>
+
         <service id="console.command.router_debug" class="Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand">
             <argument type="service" id="router" />
             <tag name="console.command" command="debug:router" />

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -41,7 +41,7 @@
         "symfony/security": "~3.4|~4.0",
         "symfony/form": "^4.1",
         "symfony/expression-language": "~3.4|~4.0",
-        "symfony/messenger": "^4.1",
+        "symfony/messenger": "^4.1-beta2",
         "symfony/process": "~3.4|~4.0",
         "symfony/security-core": "~3.4|~4.0",
         "symfony/security-csrf": "~3.4|~4.0",

--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * @experimental in 4.1
  */
-class MessengerDebugCommand extends Command
+class DebugCommand extends Command
 {
     protected static $defaultName = 'debug:messenger';
 

--- a/src/Symfony/Component/Messenger/Command/MessengerDebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/MessengerDebugCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * A console command to debug Messenger information.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ *
+ * @experimental in 4.1
+ */
+class MessengerDebugCommand extends Command
+{
+    protected static $defaultName = 'debug:messenger';
+
+    private $mapping;
+
+    public function __construct(array $mapping)
+    {
+        parent::__construct();
+
+        $this->mapping = $mapping;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setDescription('Lists messages you can dispatch using the message bus')
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> command displays all messages that can be
+dispatched using the message bus:
+
+  <info>php %command.full_name%</info>
+
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Messenger');
+        $io->text('The following messages can be dispatched:');
+        $io->newLine();
+
+        $tableRows = array();
+        foreach ($this->mapping as $message => $handlers) {
+            $tableRows[] = array(sprintf('<fg=cyan>%s</fg=cyan>', $message));
+            foreach ($handlers as $handler) {
+                $tableRows[] = array(sprintf('    handled by %s', $handler));
+            }
+        }
+
+        if ($tableRows) {
+            $io->table(array(), $tableRows);
+        } else {
+            $io->text('No messages were found that have valid handlers.');
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Adds a `debug:messenger` CLI command to expose message classes that can be dispatched. Heavily inspired by `debug:autowiring`.