### PR TITLE
[Messenger][DX] Uses the adapter name instead of the service name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1446,19 +1446,11 @@ class FrameworkExtension extends Extension
 
         $loader->load('messenger.xml');
 
-        $senderLocatorMapping = array();
         $messageToSenderIdsMapping = array();
         foreach ($config['routing'] as $message => $messageConfiguration) {
-            foreach ($messageConfiguration['senders'] as $sender) {
-                if (null !== $sender) {
-                    $senderLocatorMapping[$sender] = new Reference($sender);
-                }
-            }
-
             $messageToSenderIdsMapping[$message] = $messageConfiguration['senders'];
         }
 
-        $container->getDefinition('messenger.sender_locator')->replaceArgument(0, $senderLocatorMapping);
         $container->getDefinition('messenger.asynchronous.routing.sender_locator')->replaceArgument(1, $messageToSenderIdsMapping);
 
         if ($config['middlewares']['validation']['enabled']) {
@@ -1476,7 +1468,7 @@ class FrameworkExtension extends Extension
             ))->setArguments(array(
                 $adapter['dsn'],
                 $adapter['options'],
-            ))->addTag('messenger.sender'));
+            ))->addTag('messenger.sender', array('name' => $name)));
 
             $container->setDefinition('messenger.receiver.'.$name, (new Definition(ReceiverInterface::class))->setFactory(array(
                 new Reference('messenger.adapter_factory'),
@@ -1484,7 +1476,7 @@ class FrameworkExtension extends Extension
             ))->setArguments(array(
                 $adapter['dsn'],
                 $adapter['options'],
-            ))->addTag('messenger.receiver'));
+            ))->addTag('messenger.receiver', array('name' => $name)));
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -544,8 +544,10 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('messenger_adapter');
         $this->assertTrue($container->hasDefinition('messenger.sender.default'));
         $this->assertTrue($container->getDefinition('messenger.sender.default')->hasTag('messenger.sender'));
+        $this->assertEquals(array(array('name' => 'default')), $container->getDefinition('messenger.sender.default')->getTag('messenger.sender'));
         $this->assertTrue($container->hasDefinition('messenger.receiver.default'));
         $this->assertTrue($container->getDefinition('messenger.receiver.default')->hasTag('messenger.receiver'));
+        $this->assertEquals(array(array('name' => 'default')), $container->getDefinition('messenger.receiver.default')->getTag('messenger.receiver'));
 
         $this->assertTrue($container->hasDefinition('messenger.sender.customised'));
         $senderFactory = $container->getDefinition('messenger.sender.customised')->getFactory();
@@ -553,8 +555,8 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertEquals(array(new Reference('messenger.adapter_factory'), 'createSender'), $senderFactory);
         $this->assertCount(2, $senderArguments);
-        $this->assertEquals('amqp://localhost/%2f/messages?exchange_name=exchange_name', $senderArguments[0]);
-        $this->assertEquals(array('queue_name' => 'Queue'), $senderArguments[1]);
+        $this->assertSame('amqp://localhost/%2f/messages?exchange_name=exchange_name', $senderArguments[0]);
+        $this->assertSame(array('queue_name' => 'Queue'), $senderArguments[1]);
 
         $this->assertTrue($container->hasDefinition('messenger.receiver.customised'));
         $receiverFactory = $container->getDefinition('messenger.receiver.customised')->getFactory();
@@ -562,8 +564,8 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertEquals(array(new Reference('messenger.adapter_factory'), 'createReceiver'), $receiverFactory);
         $this->assertCount(2, $receiverArguments);
-        $this->assertEquals('amqp://localhost/%2f/messages?exchange_name=exchange_name', $receiverArguments[0]);
-        $this->assertEquals(array('queue_name' => 'Queue'), $receiverArguments[1]);
+        $this->assertSame('amqp://localhost/%2f/messages?exchange_name=exchange_name', $receiverArguments[0]);
+        $this->assertSame(array('queue_name' => 'Queue'), $receiverArguments[1]);
     }
 
     public function testTranslator()

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -60,6 +60,7 @@ class MessengerPass implements CompilerPassInterface
         }
 
         $this->registerReceivers($container);
+        $this->registerSenders($container);
         $this->registerHandlers($container);
     }
 
@@ -156,10 +157,26 @@ class MessengerPass implements CompilerPassInterface
         $receiverMapping = array();
         foreach ($container->findTaggedServiceIds('messenger.receiver') as $id => $tags) {
             foreach ($tags as $tag) {
-                $receiverMapping[$tag['id'] ?? $id] = new Reference($id);
+                $receiverMapping[$tag['name'] ?? $id] = new Reference($id);
             }
         }
 
         $container->getDefinition('messenger.receiver_locator')->replaceArgument(0, $receiverMapping);
+    }
+
+    private function registerSenders(ContainerBuilder $container)
+    {
+        $senderLocatorMapping = array();
+        foreach ($container->findTaggedServiceIds('messenger.sender') as $id => $tags) {
+            foreach ($tags as $tag) {
+                $senderLocatorMapping[$id] = new Reference($id);
+
+                if ($tag['name']) {
+                    $senderLocatorMapping[$tag['name']] = new Reference($id);
+                }
+            }
+        }
+
+        $container->getDefinition('messenger.sender_locator')->replaceArgument(0, $senderLocatorMapping);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

As a developer, I don't get why I would need to use the service name while I give a name to the adapters. This is basically what this PR means for me in terms of configuration:
```patch
framework:
    messenger:
        routing:
            # We want the command below to be handled async with the "messenger.default_sender" (AMQP producer).
-            'App\Message\Command\CreateNumber': messenger.sender.amqp
+            'App\Message\Command\CreateNumber': amqp

        adapters:
            amqp: "%env(AMQP_DSN)%"
```

And in terms of pulling the messages:
```patch
- bin/console messenger:consume-messages messenger.receiver.amqp
+ bin/console messenger:consume-messages amqp
```