### PR TITLE
[Bridge/Doctrine] count(): Parameter must be an array or an object that implements Countable

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -517,4 +517,32 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($entity, $constraint);
     }
+
+    public function testValidateUniquenessOnNullResult()
+    {
+        $repository = $this->createRepositoryMock();
+        $repository
+             ->method('find')
+             ->will($this->returnValue(null))
+        ;
+
+        $this->em = $this->createEntityManagerMock($repository);
+        $this->registry = $this->createRegistryMock($this->em);
+        $this->validator = $this->createValidator();
+        $this->validator->initialize($this->context);
+
+        $constraint = new UniqueEntity(array(
+            'message' => 'myMessage',
+            'fields' => array('name'),
+            'em' => self::EM_NAME,
+        ));
+
+        $entity = new SingleIntIdEntity(1, null);
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $this->validator->validate($entity, $constraint);
+        $this->assertNoViolation();
+    }
 }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -133,15 +133,23 @@ class UniqueEntityValidator extends ConstraintValidator
          */
         if ($result instanceof \Iterator) {
             $result->rewind();
-        } elseif (is_array($result)) {
+            if ($result instanceof \Countable && 1 < \count($result)) {
+                $result = array($result->current(), $result->current());
+            } else {
+                $result = $result->current();
+                $result = null === $result ? array() : array($result);
+            }
+        } elseif (\is_array($result)) {
             reset($result);
+        } else {
+            $result = null === $result ? array() : array($result);
         }
 
         /* If no entity matched the query criteria or a single entity matched,
          * which is the same as the entity being validated, the criteria is
          * unique.
          */
-        if (0 === count($result) || (1 === count($result) && $entity === ($result instanceof \Iterator ? $result->current() : current($result)))) {
+        if (!$result || (1 === \count($result) && current($result) === $entity)) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master |
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Php7.2 will throw a warning on count(null) [http://php.net/manual/en/migration72.incompatible.php](http://php.net/manual/en/migration72.incompatible.php)

Error:
```
count(): Parameter must be an array or an object that implements Countable
```
when no result returned on validating unique constraint

For example, on an entity with annotation uniqueEntity:
```
 @UniqueEntity(
     fields={"email"},
     repositoryMethod="findMemberWithPasswordFromEmail",
 )
```

And in repository, a method ``findMemberWithPasswordFromEmail`` which return null if no entity found (``getOneOrNullResult``)
