### PR TITLE
No such return type void

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/ServerDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ServerDumper.php
@@ -50,7 +50,7 @@ class ServerDumper implements DataDumperInterface
     /**
      * {@inheritdoc}
      */
-    public function dump(Data $data, $output = null): void
+    public function dump(Data $data, $output = null)
     {
         set_error_handler(array(self::class, 'nullErrorHandler'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Simply removes the invalid return type "void".