### PR TITLE
[DX] Improve exception message when AbstractController::getParameter fails

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -66,8 +66,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     {
         if (!$this->container->has('parameter_bag')) {
             throw new ServiceNotFoundException('parameter_bag', null, null, array(),
-                'The "parameter_bag" service could not be located. Ensure that the controller is either set '.
-                'to be autoconfigured or wired manually to inject it.');
+                sprintf('The "getParameter()" method of the controller can\'t get the value of the "%s" parameter because the "parameter_bag" service could not be located. Either enable autoconfigure for the controller service or inject a ServiceLocator referencing a "parameter_bag" service manually in the controller.', $name));
         }
 
         return $this->container->get('parameter_bag')->get($name);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 
 use Psr\Container\ContainerInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -64,7 +65,9 @@ abstract class AbstractController implements ServiceSubscriberInterface
     protected function getParameter(string $name)
     {
         if (!$this->container->has('parameter_bag')) {
-            throw new \LogicException('The "parameter_bag" service is not available. Try running "composer require dependency-injection:^4.1"');
+            throw new ServiceNotFoundException('parameter_bag', null, null, array(),
+                'The "parameter_bag" service could not be located. Ensure that symfony/dependency-injection 4.1.0 or higher '.
+                'is installed and that the controller is either set to be autoconfigured or wired manually to inject it');
         }
 
         return $this->container->get('parameter_bag')->get($name);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -65,8 +65,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     protected function getParameter(string $name)
     {
         if (!$this->container->has('parameter_bag')) {
-            throw new ServiceNotFoundException('parameter_bag', null, null, array(),
-                sprintf('The "getParameter()" method of the controller can\'t get the value of the "%s" parameter because the "parameter_bag" service could not be located. Either enable autoconfigure for the controller service or inject a ServiceLocator referencing a "parameter_bag" service manually in the controller.', $name));
+            throw new ServiceNotFoundException('parameter_bag', null, null, array(), sprintf('The "%s::getParameter()" method is missing a parameter bag to work properly. Did you forget to register your controller as a service subscriber? This can be fixed either by using autoconfiguration or by manually wiring a "parameter_bag" in the service locator passed to the controller.', get_class($this)));
         }
 
         return $this->container->get('parameter_bag')->get($name);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -65,14 +65,9 @@ abstract class AbstractController implements ServiceSubscriberInterface
     protected function getParameter(string $name)
     {
         if (!$this->container->has('parameter_bag')) {
-            $message = 'The "parameter_bag" service could not be located. ';
-            if (!interface_exists(ContainerBagInterface::class)) {
-                $message .= 'Upgrade symfony/dependency-injection to at least 4.1.0 to have it injected automatically.';
-            } else {
-                $message .= 'Ensure that the controller is either set to be autoconfigured or wired manually to inject it.';
-            }
-
-            throw new ServiceNotFoundException('parameter_bag', null, null, array(), $message);
+            throw new ServiceNotFoundException('parameter_bag', null, null, array(),
+                'The "parameter_bag" service could not be located. Ensure that the controller is either set ' .
+                'to be autoconfigured or wired manually to inject it.');
         }
 
         return $this->container->get('parameter_bag')->get($name);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -65,9 +65,14 @@ abstract class AbstractController implements ServiceSubscriberInterface
     protected function getParameter(string $name)
     {
         if (!$this->container->has('parameter_bag')) {
-            throw new ServiceNotFoundException('parameter_bag', null, null, array(),
-                'The "parameter_bag" service could not be located. Ensure that symfony/dependency-injection 4.1.0 or higher '.
-                'is installed and that the controller is either set to be autoconfigured or wired manually to inject it');
+            $message = 'The "parameter_bag" service could not be located. ';
+            if (!interface_exists(ContainerBagInterface::class)) {
+                $message .= 'Upgrade symfony/dependency-injection to at least 4.1.0 to have it injected automatically.';
+            } else {
+                $message .= 'Ensure that the controller is either set to be autoconfigured or wired manually to inject it.';
+            }
+
+            throw new ServiceNotFoundException('parameter_bag', null, null, array(), $message);
         }
 
         return $this->container->get('parameter_bag')->get($name);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -66,7 +66,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     {
         if (!$this->container->has('parameter_bag')) {
             throw new ServiceNotFoundException('parameter_bag', null, null, array(),
-                'The "parameter_bag" service could not be located. Ensure that the controller is either set ' .
+                'The "parameter_bag" service could not be located. Ensure that the controller is either set '.
                 'to be autoconfigured or wired manually to inject it.');
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -52,19 +52,31 @@ class AbstractControllerTest extends ControllerTraitTest
 
     public function testGetParameter()
     {
+        if (!class_exists(ContainerBag::class)) {
+            $this->markTestSkipped('ContainerBag class does not exist');
+        }
+
         $container = new Container(new FrozenParameterBag(array('foo' => 'bar')));
+        $container->set('parameter_bag', new ContainerBag($container));
 
         $controller = $this->createController();
         $controller->setContainer($container);
 
-        if (!class_exists(ContainerBag::class)) {
-            $this->expectException(\LogicException::class);
-            $this->expectExceptionMessage('The "parameter_bag" service is not available. Try running "composer require dependency-injection:^4.1"');
-        } else {
-            $container->set('parameter_bag', new ContainerBag($container));
-        }
-
         $this->assertSame('bar', $controller->getParameter('foo'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     * @expectedExceptionMessage The "parameter_bag" service could not be located
+     */
+    public function testMissingParameterBag()
+    {
+        $container = new Container();
+
+        $controller = $this->createController();
+        $controller->setContainer($container);
+
+        $controller->getParameter('foo');
     }
 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -67,7 +67,7 @@ class AbstractControllerTest extends ControllerTraitTest
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage The "parameter_bag" service could not be located.
+     * @expectedExceptionMessage The "getParameter()" method of the controller can't get the value of the "foo" parameter
      */
     public function testMissingParameterBag()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -67,7 +67,7 @@ class AbstractControllerTest extends ControllerTraitTest
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage The "getParameter()" method of the controller can't get the value of the "foo" parameter
+     * @expectedExceptionMessage TestAbstractController::getParameter()" method is missing a parameter bag
      */
     public function testMissingParameterBag()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -67,7 +67,7 @@ class AbstractControllerTest extends ControllerTraitTest
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage The "parameter_bag" service could not be located
+     * @expectedExceptionMessage The "parameter_bag" service could not be located.
      */
     public function testMissingParameterBag()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no (DX)
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27436
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Improve exception message for situations where the `parameter_bag` is not present in `AbstractController`. Also fixed the exception to the correct type.