### PR TITLE
[Messenger] Testing LoggingMiddleware and minor improvements

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -52,7 +52,7 @@
 
         <!-- Logging & Debug -->
         <service id="messenger.middleware.debug.logging" class="Symfony\Component\Messenger\Debug\LoggingMiddleware">
-            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="logger" />
 
             <tag name="messenger.bus_middleware" priority="10" />
             <tag name="monolog.logger" channel="messenger" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\DependencyInjection\LoggerPass;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
@@ -1089,6 +1090,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainer(array('kernel.charset' => 'UTF-8', 'kernel.secret' => 'secret'));
         $container->registerExtension(new FrameworkExtension());
+        $container->getCompilerPassConfig()->setBeforeOptimizationPasses(array(new LoggerPass()));
         $this->loadFromFile($container, 'default_config');
         $container
             ->register('foo', \stdClass::class)
@@ -1180,6 +1182,7 @@ abstract class FrameworkExtensionTest extends TestCase
             $container->getCompilerPassConfig()->setOptimizationPasses(array());
             $container->getCompilerPassConfig()->setRemovingPasses(array());
         }
+        $container->getCompilerPassConfig()->setBeforeOptimizationPasses(array(new LoggerPass()));
         $container->getCompilerPassConfig()->setBeforeRemovingPasses(array(new AddConstraintValidatorsPass(), new TranslatorPass('translator.default', 'translation.reader')));
         $container->getCompilerPassConfig()->setAfterRemovingPasses(array(new AddAnnotationsCachedReaderPass()));
 

--- a/src/Symfony/Component/Messenger/Debug/LoggingMiddleware.php
+++ b/src/Symfony/Component/Messenger/Debug/LoggingMiddleware.php
@@ -21,7 +21,7 @@ class LoggingMiddleware implements MiddlewareInterface
 {
     private $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
     }
@@ -31,10 +31,6 @@ class LoggingMiddleware implements MiddlewareInterface
      */
     public function handle($message, callable $next)
     {
-        if (null === $this->logger) {
-            return $next($message);
-        }
-
         $this->logger->debug('Starting handling message {class}', array(
             'message' => $message,
             'class' => \get_class($message),

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -49,7 +49,7 @@ class MessengerPass implements CompilerPassInterface
             return;
         }
 
-        if (!$container->getParameter('kernel.debug') || !$container->has('logger')) {
+        if (!$container->getParameter('kernel.debug') || !$container->hasAlias('logger')) {
             $container->removeDefinition('messenger.middleware.debug.logging');
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Debug/LoggingMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Debug/LoggingMiddlewareTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Debug\LoggingMiddleware;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+class LoggingMiddlewareTest extends TestCase
+{
+    public function testDebugLogAndNextMiddleware()
+    {
+        $message = new DummyMessage('Hey');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->exactly(2))
+            ->method('debug')
+        ;
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($message)
+            ->willReturn('Hello')
+        ;
+
+        $result = (new LoggingMiddleware($logger))->handle($message, $next);
+
+        $this->assertSame('Hello', $result);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testWarningLogOnException()
+    {
+        $message = new DummyMessage('Hey');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('debug')
+        ;
+        $logger
+            ->expects($this->once())
+            ->method('warning')
+        ;
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($message)
+            ->willThrowException(new \Exception())
+        ;
+
+        (new LoggingMiddleware($logger))->handle($message, $next);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -44,6 +44,8 @@ class MessengerPassTest extends TestCase
 
         (new MessengerPass())->process($container);
 
+        $this->assertFalse($container->hasDefinition('messenger.middleware.debug.logging'));
+
         $handlerLocatorDefinition = $container->getDefinition($container->getDefinition('messenger.handler_resolver')->getArgument(0));
         $this->assertSame(ServiceLocator::class, $handlerLocatorDefinition->getClass());
         $this->assertEquals(

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -19,14 +19,14 @@
         "php": "^7.1.3"
     },
     "require-dev": {
-        "symfony/serializer": "~3.4|~4.0",
+        "psr/log": "~1.0",
         "symfony/dependency-injection": "~3.4.6|~4.0",
         "symfony/http-kernel": "~3.4|~4.0",
+        "symfony/process": "~3.4|~4.0",
         "symfony/property-access": "~3.4|~4.0",
-        "symfony/var-dumper": "~3.4|~4.0",
-        "symfony/property-access": "~3.4|~4.0",
-        "symfony/process": "~4.0",
-        "symfony/validator": "~4.0"
+        "symfony/serializer": "~3.4|~4.0",
+        "symfony/validator": "~3.4|~4.0",
+        "symfony/var-dumper": "~3.4|~4.0"
     },
     "suggest": {
         "sroze/enqueue-bridge": "For using the php-enqueue library as an adapter."


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

- This add tests for `LoggingMiddleware` class 
- Similar to [`translator.logging`](https://github.com/symfony/symfony/blob/6bbb5bcc5294fdd540bec35541f77b87e212fc5f/src/Symfony/Component/Translation/LoggingTranslator.php#L33) a logging service doesn't make sense without a [hard `logger` dependency](https://github.com/symfony/symfony/blob/6bbb5bcc5294fdd540bec35541f77b87e212fc5f/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml#L25-L29) and according to:
https://github.com/symfony/symfony/blob/6bbb5bcc5294fdd540bec35541f77b87e212fc5f/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php#L52-L54

   it must be removed if `logger` alias doesn't exists.