### PR TITLE
[HttpFoundation] Change PHPDoc in ResponseHeaderBag::getCookies() to help IDEs

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -160,7 +160,7 @@ class ResponseHeaderBag extends HeaderBag
      *
      * @param string $format
      *
-     * @return array
+     * @return Cookie[]
      *
      * @throws \InvalidArgumentException When the $format is invalid
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Hello,

I'm proposing a very small change to `ResponseHeaderBag` in the HttpFoundation component. The change involves changing the PHPDoc return type of `getCookies()` from a simple `array` to `Cookie[]`. This way, IDEs will play nicely and understand that the returned value is in fact an array of Cookie objects. This is the current behavior:

![Before PR](https://user-images.githubusercontent.com/94651/40648899-d6690f84-632f-11e8-8e43-e09d71b9ccec.png)

whereas with the proposed change, the IDE correctly understands the type:

![After PR](https://user-images.githubusercontent.com/94651/40648980-109621c4-6330-11e8-8ead-f176307e5bda.png)
