### PR TITLE
[FrameworkBundle] Fix using test.service_container when Client is rebooted

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -30,15 +30,15 @@ class Client extends BaseClient
     private $hasPerformedRequest = false;
     private $profiler = false;
     private $reboot = true;
-    private $container;
+    private $testContainerId;
 
     /**
      * {@inheritdoc}
      */
-    public function __construct(KernelInterface $kernel, array $server = array(), History $history = null, CookieJar $cookieJar = null, ContainerInterface $container = null)
+    public function __construct(KernelInterface $kernel, array $server = array(), History $history = null, CookieJar $cookieJar = null, string $testContainerId = null)
     {
         parent::__construct($kernel, $server, $history, $cookieJar);
-        $this->container = $container;
+        $this->testContainerId = $testContainerId;
     }
 
     /**
@@ -48,7 +48,9 @@ class Client extends BaseClient
      */
     public function getContainer()
     {
-        return $this->container ?? $this->kernel->getContainer();
+        $container = $this->kernel->getContainer();
+
+        return null !== $this->testContainerId ? $container->get($this->testContainerId) : $container;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -16,7 +16,7 @@
             <argument>%test.client.parameters%</argument>
             <argument type="service" id="test.client.history" />
             <argument type="service" id="test.client.cookiejar" />
-            <argument type="service" id="test.service_container" />
+            <argument>test.service_container</argument>
         </service>
 
         <service id="test.client.history" class="Symfony\Component\BrowserKit\History" shared="false" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -24,27 +24,24 @@ class AutowiringTypesTest extends WebTestCase
     public function testAnnotationReaderAutowiring()
     {
         static::bootKernel(array('root_config' => 'no_annotations_cache.yml', 'environment' => 'no_annotations_cache'));
-        $container = static::$kernel->getContainer();
 
-        $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
+        $annotationReader = static::$container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(AnnotationReader::class, $annotationReader);
     }
 
     public function testCachedAnnotationReaderAutowiring()
     {
         static::bootKernel();
-        $container = static::$kernel->getContainer();
 
-        $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
+        $annotationReader = static::$container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(CachedReader::class, $annotationReader);
     }
 
     public function testTemplatingAutowiring()
     {
         static::bootKernel();
-        $container = static::$kernel->getContainer();
 
-        $autowiredServices = $container->get('test.autowiring_types.autowired_services');
+        $autowiredServices = static::$container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(FrameworkBundleEngineInterface::class, $autowiredServices->getFrameworkBundleEngine());
         $this->assertInstanceOf(ComponentEngineInterface::class, $autowiredServices->getEngine());
     }
@@ -52,24 +49,21 @@ class AutowiringTypesTest extends WebTestCase
     public function testEventDispatcherAutowiring()
     {
         static::bootKernel(array('debug' => false));
-        $container = static::$kernel->getContainer();
 
-        $autowiredServices = $container->get('test.autowiring_types.autowired_services');
+        $autowiredServices = static::$container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(EventDispatcher::class, $autowiredServices->getDispatcher(), 'The event_dispatcher service should be injected if the debug is not enabled');
 
         static::bootKernel(array('debug' => true));
-        $container = static::$kernel->getContainer();
 
-        $autowiredServices = $container->get('test.autowiring_types.autowired_services');
+        $autowiredServices = static::$container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(TraceableEventDispatcher::class, $autowiredServices->getDispatcher(), 'The debug.event_dispatcher service should be injected if the debug is enabled');
     }
 
     public function testCacheAutowiring()
     {
         static::bootKernel();
-        $container = static::$kernel->getContainer();
 
-        $autowiredServices = $container->get('test.autowiring_types.autowired_services');
+        $autowiredServices = static::$container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(FilesystemAdapter::class, $autowiredServices->getCachePool());
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -77,9 +77,8 @@ class CachePoolClearCommandTest extends WebTestCase
 
     private function createCommandTester()
     {
-        $container = static::$kernel->getContainer();
         $application = new Application(static::$kernel);
-        $application->add(new CachePoolClearCommand($container->get('cache.global_clearer')));
+        $application->add(new CachePoolClearCommand(static::$container->get('cache.global_clearer')));
 
         return new CommandTester($application->find('cache:pool:clear'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -70,7 +70,7 @@ class CachePoolsTest extends WebTestCase
     private function doTestCachePools($options, $adapterClass)
     {
         static::bootKernel($options);
-        $container = static::$kernel->getContainer();
+        $container = static::$container;
 
         $pool1 = $container->get('cache.pool1');
         $this->assertInstanceOf($adapterClass, $pool1);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -26,12 +26,12 @@ class ContainerDebugCommandTest extends WebTestCase
         $application = new Application(static::$kernel);
         $application->setAutoExit(false);
 
-        @unlink(static::$kernel->getContainer()->getParameter('debug.container.dump'));
+        @unlink(static::$container->getParameter('debug.container.dump'));
 
         $tester = new ApplicationTester($application);
         $tester->run(array('command' => 'debug:container'));
 
-        $this->assertFileExists(static::$kernel->getContainer()->getParameter('debug.container.dump'));
+        $this->assertFileExists(static::$container->getParameter('debug.container.dump'));
     }
 
     public function testNoDebug()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -19,9 +19,8 @@ class SerializerTest extends WebTestCase
     public function testDeserializeArrayOfObject()
     {
         static::bootKernel(array('test_case' => 'Serializer'));
-        $container = static::$kernel->getContainer();
 
-        $result = $container->get('serializer')->deserialize('{"bars": [{"id": 1}, {"id": 2}]}', Foo::class, 'json');
+        $result = static::$container->get('serializer')->deserialize('{"bars": [{"id": 1}, {"id": 2}]}', Foo::class, 'json');
 
         $bar1 = new Bar();
         $bar1->id = 1;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
@@ -19,15 +19,13 @@ class AutowiringTypesTest extends WebTestCase
     public function testAccessDecisionManagerAutowiring()
     {
         static::bootKernel(array('debug' => false));
-        $container = static::$kernel->getContainer();
 
-        $autowiredServices = $container->get('test.autowiring_types.autowired_services');
+        $autowiredServices = static::$container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(AccessDecisionManager::class, $autowiredServices->getAccessDecisionManager(), 'The security.access.decision_manager service should be injected in debug mode');
 
         static::bootKernel(array('debug' => true));
-        $container = static::$kernel->getContainer();
 
-        $autowiredServices = $container->get('test.autowiring_types.autowired_services');
+        $autowiredServices = static::$container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(TraceableAccessDecisionManager::class, $autowiredServices->getAccessDecisionManager(), 'The debug.security.access.decision_manager service should be injected in non-debug mode');
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
@@ -35,18 +35,18 @@ class LogoutTest extends WebTestCase
     public function testCsrfTokensAreClearedOnLogout()
     {
         $client = $this->createClient(array('test_case' => 'LogoutWithoutSessionInvalidation', 'root_config' => 'config.yml'));
-        static::$kernel->getContainer()->get('test.security.csrf.token_storage')->setToken('foo', 'bar');
+        $client->getContainer()->get('security.csrf.token_storage')->setToken('foo', 'bar');
 
         $client->request('POST', '/login', array(
             '_username' => 'johannes',
             '_password' => 'test',
         ));
 
-        $this->assertTrue(static::$kernel->getContainer()->get('test.security.csrf.token_storage')->hasToken('foo'));
-        $this->assertSame('bar', static::$kernel->getContainer()->get('test.security.csrf.token_storage')->getToken('foo'));
+        $this->assertTrue($client->getContainer()->get('security.csrf.token_storage')->hasToken('foo'));
+        $this->assertSame('bar', $client->getContainer()->get('security.csrf.token_storage')->getToken('foo'));
 
         $client->request('GET', '/logout');
 
-        $this->assertFalse(static::$kernel->getContainer()->get('test.security.csrf.token_storage')->hasToken('foo'));
+        $this->assertFalse($client->getContainer()->get('security.csrf.token_storage')->hasToken('foo'));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
@@ -1,11 +1,6 @@
 imports:
     - { resource: ./../config/framework.yml }
 
-services:
-    test.security.csrf.token_storage:
-        alias: security.csrf.token_storage
-        public: true
-
 security:
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -47,7 +47,7 @@
         "symfony/security": "4.1.0-beta1|4.1.0-beta2",
         "symfony/var-dumper": "<3.4",
         "symfony/event-dispatcher": "<3.4",
-        "symfony/framework-bundle": "<4.1",
+        "symfony/framework-bundle": "<=4.1-beta2",
         "symfony/console": "<3.4"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
