### PR TITLE
Tweak Argon2 test config

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
@@ -30,7 +30,7 @@ class Argon2iPasswordEncoderTest extends TestCase
 
     public function testValidationWithConfig()
     {
-        $encoder = new Argon2iPasswordEncoder(4, 4, 1);
+        $encoder = new Argon2iPasswordEncoder(8, 4, 1);
         $result = $encoder->encodePassword(self::PASSWORD, null);
         $this->assertTrue($encoder->isPasswordValid($result, self::PASSWORD, null));
         $this->assertFalse($encoder->isPasswordValid($result, 'anotherPassword', null));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Memory cost 8 seems to be lowest value accepted on my machine

```
Testing Symfony\Component\Security\Core\Tests\Encoder\Argon2iPasswordEncoderTest
E....                                                               5 / 5 (100%)

Time: 114 ms, Memory: 4.00MB

There was 1 error:

1) Symfony\Component\Security\Core\Tests\Encoder\Argon2iPasswordEncoderTest::testValidationWithConfig
password_hash(): Memory cost is outside of allowed memory range

/home/gadelat/PhpstormProjects/symfony/src/Symfony/Component/Security/Core/Encoder/Argon2iPasswordEncoder.php:105
/home/gadelat/PhpstormProjects/symfony/src/Symfony/Component/Security/Core/Encoder/Argon2iPasswordEncoder.php:67
/home/gadelat/PhpstormProjects/symfony/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php:34
```