### PR TITLE
[POC] add deprecation warning to remove/replace them later

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -27,7 +27,7 @@ abstract class AbstractDoctrineExtension extends Extension
     /**
      * Used inside metadata driver method to simplify aggregation of data.
      */
-    protected $aliasMap = [];
+    protected $aliasMap = array();
     /**
      * Used inside metadata driver method to simplify aggregation of data.
      */
@@ -140,7 +140,7 @@ abstract class AbstractDoctrineExtension extends Extension
      */
     protected function getMappingDriverBundleConfigDefaults(array $bundleConfig, \ReflectionClass $bundle, ContainerBuilder $container)
     {
-        $bundleDir = dirname($bundle->getFileName());
+        $bundleDir = \dirname($bundle->getFileName());
 
         if (!$bundleConfig['type']) {
             $bundleConfig['type'] = $this->detectMetadataDriver($bundleDir, $container);

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -412,8 +412,7 @@ abstract class AbstractDoctrineExtension extends Extension
             case 'zenddata':
                 if ($container->hasParameter($this->getObjectManagerElementName(sprintf('cache.%s.class', $cacheDriver['type'])))) {
                     @trigger_error(
-                        'Usage of class parameter for '.$cacheDriver['type'].' class is deprecated since version 4.2 and
-                            ill be removed in 5.0. Use configuration values instead.'
+                        'Usage of class parameter for '.$cacheDriver['type'].' class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.'
                     );
                 }
                 $cacheDef = new Definition('%' . $this->getObjectManagerElementName(sprintf('cache.%s.class', $cacheDriver['type'])) . '%');

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -350,12 +350,14 @@ abstract class AbstractDoctrineExtension extends Extension
             case 'memcached':
                 if ($container->hasParameter($this->getObjectManagerElementName('cache.memcached.class'))) {
                     @trigger_error(
-                        'Usage of class parameter for memcache class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.'
+                        'Usage of class parameter for memcache class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.',
+                        E_USER_DEPRECATED
                     );
                 }
                 if ($container->hasParameter($this->getObjectManagerElementName('cache.memcached_instance.class'))) {
                     @trigger_error(
-                        'Usage of class parameter for memcached_instance class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.'
+                        'Usage of class parameter for memcached_instance class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.',
+                        E_USER_DEPRECATED
                     );
                 }
                 $memcachedClass = !empty($cacheDriver['class']) ? $cacheDriver['class'] : '%' . $this->getObjectManagerElementName('cache.memcached.class') . '%';
@@ -378,13 +380,15 @@ abstract class AbstractDoctrineExtension extends Extension
             case 'redis':
                 if ($container->hasParameter($this->getObjectManagerElementName('cache.redis.class'))) {
                     @trigger_error(
-                        'Usage of class parameter for redis class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.'
+                        'Usage of class parameter for redis class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.',
+                        E_USER_DEPRECATED
                     );
                 }
 
                 if ($container->hasParameter($this->getObjectManagerElementName('cache.redis_instance.class'))) {
                     @trigger_error(
-                        'Usage of class parameter for redis_instance class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.'
+                        'Usage of class parameter for redis_instance class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.',
+                        E_USER_DEPRECATED
                     );
                 }
                 $redisClass = !empty($cacheDriver['class']) ? $cacheDriver['class'] : '%' . $this->getObjectManagerElementName('cache.redis.class') . '%';

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -27,8 +27,7 @@ abstract class AbstractDoctrineExtension extends Extension
     /**
      * Used inside metadata driver method to simplify aggregation of data.
      */
-    protected $aliasMap = array();
-
+    protected $aliasMap = [];
     /**
      * Used inside metadata driver method to simplify aggregation of data.
      */
@@ -141,7 +140,7 @@ abstract class AbstractDoctrineExtension extends Extension
      */
     protected function getMappingDriverBundleConfigDefaults(array $bundleConfig, \ReflectionClass $bundle, ContainerBuilder $container)
     {
-        $bundleDir = \dirname($bundle->getFileName());
+        $bundleDir = dirname($bundle->getFileName());
 
         if (!$bundleConfig['type']) {
             $bundleConfig['type'] = $this->detectMetadataDriver($bundleDir, $container);
@@ -178,8 +177,8 @@ abstract class AbstractDoctrineExtension extends Extension
     protected function registerMappingDrivers($objectManager, ContainerBuilder $container)
     {
         // configure metadata driver for each bundle based on the type of mapping files found
-        if ($container->hasDefinition($this->getObjectManagerElementName($objectManager['name'].'_metadata_driver'))) {
-            $chainDriverDef = $container->getDefinition($this->getObjectManagerElementName($objectManager['name'].'_metadata_driver'));
+        if ($container->hasDefinition($this->getObjectManagerElementName($objectManager['name'] . '_metadata_driver'))) {
+            $chainDriverDef = $container->getDefinition($this->getObjectManagerElementName($objectManager['name'] . '_metadata_driver'));
         } else {
             if ($container->hasParameter($this->getObjectManagerElementName('metadata.driver_chain.class'))) {
                 $chainDriverDefinitionClass = '%' . $this->getObjectManagerElementName('metadata.driver_chain.class%');

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -412,7 +412,8 @@ abstract class AbstractDoctrineExtension extends Extension
             case 'zenddata':
                 if ($container->hasParameter($this->getObjectManagerElementName(sprintf('cache.%s.class', $cacheDriver['type'])))) {
                     @trigger_error(
-                        'Usage of class parameter for '.$cacheDriver['type'].' class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.'
+                        'Usage of class parameter for '.$cacheDriver['type'].' class is deprecated since version 4.2 and will be removed in 5.0. Use configuration values instead.',
+                        E_USER_DEPRECATED
                     );
                 }
                 $cacheDef = new Definition('%' . $this->getObjectManagerElementName(sprintf('cache.%s.class', $cacheDriver['type'])) . '%');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for bug fixes
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes - "Tabität"
| Fixed tickets | #24835 
| License       | MIT

This will be my first proposal: I try to evaluate where to use the class parameters from. At the we have to deprecate from next version on and release 5.0 to really remove the usage. The given proposal means either use a get merhod or pass it through object manager config. 