### PR TITLE
[Form] Use symfony/polyfill-ctype

### DIFF
--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -20,7 +20,8 @@
         "symfony/event-dispatcher": "~2.1",
         "symfony/intl": "~2.7.25|^2.8.18",
         "symfony/options-resolver": "~2.6",
-        "symfony/property-access": "~2.3"
+        "symfony/property-access": "~2.3",
+        "symfony/polyfill-ctype": "~1.8"
     },
     "require-dev": {
         "doctrine/collections": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes    
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Related to: #24168  
Although it does not fix this issue, it does remove the dependency on the `ctype` extension.