### PR TITLE
Expression language evaluate traversable

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -75,7 +75,14 @@ class ExpressionLanguage
      */
     public function evaluate($expression, $values = array())
     {
-        return $this->parse($expression, array_keys($values))->getNodes()->evaluate($this->functions, $values);
+        return $this->parse(
+            $expression,
+            array_keys(
+                $values instanceof \Traversable
+                    ? iterator_to_array($values)
+                    : $values
+            )
+        )->getNodes()->evaluate($this->functions, $values);
     }
 
     /**

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -78,7 +78,7 @@ class ExpressionLanguage
         return $this->parse(
             $expression,
             array_keys(
-                $values instanceof \Traversable
+                $values instanceof \ArrayObject
                     ? iterator_to_array($values)
                     : $values
             )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4+
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

ExpressionLanguage currently only evaluates array. If I would like to pass something like collection of "lazy" objects to evaluate - I could not.
This thing allows to significally improve performance by passing a "lazy" Expressions collection in case you have a lot of "heavy" ones.