### PR TITLE
[HttpFoundation] Rename HeaderUtils methods

### DIFF
--- a/src/Symfony/Component/HttpFoundation/AcceptHeader.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeader.php
@@ -56,7 +56,7 @@ class AcceptHeader
 
         return new self(array_map(function ($subParts) use (&$index) {
             $part = array_shift($subParts);
-            $attributes = HeaderUtils::combineParts($subParts);
+            $attributes = HeaderUtils::combine($subParts);
 
             $item = new AcceptHeaderItem($part[0], $attributes);
             $item->setIndex($index++);

--- a/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
@@ -43,7 +43,7 @@ class AcceptHeaderItem
         $parts = HeaderUtils::split($itemValue, ';=');
 
         $part = array_shift($parts);
-        $attributes = HeaderUtils::combineParts($parts);
+        $attributes = HeaderUtils::combine($parts);
 
         return new self($part[0], $attributes);
     }
@@ -57,7 +57,7 @@ class AcceptHeaderItem
     {
         $string = $this->value.($this->quality < 1 ? ';q='.$this->quality : '');
         if (count($this->attributes) > 0) {
-            $string .= '; '.HeaderUtils::joinAssoc($this->attributes, ';');
+            $string .= '; '.HeaderUtils::toString($this->attributes, ';');
         }
 
         return $string;

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -219,7 +219,7 @@ class BinaryFileResponse extends Response
                 // Do X-Accel-Mapping substitutions.
                 // @link http://wiki.nginx.org/X-accel#X-Accel-Redirect
                 $parts = HeaderUtils::split($request->headers->get('X-Accel-Mapping', ''), ',=');
-                $mappings = HeaderUtils::combineParts($parts);
+                $mappings = HeaderUtils::combine($parts);
                 foreach ($mappings as $pathPrefix => $location) {
                     if (substr($path, 0, strlen($pathPrefix)) === $pathPrefix) {
                         $path = $location.substr($path, strlen($pathPrefix));

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -57,7 +57,7 @@ class Cookie
         $name = $decode ? urldecode($part[0]) : $part[0];
         $value = isset($part[1]) ? ($decode ? urldecode($part[1]) : $part[1]) : null;
 
-        $data = HeaderUtils::combineParts($parts) + $data;
+        $data = HeaderUtils::combine($parts) + $data;
 
         if (isset($data['max-age'])) {
             $data['expires'] = time() + (int) $data['max-age'];

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -296,7 +296,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
     {
         ksort($this->cacheControl);
 
-        return HeaderUtils::joinAssoc($this->cacheControl, ',');
+        return HeaderUtils::toString($this->cacheControl, ',');
     }
 
     /**
@@ -310,6 +310,6 @@ class HeaderBag implements \IteratorAggregate, \Countable
     {
         $parts = HeaderUtils::split($header, ',=');
 
-        return HeaderUtils::combineParts($parts);
+        return HeaderUtils::combine($parts);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/HeaderUtils.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderUtils.php
@@ -75,10 +75,10 @@ class HeaderUtils
      *
      * Example:
      *
-     *     HeaderUtils::combineParts(array(array("foo", "abc"), array("bar")))
+     *     HeaderUtils::combine(array(array("foo", "abc"), array("bar")))
      *     // => array("foo" => "abc", "bar" => true)
      */
-    public static function combineParts(array $parts): array
+    public static function combine(array $parts): array
     {
         $assoc = array();
         foreach ($parts as $part) {
@@ -99,10 +99,10 @@ class HeaderUtils
      *
      * Example:
      *
-     *     HeaderUtils::joinAssoc(array("foo" => "abc", "bar" => true, "baz" => "a b c"), ",")
+     *     HeaderUtils::toString(array("foo" => "abc", "bar" => true, "baz" => "a b c"), ",")
      *     // => 'foo=abc, bar, baz="a b c"'
      */
-    public static function joinAssoc(array $assoc, string $separator): string
+    public static function toString(array $assoc, string $separator): string
     {
         $parts = array();
         foreach ($assoc as $name => $value) {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1949,7 +1949,7 @@ class Request
             $forwardedValues = array();
             $param = self::$forwardedParams[$type];
             foreach ($parts as $subParts) {
-                $assoc = HeaderUtils::combineParts($subParts);
+                $assoc = HeaderUtils::combine($subParts);
                 if (isset($assoc[$param])) {
                     $forwardedValues[] = $assoc[$param];
                 }

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -295,7 +295,7 @@ class ResponseHeaderBag extends HeaderBag
             $params['filename*'] = "utf-8''".rawurlencode($filename);
         }
 
-        return $disposition.'; '.HeaderUtils::joinAssoc($params, ';');
+        return $disposition.'; '.HeaderUtils::toString($params, ';');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderUtilsTest.php
@@ -45,21 +45,21 @@ class HeaderUtilsTest extends TestCase
         $this->assertSame(array('foo', 'bar, baz\\'), HeaderUtils::split('foo, "bar, baz\\\\', ','));
     }
 
-    public function testCombineAssoc()
+    public function testCombine()
     {
-        $this->assertSame(array('foo' => '123'), HeaderUtils::combineParts(array(array('foo', '123'))));
-        $this->assertSame(array('foo' => true), HeaderUtils::combineParts(array(array('foo'))));
-        $this->assertSame(array('foo' => true), HeaderUtils::combineParts(array(array('Foo'))));
-        $this->assertSame(array('foo' => '123', 'bar' => true), HeaderUtils::combineParts(array(array('foo', '123'), array('bar'))));
+        $this->assertSame(array('foo' => '123'), HeaderUtils::combine(array(array('foo', '123'))));
+        $this->assertSame(array('foo' => true), HeaderUtils::combine(array(array('foo'))));
+        $this->assertSame(array('foo' => true), HeaderUtils::combine(array(array('Foo'))));
+        $this->assertSame(array('foo' => '123', 'bar' => true), HeaderUtils::combine(array(array('foo', '123'), array('bar'))));
     }
 
-    public function testJoinAssoc()
+    public function testToString()
     {
-        $this->assertSame('foo', HeaderUtils::joinAssoc(array('foo' => true), ','));
-        $this->assertSame('foo; bar', HeaderUtils::joinAssoc(array('foo' => true, 'bar' => true), ';'));
-        $this->assertSame('foo=123', HeaderUtils::joinAssoc(array('foo' => '123'), ','));
-        $this->assertSame('foo="1 2 3"', HeaderUtils::joinAssoc(array('foo' => '1 2 3'), ','));
-        $this->assertSame('foo="1 2 3", bar', HeaderUtils::joinAssoc(array('foo' => '1 2 3', 'bar' => true), ','));
+        $this->assertSame('foo', HeaderUtils::toString(array('foo' => true), ','));
+        $this->assertSame('foo; bar', HeaderUtils::toString(array('foo' => true, 'bar' => true), ';'));
+        $this->assertSame('foo=123', HeaderUtils::toString(array('foo' => '123'), ','));
+        $this->assertSame('foo="1 2 3"', HeaderUtils::toString(array('foo' => '1 2 3'), ','));
+        $this->assertSame('foo="1 2 3", bar', HeaderUtils::toString(array('foo' => '1 2 3', 'bar' => true), ','));
     }
 
     public function testQuote()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27026
| License       | MIT
| Doc PR        | 

Rename new HeaderUtils methods as discussed in #27026.