### PR TITLE
[Translation] Add Occitan plural rule

### DIFF
--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -107,6 +107,7 @@ class PluralizationRules
             case 'nl':
             case 'nn':
             case 'no':
+            case 'oc':
             case 'om':
             case 'or':
             case 'pa':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Enable correct plural on Occitan translations. Could be safely merged in versions branches.
