### PR TITLE
Triggering RememberMe's loginFail() when token cannot be created

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -68,7 +68,25 @@ class RememberMeListener implements ListenerInterface
         }
 
         $request = $event->getRequest();
-        if (null === $token = $this->rememberMeServices->autoLogin($request)) {
+        try {
+            if (null === $token = $this->rememberMeServices->autoLogin($request)) {
+                return;
+            }
+        } catch (AuthenticationException $e) {
+            if (null !== $this->logger) {
+                $this->logger->warning(
+                    'The token storage was not populated with remember-me token as the'
+                   .' RememberMeServices was not able to create a token from the remember'
+                   .' me information.', array('exception' => $e)
+                );
+            }
+
+            $this->rememberMeServices->loginFail($request);
+
+            if (!$this->catchExceptions) {
+                throw $e;
+            }
+
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
@@ -143,6 +143,43 @@ class RememberMeListenerTest extends TestCase
         $listener->handle($event);
     }
 
+    public function testOnCoreSecurityAuthenticationExceptionDuringAutoLoginTriggersLoginFail()
+    {
+        list($listener, $tokenStorage, $service, $manager) = $this->getListener();
+
+        $tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->will($this->returnValue(null))
+        ;
+
+        $exception = new AuthenticationException('Authentication failed.');
+        $service
+            ->expects($this->once())
+            ->method('autoLogin')
+            ->will($this->throwException($exception))
+        ;
+
+        $service
+            ->expects($this->once())
+            ->method('loginFail')
+        ;
+
+        $manager
+            ->expects($this->never())
+            ->method('authenticate')
+        ;
+
+        $event = $this->getGetResponseEvent();
+        $event
+            ->expects($this->once())
+            ->method('getRequest')
+            ->will($this->returnValue(new Request()))
+        ;
+
+        $listener->handle($event);
+    }
+
     public function testOnCoreSecurity()
     {
         list($listener, $tokenStorage, $service, $manager) = $this->getListener();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (but minor behavior change)
| Deprecations? | no->
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | not needed

This is an edge-case bug fix. If, for example, someone tampers with the remember me cookie, and so it is invalid, this causes the `->autoLogin()` call to throw an `AuthenticationException`. But, this did not call the `loginFail()` method.

Honestly, I'm not sure if the old or new behavior is correct. But, we should discuss and merge or close.
