### PR TITLE
[Routing] Fix loading multiple class annotations for invokable classes

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -119,10 +119,15 @@ abstract class AnnotationClassLoader implements LoaderInterface
             }
         }
 
-        if (0 === $collection->count() && $class->hasMethod('__invoke') && $annot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass)) {
-            $globals['path'] = '';
-            $globals['name'] = '';
-            $this->addRoute($collection, $annot, $globals, $class, $class->getMethod('__invoke'));
+        if (0 === $collection->count() && $class->hasMethod('__invoke')) {
+            foreach ($this->reader->getClassAnnotations($class) as $annot) {
+                if ($annot instanceof $this->routeAnnotationClass) {
+                    $globals['path'] = '';
+                    $globals['name'] = '';
+
+                    $this->addRoute($collection, $annot, $globals, $class, $class->getMethod('__invoke'));
+                }
+            }
         }
 
         return $collection;

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -191,9 +191,9 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         );
 
         $this->reader
-            ->expects($this->exactly(2))
-            ->method('getClassAnnotation')
-            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
+            ->expects($this->exactly(1))
+            ->method('getClassAnnotations')
+            ->will($this->returnValue(array($this->getAnnotatedRoute($classRouteData))))
         ;
         $this->reader
             ->expects($this->once())
@@ -205,8 +205,49 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $route = $routeCollection->get($classRouteData['name']);
 
         $this->assertSame($classRouteData['path'], $route->getPath(), '->load preserves class route path');
-        $this->assertEquals(array_merge($classRouteData['schemes'], $classRouteData['schemes']), $route->getSchemes(), '->load preserves class route schemes');
-        $this->assertEquals(array_merge($classRouteData['methods'], $classRouteData['methods']), $route->getMethods(), '->load preserves class route methods');
+        $this->assertEquals($classRouteData['schemes'], $route->getSchemes(), '->load preserves class route schemes');
+        $this->assertEquals($classRouteData['methods'], $route->getMethods(), '->load preserves class route methods');
+    }
+
+    public function testInvokableClassMultipleRouteLoad()
+    {
+        $classRouteData1 = array(
+            'name' => 'route1',
+            'path' => '/1',
+            'schemes' => array('https'),
+            'methods' => array('GET'),
+        );
+
+        $classRouteData2 = array(
+            'name' => 'route2',
+            'path' => '/2',
+            'schemes' => array('https'),
+            'methods' => array('GET'),
+        );
+
+        $this->reader
+            ->expects($this->exactly(1))
+            ->method('getClassAnnotations')
+            ->will($this->returnValue(array($this->getAnnotatedRoute($classRouteData1), $this->getAnnotatedRoute($classRouteData2))))
+        ;
+        $this->reader
+            ->expects($this->once())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue(array()))
+        ;
+
+        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass');
+        $route = $routeCollection->get($classRouteData1['name']);
+
+        $this->assertSame($classRouteData1['path'], $route->getPath(), '->load preserves class route path');
+        $this->assertEquals($classRouteData1['schemes'], $route->getSchemes(), '->load preserves class route schemes');
+        $this->assertEquals($classRouteData1['methods'], $route->getMethods(), '->load preserves class route methods');
+
+        $route = $routeCollection->get($classRouteData2['name']);
+
+        $this->assertSame($classRouteData2['path'], $route->getPath(), '->load preserves class route path');
+        $this->assertEquals($classRouteData2['schemes'], $route->getSchemes(), '->load preserves class route schemes');
+        $this->assertEquals($classRouteData2['methods'], $route->getMethods(), '->load preserves class route methods');
     }
 
     public function testInvokableClassWithMethodRouteLoad()

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -29,11 +29,17 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
 
     public function testLoad()
     {
-        $this->reader->expects($this->exactly(4))->method('getClassAnnotation');
+        $this->reader->expects($this->exactly(3))->method('getClassAnnotation');
 
         $this->reader
             ->expects($this->any())
             ->method('getMethodAnnotations')
+            ->will($this->returnValue(array()))
+        ;
+
+        $this->reader
+            ->expects($this->any())
+            ->method('getClassAnnotations')
             ->will($this->returnValue(array()))
         ;
 
@@ -45,13 +51,18 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
         $this->expectAnnotationsToBeReadFrom(array(
             'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
             'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass',
-            'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass',
             'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\FooClass',
         ));
 
         $this->reader
             ->expects($this->any())
             ->method('getMethodAnnotations')
+            ->will($this->returnValue(array()))
+        ;
+
+        $this->reader
+            ->expects($this->any())
+            ->method('getClassAnnotations')
             ->will($this->returnValue(array()))
         ;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | -

The support for full route definition for invokable controllers as class annotation was introduced by
https://github.com/symfony/symfony/pull/2172, but that works with one route only, which is inconsistent with how `@Route` works at other places. This PR adds support for multiple class annotations for invokable controllers and fixes the inconsistency. 

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
