### PR TITLE
[Process] Consider "executable" suffixes first on Windows

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -73,7 +73,7 @@ class ExecutableFinder
         $suffixes = array('');
         if ('\\' === DIRECTORY_SEPARATOR) {
             $pathExt = getenv('PATHEXT');
-            $suffixes = array_merge($suffixes, $pathExt ? explode(PATH_SEPARATOR, $pathExt) : $this->suffixes);
+            $suffixes = array_merge($pathExt ? explode(PATH_SEPARATOR, $pathExt) : $this->suffixes, $suffixes);
         }
         foreach ($suffixes as $suffix) {
             foreach ($dirs as $dir) {

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -129,6 +129,36 @@ class ExecutableFinderTest extends TestCase
         $this->assertSamePath(PHP_BINARY, $result);
     }
 
+    /**
+     * @requires PHP 5.4
+     */
+    public function testFindBatchExecutableOnWindows()
+    {
+        if (ini_get('open_basedir')) {
+            $this->markTestSkipped('Cannot test when open_basedir is set');
+        }
+        if ('\\' !== DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Can be only tested on windows');
+        }
+
+        $target = tempnam(sys_get_temp_dir(), 'example-windows-executable');
+
+        touch($target);
+        touch($target.'.BAT');
+
+        $this->assertFalse(is_executable($target));
+
+        $this->setPath(sys_get_temp_dir());
+
+        $finder = new ExecutableFinder();
+        $result = $finder->find(basename($target), false);
+
+        unlink($target);
+        unlink($target.'.BAT');
+
+        $this->assertSamePath($target.'.BAT', $result);
+    }
+
     private function assertSamePath($expected, $tested)
     {
         if ('\\' === DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | n/a

Executable finder should consider "executable" suffixes first on Windows because we basically ignore executability on Windows (on the lines below changed), which leads, for example, to finding usually-non-executable `phpunit` file first where both `phpunit` and `phpunit.bat` are present.

I may miss something here, so please tell me if this makes any sense. 

Same change against master: #27301