### PR TITLE
[Messenger] Fix the transport factory after moving it

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -60,7 +60,7 @@
         </service>
 
         <!-- transports -->
-        <service id="messenger.transport_factory" class="Symfony\Component\Messenger\Transport\Factory\ChainTransportFactory">
+        <service id="messenger.transport_factory" class="Symfony\Component\Messenger\Transport\TransportFactory">
             <argument type="tagged" tag="messenger.transport_factory" />
         </service>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27164
| License       | MIT
| Doc PR        | ø

`ChainTransportFactory` was renamed but the `messenger.xml` wasn't changed.