### PR TITLE
Remove reference to the test container after kernel shutdown

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -123,6 +123,7 @@ abstract class KernelTestCase extends TestCase
                 $container->reset();
             }
         }
+        static::$container = null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This reference is not working anymore, as the main container was reset and cleaned. Keeping a reference to the test container will prevent collecting the object graph.
