### PR TITLE
[PhpUnitBridge] Making private service deprecation warning supressor more strict

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -123,12 +123,13 @@ class DeprecationErrorHandler
             // triggered deprecation notice; and the fourth event (index 3)
             // represents the action that called the deprecated code. In the
             // scenario that we want to suppress, the 4th event will be an
-            // object instance of \PHPUnit\Framework\TestCase.
+            // extension of Symfony\Bundle\FrameworkBundle\Test\KernelTestCase.
             if (isset($trace[3]['object'])) {
                 $isPrivateServiceNotice = false !== strpos($msg, ' service is private, ');
                 $isNoticeForContainerGetHasUsage = 'Symfony\Component\DependencyInjection\Container' === $trace[2]['class'] && in_array($trace[2]['function'], array('get', 'has'));
-                $noticeWasTriggeredByPhpUnitTest = $trace[3]['object'] instanceof \PHPUnit\Framework\TestCase;
-                if ($isPrivateServiceNotice && $isNoticeForContainerGetHasUsage && $noticeWasTriggeredByPhpUnitTest) {
+                $kernelTestCaseClass = 'Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase';
+                $noticeWasTriggeredByKernelTestCase = $trace[3]['object'] instanceof $kernelTestCaseClass;
+                if ($isPrivateServiceNotice && $isNoticeForContainerGetHasUsage && $noticeWasTriggeredByKernelTestCase) {
                     return false;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1+ (PhpUnitBridge current/master)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27037 
| License       | MIT
| Doc PR        | na

This issue related to #27037 and, more specifically, to @stof's comment on #27312 

```
shouldn't this test for the KernelTestCase instead (the parent TestCase does not have the client) 
```

I think this is sound logic, but I think we might even want to consider taking a step further.  Really, shouldn't we be checking for extensions of `Symfony\Bundle\FrameworkBundle\Test\WebTestCase`?  After all, `WebTestCase` is the class that provides the static `createClient()` method used for building a client, from which the (test) container is retrieved, according to the current documentation: https://symfony.com/doc/current/testing.html

@stof and @nicolas-grekas, the PR here is for `KernelTestCase`, but I can easily change it to check instead for `WebTestCase` if you think the reasoning above is sound.  I've tested both against my code, and they both work, but I am struggling to think of examples whereby a (proper) client/container is used within a test without extending `WebTestCase` and using the official approaches documented on the page linked above.  Let me know what you all think.
