### PR TITLE
Disallow invalid characters in session.name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -339,7 +339,16 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('storage_id')->defaultValue('session.storage.native')->end()
                         ->scalarNode('handler_id')->defaultValue('session.handler.native_file')->end()
-                        ->scalarNode('name')->end()
+                        ->scalarNode('name')
+                            ->validate()
+                                ->ifTrue(function ($v) {
+                                    parse_str($v, $parsed);
+
+                                    return implode('&', array_keys($parsed)) !== (string) $v;
+                                })
+                                ->thenInvalid('Session name %s contains illegal character(s)')
+                            ->end()
+                        ->end()
                         ->scalarNode('cookie_lifetime')->end()
                         ->scalarNode('cookie_path')->end()
                         ->scalarNode('cookie_domain')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -42,6 +42,55 @@ class ConfigurationTest extends TestCase
     }
 
     /**
+     * @dataProvider getTestValidSessionName
+     */
+    public function testValidSessionName($sessionName)
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(
+            new Configuration(true),
+            array(array('session' => array('name' => $sessionName)))
+        );
+
+        $this->assertEquals($sessionName, $config['session']['name']);
+    }
+
+    public function getTestValidSessionName()
+    {
+        return array(
+            array(null),
+            array('PHPSESSID'),
+            array('a&b'),
+            array(',_-!@#$%^*(){}:<>/?'),
+        );
+    }
+
+    /**
+     * @dataProvider getTestInvalidSessionName
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testInvalidSessionName($sessionName)
+    {
+        $processor = new Processor();
+        $processor->processConfiguration(
+            new Configuration(true),
+            array(array('session' => array('name' => $sessionName)))
+        );
+    }
+
+    public function getTestInvalidSessionName()
+    {
+        return array(
+            array('a.b'),
+            array('a['),
+            array('a[]'),
+            array('a[b]'),
+            array('a=b'),
+            array('a+b'),
+        );
+    }
+
+    /**
      * @dataProvider getTestValidTrustedProxiesData
      */
     public function testValidTrustedProxies($trustedProxies, $processedProxies)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27023
| License       | MIT
| Doc PR        | 

PHP saves cookie with correct name, but upon deserialization to
`$_COOKIE`, it replaces "." characters with "_".

This is probably also reason why \SessionHandler is not able to find
a session.

https://harrybailey.com/2009/04/dots-arent-allowed-in-php-cookie-names/
https://bugs.php.net/bug.php?id=75883