### PR TITLE
[FrameworkBundle] Messenger requires Serializer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -27,7 +27,8 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~3.4|~4.0",
         "symfony/finder": "~3.4|~4.0",
-        "symfony/routing": "^4.1"
+        "symfony/routing": "^4.1",
+        "symfony/serializer": "^4.1"
     },
     "require-dev": {
         "doctrine/cache": "~1.0",
@@ -45,7 +46,6 @@
         "symfony/process": "~3.4|~4.0",
         "symfony/security-core": "~3.4|~4.0",
         "symfony/security-csrf": "~3.4|~4.0",
-        "symfony/serializer": "^4.1",
         "symfony/stopwatch": "~3.4|~4.0",
         "symfony/translation": "~3.4|~4.0",
         "symfony/templating": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The new Messenger component's integration with FrameworkBundle (c9cfda990b3b2c2eb2905822d73a4b7e68e5215f) makes the latter [depend on the Serializer component](https://github.com/symfony/symfony/commit/c9cfda990b3b2c2eb2905822d73a4b7e68e5215f#diff-9750ede1399d486ef37da057a9d613e1R41). This PR moves the dependency from `require-dev` to `require` in composer.json.
