### PR TITLE
[DI] Allow defining bindings on ChildDefinition

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ChildDefinition.php
+++ b/src/Symfony/Component/DependencyInjection/ChildDefinition.php
@@ -121,14 +121,6 @@ class ChildDefinition extends Definition
     {
         throw new BadMethodCallException('A ChildDefinition cannot have instanceof conditionals set on it.');
     }
-
-    /**
-     * @internal
-     */
-    public function setBindings(array $bindings)
-    {
-        throw new BadMethodCallException('A ChildDefinition cannot have bindings set on it.');
-    }
 }
 
 class_alias(ChildDefinition::class, DefinitionDecorator::class);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
@@ -103,7 +103,7 @@ class ResolveChildDefinitionsPass extends AbstractRecursivePass
         $def->setAutowired($parentDef->isAutowired());
         $def->setChanges($parentDef->getChanges());
 
-        $def->setBindings($parentDef->getBindings());
+        $def->setBindings($definition->getBindings() + $parentDef->getBindings());
 
         // overwrite with values specified in the decorator
         $changes = $definition->getChanges();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveChildDefinitionsPassTest.php
@@ -382,6 +382,27 @@ class ResolveChildDefinitionsPassTest extends TestCase
         $this->assertSame(array(2, 1, 'foo' => 3), $def->getArguments());
     }
 
+    public function testBindings()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('parent', 'stdClass')
+            ->setBindings(array('a' => '1', 'b' => '2'))
+        ;
+
+        $child = $container->setDefinition('child', new ChildDefinition('parent'))
+            ->setBindings(array('b' => 'B', 'c' => 'C'))
+        ;
+
+        $this->process($container);
+
+        $bindings = array();
+        foreach ($container->getDefinition('child')->getBindings() as $k => $v) {
+            $bindings[$k] = $v->getValues()[0];
+        }
+        $this->assertEquals(array('b' => 'B', 'c' => 'C', 'a' => '1'), $bindings);
+    }
+
     public function testSetAutoconfiguredOnServiceIsParent()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Spotted by @stof while trying to put https://github.com/symfony/monolog-bundle/pull/254 into practice.
Binding log channels doesn't work because we put this artificial restriction in place.
Let's allow ChildDefinition to have bindings (but only at the DI extension level, loaders still forbid defining them at their level because of the parent vs _defaults ambiguity.)