### PR TITLE
[DI] Extend semantic of `@param` to describe intent and use it when autowiring services and parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.2.0
+-----
+
+ * extended `@param` semantic to hint autowiring of services and parameters
+
 4.1.0
 -----
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireAnnotatedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireAnnotatedArgumentsPass.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\AutowiringFailedException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Looks for definitions with autowiring enabled and parses their "@param" annotations for service ids and parameters.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class AutowireAnnotatedArgumentsPass extends AbstractRecursivePass
+{
+    private const PARAM_REGEX = '{
+        (?:^/\*\*|\n\s*+\*)\s*+
+        @param
+        \s[^\$\*]*+
+        \$([^\s\*]++)     # argument name
+        \s++(
+             @[^\s\*]++   # service id
+            |%[^%\s\*]++% # parameter name
+        )(?=[\s\*])
+        }six';
+    private const INHERITDOC_REGEX = '#(?:^/\*\*|\n\s*+\*)\s*+(?:\{@inheritdoc\}|@inheritdoc)(?:\s|\*/$)#i';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function processValue($value, $isRoot = false)
+    {
+        $value = parent::processValue($value, $isRoot);
+
+        if (!$value instanceof Definition || !$value->isAutowired() || $value->isAbstract() || !$value->getClass()) {
+            return $value;
+        }
+        if (!$classReflector = $this->container->getReflectionClass($value->getClass(), false)) {
+            return $value;
+        }
+
+        try {
+            if ($constructor = $this->getConstructor($value, false)) {
+                $constructor = strtolower($constructor->name);
+            }
+        } catch (RuntimeException $e) {
+            return $value;
+        }
+        if (!$annotatedParams = $this->getAnnotatedParams($classReflector, $constructor, $value)) {
+            return $value;
+        }
+        $methodCalls = $value->getMethodCalls();
+
+        if ($constructor) {
+            array_unshift($methodCalls, array($constructor, $value->getArguments()));
+        }
+
+        foreach ($methodCalls as $i => $call) {
+            list($method, $arguments) = $call;
+            if (!isset($annotatedParams[$m = strtolower($method)])) {
+                continue;
+            }
+
+            foreach ($annotatedParams[$m] as $j => $v) {
+                if (!array_key_exists($j, $arguments) || ('' === $arguments[$j] && $v instanceof Reference)) {
+                    $arguments[$j] = $v;
+                }
+            }
+            ksort($arguments);
+
+            if ($arguments !== $call[1]) {
+                $methodCalls[$i][1] = $arguments;
+            }
+        }
+
+        if ($constructor) {
+            list(, $arguments) = array_shift($methodCalls);
+
+            if ($arguments !== $value->getArguments()) {
+                $value->setArguments($arguments);
+            }
+        }
+
+        if ($methodCalls !== $value->getMethodCalls()) {
+            $value->setMethodCalls($methodCalls);
+        }
+
+        return $value;
+    }
+
+    private function getAnnotatedParams(\ReflectionClass $classReflector, ?string $constructor, Definition $definition): array
+    {
+        $annotatedParams = array();
+
+        if (null !== $constructor) {
+            $annotatedParams[$constructor] = array();
+        }
+        foreach ($definition->getMethodCalls() as list($method)) {
+            $annotatedParams[strtolower($method)] = array();
+        }
+
+        foreach ($classReflector->getMethods() as $methodReflector) {
+            $r = $methodReflector;
+            if (!isset($annotatedParams[$m = strtolower($r->name)])) {
+                continue;
+            }
+
+            while (true) {
+                if (false !== $doc = $r->getDocComment()) {
+                    if (false !== stripos($doc, '@param') && preg_match_all(self::PARAM_REGEX, $doc, $params, PREG_SET_ORDER)) {
+                        $paramIndexes = array();
+                        foreach ($r->getParameters() as $i => $paramReflector) {
+                            $paramIndexes[$paramReflector->name] = array($i, $paramReflector);
+                        }
+                        foreach ($params as list(, $k, $v)) {
+                            if (!isset($paramIndexes[$k])) {
+                                $this->container->log($this, sprintf('Skipping @param "$%s": no such argument on "%s::%s()".', $k, $r->class, $r->name));
+                                continue;
+                            }
+                            list($i, $paramReflector) = $paramIndexes[$k];
+                            if ('%' === $v[0] && $this->container->hasParameter($id = substr($v, 1, -1))) {
+                                $v = $this->container->getParameter($id);
+                            } elseif ('%' === $v[0]) {
+                                throw new AutowiringFailedException($this->currentId, sprintf('Cannot autowire service "%s": parameter "%s" not found for argument "$%s" of method "%s()", you should either configure the argument explicitly or set the missing parameter.', $this->currentId, $id, $k, $r->class !== $this->currentId ? $r->class.'::'.$r->name : $r->name));
+                            } elseif ($this->container->has($id = substr($v, 1))) {
+                                $v = new Reference($id);
+                            } elseif ($paramReflector->allowsNull() || $this->container->has(ProxyHelper::getTypeHint($classReflector, $paramReflector, true))) {
+                                $this->container->log($this, sprintf('Skipping @param "$%s" on "%s::%s(): service "%s" not found.', $k, $r->class, $r->name, $id));
+                                continue;
+                            } else {
+                                throw new AutowiringFailedException($this->currentId, sprintf('Cannot autowire service "%s": service "%s" not found for argument "$%s" of method "%s()", you should either configure the argument explicitly or define the missing service.', $this->currentId, $id, $k, $r->class !== $this->currentId ? $r->class.'::'.$r->name : $r->name));
+                            }
+                            $annotatedParams[$m] += array($i => $v);
+                        }
+                    }
+                    if (false === stripos($doc, '@inheritdoc') || !preg_match(self::INHERITDOC_REGEX, $doc)) {
+                        break;
+                    }
+                }
+                try {
+                    $r = $r->getPrototype();
+                } catch (\ReflectionException $e) {
+                    break; // method has no prototype
+                }
+            }
+        }
+
+        return array_filter($annotatedParams);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -60,6 +60,7 @@ class PassConfig
             new ResolveNamedArgumentsPass(),
             new AutowireRequiredMethodsPass(),
             new ResolveBindingsPass(),
+            new AutowireAnnotatedArgumentsPass(),
             new AutowirePass(false),
             new ResolveTaggedIteratorArgumentPass(),
             new ResolveServiceSubscribersPass(),

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireAnnotatedArgumentsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireAnnotatedArgumentsPassTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
+use Symfony\Component\DependencyInjection\Compiler\AutowireAnnotatedArgumentsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+require_once __DIR__.'/../Fixtures/includes/autowiring_classes.php';
+
+class AutowireAnnotatedArgumentsPassTest extends TestCase
+{
+    public function testSetterInjection()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('a', 'a');
+        $container->setParameter('b', 'b');
+        $container->register('c');
+        $container->register('d');
+        $foo = $container->register(AnnotatedParamsFoo::class)
+            ->setArguments(array(0 => 'A', 2 => new Reference('C')))
+            ->setAutowired(true)
+        ;
+
+        (new ResolveClassPass())->process($container);
+        (new AutowireAnnotatedArgumentsPass())->process($container);
+
+        $expected = array(
+            'A',
+            'b',
+            new Reference('C'),
+            new Reference('d'),
+        );
+        $this->assertEquals($expected, $foo->getArguments());
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes.php
@@ -379,3 +379,16 @@ class NonAutowirableDecorator implements DecoratorInterface
     {
     }
 }
+
+class AnnotatedParamsFoo
+{
+    /**
+     * @param $a %a%
+     * @param $b %b%
+     * @param $c @c
+     * @param $d @d
+     */
+    public function __construct($a, $b, $c, $d)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR may come as a surprise to many. Please take time to read and understand the present description before engaging in the discussion. It's been written on the way to/back from Grand Canyon. What an inspiration :)

![image](https://user-images.githubusercontent.com/243674/39680908-c028ea0a-515a-11e8-8f17-3b8e48411314.png)

As we're gaining experience with autowiring, we know that it works well when one single service implements some interface. But it's also pretty common for several interfaces to have many different services implementing them. Comes to my mind:
- `CacheItemPoolInterface`, for different cache pools,
- `BusInterface`, for different messenger buses,
- `FilesystemInterface` from Flysystem, for different storages,
- `ContainerInterface`, for local registries of dedicated services,
- *etc.*

In similar situations, users are required to do configuration. The best solution we currently have for doing so is by [using bindings](https://github.com/symfony/symfony/pull/27054#issuecomment-386581349). While there is nothing wrong with doing configuration, I've met several ppl that trick autowiring in order to workaround doing configuration. We almost merged [a PR](https://github.com/symfony/symfony/pull/27054) doing so. The trick is clever, but it's a dead end, as it puts one's code [out of SOLID](https://github.com/symfony/symfony/pull/27054#issuecomment-386495178) principle.

IMHO, it is our responsibilty to provide a solution that encourages ppl to stay on the safe side of maintainability.

It turns out the core issue is that by type-hinting e.g. `BusInterface` somewhere, we still don't give enough hint to autowiring to allow it to select which service should be passed. The issue can be fixed at the semantic level by hinting we're seeking for a **command** bus.

This PR proposes to add this hint using a service identifier in an extended `@param` annotation.
This provides several benefits:
- by extending `@param`, we preserve compat with current docblock parsers
- we also leverage the capacity to target a specific argument, which is a requirement here
- we leverage IDEs that typically generate `@param` annotations for you already

About using service identifiers: I used to consider them as pure ref-targets with no inherent semantic; i.e. random strings to target objects in the container. That's what they are for many ids. But I recently realized that service ids also convey a generic semantic that is broader than the container itself. A canonical example for this is the "logger" service. This id is more than a random string you can reference. It's also a promise you're asking for: getting an object that belongs to the "logger" domain. Seen this way, service ids can be considered as string conveying generic semantic, thus they can fit an annotation without leading to any sort of coupling (e.g. none to Symfony's DI).

Note that *defining* services using DI is *not* what this PR is about: autowired services already exist. They "just" need to be made to work. Autowiring's job is to fill the holes (the arguments) that are missing a value. #23758, #21103, #836 were all PRs that belong to this group and that we rightfully rejected IMHO.

There has been several tentative issues and PRs that share some bits with the approach presented here: #21376, #22467, #20738. The exact syntax used in this PR has even been proposed [in a comment](https://github.com/symfony/symfony/issues/22755#issuecomment-302664224) previously.

Using annotations has a desired property: locality. The class consuming a dependency is the right place to express the way the dep is going to be used ("as a command bus", "as a storage for user pictures", etc.)
The added semantic is useful to hint the reader doing manual configuration. And it is useful to hint the autoriwing logic when doing hybrid configuration. That's how this PR leverages it.

Here is an example:
```
/**
 * @param BusInterface $commandBus @bus.command A bus to dispatch commands.
 */
```
