### PR TITLE
 [FrameworkBundle] fix typo in CacheClearCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -148,7 +148,7 @@ EOF
         if ('/' === \DIRECTORY_SEPARATOR && $mounts = @file('/proc/mounts')) {
             foreach ($mounts as $mount) {
                 $mount = array_slice(explode(' ', $mount), 1, -3);
-                if (!\in_array(array_pop($mount), array('vboxfs', 'nfs'))) {
+                if (!\in_array(array_pop($mount), array('vboxsf', 'nfs'))) {
                     continue;
                 }
                 $mount = implode(' ', $mount).'/';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

vboxsf is the correct name, see e.g. https://help.ubuntu.com/community/VirtualBox/SharedFolders
