### PR TITLE
[WebProfilerBundle] Display uploaded files in the profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -131,6 +131,33 @@
                     {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: collector.requestrequest, maxDepth: 1 }, with_context = false) }}
                 {% endif %}
 
+                <h3>Uploaded files</h3>
+
+                {% if collector.requestfiles is empty %}
+                    <div class="empty">
+                        <p>No files were uploaded</p>
+                    </div>
+                {% else %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">File Name</th>
+                                <th scope="col">MIME Type</th>
+                                <th scope="col text-right">Size (bytes)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% for file in collector.requestfiles %}
+                            <tr>
+                                <td>{{ file.name }}</td>
+                                <td>{{ file.mimetype }}</td>
+                                <td class="text-right">{{ file.size|number_format }}</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+
                 <h3>Request Attributes</h3>
 
                 {% if collector.requestattributes.all is empty %}

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -57,6 +57,17 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             $content = false;
         }
 
+        $requestFiles = array();
+        foreach ($request->files->all() as $files) {
+            foreach ($files as $fileName => $fileData) {
+                $requestFiles[] = array(
+                    'name' => $fileData->getClientOriginalName(),
+                    'mimetype' => $fileData->getMimeType(),
+                    'size' => $fileData->getSize(),
+                );
+            }
+        }
+
         $sessionMetadata = array();
         $sessionAttributes = array();
         $session = null;
@@ -95,6 +106,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             'status_code' => $statusCode,
             'request_query' => $request->query->all(),
             'request_request' => $request->request->all(),
+            'request_files' => $requestFiles,
             'request_headers' => $request->headers->all(),
             'request_server' => $request->server->all(),
             'request_cookies' => $request->cookies->all(),
@@ -193,6 +205,11 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
     public function getRequestQuery()
     {
         return new ParameterBag($this->data['request_query']->getValue());
+    }
+
+    public function getRequestFiles()
+    {
+        return $this->data['request_files']->getValue(true);
     }
 
     public function getRequestHeaders()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26926
| License       | MIT
| Doc PR        | -

![profiler_files](https://user-images.githubusercontent.com/73419/38807087-ac1e9bac-417b-11e8-99e0-317b437c986e.png)

Note: I wanted to use the VarDumper to display the table information (as we do in the rest of tables) but I had lots of problems and I just wanted to create a proof of concept for the feature to see if we like it.