### PR TITLE
[Form] Deprecate `searchAndRenderBlock` returning empty string

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -6,6 +6,25 @@ Cache
 
  * Deprecated `CacheItem::getPreviousTags()`, use `CacheItem::getMetadata()` instead.
 
+Form
+----
+
+ * Deprecated calling `FormRenderer::searchAndRenderBlock` for fields which were already rendered. 
+   Instead of expecting such calls to return empty strings, check if the field has already been rendered.
+ 
+   Before:
+   ```twig
+   {% for field in fieldsWithPotentialDuplicates %}
+      {{ form_widget(field) }}
+   {% endfor %}
+   ```
+   
+   After:
+   ```twig
+   {% for field in fieldsWithPotentialDuplicates if not field.rendered %}
+      {{ form_widget(field) }}
+   {% endfor %}
+   ```
 Security
 --------
 

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -398,7 +398,7 @@
 {# Support #}
 
 {%- block form_rows -%}
-    {% for child in form %}
+    {% for child in form if not child.rendered %}
         {{- form_row(child) -}}
     {% endfor %}
 {%- endblock form_rows -%}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_rows.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_rows.html.php
@@ -1,3 +1,5 @@
 <?php foreach ($form as $child) : ?>
-    <?php echo $view['form']->row($child) ?>
+    <?php if (!$child->isRendered()): ?>
+        <?php echo $view['form']->row($child) ?>
+    <?php endif; ?>
 <?php endforeach; ?>

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.2.0
+-----
+
+ * deprecated calling `FormRenderer::searchAndRenderBlock` for fields which were already rendered
+
 4.1.0
 -----
 

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -132,6 +132,9 @@ class FormRenderer implements FormRendererInterface
         $renderOnlyOnce = 'row' === $blockNameSuffix || 'widget' === $blockNameSuffix;
 
         if ($renderOnlyOnce && $view->isRendered()) {
+            // This is not allowed, because it would result in rendering same IDs multiple times, which is not valid.
+            @trigger_error(sprintf('You are calling "form_%s" for field "%s" which has already been rendered before, trying to render fields which were already rendered is deprecated since Symfony 4.2 and will throw an exception in 5.0.', $blockNameSuffix, $view->vars['name']), E_USER_DEPRECATED);
+            // throw new BadMethodCallException(sprintf('Field "%s" has already been rendered. Save result of previous  render call to variable and output that instead.', $view->vars['name']));
             return '';
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #26531
| License       | MIT
| Doc PR        | -

I would like to remove this silent behavior, because it's confusing