### PR TITLE
[OptionResolver] resolve arrays

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -511,7 +511,7 @@ class OptionsResolverTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but is of type "DateTime[]".
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but one of the elements is of type "DateTime[]".
      */
     public function testResolveFailsIfInvalidTypedArray()
     {
@@ -535,7 +535,7 @@ class OptionsResolverTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but is of type "integer|stdClass|array|DateTime[]".
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but one of the elements is of type "stdClass[]".
      */
     public function testResolveFailsIfTypedArrayContainsInvalidTypes()
     {
@@ -552,7 +552,7 @@ class OptionsResolverTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[][]", but is of type "double[][]".
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[][]", but one of the elements is of type "double[][]".
      */
     public function testResolveFailsWithCorrectLevelsButWrongScalar()
     {
@@ -1649,5 +1649,152 @@ class OptionsResolverTest extends TestCase
         $this->resolver->setDefault('lazy1', function () {});
 
         count($this->resolver);
+    }
+
+    public function testNestedArrays()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'int[][]');
+
+        $this->assertEquals(array(
+            'foo' => array(
+                array(
+                    1, 2,
+                ),
+            ),
+        ), $this->resolver->resolve(
+            array(
+                'foo' => array(
+                    array(1, 2),
+                ),
+            )
+        ));
+    }
+
+    public function testNested2Arrays()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'int[][][][]');
+
+        $this->assertEquals(array(
+            'foo' => array(
+                array(
+                    array(
+                        array(
+                            1, 2,
+                        ),
+                    ),
+                ),
+            ),
+        ), $this->resolver->resolve(
+            array(
+                'foo' => array(
+                    array(
+                        array(
+                            array(1, 2),
+                        ),
+                    ),
+                ),
+            )
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "float[][][][]", but one of the elements is of type "integer[][][][]".
+     */
+    public function testNestedArraysException()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'float[][][][]');
+
+        $this->resolver->resolve(
+            array(
+                'foo' => array(
+                    array(
+                        array(
+                            array(1, 2),
+                        ),
+                    ),
+                ),
+            )
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[][]", but one of the elements is of type "boolean[][]".
+     */
+    public function testNestedArrayException1()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'int[][]');
+        $this->resolver->resolve(array(
+            'foo' => array(
+                array(1, true, 'str', array(2, 3)),
+            ),
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[][]", but one of the elements is of type "boolean[][]".
+     */
+    public function testNestedArrayException2()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'int[][]');
+        $this->resolver->resolve(array(
+            'foo' => array(
+                array(true, 'str', array(2, 3)),
+            ),
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "string[][][]", but one of the elements is of type "string[][]".
+     */
+    public function testNestedArrayException3()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'string[][][]');
+        $this->resolver->resolve(array(
+            'foo' => array(
+                array('str', array(1, 2)),
+            ),
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "string[][][]", but one of the elements is of type "integer[][][]".
+     */
+    public function testNestedArrayException4()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'string[][][]');
+        $this->resolver->resolve(array(
+            'foo' => array(
+                array(
+                    array('str'), array(1, 2), ),
+            ),
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "string[]", but one of the elements is of type "array[]".
+     */
+    public function testNestedArrayException5()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'string[]');
+        $this->resolver->resolve(array(
+            'foo' => array(
+                array(
+                    array('str'), array(1, 2), ),
+            ),
+        ));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Option resolver didn't work with nested arrays

Before:


        $resolver->setDefaults([
            'integer' => [
                [
                    12,
                    23,
                ],
            ],
        ]);

        $resolver->setAllowedTypes('integer', 'integer[][]');

Error
    
    The option "host" with value array is expected to be of type "integer[][]", but is of type "integer[][]".

Option expetcted type `integer[][]` but get... `integer[][]`. So strange

Now that case work correct, and we get 

    array (size=1)
      'integer' => 
        array (size=1)
          0 => 
            array (size=2)
              0 => int 12
              1 => int 23