### PR TITLE
[Routing] Fix adding name prefix to canonical route names

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -162,6 +162,9 @@ class RouteCollection implements \IteratorAggregate, \Countable
 
         foreach ($this->routes as $name => $route) {
             $prefixedRoutes[$prefix.$name] = $route;
+            if (null !== $name = $route->getDefault('_canonical_route')) {
+                $route->setDefault('_canonical_route', $prefix.$name);
+            }
         }
 
         $this->routes = $prefixedRoutes;

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -317,4 +317,17 @@ class RouteCollectionTest extends TestCase
         $this->assertNull($collection->get('foo'));
         $this->assertNull($collection->get('bar'));
     }
+
+    public function testAddNamePrefixCanonicalRouteName()
+    {
+        $collection = new RouteCollection();
+        $collection->add('foo', new Route('/foo', array('_canonical_route' => 'foo')));
+        $collection->add('bar', new Route('/bar', array('_canonical_route' => 'bar')));
+        $collection->add('api_foo', new Route('/api/foo', array('_canonical_route' => 'api_foo')));
+        $collection->addNamePrefix('api_');
+
+        $this->assertEquals('api_foo', $collection->get('api_foo')->getDefault('_canonical_route'));
+        $this->assertEquals('api_bar', $collection->get('api_bar')->getDefault('_canonical_route'));
+        $this->assertEquals('api_api_foo', $collection->get('api_api_foo')->getDefault('_canonical_route'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  |no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27244    <!-- #-prefixed issue number(s), if any -->
| License       | MIT

This PR resolve the [bug](https://github.com/symfony/symfony/issues/27244) in the [prefix imported routes name](https://symfony.com/blog/new-in-symfony-4-1-prefix-imported-route-names) feature. Reviews are always welcomed moreover as I touch a key element ( the `_canonical_route` attribute ). I need an expert in the Routing component to avoid side effect
Thanks