### PR TITLE
[Cache] Allow to create a cache item directly via its constructor

### DIFF
--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -30,6 +30,16 @@ final class CacheItem implements CacheItemInterface
     protected $innerItem;
     protected $poolHash;
 
+    public function __construct(string $key = null, $value = null, \DateTimeInterface $expiryDate = null)
+    {
+        $this->key = $key;
+        $this->value = $value;
+
+        if (null != $expiryDate) {
+            $this->expiresAt($expiryDate);
+        }
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Cache/Tests/CacheItemTest.php
+++ b/src/Symfony/Component/Cache/Tests/CacheItemTest.php
@@ -74,4 +74,15 @@ class CacheItemTest extends TestCase
         $item = new CacheItem();
         $item->tag($tag);
     }
+
+    public function testCreateViaConstructor()
+    {
+        $item = new CacheItem('name', array('data'), $expiry = new \DateTime('+10 seconds'));
+
+        $this->assertEquals('name', $item->getKey());
+        $this->assertEquals(array('data'), $item->get());
+        call_user_func(\Closure::bind(function () use ($item, $expiry) {
+            $this->assertSame((int) $expiry->format('U'), $item->expiry);
+        }, $this, CacheItem::class));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

Because if I want to use the adapters and items directly, why couldn't it? 🤔 