### PR TITLE
ResolveBindingsPass: Don't throw error for unused service, missing parent class

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\LazyProxy\ProxyHelper;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Component\DependencyInjection\Reference;
@@ -88,8 +89,14 @@ class ResolveBindingsPass extends AbstractRecursivePass
 
         $calls = $value->getMethodCalls();
 
-        if ($constructor = $this->getConstructor($value, false)) {
-            $calls[] = array($constructor, $value->getArguments());
+        try {
+            if ($constructor = $this->getConstructor($value, false)) {
+                $calls[] = array($constructor, $value->getArguments());
+            }
+        } catch (RuntimeException $e) {
+            $this->container->getDefinition($this->currentId)->addError($e->getMessage());
+
+            return parent::processValue($value, $isRoot);
         }
 
         foreach ($calls as $i => $call) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no->
| Tests pass?   | yes 
| Fixed tickets | https://github.com/symfony/flex/issues/346#issuecomment-384955796
| License       | MIT
| Doc PR        | n/a

Hey guys!

In short: if you:

A) auto-register a class as a service
B) That class's parent class is missing
C) ... but this class/service is unused

Currently, `ResolveBindingsPass` will fail and throw an exception. The change avoids that - only throwing the exception if the service IS used. This is already done in `AutowirePass`.

The real issue is DoctrineFixturesBundle, where, on production, the bundle (and so, `Fixtures` base class) is not installed, causing a build error, even though these service classes are unused.

Cheers!