### PR TITLE
[RFC][Messenger] add MessageInstanceOf helper

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/MessageInstanceOf.php
+++ b/src/Symfony/Component/Messenger/Middleware/MessageInstanceOf.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class MessageInstanceOf implements \IteratorAggregate
+{
+    private $contract;
+
+    public function __construct(string $contract)
+    {
+        $this->contract = $contract;
+    }
+
+    public function getIterator()
+    {
+        if ((new \ReflectionClass($this->contract))->isInstantiable()) {
+            yield $this->contract;
+        }
+
+        foreach (\get_declared_classes() as $class) {
+            $refClass = new \ReflectionClass($class);
+
+            if ($refClass->isSubclassOf($this->contract) || ($refClass->isInterface() && $refClass->implementsInterface($this->contract))) {
+                yield $class;
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/MessageInstanceOfTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/MessageInstanceOfTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Middleware\MessageInstanceOf;
+
+final class MessageInstanceOfTest extends TestCase
+{
+    public function testClassesThatImplementTheInterfaceReturned()
+    {
+        $messageClasses = iterator_to_array(new MessageInstanceOf(DummyMessageInterface::class));
+        $expected = array(
+            DummyMessage1::class,
+            DummyMessage3::class,
+        );
+
+        $this->assertSame($expected, $messageClasses);
+    }
+
+    public function testClassesExtendingAbstractClassReturned()
+    {
+        $messageClasses = iterator_to_array(new MessageInstanceOf(AbstractDummyMessage::class));
+        $expected = array(
+            DummyMessage2::class,
+            DummyMessage3::class,
+        );
+
+        $this->assertSame($expected, $messageClasses);
+    }
+
+    public function testClassesExtendingInstantiableClassReturnedAndInstantiableClass()
+    {
+        $messageClasses = iterator_to_array(new MessageInstanceOf(DummyMessage4::class));
+        $expected = array(
+            DummyMessage4::class,
+            DummyMessage5::class,
+        );
+
+        $this->assertSame($expected, $messageClasses);
+    }
+}
+
+interface DummyMessageInterface
+{
+}
+
+abstract class AbstractDummyMessage
+{
+}
+
+class DummyMessage1 implements DummyMessageInterface
+{
+}
+
+class DummyMessage2 extends AbstractDummyMessage
+{
+}
+
+class DummyMessage3 extends AbstractDummyMessage implements DummyMessageInterface
+{
+}
+
+class DummyMessage4
+{
+}
+
+class DummyMessage5 extends DummyMessage4
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27076 
| License       | MIT
| Doc PR        | todo

This adds a helper class to easily let your message subscribers handle all messages that implement an interface or extend a class:

```php
class MyMessageSubscriber implements MessageSubscriberInterface
{
    public static function getHandledMessages(): iterable
    {
        return new MessageInstanceOf(SomeInterface::class);
    }
}
```

This depends on #27034 which allows `MessageSubscriberInterface::getHandledMessages()` to return `iterable`.