### PR TITLE
[Messenger][DX] Validate that the message exists to be able to configure its routing

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1496,6 +1496,10 @@ class FrameworkExtension extends Extension
 
         $messageToSenderIdsMapping = array();
         foreach ($config['routing'] as $message => $messageConfiguration) {
+            if (!class_exists($message) && !interface_exists($message, false)) {
+                throw new LogicException(sprintf('Messenger routing configuration contains a mistake: message "%s" does not exist. It needs to match an existing class or interface.', $message));
+            }
+
             $messageToSenderIdsMapping[$message] = $messageConfiguration['senders'];
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger.php
@@ -1,10 +1,13 @@
 <?php
 
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
+
 $container->loadFromExtension('framework', array(
     'messenger' => array(
         'routing' => array(
-            'App\Bar' => array('sender.bar', 'sender.biz'),
-            'App\Foo' => 'sender.foo',
+            FooMessage::class => array('sender.bar', 'sender.biz'),
+            BarMessage::class => 'sender.foo',
         ),
     ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger.xml
@@ -7,11 +7,11 @@
 
     <framework:config>
         <framework:messenger>
-            <framework:routing message-class="App\Bar">
+            <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage">
                 <framework:sender service="sender.bar" />
                 <framework:sender service="sender.biz" />
             </framework:routing>
-            <framework:routing message-class="App\Foo">
+            <framework:routing message-class="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage">
                 <framework:sender service="sender.foo" />
             </framework:routing>
         </framework:messenger>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger.yml
@@ -1,5 +1,5 @@
 framework:
     messenger:
         routing:
-            'App\Bar': ['sender.bar', 'sender.biz']
-            'App\Foo': 'sender.foo'
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage': ['sender.bar', 'sender.biz']
+            'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage': 'sender.foo'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/BarMessage.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/BarMessage.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger;
+
+class BarMessage
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/FooMessage.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/FooMessage.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger;
+
+class FooMessage
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

It attempted to me already: mispelling the message name and not understanding why it didn't work... An exception letting me know that the configured message does not exists will be 👌 