### PR TITLE
[Cache] Add stampede protection via probabilistic early expiration

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 4.1 to 4.2
 =======================
 
+Cache
+-----
+
+ * Deprecated `CacheItem::getPreviousTags()`, use `CacheItem::getMetadata()` instead.
+
 Security
 --------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 4.x to 5.0
 =======================
 
+Cache
+-----
+
+ * Removed `CacheItem::getPreviousTags()`, use `CacheItem::getMetadata()` instead.
+
 Config
 ------
 

--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -83,17 +83,17 @@ class PhpArrayAdapter implements AdapterInterface, CacheInterface, PruneableInte
     /**
      * {@inheritdoc}
      */
-    public function get(string $key, callable $callback)
+    public function get(string $key, callable $callback, float $beta = null)
     {
         if (null === $this->values) {
             $this->initialize();
         }
         if (null === $value = $this->values[$key] ?? null) {
             if ($this->pool instanceof CacheInterface) {
-                return $this->pool->get($key, $callback);
+                return $this->pool->get($key, $callback, $beta);
             }
 
-            return $this->doGet($this->pool, $key, $callback);
+            return $this->doGet($this->pool, $key, $callback, $beta ?? 1.0);
         }
         if ('N;' === $value) {
             return null;

--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -67,7 +67,7 @@ class TagAwareAdapter implements CacheInterface, TagAwareAdapterInterface, Prune
                 }
                 if (isset($itemTags[$key])) {
                     foreach ($itemTags[$key] as $tag => $version) {
-                        $item->prevTags[$tag] = $tag;
+                        $item->metadata[CacheItem::METADATA_TAGS][$tag] = $tag;
                     }
                     unset($itemTags[$key]);
                 } else {
@@ -84,7 +84,7 @@ class TagAwareAdapter implements CacheInterface, TagAwareAdapterInterface, Prune
             function ($deferred) {
                 $tagsByKey = array();
                 foreach ($deferred as $key => $item) {
-                    $tagsByKey[$key] = $item->tags;
+                    $tagsByKey[$key] = $item->newMetadata[CacheItem::METADATA_TAGS] ?? array();
                 }
 
                 return $tagsByKey;

--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -37,7 +37,7 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, PruneableInt
     /**
      * {@inheritdoc}
      */
-    public function get(string $key, callable $callback)
+    public function get(string $key, callable $callback, float $beta = null)
     {
         if (!$this->pool instanceof CacheInterface) {
             throw new \BadMethodCallException(sprintf('Cannot call "%s::get()": this class doesn\'t implement "%s".', get_class($this->pool), CacheInterface::class));
@@ -52,7 +52,7 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, PruneableInt
 
         $event = $this->start(__FUNCTION__);
         try {
-            $value = $this->pool->get($key, $callback);
+            $value = $this->pool->get($key, $callback, $beta);
             $event->result[$key] = \is_object($value) ? \get_class($value) : gettype($value);
         } finally {
             $event->end = microtime(true);

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -4,8 +4,9 @@ CHANGELOG
 4.2.0
 -----
 
- * added `CacheInterface`, which should become the preferred way to use a cache
+ * added `CacheInterface`, which provides stampede protection via probabilistic early expiration and should become the preferred way to use a cache
  * throw `LogicException` when `CacheItem::tag()` is called on an item coming from a non tag-aware pool
+ * deprecated `CacheItem::getPreviousTags()`, use `CacheItem::getMetadata()` instead
 
 3.4.0
 -----
@@ -19,7 +20,7 @@ CHANGELOG
 3.3.0
 -----
 
- * [EXPERIMENTAL] added CacheItem::getPreviousTags() to get bound tags coming from the pool storage if any
+ * added CacheItem::getPreviousTags() to get bound tags coming from the pool storage if any
  * added PSR-16 "Simple Cache" implementations for all existing PSR-6 adapters
  * added Psr6Cache and SimpleCacheAdapter for bidirectional interoperability between PSR-6 and PSR-16
  * added MemcachedAdapter (PSR-6) and MemcachedCache (PSR-16)

--- a/src/Symfony/Component/Cache/CacheInterface.php
+++ b/src/Symfony/Component/Cache/CacheInterface.php
@@ -26,8 +26,12 @@ interface CacheInterface
 {
     /**
      * @param callable(CacheItem):mixed $callback Should return the computed value for the given key/item
+     * @param float|null                $beta     A float that controls the likeliness of triggering early expiration.
+     *                                            0 disables it, INF forces immediate expiration.
+     *                                            The default (or providing null) is implementation dependent but should
+     *                                            typically be 1.0, which should provide optimal stampede protection.
      *
      * @return mixed The value corresponding to the provided key
      */
-    public function get(string $key, callable $callback);
+    public function get(string $key, callable $callback, float $beta = null);
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 class ArrayAdapterTest extends AdapterTestCase
 {
     protected $skippedTests = array(
+        'testGetMetadata' => 'ArrayAdapter does not keep metadata.',
         'testDeferredSaveWithoutCommit' => 'Assumes a shared cache which ArrayAdapter is not.',
         'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayAdapter is not.',
     );

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -24,8 +24,12 @@ use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
  */
 class ChainAdapterTest extends AdapterTestCase
 {
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0, $testMethod = null)
     {
+        if ('testGetMetadata' === $testMethod) {
+            return new ChainAdapter(array(new FilesystemAdapter('', $defaultLifetime)), $defaultLifetime);
+        }
+
         return new ChainAdapter(array(new ArrayAdapter($defaultLifetime), new ExternalAdapter(), new FilesystemAdapter('', $defaultLifetime)), $defaultLifetime);
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 
 /**
@@ -19,8 +20,12 @@ use Symfony\Component\Cache\Adapter\ProxyAdapter;
  */
 class NamespacedProxyAdapterTest extends ProxyAdapterTest
 {
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0, $testMethod = null)
     {
+        if ('testGetMetadata' === $testMethod) {
+            return new ProxyAdapter(new FilesystemAdapter(), 'foo', $defaultLifetime);
+        }
+
         return new ProxyAdapter(new ArrayAdapter($defaultLifetime), 'foo', $defaultLifetime);
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
@@ -68,8 +69,12 @@ class PhpArrayAdapterTest extends AdapterTestCase
         }
     }
 
-    public function createCachePool()
+    public function createCachePool($defaultLifetime = 0, $testMethod = null)
     {
+        if ('testGetMetadata' === $testMethod) {
+            return new PhpArrayAdapter(self::$file, new FilesystemAdapter());
+        }
+
         return new PhpArrayAdapterWrapper(self::$file, new NullAdapter());
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\CacheItem;
 
@@ -27,8 +28,12 @@ class ProxyAdapterTest extends AdapterTestCase
         'testPrune' => 'ProxyAdapter just proxies',
     );
 
-    public function createCachePool($defaultLifetime = 0)
+    public function createCachePool($defaultLifetime = 0, $testMethod = null)
     {
+        if ('testGetMetadata' === $testMethod) {
+            return new ProxyAdapter(new FilesystemAdapter(), '', $defaultLifetime);
+        }
+
         return new ProxyAdapter(new ArrayAdapter(), '', $defaultLifetime);
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\CacheItem;
 
 /**
  * @group time-sensitive
@@ -138,6 +139,9 @@ class TagAwareAdapterTest extends AdapterTestCase
         $this->assertFalse($pool->getItem('foo')->isHit());
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetPreviousTags()
     {
         $pool = $this->createCachePool();
@@ -147,6 +151,17 @@ class TagAwareAdapterTest extends AdapterTestCase
 
         $i = $pool->getItem('k');
         $this->assertSame(array('foo' => 'foo'), $i->getPreviousTags());
+    }
+
+    public function testGetMetadata()
+    {
+        $pool = $this->createCachePool();
+
+        $i = $pool->getItem('k');
+        $pool->save($i->tag('foo'));
+
+        $i = $pool->getItem('k');
+        $this->assertSame(array('foo' => 'foo'), $i->getMetadata()[CacheItem::METADATA_TAGS]);
     }
 
     public function testPrune()

--- a/src/Symfony/Component/Cache/Tests/CacheItemTest.php
+++ b/src/Symfony/Component/Cache/Tests/CacheItemTest.php
@@ -63,7 +63,7 @@ class CacheItemTest extends TestCase
         $this->assertSame($item, $item->tag(array('bar', 'baz')));
 
         call_user_func(\Closure::bind(function () use ($item) {
-            $this->assertSame(array('foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'), $item->tags);
+            $this->assertSame(array('foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'), $item->newMetadata[CacheItem::METADATA_TAGS]);
         }, $this, CacheItem::class));
     }
 

--- a/src/Symfony/Component/Cache/Traits/GetTrait.php
+++ b/src/Symfony/Component/Cache/Traits/GetTrait.php
@@ -11,9 +11,15 @@
 
 namespace Symfony\Component\Cache\Traits;
 
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\CacheItem;
 
 /**
+ * An implementation for CacheInterface that provides stampede protection via probabilistic early expiration.
+ *
+ * @see https://en.wikipedia.org/wiki/Cache_stampede
+ *
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @internal
@@ -23,21 +29,58 @@ trait GetTrait
     /**
      * {@inheritdoc}
      */
-    public function get(string $key, callable $callback)
+    public function get(string $key, callable $callback, float $beta = null)
     {
-        return $this->doGet($this, $key, $callback);
+        return $this->doGet($this, $key, $callback, $beta ?? 1.0);
     }
 
-    private function doGet(CacheItemPoolInterface $pool, string $key, callable $callback)
+    private function doGet(CacheItemPoolInterface $pool, string $key, callable $callback, float $beta)
     {
+        $t = 0;
         $item = $pool->getItem($key);
+        $recompute = !$item->isHit() || INF === $beta;
 
-        if ($item->isHit()) {
+        if ($item instanceof CacheItem && 0 < $beta) {
+            if ($recompute) {
+                $t = microtime(true);
+            } else {
+                $metadata = $item->getMetadata();
+                $expiry = $metadata[CacheItem::METADATA_EXPIRY] ?? false;
+                $ctime = $metadata[CacheItem::METADATA_CTIME] ?? false;
+
+                if ($ctime && $expiry) {
+                    $t = microtime(true);
+                    $recompute = $expiry <= $t - $ctime / 1000 * $beta * log(random_int(1, PHP_INT_MAX) / PHP_INT_MAX);
+                }
+            }
+            if ($recompute) {
+                // force applying defaultLifetime to expiry
+                $item->expiresAt(null);
+            }
+        }
+
+        if (!$recompute) {
             return $item->get();
         }
 
-        $pool->save($item->set($value = $callback($item)));
+        static $save = null;
 
-        return $value;
+        if (null === $save) {
+            $save = \Closure::bind(
+                function (CacheItemPoolInterface $pool, CacheItemInterface $item, $value, float $startTime) {
+                    if ($item instanceof CacheItem && $startTime && $item->expiry > $endTime = microtime(true)) {
+                        $item->newMetadata[CacheItem::METADATA_EXPIRY] = $item->expiry;
+                        $item->newMetadata[CacheItem::METADATA_CTIME] = 1000 * (int) ($endTime - $startTime);
+                    }
+                    $pool->save($item->set($value));
+
+                    return $value;
+                },
+                null,
+                CacheItem::class
+            );
+        }
+
+        return $save($pool, $item, $callback($item), $t);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | 

This PR implements [probabilistic early expiration](https://en.wikipedia.org/wiki/Cache_stampede#Probabilistic_early_expiration) on top of `$cache->get($key, $callback);`

It adds a 3rd arg to `CacheInterface::get`:
> float $beta A float that controls the likelyness of triggering early expiration. 0 disables it, INF forces immediate expiration. The default is implementation dependend but should typically be 1.0, which should provide optimal stampede protection.