### PR TITLE
TagAwareAdapter over non-binary memcached connections corrupts memcache

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Simple;
+
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Simple\MemcachedCache;
+
+class MemcachedCacheTextModeTest extends MemcachedCacheTest
+{
+    public function createSimpleCache($defaultLifetime = 0)
+    {
+        $client = AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'), array('binary_protocol' => false));
+
+        return new MemcachedCache($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
+++ b/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
@@ -198,7 +198,12 @@ trait MemcachedTrait
             $lifetime += time();
         }
 
-        return $this->checkResultCode($this->getClient()->setMulti($values, $lifetime));
+        $encodedValues = array();
+        foreach ($values as $key => $value) {
+            $encodedValues[rawurlencode($key)] = $value;
+        }
+
+        return $this->checkResultCode($this->getClient()->setMulti($encodedValues, $lifetime));
     }
 
     /**
@@ -208,7 +213,16 @@ trait MemcachedTrait
     {
         $unserializeCallbackHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
         try {
-            return $this->checkResultCode($this->getClient()->getMulti($ids));
+            $encodedIds = array_map('rawurlencode', $ids);
+
+            $encodedResult = $this->checkResultCode($this->getClient()->getMulti($encodedIds));
+
+            $result = array();
+            foreach ($encodedResult as $key => $value) {
+                $result[rawurldecode($key)] = $value;
+            }
+
+            return $result;
         } catch (\Error $e) {
             throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
         } finally {
@@ -221,7 +235,7 @@ trait MemcachedTrait
      */
     protected function doHave($id)
     {
-        return false !== $this->getClient()->get($id) || $this->checkResultCode(\Memcached::RES_SUCCESS === $this->client->getResultCode());
+        return false !== $this->getClient()->get(rawurlencode($id)) || $this->checkResultCode(\Memcached::RES_SUCCESS === $this->client->getResultCode());
     }
 
     /**
@@ -230,7 +244,8 @@ trait MemcachedTrait
     protected function doDelete(array $ids)
     {
         $ok = true;
-        foreach ($this->checkResultCode($this->getClient()->deleteMulti($ids)) as $result) {
+        $encodedIds = array_map('rawurlencode', $ids);
+        foreach ($this->checkResultCode($this->getClient()->deleteMulti($encodedIds)) as $result) {
             if (\Memcached::RES_SUCCESS !== $result && \Memcached::RES_NOTFOUND !== $result) {
                 $ok = false;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #27405 
| License       | MIT
| Doc PR        | 

TagAwareAdapter uses non-ascii symbols in key names. It breaks memcached connections in non-binary mode.
