### PR TITLE
[Config] Fixing GlobResource when inside phar archive

### DIFF
--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -93,7 +93,7 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface,
             return;
         }
 
-        if (false === strpos($this->pattern, '/**/') && (defined('GLOB_BRACE') || false === strpos($this->pattern, '{'))) {
+        if (0 !== strpos($this->prefix, 'phar://') && false === strpos($this->pattern, '/**/') && (defined('GLOB_BRACE') || false === strpos($this->pattern, '{'))) {
             foreach (glob($this->prefix.$this->pattern, defined('GLOB_BRACE') ? GLOB_BRACE : 0) as $path) {
                 if ($this->recursive && is_dir($path)) {
                     $files = iterator_to_array(new \RecursiveIteratorIterator(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes if old broken behavior counts as stable
| Deprecations? | no
| Tests pass?   | no tests yet
| Fixed tickets | 
| License       | MIT
| Doc PR        | N/A

When packaging an Sf4 application as a PHAR archive using globs at various locations (`Kernel`, `services.yaml`) most glob files are not found because the `glob()` PHP method [does not support PHAR streams](https://stackoverflow.com/questions/8203188/unexpected-problems-with-php-phar).

Using the regex fallback instead when operating inside PHAR archives fixes the behavior for me.

## Examples:

`src/Kernel.php::configureContainer()`:

```php
$loader->load($confDir.'/{services}'.self::CONFIG_EXTS, 'glob');
```

Expected behavior: `config/services.yaml` inside PHAR archive is found and parsed  
Actual behavior: the file will not be loaded

`config/services.yaml` (hard-coded in Kernel without using glob pattern)

```yaml
    App\:
        resource: '../src/*'
        exclude: '../src/{Entity,Migrations,Tests,Kernel.php}'
```

Expected behavior: service classes in `src/` will be found and auto-wired  
Actual behavior: services are not auto-wired because the class files are not found
