### PR TITLE
[Serializer] Allow to pass a single value for the groups opt

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -227,8 +227,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         }
 
         $groups = false;
-        if (isset($context[static::GROUPS]) && \is_array($context[static::GROUPS])) {
-            $groups = $context[static::GROUPS];
+        if (isset($context[static::GROUPS]) && (\is_array($context[static::GROUPS]) || is_scalar($context[static::GROUPS]))) {
+            $groups = (array) $context[static::GROUPS];
         } elseif (!isset($context[static::ALLOW_EXTRA_ATTRIBUTES]) || $context[static::ALLOW_EXTRA_ATTRIBUTES]) {
             return false;
         }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -92,6 +92,9 @@ class AbstractNormalizerTest extends TestCase
         $result = $this->normalizer->getAllowedAttributes('c', array(AbstractNormalizer::GROUPS => array('test')), false);
         $this->assertEquals(array($a2, $a4), $result);
 
+        $result = $this->normalizer->getAllowedAttributes('c', array(AbstractNormalizer::GROUPS => 'test'), false);
+        $this->assertEquals(array($a2, $a4), $result);
+
         $result = $this->normalizer->getAllowedAttributes('c', array(AbstractNormalizer::GROUPS => array('other')), false);
         $this->assertEquals(array($a3, $a4), $result);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |  n/a
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10312

Shortcut syntax similar to #20509 but for the context: allows to pass a string instead of an array of string in the serialization context when only one group if used.

Before:

```php
$serializer->serialize($foo, 'json', ['groups' => ['myGroup']];

/** @ApiResource(normalizationContext={"groups"={"myGroup"}}) */
```

After:

```php
$serializer->serialize($foo, 'json', ['groups' => 'myGroup'];

/** @ApiResource(normalizationContext={"groups"="myGroup") */
```