### PR TITLE
[Messenger] Non-transportable envelope items

### DIFF
--- a/src/Symfony/Component/Messenger/Asynchronous/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Asynchronous/Middleware/SendMessageMiddleware.php
@@ -15,6 +15,7 @@ use Symfony\Component\Messenger\Asynchronous\Routing\SenderLocatorInterface;
 use Symfony\Component\Messenger\Asynchronous\Transport\ReceivedMessage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\EnvelopeAwareInterface;
+use Symfony\Component\Messenger\EnvelopeItemInterface;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 
 /**
@@ -39,6 +40,10 @@ class SendMessageMiddleware implements MiddlewareInterface, EnvelopeAwareInterfa
             // It's a received message. Do not send it back:
             return $next($message);
         }
+
+        $envelope = new Envelope($envelope->getMessage(), array_filter($envelope->all(), function (EnvelopeItemInterface $item): bool {
+            return $item->isTransportable();
+        }));
 
         if (!empty($senders = $this->senderLocator->getSendersForMessage($envelope->getMessage()))) {
             foreach ($senders as $sender) {

--- a/src/Symfony/Component/Messenger/Asynchronous/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Asynchronous/Middleware/SendMessageMiddleware.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\EnvelopeAwareInterface;
 use Symfony\Component\Messenger\EnvelopeItemInterface;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\TransportableEnvelopeItemInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
@@ -41,9 +42,10 @@ class SendMessageMiddleware implements MiddlewareInterface, EnvelopeAwareInterfa
             return $next($message);
         }
 
-        $envelope = new Envelope($envelope->getMessage(), array_filter($envelope->all(), function (EnvelopeItemInterface $item): bool {
-            return $item->isTransportable();
-        }));
+        $transportableItems = array_filter($envelope->all(), function (EnvelopeItemInterface $item): bool {
+            return $item instanceof TransportableEnvelopeItemInterface;
+        });
+        $envelope = new Envelope($envelope->getMessage(), $transportableItems);
 
         if (!empty($senders = $this->senderLocator->getSendersForMessage($envelope->getMessage()))) {
             foreach ($senders as $sender) {

--- a/src/Symfony/Component/Messenger/Asynchronous/Transport/ReceivedMessage.php
+++ b/src/Symfony/Component/Messenger/Asynchronous/Transport/ReceivedMessage.php
@@ -25,13 +25,11 @@ use Symfony\Component\Messenger\EnvelopeItemInterface;
  */
 final class ReceivedMessage implements EnvelopeItemInterface
 {
-    public function serialize()
+    /**
+     * {@inheritdoc}
+     */
+    public function isTransportable(): bool
     {
-        return '';
-    }
-
-    public function unserialize($serialized)
-    {
-        // noop
+        return false;
     }
 }

--- a/src/Symfony/Component/Messenger/Asynchronous/Transport/ReceivedMessage.php
+++ b/src/Symfony/Component/Messenger/Asynchronous/Transport/ReceivedMessage.php
@@ -25,11 +25,4 @@ use Symfony\Component\Messenger\EnvelopeItemInterface;
  */
 final class ReceivedMessage implements EnvelopeItemInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function isTransportable(): bool
-    {
-        return false;
-    }
 }

--- a/src/Symfony/Component/Messenger/EnvelopeItemInterface.php
+++ b/src/Symfony/Component/Messenger/EnvelopeItemInterface.php
@@ -13,12 +13,15 @@ namespace Symfony\Component\Messenger;
 
 /**
  * An envelope item related to a message.
- * This item must be serializable for transport.
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  *
  * @experimental in 4.1
  */
-interface EnvelopeItemInterface extends \Serializable
+interface EnvelopeItemInterface
 {
+    /**
+     * @return bool True if this item can be transported. Otherwise, it'll be ignored during send.
+     */
+    public function isTransportable(): bool;
 }

--- a/src/Symfony/Component/Messenger/EnvelopeItemInterface.php
+++ b/src/Symfony/Component/Messenger/EnvelopeItemInterface.php
@@ -14,14 +14,12 @@ namespace Symfony\Component\Messenger;
 /**
  * An envelope item related to a message.
  *
+ * @see TransportableEnvelopeItemInterface for an envelope item that could be transported.
+ *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  *
  * @experimental in 4.1
  */
 interface EnvelopeItemInterface
 {
-    /**
-     * @return bool True if this item can be transported. Otherwise, it'll be ignored during send.
-     */
-    public function isTransportable(): bool;
 }

--- a/src/Symfony/Component/Messenger/Middleware/Configuration/ValidationConfiguration.php
+++ b/src/Symfony/Component/Messenger/Middleware/Configuration/ValidationConfiguration.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Middleware\Configuration;
 
-use Symfony\Component\Messenger\EnvelopeItemInterface;
+use Symfony\Component\Messenger\TransportableEnvelopeItemInterface;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 
 /**
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
  *
  * @experimental in 4.1
  */
-final class ValidationConfiguration implements EnvelopeItemInterface, \Serializable
+final class ValidationConfiguration implements TransportableEnvelopeItemInterface
 {
     private $groups;
 
@@ -34,14 +34,6 @@ final class ValidationConfiguration implements EnvelopeItemInterface, \Serializa
     public function getGroups()
     {
         return $this->groups;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isTransportable(): bool
-    {
-        return true;
     }
 
     public function serialize()

--- a/src/Symfony/Component/Messenger/Middleware/Configuration/ValidationConfiguration.php
+++ b/src/Symfony/Component/Messenger/Middleware/Configuration/ValidationConfiguration.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints\GroupSequence;
  *
  * @experimental in 4.1
  */
-final class ValidationConfiguration implements EnvelopeItemInterface
+final class ValidationConfiguration implements EnvelopeItemInterface, \Serializable
 {
     private $groups;
 
@@ -34,6 +34,14 @@ final class ValidationConfiguration implements EnvelopeItemInterface
     public function getGroups()
     {
         return $this->groups;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isTransportable(): bool
+    {
+        return true;
     }
 
     public function serialize()

--- a/src/Symfony/Component/Messenger/Tests/Asynchronous/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Asynchronous/Middleware/SendMessageMiddlewareTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\EnvelopeItemInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\TransportableEnvelopeItemInterface;
 
 class SendMessageMiddlewareTest extends TestCase
 {
@@ -137,18 +138,19 @@ class InMemorySenderLocator implements SenderLocatorInterface
     }
 }
 
-class TransportableItem implements EnvelopeItemInterface
+class TransportableItem implements TransportableEnvelopeItemInterface
 {
-    public function isTransportable(): bool
+    public function serialize()
     {
-        return true;
+        // no op
+    }
+
+    public function unserialize($serialized)
+    {
+        // no op
     }
 }
 
 class NonTransportableItem implements EnvelopeItemInterface
 {
-    public function isTransportable(): bool
-    {
-        return false;
-    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/AnEnvelopeItem.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/AnEnvelopeItem.php
@@ -15,8 +15,4 @@ use Symfony\Component\Messenger\EnvelopeItemInterface;
 
 class AnEnvelopeItem implements EnvelopeItemInterface
 {
-    public function isTransportable(): bool
-    {
-        return false;
-    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/AnEnvelopeItem.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/AnEnvelopeItem.php
@@ -15,19 +15,8 @@ use Symfony\Component\Messenger\EnvelopeItemInterface;
 
 class AnEnvelopeItem implements EnvelopeItemInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function serialize()
+    public function isTransportable(): bool
     {
-        return '';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function unserialize($serialized)
-    {
-        // noop
+        return false;
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -68,8 +68,8 @@ class Serializer implements DecoderInterface, EncoderInterface
         }
 
         $headers = array('type' => \get_class($envelope->getMessage()));
-        if ($configurations = $envelope->all()) {
-            $headers['X-Message-Envelope-Items'] = serialize($configurations);
+        if ($items = $envelope->all()) {
+            $headers['X-Message-Envelope-Items'] = serialize($items);
         }
 
         return array(

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SerializerConfiguration.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SerializerConfiguration.php
@@ -11,14 +11,14 @@
 
 namespace Symfony\Component\Messenger\Transport\Serialization;
 
-use Symfony\Component\Messenger\EnvelopeItemInterface;
+use Symfony\Component\Messenger\TransportableEnvelopeItemInterface;
 
 /**
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  *
  * @experimental in 4.1
  */
-final class SerializerConfiguration implements EnvelopeItemInterface, \Serializable
+final class SerializerConfiguration implements TransportableEnvelopeItemInterface
 {
     private $context;
 
@@ -30,14 +30,6 @@ final class SerializerConfiguration implements EnvelopeItemInterface, \Serializa
     public function getContext(): array
     {
         return $this->context;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isTransportable(): bool
-    {
-        return true;
     }
 
     public function serialize()

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SerializerConfiguration.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SerializerConfiguration.php
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\EnvelopeItemInterface;
  *
  * @experimental in 4.1
  */
-final class SerializerConfiguration implements EnvelopeItemInterface
+final class SerializerConfiguration implements EnvelopeItemInterface, \Serializable
 {
     private $context;
 
@@ -30,6 +30,14 @@ final class SerializerConfiguration implements EnvelopeItemInterface
     public function getContext(): array
     {
         return $this->context;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isTransportable(): bool
+    {
+        return true;
     }
 
     public function serialize()

--- a/src/Symfony/Component/Messenger/TransportableEnvelopeItemInterface.php
+++ b/src/Symfony/Component/Messenger/TransportableEnvelopeItemInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Messenger;
+
+/**
+ * An envelope item that could be transported.
+ *
+ * @author Konstantin Myakshin <molodchick@gmail.com>
+ *
+ * @experimental in 4.1
+ */
+interface TransportableEnvelopeItemInterface extends EnvelopeItemInterface, \Serializable
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This commit was part of the original PR, but was late so reverted to discuss about it in a next PR.
See discussion starting with https://github.com/symfony/symfony/pull/26945#issuecomment-386804255.

Not every envelope item needs to go through transport. The `ReceiverMessage` even is a simple marker item on receiver's side, so no point for it being serializable.
We could just choose to ignore non-serializable items when sending but as stated by @sroze : 
> it could be a source of potential confusion and "tricky bugs" (i.e. the middleware X doesn’t “work” anymore because I forgot to add the Serializable on my EnvelopeItem)

Adding a `EnvelopeItemInterface::isTransportable(): bool` method answers this by requiring to answer the transportable question. DX-wise, it's still one step more rather than just `MyItem implements EnvelopeItemInterface` but with far less hassle than having to implement `\Serializable` for nothing.
Also, a transportable item not implementing `\Serializable` would still be valid for transport (but I would recommend implementing it to keep PHP serialization under control) and not requiring it means less hassle in case we decide/propose an alternate way to serialize items in the future.