### PR TITLE
[SecurityBundle] Fix FirewallContext constructor 3.4 compatibility

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -150,6 +150,7 @@
         <service id="security.firewall.context" class="%security.firewall.context.class%" abstract="true">
             <argument type="collection" />
             <argument type="service" id="security.exception_listener" />
+            <argument>null</argument>  <!-- FC Symfony >3.4 -->
             <argument />  <!-- LogoutListener -->
         </service>
 

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
@@ -26,7 +26,10 @@ class FirewallContext
     private $exceptionListener;
     private $logoutListener;
 
-    public function __construct(array $listeners, ExceptionListener $exceptionListener = null, LogoutListener $logoutListener = null)
+    /**
+     * @param null $config Dummy argument for forward compatibility with Symfony 3.4
+     */
+    public function __construct(array $listeners, ExceptionListener $exceptionListener = null, $config = null, LogoutListener $logoutListener = null)
     {
         $this->listeners = $listeners;
         $this->exceptionListener = $exceptionListener;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/24805#discussion_r188441507
| License       | MIT
| Doc PR        | n/a