### PR TITLE
Minor tweak in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -4,11 +4,6 @@ about: Report errors and problems
 
 ---
 
-<!--
-    The Symfony Code of Conduct applies to all the activity on this repository.
-    See https://symfony.com/doc/current/contributing/code_of_conduct/index.html
--->
-
 **Symfony version(s) affected**: x.y.z
 
 **Description**  

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -4,11 +4,6 @@ about: RFC and ideas for new features and improvements
 
 ---
 
-<!--
-    The Symfony Code of Conduct applies to all the activity on this repository.
-    See https://symfony.com/doc/current/contributing/code_of_conduct/index.html
--->
-
 **Description**  
 <!-- A clear and concise description of the new feature. -->
 

--- a/.github/ISSUE_TEMPLATE/3_Support_question.md
+++ b/.github/ISSUE_TEMPLATE/3_Support_question.md
@@ -4,11 +4,6 @@ about: See https://symfony.com/support for questions about using Symfony and its
 
 ---
 
-<!--
-    The Symfony Code of Conduct applies to all the activity on this repository.
-    See https://symfony.com/doc/current/contributing/code_of_conduct/index.html
--->
-
 We use GitHub issues only to discuss about Symfony bugs and new features. For
 this kind of questions about using Symfony or third-party bundles, please use
 any of the support alternatives shown in https://symfony.com/support

--- a/.github/ISSUE_TEMPLATE/4_Documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/4_Documentation_issue.md
@@ -4,11 +4,6 @@ about: See https://github.com/symfony/symfony-docs/issues for documentation issu
 
 ---
 
-<!--
-    The Symfony Code of Conduct applies to all the activity on this repository.
-    See https://symfony.com/doc/current/contributing/code_of_conduct/index.html
--->
-
 Symfony Documentation has its own dedicated repository. Please open your
 documentation-related issue at https://github.com/symfony/symfony-docs/issues
 

--- a/.github/ISSUE_TEMPLATE/5_Security_issue.md
+++ b/.github/ISSUE_TEMPLATE/5_Security_issue.md
@@ -6,11 +6,6 @@ about: See https://symfony.com/security to report security-related issues
 
 ⚠ PLEASE DON'T DISCLOSE SECURITY-RELATED ISSUES PUBLICLY, SEE BELOW.
 
-<!--
-    The Symfony Code of Conduct applies to all the activity on this repository.
-    See https://symfony.com/doc/current/contributing/code_of_conduct/index.html
--->
-
 If you have found a security issue in Symfony, please send the details to
 security [at] symfony.com and don't disclose it publicly until we can provide a
 fix for it.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When these templates were created I didn't realize that GitHub already displays a link to the Code of Conduct when creating issues and PRs:

![github-code-conduct](https://user-images.githubusercontent.com/73419/39987369-e0a3b05c-5764-11e8-85d4-37c1695facda.png)

I propose to remove our custom CoC links and rely on the GitHub links, which are standard for all repositories and contributors are already used to them. Thanks!