### PR TITLE
Revert "feature #26702 Mark ExceptionInterfaces throwable (ostrolucky)"

### DIFF
--- a/src/Symfony/Component/Asset/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Asset/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Asset\Exception;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Console/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Console/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Console\Exception;
  *
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/CssSelector/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/CssSelector/Exception/ExceptionInterface.php
@@ -19,6 +19,6 @@ namespace Symfony\Component\CssSelector\Exception;
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Dotenv/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Dotenv/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Dotenv\Exception;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Filesystem/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Filesystem/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Filesystem\Exception;
  *
  * @author Romain Neutron <imprec@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Form/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Form/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Form\Exception;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Intl/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Intl/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Intl\Exception;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Ldap/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Ldap/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Ldap\Exception;
  *
  * @author Charles Sarrazin <charles@sarraz.in>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Lock/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Lock/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Lock\Exception;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Messenger/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Messenger\Exception;
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/OptionsResolver/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/OptionsResolver/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\OptionsResolver\Exception;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Process/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Process/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Process\Exception;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/PropertyAccess/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/PropertyAccess/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\PropertyAccess\Exception;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Routing/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Routing/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Routing\Exception;
  *
  * @author Alexandre Salomé <alexandre.salome@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Security/Core/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Security/Core/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Security\Core\Exception;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Serializer/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Serializer/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Serializer\Exception;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Translation/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Translation/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Translation\Exception;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Validator/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Validator/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Validator\Exception;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Workflow/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Workflow/Exception/ExceptionInterface.php
@@ -15,6 +15,6 @@ namespace Symfony\Component\Workflow\Exception;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Yaml/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Yaml/Exception/ExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Yaml\Exception;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }


### PR DESCRIPTION
This reverts commit 9fda6d3ee3ea7f32a00a13508f9748df01c2ecc7, reversing
changes made to ca53d3e0fdfce16b0bd9e8412ef220daf77cf58d.

| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27419
| License       | MIT
| Doc PR        | -

#26702 introduced a BC break.