### PR TITLE
[Serializer] deserialize from xml: Fix a collection that contains the only one element

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -255,6 +255,12 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $builtinType = Type::BUILTIN_TYPE_OBJECT;
                 $class = $collectionValueType->getClassName().'[]';
 
+                // Fix a collection that contains the only one element
+                // This is special to xml format only
+                if ('xml' === $format && !is_int(key($data))) {
+                    $data = array($data);
+                }
+
                 if (null !== $collectionKeyType = $type->getCollectionKeyType()) {
                     $context['key_type'] = $collectionKeyType;
                 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -13,9 +13,13 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 class AbstractObjectNormalizerTest extends TestCase
 {
@@ -68,6 +72,75 @@ class AbstractObjectNormalizerTest extends TestCase
             'any',
             array('allow_extra_attributes' => false)
         );
+    }
+
+    public function testDenormalizeCollectionDecodedFromXmlWithOneChild()
+    {
+        $denormalizer = $this->getDenormalizerForDummyCollection();
+
+        $dummyCollection = $denormalizer->denormalize(
+            array(
+                'children' => array(
+                    'bar' => 'first',
+                ),
+            ),
+            DummyCollection::class,
+            'xml'
+        );
+
+        $this->assertInstanceOf(DummyCollection::class, $dummyCollection);
+        $this->assertInternalType('array', $dummyCollection->children);
+        $this->assertCount(1, $dummyCollection->children);
+        $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[0]);
+    }
+
+    public function testDenormalizeCollectionDecodedFromXmlWithTwoChildren()
+    {
+        $denormalizer = $this->getDenormalizerForDummyCollection();
+
+        $dummyCollection = $denormalizer->denormalize(
+            array(
+                'children' => array(
+                    array('bar' => 'first'),
+                    array('bar' => 'second'),
+                ),
+            ),
+            DummyCollection::class,
+            'xml'
+        );
+
+        $this->assertInstanceOf(DummyCollection::class, $dummyCollection);
+        $this->assertInternalType('array', $dummyCollection->children);
+        $this->assertCount(2, $dummyCollection->children);
+        $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[0]);
+        $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[1]);
+    }
+
+    private function getDenormalizerForDummyCollection()
+    {
+        $extractor = $this->getMockBuilder('Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor')->getMock();
+        $extractor->method('getTypes')
+            ->will($this->onConsecutiveCalls(
+                array(
+                    new \Symfony\Component\PropertyInfo\Type(
+                        'array',
+                        false,
+                        null,
+                        true,
+                        new \Symfony\Component\PropertyInfo\Type('int'),
+                        new \Symfony\Component\PropertyInfo\Type('object', false, DummyChild::class)
+                    ),
+                ),
+                null
+            ));
+
+        $denormalizer = new AbstractObjectNormalizerCollectionDummy(null, null, $extractor);
+        $arrayDenormalizer = new ArrayDenormalizerDummy();
+        $serializer = new SerializerCollectionDummy(array($arrayDenormalizer, $denormalizer));
+        $arrayDenormalizer->setSerializer($serializer);
+        $denormalizer->setSerializer($serializer);
+
+        return $denormalizer;
     }
 }
 
@@ -122,5 +195,128 @@ class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
     protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = array())
     {
         $object->$attribute = $value;
+    }
+}
+
+class DummyCollection
+{
+    /** @var DummyChild[] */
+    public $children;
+}
+
+class DummyChild
+{
+    public $bar;
+}
+
+class SerializerCollectionDummy implements \Symfony\Component\Serializer\SerializerInterface, \Symfony\Component\Serializer\Normalizer\DenormalizerInterface
+{
+    /** @var \Symfony\Component\Serializer\Normalizer\DenormalizerInterface */
+    private $normalizers;
+
+    /**
+     * @param $normalizers
+     */
+    public function __construct($normalizers)
+    {
+        $this->normalizers = $normalizers;
+    }
+
+    public function serialize($data, $format, array $context = array())
+    {
+    }
+
+    public function deserialize($data, $type, $format, array $context = array())
+    {
+    }
+
+    public function denormalize($data, $type, $format = null, array $context = array())
+    {
+        foreach ($this->normalizers as $normalizer) {
+            if ($normalizer instanceof \Symfony\Component\Serializer\Normalizer\DenormalizerInterface && $normalizer->supportsDenormalization($data, $type, $format, $context)) {
+                return $normalizer->denormalize($data, $type, $format, $context);
+            }
+        }
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return true;
+    }
+}
+
+class AbstractObjectNormalizerCollectionDummy extends \Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer
+{
+    protected function extractAttributes($object, $format = null, array $context = array())
+    {
+    }
+
+    protected function getAttributeValue($object, $attribute, $format = null, array $context = array())
+    {
+    }
+
+    protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = array())
+    {
+        $object->$attribute = $value;
+    }
+
+    protected function isAllowedAttribute($classOrObject, $attribute, $format = null, array $context = array())
+    {
+        return true;
+    }
+
+    public function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes, $format = null)
+    {
+        return parent::instantiateObject($data, $class, $context, $reflectionClass, $allowedAttributes, $format);
+    }
+
+    public function serialize($data, $format, array $context = array())
+    {
+    }
+
+    public function deserialize($data, $type, $format, array $context = array())
+    {
+    }
+}
+
+class ArrayDenormalizerDummy implements DenormalizerInterface, SerializerAwareInterface
+{
+    /**
+     * @var SerializerInterface|DenormalizerInterface
+     */
+    private $serializer;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws NotNormalizableValueException
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $serializer = $this->serializer;
+        $class = substr($class, 0, -2);
+
+        foreach ($data as $key => $value) {
+            $data[$key] = $serializer->denormalize($value, $class, $format, $context);
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null, array $context = array())
+    {
+        return '[]' === substr($type, -2)
+            && $this->serializer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSerializer(SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27279
| License       | MIT
| Doc PR        | 

In xml when parent node (`restaurants`) contains several children nodes with the same tag (`restaurant`) it is clear that the children form a collection:

```
restaurants = {array} [1]
 restaurant = {array} [2]
  0 = {array} [2]
   name = "Some restaurant name"
   type = "Chinese"
  1 = {array} [2]
   name = "Another restaurant name"
   type = "Italian"
```

Afterwards the object denormalizer has no problem to create a collection of restaurants.

But when there is only one child (`restaurant`) the decoded normalized array will not contain a collection:

```
restaurants = {array} [1]
 restaurant = {array} [2]
  name = "Some restaurant name"
  type = "Chinese"
```

In this situation the object denormalizer threw unexpected exception. This PR modifies `AbstractObjectNormalizer` that is it will fill a collection containing the sole element properly.
