### PR TITLE
[Messenger][DX] Uses custom method names for handlers

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
@@ -34,9 +34,14 @@ interface MessageSubscriberInterface extends MessageHandlerInterface
      *         [SecondMessage::class, -10],
      *     ];
      *
-     * The `__invoke` method of the handler will be called as usual with the message to handle.
+     * It can also specify a method and/or a priority per message:
      *
-     * @return array
+     *     return [
+     *         FirstMessage::class => 'firstMessageMethod',
+     *         SecondMessage::class => ['secondMessageMethod', 20],
+     *     ];
+     *
+     * The `__invoke` method of the handler will be called as usual with the message to handle.
      */
-    public static function getHandledMessages(): array;
+    public static function getHandledMessages(): iterable;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/26685#issuecomment-383888657
| License       | MIT
| Doc PR        | ø

This has been discussed mostly in the [`MessageHandlerInterface` pull-request](https://github.com/symfony/symfony/pull/26685). For consistency reasons and convenience, this PR adds the ability to configure the method to be used on handlers:
```php
use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
use Symfony\Component\Messenger\Handler\MessageSubscriberConfiguration;

class CreateNumberMessageHandler implements MessageSubscriberInterface
{
    /**
     * {@inheritdoc}
     */
    public static function getHandledMessages(): array
    {
        return [
            CreateNumber::class => ['createNumber', 10],
            AnotherMessage::class => 'anotherMethod',
        ];
    }

    public function createNumber(CreateNumber $command)
    {
        // ...
    }
}
```
