### PR TITLE
[DI] do not log an inlined service as removed

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -61,6 +61,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
         }
 
         $this->container->log($this, sprintf('Inlined service "%s" to "%s".', $id, $this->currentId));
+        $definition->addTag('container.inlined');
 
         if ($definition->isShared()) {
             return $definition;

--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
@@ -73,7 +73,9 @@ class RemoveUnusedDefinitionsPass implements RepeatablePassInterface
             } elseif (0 === count($referencingAliases) && false === $isReferenced) {
                 $container->removeDefinition($id);
                 $container->resolveEnvPlaceholders(serialize($definition));
-                $container->log($this, sprintf('Removed service "%s"; reason: unused.', $id));
+                if (!$definition->hasTag('container.inlined')) {
+                    $container->log($this, sprintf('Removed service "%s"; reason: unused.', $id));
+                }
                 $hasChanged = true;
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -157,11 +157,11 @@ class InlineServiceDefinitionsPassTest extends TestCase
 
         $this->process($container);
 
-        $baz1 = $container->getDefinition('foo')->getArgument(0)->getArgument(0);
-        $baz2 = $container->getDefinition('foo')->getArgument(1)->getArgument(0);
+        $baz1 = $container->getDefinition('foo')->getArgument(0)->getArgument(0)->clearTag('container.inlined');
+        $baz2 = $container->getDefinition('foo')->getArgument(1)->getArgument(0)->clearTag('container.inlined');
 
-        $this->assertEquals($container->getDefinition('baz'), $baz1);
-        $this->assertEquals($container->getDefinition('baz'), $baz2);
+        $this->assertEquals($container->getDefinition('baz')->clearTag('container.inlined'), $baz1);
+        $this->assertEquals($container->getDefinition('baz')->clearTag('container.inlined'), $baz2);
         $this->assertNotSame($baz1, $baz2);
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
@@ -16,4 +16,4 @@ services:
     decorated:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\StdClassDecorator
         public: true
-        arguments: [!service { class: stdClass, public: false }]
+        arguments: [!service { class: stdClass, public: false, tags: [{ name: container.inlined }] }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
@@ -9,7 +9,7 @@ services:
         public: true
         file: file.php
         lazy: true
-        arguments: [!service { class: Class1, public: false }]
+        arguments: [!service { class: Class1, public: false, tags: [{ name: container.inlined }] }]
     bar:
         alias: foo
         public: true

--- a/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
+++ b/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
@@ -62,7 +62,7 @@ class FormPassTest extends TestCase
                 __CLASS__.'_Type1' => new ServiceClosureArgument(new Reference('my.type1')),
                 __CLASS__.'_Type2' => new ServiceClosureArgument(new Reference('my.type2')),
             ))))->addTag('container.service_locator')->setPublic(false),
-            $extDefinition->getArgument(0)
+            $extDefinition->getArgument(0)->clearTag('container.inlined')
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27386
| License       | MIT
| Doc PR        |

This way you can actually see real unsed services that you might be able to remove or that you can exclude from the autowiring config.

Before in an app of mine:

Class | Messages
-- | --
Symfony\Component\DependencyInjection\Compiler\InlineServiceDefinitionsPass | 875
Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass | 985

After:

Class | Messages
-- | --
Symfony\Component\DependencyInjection\Compiler\InlineServiceDefinitionsPass | 875
Symfony\Component\DependencyInjection\Compiler\RemoveUnusedDefinitionsPass | 159
