### PR TITLE
[HttpKernel] Add Kernel::getAnnotatedClassesToCompile()

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/AddAnnotatedClassesToCachePass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/AddAnnotatedClassesToCachePass.php
@@ -36,7 +36,7 @@ class AddAnnotatedClassesToCachePass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $annotatedClasses = array();
+        $annotatedClasses = $this->kernel->getAnnotatedClassesToCompile();
         foreach ($container->getExtensions() as $extension) {
             if ($extension instanceof Extension) {
                 $annotatedClasses = array_merge($annotatedClasses, $extension->getAnnotatedClassesToCompile());

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -392,6 +392,14 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     }
 
     /**
+     * Gets the patterns defining the classes to parse and cache for annotations.
+     */
+    public function getAnnotatedClassesToCompile(): array
+    {
+        return array();
+    }
+
+    /**
      * Initializes bundles.
      *
      * @throws \LogicException if two bundles share a common name


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Now that apps are usually bundle-less, we're missing a way to defined the classes to parse annotations for. Here is a PR fixing this by allowing ppl to define a new `getAnnotatedClassesToCompile()` on their kernel when needed.