### PR TITLE
[Console] Add support for error ouput in the CommandTester

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
    pass it the command as an array of its arguments instead
  * made the `ProcessHelper` class final
  * added `WrappableOutputFormatterInterface::formatAndWrap()` (implemented in `OutputFormatter`)
+ * added `capture_stderr_separately` option to `CommandTester::execute()`
 
 4.1.0
 -----

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Console\Tester;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * Eases the testing of console applications.
@@ -33,7 +31,6 @@ class ApplicationTester
     private $application;
     private $input;
     private $statusCode;
-    private $captureStreamsIndependently = false;
 
     public function __construct(Application $application)
     {
@@ -69,65 +66,12 @@ class ApplicationTester
             putenv('SHELL_INTERACTIVE=1');
         }
 
-        $this->captureStreamsIndependently = array_key_exists('capture_stderr_separately', $options) && $options['capture_stderr_separately'];
-        if (!$this->captureStreamsIndependently) {
-            $this->output = new StreamOutput(fopen('php://memory', 'w', false));
-            if (isset($options['decorated'])) {
-                $this->output->setDecorated($options['decorated']);
-            }
-            if (isset($options['verbosity'])) {
-                $this->output->setVerbosity($options['verbosity']);
-            }
-        } else {
-            $this->output = new ConsoleOutput(
-                isset($options['verbosity']) ? $options['verbosity'] : ConsoleOutput::VERBOSITY_NORMAL,
-                isset($options['decorated']) ? $options['decorated'] : null
-            );
-
-            $errorOutput = new StreamOutput(fopen('php://memory', 'w', false));
-            $errorOutput->setFormatter($this->output->getFormatter());
-            $errorOutput->setVerbosity($this->output->getVerbosity());
-            $errorOutput->setDecorated($this->output->isDecorated());
-
-            $reflectedOutput = new \ReflectionObject($this->output);
-            $strErrProperty = $reflectedOutput->getProperty('stderr');
-            $strErrProperty->setAccessible(true);
-            $strErrProperty->setValue($this->output, $errorOutput);
-
-            $reflectedParent = $reflectedOutput->getParentClass();
-            $streamProperty = $reflectedParent->getProperty('stream');
-            $streamProperty->setAccessible(true);
-            $streamProperty->setValue($this->output, fopen('php://memory', 'w', false));
-        }
+        $this->initOutput($options);
 
         $this->statusCode = $this->application->run($this->input, $this->output);
 
         putenv($shellInteractive ? "SHELL_INTERACTIVE=$shellInteractive" : 'SHELL_INTERACTIVE');
 
         return $this->statusCode;
-    }
-
-    /**
-     * Gets the output written to STDERR by the application.
-     *
-     * @param bool $normalize Whether to normalize end of lines to \n or not
-     *
-     * @return string
-     */
-    public function getErrorOutput($normalize = false)
-    {
-        if (!$this->captureStreamsIndependently) {
-            throw new \LogicException('The error output is not available when the tester is run without "capture_stderr_separately" option set.');
-        }
-
-        rewind($this->output->getErrorOutput()->getStream());
-
-        $display = stream_get_contents($this->output->getErrorOutput()->getStream());
-
-        if ($normalize) {
-            $display = str_replace(PHP_EOL, "\n", $display);
-        }
-
-        return $display;
     }
 }

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Console\Tester;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * Eases the testing of console commands.
@@ -39,9 +38,10 @@ class CommandTester
      *
      * Available execution options:
      *
-     *  * interactive: Sets the input interactive flag
-     *  * decorated:   Sets the output decorated flag
-     *  * verbosity:   Sets the output verbosity flag
+     *  * interactive:               Sets the input interactive flag
+     *  * decorated:                 Sets the output decorated flag
+     *  * verbosity:                 Sets the output verbosity flag
+     *  * capture_stderr_separately: Make output of stdOut and stdErr separately available
      *
      * @param array $input   An array of command arguments and options
      * @param array $options An array of execution options
@@ -68,11 +68,11 @@ class CommandTester
             $this->input->setInteractive($options['interactive']);
         }
 
-        $this->output = new StreamOutput(fopen('php://memory', 'w', false));
-        $this->output->setDecorated(isset($options['decorated']) ? $options['decorated'] : false);
-        if (isset($options['verbosity'])) {
-            $this->output->setVerbosity($options['verbosity']);
+        if (!isset($options['decorated'])) {
+            $options['decorated'] = false;
         }
+
+        $this->initOutput($options);
 
         return $this->statusCode = $this->command->run($this->input, $this->output);
     }

--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -12,19 +12,19 @@
 namespace Symfony\Component\Console\Tester;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
- *
- * @internal
  */
 trait TesterTrait
 {
     /** @var StreamOutput */
     private $output;
     private $inputs = array();
+    private $captureStreamsIndependently = false;
 
     /**
      * Gets the display returned by the last execution of the command or application.
@@ -38,6 +38,30 @@ trait TesterTrait
         rewind($this->output->getStream());
 
         $display = stream_get_contents($this->output->getStream());
+
+        if ($normalize) {
+            $display = str_replace(PHP_EOL, "\n", $display);
+        }
+
+        return $display;
+    }
+
+    /**
+     * Gets the output written to STDERR by the application.
+     *
+     * @param bool $normalize Whether to normalize end of lines to \n or not
+     *
+     * @return string
+     */
+    public function getErrorOutput($normalize = false)
+    {
+        if (!$this->captureStreamsIndependently) {
+            throw new \LogicException('The error output is not available when the tester is run without "capture_stderr_separately" option set.');
+        }
+
+        rewind($this->output->getErrorOutput()->getStream());
+
+        $display = stream_get_contents($this->output->getErrorOutput()->getStream());
 
         if ($normalize) {
             $display = str_replace(PHP_EOL, "\n", $display);
@@ -89,6 +113,49 @@ trait TesterTrait
         $this->inputs = $inputs;
 
         return $this;
+    }
+
+    /**
+     * Initializes the output property.
+     *
+     * Available options:
+     *
+     *  * decorated:                 Sets the output decorated flag
+     *  * verbosity:                 Sets the output verbosity flag
+     *  * capture_stderr_separately: Make output of stdOut and stdErr separately available
+     */
+    private function initOutput(array $options)
+    {
+        $this->captureStreamsIndependently = array_key_exists('capture_stderr_separately', $options) && $options['capture_stderr_separately'];
+        if (!$this->captureStreamsIndependently) {
+            $this->output = new StreamOutput(fopen('php://memory', 'w', false));
+            if (isset($options['decorated'])) {
+                $this->output->setDecorated($options['decorated']);
+            }
+            if (isset($options['verbosity'])) {
+                $this->output->setVerbosity($options['verbosity']);
+            }
+        } else {
+            $this->output = new ConsoleOutput(
+                isset($options['verbosity']) ? $options['verbosity'] : ConsoleOutput::VERBOSITY_NORMAL,
+                isset($options['decorated']) ? $options['decorated'] : null
+            );
+
+            $errorOutput = new StreamOutput(fopen('php://memory', 'w', false));
+            $errorOutput->setFormatter($this->output->getFormatter());
+            $errorOutput->setVerbosity($this->output->getVerbosity());
+            $errorOutput->setDecorated($this->output->isDecorated());
+
+            $reflectedOutput = new \ReflectionObject($this->output);
+            $strErrProperty = $reflectedOutput->getProperty('stderr');
+            $strErrProperty->setAccessible(true);
+            $strErrProperty->setValue($this->output, $errorOutput);
+
+            $reflectedParent = $reflectedOutput->getParentClass();
+            $streamProperty = $reflectedParent->getProperty('stream');
+            $streamProperty->setAccessible(true);
+            $streamProperty->setValue($this->output, fopen('php://memory', 'w', false));
+        }
     }
 
     private static function createStream(array $inputs)

--- a/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
@@ -90,4 +90,24 @@ class ApplicationTesterTest extends TestCase
     {
         $this->assertSame(0, $this->tester->getStatusCode(), '->getStatusCode() returns the status code');
     }
+
+    public function testErrorOutput()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->register('foo')
+            ->addArgument('foo')
+            ->setCode(function ($input, $output) {
+                $output->getErrorOutput()->write('foo');
+            })
+        ;
+
+        $tester = new ApplicationTester($application);
+        $tester->run(
+            array('command' => 'foo', 'foo' => 'bar'),
+            array('capture_stderr_separately' => true)
+        );
+
+        $this->assertSame('foo', $tester->getErrorOutput());
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -160,4 +160,23 @@ class CommandTesterTest extends TestCase
 
         $this->assertEquals(0, $tester->getStatusCode());
     }
+
+    public function testErrorOutput()
+    {
+        $command = new Command('foo');
+        $command->addArgument('command');
+        $command->addArgument('foo');
+        $command->setCode(function ($input, $output) {
+            $output->getErrorOutput()->write('foo');
+        }
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(
+            array('foo' => 'bar'),
+            array('capture_stderr_separately' => true)
+        );
+
+        $this->assertSame('foo', $tester->getErrorOutput());
+    }
 }


### PR DESCRIPTION
Move initialization of the streams to the trait so the `capture_stderr_separately` also works in the CommandTester.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27422 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Make it possible to test seperate stderr output.

```$tester = new CommandTester($command);
$tester->execute(
    array('foo' => 'bar'),
    array('capture_stderr_separately' => true)
);

$this->assertEquals('foo', $tester->getErrorOutput());
````