### PR TITLE
[Messenger] Add missing `@experimental` annotations

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/MessageHandlerInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/MessageHandlerInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Messenger\Handler;
  * Marker interface for message handlers.
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
+ *
+ * @experimental in 4.1
  */
 interface MessageHandlerInterface
 {

--- a/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Messenger\Handler;
  * Handlers can implement this interface to handle multiple messages.
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
+ *
+ * @experimental in 4.1
  */
 interface MessageSubscriberInterface extends MessageHandlerInterface
 {

--- a/src/Symfony/Component/Messenger/Transport/Factory/TransportFactoryInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Factory/TransportFactoryInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\Messenger\Transport\SenderInterface;
  * Creates a Messenger transport.
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
+ *
+ * @experimental in 4.1
  */
 interface TransportFactoryInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

So we have all the Messenger interfaces tagged with `@experimental`.
