### PR TITLE
[PHPUnitBridge] Add an implementation just for php 7.0

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/TestRunnerForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/TestRunnerForV7.php
@@ -19,12 +19,12 @@ use Symfony\Bridge\PhpUnit\SymfonyTestsListener;
  *
  * @internal
  */
-class TestRunnerForV6 extends BaseRunner
+class TestRunnerForV7 extends BaseRunner
 {
     /**
      * {@inheritdoc}
      */
-    protected function handleConfiguration(array &$arguments)
+    protected function handleConfiguration(array &$arguments): void
     {
         $listener = new SymfonyTestsListener();
 

--- a/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
@@ -13,8 +13,10 @@ namespace Symfony\Bridge\PhpUnit\TextUI;
 
 if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '6.0.0', '<')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\TestRunnerForV5', 'Symfony\Bridge\PhpUnit\TextUI\TestRunner');
-} else {
+} elseif (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Version::id(), '7.0.0', '<')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\TestRunnerForV6', 'Symfony\Bridge\PhpUnit\TextUI\TestRunner');
+} else {
+    class_alias('Symfony\Bridge\PhpUnit\Legacy\TestRunnerForV7', 'Symfony\Bridge\PhpUnit\TextUI\TestRunner');
 }
 
 if (false) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4, because the bug only appears on that branch and up
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

php 7 does not have the void return type, which means we have to have a specific class for the php 7.0 + phpunit 6 combination.