### PR TITLE
[Doctrine Bridge] return 0 on equality when sorting listeners/subscribers

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -66,11 +66,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
             $a = isset($a['priority']) ? $a['priority'] : 0;
             $b = isset($b['priority']) ? $b['priority'] : 0;
 
-            if ($a === $b) {
-                return 0;
-            }
-
-            return $a > $b ? -1 : 1;
+            return $b - $a;
         };
 
         if (!empty($taggedSubscribers)) {

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Registers event listeners and subscribers to the available doctrine connections.
@@ -65,6 +65,10 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
         $sortFunc = function ($a, $b) {
             $a = isset($a['priority']) ? $a['priority'] : 0;
             $b = isset($b['priority']) ? $b['priority'] : 0;
+
+            if ($a === $b) {
+                return 0;
+            }
 
             return $a > $b ? -1 : 1;
         };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes?
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In our app (simplified), we have two event subscribers, `A` and `B`.
The app relies on `A` running before `B`, but we had mistakenly left their priorities  as the default, `0`. By luck/chance, they were sorted such that `A` sorted before `B`. All was well.

Then all of a sudden, they started firing in the 'wrong' order, `B` then `A`.
Debugging this, it was because we added a third event listener, `C`, which caused the order of `A` and `B` to be reversed.
This can be seen here:
https://3v4l.org/SQefd
Note that the order of `a` and `b` is reversed once `c` is added.

Adding an equality check (mimicking the spaceship operator) "fixes" the issue (even thought the behavior of `uasort` is undefined), and makes the results consistent, I hope? 

Now, clearly it was our fault for not defining priorities, but we may have been alerted to the error of our ways if the ordering returned from the sort was consistent in the first place.
