### PR TITLE
[DI][DX] Allow exclude to be an array of patterns

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
@@ -39,7 +39,7 @@ class PrototypeConfigurator extends AbstractServiceConfigurator
 
     private $loader;
     private $resource;
-    private $exclude;
+    private $excludes;
     private $allowParent;
 
     public function __construct(ServicesConfigurator $parent, PhpFileLoader $loader, Definition $defaults, string $namespace, string $resource, bool $allowParent)
@@ -63,19 +63,21 @@ class PrototypeConfigurator extends AbstractServiceConfigurator
         parent::__destruct();
 
         if ($this->loader) {
-            $this->loader->registerClasses($this->definition, $this->id, $this->resource, $this->exclude);
+            $this->loader->registerClasses($this->definition, $this->id, $this->resource, $this->excludes);
         }
         $this->loader = null;
     }
 
     /**
-     * Excludes files from registration using a glob pattern.
+     * Excludes files from registration using glob patterns.
+     *
+     * @param string[]|string $excludes
      *
      * @return $this
      */
-    final public function exclude(string $exclude)
+    final public function exclude($excludes)
     {
-        $this->exclude = $exclude;
+        $this->excludes = (array) $excludes;
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -40,10 +40,10 @@ abstract class FileLoader extends BaseFileLoader
     /**
      * Registers a set of classes as services using PSR-4 for discovery.
      *
-     * @param Definition $prototype A definition to use as template
-     * @param string     $namespace The namespace prefix of classes in the scanned directory
-     * @param string     $resource  The directory to look for classes, glob-patterns allowed
-     * @param string     $exclude   A globed path of files to exclude
+     * @param Definition           $prototype A definition to use as template
+     * @param string               $namespace The namespace prefix of classes in the scanned directory
+     * @param string               $resource  The directory to look for classes, glob-patterns allowed
+     * @param string|string[]|null $exclude   A globbed path of files to exclude or an array of globbed paths of files to exclude
      */
     public function registerClasses(Definition $prototype, $namespace, $resource, $exclude = null)
     {
@@ -54,7 +54,7 @@ abstract class FileLoader extends BaseFileLoader
             throw new InvalidArgumentException(sprintf('Namespace is not a valid PSR-4 prefix: %s.', $namespace));
         }
 
-        $classes = $this->findClasses($namespace, $resource, $exclude);
+        $classes = $this->findClasses($namespace, $resource, (array) $exclude);
         // prepare for deep cloning
         $serializedPrototype = serialize($prototype);
         $interfaces = array();
@@ -101,14 +101,14 @@ abstract class FileLoader extends BaseFileLoader
         }
     }
 
-    private function findClasses($namespace, $pattern, $excludePattern)
+    private function findClasses($namespace, $pattern, array $excludePatterns)
     {
         $parameterBag = $this->container->getParameterBag();
 
         $excludePaths = array();
         $excludePrefix = null;
-        if ($excludePattern) {
-            $excludePattern = $parameterBag->unescapeValue($parameterBag->resolveValue($excludePattern));
+        $excludePatterns = $parameterBag->unescapeValue($parameterBag->resolveValue($excludePatterns));
+        foreach ($excludePatterns as $excludePattern) {
             foreach ($this->glob($excludePattern, true, $resource) as $path => $info) {
                 if (null === $excludePrefix) {
                     $excludePrefix = $resource->getPrefix();

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -146,7 +146,14 @@ class XmlFileLoader extends FileLoader
         foreach ($services as $service) {
             if (null !== $definition = $this->parseDefinition($service, $file, $defaults)) {
                 if ('prototype' === $service->tagName) {
-                    $this->registerClasses($definition, (string) $service->getAttribute('namespace'), (string) $service->getAttribute('resource'), (string) $service->getAttribute('exclude'));
+                    $excludes = array_column($this->getChildren($service, 'exclude'), 'nodeValue');
+                    if ($service->hasAttribute('exclude')) {
+                        if (count($excludes) > 0) {
+                            throw new InvalidArgumentException('You cannot use both the attribute "exclude" and <exclude> tags at the same time.');
+                        }
+                        $excludes = array($service->getAttribute('exclude'));
+                    }
+                    $this->registerClasses($definition, (string) $service->getAttribute('namespace'), (string) $service->getAttribute('resource'), $excludes);
                 } else {
                     $this->setDefinition((string) $service->getAttribute('id'), $definition);
                 }

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -160,6 +160,7 @@
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="bind" type="bind" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="exclude" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
     </xsd:choice>
     <xsd:attribute name="namespace" type="xsd:string" use="required" />
     <xsd:attribute name="resource" type="xsd:string" use="required" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.expected.yml
@@ -1,0 +1,25 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
+        public: true
+        tags:
+            - { name: foo }
+            - { name: baz }
+        deprecated: "%service_id%"
+        arguments: [1]
+        factory: f
+    Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar
+        public: true
+        tags:
+            - { name: foo }
+            - { name: baz }
+        deprecated: "%service_id%"
+        lazy: true
+        arguments: [1]
+        factory: f

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/prototype_array.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
+
+return function (ContainerConfigurator $c) {
+    $di = $c->services()->defaults()
+        ->tag('baz');
+    $di->load(Prototype::class.'\\', '../Prototype')
+        ->autoconfigure()
+        ->exclude(array('../Prototype/OtherDir', '../Prototype/BadClasses'))
+        ->factory('f')
+        ->deprecate('%service_id%')
+        ->args(array(0))
+        ->args(array(1))
+        ->autoconfigure(false)
+        ->tag('foo')
+        ->parent('foo');
+    $di->set('foo')->lazy()->abstract();
+    $di->get(Prototype\Foo::class)->lazy(false);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_array.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_prototype_array.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+      <prototype namespace="Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\" resource="../Prototype/*">
+          <exclude>../Prototype/OtherDir</exclude>
+          <exclude>../Prototype/BadClasses</exclude>
+      </prototype>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -136,6 +136,25 @@ class FileLoaderTest extends TestCase
         );
     }
 
+    public function testRegisterClassesWithExcludeAsArray()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('sub_dir', 'Sub');
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+        $loader->registerClasses(
+            new Definition(),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\\',
+            'Prototype/*', array(
+                'Prototype/%sub_dir%',
+                'Prototype/OtherDir/AnotherSub/DeeperBaz.php',
+            )
+        );
+        $this->assertTrue($container->has(Foo::class));
+        $this->assertTrue($container->has(Baz::class));
+        $this->assertFalse($container->has(Bar::class));
+        $this->assertFalse($container->has(DeeperBaz::class));
+    }
+
     public function testNestedRegisterClasses()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -617,6 +617,26 @@ class XmlFileLoaderTest extends TestCase
         $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
     }
 
+    public function testPrototypeExcludeWithArray()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_prototype_array.xml');
+
+        $ids = array_keys($container->getDefinitions());
+        sort($ids);
+        $this->assertSame(array(Prototype\Foo::class, Prototype\Sub\Bar::class, 'service_container'), $ids);
+
+        $resources = $container->getResources();
+
+        $fixturesDir = dirname(__DIR__).DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR;
+        $this->assertTrue(false !== array_search(new FileResource($fixturesDir.'xml'.DIRECTORY_SEPARATOR.'services_prototype_array.xml'), $resources));
+        $this->assertTrue(false !== array_search(new GlobResource($fixturesDir.'Prototype', '/*', true), $resources));
+        $resources = array_map('strval', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo', $resources);
+        $this->assertContains('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar', $resources);
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @expectedExceptionMessage Invalid attribute "class" defined for alias "bar" in


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | yes   
| Fixed tickets | #23956
| License       | MIT

This is basically continuing #24428. 

In YAML before:
```yaml
AppBundle\:
  resource: '../../src/AppBundle/*'
  exclude: '../../src/AppBundle/{Entity,Payload,Repository}'
```

in YAML after:

```yaml
AppBundle\:
  resource: '../../src/AppBundle/*'
  exclude:
    - '../../src/AppBundle/{Entity,Payload,Repository}'
    - '../../src/AppBundle/Event/*Event.php'
```

In XML before:
```xml
<prototype namespace="App\" resource="../src/*" exclude="../src/{Entity,Migrations,Tests}" />
```

in XML after:

```xml
<prototype namespace="App\" resource="../src/*">
  <exclude>../src/{Entity,Migrations,Tests}</exclude>
  <exclude>../src/Yolo</exclude>
</prototype>
```

In PHP before:
```php
$di->load(Prototype::class.'\\', '../Prototype')
        ->autoconfigure()
        ->exclude('../Prototype/{OtherDir,BadClasses}')
```

In PHP after:
```php
    $di->load(Prototype::class.'\\', '../Prototype')
        ->autoconfigure()
        ->exclude(['../Prototype/OtherDir', '../Prototype/BadClasses'])
```

Everything is backward compatible.
Maybe a decision about handling both attribute exclude and element exclude in XML should be taken.
