### PR TITLE
[Messenger] Rename TolerateNoHandler to AllowNoHandlerMiddleware

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/AllowNoHandlerMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/AllowNoHandlerMiddleware.php
@@ -16,14 +16,14 @@ use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-class TolerateNoHandler implements MiddlewareInterface
+class AllowNoHandlerMiddleware implements MiddlewareInterface
 {
     public function handle($message, callable $next)
     {
         try {
             return $next($message);
         } catch (NoHandlerForMessageException $e) {
-            // We tolerate not having a handler for this message.
+            // We allow not having a handler for this message.
         }
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Messenger\Handler\ChainHandler;
 use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Middleware\TolerateNoHandler;
+use Symfony\Component\Messenger\Middleware\AllowNoHandlerMiddleware;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
@@ -264,14 +264,14 @@ class MessengerPassTest extends TestCase
     {
         $container = $this->getContainerBuilder();
         $container->register($fooBusId = 'messenger.bus.foo', MessageBusInterface::class)->setArgument(0, array())->addTag('messenger.bus', array('name' => 'foo'));
-        $container->register('messenger.middleware.tolerate_no_handler', TolerateNoHandler::class)->setAbstract(true);
+        $container->register('messenger.middleware.allow_no_handler', AllowNoHandlerMiddleware::class)->setAbstract(true);
         $container->register(UselessMiddleware::class, UselessMiddleware::class);
 
-        $container->setParameter($middlewaresParameter = $fooBusId.'.middlewares', array(UselessMiddleware::class, 'tolerate_no_handler'));
+        $container->setParameter($middlewaresParameter = $fooBusId.'.middlewares', array(UselessMiddleware::class, 'allow_no_handler'));
 
         (new MessengerPass())->process($container);
 
-        $this->assertTrue($container->hasDefinition($childMiddlewareId = $fooBusId.'.middleware.tolerate_no_handler'));
+        $this->assertTrue($container->hasDefinition($childMiddlewareId = $fooBusId.'.middleware.allow_no_handler'));
         $this->assertEquals(array(new Reference(UselessMiddleware::class), new Reference($childMiddlewareId)), $container->getDefinition($fooBusId)->getArgument(0));
         $this->assertFalse($container->hasParameter($middlewaresParameter));
     }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/AllowNoHandlerMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/AllowNoHandlerMiddlewareTest.php
@@ -13,10 +13,10 @@ namespace Symfony\Component\Messenger\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
-use Symfony\Component\Messenger\Middleware\TolerateNoHandler;
+use Symfony\Component\Messenger\Middleware\AllowNoHandlerMiddleware;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
-class TolerateNoHandlerTest extends TestCase
+class AllowNoHandlerMiddlewareTest extends TestCase
 {
     public function testItCallsNextMiddlewareAndReturnsItsResult()
     {
@@ -25,7 +25,7 @@ class TolerateNoHandlerTest extends TestCase
         $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
         $next->expects($this->once())->method('__invoke')->with($message)->willReturn('Foo');
 
-        $middleware = new TolerateNoHandler();
+        $middleware = new AllowNoHandlerMiddleware();
         $this->assertSame('Foo', $middleware->handle($message, $next));
     }
 
@@ -34,7 +34,7 @@ class TolerateNoHandlerTest extends TestCase
         $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
         $next->expects($this->once())->method('__invoke')->will($this->throwException(new NoHandlerForMessageException()));
 
-        $middleware = new TolerateNoHandler();
+        $middleware = new AllowNoHandlerMiddleware();
 
         $this->assertNull($middleware->handle(new DummyMessage('Hey'), $next));
     }
@@ -48,7 +48,7 @@ class TolerateNoHandlerTest extends TestCase
         $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
         $next->expects($this->once())->method('__invoke')->will($this->throwException(new \RuntimeException('Something went wrong.')));
 
-        $middleware = new TolerateNoHandler();
+        $middleware = new AllowNoHandlerMiddleware();
         $middleware->handle(new DummyMessage('Hey'), $next);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I was surprised by the word "tolerate", and by the missing "middleware" suffix.
This way would be less surprizing I believe.
