### PR TITLE
[FrameworkBundle][Messenger] Remove convention-based service id generation for buses

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1468,13 +1468,11 @@ class FrameworkExtension extends Extension
                 throw new LogicException(sprintf('You need to define a default bus with the "default_bus" configuration. Possible values: %s', implode(', ', array_keys($config['buses']))));
             }
 
-            $config['default_bus'] = array_keys($config['buses'])[0];
+            $config['default_bus'] = key($config['buses']);
         }
 
         $defaultMiddlewares = array('before' => array('logging'), 'after' => array('route_messages', 'call_message_handler'));
-        foreach ($config['buses'] as $name => $bus) {
-            $busId = 'messenger.bus.'.$name;
-
+        foreach ($config['buses'] as $busId => $bus) {
             $middlewares = $bus['default_middlewares'] ? array_merge($defaultMiddlewares['before'], $bus['middlewares'], $defaultMiddlewares['after']) : $bus['middlewares'];
 
             if (!$validationConfig['enabled'] && \in_array('messenger.middleware.validation', $middlewares, true)) {
@@ -1482,9 +1480,9 @@ class FrameworkExtension extends Extension
             }
 
             $container->setParameter($busId.'.middlewares', $middlewares);
-            $container->setDefinition($busId, (new Definition(MessageBus::class, array(array())))->addTag('messenger.bus', array('name' => $name)));
+            $container->setDefinition($busId, (new Definition(MessageBus::class, array(array())))->addTag('messenger.bus'));
 
-            if ($name === $config['default_bus']) {
+            if ($busId === $config['default_bus']) {
                 $container->setAlias('message_bus', $busId);
                 $container->setAlias(MessageBusInterface::class, $busId);
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
@@ -2,15 +2,15 @@
 
 $container->loadFromExtension('framework', array(
     'messenger' => array(
-        'default_bus' => 'commands',
+        'default_bus' => 'messenger.bus.commands',
         'buses' => array(
-            'commands' => null,
-            'events' => array(
+            'messenger.bus.commands' => null,
+            'messenger.bus.events' => array(
                 'middlewares' => array(
                     'tolerate_no_handler',
                 ),
             ),
-            'queries' => array(
+            'messenger.bus.queries' => array(
                 'default_middlewares' => false,
                 'middlewares' => array(
                     'route_messages',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
@@ -6,12 +6,12 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
-        <framework:messenger default-bus="commands">
-            <framework:bus name="commands" />
-            <framework:bus name="events">
+        <framework:messenger default-bus="messenger.bus.commands">
+            <framework:bus name="messenger.bus.commands" />
+            <framework:bus name="messenger.bus.events">
                 <framework:middleware>tolerate_no_handler</framework:middleware>
             </framework:bus>
-            <framework:bus name="queries" default-middlewares="false">
+            <framework:bus name="messenger.bus.queries" default-middlewares="false">
                 <framework:middleware>route_messages</framework:middleware>
                 <framework:middleware>tolerate_no_handler</framework:middleware>
                 <framework:middleware>call_message_handler</framework:middleware>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
@@ -1,12 +1,12 @@
 framework:
     messenger:
-        default_bus: commands
+        default_bus: messenger.bus.commands
         buses:
-            commands: ~
-            events:
+            messenger.bus.commands: ~
+            messenger.bus.events:
                 middlewares:
                     - "tolerate_no_handler"
-            queries:
+            messenger.bus.queries:
                 default_middlewares: false
                 middlewares:
                     - "route_messages"

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -197,7 +197,7 @@ class MessengerPass implements CompilerPassInterface
             (new Definition(TraceableMessageBus::class, array(new Reference($tracedBusId.'.inner'))))->setDecoratedService($busId)
         );
 
-        $container->getDefinition('messenger.data_collector')->addMethodCall('registerBus', array($tag['name'] ?? $busId, new Reference($tracedBusId)));
+        $container->getDefinition('messenger.data_collector')->addMethodCall('registerBus', array($busId, new Reference($tracedBusId)));
     }
 
     private function registerBusMiddlewares(ContainerBuilder $container, string $busId, array $middlewares)

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -247,23 +247,20 @@ class MessengerPassTest extends TestCase
 
         $container = $this->getContainerBuilder();
         $container->register('messenger.data_collector', $dataCollector);
-        $container->register($fooBusId = 'messenger.bus.foo', MessageBusInterface::class)->addTag('messenger.bus', array('name' => 'foo'));
-        $container->register($barBusId = 'messenger.bus.bar', MessageBusInterface::class)->addTag('messenger.bus');
+        $container->register($fooBusId = 'messenger.bus.foo', MessageBusInterface::class)->addTag('messenger.bus');
         $container->setParameter('kernel.debug', true);
 
         (new MessengerPass())->process($container);
 
         $this->assertTrue($container->hasDefinition($debuggedFooBusId = 'debug.traced.'.$fooBusId));
         $this->assertSame(array($fooBusId, null, 0), $container->getDefinition($debuggedFooBusId)->getDecoratedService());
-        $this->assertTrue($container->hasDefinition($debuggedBarBusId = 'debug.traced.'.$barBusId));
-        $this->assertSame(array($barBusId, null, 0), $container->getDefinition($debuggedBarBusId)->getDecoratedService());
-        $this->assertEquals(array(array('registerBus', array('foo', new Reference($debuggedFooBusId))), array('registerBus', array('messenger.bus.bar', new Reference($debuggedBarBusId)))), $container->getDefinition('messenger.data_collector')->getMethodCalls());
+        $this->assertEquals(array(array('registerBus', array($fooBusId, new Reference($debuggedFooBusId)))), $container->getDefinition('messenger.data_collector')->getMethodCalls());
     }
 
     public function testRegistersMiddlewaresFromServices()
     {
         $container = $this->getContainerBuilder();
-        $container->register($fooBusId = 'messenger.bus.foo', MessageBusInterface::class)->setArgument(0, array())->addTag('messenger.bus', array('name' => 'foo'));
+        $container->register($fooBusId = 'messenger.bus.foo', MessageBusInterface::class)->setArgument(0, array())->addTag('messenger.bus');
         $container->register('messenger.middleware.allow_no_handler', AllowNoHandlerMiddleware::class)->setAbstract(true);
         $container->register(UselessMiddleware::class, UselessMiddleware::class);
 
@@ -283,7 +280,7 @@ class MessengerPassTest extends TestCase
     public function testCannotRegistersAnUndefinedMiddleware()
     {
         $container = $this->getContainerBuilder();
-        $container->register($fooBusId = 'messenger.bus.foo', MessageBusInterface::class)->setArgument(0, array())->addTag('messenger.bus', array('name' => 'foo'));
+        $container->register($fooBusId = 'messenger.bus.foo', MessageBusInterface::class)->setArgument(0, array())->addTag('messenger.bus');
         $container->setParameter($middlewaresParameter = $fooBusId.'.middlewares', array('not_defined_middleware'));
 
         (new MessengerPass())->process($container);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes (DX)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Service ids for buses are user facing ids: ppl *will* have to deal with them when wiring their services.
Like for cache pools, we should ask ppl to declare them using full identifiers, instead of having a convention-based way to turn a name into and id (which is something nobody will be able to remember at some point.)