### PR TITLE
[FrameworkBundle] Allow user to specify folder for flock

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -58,6 +58,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\StoreFactory;
 use Symfony\Component\Lock\StoreInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
@@ -1376,6 +1377,14 @@ class FrameworkExtension extends Extension
                 switch (true) {
                     case 'flock' === $storeDsn:
                         $storeDefinition = new Reference('lock.store.flock');
+                        break;
+                    case 0 === strpos($storeDsn, 'flock://'):
+                        $flockPath = substr($storeDsn, 8);
+
+                        $storeDefinitionId = '.lock.flock.store.'.$container->hash($storeDsn);
+                        $container->register($storeDefinitionId, FlockStore::class)->addArgument($flockPath);
+
+                        $storeDefinition = new Reference($storeDefinitionId);
                         break;
                     case 'semaphore' === $storeDsn:
                         $storeDefinition = new Reference('lock.store.semaphore');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT
| Doc PR        | 


In case multiple applications running on same server allow user to specify folder for flock
example:
```

framework: 
   lock:` 'flock://var/flock' # var/flock will be provided as path to flock constructor
   lock: 'flock:///var/flock' # /var/flock will be provided as path to flock constructor
   lock: flock # works as usual, null is provided to constructor and system temp folder is used


```