### PR TITLE
[DebugBundle][VarDumper] Fix server dumper placeholder command

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Command/ServerDumpPlaceholderCommand.php
+++ b/src/Symfony/Bundle/DebugBundle/Command/ServerDumpPlaceholderCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\DebugBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -24,15 +25,22 @@ use Symfony\Component\VarDumper\Server\DumpServer;
  *
  * @internal
  */
-class ServerDumpPlaceholderCommand extends ServerDumpCommand
+class ServerDumpPlaceholderCommand extends Command
 {
+    private $replacedCommand;
+
     public function __construct(DumpServer $server = null, array $descriptors = array())
     {
-        parent::__construct(new class() extends DumpServer {
-            public function __construct()
-            {
-            }
-        }, $descriptors);
+        $this->replacedCommand = new ServerDumpCommand((new \ReflectionClass(DumpServer::class))->newInstanceWithoutConstructor(), $descriptors);
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setDefinition($this->replacedCommand->getDefinition());
+        $this->setHelp($this->replacedCommand->getHelp());
+        $this->setDescription($this->replacedCommand->getDescription());
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no, fixes a deprecation warning
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no, fixes ones <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26944 <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This placeholder command was addressed in quite an unorthodox fashion and the following fix isn't really better, but I guess that's fine for an internal class.

_As a reminder: this command aims to favor discoverability of the `ServerDumpCommand` when listing available commands and by exposing its definition so you can read about it by using `--help`. Execution hints about the `debug.dump_destination` config option required to wire the actual command._

That's the only command for which we're doing this, though. So better keep this placeholder or drop it?