### PR TITLE
[Security] Fix for "Call to a member function getBaseUrl() on null" when generating a logout URL and there is no current request

### DIFF
--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -111,6 +111,10 @@ class LogoutUrlGenerator
 
             $request = $this->requestStack->getCurrentRequest();
 
+            if (!$request) {
+                throw new \LogicException('Unable to generate the logout URL without a request.');
+            }
+
             $url = UrlGeneratorInterface::ABSOLUTE_URL === $referenceType ? $request->getUriForPath($logoutPath) : $request->getBaseUrl().$logoutPath;
 
             if (!empty($parameters)) {

--- a/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
@@ -112,4 +112,22 @@ class LogoutUrlGeneratorTest extends TestCase
 
         $this->generator->getLogoutPath();
     }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Unable to generate the logout URL without a request.
+     */
+    public function testWithoutCurrentRequest()
+    {
+        // build a requestStack without a current request
+        $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
+        $request = $this->getMockBuilder(Request::class)->getMock();
+        $requestStack->method('getCurrentRequest')->willReturn(null);
+
+        $generator = new LogoutUrlGenerator($requestStack, null, $this->tokenStorage);
+
+        $generator->registerListener('secured_area', '/logout', null, null);
+        $generator->setCurrentFirewall('secured_area');
+        $generator->getLogoutPath();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 (to be switched when merging)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27174 
| License       | MIT
| Doc PR        | n/a

Adds a check if the request exists.