### PR TITLE
[Profiler] Remove propel & event_listener_loading category identifiers

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -7,10 +7,8 @@
         'default':                '#aacd4e',
         'section':                '#666',
         'event_listener':         '#3dd',
-        'event_listener_loading': '#add',
         'template':               '#dd3',
         'doctrine':               '#d3d',
-        'propel':                 '#f4d',
         'child_sections':         '#eed',
     } %}
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Part of https://github.com/symfony/symfony/issues/27262#issuecomment-388865265   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A