### PR TITLE
[Form] mention "help" field option in UPGRADE file

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -64,6 +64,9 @@ Form
    }
    ```
 
+ * Added `help` option to the form field. If you have custom Form extension for it, you should remove it. 
+   Also remove it from the custom form theme.  
+
 FrameworkBundle
 ---------------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | no 
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

When you have your own Form Extension to handle help option (e.g. similar to the one mentioned in the [blog post](https://symfony.com/blog/new-in-symfony-4-1-form-field-help)), it starts to render twice in the form after upgrading to 4.1 (where #26332 was added)

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
