### PR TITLE
[DebugBundle] Fix dump/die doesn't work with server dumper

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -50,16 +50,24 @@
             </call>
         </service>
 
+        <service id=".var_dumper.debug_dumper" class="Symfony\Bundle\DebugBundle\VarDumper\DebugDumper">
+            <argument type="service" id="var_dumper.cli_dumper" />
+            <argument type="service" id=".var_dumper.context_provider.source" />
+            <argument>0</argument> <!-- flags -->
+            <tag name="kernel.event_subscriber" />
+        </service>
+
+        <service id=".var_dumper.context_provider.source" class="Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider">
+            <argument>%kernel.charset%</argument>
+            <argument type="string">%kernel.project_dir%</argument>
+            <argument type="service" id="debug.file_link_formatter" on-invalid="null" />
+        </service>
+
         <service id="var_dumper.server_dumper" class="Symfony\Component\VarDumper\Dumper\ServerDumper">
             <argument>null</argument> <!-- server host -->
-            <argument type="service" id="var_dumper.cli_dumper" />
+            <argument type="service" id=".var_dumper.debug_dumper" />
             <argument type="collection">
-                <argument type="service" key="source">
-                    <service class="Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider">
-                        <argument>%kernel.charset%</argument>
-                        <argument type="string">%kernel.project_dir%</argument>
-                        <argument type="service" id="debug.file_link_formatter" on-invalid="null" />
-                    </service>
+                <argument type="service" key="source" id=".var_dumper.context_provider.source">
                 </argument>
                 <argument type="service" key="request">
                     <service class="Symfony\Component\VarDumper\Dumper\ContextProvider\RequestContextProvider">

--- a/src/Symfony/Bundle/DebugBundle/VarDumper/DebugDumper.php
+++ b/src/Symfony/Bundle/DebugBundle/VarDumper/DebugDumper.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DebugBundle\VarDumper;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
+use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+
+/**
+ * Used as fallback in the ServerDumper, it delays output to the end of the process for web requests.
+ * It replicates the DumpDataCollector behavior to ensure dumps are written to the output
+ * whenever the dump server isn't up and the debug toolbar not available.
+ * In cli, output is not delayed and the provided CliDumper instance is used instead.
+ *
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @internal
+ */
+final class DebugDumper implements DataDumperInterface, EventSubscriberInterface
+{
+    private $charset;
+    private $fileLinkFormat;
+    private $flags;
+    private $cliDumper;
+    private $sourceContextProvider;
+
+    /** @var array[] */
+    private $data = array();
+
+    public function __construct(CliDumper $cliDumper, SourceContextProvider $sourceContextProvider, int $flags = 0)
+    {
+        $this->cliDumper = $cliDumper;
+        $this->sourceContextProvider = $sourceContextProvider;
+        $this->flags = $flags;
+        $this->charset = $this->sourceContextProvider->getCharset();
+        $this->fileLinkFormat = $this->sourceContextProvider->getFileLinkFormatter();
+    }
+
+    public function dump(Data $data)
+    {
+        list('name' => $name, 'file' => $file, 'line' => $line) = $this->sourceContextProvider->getContext();
+        // only delay web requests
+        if (\PHP_SAPI !== 'cli' && \PHP_SAPI !== 'phpdbg') {
+            $this->data[] = array($data, $name, $file, $line);
+
+            return;
+        }
+
+        $this->doDump($this->cliDumper, $data, $name, $file, $line);
+    }
+
+    private function doDump(DataDumperInterface $dumper, Data $data, string $name, string $file, int $line)
+    {
+        if ($dumper instanceof CliDumper) {
+            $contextDumper = function (string $name, string $file, int $line, $fmt) {
+                if ($this instanceof HtmlDumper) {
+                    if ($file) {
+                        $s = $this->style('meta', '%s');
+                        $f = strip_tags($this->style('', $file));
+                        $name = strip_tags($this->style('', $name));
+                        if ($fmt && $link = is_string($fmt) ? strtr($fmt, array('%f' => $file, '%l' => $line)) : $fmt->format($file, $line)) {
+                            $name = sprintf('<a href="%s" title="%s">'.$s.'</a>', strip_tags($this->style('', $link)), $f, $name);
+                        } else {
+                            $name = sprintf('<abbr title="%s">'.$s.'</abbr>', $f, $name);
+                        }
+                    } else {
+                        $name = $this->style('meta', $name);
+                    }
+                    $this->line = $name.' on line '.$this->style('meta', $line).':';
+                } else {
+                    $this->line = $this->style('meta', $name).' on line '.$this->style('meta', $line).':';
+                }
+                $this->dumpLine(0);
+            };
+            $contextDumper = $contextDumper->bindTo($dumper, $dumper);
+            $contextDumper($name, $file, $line, $this->fileLinkFormat);
+        } else {
+            $cloner = new VarCloner();
+            $dumper->dump($cloner->cloneVar($name.' on line '.$line.':'));
+        }
+        $dumper->dump($data);
+    }
+
+    public function __destruct()
+    {
+        if ($this->data) {
+            $h = headers_list();
+            $i = \count($h);
+            array_unshift($h, 'Content-Type: '.ini_get('default_mimetype'));
+            while (0 !== stripos($h[$i], 'Content-Type:')) {
+                --$i;
+            }
+
+            if (\PHP_SAPI !== 'cli' && \PHP_SAPI !== 'phpdbg' && stripos($h[$i], 'html')) {
+                $dumper = new HtmlDumper('php://output', $this->charset);
+                $dumper->setDisplayOptions(array('fileLinkFormat' => $this->fileLinkFormat));
+            } else {
+                $dumper = new CliDumper('php://output', $this->charset, $this->flags);
+            }
+
+            foreach ($this->data as list($data, $name, $file, $line)) {
+                $this->doDump($dumper, $data, $name, $file, $line);
+            }
+
+            $this->data = array();
+        }
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $request = $event->getRequest();
+
+        // In all conditions that remove the web debug toolbar, dumps must be written on the output.
+        if (
+            !$response->headers->has('X-Debug-Token')
+            || $response->isRedirection()
+            || ($response->headers->has('Content-Type') && false === strpos($response->headers->get('Content-Type'), 'html'))
+            || 'html' !== $request->getRequestFormat()
+            || false === strripos($response->getContent(), '</body>')
+        ) {
+            return;
+        }
+
+        // Otherwise, empty data and ignore.
+        $this->data = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => array('onKernelResponse', -100),
+        );
+    }
+}

--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -164,7 +164,7 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
      */
     protected function dumpLine($depth)
     {
-        call_user_func($this->lineDumper, $this->line, $depth, $this->indentPad);
+        \call_user_func($this->lineDumper, $this->line, $depth, $this->indentPad);
         $this->line = '';
     }
 

--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/CliContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/CliContextProvider.php
@@ -15,8 +15,10 @@ namespace Symfony\Component\VarDumper\Dumper\ContextProvider;
  * Tries to provide context on CLI.
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @final
  */
-final class CliContextProvider implements ContextProviderInterface
+class CliContextProvider implements ContextProviderInterface
 {
     public function getContext(): ?array
     {

--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/RequestContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/RequestContextProvider.php
@@ -18,8 +18,10 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
  * Tries to provide context from a request.
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @final
  */
-final class RequestContextProvider implements ContextProviderInterface
+class RequestContextProvider implements ContextProviderInterface
 {
     private $requestStack;
     private $cloner;

--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
@@ -22,8 +22,10 @@ use Twig\Template;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ *
+ * @final
  */
-final class SourceContextProvider implements ContextProviderInterface
+class SourceContextProvider implements ContextProviderInterface
 {
     private $limit;
     private $charset;

--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
@@ -30,11 +30,11 @@ final class SourceContextProvider implements ContextProviderInterface
     private $projectDir;
     private $fileLinkFormatter;
 
-    public function __construct(string $charset = null, string $projectDir = null, FileLinkFormatter $fileLinkFormatter = null, int $limit = 9)
+    public function __construct(string $charset = null, string $projectDir = null, FileLinkFormatter $fileLinkFormatter = null, int $limit = 10)
     {
-        $this->charset = $charset;
+        $this->charset = $charset ?: ini_get('php.output_encoding') ?: ini_get('default_charset') ?: 'UTF-8';
         $this->projectDir = $projectDir;
-        $this->fileLinkFormatter = $fileLinkFormatter;
+        $this->fileLinkFormatter = $fileLinkFormatter ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
         $this->limit = $limit;
     }
 
@@ -108,6 +108,16 @@ final class SourceContextProvider implements ContextProviderInterface
         }
 
         return $context;
+    }
+
+    public function getCharset(): string
+    {
+        return $this->charset;
+    }
+
+    public function getFileLinkFormatter(): ?FileLinkFormatter
+    {
+        return $this->fileLinkFormatter;
     }
 
     private function htmlEncode(string $s): string

--- a/src/Symfony/Component/VarDumper/Resources/css/htmlDescriptor.css
+++ b/src/Symfony/Component/VarDumper/Resources/css/htmlDescriptor.css
@@ -22,14 +22,6 @@ a {
 a:hover {
     text-decoration: underline;
 }
-code {
-    color: #cc2255;
-    background-color: #f7f7f9;
-    border: 1px solid #e1e1e8;
-    border-radius: 3px;
-    margin-right: 5px;
-    padding: 0 3px;
-}
 .text-small {
     font-size: 12px !important;
 }
@@ -60,6 +52,12 @@ article > header > .row > h2 {
 article > header > .row > h2 > code {
     white-space: nowrap;
     user-select: none;
+    color: #cc2255;
+    background-color: #f7f7f9;
+    border: 1px solid #e1e1e8;
+    border-radius: 3px;
+    margin-right: 5px;
+    padding: 0 3px;
 }
 article > header > .row > time.col {
     flex: 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

This is an attempt to fully respect the promise made by the server dumper feature, i.e: `dump` should act exactly the same when the `ServerDumper` is wired (`debug.dump_destination: "tcp://%env(VAR_DUMPER_SERVER)%"`) but the dump server is not up (`server:dump` not running).

Currently, when using the full stack and debug bundle, the promise is broken, as someone using `dd` or `dump` + `die` would not see expected dumps in the output for web requests. This is explained by the wrapped dumper (_the one used by `ServerDumper` when failing at contacting the server_) being the `var_dumper.cli_dumper`, so it outputs on `php://stdout` instead (which is fine for cli usages).

**To reproduce**

- `composer create-project "symfony/website-skeleton:^4.1@dev" no-dd-output`
- Add a controller and `dd` inside
- Start the webserver and access the controller => get a blank page, dumps are written to the webserver output.

**What this solution is worth**

It works, but is far from ideal. It reproduces the `DumpDataCollector` behavior (code is entirely borrowed from here) in a dedicated internal dumper used as the fallback when we failed at contacting the server. Also, it misses the file & line nb usually added by the collector in the output (_or would also need duplicating this logic_). **=> Now added**
Ideally, the `ServerDumper`'s wrapped dumper should be `DumpDataCollector` but it's not easily achievable as those are already quite intricated/tangled with each other in the way they are wired together. I failed to find a proper solution so far. 
=> _See https://github.com/symfony/symfony/pull/27614#issuecomment-398023101 last paragraph for a strategy extracting, deprecating & removing some code from DumpDataCollector, limiting it to its responsibility of collecting dumps to be shown on toolbar/profiler, in favor of the `DebugDumper` ([attempt in progress](https://github.com/symfony/symfony/compare/master...ogizanagi:4.2/refacto_dump_collector))._

Reverting #26675 makes things work, but the fix is legit and it would only rely on undesired behavior while still using the cli dumper as the wrapped dumper (thus leading to duplicates at the end of the process when one is calling a controller, e.g when executing a test suite).