### PR TITLE
[DependencyInjection] add ServiceSubscriberTrait

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.2.0
+-----
+
+ * added `ServiceSubscriberTrait`
+
 4.1.0
 -----
 

--- a/src/Symfony/Component/DependencyInjection/ServiceSubscriberTrait.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceSubscriberTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Implementation of ServiceSubscriberInterface that determines subscribed services from
+ * private method return types. Service ids are available as "ClassName::methodName".
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+trait ServiceSubscriberTrait
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    public static function getSubscribedServices(): array
+    {
+        static $services;
+
+        if (null !== $services) {
+            return $services;
+        }
+
+        $services = \is_callable(array('parent', __FUNCTION__)) ? parent::getSubscribedServices() : array();
+
+        foreach ((new \ReflectionClass(self::class))->getMethods() as $method) {
+            if ($method->isStatic() || $method->isAbstract() || $method->isGenerator() || $method->isInternal() || $method->getNumberOfRequiredParameters()) {
+                continue;
+            }
+
+            if (self::class === $method->getDeclaringClass()->name && ($returnType = $method->getReturnType()) && !$returnType->isBuiltin()) {
+                $services[self::class.'::'.$method->name] = '?'.$returnType->getName();
+            }
+        }
+
+        return $services;
+    }
+
+    /**
+     * @required
+     */
+    public function setContainer(ContainerInterface $container)
+    {
+        $this->container = $container;
+
+        if (\is_callable(array('parent', __FUNCTION__))) {
+            return parent::setContainer($container);
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestDefinition1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestDefinition1.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+class TestDefinition1 extends Definition
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestDefinition2.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestDefinition2.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+class TestDefinition2 extends Definition
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestDefinition3.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestDefinition3.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+class TestDefinition3 extends Definition
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberChild.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberChild.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\ServiceSubscriberTrait;
+
+class TestServiceSubscriberChild extends TestServiceSubscriberParent
+{
+    use ServiceSubscriberTrait, TestServiceSubscriberTrait;
+
+    private function testDefinition2(): TestDefinition2
+    {
+        return $this->container->get(__METHOD__);
+    }
+
+    private function invalidDefinition(): InvalidDefinition
+    {
+        return $this->container->get(__METHOD__);
+    }
+
+    private function privateFunction1(): string
+    {
+    }
+
+    private function privateFunction2(): string
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberParent.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberParent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
+use Symfony\Component\DependencyInjection\ServiceSubscriberTrait;
+
+class TestServiceSubscriberParent implements ServiceSubscriberInterface
+{
+    use ServiceSubscriberTrait;
+
+    private function testDefinition1(): TestDefinition1
+    {
+        return $this->container->get(__METHOD__);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+trait TestServiceSubscriberTrait
+{
+    private function testDefinition3(): TestDefinition3
+    {
+        return $this->container->get(__CLASS__.'::'.__FUNCTION__);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ServiceSubscriberTraitTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
+use Symfony\Component\DependencyInjection\ServiceSubscriberTrait;
+
+class ServiceSubscriberTraitTest extends TestCase
+{
+    public function testMethodsOnParentsAndChildrenAreIgnoredInGetSubscribedServices()
+    {
+        $expected = array(TestService::class.'::aService' => '?Symfony\Component\DependencyInjection\Tests\Service2');
+
+        $this->assertEquals($expected, ChildTestService::getSubscribedServices());
+    }
+
+    public function testSetContainerIsCalledOnParent()
+    {
+        $container = new Container();
+
+        $this->assertSame($container, (new TestService())->setContainer($container));
+    }
+}
+
+class ParentTestService
+{
+    public function aParentService(): Service1
+    {
+    }
+
+    public function setContainer(ContainerInterface $container)
+    {
+        return $container;
+    }
+}
+
+class TestService extends ParentTestService implements ServiceSubscriberInterface
+{
+    use ServiceSubscriberTrait;
+
+    public function aService(): Service2
+    {
+    }
+}
+
+class ChildTestService extends TestService
+{
+    public function aChildService(): Service3
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23898
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/9809

This allows you to easily configure Service Subscribers with the following convention:

```php
class MyService implements ServiceSubscriberInterface
{
    use ServiceSubscriberTrait;

    public function doSomething()
    {
        // $this->router() ...
    }

    private function router(): RouterInterface
    {
        return $this->container->get(__METHOD__);
    }
}
```

This also allows you to create helper traits like `RouterAware`, `LoggerAware` etc... and compose your services with them (*not* using `__METHOD__` in traits because it doesn't behave as expected.).

```php
trait LoggerAware
{
    private function logger(): LoggerInterface
    {
        return $this->container->get(__CLASS__.'::'.__FUNCTION__);
    }
}
```

```php
trait RouterAware
{
    private function router(): RouterInterface
    {
        return $this->container->get(__CLASS__.'::'.__FUNCTION__);
    }
}
```

```php
class MyService implements ServiceSubscriberInterface
{
    use ServiceSubscriberTrait, LoggerAware, RouterAware;

    public function doSomething()
    {
        // $this->router() ...
        // $this->logger() ...
    }
}
```