### PR TITLE
[Messenger] Improved exception on invalid message type

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Messenger/Exception/InvalidArgumentException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Messenger/MessageBus.php
+++ b/src/Symfony/Component/Messenger/MessageBus.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger;
 
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 
 /**
@@ -39,6 +40,10 @@ class MessageBus implements MessageBusInterface
      */
     public function dispatch($message)
     {
+        if (!\is_object($message)) {
+            throw new InvalidArgumentException(sprintf('Invalid type for message argument. Expected object, but got "%s".', \gettype($message)));
+        }
+
         return \call_user_func($this->callableForNextMiddleware(0), $message);
     }
 

--- a/src/Symfony/Component/Messenger/Tests/MessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/MessageBusTest.php
@@ -26,6 +26,15 @@ class MessageBusTest extends TestCase
         $this->assertInstanceOf(MessageBusInterface::class, $bus);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Messenger\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid type for message argument. Expected object, but got "string".
+     */
+    public function testItDispatchInvalidMessageType()
+    {
+        (new MessageBus())->dispatch('wrong');
+    }
+
     public function testItCallsMiddlewareAndChainTheReturnValue()
     {
         $message = new DummyMessage('Hello');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

before:
![invalid_message_type_before](https://user-images.githubusercontent.com/2028198/39728992-91f592e6-5227-11e8-8a29-b13d1fed82f8.png)

after:
![invalid_message_type_after](https://user-images.githubusercontent.com/2028198/39728982-8ba5b790-5227-11e8-949d-64265b702fa7.png)

