### PR TITLE
[PhpUnitBridge] Fix getEnvVar for PHP <=5.4

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -37,7 +37,7 @@ $getEnvVar = function ($name, $default = false) {
     if (false !== $phpunitConfig) {
         $var = new DOMXpath($phpunitConfig);
         $var = $var->query('//php/env[@name="'.$name.'"]');
-        if ($var = $var[0]) {
+        if ($var = $var->item(0)) {
             return $var->getAttribute('value');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The merge of the PR #26811 broke some tests for old PHP versions.

The DOMNodeList started to implement the ArrayAccess interface [in PHP 5.6](https://bugs.php.net/bug.php?id=67949). For older version, we have to use the `item()` method to access a specific index.
