### PR TITLE
[Messenger] Make sure Sender and Receiver locators have valid services

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -23,6 +23,8 @@ use Symfony\Component\Messenger\Handler\ChainHandler;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
 use Symfony\Component\Messenger\TraceableMessageBus;
+use Symfony\Component\Messenger\Transport\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\SenderInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
@@ -167,6 +169,11 @@ class MessengerPass implements CompilerPassInterface
         $taggedReceivers = $container->findTaggedServiceIds($this->receiverTag);
 
         foreach ($taggedReceivers as $id => $tags) {
+            $receiverClass = $container->findDefinition($id)->getClass();
+            if (!is_subclass_of($receiverClass, ReceiverInterface::class)) {
+                throw new RuntimeException(sprintf('Invalid receiver "%s": class "%s" must implement interface "%s".', $id, $receiverClass, ReceiverInterface::class));
+            }
+
             $receiverMapping[$id] = new Reference($id);
 
             foreach ($tags as $tag) {
@@ -187,6 +194,11 @@ class MessengerPass implements CompilerPassInterface
     {
         $senderLocatorMapping = array();
         foreach ($container->findTaggedServiceIds($this->senderTag) as $id => $tags) {
+            $senderClass = $container->findDefinition($id)->getClass();
+            if (!is_subclass_of($senderClass, SenderInterface::class)) {
+                throw new RuntimeException(sprintf('Invalid sender "%s": class "%s" must implement interface "%s".', $id, $senderClass, SenderInterface::class));
+            }
+
             $senderLocatorMapping[$id] = new Reference($id);
 
             foreach ($tags as $tag) {

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -174,6 +174,19 @@ class MessengerPassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage Invalid sender "app.messenger.sender": class "Symfony\Component\Messenger\Tests\DependencyInjection\InvalidSender" must implement interface "Symfony\Component\Messenger\Transport\SenderInterface".
+     */
+    public function testItDoesNotRegisterInvalidSender()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('app.messenger.sender', InvalidSender::class)
+            ->addTag('messenger.sender');
+
+        (new MessengerPass())->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      * @expectedExceptionMessage Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandler": message class "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessage" used as argument type in method "Symfony\Component\Messenger\Tests\DependencyInjection\UndefinedMessageHandler::__invoke()" does not exist.
      */
     public function testUndefinedMessageClassForHandler()
@@ -364,6 +377,14 @@ class DummyReceiver implements ReceiverInterface
     public function stop(): void
     {
     }
+}
+
+class InvalidReceiver
+{
+}
+
+class InvalidSender
+{
 }
 
 class UndefinedMessageHandler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This make sure that Sender and Receiver locators have valid services. Also adds minor improvements into consume command.
