### PR TITLE
[Messenger] Fix missing s/tolerate_no_handler/allow_no_handler/g

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -29,7 +29,7 @@
         </service>
 
         <!-- Middlewares -->
-        <service id="messenger.middleware.tolerate_no_handler" class="Symfony\Component\Messenger\Middleware\TolerateNoHandler" abstract="true" />
+        <service id="messenger.middleware.allow_no_handler" class="Symfony\Component\Messenger\Middleware\AllowNoHandlerMiddleware" abstract="true" />
         <service id="messenger.middleware.call_message_handler" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">
             <argument type="service" id="messenger.handler_resolver" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
@@ -7,14 +7,14 @@ $container->loadFromExtension('framework', array(
             'messenger.bus.commands' => null,
             'messenger.bus.events' => array(
                 'middlewares' => array(
-                    'tolerate_no_handler',
+                    'allow_no_handler',
                 ),
             ),
             'messenger.bus.queries' => array(
                 'default_middlewares' => false,
                 'middlewares' => array(
                     'route_messages',
-                    'tolerate_no_handler',
+                    'allow_no_handler',
                     'call_message_handler',
                 ),
             ),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
@@ -9,11 +9,11 @@
         <framework:messenger default-bus="messenger.bus.commands">
             <framework:bus name="messenger.bus.commands" />
             <framework:bus name="messenger.bus.events">
-                <framework:middleware>tolerate_no_handler</framework:middleware>
+                <framework:middleware>allow_no_handler</framework:middleware>
             </framework:bus>
             <framework:bus name="messenger.bus.queries" default-middlewares="false">
                 <framework:middleware>route_messages</framework:middleware>
-                <framework:middleware>tolerate_no_handler</framework:middleware>
+                <framework:middleware>allow_no_handler</framework:middleware>
                 <framework:middleware>call_message_handler</framework:middleware>
             </framework:bus>
         </framework:messenger>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
@@ -5,10 +5,10 @@ framework:
             messenger.bus.commands: ~
             messenger.bus.events:
                 middlewares:
-                    - "tolerate_no_handler"
+                    - "allow_no_handler"
             messenger.bus.queries:
                 default_middlewares: false
                 middlewares:
                     - "route_messages"
-                    - "tolerate_no_handler"
+                    - "allow_no_handler"
                     - "call_message_handler"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -614,10 +614,10 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals(array('logging', 'route_messages', 'call_message_handler'), $container->getParameter('messenger.bus.commands.middlewares'));
         $this->assertTrue($container->has('messenger.bus.events'));
         $this->assertSame(array(), $container->getDefinition('messenger.bus.events')->getArgument(0));
-        $this->assertEquals(array('logging', 'tolerate_no_handler', 'route_messages', 'call_message_handler'), $container->getParameter('messenger.bus.events.middlewares'));
+        $this->assertEquals(array('logging', 'allow_no_handler', 'route_messages', 'call_message_handler'), $container->getParameter('messenger.bus.events.middlewares'));
         $this->assertTrue($container->has('messenger.bus.queries'));
         $this->assertSame(array(), $container->getDefinition('messenger.bus.queries')->getArgument(0));
-        $this->assertEquals(array('route_messages', 'tolerate_no_handler', 'call_message_handler'), $container->getParameter('messenger.bus.queries.middlewares'));
+        $this->assertEquals(array('route_messages', 'allow_no_handler', 'call_message_handler'), $container->getParameter('messenger.bus.queries.middlewares'));
 
         $this->assertTrue($container->hasAlias('message_bus'));
         $this->assertSame('messenger.bus.commands', (string) $container->getAlias('message_bus'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Spotted while rebasing #27128: some places weren't updated. Most are in tests and not that much important but should be updated for consistency. But moreover, the `AllowNoHandlerMiddleware` wiring in DI was still referencing the old class name.