### PR TITLE
Revert the type declaration of Role merged in #26821

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Core\Authorization\Voter;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
-use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 use Symfony\Component\ExpressionLanguage\Expression;
@@ -86,7 +85,7 @@ class ExpressionVoter implements VoterInterface
             'user' => $token->getUser(),
             'object' => $subject,
             'subject' => $subject,
-            'roles' => array_map(function (Role $role) { return $role->getRole(); }, $roles),
+            'roles' => array_map(function ($role) { return $role->getRole(); }, $roles),
             'trust_resolver' => $this->trustResolver,
         );
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

in #2681 (https://github.com/symfony/symfony/pull/26821/files#diff-5febf3ee0bb2e743b1a929abe55968e8R89)
I added a `Role` type declaration.

But users who had played duck type there could face B.C. break.
So I'd like to revert the change.

