### PR TITLE
[Serializer] added the ability to gather all deserialization errors.

### DIFF
--- a/src/Symfony/Component/Serializer/Context/AccumulatingContext.php
+++ b/src/Symfony/Component/Serializer/Context/AccumulatingContext.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Symfony\Component\Serializer\Context;
@@ -8,15 +17,15 @@ class AccumulatingContext extends \ArrayObject
 {
     public function isEmpty(): bool
     {
-        return $this->count() === 0;
+        return 0 === $this->count();
     }
 
     public function flatten(): array
     {
-        $flatContext = [];
+        $flatContext = array();
 
         foreach ($this as $key => $value) {
-            if (is_array($value)) {
+            if (\is_array($value)) {
                 $this->doFlatten($value, $key, $flatContext);
 
                 continue;
@@ -31,8 +40,8 @@ class AccumulatingContext extends \ArrayObject
     private function doFlatten(array $value, $key, array &$flatContext)
     {
         foreach ($value as $innerKey => $innerValue) {
-            if (is_string($key) && is_array($innerValue)) {
-                $this->doFlatten($innerValue, $key . '.' . $innerKey, $flatContext);
+            if (\is_string($key) && \is_array($innerValue)) {
+                $this->doFlatten($innerValue, $key.'.'.$innerKey, $flatContext);
 
                 continue;
             }

--- a/src/Symfony/Component/Serializer/Context/AccumulatingContext.php
+++ b/src/Symfony/Component/Serializer/Context/AccumulatingContext.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Serializer\Context;
+
+class AccumulatingContext extends \ArrayObject
+{
+    public function isEmpty(): bool
+    {
+        return $this->count() === 0;
+    }
+
+    public function flatten(): array
+    {
+        $flatContext = [];
+
+        foreach ($this as $key => $value) {
+            if (is_array($value)) {
+                $this->doFlatten($value, $key, $flatContext);
+
+                continue;
+            }
+
+            $flatContext[$key] = $value;
+        }
+
+        return $flatContext;
+    }
+
+    private function doFlatten(array $value, $key, array &$flatContext)
+    {
+        foreach ($value as $innerKey => $innerValue) {
+            if (is_string($key) && is_array($innerValue)) {
+                $this->doFlatten($innerValue, $key . '.' . $innerKey, $flatContext);
+
+                continue;
+            }
+
+            $flatContext[$key][] = $innerValue;
+        }
+    }
+}

--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributeException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributeException.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Serializer\Exception;
 /**
  * @author Claudio Beatrice <claudi0.beatric3@gmail.com>
  */
-class ExtraAttributeException extends RuntimeException
+class ExtraAttributeException extends \RuntimeException
 {
     /**
      * @var string

--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributeException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributeException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * @author Claudio Beatrice <claudi0.beatric3@gmail.com>
+ */
+class ExtraAttributeException extends RuntimeException
+{
+    /**
+     * @var string
+     */
+    private $extraAttribute;
+
+    public function __construct(string $extraAttribute, \Exception $previous = null)
+    {
+        $msg = sprintf('Extra attribute "%s" is not allowed.', $extraAttribute);
+
+        $this->extraAttribute = $extraAttribute;
+
+        parent::__construct($msg, 0, $previous);
+    }
+
+    /**
+     * Get the extra attribute that is not allowed.
+     */
+    public function getExtraAttribute(): string
+    {
+        return $this->extraAttribute;
+    }
+}

--- a/src/Symfony/Component/Serializer/Exception/NotDenormalizableValueException.php
+++ b/src/Symfony/Component/Serializer/Exception/NotDenormalizableValueException.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Serializer\Exception;
 
-use Throwable;
-
 /**
  * @author Claudio Beatrice <claudi0.beatric3@gmail.com>
  */
@@ -23,7 +21,7 @@ class NotDenormalizableValueException extends NotNormalizableValueException
      */
     private $field;
 
-    public function __construct(string $message = '', string $field = null, Throwable $previous = null)
+    public function __construct(string $message = '', ?string $field = null, \Throwable $previous = null)
     {
         @trigger_error(sprintf('The %s class will stop extending %s in Symfony 5.0, where it will extend %s instead.', self::class, NotNormalizableValueException::class, UnexpectedValueException::class), E_USER_NOTICE);
 

--- a/src/Symfony/Component/Serializer/Exception/NotDenormalizableValueException.php
+++ b/src/Symfony/Component/Serializer/Exception/NotDenormalizableValueException.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+use Throwable;
+
+/**
+ * @author Claudio Beatrice <claudi0.beatric3@gmail.com>
+ */
+class NotDenormalizableValueException extends NotNormalizableValueException
+{
+    /**
+     * @var null|string
+     */
+    private $field;
+
+    public function __construct(string $message = '', string $field = null, Throwable $previous = null)
+    {
+        @trigger_error(sprintf('The %s class will stop extending %s in Symfony 5.0, where it will extend %s instead.', self::class, NotNormalizableValueException::class, UnexpectedValueException::class), E_USER_NOTICE);
+
+        parent::__construct($message, $previous ? $previous->getCode() : 0, $previous);
+
+        $this->field = $field;
+    }
+
+    public function getField(): ?string
+    {
+        return $this->field;
+    }
+}

--- a/src/Symfony/Component/Serializer/Exception/UnexpectedValuesException.php
+++ b/src/Symfony/Component/Serializer/Exception/UnexpectedValuesException.php
@@ -12,29 +12,62 @@
 namespace Symfony\Component\Serializer\Exception;
 
 /**
- * UnexpectedValuesException.
- *
  * @author Claudio Beatrice <claudi0.beatric3@gmail.com>
  */
 class UnexpectedValuesException extends \RuntimeException implements ExceptionInterface
 {
     /**
-     * @var string[]
+     * @var UnexpectedValueException[]
      */
     private $unexpectedValueErrors;
 
+    /**
+     * @param UnexpectedValueException[] $unexpectedValueErrors
+     */
     public function __construct(array $unexpectedValueErrors)
     {
+        $this->validateErrors($unexpectedValueErrors);
+
         parent::__construct();
 
         $this->unexpectedValueErrors = $unexpectedValueErrors;
     }
 
     /**
-     * @return string[]
+     * @return UnexpectedValueException[]
      */
     public function getUnexpectedValueErrors(): array
     {
         return $this->unexpectedValueErrors;
+    }
+
+    /**
+     * @param mixed[] $unexpectedValueErrors
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateErrors(array $unexpectedValueErrors): void
+    {
+        foreach ($unexpectedValueErrors as $unexpectedValueError) {
+            if (!$unexpectedValueError instanceof UnexpectedValueException) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'All errors must be instances of %s, %s given.',
+                        UnexpectedValuesException::class,
+                        $this->getType($unexpectedValueError)
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * @param mixed $unexpectedValueError
+     */
+    private function getType($unexpectedValueError): string
+    {
+        return is_object($unexpectedValueError)
+            ? get_class($unexpectedValueError)
+            : gettype($unexpectedValueError);
     }
 }

--- a/src/Symfony/Component/Serializer/Exception/UnexpectedValuesException.php
+++ b/src/Symfony/Component/Serializer/Exception/UnexpectedValuesException.php
@@ -98,7 +98,7 @@ class UnexpectedValuesException extends \RuntimeException implements ExceptionIn
     /**
      * @param mixed $value
      */
-    private function assertIsError($value, string $message, $unexpectedValueErrors): void
+    private function assertIsError($value, string $message): void
     {
         if (!$value instanceof UnexpectedValueException) {
             throw new InvalidArgumentException($message);

--- a/src/Symfony/Component/Serializer/Exception/UnexpectedValuesException.php
+++ b/src/Symfony/Component/Serializer/Exception/UnexpectedValuesException.php
@@ -70,9 +70,9 @@ class UnexpectedValuesException extends \RuntimeException implements ExceptionIn
      */
     private function getType($unexpectedValueError): string
     {
-        return is_object($unexpectedValueError)
-            ? get_class($unexpectedValueError)
-            : gettype($unexpectedValueError);
+        return \is_object($unexpectedValueError)
+            ? \get_class($unexpectedValueError)
+            : \gettype($unexpectedValueError);
     }
 
     /**
@@ -90,7 +90,7 @@ class UnexpectedValuesException extends \RuntimeException implements ExceptionIn
      */
     private function assertIsString($value, string $message): void
     {
-        if ($this->getType($value) !== 'string') {
+        if ('string' !== $this->getType($value)) {
             throw new InvalidArgumentException($message);
         }
     }

--- a/src/Symfony/Component/Serializer/Exception/UnexpectedValuesException.php
+++ b/src/Symfony/Component/Serializer/Exception/UnexpectedValuesException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * UnexpectedValuesException.
+ *
+ * @author Claudio Beatrice <claudi0.beatric3@gmail.com>
+ */
+class UnexpectedValuesException extends \RuntimeException implements ExceptionInterface
+{
+    /**
+     * @var string[]
+     */
+    private $unexpectedValueErrors;
+
+    public function __construct(array $unexpectedValueErrors)
+    {
+        parent::__construct();
+
+        $this->unexpectedValueErrors = $unexpectedValueErrors;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getUnexpectedValueErrors(): array
+    {
+        return $this->unexpectedValueErrors;
+    }
+}

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -235,7 +235,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     public function denormalize($data, $class, $format = null, array $context = array(), AccumulatingContext $accumulatingContext = null)
     {
-        if ($accumulatingContext === null) {
+        if (null === $accumulatingContext) {
             $accumulatingContext = new AccumulatingContext();
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\Serializer\Exception\BadMethodCallException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\NotDenormalizableValueException;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -34,7 +34,7 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
     /**
      * {@inheritdoc}
      *
-     * @throws NotNormalizableValueException
+     * @throws NotDenormalizableValueException
      */
     public function denormalize($data, $class, $format = null, array $context = array())
     {
@@ -54,7 +54,7 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
         $builtinType = isset($context['key_type']) ? $context['key_type']->getBuiltinType() : null;
         foreach ($data as $key => $value) {
             if (null !== $builtinType && !\call_user_func('is_'.$builtinType, $key)) {
-                throw new NotNormalizableValueException(sprintf('The type of the key "%s" must be "%s" ("%s" given).', $key, $builtinType, \gettype($key)));
+                throw new NotDenormalizableValueException(sprintf('The type of the key "%s" must be "%s" ("%s" given).', $key, $builtinType, \gettype($key)), $key);
             }
 
             $data[$key] = $serializer->denormalize($value, $class, $format, $context);

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\NotDenormalizableValueException;
 
 /**
  * Normalizes an {@see \SplFileInfo} object to a data URI.
@@ -87,12 +87,12 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
      * @see https://gist.github.com/bgrins/6194623
      *
      * @throws InvalidArgumentException
-     * @throws NotNormalizableValueException
+     * @throws NotDenormalizableValueException
      */
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!preg_match('/^data:([a-z0-9][a-z0-9\!\#\$\&\-\^\_\+\.]{0,126}\/[a-z0-9][a-z0-9\!\#\$\&\-\^\_\+\.]{0,126}(;[a-z0-9\-]+\=[a-z0-9\-]+)?)?(;base64)?,[a-z0-9\!\$\&\\\'\,\(\)\*\+\,\;\=\-\.\_\~\:\@\/\?\%\s]*\s*$/i', $data)) {
-            throw new NotNormalizableValueException('The provided "data:" URI is not valid.');
+            throw new NotDenormalizableValueException('The provided "data:" URI is not valid.');
         }
 
         try {
@@ -105,7 +105,7 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
                     return new \SplFileObject($data);
             }
         } catch (\RuntimeException $exception) {
-            throw new NotNormalizableValueException($exception->getMessage(), $exception->getCode(), $exception);
+            throw new NotDenormalizableValueException($exception->getMessage(), null, $exception);
         }
 
         throw new InvalidArgumentException(sprintf('The class parameter "%s" is not supported. It must be one of "SplFileInfo", "SplFileObject" or "Symfony\Component\HttpFoundation\File\File".', $class));

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\NotDenormalizableValueException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 
 /**
@@ -71,8 +72,6 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
 
     /**
      * {@inheritdoc}
-     *
-     * @throws NotNormalizableValueException
      */
     public function denormalize($data, $class, $format = null, array $context = array())
     {
@@ -92,7 +91,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
 
             $dateTimeErrors = \DateTime::class === $class ? \DateTime::getLastErrors() : \DateTimeImmutable::getLastErrors();
 
-            throw new NotNormalizableValueException(sprintf(
+            throw new NotDenormalizableValueException(sprintf(
                 'Parsing datetime string "%s" using format "%s" resulted in %d errors:'."\n".'%s',
                 $data,
                 $dateTimeFormat,
@@ -104,7 +103,7 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         try {
             return \DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone);
         } catch (\Exception $e) {
-            throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);
+            throw new NotDenormalizableValueException($e->getMessage(), null, $e);
         }
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -15,6 +15,7 @@ use Symfony\Component\Serializer\Exception\BadMethodCallException;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\NotDenormalizableValueException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
@@ -35,12 +36,13 @@ interface DenormalizerInterface
      *
      * @return object
      *
-     * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
-     * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported
-     * @throws UnexpectedValueException Occurs when the item cannot be hydrated with the given data
-     * @throws ExtraAttributesException Occurs when the item doesn't have attribute to receive given data
-     * @throws LogicException           Occurs when the normalizer is not supposed to denormalize
-     * @throws RuntimeException         Occurs if the class cannot be instantiated
+     * @throws BadMethodCallException          Occurs when the normalizer is not called in an expected context
+     * @throws InvalidArgumentException        Occurs when the arguments are not coherent or not supported
+     * @throws UnexpectedValueException        Occurs when the item cannot be hydrated with the given data
+     * @throws ExtraAttributesException        Occurs when the item doesn't have attribute to receive given data
+     * @throws NotDenormalizableValueException Occurs when the item cannot be denormalized
+     * @throws LogicException                  Occurs when the normalizer is not supposed to denormalize
+     * @throws RuntimeException                Occurs if the class cannot be instantiated
      */
     public function denormalize($data, $class, $format = null, array $context = array());
 

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Encoder\ContextAwareEncoderInterface;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\NotDenormalizableValueException;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
@@ -165,7 +166,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
     /**
      * {@inheritdoc}
      *
-     * @throws NotNormalizableValueException
+     * @throws NotDenormalizableValueException
      */
     public function denormalize($data, $type, $format = null, array $context = array())
     {
@@ -177,7 +178,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             return $normalizer->denormalize($data, $type, $format, $context);
         }
 
-        throw new NotNormalizableValueException(sprintf('Could not denormalize object of type %s, no supporting normalizer found.', $type));
+        throw new NotDenormalizableValueException(sprintf('Could not denormalize object of type %s, no supporting normalizer found.', $type));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Context/AccumulatingContextTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/AccumulatingContextTest.php
@@ -34,36 +34,36 @@ final class AccumulatingContextTest extends TestCase
 
     public function dataToSerializeProvider(): array
     {
-        return [
-            [
-                [], [],
-            ],
-            [
-                ['foo' => [new UnexpectedValueException('test')]], ['foo' => [new UnexpectedValueException('test')]],
-            ],
-            [
-                ['foo.bar' => [new UnexpectedValueException('test')]], ['foo' => ['bar' => [new UnexpectedValueException('test')]]],
-            ],
-            [
-                [
-                    'foo.bar.baz' => [new UnexpectedValueException('test')],
-                    'foo.bar.quux' => [new UnexpectedValueException('test2')],
-                    'foo.corge.grault' => [new UnexpectedValueException('test3')],
-                    'garply' => [new UnexpectedValueException('test4')],
-                ],
-                [
-                    'foo' => [
-                        'bar' => [
-                            'baz' => [new UnexpectedValueException('test')],
-                            'quux' => [new UnexpectedValueException('test2')],
-                        ],
-                        'corge' => [
-                            'grault' => [new UnexpectedValueException('test3')],
-                        ]
-                    ],
-                    'garply' => [new UnexpectedValueException('test4')],
-                ],
-            ]
-        ];
+        return array(
+            array(
+                array(), array(),
+            ),
+            array(
+                array('foo' => array(new UnexpectedValueException('test'))), array('foo' => array(new UnexpectedValueException('test'))),
+            ),
+            array(
+                array('foo.bar' => array(new UnexpectedValueException('test'))), array('foo' => array('bar' => array(new UnexpectedValueException('test')))),
+            ),
+            array(
+                array(
+                    'foo.bar.baz' => array(new UnexpectedValueException('test')),
+                    'foo.bar.quux' => array(new UnexpectedValueException('test2')),
+                    'foo.corge.grault' => array(new UnexpectedValueException('test3')),
+                    'garply' => array(new UnexpectedValueException('test4')),
+                ),
+                array(
+                    'foo' => array(
+                        'bar' => array(
+                            'baz' => array(new UnexpectedValueException('test')),
+                            'quux' => array(new UnexpectedValueException('test2')),
+                        ),
+                        'corge' => array(
+                            'grault' => array(new UnexpectedValueException('test3')),
+                        ),
+                    ),
+                    'garply' => array(new UnexpectedValueException('test4')),
+                ),
+            ),
+        );
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Context/AccumulatingContextTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Context/AccumulatingContextTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Serializer\Tests\Context;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Context\AccumulatingContext;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+
+final class AccumulatingContextTest extends TestCase
+{
+    /**
+     * @var AccumulatingContext
+     */
+    private $accumulatingContext;
+
+    protected function setUp(): void
+    {
+        $this->accumulatingContext = new AccumulatingContext();
+    }
+
+    /**
+     * @dataProvider dataToSerializeProvider
+     */
+    public function testFlatten(array $expectedFlattenedData, array $data): void
+    {
+        foreach ($data as $key => $value) {
+            $this->accumulatingContext[$key] = $value;
+        }
+
+        $this->assertEquals($expectedFlattenedData, $this->accumulatingContext->flatten());
+    }
+
+    public function dataToSerializeProvider(): array
+    {
+        return [
+            [
+                [], [],
+            ],
+            [
+                ['foo' => [new UnexpectedValueException('test')]], ['foo' => [new UnexpectedValueException('test')]],
+            ],
+            [
+                ['foo.bar' => [new UnexpectedValueException('test')]], ['foo' => ['bar' => [new UnexpectedValueException('test')]]],
+            ],
+            [
+                [
+                    'foo.bar.baz' => [new UnexpectedValueException('test')],
+                    'foo.bar.quux' => [new UnexpectedValueException('test2')],
+                    'foo.corge.grault' => [new UnexpectedValueException('test3')],
+                    'garply' => [new UnexpectedValueException('test4')],
+                ],
+                [
+                    'foo' => [
+                        'bar' => [
+                            'baz' => [new UnexpectedValueException('test')],
+                            'quux' => [new UnexpectedValueException('test2')],
+                        ],
+                        'corge' => [
+                            'grault' => [new UnexpectedValueException('test3')],
+                        ]
+                    ],
+                    'garply' => [new UnexpectedValueException('test4')],
+                ],
+            ]
+        ];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Exception/UnexpectedValuesExceptionTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Exception/UnexpectedValuesExceptionTest.php
@@ -23,11 +23,13 @@ final class UnexpectedValuesExceptionTest extends TestCase
 
     public function testItCanBeInstantiated(): void
     {
-        new UnexpectedValuesException(array(
+        $unexpectedValuesException = new UnexpectedValuesException(array(
             'attribute1' => array(new UnexpectedValueException('foo')),
             'attribute2' => array(new UnexpectedValueException('bar')),
             'attribute3.subattibute1' => array(new UnexpectedValueException('bar')),
         ));
+
+        $this->assertCount(3, $unexpectedValuesException->getUnexpectedValueErrors());
     }
 
     public function wrongErrorsProvider()

--- a/src/Symfony/Component/Serializer/Tests/Exception/UnexpectedValuesExceptionTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Exception/UnexpectedValuesExceptionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Serializer\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\Exception\UnexpectedValuesException;
+
+final class UnexpectedValuesExceptionTest extends TestCase
+{
+    /**
+     * @dataProvider wrongErrorsProvider
+     */
+    public function testItCannotBeInstantiatedWithWrongErrors(string $expectedExceptionMessage, array $errors): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        new UnexpectedValuesException($errors);
+    }
+
+    public function testItCanBeInstantiated(): void
+    {
+        new UnexpectedValuesException([
+            'attribute1' => [new UnexpectedValueException('foo')],
+            'attribute2' => [new UnexpectedValueException('bar')],
+            'attribute3.subattibute1' => [new UnexpectedValueException('bar')],
+        ]);
+    }
+
+    public function wrongErrorsProvider()
+    {
+        return [
+            [
+                'No errors were given, at least one is expected.', [],
+            ],
+            [
+                'All keys must be strings, integer given.', [0 => []],
+            ],
+            [
+                'No errors were given for key "attribute1", at least one is expected.', ['attribute1' => []],
+            ],
+            [
+                'All errors must be instances of '.UnexpectedValueException::class.', integer given for key "attribute1".', ['attribute1' => [123]],
+            ],
+            [
+                'All errors must be instances of '.UnexpectedValueException::class.', string given for key "attribute2".', ['attribute2' => ['foo']],
+            ],
+            [
+                'All errors must be instances of '.UnexpectedValueException::class.', RuntimeException given for key "attribute3".', ['attribute3' => [new \RuntimeException('test')]],
+            ],
+            [
+                'All errors must be instances of '.UnexpectedValueException::class.', RuntimeException given for key "attribute4.subattribute1".', ['attribute4.subattribute1' => [new \RuntimeException('test')]],
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Exception/UnexpectedValuesExceptionTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Exception/UnexpectedValuesExceptionTest.php
@@ -32,7 +32,7 @@ final class UnexpectedValuesExceptionTest extends TestCase
         $this->assertCount(3, $unexpectedValuesException->getUnexpectedValueErrors());
     }
 
-    public function wrongErrorsProvider()
+    public function wrongErrorsProvider(): array
     {
         return array(
             array(

--- a/src/Symfony/Component/Serializer/Tests/Exception/UnexpectedValuesExceptionTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Exception/UnexpectedValuesExceptionTest.php
@@ -23,37 +23,37 @@ final class UnexpectedValuesExceptionTest extends TestCase
 
     public function testItCanBeInstantiated(): void
     {
-        new UnexpectedValuesException([
-            'attribute1' => [new UnexpectedValueException('foo')],
-            'attribute2' => [new UnexpectedValueException('bar')],
-            'attribute3.subattibute1' => [new UnexpectedValueException('bar')],
-        ]);
+        new UnexpectedValuesException(array(
+            'attribute1' => array(new UnexpectedValueException('foo')),
+            'attribute2' => array(new UnexpectedValueException('bar')),
+            'attribute3.subattibute1' => array(new UnexpectedValueException('bar')),
+        ));
     }
 
     public function wrongErrorsProvider()
     {
-        return [
-            [
-                'No errors were given, at least one is expected.', [],
-            ],
-            [
-                'All keys must be strings, integer given.', [0 => []],
-            ],
-            [
-                'No errors were given for key "attribute1", at least one is expected.', ['attribute1' => []],
-            ],
-            [
-                'All errors must be instances of '.UnexpectedValueException::class.', integer given for key "attribute1".', ['attribute1' => [123]],
-            ],
-            [
-                'All errors must be instances of '.UnexpectedValueException::class.', string given for key "attribute2".', ['attribute2' => ['foo']],
-            ],
-            [
-                'All errors must be instances of '.UnexpectedValueException::class.', RuntimeException given for key "attribute3".', ['attribute3' => [new \RuntimeException('test')]],
-            ],
-            [
-                'All errors must be instances of '.UnexpectedValueException::class.', RuntimeException given for key "attribute4.subattribute1".', ['attribute4.subattribute1' => [new \RuntimeException('test')]],
-            ],
-        ];
+        return array(
+            array(
+                'No errors were given, at least one is expected.', array(),
+            ),
+            array(
+                'All keys must be strings, integer given.', array(0 => array()),
+            ),
+            array(
+                'No errors were given for key "attribute1", at least one is expected.', array('attribute1' => array()),
+            ),
+            array(
+                'All errors must be instances of '.UnexpectedValueException::class.', integer given for key "attribute1".', array('attribute1' => array(123)),
+            ),
+            array(
+                'All errors must be instances of '.UnexpectedValueException::class.', string given for key "attribute2".', array('attribute2' => array('foo')),
+            ),
+            array(
+                'All errors must be instances of '.UnexpectedValueException::class.', RuntimeException given for key "attribute3".', array('attribute3' => array(new \RuntimeException('test'))),
+            ),
+            array(
+                'All errors must be instances of '.UnexpectedValueException::class.', RuntimeException given for key "attribute4.subattribute1".', array('attribute4.subattribute1' => array(new \RuntimeException('test'))),
+            ),
+        );
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -749,13 +749,13 @@ class ObjectNormalizerTest extends TestCase
 
             $this->assertCount(3, $errors);
 
-            $this->assertSame('The type of the "baz" attribute for class "Symfony\Component\Serializer\Tests\Normalizer\ObjectInner" must be one of "int" ("string" given).', $errors['inner']['baz'][0]);
+            $this->assertSame('The type of the "baz" attribute for class "Symfony\Component\Serializer\Tests\Normalizer\ObjectInner" must be one of "int" ("string" given).', $errors['inner.baz'][0]->getMessage());
 
-            $this->assertSame('The type of the key "a" must be "int" ("string" given).', $errors['inners'][0]);
-            $this->assertSame('The type of the "inners" attribute for class "Symfony\Component\Serializer\Tests\Normalizer\ObjectOuter" must be one of "Symfony\Component\Serializer\Tests\Normalizer\ObjectInner[]" ("array" given).', $errors['inners'][1]);
+            $this->assertSame('The type of the key "a" must be "int" ("string" given).', $errors['inners'][0]->getMessage());
+            $this->assertSame('The type of the "inners" attribute for class "Symfony\Component\Serializer\Tests\Normalizer\ObjectOuter" must be one of "Symfony\Component\Serializer\Tests\Normalizer\ObjectInner[]" ("array" given).', $errors['inners'][1]->getMessage());
 
-            $this->assertSame('DateTimeImmutable::__construct(): Failed to parse time string (wrong date) at position 0 (w): The timezone could not be found in the database', $errors['date'][0]);
-            $this->assertSame('The type of the "date" attribute for class "Symfony\Component\Serializer\Tests\Normalizer\ObjectOuter" must be one of "DateTimeInterface" ("string" given).', $errors['date'][1]);
+            $this->assertSame('DateTimeImmutable::__construct(): Failed to parse time string (wrong date) at position 0 (w): The timezone could not be found in the database', $errors['date'][0]->getMessage());
+            $this->assertSame('The type of the "date" attribute for class "Symfony\Component\Serializer\Tests\Normalizer\ObjectOuter" must be one of "DateTimeInterface" ("string" given).', $errors['date'][1]->getMessage());
 
             return;
         }


### PR DESCRIPTION
I'd like to propose a new "collect_all_errors" (boolean) setting in the deserialization context, that will have the normalizer loop through all the attributes and collect all the errors, as opposed to breaking at the first one.

If this proposal is acceptable, I'll gladly add the Doc PR and Changelog :)

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | tbd

This patch proposes an update to the `Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer` that allows clients to receive all deserialization errors instead of the first one only.

Additionally:
 - Introduces `NotDenormalizableValueException` for better separation of concerns between normalization and denormalization. 