### PR TITLE
[Cache] memcache connect should not add duplicate entries on sequential calls

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -45,6 +45,15 @@ class MemcachedCacheTest extends CacheTestCase
         return new MemcachedCache($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
     }
 
+    public function testCreatePersistentConnectionShouldNotDupServerList()
+    {
+        $instance = MemcachedCache::createConnection('memcached://'.getenv('MEMCACHED_HOST'), array('persistent_id' => 'persistent'));
+        $this->assertCount(1, $instance->getServerList());
+
+        $instance = MemcachedCache::createConnection('memcached://'.getenv('MEMCACHED_HOST'), array('persistent_id' => 'persistent'));
+        $this->assertCount(1, $instance->getServerList());
+    }
+
     public function testOptions()
     {
         $client = MemcachedCache::createConnection(array(), array(

--- a/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
+++ b/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
@@ -169,12 +169,12 @@ trait MemcachedTrait
                 }
 
                 if ($oldServers !== $newServers) {
-                    // before resetting, ensure $servers is valid
-                    $client->addServers($servers);
                     $client->resetServerList();
+                    $client->addServers($servers);
                 }
+            } else {
+                $client->addServers($servers);
             }
-            $client->addServers($servers);
 
             if (null !== $username || null !== $password) {
                 if (!method_exists($client, 'setSaslAuthData')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 (be careful when merging)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #27299
| License       | MIT

MemcachedCache::createConnection adds server to list of servers on every call. But resets this list only when it is not empty and does not match configured list. 
This leads to follow: after first call list contains correct entry. After second it has server entry twice. After third it clears list and set it with correct value.

With combination of libmemcached bug (segfault on adding server after reset nonempty list) it makes impossible to use MemcachedCache::createConnection to create persistent connections.
