### PR TITLE
[Messenger] Typecast the auto-setup as a bool.

### DIFF
--- a/src/Symfony/Component/Messenger/Adapter/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Adapter/AmqpExt/Connection.php
@@ -218,6 +218,6 @@ class Connection
 
     private function shouldSetup(): bool
     {
-        return !array_key_exists('auto-setup', $this->connectionCredentials) || 'false' !== $this->connectionCredentials['auto-setup'];
+        return !array_key_exists('auto-setup', $this->connectionCredentials) || !in_array($this->connectionCredentials['auto-setup'], array(false, 'false'), true);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Adapter/AmqpExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Adapter/AmqpExt/ConnectionTest.php
@@ -182,6 +182,12 @@ class ConnectionTest extends TestCase
 
         $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key', array('auto-setup' => 'false'), true, $factory);
         $connection->publish('body');
+
+        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key', array('auto-setup' => false), true, $factory);
+        $connection->publish('body');
+
+        $connection = Connection::fromDsn('amqp://localhost/%2f/messages?queue[routing_key]=my_key&auto-setup=false', array(), true, $factory);
+        $connection->publish('body');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26996
| License       | MIT
| Doc PR        |
