### PR TITLE
[HttpKernel] Make TraceableValueResolver $stopwatch mandatory

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
@@ -26,10 +26,10 @@ final class TraceableValueResolver implements ArgumentValueResolverInterface
     private $inner;
     private $stopwatch;
 
-    public function __construct(ArgumentValueResolverInterface $inner, ?Stopwatch $stopwatch = null)
+    public function __construct(ArgumentValueResolverInterface $inner, Stopwatch $stopwatch)
     {
         $this->inner = $inner;
-        $this->stopwatch = $stopwatch ?? new Stopwatch();
+        $this->stopwatch = $stopwatch;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
@@ -15,7 +15,6 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\TraceableValueResolver;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -31,11 +30,13 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
 
     private $argumentResolverService;
     private $argumentValueResolverTag;
+    private $traceableResolverStopwatch;
 
-    public function __construct(string $argumentResolverService = 'argument_resolver', string $argumentValueResolverTag = 'controller.argument_value_resolver')
+    public function __construct(string $argumentResolverService = 'argument_resolver', string $argumentValueResolverTag = 'controller.argument_value_resolver', string $traceableResolverStopwatch = 'debug.stopwatch')
     {
         $this->argumentResolverService = $argumentResolverService;
         $this->argumentValueResolverTag = $argumentValueResolverTag;
+        $this->traceableResolverStopwatch = $traceableResolverStopwatch;
     }
 
     public function process(ContainerBuilder $container)
@@ -46,12 +47,12 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
 
         $resolvers = $this->findAndSortTaggedServices($this->argumentValueResolverTag, $container);
 
-        if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
+        if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class) && $container->has($this->traceableResolverStopwatch)) {
             foreach ($resolvers as $resolverReference) {
                 $id = (string) $resolverReference;
                 $container->register("debug.$id", TraceableValueResolver::class)
                     ->setDecoratedService($id)
-                    ->setArguments(array(new Reference("debug.$id.inner"), new Reference('debug.stopwatch', ContainerInterface::NULL_ON_INVALID_REFERENCE)));
+                    ->setArguments(array(new Reference("debug.$id.inner"), new Reference($this->traceableResolverStopwatch)));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://github.com/symfony/symfony/pull/26833#discussion_r181997515   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

I understand why this was suggested in https://github.com/symfony/symfony/pull/26833#discussion_r181997515, but as stated by @iltar , I don't think it makes sense to register a traceable resolver instantiating a Stopwatch itself, as there is no way to fetch it and wouldn't be a shared instance, probably defeating the feature and registering a useless decorator.
Instead, let's make the stopwatch mandatory and make the service id to use in the pass configurable.