### PR TITLE
[Messenger] Rename tag attribute "name" by "alias"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1511,8 +1511,8 @@ class FrameworkExtension extends Extension
             $transportDefinition = (new Definition(TransportInterface::class))
                 ->setFactory(array(new Reference('messenger.transport_factory'), 'createTransport'))
                 ->setArguments(array($transport['dsn'], $transport['options']))
-                ->addTag('messenger.receiver', array('name' => $name))
-                ->addTag('messenger.sender', array('name' => $name))
+                ->addTag('messenger.receiver', array('alias' => $name))
+                ->addTag('messenger.sender', array('alias' => $name))
             ;
             $container->setDefinition('messenger.transport.'.$name, $transportDefinition);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -539,8 +539,8 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('messenger.transport.default'));
         $this->assertTrue($container->getDefinition('messenger.transport.default')->hasTag('messenger.receiver'));
         $this->assertTrue($container->getDefinition('messenger.transport.default')->hasTag('messenger.sender'));
-        $this->assertEquals(array(array('name' => 'default')), $container->getDefinition('messenger.transport.default')->getTag('messenger.receiver'));
-        $this->assertEquals(array(array('name' => 'default')), $container->getDefinition('messenger.transport.default')->getTag('messenger.sender'));
+        $this->assertEquals(array(array('alias' => 'default')), $container->getDefinition('messenger.transport.default')->getTag('messenger.receiver'));
+        $this->assertEquals(array(array('alias' => 'default')), $container->getDefinition('messenger.transport.default')->getTag('messenger.sender'));
 
         $this->assertTrue($container->hasDefinition('messenger.transport.customised'));
         $transportFactory = $container->getDefinition('messenger.transport.customised')->getFactory();

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -63,7 +63,7 @@ class MessengerPass implements CompilerPassInterface
             }
 
             if ($container->hasDefinition('messenger.data_collector')) {
-                $this->registerBusToCollector($container, $busId, $tags[0]);
+                $this->registerBusToCollector($container, $busId);
             }
         }
 
@@ -177,8 +177,8 @@ class MessengerPass implements CompilerPassInterface
             $receiverMapping[$id] = new Reference($id);
 
             foreach ($tags as $tag) {
-                if (isset($tag['name'])) {
-                    $receiverMapping[$tag['name']] = $receiverMapping[$id];
+                if (isset($tag['alias'])) {
+                    $receiverMapping[$tag['alias']] = $receiverMapping[$id];
                 }
             }
         }
@@ -202,8 +202,8 @@ class MessengerPass implements CompilerPassInterface
             $senderLocatorMapping[$id] = new Reference($id);
 
             foreach ($tags as $tag) {
-                if (isset($tag['name'])) {
-                    $senderLocatorMapping[$tag['name']] = $senderLocatorMapping[$id];
+                if (isset($tag['alias'])) {
+                    $senderLocatorMapping[$tag['alias']] = $senderLocatorMapping[$id];
                 }
             }
         }
@@ -211,7 +211,7 @@ class MessengerPass implements CompilerPassInterface
         $container->getDefinition('messenger.sender_locator')->replaceArgument(0, $senderLocatorMapping);
     }
 
-    private function registerBusToCollector(ContainerBuilder $container, string $busId, array $tag)
+    private function registerBusToCollector(ContainerBuilder $container, string $busId)
     {
         $container->setDefinition(
             $tracedBusId = 'debug.traced.'.$busId,

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -101,7 +101,7 @@ class MessengerPassTest extends TestCase
     public function testItRegistersReceivers()
     {
         $container = $this->getContainerBuilder();
-        $container->register(AmqpReceiver::class, AmqpReceiver::class)->addTag('messenger.receiver', array('name' => 'amqp'));
+        $container->register(AmqpReceiver::class, AmqpReceiver::class)->addTag('messenger.receiver', array('alias' => 'amqp'));
 
         (new MessengerPass())->process($container);
 
@@ -128,7 +128,7 @@ class MessengerPassTest extends TestCase
             null,
         ));
 
-        $container->register(AmqpReceiver::class, AmqpReceiver::class)->addTag('messenger.receiver', array('name' => 'amqp'));
+        $container->register(AmqpReceiver::class, AmqpReceiver::class)->addTag('messenger.receiver', array('alias' => 'amqp'));
 
         (new MessengerPass())->process($container);
 
@@ -145,8 +145,8 @@ class MessengerPassTest extends TestCase
             null,
         ));
 
-        $container->register(AmqpReceiver::class, AmqpReceiver::class)->addTag('messenger.receiver', array('name' => 'amqp'));
-        $container->register(DummyReceiver::class, DummyReceiver::class)->addTag('messenger.receiver', array('name' => 'dummy'));
+        $container->register(AmqpReceiver::class, AmqpReceiver::class)->addTag('messenger.receiver', array('alias' => 'amqp'));
+        $container->register(DummyReceiver::class, DummyReceiver::class)->addTag('messenger.receiver', array('alias' => 'dummy'));
 
         (new MessengerPass())->process($container);
 
@@ -156,7 +156,7 @@ class MessengerPassTest extends TestCase
     public function testItRegistersSenders()
     {
         $container = $this->getContainerBuilder();
-        $container->register(AmqpSender::class, AmqpSender::class)->addTag('messenger.sender', array('name' => 'amqp'));
+        $container->register(AmqpSender::class, AmqpSender::class)->addTag('messenger.sender', array('alias' => 'amqp'));
 
         (new MessengerPass())->process($container);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As "name" is a reserved attribute in YAML and XML schema it makes impossible to register manually a custom Sender or Receiver with another "name" attribute.

> The file ".../demos/messenger-flex/config/services.yaml" does not contain valid YAML.  
Duplicate key "name" detected at line 30 (near "- { name: 'messenger.receiver', name: 'mail' }"). 
