### PR TITLE
Remove "Tests pass" row from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,6 @@
 | New feature?  | yes/no <!-- don't forget to update src/**/CHANGELOG.md files -->
 | BC breaks?    | no     <!-- see https://symfony.com/bc -->
 | Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
-| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
 | Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
 | License       | MIT
 | Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
@@ -17,4 +16,5 @@ Additionally:
  - Bug fixes must be submitted against the lowest branch where they apply
    (lowest branches are regularly merged to upper ones so they get the fixes too).
  - Features and deprecations must be submitted against the master branch.
+ - Please add some tests. It'll usually be required by reviewers -->
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,8 @@
 | License       | MIT
 | Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
 
+- [x] _Tests were added or updated when relevant and CI checks are green_
+
 <!--
 Write a short README entry for your feature/bugfix here (replace this comment block.)
 This will help people understand your PR and can be used as a start of the Doc PR.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

- [x] _Tests were added or updated when relevant and CI checks are green_

Just wondering if this row is actually useful in some way?

I assume it's to aknowledge contributors they should write some tests when relevant and the CI must be green, but that just echoes CI checks at the bottom of the PR and green ticks/red crosses next to commits / PR list.

When creating a PR, tests can also pass locally and be red on the CI. Nevertheless, the contributor would already have answered "yes".

Hence I don't really see any value to it. I'd suggest to simply add a note about adding tests and perhaps a checklist entry (checked by default, see above) the contributor can uncheck to indicate there is still some work to do.