### PR TITLE
[PhpUnitBridge] Always segregate vendor and non vendor deprecations

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -54,9 +54,9 @@ class DeprecationErrorHandler
             if (false === $mode) {
                 $mode = getenv('SYMFONY_DEPRECATIONS_HELPER');
             }
-            if (DeprecationErrorHandler::MODE_DISABLED !== $mode
-                && DeprecationErrorHandler::MODE_WEAK !== $mode
-                && DeprecationErrorHandler::MODE_WEAK_VENDORS !== $mode
+            if (self::MODE_DISABLED !== $mode
+                && self::MODE_WEAK !== $mode
+                && self::MODE_WEAK_VENDORS !== $mode
                 && (!isset($mode[0]) || '/' !== $mode[0])
             ) {
                 $mode = preg_match('/^[1-9][0-9]*$/', $mode) ? (int) $mode : 0;
@@ -106,7 +106,7 @@ class DeprecationErrorHandler
         );
         $deprecationHandler = function ($type, $msg, $file, $line, $context = array()) use (&$deprecations, $getMode, $UtilPrefix, $inVendors) {
             $mode = $getMode();
-            if ((E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) || DeprecationErrorHandler::MODE_DISABLED === $mode) {
+            if ((E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) || self::MODE_DISABLED === $mode) {
                 $ErrorHandler = $UtilPrefix.'ErrorHandler';
 
                 return $ErrorHandler::handleError($type, $msg, $file, $line, $context);
@@ -114,7 +114,7 @@ class DeprecationErrorHandler
 
             $trace = debug_backtrace();
             $group = 'other';
-            $isVendor = DeprecationErrorHandler::MODE_WEAK_VENDORS === $mode && $inVendors($file);
+            $isVendor = $inVendors($file);
 
             $i = \count($trace);
             while (1 < $i && (!isset($trace[--$i]['class']) || ('ReflectionMethod' === $trace[$i]['class'] || 0 === strpos($trace[$i]['class'], 'PHPUnit_') || 0 === strpos($trace[$i]['class'], 'PHPUnit\\')))) {
@@ -131,7 +131,7 @@ class DeprecationErrorHandler
                     // \Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerTrait::endTest()
                     // then we need to use the serialized information to determine
                     // if the error has been triggered from vendor code.
-                    $isVendor = DeprecationErrorHandler::MODE_WEAK_VENDORS === $mode && isset($parsedMsg['triggering_file']) && $inVendors($parsedMsg['triggering_file']);
+                    $isVendor = isset($parsedMsg['triggering_file']) && $inVendors($parsedMsg['triggering_file']);
                 } else {
                     $class = isset($trace[$i]['object']) ? \get_class($trace[$i]['object']) : $trace[$i]['class'];
                     $method = $trace[$i]['function'];
@@ -168,13 +168,13 @@ class DeprecationErrorHandler
 
                     exit(1);
                 }
-                if ('legacy' !== $group && DeprecationErrorHandler::MODE_WEAK !== $mode) {
+                if ('legacy' !== $group && self::MODE_WEAK !== $mode) {
                     $ref = &$deprecations[$group][$msg]['count'];
                     ++$ref;
                     $ref = &$deprecations[$group][$msg][$class.'::'.$method];
                     ++$ref;
                 }
-            } elseif (DeprecationErrorHandler::MODE_WEAK !== $mode) {
+            } elseif (self::MODE_WEAK !== $mode) {
                 $ref = &$deprecations[$group][$msg]['count'];
                 ++$ref;
             }
@@ -207,7 +207,7 @@ class DeprecationErrorHandler
                 $currErrorHandler = set_error_handler('var_dump');
                 restore_error_handler();
 
-                if (DeprecationErrorHandler::MODE_WEAK === $mode) {
+                if (self::MODE_WEAK === $mode) {
                     $colorize = function ($str) { return $str; };
                 }
                 if ($currErrorHandler !== $deprecationHandler) {
@@ -218,11 +218,7 @@ class DeprecationErrorHandler
                     return $b['count'] - $a['count'];
                 };
 
-                $groups = array('unsilenced', 'remaining');
-                if (DeprecationErrorHandler::MODE_WEAK_VENDORS === $mode) {
-                    $groups[] = 'remaining vendor';
-                }
-                array_push($groups, 'legacy', 'other');
+                $groups = array('unsilenced', 'remaining', 'remaining vendor', 'legacy', 'other');
 
                 $displayDeprecations = function ($deprecations) use ($colorize, $cmp, $groups) {
                     foreach ($groups as $group) {
@@ -253,16 +249,26 @@ class DeprecationErrorHandler
                 };
 
                 $displayDeprecations($deprecations);
+                $isPassing = function ($mode, $deprecations) {
+                    if (self::MODE_WEAK === $mode) {
+                        return true;
+                    }
+                    if (self::MODE_WEAK_VENDORS === $mode) {
+                        return 0 === $deprecations['unsilencedCount'] + $deprecations['remainingCount'] + $deprecations['otherCount'];
+                    }
+
+                    return 0 === $deprecations['unsilencedCount'] + $deprecations['remainingCount'] + $deprecations['remaining vendorCount'] + $deprecations['otherCount'];
+                };
 
                 // store failing status
-                $isFailing = DeprecationErrorHandler::MODE_WEAK !== $mode && $mode < $deprecations['unsilencedCount'] + $deprecations['remainingCount'] + $deprecations['otherCount'];
+                $passesBeforeShutdown = $isPassing($mode, $deprecations);
 
                 // reset deprecations array
                 foreach ($deprecations as $group => $arrayOrInt) {
                     $deprecations[$group] = \is_int($arrayOrInt) ? 0 : array();
                 }
 
-                register_shutdown_function(function () use (&$deprecations, $isFailing, $displayDeprecations, $mode) {
+                register_shutdown_function(function () use (&$deprecations, $passesBeforeShutdown, $displayDeprecations, $isPassing, $mode) {
                     foreach ($deprecations as $group => $arrayOrInt) {
                         if (0 < (\is_int($arrayOrInt) ? $arrayOrInt : \count($arrayOrInt))) {
                             echo "Shutdown-time deprecations:\n";
@@ -270,7 +276,7 @@ class DeprecationErrorHandler
                         }
                     }
                     $displayDeprecations($deprecations);
-                    if ($isFailing || DeprecationErrorHandler::MODE_WEAK !== $mode && $mode < $deprecations['unsilencedCount'] + $deprecations['remainingCount'] + $deprecations['otherCount']) {
+                    if (!$passesBeforeShutdown || !$isPassing($mode, $deprecations)) {
                         exit(1);
                     }
                 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | I don't think it warrants one

Even if it does not make the exit code change, this is valuable
information. Besides, not doing this reduces the complexity (fewer tests
for the weak vendors mode).
I introduced a new closure for computing whether the build is failing or
not, named using positive logic so that things are easier to understand.