### PR TITLE
[FrameworkBundle] Deprecate auto-injection of the container in AbstractController instances

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Allowed configuring taggable cache pools via a new `framework.cache.pools.tags` option (bool|service-id)
+ * Deprecated auto-injection of the container in AbstractController instances, register them as service subscribers instead
 
 4.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -92,6 +92,10 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         $this->assertSame($container, $controller->getContainer());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Auto-injection of the container for "Symfony\Bundle\FrameworkBundle\Tests\Controller\TestAbstractController" is deprecated since Symfony 4.2. Configure it as a service instead.
+     */
     public function testAbstractControllerGetsContainerWhenNotSet()
     {
         class_exists(AbstractControllerTest::class);
@@ -110,6 +114,10 @@ class ControllerResolverTest extends ContainerControllerResolverTest
         $this->assertSame($container, $controller->setContainer($container));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Auto-injection of the container for "Symfony\Bundle\FrameworkBundle\Tests\Controller\DummyController" is deprecated since Symfony 4.2. Configure it as a service instead.
+     */
     public function testAbstractControllerServiceWithFcqnIdGetsContainerWhenNotSet()
     {
         class_exists(AbstractControllerTest::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Should enhance DX by preventing situations like #27436.