### PR TITLE
simple-phpunit: remove outdated appveryor workaround

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -188,15 +188,6 @@ if ($components) {
         }
     }
 
-    // Fixes for colors support on appveyor
-    // See https://github.com/appveyor/ci/issues/373
-    $colorFixes = array(
-        array("S\033[0m\033[0m\033[36m\033[1mS", "E\033[0m\033[0m\033[31m\033[1mE", "I\033[0m\033[0m\033[33m\033[1mI", "F\033[0m\033[0m\033[41m\033[37mF"),
-        array("SS", "EE", "II", "FF"),
-    );
-    $colorFixes[0] = array_merge($colorFixes[0], $colorFixes[0]);
-    $colorFixes[1] = array_merge($colorFixes[1], $colorFixes[1]);
-
     while ($runningProcs) {
         usleep(300000);
         $terminatedProcs = array();
@@ -212,20 +203,7 @@ if ($components) {
         foreach ($terminatedProcs as $component => $procStatus) {
             foreach (array('out', 'err') as $file) {
                 $file = "$component/phpunit.std$file";
-
-                if ('\\' === DIRECTORY_SEPARATOR) {
-                    $h = fopen($file, 'rb');
-                    while (false !== $line = fgets($h)) {
-                        echo str_replace($colorFixes[0], $colorFixes[1], preg_replace(
-                            '/(\033\[[0-9]++);([0-9]++m)(?:(.)(\033\[0m))?/',
-                            "$1m\033[$2$3$4$4",
-                            $line
-                        ));
-                    }
-                    fclose($h);
-                } else {
-                    readfile($file);
-                }
+                readfile($file);
                 unlink($file);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Referenced issue seems to be resolved long time ago