### PR TITLE
[HttpKernel] reset kernel start time on reboot

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -87,18 +87,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $this->debug = (bool) $debug;
         $this->rootDir = $this->getRootDir();
         $this->name = $this->getName();
-
-        if ($this->debug) {
-            $this->startTime = microtime(true);
-        }
     }
 
     public function __clone()
     {
-        if ($this->debug) {
-            $this->startTime = microtime(true);
-        }
-
         $this->booted = false;
         $this->container = null;
         $this->requestStackSize = 0;
@@ -110,6 +102,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     public function boot()
     {
+        if ($this->debug) {
+            $this->startTime = microtime(true);
+        }
+
         if (true === $this->booted) {
             if (!$this->requestStackSize && $this->resetServices) {
                 if ($this->container->has('services_resetter')) {

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -902,6 +902,21 @@ EOF;
     }
 
     /**
+     * @group time-sensitive
+     */
+    public function testKernelStartTimeIsResetWhileBootingAlreadyBootedKernel()
+    {
+        $kernel = $this->getKernelForTest(array('initializeBundles'), true);
+        $kernel->boot();
+        $preReBoot = $kernel->getStartTime();
+
+        sleep(3600); //Intentionally large value to detect if ClockMock ever breaks
+        $kernel->boot();
+
+        $this->assertGreaterThan($preReBoot, $kernel->getStartTime());
+    }
+
+    /**
      * Returns a mock for the BundleInterface.
      *
      * @return BundleInterface
@@ -970,10 +985,10 @@ EOF;
         return $kernel;
     }
 
-    protected function getKernelForTest(array $methods = array())
+    protected function getKernelForTest(array $methods = array(), $debug = false)
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->setConstructorArgs(array('test', false))
+            ->setConstructorArgs(array('test', $debug))
             ->setMethods($methods)
             ->getMock();
         $p = new \ReflectionProperty($kernel, 'rootDir');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27319 
| License       | MIT
| Doc PR        | n/a

I created branch from 3.4, since the furthest thing I could find for the reboot feature was https://github.com/symfony/symfony/commit/a4fc49294eb40ae92ea99bede176f0c97086da09 and it originated during stabilization phase of 3.4.

ping @nicolas-grekas 