### PR TITLE
[Lock][PhpDoc] There is no attempt to create the directory

### DIFF
--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -34,7 +34,7 @@ class FlockStore implements StoreInterface
     /**
      * @param string|null $lockPath the directory to store the lock, defaults to the system's temporary directory
      *
-     * @throws LockStorageException If the lock directory could not be created or is not writable
+     * @throws LockStorageException If the lock directory doesn’t exist or is not writable
      */
     public function __construct($lockPath = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When the lock component [was](https://github.com/symfony/symfony/pull/21093) [created](https://github.com/symfony/symfony/pull/22597), the `FlockStore` implementation was copied from the filesystem component. But the dependency to its origin was dropped, and as part of that, the attempt to create the parent directory for the locks. The PhpDoc wasn’t updated to reflect this change.