### PR TITLE
[Validator] fixes phpdoc reference to an interface that was removed in Symfony 3.0

### DIFF
--- a/src/Symfony/Component/Validator/ObjectInitializerInterface.php
+++ b/src/Symfony/Component/Validator/ObjectInitializerInterface.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator;
 /**
  * Prepares an object for validation.
  *
- * Concrete implementations of this interface are used by {@link ValidationVisitorInterface}
+ * Concrete implementations of this interface are used by {@link Validator\ContextualValidatorInterface}
  * to initialize objects just before validating them.
  *
  * @author Fabien Potencier <fabien@symfony.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~
