### PR TITLE
[WebProfilerBundle] Make Twig bundle an explicit dependency

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.1.3",
         "symfony/http-kernel": "~4.1",
         "symfony/routing": "~3.4|~4.0",
-        "symfony/twig-bridge": "~3.4|~4.0",
+        "symfony/twig-bundle": "^3.4.3|^4.0.3",
         "symfony/var-dumper": "~3.4|~4.0",
         "twig/twig": "~1.34|~2.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26115
| License       | MIT

Let's make Twig bundle an explicit dependency of WebProfilerBundle. That's better for DX and as Silex won't be maintained when 4.2 is out, it's the right time to do so.
