### PR TITLE
Fix wrong phpdoc

### DIFF
--- a/src/Symfony/Component/Serializer/Exception/MissingConstructorArgumentsException.php
+++ b/src/Symfony/Component/Serializer/Exception/MissingConstructorArgumentsException.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Serializer\Exception;
 
 /**
- * IncompleteInputDataException.
+ * MissingConstructorArgumentsException.
  *
  * @author Maxime VEBER <maxime.veber@nekland.fr>
  */


### PR DESCRIPTION
The exception was renamed but the phpdoc not updated. This has no impact on anything (even IDE autocompletion) but looks bad. Here is a fix.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? |no
| Tests pass?   | yes 
| Fixed tickets | none
| License       | MIT
| Doc PR        | Not needed
