### PR TITLE
[Messenger] Add a new time limit receiver

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Enhancers/StopWhenTimeLimitIsReachedReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Enhancers/StopWhenTimeLimitIsReachedReceiverTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\Enhancers;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\CallbackReceiver;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Enhancers\StopWhenTimeLimitIsReachedReceiver;
+
+class StopWhenTimeLimitIsReachedReceiverTest extends TestCase
+{
+    /**
+     * @group time-sensitive
+     */
+    public function testReceiverStopsWhenTimeLimitIsReached()
+    {
+        $callable = function ($handler) {
+            $handler(new DummyMessage('API'));
+        };
+
+        $decoratedReceiver = $this->getMockBuilder(CallbackReceiver::class)
+            ->setConstructorArgs(array($callable))
+            ->enableProxyingToOriginalMethods()
+            ->getMock();
+
+        $decoratedReceiver->expects($this->once())->method('receive');
+        $decoratedReceiver->expects($this->once())->method('stop');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info')
+            ->with('Receiver stopped due to time limit of {timeLimit}s reached', array('timeLimit' => 1));
+
+        $timeoutReceiver = new StopWhenTimeLimitIsReachedReceiver($decoratedReceiver, 1, $logger);
+        $timeoutReceiver->receive(function () {
+            sleep(2);
+        });
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Enhancers/StopWhenTimeLimitIsReachedReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/Enhancers/StopWhenTimeLimitIsReachedReceiver.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Enhancers;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Transport\ReceiverInterface;
+
+/**
+ * @author Simon Delicata <simon.delicata@free.fr>
+ */
+class StopWhenTimeLimitIsReachedReceiver implements ReceiverInterface
+{
+    private $decoratedReceiver;
+    private $timeLimitInSeconds;
+    private $logger;
+
+    public function __construct(ReceiverInterface $decoratedReceiver, int $timeLimitInSeconds, LoggerInterface $logger = null)
+    {
+        $this->decoratedReceiver = $decoratedReceiver;
+        $this->timeLimitInSeconds = $timeLimitInSeconds;
+        $this->logger = $logger;
+    }
+
+    public function receive(callable $handler): void
+    {
+        $startTime = time();
+        $endTime = $startTime + $this->timeLimitInSeconds;
+
+        $this->decoratedReceiver->receive(function ($message) use ($handler, $endTime) {
+            $handler($message);
+
+            if ($endTime < time()) {
+                $this->stop();
+                if (null !== $this->logger) {
+                    $this->logger->info('Receiver stopped due to time limit of {timeLimit}s reached', array('timeLimit' => $this->timeLimitInSeconds));
+                }
+            }
+        });
+    }
+
+    public function stop(): void
+    {
+        $this->decoratedReceiver->stop();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

New feature to add a time limit option to the ConsumeMessagesCommand.
```
bin/console messenger:consume-messages <receiver-name> -t 3600
```