### PR TITLE
Fix tests in ArgumentMetadataFactoryTest

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -36,9 +36,10 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata(array($this, 'signature1'));
 
         $this->assertEquals(array(
-            new ArgumentMetadata('foo', self::class, false, false, null),
+            new ArgumentMetadata('foo', 'self', false, false, null),
             new ArgumentMetadata('bar', 'array', false, false, null),
             new ArgumentMetadata('baz', 'callable', false, false, null),
+            new ArgumentMetadata('quux', TestCase::class, false, false, null),
         ), $arguments);
     }
 
@@ -47,7 +48,7 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata(array($this, 'signature2'));
 
         $this->assertEquals(array(
-            new ArgumentMetadata('foo', self::class, false, true, null, true),
+            new ArgumentMetadata('foo', 'self', false, true, null, true),
             new ArgumentMetadata('bar', __NAMESPACE__.'\FakeClassThatDoesNotExist', false, true, null, true),
             new ArgumentMetadata('baz', 'Fake\ImportedAndFake', false, true, null, true),
         ), $arguments);
@@ -117,7 +118,7 @@ class ArgumentMetadataFactoryTest extends TestCase
         ), $arguments);
     }
 
-    private function signature1(self $foo, array $bar, callable $baz)
+    private function signature1(self $foo, array $bar, callable $baz, TestCase $quux)
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | bo

It fixes `ArgumentMetadataFactoryTest`. Keyword `self` in method's signature means "self" pseudo-type.

It doesn't matter because `ArgumentMetadataFactory` uses for controllers. However it is possible to convert "self" type to class name.