### PR TITLE
Keep query params on redirect

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 4.1.0
 -----
 
+ * Added optional $keepQueryParams argument to redirect() and redirectToRoute() methods
  * Allowed to pass an optional `LoggerInterface $logger` instance to the `Router`
  * Added a new `parameter_bag` service with related autowiring aliases to access parameters as-a-service
  * Allowed the `Router` to work with any PSR-11 container

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -106,6 +106,7 @@ trait ControllerTrait
                 }
             }
         }
+
         return new RedirectResponse($url, $status);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -94,8 +94,18 @@ trait ControllerTrait
      *
      * @final
      */
-    protected function redirect(string $url, int $status = 302): RedirectResponse
+    protected function redirect(string $url, int $status = 302, bool $keepQueryParams = false): RedirectResponse
     {
+        if ($keepQueryParams) {
+            $qs = $this->container->get('request_stack')->getCurrentRequest()->getQueryString();
+            if ($qs) {
+                if (false === strpos($url, '?')) {
+                    $url .= '?'.$qs;
+                } else {
+                    $url .= '&'.$qs;
+                }
+            }
+        }
         return new RedirectResponse($url, $status);
     }
 
@@ -104,9 +114,9 @@ trait ControllerTrait
      *
      * @final
      */
-    protected function redirectToRoute(string $route, array $parameters = array(), int $status = 302): RedirectResponse
+    protected function redirectToRoute(string $route, array $parameters = array(), int $status = 302, bool $keepQueryParams = false): RedirectResponse
     {
-        return $this->redirect($this->generateUrl($route, $parameters), $status);
+        return $this->redirect($this->generateUrl($route, $parameters), $status, $keepQueryParams);
     }
 
     /**


### PR DESCRIPTION
Added optional $keepQueryParams to redirect() and redirectToRoute() methods.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
I liked the addition of $keepQueryParams to the redirectAction() method,
but I thought it would be an even more useful addition to the
ControllerTraits redirect() and redirectToRoute() methods.

This is my first submission to the Symfony project, so I hope I did everything right.
-->
