### PR TITLE
[DI] Allow binding by type+name

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -208,7 +208,7 @@ class AutowirePass extends AbstractRecursivePass
                         continue;
                     }
                     $type = ProxyHelper::getTypeHint($reflectionMethod, $parameter, false);
-                    $type = $type ? sprintf('is type-hinted "%s"', $type) : 'has no type-hint';
+                    $type = $type ? sprintf('is type-hinted "%s"', ltrim($type, '\\')) : 'has no type-hint';
 
                     throw new AutowiringFailedException($this->currentId, sprintf('Cannot autowire service "%s": argument "$%s" of method "%s()" %s, you should configure its value explicitly.', $this->currentId, $parameter->name, $class !== $this->currentId ? $class.'::'.$method : $method, $type));
                 }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -859,6 +859,10 @@ class Definition
     public function setBindings(array $bindings)
     {
         foreach ($bindings as $key => $binding) {
+            if (0 < strpos($key, '$') && $key !== $k = preg_replace('/[ \t]*\$/', ' $', $key)) {
+                unset($bindings[$key]);
+                $bindings[$key = $k] = $binding;
+            }
             if (!$binding instanceof BoundArgument) {
                 $bindings[$key] = new BoundArgument($binding);
             }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
@@ -31,7 +31,7 @@ trait BindTrait
     final public function bind($nameOrFqcn, $valueOrRef)
     {
         $valueOrRef = static::processValue($valueOrRef, true);
-        if (isset($nameOrFqcn[0]) && '$' !== $nameOrFqcn[0] && !$valueOrRef instanceof Reference) {
+        if (!preg_match('/^(?:(?:array|bool|float|int|string)[ \t]*+)?\$/', $nameOrFqcn) && !$valueOrRef instanceof Reference) {
             throw new InvalidArgumentException(sprintf('Invalid binding for service "%s": named arguments must start with a "$", and FQCN must map to references. Neither applies to binding "%s".', $this->id, $nameOrFqcn));
         }
         $bindings = $this->definition->getBindings();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -95,4 +95,28 @@ class ResolveBindingsPassTest extends TestCase
 
         $this->assertEquals(array(array('setDefaultLocale', array('fr'))), $definition->getMethodCalls());
     }
+
+    public function testTupleBinding()
+    {
+        $container = new ContainerBuilder();
+
+        $bindings = array(
+            '$c' => new BoundArgument(new Reference('bar')),
+            CaseSensitiveClass::class.'$c' => new BoundArgument(new Reference('foo')),
+        );
+
+        $definition = $container->register(NamedArgumentsDummy::class, NamedArgumentsDummy::class);
+        $definition->addMethodCall('setSensitiveClass');
+        $definition->addMethodCall('setAnotherC');
+        $definition->setBindings($bindings);
+
+        $pass = new ResolveBindingsPass();
+        $pass->process($container);
+
+        $expected = array(
+            array('setSensitiveClass', array(new Reference('foo'))),
+            array('setAnotherC', array(new Reference('bar'))),
+        );
+        $this->assertEquals($expected, $definition->getMethodCalls());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedArgumentsDummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NamedArgumentsDummy.php
@@ -18,4 +18,8 @@ class NamedArgumentsDummy
     public function setSensitiveClass(CaseSensitiveClass $c)
     {
     }
+
+    public function setAnotherC($c)
+    {
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -308,16 +308,23 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
     public function provideBindings()
     {
-        return array(array(ControllerDummy::class), array('$bar'));
+        return array(
+            array(ControllerDummy::class.'$bar'),
+            array(ControllerDummy::class),
+            array('$bar'),
+        );
     }
 
-    public function testBindScalarValueToControllerArgument()
+    /**
+     * @dataProvider provideBindScalarValueToControllerArgument
+     */
+    public function testBindScalarValueToControllerArgument($bindingKey)
     {
         $container = new ContainerBuilder();
         $resolver = $container->register('argument_resolver.service')->addArgument(array());
 
         $container->register('foo', ArgumentWithoutTypeController::class)
-            ->setBindings(array('$someArg' => '%foo%'))
+            ->setBindings(array($bindingKey => '%foo%'))
             ->addTag('controller.service_arguments');
 
         $container->setParameter('foo', 'foo_val');
@@ -338,6 +345,12 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
         // make sure this service *does* exist and returns the correct value
         $this->assertTrue($container->has((string) $reference));
         $this->assertSame('foo_val', $container->get((string) $reference));
+    }
+
+    public function provideBindScalarValueToControllerArgument()
+    {
+        yield array('$someArg');
+        yield array('string $someArg');
     }
 }
 
@@ -396,7 +409,7 @@ class NonExistentClassOptionalController
 
 class ArgumentWithoutTypeController
 {
-    public function fooAction($someArg)
+    public function fooAction(string $someArg)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This would allow to bind by type + argument name, e.g.:
```yaml
bind:
  Psr\Log\LoggerInterface $logger: @logger
```

Allows more precise targets for bindings as it will match only if both the type and the name match.
Works with scalar/array types also for consistency.