### PR TITLE
[HttpKernel] Better exception page when the controller returns nothing

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/ControllerDoesNotReturnResponseException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ControllerDoesNotReturnResponseException.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class ControllerDoesNotReturnResponseException extends \LogicException
+{
+    public function __construct(string $message, callable $controller, string $file, int $line)
+    {
+        parent::__construct($message);
+
+        if (!$controllerDefinition = $this->parseControllerDefinition($controller)) {
+            return;
+        }
+
+        $this->file = $controllerDefinition['file'];
+        $this->line = $controllerDefinition['line'];
+        $r = new \ReflectionProperty(\Exception::class, 'trace');
+        $r->setAccessible(true);
+        $r->setValue($this, array_merge(array(
+            array(
+                'line' => $line,
+                'file' => $file,
+            ),
+        ), $this->getTrace()));
+    }
+
+    private function parseControllerDefinition(callable $controller): ?array
+    {
+        if (is_string($controller) && false !== strpos($controller, '::')) {
+            $controller = explode('::', $controller);
+        }
+
+        if (is_array($controller)) {
+            try {
+                $r = new \ReflectionMethod($controller[0], $controller[1]);
+
+                return array(
+                    'file' => $r->getFileName(),
+                    'line' => $r->getEndLine(),
+                );
+            } catch (\ReflectionException $e) {
+                return null;
+            }
+        }
+
+        if ($controller instanceof \Closure) {
+            $r = new \ReflectionFunction($controller);
+
+            return array(
+                'file' => $r->getFileName(),
+                'line' => $r->getEndLine(),
+            );
+        }
+
+        if (is_object($controller)) {
+            $r = new \ReflectionClass($controller);
+
+            return array(
+                'file' => $r->getFileName(),
+                'line' => $r->getEndLine(),
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ControllerDoesNotReturnResponseException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -162,7 +163,8 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
                 if (null === $response) {
                     $msg .= ' Did you forget to add a return statement somewhere in your controller?';
                 }
-                throw new \LogicException($msg);
+
+                throw new ControllerDoesNotReturnResponseException($msg, $controller, __FILE__, __LINE__ - 17);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27137
| License       | MIT
| Doc PR        |

---

Before:

![before](https://user-images.githubusercontent.com/408368/39580501-9c8d5e0a-4ee9-11e8-84a9-aad8566da4b6.png)

after:

![after](https://user-images.githubusercontent.com/408368/39580504-a23e3b76-4ee9-11e8-9a89-01e519b94a20.png)
