### PR TITLE
[Cache] Prevent stampede at warmup using apcu_entry() for locking 

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -160,6 +160,14 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
     /**
      * {@inheritdoc}
      */
+    public function get(string $key, callable $callback, float $beta = null)
+    {
+        return $this->doGet($this, $key, $callback, $beta ?? 1.0, '' !== $this->namespace ? $this->getId($key) : null);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getItem($key)
     {
         if ($this->deferred) {

--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -94,7 +94,7 @@ class ProxyAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
     public function get(string $key, callable $callback, float $beta = null)
     {
         if (!$this->pool instanceof CacheInterface) {
-            return $this->doGet($this, $key, $callback, $beta ?? 1.0);
+            return $this->doGet($this, $key, $callback, $beta ?? 1.0, $this->namespaceLen ? $this->getId($key) : null);
         }
 
         return $this->pool->get($this->getId($key), function ($innerItem) use ($key, $callback) {

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `CacheInterface`, which provides stampede protection via probabilistic early expiration and should become the preferred way to use a cache
+ * added warmup-time stampede protection using `apcu_entry()` for locking when available
  * added sub-second expiry accuracy for backends that support it
  * throw `LogicException` when `CacheItem::tag()` is called on an item coming from a non tag-aware pool
  * deprecated `CacheItem::getPreviousTags()`, use `CacheItem::getMetadata()` instead


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When a cache is cold, all concurrent processes will end up recomputing the same value, which can be slow at best and can create a cascading failure at worst.

By leveraging `apcu_entry()`, we can ensure only one process per front is actually computing the value.

In theory, you might wonder if this could be implemented in a generic way using e.g. the Lock component. This would allow using distributed locking, thus allow locking the computation across a cluster of fronts.

But in practice, `apcu_entry()` is the only primitive that works, because it knows when to *not* compute the callback when it waited for a concurrent process, which is something really hard to achieve with other locking mechanisms (if possible at all without all sort of race conditions.) Also, computing only once per-front is already a significant improvement. People having more advanced needs could still create a proxy to handle the distributed lock.

For core, relying on `apcu_entry()` to provide this behavior is what I propose here.