### PR TITLE
[HttpKernel] fix session tracking in surrogate master requests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -29,7 +29,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     private $flashName;
     private $attributeName;
     private $data = array();
-    private $hasBeenStarted;
+    private $usageIndex = 0;
 
     /**
      * @param SessionStorageInterface $storage    A SessionStorageInterface instance
@@ -54,6 +54,8 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function start()
     {
+        ++$this->usageIndex;
+
         return $this->storage->start();
     }
 
@@ -142,13 +144,13 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     }
 
     /**
-     * @return bool
+     * @return int
      *
      * @internal
      */
-    public function hasBeenStarted()
+    public function getUsageIndex()
     {
-        return $this->hasBeenStarted;
+        return $this->usageIndex;
     }
 
     /**
@@ -158,6 +160,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function isEmpty()
     {
+        ++$this->usageIndex;
         foreach ($this->data as &$data) {
             if (!empty($data)) {
                 return false;
@@ -182,6 +185,8 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function migrate($destroy = false, $lifetime = null)
     {
+        ++$this->usageIndex;
+
         return $this->storage->regenerate($destroy, $lifetime);
     }
 
@@ -190,6 +195,8 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function save()
     {
+        ++$this->usageIndex;
+
         $this->storage->save();
     }
 
@@ -230,6 +237,8 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function getMetadataBag()
     {
+        ++$this->usageIndex;
+
         return $this->storage->getMetadataBag();
     }
 
@@ -238,7 +247,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function registerBag(SessionBagInterface $bag)
     {
-        $this->storage->registerBag(new SessionBagProxy($bag, $this->data, $this->hasBeenStarted));
+        $this->storage->registerBag(new SessionBagProxy($bag, $this->data, $this->usageIndex));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
@@ -20,13 +20,13 @@ final class SessionBagProxy implements SessionBagInterface
 {
     private $bag;
     private $data;
-    private $hasBeenStarted;
+    private $usageIndex;
 
-    public function __construct(SessionBagInterface $bag, array &$data, &$hasBeenStarted)
+    public function __construct(SessionBagInterface $bag, array &$data, &$usageIndex)
     {
         $this->bag = $bag;
         $this->data = &$data;
-        $this->hasBeenStarted = &$hasBeenStarted;
+        $this->usageIndex = &$usageIndex;
     }
 
     /**
@@ -34,6 +34,8 @@ final class SessionBagProxy implements SessionBagInterface
      */
     public function getBag()
     {
+        ++$this->usageIndex;
+
         return $this->bag;
     }
 
@@ -42,6 +44,8 @@ final class SessionBagProxy implements SessionBagInterface
      */
     public function isEmpty()
     {
+        ++$this->usageIndex;
+
         return empty($this->data[$this->bag->getStorageKey()]);
     }
 
@@ -58,7 +62,7 @@ final class SessionBagProxy implements SessionBagInterface
      */
     public function initialize(array &$array)
     {
-        $this->hasBeenStarted = true;
+        ++$this->usageIndex;
         $this->data[$this->bag->getStorageKey()] = &$array;
 
         $this->bag->initialize($array);
@@ -77,6 +81,8 @@ final class SessionBagProxy implements SessionBagInterface
      */
     public function clear()
     {
+        ++$this->usageIndex;
+
         return $this->bag->clear();
     }
 }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.5.9|>=7.0.8",
         "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-        "symfony/http-foundation": "^3.4.4|^4.0.4",
+        "symfony/http-foundation": "~3.4.12|~4.0.12|^4.1.1",
         "symfony/debug": "~2.8|~3.0|~4.0",
         "symfony/polyfill-ctype": "~1.8",
         "psr/log": "~1.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Spotted while looking at ESI fragments resolved by`HttpCache`: right now when the master request starts the session, fragments are not cacheable anymore, even when they do not use the session.
