### PR TITLE
[PropertyInfo] Add an alias to the property info type extractor

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
@@ -13,7 +13,11 @@
             <argument type="collection" />
             <argument type="collection" />
         </service>
+        <service id="Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface" alias="property_info" />
+        <service id="Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface" alias="property_info" />
         <service id="Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface" alias="property_info" />
+        <service id="Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface" alias="property_info" />
+        <service id="Symfony\Component\PropertyInfo\PropertyListExtractorInterface" alias="property_info" />
 
         <!-- Extractor -->
         <service id="property_info.reflection_extractor" class="Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27139
| License       | MIT
| Doc PR        | ø

As spotted in #27139, we only alias the main PropertyInfo interface but we don't alias the other one, gathering only the types (while we implement it). This fixes the "problem" of auto-wiring it.