### PR TITLE
[Messenger][DX] Uses a default receiver when only one is defined

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -73,6 +73,7 @@
             <argument type="service" id="message_bus" />
             <argument type="service" id="messenger.receiver_locator" />
             <argument type="service" id="logger" on-invalid="null" />
+            <argument>null</argument> <!-- Default receiver name -->
 
             <tag name="console.command" command="messenger:consume-messages" />
         </service>

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -37,14 +37,16 @@ class ConsumeMessagesCommand extends Command
     private $bus;
     private $receiverLocator;
     private $logger;
+    private $defaultReceiverName;
 
-    public function __construct(MessageBusInterface $bus, ContainerInterface $receiverLocator, LoggerInterface $logger = null)
+    public function __construct(MessageBusInterface $bus, ContainerInterface $receiverLocator, LoggerInterface $logger = null, string $defaultReceiverName = null)
     {
         parent::__construct();
 
         $this->bus = $bus;
         $this->receiverLocator = $receiverLocator;
         $this->logger = $logger;
+        $this->defaultReceiverName = $defaultReceiverName;
     }
 
     /**
@@ -54,7 +56,7 @@ class ConsumeMessagesCommand extends Command
     {
         $this
             ->setDefinition(array(
-                new InputArgument('receiver', InputArgument::REQUIRED, 'Name of the receiver'),
+                new InputArgument('receiver', $this->defaultReceiverName ? InputArgument::OPTIONAL : InputArgument::REQUIRED, 'Name of the receiver', $this->defaultReceiverName),
                 new InputOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Limit the number of received messages'),
                 new InputOption('memory-limit', 'm', InputOption::VALUE_REQUIRED, 'The memory limit the worker can consume'),
                 new InputOption('time-limit', 't', InputOption::VALUE_REQUIRED, 'The time limit in seconds the worker can run'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

When using only one receiver, as a developer, it makes no sense for me to have to precise the receiver name when using the `messenger:consume-messages` command. This is the change:

```patch
- bin/console messenger:consume-messages default
+ bin/console messenger:consume-messages
```

If I have more than one transport configured, I'll get the following message:

> 
>  You have 0 or more than one receiver (no default have been found). You need to specify the receiver name with an argument.
>