### PR TITLE
Consider "executable" suffixes first on Windows

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -73,7 +73,7 @@ class ExecutableFinder
         $suffixes = array('');
         if ('\\' === DIRECTORY_SEPARATOR) {
             $pathExt = getenv('PATHEXT');
-            $suffixes = array_merge($suffixes, $pathExt ? explode(PATH_SEPARATOR, $pathExt) : $this->suffixes);
+            $suffixes = array_merge($pathExt ? explode(PATH_SEPARATOR, $pathExt) : $this->suffixes, $suffixes);
         }
         foreach ($suffixes as $suffix) {
             foreach ($dirs as $dir) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes   
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a

Executable finder should consider "executable" suffixes first on Windows because we basically ignore executability on Windows (line 80 below the change), which leads, for example, to finding usually-non-executable `phpunit` file first where both `phpunit` and `phpunit.bat` are present.

I may miss something here, so please tell me if this makes any sense. If so, I'll try my best to rebase this against an earlier version (what version BTW?).