### PR TITLE
[WebProfilerBundle] Inject debug toolbar differently

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -115,23 +115,15 @@ class WebDebugToolbarListener implements EventSubscriberInterface
      */
     protected function injectToolbar(Response $response, Request $request, array $nonces)
     {
-        $content = $response->getContent();
-        $pos = strripos($content, '</body>');
+        $toolbar = $this->twig->render('@WebProfiler/Profiler/toolbar_js.html.twig', array(
+                'excluded_ajax_paths' => $this->excludedAjaxPaths,
+                'token' => $response->headers->get('X-Debug-Token'),
+                'request' => $request,
+                'csp_script_nonce' => isset($nonces['csp_script_nonce']) ? $nonces['csp_script_nonce'] : null,
+                'csp_style_nonce' => isset($nonces['csp_style_nonce']) ? $nonces['csp_style_nonce'] : null,
+        ));
 
-        if (false !== $pos) {
-            $toolbar = "\n".str_replace("\n", '', $this->twig->render(
-                '@WebProfiler/Profiler/toolbar_js.html.twig',
-                array(
-                    'excluded_ajax_paths' => $this->excludedAjaxPaths,
-                    'token' => $response->headers->get('X-Debug-Token'),
-                    'request' => $request,
-                    'csp_script_nonce' => isset($nonces['csp_script_nonce']) ? $nonces['csp_script_nonce'] : null,
-                    'csp_style_nonce' => isset($nonces['csp_style_nonce']) ? $nonces['csp_style_nonce'] : null,
-                )
-            ))."\n";
-            $content = substr($content, 0, $pos).$toolbar.substr($content, $pos);
-            $response->setContent($content);
-        }
+        $response->setContent($response->getContent()."\n".$toolbar);
     }
 
     public static function getSubscribedEvents()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Currently, the web debug toolbar is injected in HTML pages following a simple strategy: look for `</body>` in the HTML content and inject the toolbar just before that closing tag.

In the past we've received issues about this because some HTML pages don't contain `</body>` and, believe it or not, [Google officially recommends to not include `</body>`](https://google.github.io/styleguide/htmlcssguide.html#Optional_Tags), so this could be more and more popular in the future.

This is **NOT recommended** by Google:

```html
<!DOCTYPE html>
<html>
  <head>
    <title>Some title</title>
  </head>
  <body>
    <p>Some content</p>
  </body>
</html>
```

This is **recommended** by Google:

```html
<!DOCTYPE html>
<title>Some title</title>
<p>Some content
```

In this PR I propose to inject the debug toolbar at the end of the HTML pages, solving all issues for once and for all. This means that sometimes the toolbar content goes **after the closing `</body>` and `</html>`** elements. Some of you will say that this is not allowed by the HTML standard. Just remember that HTML is not a strict standard. Browsers allow almost everything. I've tested this on Chrome, Firefox and Safari and works as expected.