### PR TITLE
[Messenger][AmqpExt] Add a retry mechanism for AMQP messages

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -88,7 +88,9 @@ Messenger
 ---------
 
  * The `handle` method of the `Symfony\Component\Messenger\Middleware\ValidationMiddleware` and `Symfony\Component\Messenger\Asynchronous\Middleware\SendMessageMiddleware` middlewares now requires an `Envelope` object to be given (because they implement the `EnvelopeAwareInterface`). When using these middleware with the provided `MessageBus`, you will not have to do anything. If you use the middlewares any other way, you can use `Envelope::wrap($message)` to create an envelope for your message.
-
+ * The method `getConnectionCredentials` of the AMQP transport class `Symfony\Component\Messenger\Transport\AmqpExt\Connection`
+   has been renamed to `getConnectionConfiguration`.
+ 
 Security
 --------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -64,6 +64,7 @@
             <argument type="service" id="messenger.transport.encoder" />
             <argument type="service" id="messenger.transport.decoder" />
             <argument>%kernel.debug%</argument>
+            <argument type="service" id="logger" on-invalid="null" />
 
             <tag name="messenger.transport_factory" />
         </service>

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportFactoryTest.php
@@ -41,7 +41,7 @@ class AmqpTransportFactoryTest extends TestCase
             true
         );
 
-        $expectedTransport = new AmqpTransport($encoder, $decoder, Connection::fromDsn('amqp://localhost', array('foo' => 'bar'), true), array('foo' => 'bar'), true);
+        $expectedTransport = new AmqpTransport($encoder, $decoder, Connection::fromDsn('amqp://localhost', array('foo' => 'bar'), true));
 
         $this->assertEquals($expectedTransport, $factory->createTransport('amqp://localhost', array('foo' => 'bar')));
     }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Transport\AmqpExt\Exception\RejectMessageExceptionInterface;
 use Symfony\Component\Messenger\Transport\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
@@ -22,14 +23,18 @@ use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
  */
 class AmqpReceiver implements ReceiverInterface
 {
+    private const DEFAULT_LOOP_SLEEP_IN_MICRO_SECONDS = 200000;
+
     private $decoder;
     private $connection;
+    private $logger;
     private $shouldStop;
 
-    public function __construct(DecoderInterface $decoder, Connection $connection)
+    public function __construct(DecoderInterface $decoder, Connection $connection, LoggerInterface $logger = null)
     {
         $this->decoder = $decoder;
         $this->connection = $connection;
+        $this->logger = $logger;
     }
 
     /**
@@ -39,10 +44,11 @@ class AmqpReceiver implements ReceiverInterface
     {
         while (!$this->shouldStop) {
             $AMQPEnvelope = $this->connection->get();
+
             if (null === $AMQPEnvelope) {
                 $handler(null);
 
-                usleep($this->connection->getConnectionCredentials()['loop_sleep'] ?? 200000);
+                usleep($this->connection->getConnectionConfiguration()['loop_sleep'] ?? self::DEFAULT_LOOP_SLEEP_IN_MICRO_SECONDS);
                 if (\function_exists('pcntl_signal_dispatch')) {
                     pcntl_signal_dispatch();
                 }
@@ -62,9 +68,25 @@ class AmqpReceiver implements ReceiverInterface
 
                 throw $e;
             } catch (\Throwable $e) {
-                $this->connection->nack($AMQPEnvelope, AMQP_REQUEUE);
+                try {
+                    $retried = $this->connection->publishForRetry($AMQPEnvelope);
+                } catch (\Throwable $retryException) {
+                    $this->logger && $this->logger->warning(sprintf('Retrying message #%s failed. Requeuing it now.', $AMQPEnvelope->getMessageId()), array(
+                        'retryException' => $retryException,
+                        'exception' => $e,
+                    ));
 
-                throw $e;
+                    $retried = false;
+                }
+
+                if (!$retried) {
+                    $this->connection->nack($AMQPEnvelope, AMQP_REQUEUE);
+
+                    throw $e;
+                }
+
+                // Acknowledge current message as another one as been requeued.
+                $this->connection->ack($AMQPEnvelope);
             } finally {
                 if (\function_exists('pcntl_signal_dispatch')) {
                     pcntl_signal_dispatch();
@@ -73,6 +95,9 @@ class AmqpReceiver implements ReceiverInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function stop(): void
     {
         $this->shouldStop = true;

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\EncoderInterface;
@@ -26,12 +27,14 @@ class AmqpTransport implements TransportInterface
     private $connection;
     private $receiver;
     private $sender;
+    private $logger;
 
-    public function __construct(EncoderInterface $encoder, DecoderInterface $decoder, Connection $connection)
+    public function __construct(EncoderInterface $encoder, DecoderInterface $decoder, Connection $connection, LoggerInterface $logger = null)
     {
         $this->encoder = $encoder;
         $this->decoder = $decoder;
         $this->connection = $connection;
+        $this->logger = $logger;
     }
 
     /**
@@ -60,7 +63,7 @@ class AmqpTransport implements TransportInterface
 
     private function getReceiver()
     {
-        return $this->receiver = new AmqpReceiver($this->decoder, $this->connection);
+        return $this->receiver = new AmqpReceiver($this->decoder, $this->connection, $this->logger);
     }
 
     private function getSender()

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\EncoderInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
@@ -24,17 +25,19 @@ class AmqpTransportFactory implements TransportFactoryInterface
     private $encoder;
     private $decoder;
     private $debug;
+    private $logger;
 
-    public function __construct(EncoderInterface $encoder, DecoderInterface $decoder, bool $debug)
+    public function __construct(EncoderInterface $encoder, DecoderInterface $decoder, bool $debug, LoggerInterface $logger = null)
     {
         $this->encoder = $encoder;
         $this->decoder = $decoder;
         $this->debug = $debug;
+        $this->logger = $logger;
     }
 
     public function createTransport(string $dsn, array $options): TransportInterface
     {
-        return new AmqpTransport($this->encoder, $this->decoder, Connection::fromDsn($dsn, $options, $this->debug));
+        return new AmqpTransport($this->encoder, $this->decoder, Connection::fromDsn($dsn, $options, $this->debug), $this->logger);
     }
 
     public function supports(string $dsn, array $options): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | symfony/symfony-docs#9756

One of the most asked features (and required to have an enterprise-grade management of errors). I chose the approach of an AmqpExt-only retry mechanism to ensure we have a great user experience with this one at least. There are discussions on-going (#26945) to have more generic things like that across adapters. 

---

# So what's the point? 

When processing some messages, some error might happen. It might be that one of our 3rd party is down, that something is wrong with the last deployment, etc... All of these things will throw exceptions in the message handlers. The way of tackling this problem is very well described in @odolbeau's [Swarrot Retry provider real-life example](https://github.com/swarrot/swarrot/tree/master/src/Swarrot/Processor/Retry#real-example).

# How to configure it

Same than for the rest, this can be configured both via the DSN or the `options` when creating the adapter. Here is a bunch of working DSNs with their corresponding effect:

1. **Enable 3 retries** before having an exception
```yaml
amqp://guest:guest@localhost:5672/%2f/messages
    ?retry[attempts]=3
```

2. **Enable 3 retries** before message to be queue in a "dead queue" (i.e. messages to be looked at manually later)
```yaml
amqp://guest:guest@localhost:5672/%2f/messages
    ?retry[attempts]=3
    &retry[dead_queue]=dead_queue
```

3. **Enable 3 retries, dead queue and custom settings**
```yaml
amqp://guest:guest@localhost:5672/%2f/messages
    ?retry[attempts]=3
    &retry[exchange_name]=retry
    &retry[routing_key_pattern]=retry_attempt_%25attempt%25
    &retry[queue_name_pattern]=retry_queue_%attempt%
    &retry[dead_queue]=dead_queue
    &retry[dead_routing_key]=dead_routing_key
```

4. **Enable 3 retries, with custom TTLs per attempt.** Waits 10 seconds before retrying for the first attempt, 30 seconds for the 2nd attempt and 5 minutes for the 3rd one.
```yaml
amqp://guest:guest@localhost:5672/%2f/messages
    ?retry[attempts]=3
    &retry[ttl][0]=10000
    &retry[ttl][1]=30000
    &retry[ttl][2]=300000
```
