### PR TITLE
[Security] reusing AuthorizationChecker in AccessListener

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -68,6 +68,9 @@ CHANGELOG
  * Added support for the new Argon2i password encoder
  * added `stateless` option to the `switch_user` listener
  * deprecated auto picking the first registered provider when no configured provider on a firewall and ambiguous
+ * `AccessListener` reuses logic of `AuthorizationCheckerInterface`.
+   `AccessListener::__construct` now accepts `TokenStorageInterface`, `AccessMapInterface` and `AuthorizationCheckerInterface`,
+   if old signature is used `E_USER_DEPRECATED` will be triggered 
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -242,9 +242,8 @@
         <service id="security.access_listener" class="Symfony\Component\Security\Http\Firewall\AccessListener">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.token_storage" />
-            <argument type="service" id="security.access.decision_manager" />
             <argument type="service" id="security.access_map" />
-            <argument type="service" id="security.authentication.manager" />
+            <argument type="service" id="security.authorization_checker"/>
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Http\AccessMapInterface;
@@ -27,15 +28,42 @@ use Symfony\Component\Security\Http\AccessMapInterface;
 class AccessListener implements ListenerInterface
 {
     private $tokenStorage;
+
+    /**
+     * @deprecated since Symfony 4.3
+     */
     private $accessDecisionManager;
     private $map;
-    private $authManager;
 
-    public function __construct(TokenStorageInterface $tokenStorage, AccessDecisionManagerInterface $accessDecisionManager, AccessMapInterface $map, AuthenticationManagerInterface $authManager)
+    /**
+     * @deprecated since Symfony 4.3
+     */
+    private $authManager;
+    private $authorizationChecker;
+
+    /**
+     * @param AccessDecisionManagerInterface|AccessMapInterface $map
+     * @param AccessMapInterface|AuthorizationCheckerInterface  $authorizationChecker
+     * @param AuthenticationManagerInterface|null               $authManager
+     */
+    public function __construct(TokenStorageInterface $tokenStorage, $map, $authorizationChecker, $authManager = null)
     {
+        if ($authorizationChecker instanceof AccessMapInterface) {
+            @trigger_error(sprintf('Signature "%s()" has changed since Symfony 4.2, now it accepts TokenStorageInterface, AccessMapInterface, AuthorizationCheckerInterface.', __METHOD__), E_USER_DEPRECATED);
+            $accessDecisionManager = $map;
+            $map = $authorizationChecker;
+            $authorizationChecker = null;
+        } elseif (!$authorizationChecker instanceof AuthorizationCheckerInterface) {
+            throw new \InvalidArgumentException(sprintf('Argument 3 passed to %s() must be an instance of %s or null, %s given.', __METHOD__, AuthorizationCheckerInterface::class, \is_object($authorizationChecker) ? \get_class($authorizationChecker) : \gettype($authorizationChecker)));
+        } else {
+            $accessDecisionManager = null;
+            $authManager = null;
+        }
+
         $this->tokenStorage = $tokenStorage;
-        $this->accessDecisionManager = $accessDecisionManager;
         $this->map = $map;
+        $this->authorizationChecker = $authorizationChecker;
+        $this->accessDecisionManager = $accessDecisionManager;
         $this->authManager = $authManager;
     }
 
@@ -56,6 +84,18 @@ class AccessListener implements ListenerInterface
         list($attributes) = $this->map->getPatterns($request);
 
         if (null === $attributes) {
+            return;
+        }
+
+        if (null !== $this->authorizationChecker) {
+            if (!$this->authorizationChecker->isGranted($attributes, $request)) {
+                $exception = new AccessDeniedException();
+                $exception->setAttributes($attributes);
+                $exception->setSubject($request);
+
+                throw $exception;
+            }
+
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -17,9 +17,37 @@ use Symfony\Component\Security\Http\Firewall\AccessListener;
 class AccessListenerTest extends TestCase
 {
     /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testBadConstructorSignature()
+    {
+        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+
+        new AccessListener($tokenStorage, null, null, null);
+    }
+
+    /**
+     * @deprecated
+     * @group legacy
+     * @expectedDeprecation Signature "Symfony\Component\Security\Http\Firewall\AccessListener::__construct()" has changed since Symfony 4.2, now it accepts TokenStorageInterface, AccessMapInterface, AuthorizationCheckerInterface.
+     */
+    public function testOldConstructorSignature()
+    {
+        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
+        $accessDecisionManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock();
+        $authManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
+
+        new AccessListener($tokenStorage, $accessDecisionManager, $accessMap, $authManager);
+    }
+
+    /**
+     * @deprecated
+     * @group legacy
+     * @expectedDeprecation Signature "Symfony\Component\Security\Http\Firewall\AccessListener::__construct()" has changed since Symfony 4.2, now it accepts TokenStorageInterface, AccessMapInterface, AuthorizationCheckerInterface.
      * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
      */
-    public function testHandleWhenTheAccessDecisionManagerDecidesToRefuseAccess()
+    public function testOldHandleWhenTheAccessDecisionManagerDecidesToRefuseAccess()
     {
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
 
@@ -70,7 +98,56 @@ class AccessListenerTest extends TestCase
         $listener->handle($event);
     }
 
-    public function testHandleWhenTheTokenIsNotAuthenticated()
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     */
+    public function testHandleWhenTheAccessDecisionManagerDecidesToRefuseAccess()
+    {
+        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
+        $authorizationChecker = $this->getMockBuilder('\Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')->getMock();
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
+        $attributes = ['foo' => 'bar'];
+
+        $tokenStorage
+            ->expects($this->any())
+            ->method('getToken')
+            ->will($this->returnValue($token))
+        ;
+
+        $accessMap
+            ->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->will($this->returnValue([$attributes, null]))
+        ;
+
+        $authorizationChecker
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with($this->equalTo($attributes), $this->equalTo($request))
+            ->will($this->returnValue(false))
+        ;
+
+        $listener = new AccessListener($tokenStorage, $accessMap, $authorizationChecker);
+
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->will($this->returnValue($request))
+        ;
+
+        $listener->handle($event);
+    }
+
+    /**
+     * @deprecated
+     * @group legacy
+     * @expectedDeprecation Signature "Symfony\Component\Security\Http\Firewall\AccessListener::__construct()" has changed since Symfony 4.2, now it accepts TokenStorageInterface, AccessMapInterface, AuthorizationCheckerInterface.
+     */
+    public function testOldHandleWhenTheTokenIsNotAuthenticated()
     {
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
 
@@ -141,7 +218,12 @@ class AccessListenerTest extends TestCase
         $listener->handle($event);
     }
 
-    public function testHandleWhenThereIsNoAccessMapEntryMatchingTheRequest()
+    /**
+     * @deprecated
+     * @group legacy
+     * @expectedDeprecation Signature "Symfony\Component\Security\Http\Firewall\AccessListener::__construct()" has changed since Symfony 4.2, now it accepts TokenStorageInterface, AccessMapInterface, AuthorizationCheckerInterface.
+     */
+    public function testOldHandleWhenThereIsNoAccessMapEntryMatchingTheRequest()
     {
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
 
@@ -183,10 +265,51 @@ class AccessListenerTest extends TestCase
         $listener->handle($event);
     }
 
+    public function testHandleWhenThereIsNoAccessMapEntryMatchingTheRequest()
+    {
+        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        $authorizationChecker = $this->getMockBuilder('\Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')->getMock();
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
+        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
+
+        $tokenStorage
+            ->expects($this->any())
+            ->method('getToken')
+            ->will($this->returnValue($token))
+        ;
+
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->will($this->returnValue($request))
+        ;
+
+        $accessMap
+            ->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->will($this->returnValue([null, null]))
+        ;
+
+        $authorizationChecker
+            ->expects($this->never())
+            ->method('isGranted')
+        ;
+
+        $listener = new AccessListener($tokenStorage, $accessMap, $authorizationChecker);
+
+        $listener->handle($event);
+    }
+
     /**
+     * @deprecated
+     * @group legacy
+     * @expectedDeprecation Signature "Symfony\Component\Security\Http\Firewall\AccessListener::__construct()" has changed since Symfony 4.2, now it accepts TokenStorageInterface, AccessMapInterface, AuthorizationCheckerInterface.
      * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
      */
-    public function testHandleWhenTheSecurityTokenStorageHasNoToken()
+    public function testOldHandleWhenTheSecurityTokenStorageHasNoToken()
     {
         $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
         $tokenStorage
@@ -195,14 +318,50 @@ class AccessListenerTest extends TestCase
             ->will($this->returnValue(null))
         ;
 
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+
+        $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
+        $accessMap
+            ->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->will($this->returnValue([['foo' => 'bar'], null]))
+        ;
+
         $listener = new AccessListener(
             $tokenStorage,
             $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock(),
-            $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock(),
+            $accessMap,
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock()
         );
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->will($this->returnValue($request))
+        ;
+
+        $listener->handle($event);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
+     */
+    public function testHandleWhenTheSecurityTokenStorageHasNoToken()
+    {
+        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
+        $authorizationChecker = $this->getMockBuilder('\Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')->getMock();
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
+
+        $tokenStorage
+            ->expects($this->any())
+            ->method('getToken')
+            ->will($this->returnValue(null))
+        ;
+
+        $listener = new AccessListener($tokenStorage, $accessMap, $authorizationChecker);
 
         $listener->handle($event);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Fixed tickets | #21571

While investigating why `AuthenticationEvents::AUTHENTICATION_SUCCESS` is not dispatched, noticed similarity between `AccessListener` and `AuthorizationChecker` and the only real difference is `alwaysAuthenticate` flag.

**Case 1:**
When `UsernamePasswordToken` is serialized it will be serialized with state of `authenticated`,
so when application will load token from session `AccessListener` won't call `authenticate` because `authenticated=true`, even if `alwaysAuthenticate=true`

**Case 2:**
User A has roles `foo, bar and admin`, User A is signed-in into application and token is persisted, later another User B with role `admin`, decided to restrict role `admin` for User A, so User A won't lose it's privileges until session is expired or logout, because token is persisted with `roles` and `authenticated=true` and AccessListener does not call `authenticate` even if `alwaysAuthenticate=true`

**TODO**
- [x] - reuse AuthorizationChecker in AccessListener
- [ ] - adjust unit tests
- [x] - add deprecation notices
- [x] - update CHANGELOG and UPGRADE*