### PR TITLE
[Serializer] Fix serializer tries to denormalize null values on nullable properties

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -349,6 +349,12 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
                     }
                 } elseif ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
                     $parameterData = $data[$key];
+                    if (null === $parameterData && $constructorParameter->allowsNull()) {
+                        $params[] = null;
+                        // Don't run set for a parameter passed to the constructor
+                        unset($data[$key]);
+                        continue;
+                    }
                     try {
                         if (null !== $constructorParameter->getClass()) {
                             if (!$this->serializer instanceof DenormalizerInterface) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NullableConstructorArgumentDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NullableConstructorArgumentDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class NullableConstructorArgumentDummy
+{
+    private $foo;
+
+    public function __construct(?\stdClass $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function setFoo($foo)
+    {
+        $this->foo = 'this setter should not be called when using the constructor argument';
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractNormalizerDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\NullableConstructorArgumentDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\ProxyDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorNormalizer;
@@ -115,5 +116,16 @@ class AbstractNormalizerTest extends TestCase
         $this->assertInstanceOf(StaticConstructorDummy::class, $dummy);
         $this->assertEquals('baz', $dummy->quz);
         $this->assertNull($dummy->foo);
+    }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function testObjectWithNullableConstructorArgument()
+    {
+        $normalizer = new ObjectNormalizer();
+        $dummy = $normalizer->denormalize(array('foo' => null), NullableConstructorArgumentDummy::class);
+
+        $this->assertNull($dummy->getFoo());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27384   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A