### PR TITLE
[Cache] Add missing `@internal` tag on ProxyTrait

### DIFF
--- a/src/Symfony/Component/Cache/Traits/ProxyTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ProxyTrait.php
@@ -16,6 +16,8 @@ use Symfony\Component\Cache\ResettableInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
  */
 trait ProxyTrait
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

All traits in Cache are internal. We just forgot the annotation on this one.