### PR TITLE
[HttpKernel] Fix response always private and overwritten if session is started

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -46,7 +46,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$session = $this->getSession()) {
+        if (!$session = $event->getRequest()->getSession()) {
             return;
         }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -46,12 +46,17 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$session = $event->getRequest()->getSession()) {
+        if (!$session = $this->getSession()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        if ($response->isCacheable()) {
             return;
         }
 
         if ($session->isStarted() || ($session instanceof Session && $session->hasBeenStarted())) {
-            $event->getResponse()
+            $response
                 ->setPrivate()
                 ->setMaxAge(0)
                 ->headers->addCacheControlDirective('must-revalidate');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #26769 
| License       | MIT

This PR resolves the [bug](https://github.com/symfony/symfony/issues/26769) where the response caching directives where always overwritten in the master request by the listener even if the controller response was trying to set caching directives. This fix adds an additional check in the listener to check if the response was cacheable at first.