### PR TITLE
[Cache] TagAwareAdapterInterface::invalidateTags() should commit deferred items

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -71,6 +71,22 @@ class TagAwareAdapterTest extends AdapterTestCase
         $this->assertTrue($pool->getItem('foo')->isHit());
     }
 
+    public function testInvalidateCommits()
+    {
+        $pool1 = $this->createCachePool();
+
+        $foo = $pool1->getItem('foo');
+        $foo->tag('tag');
+
+        $pool1->saveDeferred($foo->set('foo'));
+        $pool1->invalidateTags(array('tag'));
+
+        $pool2 = $this->createCachePool();
+        $foo = $pool2->getItem('foo');
+
+        $this->assertTrue($foo->isHit());
+    }
+
     public function testTagsAreCleanedOnSave()
     {
         $pool = $this->createCachePool();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I noticed that we have a race condition window when invalidating tags.
This PR fixes it by making `invalidateTags()` commit deferred items before actually invalidating tags on the back end. Deferred items are stored with the future version of the invalidated tags so that they can be fetched by concurrent processes and considered valid before and after the invalidation is committed.