### PR TITLE
[VarDumper] Add dd() helper == dump() + exit()

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -30,3 +30,16 @@ if (!function_exists('dump')) {
         return $var;
     }
 }
+
+if (!function_exists('dd')) {
+    function dd($var, ...$moreVars)
+    {
+        VarDumper::dump($var);
+
+        foreach ($moreVars as $var) {
+            VarDumper::dump($var);
+        }
+
+        exit(1);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

By popular demand, I feel like we should reconsider our refusal for a `dd()` global helper.
For past references, see #26965, #26906, #13657, #17267, #19096.