### PR TITLE
[FrameworkBundle] Register all private services on the test service container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
@@ -31,7 +31,7 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
         $definitions = $container->getDefinitions();
 
         foreach ($definitions as $id => $definition) {
-            if (!$definition->isPublic() && !$definition->getErrors() && !$definition->isAbstract()) {
+            if ((!$definition->isPublic() || $definition->isPrivate()) && !$definition->getErrors() && !$definition->isAbstract()) {
                 $privateServices[$id] = new ServiceClosureArgument(new Reference($id, ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE));
             }
         }
@@ -39,7 +39,7 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
         $aliases = $container->getAliases();
 
         foreach ($aliases as $id => $alias) {
-            if (!$alias->isPublic()) {
+            if (!$alias->isPublic() || $alias->isPrivate()) {
                 while (isset($aliases[$target = (string) $alias])) {
                     $alias = $aliases[$target];
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/NonPublicService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/NonPublicService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer;
+
+class NonPublicService
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/PrivateService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/PrivateService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer;
+
+class PrivateService
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/PublicService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/PublicService.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer;
+
+class PublicService
+{
+    private $nonPublicService;
+
+    private $privateService;
+
+    public function __construct(NonPublicService $nonPublicService, PrivateService $privateService)
+    {
+        $this->nonPublicService = $nonPublicService;
+        $this->privateService = $privateService;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/UnusedPrivateService.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/TestServiceContainer/UnusedPrivateService.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer;
+
+class UnusedPrivateService
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\TestContainer;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\NonPublicService;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PublicService;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\UnusedPrivateService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class TestServiceContainerTest extends WebTestCase
+{
+    public function testThatPrivateServicesAreUnavailableIfTestConfigIsDisabled()
+    {
+        static::bootKernel(array('test_case' => 'TestServiceContainer', 'root_config' => 'test_disabled.yml', 'environment' => 'test_disabled'));
+
+        $this->assertInstanceOf(ContainerInterface::class, static::$container);
+        $this->assertNotInstanceOf(TestContainer::class, static::$container);
+        $this->assertTrue(static::$container->has(PublicService::class));
+        $this->assertFalse(static::$container->has(NonPublicService::class));
+        $this->assertFalse(static::$container->has(PrivateService::class));
+        $this->assertFalse(static::$container->has('private_service'));
+        $this->assertFalse(static::$container->has(UnusedPrivateService::class));
+    }
+
+    public function testThatPrivateServicesAreAvailableIfTestConfigIsEnabled()
+    {
+        static::bootKernel(array('test_case' => 'TestServiceContainer'));
+
+        $this->assertInstanceOf(TestContainer::class, static::$container);
+        $this->assertTrue(static::$container->has(PublicService::class));
+        $this->assertTrue(static::$container->has(NonPublicService::class));
+        $this->assertTrue(static::$container->has(PrivateService::class));
+        $this->assertTrue(static::$container->has('private_service'));
+        $this->assertTrue(static::$container->has(UnusedPrivateService::class));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return array(
+    new FrameworkBundle(),
+);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/config.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: ../config/default.yml }
+    - { resource: services.yml }
+
+framework:
+    test: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/services.yml
@@ -1,0 +1,15 @@
+services:
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\NonPublicService:
+        public: false
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService: ~
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\UnusedPrivateService: ~
+
+    private_service: '@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService'
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PublicService:
+        public: true
+        arguments:
+            - '@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\NonPublicService'
+            - '@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestServiceContainer\PrivateService'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/test_disabled.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/TestServiceContainer/test_disabled.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: ../config/default.yml }
+    - { resource: services.yml }
+
+framework:
+    test: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Before this fix, only services explicitly configured with public=false were exposed via the test service container:

```php
$container->register(PrivateService::class, PrivateService::class)->setPublic(false);
```

but not those explicitly configured as private:

```php
$container->register(PrivateService::class, PrivateService::class)->setPrivate(true);
```

nor those implicitly configured as private:

```php
$container->register(PrivateService::class, PrivateService::class);
```

