### PR TITLE
[Profiler] Fix dump makes toolbar disappear

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -418,12 +418,10 @@
                     '{{ path("_wdt", { "token": "xxxxxx" }) }}'.replace(/xxxxxx/, newToken),
                     function(xhr, el) {
 
-                        /* Evaluate embedded scripts inside the toolbar */
-                        var i, scripts = [].slice.call(el.querySelectorAll('script'));
-
-                        for (i = 0; i < scripts.length; ++i) {
-                            eval(scripts[i].firstChild.nodeValue);
-                        }
+                        /* Evaluate in global scope scripts embedded inside the toolbar */
+                        eval.call({}, ([].slice.call(el.querySelectorAll('script')).map(function (script) {
+                          return script.firstChild.nodeValue;
+                        }).join('\n')));
 
                         el.style.display = -1 !== xhr.responseText.indexOf('sf-toolbarreset') ? 'block' : 'none';
 
@@ -442,7 +440,7 @@
                         }
 
                         /* Handle toolbar-info position */
-                        var toolbarBlocks = [].slice.call(el.querySelectorAll('.sf-toolbar-block'));
+                        var i, toolbarBlocks = [].slice.call(el.querySelectorAll('.sf-toolbar-block'));
                         for (i = 0; i < toolbarBlocks.length; ++i) {
                             toolbarBlocks[i].onmouseover = function () {
                                 var toolbarInfo = this.querySelectorAll('.sf-toolbar-info')[0];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27180   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Don't know if there is a better solution than executing eval on the global scope.

For ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
> If you use the eval function indirectly, by invoking it via a reference other than eval, as of ECMAScript 5 it works in the global scope rather than the local scope. This means, for instance, that function declarations create global functions, and that the code being evaluated doesn't have access to local variables within the scope where it's being called.