### PR TITLE
[Messenger] Improve the profiler panel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -4,17 +4,33 @@
 
 {% block toolbar %}
     {% if collector.messages|length > 0 %}
+        {% set status_color = collector.exceptionsCount ? 'red' %}
         {% set icon %}
             {{ include('@WebProfiler/Icon/messenger.svg') }}
             <span class="sf-toolbar-value">{{ collector.messages|length }}</span>
         {% endset %}
 
-        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: 'messenger' }) }}
+        {% set text %}
+            {% for bus in collector.buses %}
+                {% set exceptionsCount = collector.exceptionsCount(bus) %}
+                <div class="sf-toolbar-info-piece">
+                    <b>{{ bus }}</b>
+                    <span
+                        title="{{ exceptionsCount }} message(s) with exceptions"
+                        class="sf-toolbar-status sf-toolbar-status-{{ exceptionsCount ? 'red' }}"
+                    >
+                        {{ collector.messages(bus)|length }}
+                    </span>
+                </div>
+            {% endfor %}
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: 'messenger', status: status_color }) }}
     {% endif %}
 {% endblock %}
 
 {% block menu %}
-<span class="label">
+<span class="label {{ collector.exceptionsCount ? 'label-status-error' }}">
     <span class="icon">{{ include('@WebProfiler/Icon/messenger.svg') }}</span>
     <strong>Messages</strong>
 
@@ -24,7 +40,28 @@
 </span>
 {% endblock %}
 
+{% block head %}
+    {{ parent() }}
+    <style>
+        .message-item thead th { position: relative; cursor: pointer; user-select: none; padding-right: 35px; }
+        .message-item tbody tr td:first-child { width: 115px; }
+
+        .message-item .label { float: right; padding: 1px 5px; opacity: .75; margin-left: 5px; }
+        .message-item .toggle-button { position: absolute; right: 6px; top: 6px; opacity: .5; pointer-events: none }
+        .message-item .icon svg { height: 24px; width: 24px; }
+
+        .message-item .sf-toggle-off .icon-close, .sf-toggle-on .icon-open { display: none; }
+        .message-item .sf-toggle-off .icon-open, .sf-toggle-on .icon-close { display: block; }
+
+        .message-bus .badge.status-some-errors { line-height: 16px; border-bottom: 2px solid #B0413E; }
+
+        .message-item .sf-toggle-content.sf-toggle-visible { display: table-row-group; }
+    </style>
+{% endblock %}
+
 {% block panel %}
+    {% import _self as helper %}
+
     <h2>Messages</h2>
 
     {% if collector.messages is empty %}
@@ -32,41 +69,99 @@
             <p>No messages have been collected.</p>
         </div>
     {% else %}
-        <table>
-            <thead>
-            <tr>
-                <th>Bus</th>
-                <th>Message</th>
-                <th>Result</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for message in collector.messages %}
-                <tr>
-                    <td>{{ message.bus }}</td>
-                    <td>
-                        {% if message.result.object is defined %}
-                            {{ profiler_dump(message.message.object, maxDepth=2) }}
-                        {% else %}
-                            {{ message.message.type }}
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if message.result.object is defined %}
-                            {{ profiler_dump(message.result.object, maxDepth=2) }}
-                        {% elseif message.result.type is defined %}
-                            {{ message.result.type }}
-                            {% if message.result.value is defined %}
-                                {{ message.result.value }}
-                            {% endif %}
-                        {% endif %}
-                        {% if message.exception.type is defined %}
-                            {{ message.exception.type }}
-                        {% endif %}
-                    </td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
+
+    <div class="sf-tabs message-bus">
+        <div class="tab">
+            {% set messages = collector.messages %}
+            {% set exceptionsCount = collector.exceptionsCount %}
+            <h3 class="tab-title">All<span class="badge {{ exceptionsCount ? exceptionsCount == messages|length ? 'status-error' : 'status-some-errors' }}">{{ messages|length }}</span></h3>
+
+            <div class="tab-content">
+                <p class="text-muted">Ordered list of dispatched messages across all your buses</p>
+                {{ helper.render_bus_messages(messages, true) }}
+            </div>
+        </div>
+
+        {% for bus in collector.buses %}
+        <div class="tab message-bus">
+            {% set messages = collector.messages(bus) %}
+            {% set exceptionsCount = collector.exceptionsCount(bus) %}
+            <h3 class="tab-title">{{ bus }}<span class="badge {{ exceptionsCount ? exceptionsCount == messages|length ? 'status-error' : 'status-some-errors' }}">{{ messages|length }}</span></h3>
+
+            <div class="tab-content">
+                <p class="text-muted">Ordered list of messages dispatched on the <code>{{ bus }}</code> bus</p>
+                {{ helper.render_bus_messages(messages) }}
+            </div>
+        </div>
+        {% endfor %}
     {% endif %}
+
 {% endblock %}
+
+{% macro render_bus_messages(messages, showBus = false) %}
+    {% set discr = random() %}
+    {% for i, dispatchCall in messages %}
+    <table class="message-item">
+        <thead>
+        <tr>
+            <th colspan="2" class="sf-toggle"
+                data-toggle-selector="#message-item-{{ discr }}-{{ i }}-details"
+                data-toggle-initial="{{ loop.first ? 'display' }}"
+            >
+                <span class="dump-inline">{{ profiler_dump(dispatchCall.message.type) }}</span>
+                {% if showBus %}
+                    <span class="label">{{ dispatchCall.bus }}</span>
+                {% endif %}
+                {% if dispatchCall.exception is defined %}
+                    <span class="label status-error">exception</span>
+                {% endif %}
+                <a class="toggle-button">
+                    <span class="icon icon-close">{{ include('@Twig/images/icon-minus-square.svg') }}</span>
+                    <span class="icon icon-open">{{ include('@Twig/images/icon-plus-square.svg') }}</span>
+                </a>
+            </th>
+        </tr>
+        </thead>
+        <tbody id="message-item-{{ discr }}-{{ i }}-details" class="sf-toggle-content">
+            {% if showBus %}
+            <tr>
+                <td class="text-bold">Bus</td>
+                <td>{{ dispatchCall.bus }}</td>
+            </tr>
+            {% endif %}
+            <tr>
+                <td class="text-bold">Message</td>
+                <td>{{ profiler_dump(dispatchCall.message.value, maxDepth=2) }}</td>
+            </tr>
+            <tr>
+                <td class="text-bold">Envelope items</td>
+                <td>
+                    {% for item in dispatchCall.envelopeItems %}
+                        {{ profiler_dump(item) }}
+                    {% else %}
+                        <span class="text-muted">No items</span>
+                    {% endfor %}
+                </td>
+            </tr>
+            <tr>
+                <td class="text-bold">Result</td>
+                <td>
+                    {% if dispatchCall.result is defined %}
+                        {{ profiler_dump(dispatchCall.result.seek('value'), maxDepth=2) }}
+                    {% elseif dispatchCall.exception is defined %}
+                        <span class="text-danger">No result as an exception occurred</span>
+                    {% endif %}
+                </td>
+            </tr>
+            {% if dispatchCall.exception is defined %}
+            <tr>
+                <td class="text-bold">Exception</td>
+                <td>
+                    {{ profiler_dump(dispatchCall.exception.value, maxDepth=1) }}
+                </td>
+            </tr>
+            {% endif %}
+        </tbody>
+    </table>
+    {% endfor %}
+{% endmacro %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -215,6 +215,9 @@ table tbody ul {
 .text-muted {
     color: #999;
 }
+.text-danger {
+    color: {{ colors.error|raw }};
+}
 .text-bold {
     font-weight: bold;
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/AnEnvelopeItem.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/AnEnvelopeItem.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\EnvelopeItemInterface;
+
+class AnEnvelopeItem implements EnvelopeItemInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        // noop
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/MessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/MessageBusTest.php
@@ -15,10 +15,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Asynchronous\Transport\ReceivedMessage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\EnvelopeAwareInterface;
-use Symfony\Component\Messenger\EnvelopeItemInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\AnEnvelopeItem;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
 class MessageBusTest extends TestCase
@@ -158,24 +158,5 @@ class MessageBusTest extends TestCase
         ));
 
         $bus->dispatch($envelope);
-    }
-}
-
-class AnEnvelopeItem implements EnvelopeItemInterface
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function serialize()
-    {
-        return '';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function unserialize($serialized)
-    {
-        return new self();
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\AnEnvelopeItem;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\TraceableMessageBus;
 
@@ -28,19 +29,29 @@ class TraceableMessageBusTest extends TestCase
 
         $traceableBus = new TraceableMessageBus($bus);
         $this->assertSame($result, $traceableBus->dispatch($message));
-        $this->assertSame(array(array('message' => $message, 'result' => $result)), $traceableBus->getDispatchedMessages());
+        $this->assertCount(1, $tracedMessages = $traceableBus->getDispatchedMessages());
+        $this->assertArraySubset(array(
+            'message' => $message,
+            'result' => $result,
+            'envelopeItems' => null,
+        ), $tracedMessages[0], true);
     }
 
     public function testItTracesResultWithEnvelope()
     {
-        $envelope = Envelope::wrap($message = new DummyMessage('Hello'));
+        $envelope = Envelope::wrap($message = new DummyMessage('Hello'))->with($envelopeItem = new AnEnvelopeItem());
 
         $bus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
         $bus->expects($this->once())->method('dispatch')->with($envelope)->willReturn($result = array('foo' => 'bar'));
 
         $traceableBus = new TraceableMessageBus($bus);
         $this->assertSame($result, $traceableBus->dispatch($envelope));
-        $this->assertSame(array(array('message' => $message, 'result' => $result)), $traceableBus->getDispatchedMessages());
+        $this->assertCount(1, $tracedMessages = $traceableBus->getDispatchedMessages());
+        $this->assertArraySubset(array(
+            'message' => $message,
+            'result' => $result,
+            'envelopeItems' => array($envelopeItem),
+        ), $tracedMessages[0], true);
     }
 
     public function testItTracesExceptions()
@@ -58,6 +69,11 @@ class TraceableMessageBusTest extends TestCase
             $this->assertSame($exception, $e);
         }
 
-        $this->assertSame(array(array('message' => $message, 'exception' => $exception)), $traceableBus->getDispatchedMessages());
+        $this->assertCount(1, $tracedMessages = $traceableBus->getDispatchedMessages());
+        $this->assertArraySubset(array(
+            'message' => $message,
+            'exception' => $exception,
+            'envelopeItems' => null,
+        ), $tracedMessages[0], true);
     }
 }

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -29,21 +29,27 @@ class TraceableMessageBus implements MessageBusInterface
      */
     public function dispatch($message)
     {
+        $callTime = microtime(true);
         $messageToTrace = $message instanceof Envelope ? $message->getMessage() : $message;
+        $envelopeItems = $message instanceof Envelope ? array_values($message->all()) : null;
 
         try {
             $result = $this->decoratedBus->dispatch($message);
 
             $this->dispatchedMessages[] = array(
+                'envelopeItems' => $envelopeItems,
                 'message' => $messageToTrace,
                 'result' => $result,
+                'callTime' => $callTime,
             );
 
             return $result;
         } catch (\Throwable $e) {
             $this->dispatchedMessages[] = array(
+                'envelopeItems' => $envelopeItems,
                 'message' => $messageToTrace,
                 'exception' => $e,
+                'callTime' => $callTime,
             );
 
             throw $e;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #26597  issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This is an attempt to enhance the profiler panel a bit.

**with the following messages dispatched:**

```php
$queryBus->dispatch(Envelope::wrap(new GetGreetingsQuery('Hello you'))
    ->with(new JustAFriendOfMine())
    ->with(new AndHisPlusO̶n̶e̶Eleven())
);
$commandBus->dispatch(new SendGiftCommand());
$queryBus->dispatch(new GetGreetingsQuery('Exterminate!'));
```

## Before

<img width="1084" alt="screenshot 2018-05-12 a 13 57 57" src="https://user-images.githubusercontent.com/2211145/39957055-8a0f009e-55ec-11e8-9d8e-bf79aad4b420.PNG">

🐛calls order are wrong here, fixed in this PR

## After

### collapsed

<!-- <img width="1083" alt="screenshot 2018-05-10 a 23 51 07" src="https://user-images.githubusercontent.com/2211145/39896093-19a8c7ee-54ad-11e8-8dcb-4e165ffd2eae.PNG">-->

<img width="1085" alt="screenshot 2018-05-12 a 13 18 35" src="https://user-images.githubusercontent.com/2211145/39956802-9d4c38a2-55e7-11e8-8425-ad090c0871b6.PNG">
<img width="1085" alt="screenshot 2018-05-12 a 13 26 44" src="https://user-images.githubusercontent.com/2211145/39956827-25d9e426-55e8-11e8-9116-160603649f33.PNG">

📝 _When loading the page, all messages details are collapsed by default but the first one per tab._

### expanded

<!-- <img width="1083" alt="screenshot 2018-05-10 a 23 13 39" src="https://user-images.githubusercontent.com/2211145/39894779-42c9cc9a-54a8-11e8-9529-6292481536d4.PNG"> -->

<img width="1086" alt="screenshot 2018-05-12 a 13 49 42" src="https://user-images.githubusercontent.com/2211145/39956981-639fc3d6-55eb-11e8-9224-a48f591db3da.PNG">

### live

<!-- ![mai-10-2018 23-16-17](https://user-images.githubusercontent.com/2211145/39894789-4b8fa138-54a8-11e8-986c-fccf6cd0234f.gif) -->

![mai-12-2018 13-55-40](https://user-images.githubusercontent.com/2211145/39957041-37f17b34-55ec-11e8-8569-a733a104bf82.gif)

### toolbar (with exceptions)

<img width="284" alt="screenshot 2018-05-10 a 23 18 32" src="https://user-images.githubusercontent.com/2211145/39895011-0467f2a0-54a9-11e8-9d78-25461cf71c41.PNG">

## Notes

- Table headers are clickable, so you can jump directly to the message class in the code
- Reversing headers/rows allows to have a wider space for dumps and allows to add more entries in the future. This is an issue we already have with the Validator panel (when there is both an invalid value as object and a constraint violation dumped) which I'd like to revamp soon.
- ~~I wonder if we should keep the dispatched messages in call order, or if we can segregate by bus (using tabs?).~~
- ~~we could add a left container listing messages classes only, allowing to show details of a single message dispatched on a right container (similar to what the Form panel does). I'll probably suggest the same for the Validator panel.~~