### PR TITLE
[WebProfilerBundle] fixed getSession when no session has been set deprecation warnings

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -180,7 +180,7 @@ class ProfilerController
             $this->cspHandler->disableCsp();
         }
 
-        if (null === $session = $request->getSession()) {
+        if (!$request->hasSession()) {
             $ip =
             $method =
             $statusCode =
@@ -190,6 +190,8 @@ class ProfilerController
             $limit =
             $token = null;
         } else {
+            $session = $request->getSession();
+
             $ip = $request->query->get('ip', $session->get('_profiler_search_ip'));
             $method = $request->query->get('method', $session->get('_profiler_search_method'));
             $statusCode = $request->query->get('status_code', $session->get('_profiler_search_status_code'));
@@ -289,7 +291,9 @@ class ProfilerController
         $limit = $request->query->get('limit');
         $token = $request->query->get('token');
 
-        if (null !== $session = $request->getSession()) {
+        if ($request->hasSession()) {
+            $session = $request->getSession();
+
             $session->set('_profiler_search_ip', $ip);
             $session->set('_profiler_search_method', $method);
             $session->set('_profiler_search_status_code', $statusCode);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -1,7 +1,7 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% macro profile_search_filter(request, result, property) %}
-    {%- if request.session is not null -%}
+    {%- if request.hasSession -%}
         <a href="{{ path('_profiler_search_results', request.query.all|merge({token: result.token})|merge({ (property): result[property] })) }}" title="Search"><span title="Search" class="sf-icon sf-search">{{ include('@WebProfiler/Icon/search.svg') }}</span></a>
     {%- endif -%}
 {% endmacro %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none but see comment
| License       | MIT

Symfony 4.1 adds deprecation warnings when getSession is called and a session has not been set.
Some code in the WebProfiler was not up-to-date to use hasSession before.

(this actually caused [Silex-WebProfiler](https://github.com/silexphp/Silex-WebProfiler)'s tests to fail)
