### PR TITLE
[HttpFoundation File] Add getPathinfoExtension() in File class to find extension by pathinfo()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.1.0
 -----
 
+ * added `getPathinfoExtension()` to find extension File by pathinfo function.
  * Query string normalization uses `parse_str()` instead of custom parsing logic.
  * Passing the file size to the constructor of the `UploadedFile` class is deprecated.
  * The `getClientSize()` method of the `UploadedFile` class is deprecated. Use `getSize()` instead.

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -76,6 +76,7 @@ class File extends \SplFileInfo
         if (array_key_exists('extension', $info)) {
             return $info['extension'];
         }
+        
         return null;
     }
 

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -77,6 +77,7 @@ class File extends \SplFileInfo
         if (array_key_exists('extension', $info)) {
             $extension = $info['extension'];
         }
+        
         return $extension;
     }
 

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -80,7 +80,6 @@ class File extends \SplFileInfo
         return null;
     }
 
-
     /**
      * Returns the mime type of the file.
      *

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -62,6 +62,25 @@ class File extends \SplFileInfo
     }
 
     /**
+     * Returns the extension based on the original name with pathinfo.
+     *
+     * This method uses pathinfo() function.
+     *
+     * @return string|null The pathinfo extension or null if it cannot be guessed
+     *
+     * @see pathinfo()
+     */
+    public function getPathinfoExtension()
+    {
+        $info = pathinfo($this->getClientOriginalName());
+        if(array_key_exists('extension', $info)){
+            return $info['extension'];
+        }
+        return null;
+    }
+
+
+    /**
      * Returns the mime type of the file.
      *
      * The mime type is guessed using a MimeTypeGuesser instance, which uses finfo(),

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -77,7 +77,6 @@ class File extends \SplFileInfo
         if (array_key_exists('extension', $info)) {
             $extension = $info['extension'];
         }
-        
         return $extension;
     }
 

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -73,7 +73,7 @@ class File extends \SplFileInfo
     public function getPathinfoExtension()
     {
         $info = pathinfo($this->getClientOriginalName());
-        if(array_key_exists('extension', $info)){
+        if (array_key_exists('extension', $info)) {
             return $info['extension'];
         }
         return null;

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -72,12 +72,13 @@ class File extends \SplFileInfo
      */
     public function getPathinfoExtension()
     {
+        $extension = null;
         $info = pathinfo($this->getClientOriginalName());
         if (array_key_exists('extension', $info)) {
-            return $info['extension'];
+            $extension = $info['extension'];
         }
         
-        return null;
+        return $extension;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

It's important to have a method to get extension file which is based on the client name and not on the MimeType.
Because if you rename for example a file test.jpeg in test.php, you can write some malicious code in this picture and upload it while trespassing all the security bounds (of course, if you test the MimeType AND the extension during the uploading). And test.php could be executed.
