### PR TITLE
[Cache] Allow to configure serializator for cache instances.

### DIFF
--- a/src/Symfony/Component/Cache/Serializer/IdentitySerializer.php
+++ b/src/Symfony/Component/Cache/Serializer/IdentitySerializer.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Serializer;
+
+use Symfony\Component\Cache\SerializerInterface;
+
+class IdentitySerializer implements SerializerInterface
+{
+    public function serialize($data)
+    {
+        return $data;
+    }
+
+    public function unserialize($serialized)
+    {
+        return $serialized;
+    }
+}

--- a/src/Symfony/Component/Cache/Serializer/IgbinarySerializer.php
+++ b/src/Symfony/Component/Cache/Serializer/IgbinarySerializer.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Serializer;
+
+use Symfony\Component\Cache\Exception\CacheException;
+use Symfony\Component\Cache\SerializerInterface;
+
+class IgbinarySerializer implements SerializerInterface
+{
+    public function serialize($data)
+    {
+        return igbinary_serialize($data);
+    }
+
+    public function unserialize($serialized)
+    {
+        $unserializeCallbackHandler = ini_set(
+            'unserialize_callback_func',
+            PhpSerializer::class.'::handleUnserializeCallback'
+        );
+        try {
+            $value = igbinary_unserialize($serialized);
+            if (false === $value && igbinary_serialize(false) !== $serialized) {
+                throw new CacheException('failed to unserialize value');
+            }
+
+            return $value;
+        } catch (\Error $e) {
+            throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
+        } finally {
+            ini_set('unserialize_callback_func', $unserializeCallbackHandler);
+        }
+    }
+}

--- a/src/Symfony/Component/Cache/Serializer/PhpSerializer.php
+++ b/src/Symfony/Component/Cache/Serializer/PhpSerializer.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Serializer;
+
+use Symfony\Component\Cache\Exception\CacheException;
+use Symfony\Component\Cache\SerializerInterface;
+
+class PhpSerializer implements SerializerInterface
+{
+    public function serialize($data)
+    {
+        return serialize($data);
+    }
+
+    public function unserialize($serialized)
+    {
+        $unserializeCallbackHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
+        try {
+            if ('b:0;' === $serialized) {
+                return false;
+            } elseif (false === $value = unserialize($serialized)) {
+                throw new CacheException('failed to unserialize value');
+            }
+
+            return $value;
+        } catch (\Error $e) {
+            throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
+        } finally {
+            ini_set('unserialize_callback_func', $unserializeCallbackHandler);
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public static function handleUnserializeCallback($class)
+    {
+        throw new \DomainException('Class not found: '.$class);
+    }
+}

--- a/src/Symfony/Component/Cache/SerializerInterface.php
+++ b/src/Symfony/Component/Cache/SerializerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache;
+
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+
+/**
+ * @author Alexei Prilipko <palex.fpt@gmail.com>
+ */
+interface SerializerInterface
+{
+    /**
+     * Generates a storable representation of a value.
+     *
+     * @param $data mixed
+     *
+     * @return string|mixed serialized value
+     *
+     * @throws InvalidArgumentException when $data can not be serialized
+     */
+    public function serialize($data);
+
+    /**
+     * Creates a PHP value from a stored representation.
+     *
+     * @param string|mixed $serialized the serialized string
+     *
+     * @return mixed Original value
+     */
+    public function unserialize($serialized);
+}

--- a/src/Symfony/Component/Cache/Tests/Serializer/IgbinarySerializerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Serializer/IgbinarySerializerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Serializer;
+
+use Symfony\Component\Cache\Serializer\IgbinarySerializer;
+use Symfony\Component\Cache\SerializerInterface;
+
+class IgbinarySerializerTest extends SerializerTest
+{
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        if (!extension_loaded('igbinary')) {
+            self::markTestSkipped('Extension igbinary is not loaded.');
+        }
+    }
+
+    protected function createSerializer(): SerializerInterface
+    {
+        return new IgbinarySerializer();
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Serializer/PhpSerializerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Serializer/PhpSerializerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Serializer;
+
+use Symfony\Component\Cache\Serializer\PhpSerializer;
+use Symfony\Component\Cache\SerializerInterface;
+
+class PhpSerializerTest extends SerializerTest
+{
+    protected function createSerializer(): SerializerInterface
+    {
+        return new PhpSerializer();
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Serializer/SerializerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Serializer/SerializerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\SerializerInterface;
+
+abstract class SerializerTest extends TestCase
+{
+    /** @var SerializerInterface */
+    private $serializer;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->serializer = $this->createSerializer();
+    }
+
+    abstract protected function createSerializer(): SerializerInterface;
+
+    /**
+     * @dataProvider validData
+     */
+    public function testSerializeInvariants($value)
+    {
+        $serialized = $this->serializer->serialize($value);
+        $restored = $this->serializer->unserialize($serialized);
+        $this->assertEquals($value, $restored);
+    }
+
+    /**
+     * Data provider for valid data to store.
+     *
+     * @return array
+     */
+    public static function validData()
+    {
+        return array(
+            array(false),
+            array('AbC19_.'),
+            array(4711),
+            array(47.11),
+            array(true),
+            array(null),
+            array(array('key' => 'value')),
+            array(new \stdClass()),
+        );
+    }
+}
+
+class NotUnserializable implements \Serializable
+{
+    public function serialize()
+    {
+        return serialize(123);
+    }
+
+    public function unserialize($ser)
+    {
+        throw new \Exception(__CLASS__);
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractTrait.php
@@ -202,33 +202,6 @@ trait AbstractTrait
         $this->ids = array();
     }
 
-    /**
-     * Like the native unserialize() function but throws an exception if anything goes wrong.
-     *
-     * @param string $value
-     *
-     * @return mixed
-     *
-     * @throws \Exception
-     */
-    protected static function unserialize($value)
-    {
-        if ('b:0;' === $value) {
-            return false;
-        }
-        $unserializeCallbackHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
-        try {
-            if (false !== $value = unserialize($value)) {
-                return $value;
-            }
-            throw new \DomainException('Failed to unserialize cached value');
-        } catch (\Error $e) {
-            throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
-        } finally {
-            ini_set('unserialize_callback_func', $unserializeCallbackHandler);
-        }
-    }
-
     private function getId($key)
     {
         if ($this->versioningIsEnabled && '' === $this->namespaceVersion) {
@@ -254,13 +227,5 @@ trait AbstractTrait
         }
 
         return $id;
-    }
-
-    /**
-     * @internal
-     */
-    public static function handleUnserializeCallback($class)
-    {
-        throw new \DomainException('Class not found: '.$class);
     }
 }

--- a/src/Symfony/Component/Cache/Traits/ArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ArrayTrait.php
@@ -22,8 +22,8 @@ use Symfony\Component\Cache\CacheItem;
 trait ArrayTrait
 {
     use LoggerAwareTrait;
+    use SerializerTrait;
 
-    private $storeSerialized;
     private $values = array();
     private $expiries = array();
 
@@ -83,13 +83,8 @@ trait ArrayTrait
             try {
                 if (!$isHit = isset($this->expiries[$key]) && ($this->expiries[$key] > $now || !$this->deleteItem($key))) {
                     $this->values[$key] = $value = null;
-                } elseif (!$this->storeSerialized) {
-                    $value = $this->values[$key];
-                } elseif ('b:0;' === $value = $this->values[$key]) {
-                    $value = false;
-                } elseif (false === $value = unserialize($value)) {
-                    $this->values[$key] = $value = null;
-                    $isHit = false;
+                } else {
+                    $value = $this->unserialize($this->values[$key]);
                 }
             } catch (\Exception $e) {
                 CacheItem::log($this->logger, 'Failed to unserialize key "{key}"', array('key' => $key, 'exception' => $e));

--- a/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
+++ b/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Traits;
 
 use Symfony\Component\Cache\Exception\CacheException;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
+use Symfony\Component\Cache\Serializer\PhpSerializer;
 
 /**
  * @author Rob Frawley 2nd <rmf@src.run>
@@ -211,7 +212,7 @@ trait MemcachedTrait
      */
     protected function doFetch(array $ids)
     {
-        $unserializeCallbackHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
+        $unserializeCallbackHandler = ini_set('unserialize_callback_func', PhpSerializer::class.'::handleUnserializeCallback');
         try {
             $encodedIds = array_map('rawurlencode', $ids);
 
@@ -223,8 +224,6 @@ trait MemcachedTrait
             }
 
             return $result;
-        } catch (\Error $e) {
-            throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
         } finally {
             ini_set('unserialize_callback_func', $unserializeCallbackHandler);
         }

--- a/src/Symfony/Component/Cache/Traits/SerializerTrait.php
+++ b/src/Symfony/Component/Cache/Traits/SerializerTrait.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+use Symfony\Component\Cache\SerializerInterface;
+
+/**
+ * @author Alexei Prilipko <palex.fpt@gmail.com>
+ *
+ * @internal
+ */
+trait SerializerTrait
+{
+    /** @var SerializerInterface */
+    private $serializer;
+
+    public function setSerializer(SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * Generates a storable representation of a value.
+     *
+     * @param $data mixed
+     *
+     * @return string|mixed serialized value
+     */
+    protected function serialize($data)
+    {
+        return $this->serializer->serialize($data);
+    }
+
+    /**
+     * Creates a PHP value from a stored representation.
+     *
+     * @param string|mixed $serialized the serialized string
+     *
+     * @return mixed Original value
+     */
+    protected function unserialize($serialized)
+    {
+        return $this->serializer->unserialize($serialized);
+    }
+
+    protected function serializeMultiple(iterable $values)
+    {
+        foreach ($values as $key => $value) {
+            yield $key => $this->serialize($value);
+        }
+    }
+
+    protected function unserializeMultiple(iterable $serializedValues)
+    {
+        foreach ($serializedValues as $key => $value) {
+            yield $key => $this->unserialize($value);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Extract object serialization logic into SerializerInterface.
Allow opcache related caches to store __set_state enabled objects without serialization.