### PR TITLE
[Bridge/Monolog] declare type in array_map in TokenProcessor

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Monolog\Processor;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Role\Role;
 
 /**
  * Adds the current security token to the log entry.
@@ -34,7 +35,7 @@ class TokenProcessor
             $records['extra']['token'] = array(
                 'username' => $token->getUsername(),
                 'authenticated' => $token->isAuthenticated(),
-                'roles' => array_map(function ($role) { return $role->getRole(); }, $token->getRoles()),
+                'roles' => array_map(function (Role $role) { return $role->getRole(); }, $token->getRoles()),
             );
         }
 

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Role\Role;
 
 /**
  * Tests the TokenProcessor.
@@ -36,7 +37,7 @@ class TokenProcessorTest extends TestCase
         $this->assertArrayHasKey('token', $record['extra']);
         $this->assertEquals($token->getUsername(), $record['extra']['token']['username']);
         $this->assertEquals($token->isAuthenticated(), $record['extra']['token']['authenticated']);
-        $roles = array_map(function ($role) { return $role->getRole(); }, $token->getRoles());
+        $roles = array_map(function (Role $role) { return $role->getRole(); }, $token->getRoles());
         $this->assertEquals($roles, $record['extra']['token']['roles']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Add type declaration in callback of array_map.
It would be helpful especially when reading code in IDE.
