### PR TITLE
[FrameworkBundle] Fix test-container on kernel reboot, revert to returning the real container from Client::getContainer()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -30,15 +30,13 @@ class Client extends BaseClient
     private $hasPerformedRequest = false;
     private $profiler = false;
     private $reboot = true;
-    private $testContainerId;
 
     /**
      * {@inheritdoc}
      */
-    public function __construct(KernelInterface $kernel, array $server = array(), History $history = null, CookieJar $cookieJar = null, string $testContainerId = null)
+    public function __construct(KernelInterface $kernel, array $server = array(), History $history = null, CookieJar $cookieJar = null)
     {
         parent::__construct($kernel, $server, $history, $cookieJar);
-        $this->testContainerId = $testContainerId;
     }
 
     /**
@@ -48,9 +46,7 @@ class Client extends BaseClient
      */
     public function getContainer()
     {
-        $container = $this->kernel->getContainer();
-
-        return null !== $this->testContainerId ? $container->get($this->testContainerId) : $container;
+        return $this->kernel->getContainer();
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerRealRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerRealRefPass.php
@@ -22,15 +22,11 @@ class TestServiceContainerRealRefPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('test.service_container')) {
+        if (!$container->hasDefinition('test.private_services_locator')) {
             return;
         }
 
-        $testContainer = $container->getDefinition('test.service_container');
-        $privateContainer = $testContainer->getArgument(2);
-        if ($privateContainer instanceof Reference) {
-            $privateContainer = $container->getDefinition((string) $privateContainer);
-        }
+        $privateContainer = $container->getDefinition('test.private_services_locator');
         $definitions = $container->getDefinitions();
         $privateServices = $privateContainer->getArgument(0);
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
@@ -23,7 +23,7 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('test.service_container')) {
+        if (!$container->hasDefinition('test.private_services_locator')) {
             return;
         }
 
@@ -50,7 +50,7 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
         }
 
         if ($privateServices) {
-            $definitions[(string) $definitions['test.service_container']->getArgument(2)]->replaceArgument(0, $privateServices);
+            $definitions['test.private_services_locator']->replaceArgument(0, $privateServices);
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -16,7 +16,6 @@
             <argument>%test.client.parameters%</argument>
             <argument type="service" id="test.client.history" />
             <argument type="service" id="test.client.cookiejar" />
-            <argument>test.service_container</argument>
         </service>
 
         <service id="test.client.history" class="Symfony\Component\BrowserKit\History" shared="false" />
@@ -36,13 +35,12 @@
         </service>
 
         <service id="test.service_container" class="Symfony\Bundle\FrameworkBundle\Test\TestContainer" public="true">
-            <argument type="service" id="parameter_bag" on-invalid="null" />
-            <argument type="service" id="service_container" />
-            <argument type="service">
-                <service class="Symfony\Component\DependencyInjection\ServiceLocator">
-                    <argument type="collection" />
-                </service>
-            </argument>
+            <argument type="service" id="kernel" />
+            <argument>test.private_services_locator</argument>
+        </service>
+
+        <service id="test.private_services_locator" class="Symfony\Component\DependencyInjection\ServiceLocator" public="true">
+            <argument type="collection" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
@@ -11,24 +11,23 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
-use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
  */
 class TestContainer extends Container
 {
-    private $publicContainer;
-    private $privateContainer;
+    private $kernel;
+    private $privateServicesLocatorId;
 
-    public function __construct(?ParameterBagInterface $parameterBag, SymfonyContainerInterface $publicContainer, PsrContainerInterface $privateContainer)
+    public function __construct(KernelInterface $kernel, string $privateServicesLocatorId)
     {
-        $this->parameterBag = $parameterBag ?? $publicContainer->getParameterBag();
-        $this->publicContainer = $publicContainer;
-        $this->privateContainer = $privateContainer;
+        $this->kernel = $kernel;
+        $this->privateServicesLocatorId = $privateServicesLocatorId;
     }
 
     /**
@@ -36,7 +35,7 @@ class TestContainer extends Container
      */
     public function compile()
     {
-        $this->publicContainer->compile();
+        $this->getPublicContainer()->compile();
     }
 
     /**
@@ -44,7 +43,39 @@ class TestContainer extends Container
      */
     public function isCompiled()
     {
-        return $this->publicContainer->isCompiled();
+        return $this->getPublicContainer()->isCompiled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameterBag()
+    {
+        return $this->getPublicContainer()->getParameterBag();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameter($name)
+    {
+        return $this->getPublicContainer()->getParameter($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasParameter($name)
+    {
+        return $this->getPublicContainer()->hasParameter($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParameter($name, $value)
+    {
+        $this->getPublicContainer()->setParameter($name, $value);
     }
 
     /**
@@ -52,7 +83,7 @@ class TestContainer extends Container
      */
     public function set($id, $service)
     {
-        $this->publicContainer->set($id, $service);
+        $this->getPublicContainer()->set($id, $service);
     }
 
     /**
@@ -60,7 +91,7 @@ class TestContainer extends Container
      */
     public function has($id)
     {
-        return $this->publicContainer->has($id) || $this->privateContainer->has($id);
+        return $this->getPublicContainer()->has($id) || $this->getPrivateContainer()->has($id);
     }
 
     /**
@@ -68,7 +99,7 @@ class TestContainer extends Container
      */
     public function get($id, $invalidBehavior = /* self::EXCEPTION_ON_INVALID_REFERENCE */ 1)
     {
-        return $this->privateContainer->has($id) ? $this->privateContainer->get($id) : $this->publicContainer->get($id, $invalidBehavior);
+        return $this->getPrivateContainer()->has($id) ? $this->getPrivateContainer()->get($id) : $this->getPublicContainer()->get($id, $invalidBehavior);
     }
 
     /**
@@ -76,7 +107,7 @@ class TestContainer extends Container
      */
     public function initialized($id)
     {
-        return $this->publicContainer->initialized($id);
+        return $this->getPublicContainer()->initialized($id);
     }
 
     /**
@@ -84,7 +115,7 @@ class TestContainer extends Container
      */
     public function reset()
     {
-        $this->publicContainer->reset();
+        $this->getPublicContainer()->reset();
     }
 
     /**
@@ -92,7 +123,7 @@ class TestContainer extends Container
      */
     public function getServiceIds()
     {
-        return $this->publicContainer->getServiceIds();
+        return $this->getPublicContainer()->getServiceIds();
     }
 
     /**
@@ -100,6 +131,20 @@ class TestContainer extends Container
      */
     public function getRemovedIds()
     {
-        return $this->publicContainer->getRemovedIds();
+        return $this->getPublicContainer()->getRemovedIds();
+    }
+
+    private function getPublicContainer()
+    {
+        if (null === $container = $this->kernel->getContainer()) {
+            throw new \LogicException('Cannot access the container on a non-booted kernel. Did you forget to boot it?');
+        }
+
+        return $container;
+    }
+
+    private function getPrivateContainer()
+    {
+        return $this->getPublicContainer()->get($this->privateServicesLocatorId);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDumpTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDumpTest.php
@@ -20,13 +20,13 @@ class ContainerDumpTest extends WebTestCase
     {
         $client = $this->createClient(array('test_case' => 'ContainerDump', 'root_config' => 'config.yml'));
 
-        $this->assertTrue($client->getContainer()->has('serializer'));
+        $this->assertTrue(static::$container->has('serializer'));
     }
 
     public function testContainerCompilation()
     {
         $client = $this->createClient(array('test_case' => 'ContainerDump', 'root_config' => 'config.yml', 'debug' => false));
 
-        $this->assertTrue($client->getContainer()->has('serializer'));
+        $this->assertTrue(static::$container->has('serializer'));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
@@ -35,18 +35,18 @@ class LogoutTest extends WebTestCase
     public function testCsrfTokensAreClearedOnLogout()
     {
         $client = $this->createClient(array('test_case' => 'LogoutWithoutSessionInvalidation', 'root_config' => 'config.yml'));
-        $client->getContainer()->get('security.csrf.token_storage')->setToken('foo', 'bar');
+        static::$container->get('security.csrf.token_storage')->setToken('foo', 'bar');
 
         $client->request('POST', '/login', array(
             '_username' => 'johannes',
             '_password' => 'test',
         ));
 
-        $this->assertTrue($client->getContainer()->get('security.csrf.token_storage')->hasToken('foo'));
-        $this->assertSame('bar', $client->getContainer()->get('security.csrf.token_storage')->getToken('foo'));
+        $this->assertTrue(static::$container->get('security.csrf.token_storage')->hasToken('foo'));
+        $this->assertSame('bar', static::$container->get('security.csrf.token_storage')->getToken('foo'));
 
         $client->request('GET', '/logout');
 
-        $this->assertFalse($client->getContainer()->get('security.csrf.token_storage')->hasToken('foo'));
+        $this->assertFalse(static::$container->get('security.csrf.token_storage')->hasToken('foo'));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -47,7 +47,7 @@
         "symfony/security": "4.1.0-beta1|4.1.0-beta2",
         "symfony/var-dumper": "<3.4",
         "symfony/event-dispatcher": "<3.4",
-        "symfony/framework-bundle": "<=4.1-beta2",
+        "symfony/framework-bundle": "<4.1.1",
         "symfony/console": "<3.4"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | -
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27494
| License       | MIT
| Doc PR        | -

By making `Client::getContainer()` return the new test container, we broke BC, as spotted in linked issue.

Always use `static::$container` in your tests instead.

While reverting to returning the real container, I noticed we have a serious design issue in the way the test container currently works: because the kernel can be rebooted, we cannot inject the container directly, but have to go through the kernel all the time. Fixing this forces doing a BC break on the constructor of `TestContainer`. Since this is a new class and since it's mostly internal, I think we should do it now. I've marked the class as internal to further strengthen this.