### PR TITLE
[Validator] Use strict type in URL validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -92,7 +92,7 @@ class UrlValidator extends ConstraintValidator
                 Url::CHECK_DNS_TYPE_SOA,
                 Url::CHECK_DNS_TYPE_SRV,
                 Url::CHECK_DNS_TYPE_TXT,
-            ))) {
+            ), true)) {
                 throw new InvalidOptionsException(sprintf('Invalid value for option "checkDNS" in constraint %s', get_class($constraint)), array('checkDNS'));
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
 Fixed tickets | -
| License       | MIT
| Doc PR        | -


Using `checkDNS` option with value `true` generate error `Warning: checkdnsrr(): Type '1' not supported`.
In SF 3.4  it was mark as depreciation and silently converted to `ANY`  https://github.com/symfony/symfony/blob/v3.4.9/src/Symfony/Component/Validator/Constraints/UrlValidator.php#L79


~~Test are failing on `Symfony\Component\HttpKernel\Tests\ControllerMetadata\ArgumentMetadataFactoryTest::testSignature1` - I think its not related~~