### PR TITLE
[HttpFoundation] Fix cookie test with xdebug

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/common.inc
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/common.inc
@@ -22,6 +22,10 @@ error_reporting(-1);
 ini_set('html_errors', 0);
 ini_set('display_errors', 1);
 
+if (ini_get('xdebug.default_enable')) {
+    xdebug_disable();
+}
+
 header_remove('X-Powered-By');
 header('Content-Type: text/plain; charset=utf-8');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Here's the failure without this patch:

```
Testing Symfony\Component\HttpFoundation\Tests\ResponseFunctionalTest
F.....                                                              6 / 6 (100%)

Time: 1.07 seconds, Memory: 4.00MB

There was 1 failure:

1) Symfony\Component\HttpFoundation\Tests\ResponseFunctionalTest::testCookie with data set #0 ('cookie_max_age')
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 Warning: Expiry date cannot have a year greater than 9999 in /home/gadelat/PhpstormProjects/symfony/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.php on line 10
 
+Call Stack:
+    0.0004     390392   1. {main}() /home/gadelat/PhpstormProjects/symfony/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.php:0
+    0.0178     500960   2. setcookie() /home/gadelat/PhpstormProjects/symfony/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.php:10
+
+
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
     [1] => Cache-Control: no-cache, private
     [2] => Date: Sat, 12 Nov 1955 20:04:00 GMT
-    [3] => Set-Cookie: foo=bar; expires=Sat, 01-Jan-10000 02:46:40 GMT; Max-Age=%d; path=/
+    [3] => Set-Cookie: foo=bar; expires=Sat, 01-Jan-10000 02:46:40 GMT; Max-Age=251875115405; path=/
 )
 shutdown

/home/gadelat/PhpstormProjects/symfony/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php:49
```