### PR TITLE
[Serializer] Allow denormalization of constructor arguments to array of objects

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added support for denormalization of constructor arguments to an array of objects
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -158,6 +158,18 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     }
 
     /**
+     * @internal
+     */
+    protected function parseConstructorParameter(array &$data, $key, array &$context, \ReflectionParameter $constructorParameter, $format)
+    {
+        if (!$constructorParameter->hasType() || $constructorParameter->getType()->isBuiltin()) {
+            return $this->validateAndDenormalize($constructorParameter->getDeclaringClass()->name, $constructorParameter->name, $data[$key], $format, $context);
+        }
+
+        return parent::parseConstructorParameter($data, $key, $context, $constructorParameter, $format);
+    }
+
+    /**
      * Gets and caches attributes for the given object, format and context.
      *
      * @param object      $object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #25524
| License       | MIT
| Doc PR        | todo


Currently it is not possible to denormalize array of objects passed to the class constructor as described in the issue #25524. When instantiating an object if constructor parameter is of array type its value is being set as it is without any further denormalization. 

This pull request handles it by providing this further denormalization in the same way like it is currently done for non-constructor parameters. It means that now the constructor parameter type can be read from the php doc annotation and if it is an array of objects it will be denormalized correctly.