### PR TITLE
[Messenger] make return type of MessageSubscriberInterface::getHandledMessages() iterable

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
@@ -34,7 +34,7 @@ interface MessageSubscriberInterface extends MessageHandlerInterface
      *
      * The `__invoke` method of the handler will be called as usual with the message to handle.
      *
-     * @return array
+     * @return iterable
      */
-    public static function getHandledMessages(): array;
+    public static function getHandledMessages(): iterable;
 }

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -342,7 +342,7 @@ class UndefinedMessageHandler
 
 class UndefinedMessageHandlerViaInterface implements MessageSubscriberInterface
 {
-    public static function getHandledMessages(): array
+    public static function getHandledMessages(): iterable
     {
         return array(UndefinedMessage::class);
     }
@@ -379,7 +379,7 @@ class BuiltinArgumentTypeHandler
 
 class HandlerWithMultipleMessages implements MessageSubscriberInterface
 {
-    public static function getHandledMessages(): array
+    public static function getHandledMessages(): iterable
     {
         return array(
             DummyMessage::class,
@@ -390,7 +390,7 @@ class HandlerWithMultipleMessages implements MessageSubscriberInterface
 
 class PrioritizedHandler implements MessageSubscriberInterface
 {
-    public static function getHandledMessages(): array
+    public static function getHandledMessages(): iterable
     {
         return array(
             array(SecondMessage::class, 10),
@@ -400,7 +400,7 @@ class PrioritizedHandler implements MessageSubscriberInterface
 
 class HandleNoMessageHandler implements MessageSubscriberInterface
 {
-    public static function getHandledMessages(): array
+    public static function getHandledMessages(): iterable
     {
         return array();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

For reasons described in #27034 and #27076.
