### PR TITLE
[Serializer] Fix and improve constraintViolationListNormalizer's RFC7807 compliance

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
@@ -43,19 +43,20 @@ class ConstraintViolationListNormalizerTest extends TestCase
         ));
 
         $expected = array(
-            'title' => 'An error occurred',
+            'type' => 'https://symfony.com/errors/validation',
+            'title' => 'Validation Failed',
             'detail' => 'd: a
 4: 1',
             'violations' => array(
                     array(
                         'propertyPath' => 'd',
-                        'message' => 'a',
-                        'code' => 'f',
+                        'title' => 'a',
+                        'type' => 'urn:uuid:f',
                     ),
                     array(
                         'propertyPath' => '4',
-                        'message' => '1',
-                        'code' => '6',
+                        'title' => '1',
+                        'type' => 'urn:uuid:6',
                     ),
                 ),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://github.com/symfony/symfony/pull/22150#discussion_r188674031
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/9855

This PR fixes and improves [RFC 7807](https://tools.ietf.org/html/rfc7807#section-3.2) compliance of `ConstraintViolationListNormalizer` (introduced in 4.1):

* As recommended, use a specific namespace for Symfony validation error (`http://symfony.com/doc/current/validation.html`, because it already exists and gives information about the error.
* Allow to set all properties defined in the RFC using the serialization context
* Remove the `detail` key if no detail is provided (according to the spec)
* Change the Symfony specific extension to use the same terminology than the RFC itself (type and title)
* Use the proper `urn:uuid` scheme (RFC 4122) for the UUID code (more standard, and improve hypermedia capabilities).

ping @teohhanhui 