### PR TITLE
[WebProfilerBundle][Cache] Fix misses calculation when calling getItems

### DIFF
--- a/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
+++ b/src/Symfony/Component/Cache/DataCollector/CacheDataCollector.php
@@ -132,10 +132,9 @@ class CacheDataCollector extends DataCollector implements LateDataCollectorInter
                         $statistics[$name]['misses'] += 1;
                     }
                 } elseif ('getItems' === $call->name) {
-                    $count = $call->hits + $call->misses;
-                    $statistics[$name]['reads'] += $count;
+                    $statistics[$name]['reads'] += $call->hits + $call->misses;
                     $statistics[$name]['hits'] += $call->hits;
-                    $statistics[$name]['misses'] += $count - $call->misses;
+                    $statistics[$name]['misses'] += $call->misses;
                 } elseif ('hasItem' === $call->name) {
                     $statistics[$name]['reads'] += 1;
                     if (false === $call->result) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Hello,

This PR fixes a bug in the misses calculation in the cache data collector when calling the `getItems` method.

Found this while trying to understand why I had an inconsistency in the profiler:
![misses](https://user-images.githubusercontent.com/4130750/39875423-e6212f60-5470-11e8-87be-c075ee76aeaa.png)
