### PR TITLE
refactor(UserInterface): update on UserInterface return.

### DIFF
--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -41,12 +41,7 @@ final class Security
             return null;
         }
 
-        $user = $token->getUser();
-        if (!is_object($user)) {
-            return null;
-        }
-
-        return $user;
+        return is_object($token->getUser()) ? $token->getUser() : null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | yes     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | No changement is the actual tests.    <!-- please add some, will be required by reviewers -->
| License       | MIT

Hi everyone, as the `UserInterface` is accessible through the `getUser()` method and the token is checked before the return block, I think it could be a good idea to use a ternary in order to minify the return sentence.

A second approach could be to use the `instanceof` check: 

```php
<?php 

return is_object($token->getUser()) && $token->getUser() instanceof UserInterface 
    ? $token->getUser() 
    : null;
```

But personnaly, I found the first usage way cleaner, I know this is just a "style" suggestion but I find strange the way the check is processed, the `getUser()` could return a variety of type and once the type is checked, it's easy to return null if the sentence does not match. 

PS: Sorry for the PR array, I'm not pretty sure about the BC as the method was added with the 3.4 branch and as this one is a LTS. 