### PR TITLE
[DebugBundle] DebugBundle::registerCommands should be noop

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DebugBundle.php
+++ b/src/Symfony/Bundle/DebugBundle/DebugBundle.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\DebugBundle;
 
 use Symfony\Bundle\DebugBundle\DependencyInjection\Compiler\DumpDataCollectorPass;
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\VarDumper\VarDumper;
@@ -51,5 +52,10 @@ class DebugBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new DumpDataCollectorPass());
+    }
+
+    public function registerCommands(Application $application)
+    {
+        // noop
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27493   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A