### PR TITLE
Create an accessible class/id version of the TestContainer service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -44,5 +44,7 @@
                 </service>
             </argument>
         </service>
+
+        <service id="Symfony\Bundle\FrameworkBundle\Test\TestContainer" alias="test.service_container" public="true" />
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 (but maybe master, not sure)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Now we can write `$container = static::bootKernel()->getContainer()->get(TestContainer::class);` to get the container by calling the class name instead of the service id.