### PR TITLE
[Form] Fix error when rendering a DateIntervalType form with exactly 0 weeks

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
@@ -89,7 +89,7 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
             $result[$field] = $dateInterval->format('%'.($this->pad ? strtoupper($char) : $char));
         }
         if (in_array('weeks', $this->fields, true)) {
-            $result['weeks'] = 0;
+            $result['weeks'] = '0';
             if (isset($result['days']) && (int) $result['days'] >= 7) {
                 $result['weeks'] = (string) floor($result['days'] / 7);
                 $result['days'] = (string) ($result['days'] % 7);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateIntervalToArrayTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateIntervalToArrayTransformerTest.php
@@ -90,6 +90,21 @@ class DateIntervalToArrayTransformerTest extends DateIntervalTestCase
         $this->assertSame($output, $input);
     }
 
+    public function testTransformWithZeroWeek()
+    {
+        $transformer = new DateIntervalToArrayTransformer(array('weeks', 'minutes', 'seconds'));
+        $input = new \DateInterval('P1Y2M0WT4H5M6S');
+        $output = array(
+            'weeks' => '0',
+            'minutes' => '5',
+            'seconds' => '6',
+        );
+        $input = $transformer->transform($input);
+        ksort($input);
+        ksort($output);
+        $this->assertSame($output, $input);
+    }
+
     public function testTransformDaysToWeeks()
     {
         $transformer = new DateIntervalToArrayTransformer(array('weeks', 'minutes', 'seconds'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27378
| License       | MIT

Fixes the issue described in #27378
