### PR TITLE
[Validator] Use symfony/polyfill-ctype

### DIFF
--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/translation": "~2.4"
+        "symfony/translation": "~2.4",
+        "symfony/polyfill-ctype": "~1.8"
     },
     "require-dev": {
         "doctrine/common": "~2.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes    
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Related to: #24168 
Although it does not fix this issue, it does remove the dependency on the `ctype` extension.