### PR TITLE
Add dump_die function

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -15,8 +15,7 @@ if (!function_exists('dump')) {
     /**
      * @author Nicolas Grekas <p@tchwork.com>
      */
-    function dump($var, ...$moreVars)
-    {
+    function dump($var, ...$moreVars) {
         VarDumper::dump($var);
 
         foreach ($moreVars as $var) {
@@ -28,5 +27,15 @@ if (!function_exists('dump')) {
         }
 
         return $var;
+    }
+}
+
+if (!function_exists('dump_die')) {
+    /**
+     * @author Joubert RedRat <me+symfony@redrat.com.br>
+     */
+    function dump_die($var, ...$moreVars) {
+        dump($var, $moreVars);
+        die;
     }
 }


### PR DESCRIPTION
Today I use `dump` and `die` when I'm debugging my project, then I think that is best to encapsulate this into `dump_die` function.

| Q             | A
| ------------- | ---
| Branch?       | 3.4 and newer
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets |
| License       | MIT
| Doc PR        | 

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
