### PR TITLE
[Console][VarDumper] Added environment check to color-support check methods

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -311,6 +311,11 @@ class DeprecationErrorHandler
             return false;
         }
 
+        $colorEnv = getenv('ANSI');
+        if (in_array($colorEnv, array('0', '1'))) {
+            return '1' === $colorEnv;
+        }
+
         if (DIRECTORY_SEPARATOR === '\\') {
             return (function_exists('sapi_windows_vt100_support')
                 && sapi_windows_vt100_support(STDOUT))

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -307,13 +307,13 @@ class DeprecationErrorHandler
      */
     private static function hasColorSupport()
     {
-        if (!defined('STDOUT')) {
-            return false;
-        }
-
         $colorEnv = getenv('ANSI');
         if (in_array($colorEnv, array('0', '1'))) {
             return '1' === $colorEnv;
+        }
+
+        if (!defined('STDOUT')) {
+            return false;
         }
 
         if (DIRECTORY_SEPARATOR === '\\') {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/default.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/default.phpt
@@ -7,6 +7,7 @@ putenv('SYMFONY_DEPRECATIONS_HELPER');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');
+putenv('ANSI');
 
 $vendor = __DIR__;
 while (!file_exists($vendor.'/vendor')) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/env-color.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/env-color.phpt
@@ -1,13 +1,13 @@
 --TEST--
-Test DeprecationErrorHandler in weak mode
+Test DeprecationErrorHandler in forced color mode
 --FILE--
 <?php
 
-putenv('SYMFONY_DEPRECATIONS_HELPER=disabled');
+putenv('SYMFONY_DEPRECATIONS_HELPER');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');
-putenv('ANSI');
+putenv('ANSI=1');
 
 $vendor = __DIR__;
 while (!file_exists($vendor.'/vendor')) {
@@ -17,9 +17,10 @@ define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
 require PHPUNIT_COMPOSER_INSTALL;
 require_once __DIR__.'/../../bootstrap.php';
 
-echo (int) set_error_handler('var_dump');
-echo (int) class_exists('Symfony\Bridge\PhpUnit\DeprecationErrorHandler', false);
+trigger_error('root deprecation', E_USER_DEPRECATED);
 
 ?>
---EXPECTF--
-00
+--EXPECTREGEX--
+.\[[0-9;]+mOther deprecation notices \(1\).\[0m
+
+  1x: root deprecation

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/env-no-color.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/env-no-color.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test DeprecationErrorHandler in forced colorless mode
+--FILE--
+<?php
+
+putenv('SYMFONY_DEPRECATIONS_HELPER');
+putenv('ANSICON=true');
+putenv('ConEmuANSI=ON');
+putenv('TERM=xterm');
+putenv('ANSI=0');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+trigger_error('root deprecation', E_USER_DEPRECATED);
+
+?>
+--EXPECT--
+Other deprecation notices (1)
+
+  1x: root deprecation

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/regexp.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/regexp.phpt
@@ -7,6 +7,7 @@ putenv('SYMFONY_DEPRECATIONS_HELPER=/foo/');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');
+putenv('ANSI');
 
 $vendor = __DIR__;
 while (!file_exists($vendor.'/vendor')) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/shutdown_deprecations.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/shutdown_deprecations.phpt
@@ -7,6 +7,7 @@ putenv('SYMFONY_DEPRECATIONS_HELPER');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');
+putenv('ANSI');
 
 $vendor = __DIR__;
 while (!file_exists($vendor.'/vendor')) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak.phpt
@@ -7,6 +7,7 @@ putenv('SYMFONY_DEPRECATIONS_HELPER=weak');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');
+putenv('ANSI');
 
 $vendor = __DIR__;
 while (!file_exists($vendor.'/vendor')) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_eval_d_deprecation.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_eval_d_deprecation.phpt
@@ -7,6 +7,7 @@ putenv('SYMFONY_DEPRECATIONS_HELPER=weak_vendors');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');
+putenv('ANSI');
 
 $vendor = __DIR__;
 while (!file_exists($vendor.'/vendor')) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_non_vendor.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_non_vendor.phpt
@@ -7,6 +7,7 @@ putenv('SYMFONY_DEPRECATIONS_HELPER=weak_vendors');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');
+putenv('ANSI');
 
 $vendor = __DIR__;
 while (!file_exists($vendor.'/vendor')) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_phar_deprecation.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_phar_deprecation.phpt
@@ -8,6 +8,7 @@ putenv('SYMFONY_DEPRECATIONS_HELPER=weak_vendors');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');
+putenv('ANSI');
 
 $vendor = __DIR__;
 while (!file_exists($vendor.'/vendor')) {

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_vendor.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/weak_vendors_on_vendor.phpt
@@ -7,6 +7,7 @@ putenv('SYMFONY_DEPRECATIONS_HELPER=weak_vendors');
 putenv('ANSICON');
 putenv('ConEmuANSI');
 putenv('TERM');
+putenv('ANSI');
 
 $vendor = __DIR__;
 while (!file_exists($vendor.'/vendor')) {

--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -93,6 +93,11 @@ class StreamOutput extends Output
      */
     protected function hasColorSupport()
     {
+        $colorEnv = getenv('ANSI');
+        if (in_array($colorEnv, array('0', '1'))) {
+            return '1' === $colorEnv;
+        }
+
         if (DIRECTORY_SEPARATOR === '\\') {
             return (function_exists('sapi_windows_vt100_support')
                 && @sapi_windows_vt100_support($this->stream))

--- a/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
@@ -58,4 +58,28 @@ class StreamOutputTest extends TestCase
         rewind($output->getStream());
         $this->assertEquals('foo'.PHP_EOL, stream_get_contents($output->getStream()), '->doWrite() writes to the stream');
     }
+
+    public function testSetDecoratedFromEnv()
+    {
+        try {
+            putenv('ANSI=1');
+            $output = new StreamOutput(STDOUT);
+
+            $this->assertTrue($output->isDecorated());
+        } finally {
+            putenv('ANSI');
+        }
+    }
+
+    public function testDisableDecoratedFromEnv()
+    {
+        try {
+            putenv('ANSI=0');
+            $output = new StreamOutput(STDOUT);
+
+            $this->assertFalse($output->isDecorated());
+        } finally {
+            putenv('ANSI');
+        }
+    }
 }

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -541,6 +541,11 @@ class CliDumper extends AbstractDumper
             return false;
         }
 
+        $colorEnv = getenv('ANSI');
+        if (in_array($colorEnv, array('0', '1'))) {
+            return '1' === $colorEnv;
+        }
+
         if (DIRECTORY_SEPARATOR === '\\') {
             return (function_exists('sapi_windows_vt100_support')
                 && @sapi_windows_vt100_support($stream))

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -518,6 +518,62 @@ EOTXT
         );
     }
 
+    public function testSetColorFromEnv()
+    {
+        $cloner = new VarCloner();
+        $data = $cloner->cloneVar('test');
+
+        CliDumper::$defaultColors = null;
+        CliDumper::$defaultOutput = fopen('php://output', 'wb');
+
+        $dumper = new CliDumper(CliDumper::$defaultOutput);
+        $dumper->setColors(true);
+        ob_start();
+        $dumper->dump($data);
+        $expectedOutput = ob_get_clean();
+
+        try {
+            putenv('ANSI=1');
+
+            $dumper = new CliDumper(CliDumper::$defaultOutput);
+            ob_start();
+            $dumper->dump($data);
+            $out = ob_get_clean();
+        } finally {
+            putenv('ANSI');
+        }
+
+        $this->assertEquals($expectedOutput, $out);
+    }
+
+    public function testDisableColorFromEnv()
+    {
+        $cloner = new VarCloner();
+        $data = $cloner->cloneVar('test');
+
+        CliDumper::$defaultColors = null;
+        CliDumper::$defaultOutput = fopen('php://output', 'wb');
+
+        $dumper = new CliDumper(CliDumper::$defaultOutput);
+        $dumper->setColors(false);
+        ob_start();
+        $dumper->dump($data);
+        $expectedOutput = ob_get_clean();
+
+        try {
+            putenv('ANSI=0');
+
+            $dumper = new CliDumper(CliDumper::$defaultOutput);
+            ob_start();
+            $dumper->dump($data);
+            $out = ob_get_clean();
+        } finally {
+            putenv('ANSI');
+        }
+
+        $this->assertEquals($expectedOutput, $out);
+    }
+
     private function getSpecialVars()
     {
         foreach (array_keys($GLOBALS) as $var) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | tbd

Added allowing using an environment variable to set the console color setting, superseding auto detection. Symfony 2.7 was colorless when run from cron on Amazon Linux. Symfony 3.4 was colorful in the same context.


```sh
# Disable color, ignoring auto-detection
export ANSI=0
# Enable color, ignoring auto-detection
export ANSI=1
```

Or at the top of crontab:
```
ANSI=0
```

This is a redo/restart of #26707