### PR TITLE
[Lock] Added Symfony/Component/Lock/Store/MongoDbStore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
         "doctrine/dbal": "~2.4",
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/doctrine-bundle": "~1.4",
+        "mongodb/mongodb": "~1.0",
         "monolog/monolog": "~1.11",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "predis/predis": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,6 @@
         "doctrine/dbal": "~2.4",
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/doctrine-bundle": "~1.4",
-        "mongodb/mongodb": "~1.0",
         "monolog/monolog": "~1.11",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "predis/predis": "~1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,7 @@
         <env name="LDAP_PORT" value="3389" />
         <env name="REDIS_HOST" value="localhost" />
         <env name="MEMCACHED_HOST" value="localhost" />
+        <env name="MONGODB_HOST" value="localhost" />
     </php>
 
     <testsuites>

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -195,6 +195,7 @@ class MongoDbStore implements StoreInterface
         );
 
         $key->reduceLifetime($ttl);
+
         try {
             $this->getCollection()->updateOne($filter, $update, $options);
         } catch (\MongoDB\Driver\Exception\WriteException $e) {

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -43,13 +43,13 @@ class MongoDbStore implements StoreInterface
      * lock collection.
      * An indexed field's value in MongoDB can be a maximum of 1024 bytes in
      * length inclusive of structural overhead.
+     *
      * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      *
      * CAUTION: This store relies on all client and server nodes to have
      * synchronized clocks for lock expiry to occur at the correct time.
      * To ensure locks don't expire prematurely; the lock TTL should be set
      * with enough extra time to account for any clock drift between nodes.
-     *
      * @see self::createTTLIndex()
      *
      * writeConcern, readConcern and readPreference are not specified by

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -35,12 +35,12 @@ class MongoDbStore implements StoreInterface
 
     /**
      * @param \MongoDB\Client $mongo
-     * @param array           $options
+     * @param array           $options      See below
+     * @param float           $initialTtl   The expiration delay of locks in seconds
      *
-     * database:    The name of the database [required]
-     * collection:  The name of the collection [default: lock]
-     *
-     * @param float $initialTtl the expiration delay of locks in seconds
+     * Options:
+     *      database:    The name of the database [required]
+     *      collection:  The name of the collection [default: lock]
      *
      * CAUTION: The locked resouce name is indexed in the _id field of the
      * lock collection.

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -45,10 +45,12 @@ class MongoDbStore implements StoreInterface
      *
      * writeConcern, readConcern and readPreference are not specified by MongoDbStore
      * meaning the collection's settings will take effect.
+     *
      * @see https://docs.mongodb.com/manual/applications/replication/
      *
      * Please note, the Symfony\Component\Lock\Key's $resource
      * must not exceed 1024 bytes including structural overhead.
+     *
      * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      */
     public function __construct(\MongoDB\Client $mongo, array $options)

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -1,0 +1,296 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Store;
+
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\LockExpiredException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\StoreInterface;
+
+/**
+ * MongoDbStore is a StoreInterface implementation using MongoDB as store engine.
+ *
+ * @author Joe Bennett <joe@assimtech.com>
+ */
+class MongoDbStore implements StoreInterface
+{
+    private $mongo;
+    private $options;
+    private $initialTtl;
+    private $collection;
+
+    /**
+     * @param \MongoDB\Client $mongo
+     * @param array $options
+     * List of available options:
+     *  * database: The name of the database [required]
+     *  * collection: The name of the collection [default: lock]
+     *  * resource_field: The field name for storing the lock id [default: _id] MUST be uniquely indexed if you chage it
+     *  * token_field: The field name for storing the lock token [default: token]
+     *  * aquired_field: The field name for storing the acquisition timestamp [default: aquired_at]
+     *  * expiry_field: The field name for storing the expiry-timestamp [default: expires_at].
+     *
+     * It is strongly recommended to put an index on the `expiry_field` for
+     * garbage-collection. Alternatively it's possible to automatically expire
+     * the locks in the database as described below:
+     *
+     * A TTL collections can be used on MongoDB 2.2+ to cleanup expired locks
+     * automatically. Such an index can for example look like this:
+     *
+     *     db.<session-collection>.ensureIndex(
+     *         { "<expiry-field>": 1 },
+     *         { "expireAfterSeconds": 0 }
+     *     )
+     *
+     * More details on: http://docs.mongodb.org/manual/tutorial/expire-data/
+     *
+     * @param float $initialTtl The expiration delay of locks in seconds
+     */
+    public function __construct(\MongoDB\Client $mongo, array $options = [], float $initialTtl = 300.0)
+    {
+        if (!isset($options['database'])) {
+            throw new \InvalidArgumentException(
+                'You must provide the "database" option for MongoDBStore'
+            );
+        }
+
+        $this->mongo = $mongo;
+
+        $this->options = array_merge([
+            'collection' => 'lock',
+            'resource_field' => '_id',
+            'token_field' => 'token',
+            'aquired_field' => 'aquired_at',
+            'expiry_field' => 'expires_at',
+        ], $options);
+
+        $this->initialTtl = $initialTtl;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * db.lock.update(
+     *     {
+     *         _id: "test",
+     *         expires_at: {
+     *             $lte : new Date()
+     *         }
+     *     },
+     *     {
+     *         _id: "test",
+     *         token: {# unique token #},
+     *         aquired: new Date(),
+     *         expires_at: new Date({# now + ttl #})
+     *     },
+     *     {
+     *         upsert: 1
+     *     }
+     * );
+     */
+    public function save(Key $key)
+    {
+        $expiry = $this->createDateTime(microtime(true) + $this->initialTtl);
+
+        $filter = [
+            $this->options['resource_field'] => (string)$key,
+            '$or' => [
+                [
+                    $this->options['token_field'] => $this->getToken($key),
+                ],
+                [
+                    $this->options['expiry_field'] => [
+                        '$lte' => $this->createDateTime(),
+                    ],
+                ],
+            ],
+        ];
+
+        $update = [
+            '$set' => [
+                $this->options['resource_field'] => (string)$key,
+                $this->options['token_field'] => $this->getToken($key),
+                $this->options['aquired_field'] => $this->createDateTime(),
+                $this->options['expiry_field'] => $expiry,
+            ],
+        ];
+
+        $options = [
+            'upsert' => true,
+        ];
+
+        $key->reduceLifetime($this->initialTtl);
+        try {
+            $this->getCollection()->updateOne($filter, $update, $options);
+        } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
+            throw new LockConflictedException('Failed to aquire lock', 0, $e);
+        }
+
+        if ($key->isExpired()) {
+            throw new LockExpiredException(sprintf('Failed to store the "%s" lock.', $key));
+        }
+    }
+
+    public function waitAndSave(Key $key)
+    {
+        throw new InvalidArgumentException(sprintf(
+            'The store "%s" does not supports blocking locks.',
+            __CLASS__
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * db.lock.update(
+     *     {
+     *         _id: "test",
+     *         token: {# unique token #},
+     *         expires_at: {
+     *             $gte : new Date()
+     *         }
+     *     },
+     *     {
+     *         _id: "test",
+     *         expires_at: new Date({# now + ttl #})
+     *     },
+     *     {
+     *         upsert: 1
+     *     }
+     * );
+     */
+    public function putOffExpiration(Key $key, $ttl)
+    {
+        $expiry = $this->createDateTime(microtime(true) + $ttl);
+
+        $filter = [
+            $this->options['resource_field'] => (string)$key,
+            $this->options['token_field'] => $this->getToken($key),
+            $this->options['expiry_field'] => [
+                '$gte' => $this->createDateTime(),
+            ],
+        ];
+
+        $update = [
+            '$set' =>[
+                $this->options['resource_field'] => (string)$key,
+                $this->options['expiry_field'] => $expiry,
+            ],
+        ];
+
+        $options = [
+            'upsert' => true,
+        ];
+
+        $key->reduceLifetime($ttl);
+        try {
+            $this->getCollection()->updateOne($filter, $update, $options);
+        } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
+            throw new LockConflictedException('Failed to put off the expiration of the lock', 0, $e);
+        }
+
+        if ($key->isExpired()) {
+            throw new LockExpiredException(sprintf(
+                'Failed to put off the expiration of the "%s" lock within the specified time.',
+                $key
+            ));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * db.lock.remove({
+     *     _id: "test"
+     * });
+     */
+    public function delete(Key $key)
+    {
+        $filter = [
+            $this->options['resource_field'] => (string)$key,
+            $this->options['token_field'] => $this->getToken($key),
+        ];
+
+        try {
+            $result = $this->getCollection()->deleteOne($filter);
+        } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
+            throw new LockConflictedException('Failed to delete lock', 0, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * db.lock.find({
+     *     _id: "test",
+     *     expires_at: {
+     *         $gte : new Date()
+     *     }
+     * });
+     */
+    public function exists(Key $key)
+    {
+        $filter = [
+            $this->options['resource_field'] => (string)$key,
+            $this->options['expiry_field'] => [
+                '$gte' => $this->createDateTime(),
+            ],
+        ];
+
+        $key->reduceLifetime($this->initialTtl);
+        $doc = $this->getCollection()->findOne($filter);
+
+        return $doc && $doc['token'] === $this->getToken($key);
+    }
+
+    private function getCollection(): \MongoDB\Collection
+    {
+        if (null === $this->collection) {
+            $this->collection = $this->mongo->selectCollection(
+                $this->options['database'],
+                $this->options['collection']
+            );
+        }
+
+        return $this->collection;
+    }
+
+    /**
+     * @param float $seconds Seconds since 1970-01-01T00:00:00.000Z supporting millisecond precision. Defaults to now.
+     *
+     * @return \MongoDB\BSON\UTCDateTime
+     */
+    private function createDateTime(float $seconds = null): \MongoDB\BSON\UTCDateTime
+    {
+        if (null === $seconds) {
+            $seconds = microtime(true);
+        }
+
+        $milliseconds = $seconds * 1000;
+
+        return new \MongoDB\BSON\UTCDateTime($milliseconds);
+    }
+
+    /**
+     * Retrieves an unique token for the given key.
+     */
+    private function getToken(Key $key): string
+    {
+        if (!$key->hasState(__CLASS__)) {
+            $token = base64_encode(random_bytes(32));
+            $key->setState(__CLASS__, $token);
+        }
+
+        return $key->getState(__CLASS__);
+    }
+}

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -37,7 +37,7 @@ class MongoDbStore implements StoreInterface
      *  * collection: The name of the collection [default: lock]
      *  * resource_field: The field name for storing the lock id [default: _id] MUST be uniquely indexed if you chage it
      *  * token_field: The field name for storing the lock token [default: token]
-     *  * aquired_field: The field name for storing the acquisition timestamp [default: aquired_at]
+     *  * acquired_field: The field name for storing the acquisition timestamp [default: acquired_at]
      *  * expiry_field: The field name for storing the expiry-timestamp [default: expires_at].
      *
      * It is strongly recommended to put an index on the `expiry_field` for
@@ -70,7 +70,7 @@ class MongoDbStore implements StoreInterface
             'collection' => 'lock',
             'resource_field' => '_id',
             'token_field' => 'token',
-            'aquired_field' => 'aquired_at',
+            'acquired_field' => 'acquired_at',
             'expiry_field' => 'expires_at',
         ], $options);
 
@@ -90,7 +90,7 @@ class MongoDbStore implements StoreInterface
      *     {
      *         _id: "test",
      *         token: {# unique token #},
-     *         aquired: new Date(),
+     *         acquired: new Date(),
      *         expires_at: new Date({# now + ttl #})
      *     },
      *     {
@@ -120,7 +120,7 @@ class MongoDbStore implements StoreInterface
             '$set' => [
                 $this->options['resource_field'] => (string)$key,
                 $this->options['token_field'] => $this->getToken($key),
-                $this->options['aquired_field'] => $this->createDateTime(),
+                $this->options['acquired_field'] => $this->createDateTime(),
                 $this->options['expiry_field'] => $expiry,
             ],
         ];
@@ -133,7 +133,7 @@ class MongoDbStore implements StoreInterface
         try {
             $this->getCollection()->updateOne($filter, $update, $options);
         } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
-            throw new LockConflictedException('Failed to aquire lock', 0, $e);
+            throw new LockConflictedException('Failed to acquire lock', 0, $e);
         }
 
         if ($key->isExpired()) {

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -45,7 +45,6 @@ class MongoDbStore implements StoreInterface
      *
      * A TTL index MUST BE used on MongoDB 2.2+ to automatically clean up expired locks.
      *
-     *
      *     db.lock.ensureIndex(
      *         { "expires_at": 1 },
      *         { "expireAfterSeconds": 0 }

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -88,10 +88,11 @@ class MongoDbStore implements StoreInterface
      *
      * @see http://docs.mongodb.org/manual/tutorial/expire-data/
      *
-     * @return string The name of the created index as a string.
+     * @return string The name of the created index as a string
      *
-     * @throws \MongoDB\Exception\UnsupportedException
-     * @throws \MongoDB\Exception\InvalidArgumentException
+     * @throws \MongoDB\Exception\UnsupportedException if options are not supported by the selected server
+     * @throws \MongoDB\Exception\InvalidArgumentException for parameter/option parsing errors
+     * @throws \MongoDB\Exception\DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     public function createTTLIndex(): string
     {

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -50,7 +50,6 @@ class MongoDbStore implements StoreInterface
      *
      * Please note, the Symfony\Component\Lock\Key's $resource
      * must not exceed 1024 bytes including structural overhead.
-     *
      * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      */
     public function __construct(\MongoDB\Client $mongo, array $options)

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -246,7 +246,6 @@ class MongoDbStore implements StoreInterface
             ),
         );
 
-        $key->reduceLifetime($this->initialTtl);
         $doc = $this->getCollection()->findOne($filter);
 
         return $doc && $doc['token'] === $this->getToken($key);

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -40,16 +40,19 @@ class MongoDbStore implements StoreInterface
      *
      * CAUTION: This store relies on all client and server nodes to have
      * synchronized clocks for lock expiry to occur at the correct time.
-     * To ensure locks don't expire prematurely; the ttl's should be set with enough
-     * extra time to account for any clock drift between nodes.
+     * To ensure locks don't expire prematurely; the lock TTL should be set
+     * with enough extra time to account for any clock drift between nodes.
      *
-     * writeConcern, readConcern and readPreference are not specified by MongoDbStore
-     * meaning the collection's settings will take effect.
+     * @see self::createTTLIndex() For more info on creating a TTL index
+     *
+     * writeConcern, readConcern and readPreference are not specified by
+     * MongoDbStore meaning the collection's settings will take effect.
      *
      * @see https://docs.mongodb.com/manual/applications/replication/
      *
      * Please note, the Symfony\Component\Lock\Key's $resource
      * must not exceed 1024 bytes including structural overhead.
+     *
      * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      */
     public function __construct(\MongoDB\Client $mongo, array $options)

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -47,12 +47,10 @@ class MongoDbStore implements StoreInterface
      *
      * writeConcern, readConcern and readPreference are not specified by
      * MongoDbStore meaning the collection's settings will take effect.
-     *
      * @see https://docs.mongodb.com/manual/applications/replication/
      *
      * Please note, the Symfony\Component\Lock\Key's $resource
      * must not exceed 1024 bytes including structural overhead.
-     *
      * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      */
     public function __construct(\MongoDB\Client $mongo, array $options)

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -90,9 +90,9 @@ class MongoDbStore implements StoreInterface
      *
      * @return string The name of the created index as a string
      *
-     * @throws \MongoDB\Exception\UnsupportedException if options are not supported by the selected server
+     * @throws \MongoDB\Exception\UnsupportedException     if options are not supported by the selected server
      * @throws \MongoDB\Exception\InvalidArgumentException for parameter/option parsing errors
-     * @throws \MongoDB\Exception\DriverRuntimeException for other driver errors (e.g. connection errors)
+     * @throws \MongoDB\Exception\DriverRuntimeException   for other driver errors (e.g. connection errors)
      */
     public function createTTLIndex(): string
     {

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -56,7 +56,7 @@ class MongoDbStore implements StoreInterface
      * must not exceed 1024 bytes including structural overhead.
      * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      *
-     * @param float           $initialTtl The expiration delay of locks in seconds
+     * @param float $initialTtl The expiration delay of locks in seconds
      */
     public function __construct(\MongoDB\Client $mongo, array $options, float $initialTtl = 300.0)
     {

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -39,17 +39,18 @@ class MongoDbStore implements StoreInterface
      * collection:  The name of the collection [default: lock]
      * initialTtl:  The expiration delay of locks in seconds [default: 300.0]
      *
-     * CAUTION: This store relies on all client and server nodes to have
-     * synchronized clocks for lock expiry to occur at the correct time.
-     * To ensure locks don't expire prematurely; the lock TTL should be set
-     * with enough extra time to account for any clock drift between nodes.
-     * @see self::createTTLIndex()
-     *
-     * CAUTION: The locked resouce name is indexed in the ``_id`` field of the
+     * CAUTION: The locked resouce name is indexed in the _id field of the
      * lock collection.
      * An indexed field's value in MongoDB can be a maximum of 1024 bytes in
      * length inclusive of structural overhead.
      * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
+     *
+     * CAUTION: This store relies on all client and server nodes to have
+     * synchronized clocks for lock expiry to occur at the correct time.
+     * To ensure locks don't expire prematurely; the lock TTL should be set
+     * with enough extra time to account for any clock drift between nodes.
+     *
+     * @see self::createTTLIndex()
      *
      * writeConcern, readConcern and readPreference are not specified by
      * MongoDbStore meaning the collection's settings will take effect.

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -35,8 +35,8 @@ class MongoDbStore implements StoreInterface
 
     /**
      * @param \MongoDB\Client $mongo
-     * @param array           $options      See below
-     * @param float           $initialTtl   The expiration delay of locks in seconds
+     * @param array           $options    See below
+     * @param float           $initialTtl The expiration delay of locks in seconds
      *
      * Options:
      *      database:    The name of the database [required]

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -33,7 +33,7 @@ class MongoDbStore implements StoreInterface
 
     /**
      * @param \MongoDB\Client $mongo
-     * @param array $options
+     * @param array           $options
      *
      * database:    The name of the database [required]
      * collection:  The name of the collection [default: lock]
@@ -53,11 +53,10 @@ class MongoDbStore implements StoreInterface
      * @see http://docs.mongodb.org/manual/tutorial/expire-data/
      *
      * Please note, the Symfony\Component\Lock\Key's $resource
-     * must not exceed 1024 bytes including structual overhead.
-     *
+     * must not exceed 1024 bytes including structural overhead.
      * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      *
-     * @param float $initialTtl The expiration delay of locks in seconds
+     * @param float           $initialTtl The expiration delay of locks in seconds
      */
     public function __construct(\MongoDB\Client $mongo, array $options, float $initialTtl = 300.0)
     {

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -146,6 +146,7 @@ class MongoDbStore implements StoreInterface
         );
 
         $key->reduceLifetime($this->initialTtl);
+
         try {
             $this->getCollection()->updateOne($filter, $update, $options);
         } catch (\MongoDB\Driver\Exception\WriteException $e) {

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -20,7 +20,8 @@ use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
 
 /**
- * MongoDbStore is a StoreInterface implementation using MongoDB as store engine.
+ * MongoDbStore is a StoreInterface implementation using MongoDB as a storage
+ * engine.
  *
  * @author Joe Bennett <joe@assimtech.com>
  */
@@ -42,16 +43,17 @@ class MongoDbStore implements StoreInterface
      * synchronized clocks for lock expiry to occur at the correct time.
      * To ensure locks don't expire prematurely; the lock TTL should be set
      * with enough extra time to account for any clock drift between nodes.
+     * @see self::createTTLIndex()
      *
-     * @see self::createTTLIndex() For more info on creating a TTL index
+     * CAUTION: The locked resouce name is indexed in the ``_id`` field of the
+     * lock collection.
+     * An indexed field's value in MongoDB can be a maximum of 1024 bytes in
+     * length inclusive of structural overhead.
+     * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      *
      * writeConcern, readConcern and readPreference are not specified by
      * MongoDbStore meaning the collection's settings will take effect.
      * @see https://docs.mongodb.com/manual/applications/replication/
-     *
-     * Please note, the Symfony\Component\Lock\Key's $resource
-     * must not exceed 1024 bytes including structural overhead.
-     * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      */
     public function __construct(\MongoDB\Client $mongo, array $options)
     {

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -87,8 +87,13 @@ class MongoDbStore implements StoreInterface
      * A TTL index MUST BE used on MongoDB 2.2+ to automatically clean up expired locks.
      *
      * @see http://docs.mongodb.org/manual/tutorial/expire-data/
+     *
+     * @return string The name of the created index as a string.
+     *
+     * @throws \MongoDB\Exception\UnsupportedException
+     * @throws \MongoDB\Exception\InvalidArgumentException
      */
-    public function createTTLIndex(): bool
+    public function createTTLIndex(): string
     {
         $keys = array(
             'expires_at' => 1,

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -45,12 +45,10 @@ class MongoDbStore implements StoreInterface
      *
      * writeConcern, readConcern and readPreference are not specified by MongoDbStore
      * meaning the collection's settings will take effect.
-     *
      * @see https://docs.mongodb.com/manual/applications/replication/
      *
      * Please note, the Symfony\Component\Lock\Key's $resource
      * must not exceed 1024 bytes including structural overhead.
-     *
      * @see https://docs.mongodb.com/manual/reference/limits/#Index-Key-Limit
      */
     public function __construct(\MongoDB\Client $mongo, array $options)
@@ -90,9 +88,11 @@ class MongoDbStore implements StoreInterface
         $keys = array(
             'expires_at' => 1,
         );
+
         $options = array(
             'expireAfterSeconds' => 0,
         );
+
         return $this->getCollection()->createIndex($keys, $options);
     }
 

--- a/src/Symfony/Component/Lock/StoreInterface.php
+++ b/src/Symfony/Component/Lock/StoreInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock;
 
 use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\LockExpiredException;
 use Symfony\Component\Lock\Exception\NotSupportedException;
 
 /**
@@ -25,6 +26,7 @@ interface StoreInterface
      * Stores the resource if it's not locked by someone else.
      *
      * @throws LockConflictedException
+     * @throws LockExpiredException
      */
     public function save(Key $key);
 
@@ -34,6 +36,7 @@ interface StoreInterface
      * If the store does not support this feature it should throw a NotSupportedException.
      *
      * @throws LockConflictedException
+     * @throws LockExpiredException
      * @throws NotSupportedException
      */
     public function waitAndSave(Key $key);
@@ -46,6 +49,7 @@ interface StoreInterface
      * @param float $ttl amount of second to keep the lock in the store
      *
      * @throws LockConflictedException
+     * @throws LockExpiredException
      * @throws NotSupportedException
      */
     public function putOffExpiration(Key $key, $ttl);

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use Symfony\Component\Lock\Store\MongoDbStore;
+
+/**
+ * @author Joe Bennett <joe@assimtech.com>
+ */
+class MongoDbClientTest extends AbstractStoreTest
+{
+    use ExpiringStoreTestTrait;
+
+    public static function setupBeforeClass()
+    {
+        try {
+            $client = self::getMongoConnection();
+            $client->listDatabases();
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
+        }
+    }
+
+    protected static function getMongoConnection(): \MongoDB\Client
+    {
+        return new \MongoDB\Client('mongodb://'.getenv('MONGODB_HOST'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getClockDelay()
+    {
+        return 250000;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStore()
+    {
+        return new MongoDbStore(self::getMongoConnection(), [
+            'database' => 'test',
+        ]);
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
@@ -60,6 +60,6 @@ class MongoDbClientTest extends AbstractStoreTest
     {
         $store = $this->getStore();
 
-        $this->assertTrue($store->createTTLIndex());
+        $this->assertEquals($store->createTTLIndex(), 'expires_at_1');
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
@@ -55,4 +55,11 @@ class MongoDbClientTest extends AbstractStoreTest
             'database' => 'test',
         ));
     }
+
+    public function testCreateIndex()
+    {
+        $store = $this->getStore();
+
+        $this->assertTrue($store->createTTLIndex());
+    }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
@@ -23,6 +23,9 @@ class MongoDbClientTest extends AbstractStoreTest
     public static function setupBeforeClass()
     {
         try {
+            if (!class_exists(\MongoDB\Client::class)) {
+                throw new \RuntimeException('The mongodb/mongodb package is required.');
+            }
             $client = self::getMongoConnection();
             $client->listDatabases();
         } catch (\Exception $e) {

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbClientTest.php
@@ -48,8 +48,8 @@ class MongoDbClientTest extends AbstractStoreTest
      */
     public function getStore()
     {
-        return new MongoDbStore(self::getMongoConnection(), [
+        return new MongoDbStore(self::getMongoConnection(), array(
             'database' => 'test',
-        ]);
+        ));
     }
 }

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -20,7 +20,8 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "predis/predis": "~1.0"
+        "predis/predis": "~1.0",
+        "mongodb/mongodb": "~1.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Lock\\": "" },

--- a/src/Symfony/Component/Lock/phpunit.xml.dist
+++ b/src/Symfony/Component/Lock/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1" />
         <env name="REDIS_HOST" value="localhost" />
         <env name="MEMCACHED_HOST" value="localhost" />
+        <env name="MONGODB_HOST" value="localhost" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (requires `ext-mongodb` and `mongodb/mongodb` to test)
| Fixed tickets | #27345 
| License       | MIT
| Doc PR        | symfony/symfony-docs#9807

**Testing caveat**  
In order to test this, the test environment needs `ext-mongodb` and `mongodb/mongodb`. Travis has `ext-mongodb` but Appveyor doesn't meaning I can't `require-dev` `mongodb/mongodb`. I had a look at `Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler` since it poses the same issue and neither `symfony/symfony/src/Symfony/Component/HttpFoundation/composer.json` nor `symfony/symfony/composer.json` `require-dev` `mongodb/mongodb`. They both skip mongo based tests in the ci environments. I have therefore chosen to omit `require-dev` `mongodb/mongodb`.

I have both written the test and tested `Symfony\Component\Lock\Store\MongoDbStore` and it does pass in an environment with `ext-mongodb` and `mongodb/mongodb`.

**Description**  
We should support Semaphore Locks with a MongoDB back end to allow those that already use MongoDB as a distributed storage engine.

Symfony already partially supports MongoDB for session storage: `Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandler`

**Example**

```php
$client = new MongoDb\Client();

$store = new Symfony\Component\Lock\Store\MongoDbStore(
    $client
    array(
        'database' => 'my-app',
    )
);
$lockFactory = new Symfony\Component\Lock\Factory($store);
$lock = $lockFactory->createLock('my-resource');
```