### PR TITLE
[Messenger] Lazy dependency to the Serializer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -44,7 +44,7 @@
 
         <!-- Message encoding/decoding -->
         <service id="messenger.transport.serialize_message_with_type_in_headers" class="Symfony\Component\Messenger\Transport\Serialization\Serializer">
-            <argument type="service" id="serializer" />
+            <argument type="service" id="serializer" on-invalid="null" />
         </service>
 
         <service id="messenger.transport.default_encoder" alias="messenger.transport.serialize_message_with_type_in_headers" public="true" />

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -53,12 +53,6 @@ class MessengerPass implements CompilerPassInterface
             $container->removeDefinition('messenger.middleware.debug.logging');
         }
 
-        if (!$container->has('serializer')) {
-            $container->removeDefinition('messenger.transport.serialize_message_with_type_in_headers');
-            $container->removeAlias('messenger.transport.default_encoder');
-            $container->removeAlias('messenger.transport.default_decoder');
-        }
-
         $this->registerReceivers($container);
         $this->registerHandlers($container);
     }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -21,8 +21,12 @@ class Serializer implements DecoderInterface, EncoderInterface
     private $serializer;
     private $format;
 
-    public function __construct(SerializerInterface $serializer, string $format = 'json')
+    public function __construct(SerializerInterface $serializer = null, string $format = 'json')
     {
+        if (null === $serializer) {
+            throw new \InvalidArgumentException('A Serializer is required to use this Messenger transport. Try running "composer req serializer".');
+        }
+
         $this->serializer = $serializer;
         $this->format = $format;
     }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -24,7 +24,7 @@ class Serializer implements DecoderInterface, EncoderInterface
     public function __construct(SerializerInterface $serializer = null, string $format = 'json')
     {
         if (null === $serializer) {
-            throw new \InvalidArgumentException('A Serializer is required to use this Messenger transport. Try running "composer req serializer".');
+            throw new \InvalidArgumentException('A Serializer is required to use this Messenger transport. Try running "composer require symfony/serializer".');
         }
 
         $this->serializer = $serializer;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26905
| License       | MIT
| Doc PR        | ø

So far, when the serializer was not installed we had the following error message:
```
In CheckExceptionOnInvalidReferenceBehaviorPass.php line 32:

  The service "messenger.adapter.amqp.factory" has a dependency on a non-existent service "messenger.transport.default_encoder".

```

It will now be:
```
In Serializer.php line 27:

  A Serializer is required to use this Messenger transport. Try running "composer req serializer".

```