### PR TITLE
[HttpKernel] Remove decoration from actual output in tests

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -67,7 +67,7 @@ class DumpDataCollectorTest extends TestCase
 
         ob_start();
         $collector->collect(new Request(), new Response());
-        $output = ob_get_clean();
+        $output = preg_replace("/\033\[[^m]*m/", '', ob_get_clean());
 
         if (\PHP_VERSION_ID >= 50400) {
             $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n123\n", $output);
@@ -125,10 +125,11 @@ EOTXT;
 
         ob_start();
         $collector->__destruct();
+        $output = preg_replace("/\033\[[^m]*m/", '', ob_get_clean());
         if (\PHP_VERSION_ID >= 50400) {
-            $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n456\n", ob_get_clean());
+            $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n456\n", $output);
         } else {
-            $this->assertSame("\"DumpDataCollectorTest.php on line {$line}:\"\n456\n", ob_get_clean());
+            $this->assertSame("\"DumpDataCollectorTest.php on line {$line}:\"\n456\n", $output);
         }
     }
 
@@ -141,10 +142,11 @@ EOTXT;
         ob_start();
         $collector->dump($data);
         $line = __LINE__ - 1;
+        $output = preg_replace("/\033\[[^m]*m/", '', ob_get_clean());
         if (\PHP_VERSION_ID >= 50400) {
-            $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n456\n", ob_get_clean());
+            $this->assertSame("DumpDataCollectorTest.php on line {$line}:\n456\n", $output);
         } else {
-            $this->assertSame("\"DumpDataCollectorTest.php on line {$line}:\"\n456\n", ob_get_clean());
+            $this->assertSame("\"DumpDataCollectorTest.php on line {$line}:\"\n456\n", $output);
         }
 
         ob_start();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes green again
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

AppVeyor has color support since #26910, that breaks the build. 
Fixes it by removing decoration from tested DumpDataCollector CLI outputs, same as what's already done for HTML dumps
