### PR TITLE
[Messenger] Allow to scope handlers per bus

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1483,7 +1483,7 @@ class FrameworkExtension extends Extension
             }
 
             $container->setParameter($busId.'.middleware', $middleware);
-            $container->setDefinition($busId, (new Definition(MessageBus::class, array(array())))->addTag('messenger.bus'));
+            $container->register($busId, MessageBus::class)->addArgument(array())->addTag('messenger.bus');
 
             if ($busId === $config['default_bus']) {
                 $container->setAlias('message_bus', $busId);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -7,11 +7,6 @@
     <services>
         <defaults public="false" />
 
-        <!-- Handlers -->
-        <service id="messenger.handler_resolver" class="Symfony\Component\Messenger\Handler\Locator\ContainerHandlerLocator">
-            <argument type="service" id="service_container"/>
-        </service>
-
         <!-- Asynchronous -->
         <service id="messenger.asynchronous.routing.sender_locator" class="Symfony\Component\Messenger\Asynchronous\Routing\SenderLocator">
             <argument type="service" id="messenger.sender_locator" />
@@ -32,7 +27,7 @@
         <!-- Middleware -->
         <service id="messenger.middleware.allow_no_handler" class="Symfony\Component\Messenger\Middleware\AllowNoHandlerMiddleware" abstract="true" />
         <service id="messenger.middleware.call_message_handler" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">
-            <argument type="service" id="messenger.handler_resolver" />
+            <argument /> <!-- Bus handler resolver -->
         </service>
 
         <service id="messenger.middleware.validation" class="Symfony\Component\Messenger\Middleware\ValidationMiddleware" abstract="true">

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -26,12 +26,12 @@ use Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler;
  */
 class DebugCommandTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         putenv('COLUMNS='.(119 + strlen(PHP_EOL)));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         putenv('COLUMNS=');
     }

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Command\DebugCommand;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyCommand;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyQuery;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler;
+use Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class DebugCommandTest extends TestCase
+{
+    public function setUp()
+    {
+        putenv('COLUMNS='.(119 + strlen(PHP_EOL)));
+    }
+
+    public function tearDown()
+    {
+        putenv('COLUMNS=');
+    }
+
+    public function testOutput()
+    {
+        $command = new DebugCommand(
+            array(
+                'command_bus' => array(
+                    DummyCommand::class => array(DummyCommandHandler::class),
+                    MultipleBusesMessage::class => array(MultipleBusesMessageHandler::class),
+                ),
+                'query_bus' => array(
+                    DummyQuery::class => array(DummyQueryHandler::class),
+                    MultipleBusesMessage::class => array(MultipleBusesMessageHandler::class),
+                ),
+            )
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(array(), array('decorated' => false));
+
+        $this->assertSame(<<<TXT
+
+Messenger
+=========
+
+command_bus
+-----------
+
+ The following messages can be dispatched:
+
+ --------------------------------------------------------------------------------------- 
+  Symfony\Component\Messenger\Tests\Fixtures\DummyCommand                                
+      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler          
+  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                        
+      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler  
+ --------------------------------------------------------------------------------------- 
+
+query_bus
+---------
+
+ The following messages can be dispatched:
+
+ --------------------------------------------------------------------------------------- 
+  Symfony\Component\Messenger\Tests\Fixtures\DummyQuery                                  
+      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler            
+  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                        
+      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler  
+ --------------------------------------------------------------------------------------- 
+
+
+TXT
+            , $tester->getDisplay(true)
+        );
+
+        $tester->execute(array('bus' => 'query_bus'), array('decorated' => false));
+
+        $this->assertSame(<<<TXT
+
+Messenger
+=========
+
+query_bus
+---------
+
+ The following messages can be dispatched:
+
+ --------------------------------------------------------------------------------------- 
+  Symfony\Component\Messenger\Tests\Fixtures\DummyQuery                                  
+      handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler            
+  Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                        
+      handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler  
+ --------------------------------------------------------------------------------------- 
+
+
+TXT
+            , $tester->getDisplay(true)
+        );
+    }
+
+    public function testOutputWithoutMessages()
+    {
+        $command = new DebugCommand(array('command_bus' => array(), 'query_bus' => array()));
+
+        $tester = new CommandTester($command);
+        $tester->execute(array(), array('decorated' => false));
+
+        $this->assertSame(<<<TXT
+
+Messenger
+=========
+
+command_bus
+-----------
+
+ [WARNING] No handled message found in bus "command_bus".                                                               
+
+query_bus
+---------
+
+ [WARNING] No handled message found in bus "query_bus".                                                                 
+
+
+TXT
+            , $tester->getDisplay(true)
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
+     * @expectedExceptionMessage Bus "unknown_bus" does not exist. Known buses are command_bus, query_bus.
+     */
+    public function testExceptionOnUnknownBusArgument()
+    {
+        $command = new DebugCommand(array('command_bus' => array(), 'query_bus' => array()));
+
+        $tester = new CommandTester($command);
+        $tester->execute(array('bus' => 'unknown_bus'), array('decorated' => false));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyCommand.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class DummyCommand
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyCommandHandler.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyCommandHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class DummyCommandHandler
+{
+    public function __invoke(DummyCommand $command)
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyQuery.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class DummyQuery
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyQueryHandler.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyQueryHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class DummyQueryHandler
+{
+    public function __invoke(DummyQuery $query)
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/MultipleBusesMessage.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/MultipleBusesMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class MultipleBusesMessage
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/MultipleBusesMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/MultipleBusesMessageHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class MultipleBusesMessageHandler
+{
+    public function __invoke(MultipleBusesMessage $message)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo


<img width="970" alt="screenshot 2018-05-15 a 18 34 11" src="https://user-images.githubusercontent.com/2211145/40070551-b36d1f50-586e-11e8-8a44-c6a1503312dd.PNG">


This prevents from dispatching a message in the wrong bus. It works especially great with PSR-4 discovery in DI:

```yaml
command_handlers:
    namespace: App\Message\
    resource: '%kernel.project_dir%/src/Message/*CommandHandler.php'
    tags:
        - { name: messenger.message_handler, bus: command_bus }

query_handlers:
    namespace: App\Message\
    resource: '%kernel.project_dir%/src/Message/*QueryHandler.php'
    tags:
        - { name: messenger.message_handler, bus: query_bus }
```

<details>

<summary>(or in some layered architecture)</summary>

```yaml
command_handlers:
    namespace: App\Application\
    resource: '%kernel.project_dir%/src/Application/**/Handler/*CommandHandler.php'
    tags:
        - { name: messenger.message_handler, bus: command_bus }

query_handlers:
    namespace: App\Application\
    resource: '%kernel.project_dir%/src/Application/**/Handler/*QueryHandler.php'
    tags:
        - { name: messenger.message_handler, bus: query_bus }
```

</details>

---
It also updates (and add tests for) the `DebugCommand`, so we can inspect easily where is supposed to be handled each message.
It's totally optional, and if the bus isn't provided, then it stays available in every bus.