### PR TITLE
[DI] Shared services should not be inlined in non-shared ones

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -138,6 +138,6 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
             return false;
         }
 
-        return true;
+        return $this->container->getDefinition($ids[0])->isShared();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -92,7 +92,7 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $this->assertNotSame($container->getDefinition('bar'), $arguments[2]);
     }
 
-    public function testProcessInlinesMixedServicesLoop()
+    public function testProcessDoesNotInlineMixedServicesLoop()
     {
         $container = new ContainerBuilder();
         $container
@@ -108,7 +108,7 @@ class InlineServiceDefinitionsPassTest extends TestCase
 
         $this->process($container);
 
-        $this->assertEquals($container->getDefinition('foo')->getArgument(0), $container->getDefinition('bar'));
+        $this->assertEquals(new Reference('bar'), $container->getDefinition('foo')->getArgument(0));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

[Already good on 2.7/2.8.](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php#L152)