### PR TITLE
[Validator] Fix LazyLoadingMetadataFactory with PSR6Cache for non classname if tested values isn't existing class

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -90,7 +90,7 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
             return $this->loadedClasses[$class];
         }
 
-        if (!class_exists($class) && !interface_exists($class)) {
+        if (!class_exists($class) && !interface_exists($class, false)) {
             throw new NoSuchMetadataException(sprintf('The class or interface "%s" does not exist.', $class));
         }
 

--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -90,15 +90,15 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
             return $this->loadedClasses[$class];
         }
 
+        if (!class_exists($class) && !interface_exists($class)) {
+            throw new NoSuchMetadataException(sprintf('The class or interface "%s" does not exist.', $class));
+        }
+
         if (null !== $this->cache && false !== ($metadata = $this->cache->read($class))) {
             // Include constraints from the parent class
             $this->mergeConstraints($metadata);
 
             return $this->loadedClasses[$class] = $metadata;
-        }
-
-        if (!class_exists($class) && !interface_exists($class)) {
-            throw new NoSuchMetadataException(sprintf('The class or interface "%s" does not exist.', $class));
         }
 
         $metadata = new ClassMetadata($class);

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -149,6 +149,21 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         $this->assertEquals($metadata, $factory->getMetadataFor(self::PARENT_CLASS));
     }
 
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\NoSuchMetadataException
+     */
+    public function testNonClassNameStringValues()
+    {
+        $testedValue = 'error@example.com';
+        $loader = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')->getMock();
+        $cache = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Cache\CacheInterface')->getMock();
+        $factory = new LazyLoadingMetadataFactory($loader, $cache);
+        $cache
+            ->expects($this->never())
+            ->method('read');
+        $factory->getMetadataFor($testedValue);
+    }
+
     public function testMetadataCacheWithRuntimeConstraint()
     {
         $cache = $this->getMockBuilder('Symfony\Component\Validator\Mapping\Cache\CacheInterface')->getMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26313
| License       | MIT

If @Assert\Valid is applied to a string value, the value is searched in metadata cache and some characters aren't allowed in this cache. This create an unexpected exception.

Class existence is now tested before cache read.
