### PR TITLE
[Cache][Lock] Fix usages of error_get_last()

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -126,9 +126,12 @@ trait RedisTrait
                     throw new InvalidArgumentException(sprintf('Redis connection failed (%s): %s', $e->getMessage(), $dsn));
                 }
 
-                if (@!$redis->isConnected()) {
-                    $e = ($e = error_get_last()) && preg_match('/^Redis::p?connect\(\): (.*)/', $e['message'], $e) ? sprintf(' (%s)', $e[1]) : '';
-                    throw new InvalidArgumentException(sprintf('Redis connection failed%s: %s', $e, $dsn));
+                set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
+                $isConnected = $redis->isConnected();
+                restore_error_handler();
+                if (!$isConnected) {
+                    $error = preg_match('/^Redis::p?connect\(\): (.*)/', $error, $error) ? sprintf(' (%s)', $error[1]) : '';
+                    throw new InvalidArgumentException(sprintf('Redis connection failed%s: %s', $error, $dsn));
                 }
 
                 if ((null !== $auth && !$redis->auth($auth))

--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -78,8 +78,7 @@ class FlockStore implements StoreInterface
         );
 
         // Silence error reporting
-        set_error_handler(function () {
-        });
+        set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
         if (!$handle = fopen($fileName, 'r')) {
             if ($handle = fopen($fileName, 'x')) {
                 chmod($fileName, 0444);
@@ -91,8 +90,7 @@ class FlockStore implements StoreInterface
         restore_error_handler();
 
         if (!$handle) {
-            $error = error_get_last();
-            throw new LockStorageException($error['message'], 0, null);
+            throw new LockStorageException($error, 0, null);
         }
 
         // On Windows, even if PHP doc says the contrary, LOCK_NB works, see


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When a userland error handler doesn't return `false`, `error_get_last()` is not updated, so we cannot see the real last error, but the previous one.

See https://3v4l.org/Smmt7