### PR TITLE
[Messenger][DX] Do not register a middleware unaware of MiddlewareInterface

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -23,6 +23,7 @@ use Symfony\Component\Messenger\Handler\ChainHandler;
 use Symfony\Component\Messenger\Handler\Locator\ContainerHandlerLocator;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\TraceableMessageBus;
 use Symfony\Component\Messenger\Transport\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\SenderInterface;
@@ -304,6 +305,10 @@ class MessengerPass implements CompilerPassInterface
                 $container->setDefinition($messengerMiddlewareId = $busId.'.middleware.'.$id, $childDefinition);
             } elseif ($arguments) {
                 throw new RuntimeException(sprintf('Invalid middleware factory "%s": a middleware factory must be an abstract definition.', $id));
+            }
+
+            if (!is_subclass_of($definition->getClass(), MiddlewareInterface::class)) {
+                throw new RuntimeException(sprintf('Invalid middleware "%s": class "%s" must implement interface "%s".', $messengerMiddlewareId, $definition->getClass(), MiddlewareInterface::class));
             }
 
             $middlewareReferences[] = new Reference($messengerMiddlewareId);

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -466,6 +466,21 @@ class MessengerPassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage Invalid middleware "foo_middleware": class "stdClass" must implement interface "Symfony\Component\Messenger\Middleware\MiddlewareInterface".
+     */
+    public function testCannotRegistersAnUnawaredMiddleware()
+    {
+        $container = $this->getContainerBuilder($fooBusId = 'messenger.bus.foo');
+        $container->register('foo_middleware', \stdClass::class);
+        $container->setParameter($middlewareParameter = $fooBusId.'.middleware', array(
+            array('id' => 'foo_middleware', 'arguments' => array()),
+        ));
+
+        (new MessengerPass())->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      * @expectedExceptionMessage Invalid middleware factory "not_an_abstract_definition": a middleware factory must be an abstract definition.
      */
     public function testMiddlewareFactoryDefinitionMustBeAbstract()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Providing a DX improvement:

**before (error at runtime):**
![middleware-before](https://user-images.githubusercontent.com/2028198/40684771-486e5f82-6360-11e8-9e91-223f9b42aac6.png)

**after (error at compiler time):**
![middleware-after](https://user-images.githubusercontent.com/2028198/40684802-6501410a-6360-11e8-84c5-9871a977e10a.png)
