### PR TITLE
[DX] Redirect to proper Symfony version documentation

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/layout.html.twig
@@ -15,7 +15,7 @@
                 <h1 class="logo">{{ include('@Twig/images/symfony-logo.svg') }} Symfony Exception</h1>
 
                 <div class="help-link">
-                    <a href="https://symfony.com/doc">
+                    <a href="https://symfony.com/doc/{{ constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION') }}/index.html">
                         <span class="icon">{{ include('@Twig/images/icon-book.svg') }}</span>
                         <span class="hidden-xs-down">Symfony</span> Docs
                     </a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | 

Just a small improvement
I think this can make some dev target the right documentation instead of reading an other version that the one they are developing on

EDIT: I do not know if including the constant directly is the good choice, or it is better to add a global symfony version collector?