### PR TITLE
[DI] Select specific key from an array resolved env var

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -38,6 +38,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'float' => array('float'),
             'int' => array('int'),
             'json' => array('array'),
+            'key' => array('bool', 'int', 'float', 'string', 'array'),
             'resolve' => array('string'),
             'string' => array('string'),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Discussed in #25643    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#9734 <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

As discussed in #25643, it would be convenient to have an key processor for environment variables which have been read from for example a JSON file. 

The main advantage of this feature lies in specifying a single file for your secrets, that can be directly used in your configuration, without leaking them into your env.

## Example
**.secrets.json**
```json
{
  "database_password": "xxx"
}
```
**.env**
```env
APP_SECRETS=/opt/application/.secrets.json
DATABASE_URL=mysql://myuser:%database_password%@localhost:3306/mydb
```
**services.yaml**
```yaml
parameters:
  database_password: '%env(key:database_password:json:file:APP_SECRETS)%'
```

This example configuration will result in a `database_password` parameter being filled with `xxx`, and due to Doctrine defaults, the database url will be resolved with the correct password.