### PR TITLE
[Lock] Skip test if posix extension is not installed

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/BlockingStoreTestTrait.php
@@ -31,6 +31,7 @@ trait BlockingStoreTestTrait
      * This test is time sensible: the $clockDelay could be adjust.
      *
      * @requires extension pcntl
+     * @requires extension posix
      * @requires function pcntl_sigwaitinfo
      */
     public function testBlockingLocks()


### PR DESCRIPTION
This isn't installed by default on Fedora

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
