### PR TITLE
[Debug] Fix populating error_get_last() for handled silent errors

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -377,13 +377,15 @@ class ErrorHandler
      */
     public function handleError($type, $message, $file, $line)
     {
-        $level = error_reporting() | E_RECOVERABLE_ERROR | E_USER_ERROR | E_DEPRECATED | E_USER_DEPRECATED;
+        $level = error_reporting();
+        $silenced = 0 === ($level & $type);
+        $level |= E_RECOVERABLE_ERROR | E_USER_ERROR | E_DEPRECATED | E_USER_DEPRECATED;
         $log = $this->loggedErrors & $type;
         $throw = $this->thrownErrors & $type & $level;
         $type &= $level | $this->screamedErrors;
 
         if (!$type || (!$log && !$throw)) {
-            return $type && $log;
+            return !$silenced && $type && $log;
         }
         $scope = $this->scopedErrors & $type;
 
@@ -479,7 +481,7 @@ class ErrorHandler
             }
         }
 
-        return $type && $log;
+        return !$silenced && $type && $log;
     }
 
     /**

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -64,6 +64,30 @@ class ErrorHandlerTest extends TestCase
         }
     }
 
+    public function testErrorGetLast()
+    {
+        $handler = ErrorHandler::register();
+        $logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+        $handler->setDefaultLogger($logger);
+        $handler->screamAt(E_ALL);
+
+        try {
+            @trigger_error('Hello', E_USER_WARNING);
+            $expected = array(
+                'type' => E_USER_WARNING,
+                'message' => 'Hello',
+                'file' => __FILE__,
+                'line' => __LINE__ - 5,
+            );
+            $this->assertSame($expected, error_get_last());
+        } catch (\Exception $e) {
+            restore_error_handler();
+            restore_exception_handler();
+
+            throw $e;
+        }
+    }
+
     public function testNotice()
     {
         ErrorHandler::register();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When a userland error handler doesn't return `false`, `error_get_last()` is not updated, so we cannot see the real last error, but the previous one.

See https://3v4l.org/Smmt7