### PR TITLE
[DI][FrameworkBundle] Use container.hidden tag to hide services from debug:container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -48,8 +48,9 @@ class ContainerDebugCommand extends Command
         $this
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::OPTIONAL, 'A service name (foo)'),
-                new InputOption('show-private', null, InputOption::VALUE_NONE, 'Used to show public *and* private services'),
+                new InputOption('show-private', null, InputOption::VALUE_NONE, 'Used to show public *and* private services (deprecated)'),
                 new InputOption('show-arguments', null, InputOption::VALUE_NONE, 'Used to show arguments in services'),
+                new InputOption('show-hidden', null, InputOption::VALUE_NONE, 'Used to show hidden (internal) services'),
                 new InputOption('tag', null, InputOption::VALUE_REQUIRED, 'Shows all services with a specific tag'),
                 new InputOption('tags', null, InputOption::VALUE_NONE, 'Displays tagged services for an application'),
                 new InputOption('parameter', null, InputOption::VALUE_REQUIRED, 'Displays a specific parameter for an application'),
@@ -71,11 +72,6 @@ To get specific information about a service, specify its name:
 To see available types that can be used for autowiring, use the <info>--types</info> flag:
 
   <info>php %command.full_name% --types</info>
-
-By default, private services are hidden. You can display all services by
-using the <info>--show-private</info> flag:
-
-  <info>php %command.full_name% --show-private</info>
 
 Use the --tags option to display tagged <comment>public</comment> services grouped by tag:
 
@@ -103,6 +99,10 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($input->getOption('show-private')) {
+            @trigger_error('The "--show-private" option no longer has any effect and is deprecated since Symfony 4.1.', E_USER_DEPRECATED);
+        }
+
         $io = new SymfonyStyle($input, $output);
         $errorIo = $io->getErrorStyle();
 
@@ -110,7 +110,7 @@ EOF
         $object = $this->getContainerBuilder();
 
         if ($input->getOption('types')) {
-            $options = array('show_private' => true);
+            $options = array();
             $options['filter'] = array($this, 'filterToServiceTypes');
         } elseif ($input->getOption('parameters')) {
             $parameters = array();
@@ -122,19 +122,20 @@ EOF
         } elseif ($parameter = $input->getOption('parameter')) {
             $options = array('parameter' => $parameter);
         } elseif ($input->getOption('tags')) {
-            $options = array('group_by' => 'tags', 'show_private' => $input->getOption('show-private'));
+            $options = array('group_by' => 'tags');
         } elseif ($tag = $input->getOption('tag')) {
-            $options = array('tag' => $tag, 'show_private' => $input->getOption('show-private'));
+            $options = array('tag' => $tag);
         } elseif ($name = $input->getArgument('name')) {
             $name = $this->findProperServiceName($input, $errorIo, $object, $name);
             $options = array('id' => $name);
         } else {
-            $options = array('show_private' => $input->getOption('show-private'));
+            $options = array();
         }
 
         $helper = new DescriptorHelper();
         $options['format'] = $input->getOption('format');
         $options['show_arguments'] = $input->getOption('show-arguments');
+        $options['show_hidden'] = $input->getOption('show-hidden');
         $options['raw_text'] = $input->getOption('raw');
         $options['output'] = $io;
         $helper->describe($io, $object, $options);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Descriptor\DescriptorInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -230,27 +231,34 @@ abstract class Descriptor implements DescriptorInterface
             return $builder->getAlias($serviceId);
         }
 
+        if ('service_container' === $serviceId) {
+            return (new Definition(ContainerInterface::class))->setPublic(true)->setSynthetic(true);
+        }
+
         // the service has been injected in some special way, just return the service
         return $builder->get($serviceId);
     }
 
     /**
      * @param ContainerBuilder $builder
-     * @param bool             $showPrivate
+     * @param bool             $showHidden
      *
      * @return array
      */
-    protected function findDefinitionsByTag(ContainerBuilder $builder, $showPrivate)
+    protected function findDefinitionsByTag(ContainerBuilder $builder, $showHidden)
     {
         $definitions = array();
         $tags = $builder->findTags();
         asort($tags);
 
         foreach ($tags as $tag) {
+            if ('container.hidden' === $tag) {
+                continue;
+            }
             foreach ($builder->findTaggedServiceIds($tag) as $serviceId => $attributes) {
                 $definition = $this->resolveServiceDefinition($builder, $serviceId);
 
-                if (!$definition instanceof Definition || !$showPrivate && !$definition->isPublic()) {
+                if (!$definition instanceof Definition || ($showHidden xor $definition->hasTag('container.hidden'))) {
                     continue;
                 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -63,10 +63,10 @@ class JsonDescriptor extends Descriptor
      */
     protected function describeContainerTags(ContainerBuilder $builder, array $options = array())
     {
-        $showPrivate = isset($options['show_private']) && $options['show_private'];
+        $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $data = array();
 
-        foreach ($this->findDefinitionsByTag($builder, $showPrivate) as $tag => $definitions) {
+        foreach ($this->findDefinitionsByTag($builder, $showHidden) as $tag => $definitions) {
             $data[$tag] = array();
             foreach ($definitions as $definition) {
                 $data[$tag][] = $this->getContainerDefinitionData($definition, true);
@@ -100,7 +100,7 @@ class JsonDescriptor extends Descriptor
     protected function describeContainerServices(ContainerBuilder $builder, array $options = array())
     {
         $serviceIds = isset($options['tag']) && $options['tag'] ? array_keys($builder->findTaggedServiceIds($options['tag'])) : $builder->getServiceIds();
-        $showPrivate = isset($options['show_private']) && $options['show_private'];
+        $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $omitTags = isset($options['omit_tags']) && $options['omit_tags'];
         $showArguments = isset($options['show_arguments']) && $options['show_arguments'];
         $data = array('definitions' => array(), 'aliases' => array(), 'services' => array());
@@ -113,11 +113,11 @@ class JsonDescriptor extends Descriptor
             $service = $this->resolveServiceDefinition($builder, $serviceId);
 
             if ($service instanceof Alias) {
-                if ($showPrivate || ($service->isPublic() && !$service->isPrivate())) {
+                if (!$showHidden) {
                     $data['aliases'][$serviceId] = $this->getContainerAliasData($service);
                 }
             } elseif ($service instanceof Definition) {
-                if (($showPrivate || ($service->isPublic() && !$service->isPrivate()))) {
+                if (!($showHidden xor $service->hasTag('container.hidden'))) {
                     $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service, $omitTags, $showArguments);
                 }
             } else {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -82,10 +82,10 @@ class MarkdownDescriptor extends Descriptor
      */
     protected function describeContainerTags(ContainerBuilder $builder, array $options = array())
     {
-        $showPrivate = isset($options['show_private']) && $options['show_private'];
+        $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $this->write("Container tags\n==============");
 
-        foreach ($this->findDefinitionsByTag($builder, $showPrivate) as $tag => $definitions) {
+        foreach ($this->findDefinitionsByTag($builder, $showHidden) as $tag => $definitions) {
             $this->write("\n\n".$tag."\n".str_repeat('-', strlen($tag)));
             foreach ($definitions as $serviceId => $definition) {
                 $this->write("\n\n");
@@ -119,9 +119,9 @@ class MarkdownDescriptor extends Descriptor
      */
     protected function describeContainerServices(ContainerBuilder $builder, array $options = array())
     {
-        $showPrivate = isset($options['show_private']) && $options['show_private'];
+        $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
 
-        $title = $showPrivate ? 'Public and private services' : 'Public services';
+        $title = $showHidden ? 'Hidden services' : 'Services';
         if (isset($options['tag'])) {
             $title .= ' with tag `'.$options['tag'].'`';
         }
@@ -139,11 +139,11 @@ class MarkdownDescriptor extends Descriptor
             $service = $this->resolveServiceDefinition($builder, $serviceId);
 
             if ($service instanceof Alias) {
-                if ($showPrivate || ($service->isPublic() && !$service->isPrivate())) {
+                if (!$showHidden) {
                     $services['aliases'][$serviceId] = $service;
                 }
             } elseif ($service instanceof Definition) {
-                if (($showPrivate || ($service->isPublic() && !$service->isPrivate()))) {
+                if (!($showHidden xor $service->hasTag('container.hidden'))) {
                     $services['definitions'][$serviceId] = $service;
                 }
             } else {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -122,15 +122,15 @@ class TextDescriptor extends Descriptor
      */
     protected function describeContainerTags(ContainerBuilder $builder, array $options = array())
     {
-        $showPrivate = isset($options['show_private']) && $options['show_private'];
+        $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
 
-        if ($showPrivate) {
-            $options['output']->title('Symfony Container Public and Private Tags');
+        if ($showHidden) {
+            $options['output']->title('Symfony Container Hidden Tags');
         } else {
-            $options['output']->title('Symfony Container Public Tags');
+            $options['output']->title('Symfony Container Tags');
         }
 
-        foreach ($this->findDefinitionsByTag($builder, $showPrivate) as $tag => $definitions) {
+        foreach ($this->findDefinitionsByTag($builder, $showHidden) as $tag => $definitions) {
             $options['output']->section(sprintf('"%s" tag', $tag));
             $options['output']->listing(array_keys($definitions));
         }
@@ -165,13 +165,13 @@ class TextDescriptor extends Descriptor
      */
     protected function describeContainerServices(ContainerBuilder $builder, array $options = array())
     {
-        $showPrivate = isset($options['show_private']) && $options['show_private'];
+        $showHidden = isset($options['show_hidden']) && $options['show_hidden'];
         $showTag = isset($options['tag']) ? $options['tag'] : null;
 
-        if ($showPrivate) {
-            $title = 'Symfony Container Public and Private Services';
+        if ($showHidden) {
+            $title = 'Symfony Container Hidden Services';
         } else {
-            $title = 'Symfony Container Public Services';
+            $title = 'Symfony Container Services';
         }
 
         if ($showTag) {
@@ -190,8 +190,8 @@ class TextDescriptor extends Descriptor
         foreach ($serviceIds as $key => $serviceId) {
             $definition = $this->resolveServiceDefinition($builder, $serviceId);
             if ($definition instanceof Definition) {
-                // filter out private services unless shown explicitly
-                if (!$showPrivate && (!$definition->isPublic() || $definition->isPrivate())) {
+                // filter out hidden services unless shown explicitly
+                if ($showHidden xor $definition->hasTag('container.hidden')) {
                     unset($serviceIds[$key]);
                     continue;
                 }
@@ -209,7 +209,7 @@ class TextDescriptor extends Descriptor
                     }
                 }
             } elseif ($definition instanceof Alias) {
-                if (!$showPrivate && (!$definition->isPublic() || $definition->isPrivate())) {
+                if ($showHidden) {
                     unset($serviceIds[$key]);
                     continue;
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -58,7 +58,7 @@ class XmlDescriptor extends Descriptor
      */
     protected function describeContainerTags(ContainerBuilder $builder, array $options = array())
     {
-        $this->writeDocument($this->getContainerTagsDocument($builder, isset($options['show_private']) && $options['show_private']));
+        $this->writeDocument($this->getContainerTagsDocument($builder, isset($options['show_hidden']) && $options['show_hidden']));
     }
 
     /**
@@ -78,7 +78,7 @@ class XmlDescriptor extends Descriptor
      */
     protected function describeContainerServices(ContainerBuilder $builder, array $options = array())
     {
-        $this->writeDocument($this->getContainerServicesDocument($builder, isset($options['tag']) ? $options['tag'] : null, isset($options['show_private']) && $options['show_private'], isset($options['show_arguments']) && $options['show_arguments'], isset($options['filter']) ? $options['filter'] : null));
+        $this->writeDocument($this->getContainerServicesDocument($builder, isset($options['tag']) ? $options['tag'] : null, isset($options['show_hidden']) && $options['show_hidden'], isset($options['show_arguments']) && $options['show_arguments'], isset($options['filter']) ? $options['filter'] : null));
     }
 
     /**
@@ -231,12 +231,12 @@ class XmlDescriptor extends Descriptor
         return $dom;
     }
 
-    private function getContainerTagsDocument(ContainerBuilder $builder, bool $showPrivate = false): \DOMDocument
+    private function getContainerTagsDocument(ContainerBuilder $builder, bool $showHidden = false): \DOMDocument
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($containerXML = $dom->createElement('container'));
 
-        foreach ($this->findDefinitionsByTag($builder, $showPrivate) as $tag => $definitions) {
+        foreach ($this->findDefinitionsByTag($builder, $showHidden) as $tag => $definitions) {
             $containerXML->appendChild($tagXML = $dom->createElement('tag'));
             $tagXML->setAttribute('name', $tag);
 
@@ -269,7 +269,7 @@ class XmlDescriptor extends Descriptor
         return $dom;
     }
 
-    private function getContainerServicesDocument(ContainerBuilder $builder, string $tag = null, bool $showPrivate = false, bool $showArguments = false, callable $filter = null): \DOMDocument
+    private function getContainerServicesDocument(ContainerBuilder $builder, string $tag = null, bool $showHidden = false, bool $showArguments = false, callable $filter = null): \DOMDocument
     {
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($containerXML = $dom->createElement('container'));
@@ -283,7 +283,7 @@ class XmlDescriptor extends Descriptor
         foreach ($this->sortServiceIds($serviceIds) as $serviceId) {
             $service = $this->resolveServiceDefinition($builder, $serviceId);
 
-            if (($service instanceof Definition || $service instanceof Alias) && !($showPrivate || ($service->isPublic() && !$service->isPrivate()))) {
+            if (($service instanceof Alias && $showHidden) || ($service instanceof Definition && ($showHidden xor $service->hasTag('container.hidden')))) {
                 continue;
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -25,6 +25,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'annotations.cached_reader',
         'cache.pool.clearer',
         'console.command',
+        'container.hidden',
         'container.hot_path',
         'container.service_locator',
         'container.service_subscriber',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -130,8 +130,10 @@ abstract class AbstractDescriptorTest extends TestCase
         $i = 0;
         $data = $this->getDescriptionTestData($aliasesWithDefinitions);
         foreach ($aliases as $name => $alias) {
+            $file = array_pop($data[$i]);
             $data[$i][] = $builder;
             $data[$i][] = array('id' => $name);
+            $data[$i][] = $file;
             ++$i;
         }
 
@@ -148,8 +150,12 @@ abstract class AbstractDescriptorTest extends TestCase
     {
         $data = $this->getDescriptionTestData(ObjectsProvider::getContainerParameter());
 
+        $file = array_pop($data[0]);
         $data[0][] = array('parameter' => 'database_name');
+        $data[0][] = $file;
+        $file = array_pop($data[1]);
         $data[1][] = array('parameter' => 'twig.form.resources');
+        $data[1][] = $file;
 
         return $data;
     }
@@ -203,8 +209,9 @@ abstract class AbstractDescriptorTest extends TestCase
     {
         $data = array();
         foreach ($objects as $name => $object) {
-            $description = file_get_contents(sprintf('%s/../../Fixtures/Descriptor/%s.%s', __DIR__, $name, $this->getFormat()));
-            $data[] = array($object, $description);
+            $file = sprintf('%s.%s', $name, $this->getFormat());
+            $description = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
+            $data[] = array($object, $description, $file);
         }
 
         return $data;
@@ -213,18 +220,19 @@ abstract class AbstractDescriptorTest extends TestCase
     private function getContainerBuilderDescriptionTestData(array $objects)
     {
         $variations = array(
-            'services' => array('show_private' => true),
-            'public' => array('show_private' => false),
-            'tag1' => array('show_private' => true, 'tag' => 'tag1'),
-            'tags' => array('group_by' => 'tags', 'show_private' => true),
-            'arguments' => array('show_private' => false, 'show_arguments' => true),
+            'services' => array('show_hidden' => true),
+            'public' => array('show_hidden' => false),
+            'tag1' => array('show_hidden' => true, 'tag' => 'tag1'),
+            'tags' => array('group_by' => 'tags', 'show_hidden' => true),
+            'arguments' => array('show_hidden' => false, 'show_arguments' => true),
         );
 
         $data = array();
         foreach ($objects as $name => $object) {
             foreach ($variations as $suffix => $options) {
-                $description = file_get_contents(sprintf('%s/../../Fixtures/Descriptor/%s_%s.%s', __DIR__, $name, $suffix, $this->getFormat()));
-                $data[] = array($object, $description, $options);
+                $file = sprintf('%s_%s.%s', $name, $suffix, $this->getFormat());
+                $description = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
+                $data[] = array($object, $description, $options, $file);
             }
         }
 
@@ -241,8 +249,9 @@ abstract class AbstractDescriptorTest extends TestCase
         $data = array();
         foreach ($objects as $name => $object) {
             foreach ($variations as $suffix => $options) {
-                $description = file_get_contents(sprintf('%s/../../Fixtures/Descriptor/%s_%s.%s', __DIR__, $name, $suffix, $this->getFormat()));
-                $data[] = array($object, $description, $options);
+                $file = sprintf('%s_%s.%s', $name, $suffix, $this->getFormat());
+                $description = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
+                $data[] = array($object, $description, $options, $file);
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -129,6 +129,7 @@ class ObjectsProvider
                 ->addTag('tag1', array('attr1' => 'val1', 'attr2' => 'val2'))
                 ->addTag('tag1', array('attr3' => 'val3'))
                 ->addTag('tag2')
+                ->addTag('container.hidden')
                 ->addMethodCall('setMailer', array(new Reference('mailer')))
                 ->setFactory(array(new Reference('factory.service'), 'get')),
         );

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.json
@@ -35,6 +35,10 @@
             {
                 "name": "tag2",
                 "parameters": []
+            },
+            {
+                "name": "container.hidden",
+                "parameters": []
             }
         ]
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.md
@@ -23,3 +23,4 @@
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `container.hidden`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
@@ -10,7 +10,8 @@
   Class             Full\Qualified\Class2            
 [39;49m  Tags              tag1 ([39;49m[32mattr1[39m[39;49m: val1, [39;49m[32mattr2[39m[39;49m: val2)[39;49m[39;49m  [39;49m
 [39;49m                    [39;49m[39;49mtag1 ([39;49m[32mattr3[39m[39;49m: val3)[39;49m[39;49m               [39;49m
-[39;49m                    [39;49mtag2                             
+[39;49m                    [39;49m[39;49mtag2[39;49m[39;49m                             [39;49m
+[39;49m                    [39;49mcontainer.hidden                 
   Calls             setMailer                        
   Public            no                               
   Synthetic         yes                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.xml
@@ -14,5 +14,6 @@
       <parameter name="attr3">val3</parameter>
     </tag>
     <tag name="tag2"/>
+    <tag name="container.hidden"/>
   </tags>
 </definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
@@ -66,15 +66,30 @@
             "factory_class": "Full\\Qualified\\FactoryClass",
             "factory_method": "get",
             "tags": []
+        },
+        "service_container": {
+            "class": "Symfony\\Component\\DependencyInjection\\ContainerInterface",
+            "public": true,
+            "synthetic": true,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": false,
+            "arguments": [],
+            "file": null,
+            "tags": []
         }
     },
     "aliases": {
         "alias_1": {
             "service": "service_1",
             "public": true
+        },
+        "alias_2": {
+            "service": "service_2",
+            "public": false
         }
     },
-    "services": {
-        "service_container": "Symfony\\Component\\DependencyInjection\\ContainerBuilder"
-    }
+    "services": []
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.md
@@ -1,5 +1,5 @@
-Public services
-===============
+Services
+========
 
 Definitions
 -----------
@@ -18,6 +18,18 @@ Definitions
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`
 
+### service_container
+
+- Class: `Symfony\Component\DependencyInjection\ContainerInterface`
+- Public: yes
+- Synthetic: yes
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+- Arguments: no
+
 
 Aliases
 -------
@@ -27,8 +39,9 @@ Aliases
 - Service: `service_1`
 - Public: yes
 
+### alias_2
 
-Services
---------
+- Service: `service_2`
+- Public: no
 
-- `service_container`: `Symfony\Component\DependencyInjection\ContainerBuilder`
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.txt
@@ -1,12 +1,13 @@
 
-[33mSymfony Container Public Services[39m
-[33m=================================[39m
+[33mSymfony Container Services[39m
+[33m==========================[39m
 
- ------------------- -------------------------------------------------------- 
- [32m Service ID        [39m [32m Class name                                             [39m 
- ------------------- -------------------------------------------------------- 
-  alias_1             alias for "service_1"                                   
-  definition_1        Full\Qualified\Class1                                   
-  service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
- ------------------- -------------------------------------------------------- 
+ ------------------- ---------------------------------------------------------- 
+ [32m Service ID        [39m [32m Class name                                               [39m 
+ ------------------- ---------------------------------------------------------- 
+  alias_1             alias for "service_1"                                     
+  alias_2             alias for "service_2"                                     
+  definition_1        Full\Qualified\Class1                                     
+  service_container   Symfony\Component\DependencyInjection\ContainerInterface  
+ ------------------- ---------------------------------------------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container>
   <alias id="alias_1" service="service_1" public="true"/>
+  <alias id="alias_2" service="service_2" public="false"/>
   <definition id="definition_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" autoconfigured="false" file="">
     <factory class="Full\Qualified\FactoryClass" method="get"/>
     <argument type="service" id="definition2"/>
@@ -23,5 +24,5 @@
       <argument type="service" id="definition_2"/>
     </argument>
   </definition>
-  <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
+  <definition id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file=""/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
@@ -13,15 +13,29 @@
             "factory_class": "Full\\Qualified\\FactoryClass",
             "factory_method": "get",
             "tags": []
+        },
+        "service_container": {
+            "class": "Symfony\\Component\\DependencyInjection\\ContainerInterface",
+            "public": true,
+            "synthetic": true,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": false,
+            "file": null,
+            "tags": []
         }
     },
     "aliases": {
         "alias_1": {
             "service": "service_1",
             "public": true
+        },
+        "alias_2": {
+            "service": "service_2",
+            "public": false
         }
     },
-    "services": {
-        "service_container": "Symfony\\Component\\DependencyInjection\\ContainerBuilder"
-    }
+    "services": []
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
@@ -1,5 +1,5 @@
-Public services
-===============
+Services
+========
 
 Definitions
 -----------
@@ -17,6 +17,17 @@ Definitions
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`
 
+### service_container
+
+- Class: `Symfony\Component\DependencyInjection\ContainerInterface`
+- Public: yes
+- Synthetic: yes
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+
 
 Aliases
 -------
@@ -26,8 +37,8 @@ Aliases
 - Service: `service_1`
 - Public: yes
 
+### alias_2
 
-Services
---------
+- Service: `service_2`
+- Public: no
 
-- `service_container`: `Symfony\Component\DependencyInjection\ContainerBuilder`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.txt
@@ -1,12 +1,13 @@
 
-[33mSymfony Container Public Services[39m
-[33m=================================[39m
+[33mSymfony Container Services[39m
+[33m==========================[39m
 
- ------------------- -------------------------------------------------------- 
- [32m Service ID        [39m [32m Class name                                             [39m 
- ------------------- -------------------------------------------------------- 
-  alias_1             alias for "service_1"                                   
-  definition_1        Full\Qualified\Class1                                   
-  service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
- ------------------- -------------------------------------------------------- 
+ ------------------- ---------------------------------------------------------- 
+ [32m Service ID        [39m [32m Class name                                               [39m 
+ ------------------- ---------------------------------------------------------- 
+  alias_1             alias for "service_1"                                     
+  alias_2             alias for "service_2"                                     
+  definition_1        Full\Qualified\Class1                                     
+  service_container   Symfony\Component\DependencyInjection\ContainerInterface  
+ ------------------- ---------------------------------------------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container>
   <alias id="alias_1" service="service_1" public="true"/>
+  <alias id="alias_2" service="service_2" public="false"/>
   <definition id="definition_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" autoconfigured="false" file="">
     <factory class="Full\Qualified\FactoryClass" method="get"/>
   </definition>
-  <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
+  <definition id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file=""/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
@@ -1,19 +1,5 @@
 {
     "definitions": {
-        "definition_1": {
-            "class": "Full\\Qualified\\Class1",
-            "public": true,
-            "synthetic": false,
-            "lazy": true,
-            "shared": true,
-            "abstract": true,
-            "autowire": false,
-            "autoconfigure": false,
-            "file": null,
-            "factory_class": "Full\\Qualified\\FactoryClass",
-            "factory_method": "get",
-            "tags": []
-        },
         "definition_2": {
             "class": "Full\\Qualified\\Class2",
             "public": false,
@@ -46,21 +32,14 @@
                 {
                     "name": "tag2",
                     "parameters": []
+                },
+                {
+                    "name": "container.hidden",
+                    "parameters": []
                 }
             ]
         }
     },
-    "aliases": {
-        "alias_1": {
-            "service": "service_1",
-            "public": true
-        },
-        "alias_2": {
-            "service": "service_2",
-            "public": false
-        }
-    },
-    "services": {
-        "service_container": "Symfony\\Component\\DependencyInjection\\ContainerBuilder"
-    }
+    "aliases": [],
+    "services": []
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
@@ -1,21 +1,8 @@
-Public and private services
-===========================
+Hidden services
+===============
 
 Definitions
 -----------
-
-### definition_1
-
-- Class: `Full\Qualified\Class1`
-- Public: yes
-- Synthetic: no
-- Lazy: yes
-- Shared: yes
-- Abstract: yes
-- Autowired: no
-- Autoconfigured: no
-- Factory Class: `Full\Qualified\FactoryClass`
-- Factory Method: `get`
 
 ### definition_2
 
@@ -37,23 +24,6 @@ Definitions
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `container.hidden`
 
 
-Aliases
--------
-
-### alias_1
-
-- Service: `service_1`
-- Public: yes
-
-### alias_2
-
-- Service: `service_2`
-- Public: no
-
-
-Services
---------
-
-- `service_container`: `Symfony\Component\DependencyInjection\ContainerBuilder`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.txt
@@ -1,14 +1,10 @@
 
-[33mSymfony Container Public and Private Services[39m
-[33m=============================================[39m
+[33mSymfony Container Hidden Services[39m
+[33m=================================[39m
 
- ------------------- -------------------------------------------------------- 
- [32m Service ID        [39m [32m Class name                                             [39m 
- ------------------- -------------------------------------------------------- 
-  alias_1             alias for "service_1"                                   
-  alias_2             alias for "service_2"                                   
-  definition_1        Full\Qualified\Class1                                   
-  definition_2        Full\Qualified\Class2                                   
-  service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
- ------------------- -------------------------------------------------------- 
+ -------------- ----------------------- 
+ [32m Service ID   [39m [32m Class name            [39m 
+ -------------- ----------------------- 
+  definition_2   Full\Qualified\Class2  
+ -------------- ----------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container>
-  <alias id="alias_1" service="service_1" public="true"/>
-  <alias id="alias_2" service="service_2" public="false"/>
-  <definition id="definition_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" autoconfigured="false" file="">
-    <factory class="Full\Qualified\FactoryClass" method="get"/>
-  </definition>
   <definition id="definition_2" class="Full\Qualified\Class2" public="false" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file="/path/to/file">
     <factory service="factory.service" method="get"/>
     <calls>
@@ -19,7 +14,7 @@
         <parameter name="attr3">val3</parameter>
       </tag>
       <tag name="tag2"/>
+      <tag name="container.hidden"/>
     </tags>
   </definition>
-  <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.json
@@ -32,6 +32,10 @@
                 {
                     "name": "tag2",
                     "parameters": []
+                },
+                {
+                    "name": "container.hidden",
+                    "parameters": []
                 }
             ]
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
@@ -1,5 +1,5 @@
-Public and private services with tag `tag1`
-===========================================
+Hidden services with tag `tag1`
+===============================
 
 Definitions
 -----------
@@ -24,3 +24,4 @@ Definitions
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `container.hidden`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.txt
@@ -1,6 +1,6 @@
 
-[33mSymfony Container Public and Private Services Tagged with "tag1" Tag[39m
-[33m====================================================================[39m
+[33mSymfony Container Hidden Services Tagged with "tag1" Tag[39m
+[33m========================================================[39m
 
  -------------- ------- ------- ------- ----------------------- 
  [32m Service ID   [39m [32m attr1 [39m [32m attr2 [39m [32m attr3 [39m [32m Class name            [39m 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.xml
@@ -14,6 +14,7 @@
         <parameter name="attr3">val3</parameter>
       </tag>
       <tag name="tag2"/>
+      <tag name="container.hidden"/>
     </tags>
   </definition>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tags.txt
@@ -1,6 +1,6 @@
 
-[33mSymfony Container Public and Private Tags[39m
-[33m=========================================[39m
+[33mSymfony Container Hidden Tags[39m
+[33m=============================[39m
 
 [33m"tag1" tag[39m
 [33m----------[39m

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.json
@@ -30,6 +30,10 @@
         {
             "name": "tag2",
             "parameters": []
+        },
+        {
+            "name": "container.hidden",
+            "parameters": []
         }
     ]
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.md
@@ -16,3 +16,4 @@
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `container.hidden`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
@@ -5,7 +5,8 @@
   Class             Full\Qualified\Class2            
 [39;49m  Tags              tag1 ([39;49m[32mattr1[39m[39;49m: val1, [39;49m[32mattr2[39m[39;49m: val2)[39;49m[39;49m  [39;49m
 [39;49m                    [39;49m[39;49mtag1 ([39;49m[32mattr3[39m[39;49m: val3)[39;49m[39;49m               [39;49m
-[39;49m                    [39;49mtag2                             
+[39;49m                    [39;49m[39;49mtag2[39;49m[39;49m                             [39;49m
+[39;49m                    [39;49mcontainer.hidden                 
   Calls             setMailer                        
   Public            no                               
   Synthetic         yes                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.xml
@@ -13,5 +13,6 @@
       <parameter name="attr3">val3</parameter>
     </tag>
     <tag name="tag2"/>
+    <tag name="container.hidden"/>
   </tags>
 </definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.json
@@ -31,6 +31,10 @@
         {
             "name": "tag2",
             "parameters": []
+        },
+        {
+            "name": "container.hidden",
+            "parameters": []
         }
     ]
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.md
@@ -17,3 +17,4 @@
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Tag: `container.hidden`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.txt
@@ -5,7 +5,8 @@
   Class             Full\Qualified\Class2            
 [39;49m  Tags              tag1 ([39;49m[32mattr1[39m[39;49m: val1, [39;49m[32mattr2[39m[39;49m: val2)[39;49m[39;49m  [39;49m
 [39;49m                    [39;49m[39;49mtag1 ([39;49m[32mattr3[39m[39;49m: val3)[39;49m[39;49m               [39;49m
-[39;49m                    [39;49mtag2                             
+[39;49m                    [39;49m[39;49mtag2[39;49m[39;49m                             [39;49m
+[39;49m                    [39;49mcontainer.hidden                 
   Calls             setMailer                        
   Public            no                               
   Synthetic         yes                              

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_2.xml
@@ -13,5 +13,6 @@
       <parameter name="attr3">val3</parameter>
     </tag>
     <tag name="tag2"/>
+    <tag name="container.hidden"/>
   </tags>
 </definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -55,12 +55,12 @@ class ContainerDebugCommandTest extends WebTestCase
         $application->setAutoExit(false);
 
         $tester = new ApplicationTester($application);
-        $tester->run(array('command' => 'debug:container', '--show-private' => true));
-        $this->assertContains('public', $tester->getDisplay());
-        $this->assertContains('private_alias', $tester->getDisplay());
+        $tester->run(array('command' => 'debug:container', '--show-hidden' => true));
+        $this->assertNotContains('public', $tester->getDisplay());
+        $this->assertNotContains('private_alias', $tester->getDisplay());
 
         $tester->run(array('command' => 'debug:container'));
         $this->assertContains('public', $tester->getDisplay());
-        $this->assertNotContains('private_alias', $tester->getDisplay());
+        $this->assertContains('private_alias', $tester->getDisplay());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -433,6 +433,7 @@ class XmlFileLoader extends FileLoader
         uksort($definitions, 'strnatcmp');
         foreach (array_reverse($definitions) as $id => list($domElement, $file)) {
             if (null !== $definition = $this->parseDefinition($domElement, $file, array())) {
+                $definition->addTag('container.hidden');
                 $this->setDefinition($id, $definition);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #26630
| License       | MIT
| Doc PR        | -

Now that services are private by default, the `debug:container` should display them by default.
In fact, the public/private concept should not trigger a difference in visibility for this command.
Instead, I propose to handle a new `container.hidden` tag, for the purpose of tagging services as hidden (~internal).

I now need to apply the tag to more services created internally.

Any comments at this stage?