### PR TITLE
Insert correct parameter_bag service in AbstractController

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 
 use Psr\Container\ContainerInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -84,7 +85,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
             'form.factory' => '?'.FormFactoryInterface::class,
             'security.token_storage' => '?'.TokenStorageInterface::class,
             'security.csrf.token_manager' => '?'.CsrfTokenManagerInterface::class,
-            'parameter_bag' => '?'.ContainerInterface::class,
+            'parameter_bag' => '?'.ContainerBagInterface::class,
             'message_bus' => '?'.MessageBusInterface::class,
         );
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -24,6 +24,32 @@ class AbstractControllerTest extends ControllerTraitTest
         return new TestAbstractController();
     }
 
+    /**
+     * This test protects the default subscribed core services against accidental modification.
+     */
+    public function testSubscribedServices()
+    {
+        $subscribed = AbstractController::getSubscribedServices();
+        $expectedServices = array(
+            'router' => '?Symfony\\Component\\Routing\\RouterInterface',
+            'request_stack' => '?Symfony\\Component\\HttpFoundation\\RequestStack',
+            'http_kernel' => '?Symfony\\Component\\HttpKernel\\HttpKernelInterface',
+            'serializer' => '?Symfony\\Component\\Serializer\\SerializerInterface',
+            'session' => '?Symfony\\Component\\HttpFoundation\\Session\\SessionInterface',
+            'security.authorization_checker' => '?Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationCheckerInterface',
+            'templating' => '?Symfony\\Component\\Templating\\EngineInterface',
+            'twig' => '?Twig\\Environment',
+            'doctrine' => '?Doctrine\\Common\\Persistence\\ManagerRegistry',
+            'form.factory' => '?Symfony\\Component\\Form\\FormFactoryInterface',
+            'parameter_bag' => '?Symfony\\Component\\DependencyInjection\\ParameterBag\\ContainerBagInterface',
+            'message_bus' => '?Symfony\\Component\\Messenger\\MessageBusInterface',
+            'security.token_storage' => '?Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface',
+            'security.csrf.token_manager' => '?Symfony\\Component\\Security\\Csrf\\CsrfTokenManagerInterface',
+        );
+
+        $this->assertEquals($expectedServices, $subscribed, 'Subscribed core services in AbstractController have changed');
+    }
+
     public function testGetParameter()
     {
         $container = new Container(new FrozenParameterBag(array('foo' => 'bar')));


### PR DESCRIPTION
Reverts this feature being broken in https://github.com/symfony/symfony/commit/3051289791d25e78f059d965a236b7bd60165a31#diff-ef10778bc68793f8c8f4b71a7ba67790R86 - `getParameter` could never work now as it was querying the container itself instead of the parameter bag.

| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

Also see comments at https://github.com/symfony/symfony/pull/25439#issuecomment-392975418