### PR TITLE
[Messenger] Make sure default receiver name is set before command configuration

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -41,12 +41,12 @@ class ConsumeMessagesCommand extends Command
 
     public function __construct(MessageBusInterface $bus, ContainerInterface $receiverLocator, LoggerInterface $logger = null, string $defaultReceiverName = null)
     {
-        parent::__construct();
-
         $this->bus = $bus;
         $this->receiverLocator = $receiverLocator;
         $this->logger = $logger;
         $this->defaultReceiverName = $defaultReceiverName;
+
+        parent::__construct();
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
+use Symfony\Component\Messenger\MessageBus;
+
+class ConsumeMessagesCommandTest extends TestCase
+{
+    public function testConfigurationWithDefaultReceiver()
+    {
+        $command = new ConsumeMessagesCommand($this->createMock(MessageBus::class), $this->createMock(ServiceLocator::class), null, 'messenger.transport.amqp');
+        $inputArgument = $command->getDefinition()->getArgument('receiver');
+        $this->assertFalse($inputArgument->isRequired());
+        $this->assertSame('messenger.transport.amqp', $inputArgument->getDefault());
+    }
+
+    public function testConfigurationWithoutDefaultReceiver()
+    {
+        $command = new ConsumeMessagesCommand($this->createMock(MessageBus::class), $this->createMock(ServiceLocator::class));
+        $inputArgument = $command->getDefinition()->getArgument('receiver');
+        $this->assertTrue($inputArgument->isRequired());
+        $this->assertNull($inputArgument->getDefault());
+    }
+}

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -20,6 +20,7 @@
     },
     "require-dev": {
         "psr/log": "~1.0",
+        "symfony/console": "~3.4|~4.0",
         "symfony/dependency-injection": "~3.4.6|~4.0",
         "symfony/http-kernel": "~3.4|~4.0",
         "symfony/process": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27203
| License       | MIT
| Doc PR        | -

Otherwise the receiver's name would still be required always.

https://github.com/symfony/symfony/blob/3cc4a701e6f24cb2eaaf1234b331f182dea0c9b4/src/Symfony/Component/Console/Command/Command.php#L77