### PR TITLE
[Cache] fix logic for fetching tag versions on TagAwareAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -345,6 +345,7 @@ class TagAwareAdapter implements TagAwareAdapterInterface, PruneableInterface, R
         foreach ($tagVersions as $tag => $version) {
             $tags[$tag.static::TAGS_PREFIX] = $tag;
             if ($fetchTagVersions || !isset($this->knownTagVersions[$tag])) {
+                $fetchTagVersions = true;
                 continue;
             }
             $version -= $this->knownTagVersions[$tag][1];

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -69,6 +69,12 @@ class TagAwareAdapterTest extends AdapterTestCase
         $this->assertFalse($pool->getItem('i1')->isHit());
         $this->assertFalse($pool->getItem('i3')->isHit());
         $this->assertTrue($pool->getItem('foo')->isHit());
+
+        $anotherPoolInstance = $this->createCachePool();
+
+        $this->assertFalse($anotherPoolInstance->getItem('i1')->isHit());
+        $this->assertFalse($anotherPoolInstance->getItem('i3')->isHit());
+        $this->assertTrue($anotherPoolInstance->getItem('foo')->isHit());
     }
 
     public function testInvalidateCommits()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #27147
| License       | MIT
| Doc PR        | -

There was a problem introduced in https://github.com/symfony/symfony/pull/27007 which breaks tag invalidation. 

From what I can see there were some cases when the actual tag versions were never fetched from the tags pool and version=0 was used.

@nicolas-grekas this is my attempt of understanding the logic within `TagAwareAdapter`. Please have a look if this makes sense to you :wink: 
