### PR TITLE
[Messenger] Fix return senders based on the message parents/interfaces

### DIFF
--- a/src/Symfony/Component/Messenger/Asynchronous/Routing/SenderLocator.php
+++ b/src/Symfony/Component/Messenger/Asynchronous/Routing/SenderLocator.php
@@ -32,13 +32,29 @@ class SenderLocator implements SenderLocatorInterface
      */
     public function getSendersForMessage($message): array
     {
-        $senderIds = $this->messageToSenderIdsMapping[\get_class($message)] ?? $this->messageToSenderIdsMapping['*'] ?? array();
-
         $senders = array();
-        foreach ($senderIds as $senderId) {
+        foreach ($this->getSenderIds($message) as $senderId) {
             $senders[] = $this->senderServiceLocator->get($senderId);
         }
 
         return $senders;
+    }
+
+    private function getSenderIds($message): array
+    {
+        if (isset($this->messageToSenderIdsMapping[\get_class($message)])) {
+            return $this->messageToSenderIdsMapping[\get_class($message)];
+        }
+        if ($messageToSenderIdsMapping = array_intersect_key($this->messageToSenderIdsMapping, class_parents($message))) {
+            return current($messageToSenderIdsMapping);
+        }
+        if ($messageToSenderIdsMapping = array_intersect_key($this->messageToSenderIdsMapping, class_implements($message))) {
+            return current($messageToSenderIdsMapping);
+        }
+        if (isset($this->messageToSenderIdsMapping['*'])) {
+            return $this->messageToSenderIdsMapping['*'];
+        }
+
+        return array();
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessage.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessage.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\Messenger\Tests\Fixtures;
 
-class DummyMessage
+class DummyMessage implements DummyMessageInterface
 {
     private $message;
 

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterface.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+interface DummyMessageInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/blob/c3d4536203981d425adc47552c553a9633186a5e/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1494-L1499

According to the code a message interface is supported into routing configuration, but it doesn't work when `SendMessageMiddleware` gets the mapping senders for the current object message.

This PR tries to fix it.
