### PR TITLE
[DI] Minor performance tweak in PriorityTaggedServiceTrait

### DIFF
--- a/link
+++ b/link
@@ -38,7 +38,7 @@ $sfPackages = array('symfony/symfony' => __DIR__);
 
 $filesystem = new Filesystem();
 $braces = array('Bundle', 'Bridge', 'Component', 'Component/Security');
-$directories = call_user_func_array('array_merge', array_values(array_map(function ($part) {
+$directories = array_merge(...array_values(array_map(function ($part) {
     return glob(__DIR__.'/src/Symfony/'.$part.'/*', GLOB_ONLYDIR | GLOB_NOSORT);
 }, $braces)));
 

--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -64,7 +64,11 @@ class DebugProcessor implements DebugLoggerInterface
             return $this->records[$hash];
         }
 
-        return $this->records ? \call_user_func_array('array_merge', $this->records) : array();
+        if (0 === \count($this->records)) {
+            return array();
+        }
+
+        return array_merge(...array_values($this->records));
     }
 
     /**

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/DebugProcessorTest.php
@@ -29,6 +29,14 @@ class DebugProcessorTest extends TestCase
         $this->assertSame(1, $processor->countErrors());
     }
 
+    public function testDebugProcessorWithoutLogs()
+    {
+        $processor = new DebugProcessor();
+
+        $this->assertCount(0, $processor->getLogs());
+        $this->assertSame(0, $processor->countErrors());
+    }
+
     public function testWithRequestStack()
     {
         $stack = new RequestStack();

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -210,9 +210,9 @@ class TextDescriptor extends Descriptor
             }
 
             // calculate max. width based on available commands per namespace
-            $width = $this->getColumnWidth(call_user_func_array('array_merge', array_map(function ($namespace) use ($commands) {
+            $width = $this->getColumnWidth(array_merge(...array_values(array_map(function ($namespace) use ($commands) {
                 return array_intersect($namespace['commands'], array_keys($commands));
-            }, $namespaces)));
+            }, $namespaces))));
 
             if ($describedNamespace) {
                 $this->writeText(sprintf('<comment>Available commands for the "%s" namespace:</comment>', $describedNamespace), $options);

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -258,13 +258,13 @@ class PassConfig
      */
     private function sortPasses(array $passes)
     {
-        if (0 === count($passes)) {
+        if (0 === \count($passes)) {
             return array();
         }
 
         krsort($passes);
 
         // Flatten the array
-        return call_user_func_array('array_merge', $passes);
+        return array_merge(...$passes);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -47,7 +47,7 @@ trait PriorityTaggedServiceTrait
 
         if ($services) {
             krsort($services);
-            $services = call_user_func_array('array_merge', $services);
+            $services = array_merge(...$services);
         }
 
         return $services;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
@@ -35,4 +35,20 @@ class PassConfigTest extends TestCase
         $this->assertSame($pass2, $passes[0]);
         $this->assertSame($pass1, $passes[1]);
     }
+
+    public function testPassOrderingWithoutPasses()
+    {
+        $config = new PassConfig();
+        $config->setBeforeOptimizationPasses(array());
+        $config->setAfterRemovingPasses(array());
+        $config->setBeforeRemovingPasses(array());
+        $config->setOptimizationPasses(array());
+        $config->setRemovingPasses(array());
+
+        $this->assertEmpty($config->getBeforeOptimizationPasses());
+        $this->assertEmpty($config->getAfterRemovingPasses());
+        $this->assertEmpty($config->getBeforeRemovingPasses());
+        $this->assertEmpty($config->getOptimizationPasses());
+        $this->assertEmpty($config->getRemovingPasses());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -78,6 +78,13 @@ class PriorityTaggedServiceTraitTest extends TestCase
 
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test('my_custom_tag', $container));
     }
+
+    public function testWithEmptyArray()
+    {
+        $container = new ContainerBuilder();
+        $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
+        $this->assertEquals(array(), $priorityTaggedServiceTraitImplementation->test('my_custom_tag', $container));
+    }
 }
 
 class PriorityTaggedServiceTraitImplementation

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/ProjectExtension.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/ProjectExtension.php
@@ -1,7 +1,6 @@
 <?php
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class ProjectExtension implements ExtensionInterface
@@ -12,7 +11,7 @@ class ProjectExtension implements ExtensionInterface
         $configs = array_filter($configs);
 
         if ($configs) {
-            $config = call_user_func_array('array_merge', $configs);
+            $config = array_merge(...$configs);
         } else {
             $config = array();
         }

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -100,7 +100,7 @@ class MessengerPass implements CompilerPassInterface
 
         foreach ($handlersByMessage as $message => $handlers) {
             krsort($handlersByMessage[$message]);
-            $handlersByMessage[$message] = \call_user_func_array('array_merge', $handlersByMessage[$message]);
+            $handlersByMessage[$message] = array_merge(...$handlersByMessage[$message]);
         }
 
         $definitions = array();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

When this feature was added, we were limited to older php versions that didn't have the argument unpacking feature. This should improve performance a little (also came up with php inspections).