### PR TITLE
[FrameworkBundle] cleanup generated test container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerRealRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerRealRefPass.php
@@ -27,13 +27,21 @@ class TestServiceContainerRealRefPass implements CompilerPassInterface
         }
 
         $testContainer = $container->getDefinition('test.service_container');
-        $privateContainer = $container->getDefinition((string) $testContainer->getArgument(2));
+        $privateContainer = $testContainer->getArgument(2);
+        if ($privateContainer instanceof Reference) {
+            $privateContainer = $container->getDefinition((string) $privateContainer);
+        }
         $definitions = $container->getDefinitions();
+        $privateServices = $privateContainer->getArgument(0);
 
-        foreach ($privateContainer->getArgument(0) as $id => $argument) {
+        foreach ($privateServices as $id => $argument) {
             if (isset($definitions[$target = (string) $argument->getValues()[0]])) {
                 $argument->setValues(array(new Reference($target)));
+            } else {
+                unset($privateServices[$id]);
             }
         }
+
+        $privateContainer->replaceArgument(0, $privateServices);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
@@ -31,7 +31,7 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
         $definitions = $container->getDefinitions();
 
         foreach ($definitions as $id => $definition) {
-            if ((!$definition->isPublic() || $definition->isPrivate()) && !$definition->getErrors() && !$definition->isAbstract()) {
+            if ($id && '.' !== $id[0] && (!$definition->isPublic() || $definition->isPrivate()) && !$definition->getErrors() && !$definition->isAbstract()) {
                 $privateServices[$id] = new ServiceClosureArgument(new Reference($id, ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE));
             }
         }
@@ -39,7 +39,7 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
         $aliases = $container->getAliases();
 
         foreach ($aliases as $id => $alias) {
-            if (!$alias->isPublic() || $alias->isPrivate()) {
+            if ($id && '.' !== $id[0] && (!$alias->isPublic() || $alias->isPrivate())) {
                 while (isset($aliases[$target = (string) $alias])) {
                     $alias = $aliases[$target];
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/TestServiceContainerTest.php
@@ -42,6 +42,6 @@ class TestServiceContainerTest extends WebTestCase
         $this->assertTrue(static::$container->has(NonPublicService::class));
         $this->assertTrue(static::$container->has(PrivateService::class));
         $this->assertTrue(static::$container->has('private_service'));
-        $this->assertTrue(static::$container->has(UnusedPrivateService::class));
+        $this->assertFalse(static::$container->has(UnusedPrivateService::class));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Cleans up removed and hidden services, fixes an issue when the private container locator is inlined.