### PR TITLE
[Workflow] add is deprecated since Symfony 4.1. Use addWorkflow() instead

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -572,10 +572,10 @@ class FrameworkExtension extends Extension
                 foreach ($workflow['supports'] as $supportedClassName) {
                     $strategyDefinition = new Definition(Workflow\SupportStrategy\InstanceOfSupportStrategy::class, array($supportedClassName));
                     $strategyDefinition->setPublic(false);
-                    $registryDefinition->addMethodCall('add', array(new Reference($workflowId), $strategyDefinition));
+                    $registryDefinition->addMethodCall('addWorkflow', array(new Reference($workflowId), $strategyDefinition));
                 }
             } elseif (isset($workflow['support_strategy'])) {
-                $registryDefinition->addMethodCall('add', array(new Reference($workflowId), new Reference($workflow['support_strategy'])));
+                $registryDefinition->addMethodCall('addWorkflow', array(new Reference($workflowId), new Reference($workflow['support_strategy'])));
             }
 
             // Enable the AuditTrail

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -51,7 +51,7 @@
         "symfony/templating": "~3.4|~4.0",
         "symfony/validator": "^4.1",
         "symfony/var-dumper": "~3.4|~4.0",
-        "symfony/workflow": "~3.4|~4.0",
+        "symfony/workflow": "^4.1",
         "symfony/yaml": "~3.4|~4.0",
         "symfony/property-info": "~3.4|~4.0",
         "symfony/lock": "~3.4|~4.0",
@@ -72,7 +72,7 @@
         "symfony/stopwatch": "<3.4",
         "symfony/translation": "<3.4",
         "symfony/validator": "<4.1",
-        "symfony/workflow": "<3.4"
+        "symfony/workflow": "<4.1"
     },
     "suggest": {
         "ext-apcu": "For best performance of the system caches",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #...   
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->