### PR TITLE
[DebugBundle][HttpKernel] Update var-dumper requirement for components using SourceContextProvider

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -20,7 +20,7 @@
         "ext-xml": "*",
         "symfony/http-kernel": "~3.4|~4.0",
         "symfony/twig-bridge": "~3.4|~4.0",
-        "symfony/var-dumper": "~3.4|~4.0"
+        "symfony/var-dumper": "~4.1"
     },
     "require-dev": {
         "symfony/config": "~3.4|~4.0",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -46,7 +46,7 @@
     "conflict": {
         "symfony/config": "<3.4",
         "symfony/dependency-injection": "<4.1",
-        "symfony/var-dumper": "<3.4",
+        "symfony/var-dumper": "<4.1",
         "twig/twig": "<1.34|<2.4,>=2"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

The DebugBundle is using the SourceContextProvider class that was introduced in v4.1
