### PR TITLE
Add symfony/contracts: a set of abstractions extracted out of the Symfony components

### DIFF
--- a/.github/build-packages.php
+++ b/.github/build-packages.php
@@ -49,7 +49,7 @@ foreach ($dirs as $k => $dir) {
 
     $packages[$package->name][$package->version] = $package;
 
-    $versions = file_get_contents('https://packagist.org/p/'.$package->name.'.json');
+    $versions = @file_get_contents('https://packagist.org/p/'.$package->name.'.json') ?: sprintf('{"packages":{"%s":{"dev-master":%s}}}', $package->name, file_get_contents($dir.'/composer.json'));
     $versions = json_decode($versions)->packages->{$package->name};
 
     if ($package->version === str_replace('-dev', '.x-dev', $versions->{'dev-master'}->extra->{'branch-alias'}->{'dev-master'})) {

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ before_install:
           deps=skip
           skip=1
       else
-          COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n')
+          COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h\n')
       fi
 
     - |
@@ -181,7 +181,7 @@ install:
           SYMFONY_VERSION=$(git ls-remote --heads | grep -o '/[1-9].*' | tail -n 1 | sed s/.//) &&
           git fetch origin $SYMFONY_VERSION &&
           git checkout -m FETCH_HEAD &&
-          COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n')
+          COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h\n')
       elif [[ ! $skip ]]; then
           SYMFONY_VERSION=$(cat composer.json | grep '^ *"dev-master". *"[1-9]' | grep -o '[0-9.]*')
       fi

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "symfony/cache": "self.version",
         "symfony/config": "self.version",
         "symfony/console": "self.version",
+        "symfony/contracts": "1.0.0",
         "symfony/css-selector": "self.version",
         "symfony/dependency-injection": "self.version",
         "symfony/debug": "self.version",
@@ -118,7 +119,8 @@
             "Symfony\\Bridge\\ProxyManager\\": "src/Symfony/Bridge/ProxyManager/",
             "Symfony\\Bridge\\Twig\\": "src/Symfony/Bridge/Twig/",
             "Symfony\\Bundle\\": "src/Symfony/Bundle/",
-            "Symfony\\Component\\": "src/Symfony/Component/"
+            "Symfony\\Component\\": "src/Symfony/Component/",
+            "Symfony\\Contract\\": "src/Symfony/Contract/"
         },
         "classmap": [
             "src/Symfony/Component/Intl/Resources/stubs"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,7 @@
             <directory>./src/Symfony/Bridge/*/Tests/</directory>
             <directory>./src/Symfony/Component/*/Tests/</directory>
             <directory>./src/Symfony/Component/*/*/Tests/</directory>
+            <directory>./src/Symfony/Contract/*/Tests/</directory>
             <directory>./src/Symfony/Bundle/*/Tests/</directory>
         </testsuite>
     </testsuites>
@@ -44,6 +45,7 @@
                 <directory>./src/Symfony/Bridge/*/Tests</directory>
                 <directory>./src/Symfony/Component/*/Tests</directory>
                 <directory>./src/Symfony/Component/*/*/Tests</directory>
+                <directory>./src/Symfony/Contract/*/Tests</directory>
                 <directory>./src/Symfony/Bundle/*/Tests</directory>
                 <directory>./src/Symfony/Bundle/*/Resources</directory>
                 <directory>./src/Symfony/Component/*/Resources</directory>
@@ -52,6 +54,7 @@
                 <directory>./src/Symfony/Bundle/*/vendor</directory>
                 <directory>./src/Symfony/Component/*/vendor</directory>
                 <directory>./src/Symfony/Component/*/*/vendor</directory>
+                <directory>./src/Symfony/Contract/*/vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -24,8 +24,9 @@ use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contract\Service\ResetInterface;
 
-abstract class DoctrineType extends AbstractType
+abstract class DoctrineType extends AbstractType implements ResetInterface
 {
     /**
      * @var ManagerRegistry

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "doctrine/common": "~2.4@stable",
+        "symfony/contracts": "^1.0",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0"
     },

--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -14,13 +14,14 @@ namespace Symfony\Bridge\Monolog;
 use Monolog\Logger as BaseLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * Logger.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Logger extends BaseLogger implements DebugLoggerInterface
+class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
 {
     /**
      * {@inheritdoc}
@@ -54,6 +55,14 @@ class Logger extends BaseLogger implements DebugLoggerInterface
         if ($logger = $this->getDebugLogger()) {
             $logger->clear();
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->clear();
     }
 
     /**

--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -15,8 +15,9 @@ use Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Contract\Service\ResetInterface;
 
-class DebugProcessor implements DebugLoggerInterface
+class DebugProcessor implements DebugLoggerInterface, ResetInterface
 {
     private $records = array();
     private $errorCount = array();
@@ -90,5 +91,13 @@ class DebugProcessor implements DebugLoggerInterface
     {
         $this->records = array();
         $this->errorCount = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->clear();
     }
 }

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "monolog/monolog": "~1.19",
+        "symfony/contracts": "^1.0",
         "symfony/http-kernel": "~3.4|~4.0"
     },
     "require-dev": {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -25,7 +25,6 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
-use Symfony\Component\Cache\ResettableInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\DirectoryResource;
@@ -95,6 +94,7 @@ use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Symfony\Component\Workflow;
 use Symfony\Component\Yaml\Command\LintCommand as BaseYamlLintCommand;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * FrameworkExtension.
@@ -324,7 +324,7 @@ class FrameworkExtension extends Extension
             ->addTag('kernel.cache_warmer');
         $container->registerForAutoconfiguration(EventSubscriberInterface::class)
             ->addTag('kernel.event_subscriber');
-        $container->registerForAutoconfiguration(ResettableInterface::class)
+        $container->registerForAutoconfiguration(ResetInterface::class)
             ->addTag('kernel.reset', array('method' => 'reset'));
         $container->registerForAutoconfiguration(ProcessorInterface::class)
             ->addTag('monolog.processor');

--- a/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
@@ -19,6 +19,7 @@ use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\ResettableInterface;
 use Symfony\Component\Cache\Traits\GetTrait;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * Chains several adapters together.
@@ -301,7 +302,7 @@ class ChainAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
     public function reset()
     {
         foreach ($this->adapters as $adapter) {
-            if ($adapter instanceof ResettableInterface) {
+            if ($adapter instanceof ResetInterface) {
                 $adapter->reset();
             }
         }

--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -16,6 +16,7 @@ use Symfony\Component\Cache\CacheInterface;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * An adapter that collects data about all cache calls.
@@ -225,7 +226,7 @@ class TraceableAdapter implements AdapterInterface, CacheInterface, PruneableInt
      */
     public function reset()
     {
-        if (!$this->pool instanceof ResettableInterface) {
+        if (!$this->pool instanceof ResetInterface) {
             return;
         }
         $event = $this->start(__FUNCTION__);

--- a/src/Symfony/Component/Cache/DoctrineProvider.php
+++ b/src/Symfony/Component/Cache/DoctrineProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache;
 
 use Doctrine\Common\Cache\CacheProvider;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -39,7 +40,7 @@ class DoctrineProvider extends CacheProvider implements PruneableInterface, Rese
      */
     public function reset()
     {
-        if ($this->pool instanceof ResettableInterface) {
+        if ($this->pool instanceof ResetInterface) {
             $this->pool->reset();
         }
         $this->setNamespace($this->getNamespace());

--- a/src/Symfony/Component/Cache/ResettableInterface.php
+++ b/src/Symfony/Component/Cache/ResettableInterface.php
@@ -11,10 +11,11 @@
 
 namespace Symfony\Component\Cache;
 
+use Symfony\Contract\Service\ResetInterface;
+
 /**
  * Resets a pool's local state.
  */
-interface ResettableInterface
+interface ResettableInterface extends ResetInterface
 {
-    public function reset();
 }

--- a/src/Symfony/Component/Cache/Simple/ChainCache.php
+++ b/src/Symfony/Component/Cache/Simple/ChainCache.php
@@ -15,6 +15,7 @@ use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * Chains several caches together.
@@ -244,7 +245,7 @@ class ChainCache implements CacheInterface, PruneableInterface, ResettableInterf
     public function reset()
     {
         foreach ($this->caches as $cache) {
-            if ($cache instanceof ResettableInterface) {
+            if ($cache instanceof ResetInterface) {
                 $cache->reset();
             }
         }

--- a/src/Symfony/Component/Cache/Simple/TraceableCache.php
+++ b/src/Symfony/Component/Cache/Simple/TraceableCache.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Cache\Simple;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * An adapter that collects data about all cache calls.
@@ -200,7 +201,7 @@ class TraceableCache implements CacheInterface, PruneableInterface, ResettableIn
      */
     public function reset()
     {
-        if (!$this->pool instanceof ResettableInterface) {
+        if (!$this->pool instanceof ResetInterface) {
             return;
         }
         $event = $this->start(__FUNCTION__);

--- a/src/Symfony/Component/Cache/Traits/ProxyTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ProxyTrait.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Cache\Traits;
 
 use Symfony\Component\Cache\PruneableInterface;
-use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -36,7 +36,7 @@ trait ProxyTrait
      */
     public function reset()
     {
-        if ($this->pool instanceof ResettableInterface) {
+        if ($this->pool instanceof ResetInterface) {
             $this->pool->reset();
         }
     }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -23,7 +23,8 @@
         "php": "^7.1.3",
         "psr/cache": "~1.0",
         "psr/log": "~1.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0",
+        "symfony/contracts": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "dev-master",

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
@@ -12,11 +12,12 @@
 namespace Symfony\Component\Console\Formatter;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * @author Jean-François Simon <contact@jfsimon.fr>
  */
-class OutputFormatterStyleStack
+class OutputFormatterStyleStack implements ResetInterface
 {
     /**
      * @var OutputFormatterStyleInterface[]

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "symfony/contracts": "^1.0",
         "symfony/polyfill-mbstring": "~1.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/DependencyInjection/ResettableContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ResettableContainerInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Symfony\Contract\Service\ResetInterface;
+
 /**
  * ResettableContainerInterface defines additional resetting functionality
  * for containers, allowing to release shared services when the container is
@@ -18,7 +20,7 @@ namespace Symfony\Component\DependencyInjection;
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-interface ResettableContainerInterface extends ContainerInterface
+interface ResettableContainerInterface extends ContainerInterface, ResetInterface
 {
     /**
      * Resets shared services from the container.

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0",
+        "symfony/contracts": "^1.0"
     },
     "require-dev": {
         "symfony/yaml": "~3.4|~4.0",

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
@@ -12,13 +12,14 @@
 namespace Symfony\Component\EventDispatcher\Debug;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * @deprecated since Symfony 4.1
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface TraceableEventDispatcherInterface extends EventDispatcherInterface
+interface TraceableEventDispatcherInterface extends EventDispatcherInterface, ResetInterface
 {
     /**
      * Gets the called listeners.
@@ -33,9 +34,4 @@ interface TraceableEventDispatcherInterface extends EventDispatcherInterface
      * @return array An array of not called listeners
      */
     public function getNotCalledListeners();
-
-    /**
-     * Resets the trace.
-     */
-    public function reset();
 }

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "symfony/contracts": "^1.0"
     },
     "require-dev": {
         "symfony/dependency-injection": "~3.4|~4.0",

--- a/src/Symfony/Component/ExpressionLanguage/Compiler.php
+++ b/src/Symfony/Component/ExpressionLanguage/Compiler.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Component\ExpressionLanguage;
 
+use Symfony\Contract\Service\ResetInterface;
+
 /**
  * Compiles a node to PHP code.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Compiler
+class Compiler implements ResetInterface
 {
     private $source;
     private $functions;

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
@@ -13,13 +13,14 @@ namespace Symfony\Component\HttpKernel\DataCollector;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * DataCollectorInterface.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface DataCollectorInterface
+interface DataCollectorInterface extends ResetInterface
 {
     /**
      * Collects data for the given Request and Response.
@@ -32,9 +33,4 @@ interface DataCollectorInterface
      * @return string The collector name
      */
     public function getName();
-
-    /**
-     * Resets this data collector to its initial state.
-     */
-    public function reset();
 }

--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -16,6 +16,7 @@ use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * EventDataCollector.
@@ -47,7 +48,7 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
     {
         $this->data = array();
 
-        if ($this->dispatcher instanceof TraceableEventDispatcherInterface) {
+        if ($this->dispatcher instanceof ResetInterface) {
             $this->dispatcher->reset();
         }
     }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\DependencyInjection;
 
+use Symfony\Contract\Service\ResetInterface;
+
 /**
  * Resets provided services.
  *
@@ -19,7 +21,7 @@ namespace Symfony\Component\HttpKernel\DependencyInjection;
  *
  * @internal
  */
-class ServicesResetter
+class ServicesResetter implements ResetInterface
 {
     private $resettableServices;
     private $resetMethods;

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+use Symfony\Contract\Service\ResetInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -23,7 +24,7 @@ use Psr\Log\LoggerInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Profiler
+class Profiler implements ResetInterface
 {
     private $storage;
 

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "symfony/contracts": "^1.0",
         "symfony/event-dispatcher": "~4.1",
         "symfony/http-foundation": "^4.1.1",
         "symfony/debug": "~3.4|~4.0",

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authentication\Token\Storage;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * TokenStorage contains a TokenInterface.
@@ -21,7 +22,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class TokenStorage implements TokenStorageInterface
+class TokenStorage implements TokenStorageInterface, ResetInterface
 {
     private $token;
 
@@ -39,5 +40,10 @@ class TokenStorage implements TokenStorageInterface
     public function setToken(TokenInterface $token = null)
     {
         $this->token = $token;
+    }
+
+    public function reset()
+    {
+        $this->setToken(null);
     }
 }

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "symfony/contracts": "^1.0"
     },
     "require-dev": {
         "psr/container": "^1.0",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "symfony/contracts": "^1.0",
         "symfony/event-dispatcher": "~3.4|~4.0",
         "symfony/http-foundation": "~3.4|~4.0",
         "symfony/http-kernel": "~3.4|~4.0",

--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Component\Stopwatch;
 
+use Symfony\Contract\Service\ResetInterface;
+
 /**
  * Stopwatch provides a way to profile code.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Stopwatch
+class Stopwatch implements ResetInterface
 {
     /**
      * @var bool

--- a/src/Symfony/Component/Stopwatch/composer.json
+++ b/src/Symfony/Component/Stopwatch/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "symfony/contracts": "^1.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Stopwatch\\": "" },

--- a/src/Symfony/Component/Validator/Validator/TraceableValidator.php
+++ b/src/Symfony/Component/Validator/Validator/TraceableValidator.php
@@ -12,13 +12,14 @@
 namespace Symfony\Component\Validator\Validator;
 
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Contract\Service\ResetInterface;
 
 /**
  * Collects some data about validator calls.
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
-class TraceableValidator implements ValidatorInterface
+class TraceableValidator implements ValidatorInterface, ResetInterface
 {
     private $validator;
     private $collectedData = array();

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "symfony/contracts": "^1.0",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/translation": "~3.4|~4.0"

--- a/src/Symfony/Contract/.gitignore
+++ b/src/Symfony/Contract/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+phpunit.xml
+vendor/

--- a/src/Symfony/Contract/CHANGELOG.md
+++ b/src/Symfony/Contract/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+1.0.0
+-----
+
+ * added `Service\ResetInterface` to provides a way to reset an object to its initial state

--- a/src/Symfony/Contract/LICENSE
+++ b/src/Symfony/Contract/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Contract/README.md
+++ b/src/Symfony/Contract/README.md
@@ -1,0 +1,68 @@
+Symfony Contracts
+=================
+
+A set of abstractions extracted out of the Symfony components.
+
+Can be used to build on semantics that the Symfony components proved useful - and
+that already have battle tested implementations.
+
+Design Principles
+-----------------
+
+ * contracts are split by domain, each into their own sub-namespaces;
+ * contracts are small and consistent sets of PHP interfaces, traits, normative
+   docblocks and reference test suites when applicable, etc.;
+ * all contracts must have a proven implementation to enter this repository;
+ * they must be backward compatible with existing Symfony components.
+
+FAQ
+---
+
+### How to use this package?
+
+The abstractions in this package are useful to achieve loose coupling and
+interoperability. By using the provided interfaces as type hints, you are able
+to reuse any implementations that match their contracts. It could be a Symfony
+component, or another one provided by the PHP community at large.
+
+Depending on their semantics, some interfaces can be combined with autowiring to
+seamlessly inject a service in your classes.
+
+Others might be useful as labeling interfaces, to hint about a specific behavior
+that could be enabled when using autoconfiguration or manual service tagging (or
+any other means provided by your framework.)
+
+### How is this different from PHP-FIG's PSRs?
+
+When applicable, the provided contracts are built on top of PHP-FIG's PSR. We
+encourage relying on them and won't duplicate the effort. Still, the FIG has
+different goals and different processes. Here, we don't need to seek universal
+standards. Instead, we're providing abstractions that are compatible with the
+implementations provided by Symfony. This should actually also contribute
+positively to the PHP-FIG (from which Symfony is a member), by hinting the group
+at some abstractions the PHP world might like to take inspiration from.
+
+### Why isn't this package split into several packages?
+
+Putting all interfaces in one package eases discoverability and dependency
+management. Instead of dealing with a myriad of small packages and the
+corresponding matrix of versions, you just need to deal with one package and one
+version. Also when using IDE autocompletion or just reading the source code, it
+makes it easier to figure out which contracts are provided.
+
+There are two downsides to this approach: you may have unused files in your
+`vendor/` directory, and in the future, it will be impossible to use two
+different sub-namespaces in different major versions of the package. For the
+"unused files" downside, it has no practical consequences: their file sizes are
+very small, and there is no performance overhead at all since they are never
+loaded. For major versions, this package follows the Symfony BC + deprecation
+policies, with an additional restriction to never remove deprecated interfaces.
+
+Resources
+---------
+
+  * [Documentation](https://symfony.com/doc/current/components/contracts.html)
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Contract/Service/ResetInterface.php
+++ b/src/Symfony/Contract/Service/ResetInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contract\Service;
+
+/**
+ * Provides a way to reset an object to its initial state.
+ *
+ * When calling the "reset()" method on an object, it should be put back to its
+ * initial state. This usually means clearing any internal buffers and forwarding
+ * the call to internal dependencies. All properties of the object should be put
+ * back to the same state it had when it was first ready to use.
+ *
+ * This method could be called, for example, to recycle objects that are used as
+ * services, so that they can be used to handle several requests in the same
+ * process loop (note that we advise making your services stateless instead of
+ * implementing this interface when possible.)
+ */
+interface ResetInterface
+{
+    public function reset();
+}

--- a/src/Symfony/Contract/composer.json
+++ b/src/Symfony/Contract/composer.json
@@ -1,14 +1,14 @@
 {
-    "name": "symfony/expression-language",
+    "name": "symfony/contracts",
     "type": "library",
-    "description": "Symfony ExpressionLanguage Component",
-    "keywords": [],
+    "description": "A set of abstractions extracted out of the Symfony components",
+    "keywords": ["abstractions", "contracts", "decoupling", "interfaces", "interoperability", "standards"],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [
         {
-            "name": "Fabien Potencier",
-            "email": "fabien@symfony.com"
+            "name": "Nicolas Grekas",
+            "email": "p@tchwork.com"
         },
         {
             "name": "Symfony Community",
@@ -16,20 +16,18 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
-        "symfony/cache": "~3.4|~4.0",
-        "symfony/contracts": "^1.0"
+        "php": "^7.1.3"
     },
     "autoload": {
-        "psr-4": { "Symfony\\Component\\ExpressionLanguage\\": "" },
+        "psr-4": { "Symfony\\Contract\\": "" },
         "exclude-from-classmap": [
-            "/Tests/"
+            "**/Tests/"
         ]
     },
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "4.2-dev"
+            "dev-master": "1.0-dev"
         }
     }
 }

--- a/src/Symfony/Contract/phpunit.xml.dist
+++ b/src/Symfony/Contract/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Contracts Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | -
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

A set of abstractions extracted out of the Symfony components.

This is a topic I've been thinking about for a long time. I feel like the time has come for Symfony to publish some abstractions so that people could build on them in a decoupled way.
I've identified interfaces in some components that would greatly benefit from being moved out from the components where they are for now. E.g. #26929 is something that has a broader scope than the Cache component itself.

By putting them in a new `symfony/abstractions` package, we would allow more innovation in the Symfony community, at the abstraction level.

In order to start small, I propose only one interface that gathers a concept that is shared amongst many components already: `ResetInterface`. It would provide a standard `reset()` method, whose purpose is to set an object back to its initial state, allowing it to be reused many times with no side effects/leaks related to its history. By this definition, it could also be autoconfigured (as done here, see update in FrameworkExtension). See wording in the docblock in the attached source code.

Ideally, I'd like this package to provide not only interfaces, by also generic traits, and reference test suites when possible. We could work on adding more abstractions during the 4.2 cycle. WDYT?

## Here is the attached README:

A set of abstractions extracted out of the Symfony components.

Can be used to build on semantics that the Symfony components proved useful - and
that already have battle tested implementations.

Design Principles
-----------------

 * contracts are split by domain, each into their own sub-namespaces;
 * contracts are small and consistent sets of PHP interfaces, traits, normative
   docblocks and reference test suites when applicable, etc.;
 * all contracts must have a proven implementation to enter this repository;
 * they must be backward compatible with existing Symfony components.

FAQ
---

### How to use this package?

The abstractions in this package are useful to achieve loose coupling and
interoperability. By using the provided interfaces as type hints, you are able
to reuse any implementations that match their contracts. It could be a Symfony
component, or another one provided by the PHP community at large.

Depending on their semantics, some interfaces can be combined with autowiring to
seamlessly inject a service in your classes.

Others might be useful as labeling interfaces, to hint about a specific behavior
that could be enabled when using autoconfiguration or manual service tagging (or
any other means provided by your framework.)

### How is this different from PHP-FIG's PSRs?

When applicable, the provided contracts are built on top of PHP-FIG's PSRs. But
the group has different goals and different processes. Here, we're focusing on
providing abstractions that are useful on their own while still compatible with
implementations provided by Symfony. Although not the main target, we hope that
the declared contracts will directly or indirectly contribute to the PHP-FIG.

### Why isn't this package split into several packages?

Putting all interfaces in one package eases discoverability and dependency
management. Instead of dealing with a myriad of small packages and the
corresponding matrix of versions, you just need to deal with one package and one
version. Also when using IDE autocompletion or just reading the source code, it
makes it easier to figure out which contracts are provided.

There are two downsides to this approach: you may have unused files in your
`vendor/` directory, and in the future, it will be impossible to use two
different sub-namespaces in different major versions of the package. For the
"unused files" downside, it has no practical consequences: their file sizes are
very small, and there is no performance overhead at all since they are never
loaded. For major versions, this package follows the Symfony BC + deprecation
policies, with an additional restriction to never remove deprecated interfaces.

Resources
---------

  * [Documentation](https://symfony.com/doc/current/components/contracts.html)
  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
  * [Report issues](https://github.com/symfony/symfony/issues) and
    [send Pull Requests](https://github.com/symfony/symfony/pulls)
    in the [main Symfony repository](https://github.com/symfony/symfony)
