### PR TITLE
[Workflow] "clear()" instead of "reset()"

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -154,6 +154,7 @@ Validator
 Workflow
 --------
 
+ * Deprecated the `DefinitionBuilder::reset()` method, use the `clear()` one instead.
  * Deprecated the `add` method in favor of the `addWorkflow` method in `Workflow\Registry`.
  * Deprecated `SupportStrategyInterface` in favor of `WorkflowSupportStrategyInterface`.
  * Deprecated the class `ClassInstanceSupportStrategy` in favor of the class `InstanceOfSupportStrategy`.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -107,6 +107,7 @@ Validator
 Workflow
 --------
 
+ * The `DefinitionBuilder::reset()` method has been removed, use the `clear()` one instead.
  * `add` method has been removed use `addWorkflow` method in `Workflow\Registry` instead.
  * `SupportStrategyInterface` has been removed, use `WorkflowSupportStrategyInterface` instead.
  * `ClassInstanceSupportStrategy` has been removed, use `InstanceOfSupportStrategy` instead.

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -4,8 +4,9 @@ CHANGELOG
 4.1.0
 -----
 
- * Deprecate the usage of `add(Workflow $workflow, $supportStrategy)` in `Workflow/Registry`, use `addWorkflow(WorkflowInterface, $supportStrategy)` instead.
- * Deprecate the usage of `SupportStrategyInterface`, use `WorkflowSupportStrategyInterface` instead.
+ * Deprecated the `DefinitionBuilder::reset()` method, use the `clear()` one instead.
+ * Deprecated the usage of `add(Workflow $workflow, $supportStrategy)` in `Workflow/Registry`, use `addWorkflow(WorkflowInterface, $supportStrategy)` instead.
+ * Deprecated the usage of `SupportStrategyInterface`, use `WorkflowSupportStrategyInterface` instead.
  * The `Workflow` class now implements `WorkflowInterface`.
  * Deprecated the class `ClassInstanceSupportStrategy` in favor of the class `InstanceOfSupportStrategy`.
  * Added TransitionBlockers as a way to pass around reasons why exactly

--- a/src/Symfony/Component/Workflow/DefinitionBuilder.php
+++ b/src/Symfony/Component/Workflow/DefinitionBuilder.php
@@ -47,7 +47,7 @@ class DefinitionBuilder
      *
      * @return $this
      */
-    public function reset()
+    public function clear()
     {
         $this->places = array();
         $this->transitions = array();
@@ -120,5 +120,17 @@ class DefinitionBuilder
         $this->transitions[] = $transition;
 
         return $this;
+    }
+
+    /**
+     * @deprecated since Symfony 4.1, use the clear() method instead.
+     *
+     * @return $this
+     */
+    public function reset()
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated since Symfony 4.1, use the "clear()" method instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->clear();
     }
 }

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -42,7 +42,7 @@ class GuardEvent extends Event
     public function setBlocked($blocked)
     {
         if (!$blocked) {
-            $this->transitionBlockerList->reset();
+            $this->transitionBlockerList->clear();
 
             return;
         }

--- a/src/Symfony/Component/Workflow/TransitionBlockerList.php
+++ b/src/Symfony/Component/Workflow/TransitionBlockerList.php
@@ -37,7 +37,7 @@ final class TransitionBlockerList implements \IteratorAggregate, \Countable
         $this->blockers[] = $blocker;
     }
 
-    public function reset(): void
+    public function clear(): void
     {
         $this->blockers = array();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

While working on another PR (to come), I noticed that the workflow component is using the word "reset" for something that is consistently called "clear" in the rest of the code base (emptying the state of an object) - and also that "reset" is consistently used for setting an object back to its initial state (which might not be the empty state, contrary to what clear does).

Here is a PR fixing this inconsistency. Should be on 4.1 so that we won't have to deal with another BC layer in 4.2.