### PR TITLE
[Security] Add missing upgrade note about GuardAuthenticationListener-related deprecation

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -344,6 +344,9 @@ Security
 
  * The `GuardAuthenticatorInterface` has been deprecated and will be removed in 4.0.
    Use `AuthenticatorInterface` instead.
+   
+ * When extending `AbstractGuardAuthenticator` it's deprecated to return `null` from `getCredentials()`.
+   Return `false` from `supports()` if no credentials available.
 
 SecurityBundle
 --------------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -758,6 +758,9 @@ Security
 
  * The `GuardAuthenticatorInterface` interface has been removed.
    Use `AuthenticatorInterface` instead.
+   
+ * When extending `AbstractGuardAuthenticator` getCredentials() cannot return 
+   `null` anymore, return false from `supports()` if no credentials available instead.
 
 SecurityBundle
 --------------

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -16,6 +16,8 @@ CHANGELOG
  * deprecated HTTP digest authentication
  * Added a new password encoder for the Argon2i hashing algorithm
  * deprecated `GuardAuthenticatorInterface` in favor of `AuthenticatorInterface`
+ * deprecated to return `null` from `getCredentials()` in classes that extend 
+   `AbstractGuardAuthenticator`. Return `false` from `supports()` instead.
 
 3.3.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   |
| Fixed tickets |
| License       | MIT
| Doc PR        | 

This https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php#L127 was not reported.