### PR TITLE
[Messenger] Activation middleware decorator

### DIFF
--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -86,4 +86,15 @@ final class Envelope
     {
         return $this->message;
     }
+
+    /**
+     * @param object $target
+     *
+     * @return Envelope|object The original message or the envelope if the target supports it
+     *                         (i.e implements {@link EnvelopeAwareInterface}).
+     */
+    public function getMessageFor($target)
+    {
+        return $target instanceof EnvelopeAwareInterface ? $this : $this->message;
+    }
 }

--- a/src/Symfony/Component/Messenger/Middleware/Enhancers/ActivationMiddlewareDecorator.php
+++ b/src/Symfony/Component/Messenger/Middleware/Enhancers/ActivationMiddlewareDecorator.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware\Enhancers;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\EnvelopeAwareInterface;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+
+/**
+ * Execute the inner middleware according to an activation strategy.
+ *
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class ActivationMiddlewareDecorator implements MiddlewareInterface, EnvelopeAwareInterface
+{
+    private $inner;
+    private $activated;
+
+    /**
+     * @param bool|callable $activated
+     */
+    public function __construct(MiddlewareInterface $inner, $activated)
+    {
+        $this->inner = $inner;
+        $this->activated = $activated;
+    }
+
+    /**
+     * @param Envelope $message
+     */
+    public function handle($message, callable $next)
+    {
+        if (\is_callable($this->activated) ? ($this->activated)($message) : $this->activated) {
+            return $this->inner->handle($message->getMessageFor($this->inner), $next);
+        }
+
+        return $next($message);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/Enhancers/ActivationMiddlewareDecoratorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/Enhancers/ActivationMiddlewareDecoratorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware\Enhancers;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\EnvelopeAwareInterface;
+use Symfony\Component\Messenger\Middleware\Enhancers\ActivationMiddlewareDecorator;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class ActivationMiddlewareDecoratorTest extends TestCase
+{
+    public function testExecuteMiddlewareOnActivated()
+    {
+        $message = new DummyMessage('Hello');
+        $envelope = Envelope::wrap($message);
+
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next->expects($this->never())->method('__invoke');
+
+        $middleware = $this->createMock(MiddlewareInterface::class);
+        $middleware->expects($this->once())->method('handle')->with($message, $next)->willReturn('Hello from middleware');
+
+        $decorator = new ActivationMiddlewareDecorator($middleware, true);
+
+        $this->assertSame('Hello from middleware', $decorator->handle($envelope, $next));
+    }
+
+    public function testExecuteMiddlewareOnActivatedWithCallable()
+    {
+        $message = new DummyMessage('Hello');
+        $envelope = Envelope::wrap($message);
+
+        $activated = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $activated->expects($this->once())->method('__invoke')->with($envelope)->willReturn(true);
+
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next->expects($this->never())->method('__invoke');
+
+        $middleware = $this->createMock(MiddlewareInterface::class);
+        $middleware->expects($this->once())->method('handle')->with($message, $next)->willReturn('Hello from middleware');
+
+        $decorator = new ActivationMiddlewareDecorator($middleware, $activated);
+
+        $this->assertSame('Hello from middleware', $decorator->handle($envelope, $next));
+    }
+
+    public function testExecuteEnvelopeAwareMiddlewareWithEnvelope()
+    {
+        $message = new DummyMessage('Hello');
+        $envelope = Envelope::wrap($message);
+
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next->expects($this->never())->method('__invoke');
+
+        $middleware = $this->createMock(array(MiddlewareInterface::class, EnvelopeAwareInterface::class));
+        $middleware->expects($this->once())->method('handle')->with($envelope, $next)->willReturn('Hello from middleware');
+
+        $decorator = new ActivationMiddlewareDecorator($middleware, true);
+
+        $this->assertSame('Hello from middleware', $decorator->handle($envelope, $next));
+    }
+
+    public function testExecuteMiddlewareOnDeactivated()
+    {
+        $message = new DummyMessage('Hello');
+        $envelope = Envelope::wrap($message);
+
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next->expects($this->once())->method('__invoke')->with($envelope)->willReturn('Hello from $next');
+
+        $middleware = $this->createMock(MiddlewareInterface::class);
+        $middleware->expects($this->never())->method('handle');
+
+        $decorator = new ActivationMiddlewareDecorator($middleware, false);
+
+        $this->assertSame('Hello from $next', $decorator->handle($envelope, $next));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | part of #26901   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | TODO: https://github.com/symfony/symfony-docs/issues/10035

A small middleware decorator that can be wired using DI decoration to enable/disable a middleware on an arbitrary condition. This can be used to keep the same middleware stack across env but enable/disable some of them through this.