### PR TITLE
Make the simple auth provider the same as in Symfony 2.7

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Provider;
 
-use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserChecker;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -50,20 +48,7 @@ class SimpleAuthenticationProvider implements AuthenticationProviderInterface
         $user = $authToken->getUser();
 
         if (!$user instanceof UserInterface) {
-            try {
-                $user = $this->userProvider->loadUserByUsername($user);
-
-                if (!$user instanceof UserInterface) {
-                    return $authToken;
-                }
-            } catch (UsernameNotFoundException $e) {
-                $e->setUsername($user);
-                throw $e;
-            } catch (\Exception $e) {
-                $e = new AuthenticationServiceException($e->getMessage(), 0, $e);
-                $e->setToken($token);
-                throw $e;
-            }
+            return $authToken;
         }
 
         $this->userChecker->checkPreAuth($user);

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Provider\SimpleAuthenticationProvider;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\LockedException;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserChecker;
 
 class SimpleAuthenticationProviderTest extends TestCase
@@ -72,54 +71,6 @@ class SimpleAuthenticationProviderTest extends TestCase
         $provider = $this->getProvider($authenticator, null, $userChecker);
 
         $provider->authenticate($token);
-    }
-
-    public function testAuthenticateFromString()
-    {
-        $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
-
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
-        $token->expects($this->any())
-            ->method('getUser')
-            ->will($this->returnValue('foo'));
-
-        $authenticator = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface')->getMock();
-        $authenticator->expects($this->once())
-            ->method('authenticateToken')
-            ->will($this->returnValue($token));
-
-        $userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();
-        $userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->willReturn($this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock());
-        $provider = $this->getProvider($authenticator, $userProvider);
-
-        $this->assertSame($token, $provider->authenticate($token));
-    }
-
-    /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
-     */
-    public function testUsernameNotFound()
-    {
-        $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
-
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
-        $token->expects($this->any())
-            ->method('getUser')
-            ->will($this->returnValue('foo'));
-
-        $authenticator = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface')->getMock();
-        $authenticator->expects($this->once())
-            ->method('authenticateToken')
-            ->will($this->returnValue($token));
-
-        $userProvider = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')->getMock();
-        $userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->willThrowException(new UsernameNotFoundException());
-
-        $this->getProvider($authenticator, $userProvider)->authenticate($token);
     }
 
     public function testAuthenticateSkipsUserChecksForNonUserInterfaceObjects()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27044
| License       | MIT

This PR adds the `SimpleAuthenticationProvider` changes made in Symfony 2.7 to Symfony 2.8. See https://github.com/symfony/symfony/pull/27044#issuecomment-384580979