### PR TITLE
[HttpKernel] Set first trusted proxy as REMOTE_ADDR in InlineFragmentRenderer.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -122,7 +122,9 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
             // Do nothing
         }
 
-        $server['REMOTE_ADDR'] = '127.0.0.1';
+        $trustedProxies = Request::getTrustedProxies();
+        $server['REMOTE_ADDR'] = $trustedProxies ? reset($trustedProxies) : '127.0.0.1';
+
         unset($server['HTTP_IF_MODIFIED_SINCE']);
         unset($server['HTTP_IF_NONE_MATCH']);
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -56,6 +56,7 @@ class InlineFragmentRendererTest extends TestCase
         $subRequest->attributes->replace(array('object' => $object, '_format' => 'html', '_controller' => 'main_controller', '_locale' => 'en'));
         $subRequest->headers->set('x-forwarded-for', array('127.0.0.1'));
         $subRequest->server->set('HTTP_X_FORWARDED_FOR', '127.0.0.1');
+        $subRequest->server->set('REMOTE_ADDR', '1.1.1.1');
 
         $strategy = new InlineFragmentRenderer($this->getKernelExpectingRequest($subRequest));
 
@@ -84,7 +85,7 @@ class InlineFragmentRendererTest extends TestCase
     {
         Request::setTrustedHeaderName(Request::HEADER_CLIENT_IP, '');
 
-        $strategy = new InlineFragmentRenderer($this->getKernelExpectingRequest(Request::create('/')));
+        $strategy = new InlineFragmentRenderer($this->getKernelExpectingRequest(Request::create('/', 'GET', array(), array(), array(), array('REMOTE_ADDR' => '1.1.1.1'))));
         $this->assertSame('foo', $strategy->render('/', Request::create('/'))->getContent());
     }
 
@@ -168,6 +169,7 @@ class InlineFragmentRendererTest extends TestCase
     {
         $expectedSubRequest = Request::create('/');
         $expectedSubRequest->headers->set('Surrogate-Capability', 'abc="ESI/1.0"');
+        $expectedSubRequest->server->set('REMOTE_ADDR', '1.1.1.1');
 
         if (Request::getTrustedHeaderName(Request::HEADER_CLIENT_IP)) {
             $expectedSubRequest->headers->set('x-forwarded-for', array('127.0.0.1'));
@@ -193,7 +195,7 @@ class InlineFragmentRendererTest extends TestCase
 
     public function testHeadersPossiblyResultingIn304AreNotAssignedToSubrequest()
     {
-        $expectedSubRequest = Request::create('/');
+        $expectedSubRequest = Request::create('/', 'GET', array(), array(), array(), array('REMOTE_ADDR' => '1.1.1.1'));
         if (Request::getTrustedHeaderName(Request::HEADER_CLIENT_IP)) {
             $expectedSubRequest->headers->set('x-forwarded-for', array('127.0.0.1'));
             $expectedSubRequest->server->set('HTTP_X_FORWARDED_FOR', '127.0.0.1');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 and up
| Bug fix?      | improvement
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ---
| License       | MIT
| Doc PR        | ---

SubRequest used in `InlineFragmentRendered` explicitly sets `$server['REMOTE_ADDR']` to `127.0.0.1`. Therefore, it's required to configure `127.0.0.1` address in TRUSTED_PROXIES environment variable. Without that, `Request::isFromTrustedProxy()` will return false. 
The current behavior might be a little bit problematic, for instance, in case where images are rendered through subrequests. These might end-up with an incorrect schema in URL (`http` instead of `https`). 
