### PR TITLE
Bugfix/simple authentication provider anonymous token

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Authentication\Provider;
 
 use Symfony\Component\Security\Core\User\UserChecker;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface;
@@ -45,8 +46,11 @@ class SimpleAuthenticationProvider implements AuthenticationProviderInterface
         }
 
         $user = $authToken->getUser();
-        $this->userChecker->checkPreAuth($user);
-        $this->userChecker->checkPostAuth($user);
+
+        if ($user instanceof UserInterface) {
+            $this->userChecker->checkPreAuth($user);
+            $this->userChecker->checkPostAuth($user);
+        }
 
         return $authToken;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
@@ -72,6 +72,32 @@ class SimpleAuthenticationProviderTest extends TestCase
         $provider->authenticate($token);
     }
 
+    /**
+     * Confirm an anonymous token is not checked by the user checker.
+     */
+    public function testAnonymousToken()
+    {
+        $user = 'anon.';
+
+        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $token->expects($this->any())
+            ->method('getUser')
+            ->will($this->returnValue($user));
+
+        $userChecker = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserCheckerInterface')->getMock();
+        $userChecker->expects($this->never())->method('checkPreAuth');
+        $userChecker->expects($this->never())->method('checkPostAuth');
+
+        $authenticator = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface')->getMock();
+        $authenticator->expects($this->once())
+            ->method('authenticateToken')
+            ->will($this->returnValue($token));
+
+        $provider = $this->getProvider($authenticator, null, $userChecker);
+
+        $provider->authenticate($token);
+    }
+
     protected function getProvider($simpleAuthenticator = null, $userProvider = null, $userChecker = null, $key = 'test')
     {
         if (null === $userChecker) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26807
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The `checkPreAuth()` and `checkPostAuth()` methods on the `UserCheckerInterface` expect their argument to be an instance of `UserInterface`. When the `SimpleAuthenticationProvider` acquires a token, it doesn't confirm this fact before checking the user. For instance, when the `SimpleAuthenticationProvider`'s `SimpleAuthenticatorInterface` instance returns an anonymous token (i.e. a token whose `getUser()` interface returns `"anon."`) a fatal error is thrown due to the type mismatch when calling the user checker check* methods.

This branch confirms the user is an instance of UserInterface before passing it to the checker.