### PR TITLE
[DI][Routing] Allow invokable objects to be used as PHP-DSL loaders

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -43,7 +43,7 @@ class PhpFileLoader extends FileLoader
 
         $callback = $load($path);
 
-        if ($callback instanceof \Closure) {
+        if (\is_object($callback) && \is_callable($callback)) {
             $callback(new ContainerConfigurator($this->container, $this, $this->instanceof, $path, $resource), $this->container, $this);
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.expected.yml
@@ -1,0 +1,10 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    App\BarService:
+        class: App\BarService
+        public: true
+        arguments: [!service { class: FooClass }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use App\BarService;
+
+return new class() {
+    public function __invoke(ContainerConfigurator $c)
+    {
+        $s = $c->services();
+        $s->set(BarService::class)
+            ->args(array(inline('FooClass')));
+    }
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -68,6 +68,7 @@ class PhpFileLoaderTest extends TestCase
     public function provideConfig()
     {
         yield array('basic');
+        yield array('object');
         yield array('defaults');
         yield array('instanceof');
         yield array('prototype');

--- a/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
@@ -46,7 +46,7 @@ class PhpFileLoader extends FileLoader
 
         $result = $load($path);
 
-        if ($result instanceof \Closure) {
+        if (\is_object($result) && \is_callable($result)) {
             $collection = new RouteCollection();
             $result(new RoutingConfigurator($collection, $this, $path, $file), $this);
         } else {

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_object_dsl.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_object_dsl.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return new class() {
+    public function __invoke(RoutingConfigurator $routes)
+    {
+        $routes
+            ->collection()
+            ->add('foo', '/foo')
+            ->condition('abc')
+            ->options(array('utf8' => true))
+            ->add('buz', 'zub')
+            ->controller('foo:act');
+
+        $routes->import('php_dsl_sub.php')
+            ->prefix('/sub')
+            ->requirements(array('id' => '\d+'));
+
+        $routes->import('php_dsl_sub.php')
+            ->namePrefix('z_')
+            ->prefix('/zub');
+
+        $routes->import('php_dsl_sub_root.php')
+            ->prefix('/bus', false);
+
+        $routes->add('ouf', '/ouf')
+            ->schemes(array('https'))
+            ->methods(array('GET'))
+            ->defaults(array('id' => 0));
+    }
+};

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -88,7 +88,8 @@ class PhpFileLoaderTest extends TestCase
     {
         $locator = new FileLocator(array(__DIR__.'/../Fixtures'));
         $loader = new PhpFileLoader($locator);
-        $routeCollection = $loader->load('php_dsl.php');
+        $routeCollectionClosure = $loader->load('php_dsl.php');
+        $routeCollectionObject = $loader->load('php_object_dsl.php');
 
         $expectedCollection = new RouteCollection();
 
@@ -122,9 +123,15 @@ class PhpFileLoaderTest extends TestCase
 
         $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl_sub.php')));
         $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl_sub_root.php')));
-        $expectedCollection->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl.php')));
 
-        $this->assertEquals($expectedCollection, $routeCollection);
+        $expectedCollectionClosure = $expectedCollection;
+        $expectedCollectionObject = clone $expectedCollection;
+
+        $expectedCollectionClosure->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_dsl.php')));
+        $expectedCollectionObject->addResource(new FileResource(realpath(__DIR__.'/../Fixtures/php_object_dsl.php')));
+
+        $this->assertEquals($expectedCollectionClosure, $routeCollectionClosure);
+        $this->assertEquals($expectedCollectionObject, $routeCollectionObject);
     }
 
     public function testRoutingConfiguratorCanImportGlobPatterns()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26583, #25630
| License       | MIT
| Doc PR        | none

Changed DI/Router PHPFileLoader to check is_object && is_callable instead of instance of Closure