### PR TITLE
[FrameworkBundle][TwigBridge] Fix BC break from strong dependency on CSRF token storage

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CsrfRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/CsrfRuntime.php
@@ -11,22 +11,23 @@
 
 namespace Symfony\Bridge\Twig\Extension;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-class CsrfExtension extends AbstractExtension
+class CsrfRuntime
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getFunctions(): array
+    private $csrfTokenManager;
+
+    public function __construct(CsrfTokenManagerInterface $csrfTokenManager)
     {
-        return array(
-            new TwigFunction('csrf_token', array(CsrfRuntime::class, 'getCsrfToken')),
-        );
+        $this->csrfTokenManager = $csrfTokenManager;
+    }
+
+    public function getCsrfToken(string $tokenId): string
+    {
+        return $this->csrfTokenManager->getToken($tokenId)->getValue();
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.xml
@@ -22,9 +22,13 @@
         </service>
         <service id="Symfony\Component\Security\Csrf\CsrfTokenManagerInterface" alias="security.csrf.token_manager" />
 
+        <service id="twig.runtime.security_csrf" class="Symfony\Bridge\Twig\Extension\CsrfRuntime">
+            <tag name="twig.runtime" />
+            <argument type="service" id="security.csrf.token_manager" />
+        </service>
+
         <service id="twig.extension.security_csrf" class="Symfony\Bridge\Twig\Extension\CsrfExtension">
             <tag name="twig.extension" />
-            <argument type="service" id="security.csrf.token_manager" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The PR https://github.com/symfony/symfony/pull/25197 introduced the `csrf_token` function in Twig. This extension relies on `CsrfTokenManagerInterface`, which itself relies on the session. In some contexts such as when sessions are stored in Redis and we try to warmup the cache in CLI without Redis available, this makes the process fails.

This PR fixes this by using a Twig runtime instead of a direct extension to avoid a strong dependency on `CsrfTokenManagerInterface`.