### PR TITLE
[DI] Add check of internal type to ContainerBuilder::getReflectionClass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -124,6 +124,20 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     private $removedIds = array();
     private $alreadyLoading = array();
 
+    private static $internalTypes = array(
+        'int' => true,
+        'float' => true,
+        'string' => true,
+        'bool' => true,
+        'resource' => true,
+        'object' => true,
+        'array' => true,
+        'null' => true,
+        'callable' => true,
+        'iterable' => true,
+        'mixed' => true,
+    );
+
     public function __construct(ParameterBagInterface $parameterBag = null)
     {
         parent::__construct($parameterBag);
@@ -341,6 +355,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         if (!$class = $this->getParameterBag()->resolveValue($class)) {
             return;
         }
+
+        if (isset(self::$internalTypes[$class])) {
+            return null;
+        }
+
         $resource = null;
 
         try {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -906,6 +906,23 @@ class ContainerBuilderTest extends TestCase
         $this->assertSame('BarMissingClass', (string) end($resources));
     }
 
+    public function testGetReflectionClassOnInternalTypes()
+    {
+        $container = new ContainerBuilder();
+
+        $this->assertNull($container->getReflectionClass('int'));
+        $this->assertNull($container->getReflectionClass('float'));
+        $this->assertNull($container->getReflectionClass('string'));
+        $this->assertNull($container->getReflectionClass('bool'));
+        $this->assertNull($container->getReflectionClass('resource'));
+        $this->assertNull($container->getReflectionClass('object'));
+        $this->assertNull($container->getReflectionClass('array'));
+        $this->assertNull($container->getReflectionClass('null'));
+        $this->assertNull($container->getReflectionClass('callable'));
+        $this->assertNull($container->getReflectionClass('iterable'));
+        $this->assertNull($container->getReflectionClass('mixed'));
+    }
+
     public function testCompilesClassDefinitionsOfLazyServices()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27018 
| License       | MIT
| Doc PR        | no

This PR fixes bug described in #27018 issue.
I think that `getReflectionClass` should return `NULL` when internal type was used instead class name but not throws exception. As well as it does when class is empty. If someone have other opinion we can discuss it.
