### PR TITLE
Removing the session migration on SimplePreAuthenticationListener

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -87,8 +87,6 @@ class SimplePreAuthenticationListener implements ListenerInterface
 
             $token = $this->authenticationManager->authenticate($token);
 
-            $this->migrateSession($request);
-
             $this->tokenStorage->setToken($token);
 
             if (null !== $this->dispatcher) {
@@ -122,17 +120,5 @@ class SimplePreAuthenticationListener implements ListenerInterface
                 throw new \UnexpectedValueException(sprintf('The %s::onAuthenticationSuccess method must return null or a Response object', get_class($this->simpleAuthenticator)));
             }
         }
-    }
-
-    private function migrateSession(Request $request)
-    {
-        if (!$request->hasSession() || !$request->hasPreviousSession()) {
-            return;
-        }
-
-        // Destroying the old session is broken in php 5.4.0 - 5.4.10
-        // See https://bugs.php.net/63379
-        $destroy = \PHP_VERSION_ID < 50400 || \PHP_VERSION_ID >= 50411;
-        $request->getSession()->migrate($destroy);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8 (because 2.7 is now EOL)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no->
| Tests pass?   | yes
| Fixed tickets | Part of #27395
| License       | MIT
| Doc PR        | n/a

This partially reverts the session migration patches applied recently. Here are the details:

1) Contao has a legacy security system. In this system they have a SimplePreAuthenticator that creates a`ContaoToken` on every request:

https://github.com/contao/core-bundle/blob/504d8ed7c14a8e135def5722e47ffa1dc7c4d6ed/src/Security/ContaoAuthenticator.php#L88

2) When that token (`ContaoToken`) is instantiated, it actually does a legacy, cookie-based authentication where a cookie is set by using the session id as a hash.

3) But, then, because the `ContaoAuthenticator` returns the `ContaoToken`, the session is migrated, which effectively invalidates the cookie set by their legacy auth system (because the hash for the cookie uses the session id).

This is a legacy system that does some crazy stuff (their WIP newer version apparently already makes a lot of nice changes), but the point is that the patch causes side effects. We decided to migrate the session in `SimplePreAuthenticationListener` just to be extra safe: this authentication mechanism is not meant to be used with session-based authentication.

The downside of this revert is that, it makes session fixation a *possibility* with `SimplePreAuthenticationListener`. But, I believe this would only be possible if someone creates a "SimplePreAuthenticator" in order to make a traditional, session-based authentication system - e.g. a login form.
