### PR TITLE
[Messenger] Fix default bus name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1047,7 +1047,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('default_bus')->defaultValue(null)->end()
                         ->arrayNode('buses')
-                            ->defaultValue(array('default' => array('default_middleware' => true, 'middleware' => array())))
+                            ->defaultValue(array('messenger.bus.default' => array('default_middleware' => true, 'middleware' => array())))
                             ->useAttributeAsKey('name')
                             ->prototype('array')
                                 ->addDefaultsIfNotSet()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -263,7 +263,7 @@ class ConfigurationTest extends TestCase
                 'encoder' => 'messenger.transport.serializer',
                 'decoder' => 'messenger.transport.serializer',
                 'default_bus' => null,
-                'buses' => array('default' => array('default_middleware' => true, 'middleware' => array())),
+                'buses' => array('messenger.bus.default' => array('default_middleware' => true, 'middleware' => array())),
             ),
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | yesish
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27162   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

After #27162, the default bus name configured automatically should use a full service id too, otherwise we currently get a `default` service id, no namespace identifier, which is the default bus. 