### PR TITLE
[Messenger] Reset traceable buses

### DIFF
--- a/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
@@ -67,6 +67,9 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
     public function reset()
     {
         $this->data = array();
+        foreach ($this->traceableBuses as $traceableBus) {
+            $traceableBus->reset();
+        }
     }
 
     private function collectMessage(string $busName, array $tracedMessage)

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -52,4 +52,9 @@ class TraceableMessageBus implements MessageBusInterface
     {
         return $this->dispatchedMessages;
     }
+
+    public function reset()
+    {
+        $this->dispatchedMessages = array();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

So the dispatched messages list is empty on new requests without rebooting the kernel.