### PR TITLE
[HttpKernel] Turn HTTP exceptions to responses on terminateWithException()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -68,8 +68,9 @@
         </service>
 
         <service id="http_exception_listener" class="Symfony\Component\HttpKernel\EventListener\ExceptionListener">
-            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-256"/>
+            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-2048" />
             <tag name="monolog.logger" channel="request" />
+            <tag name="kernel.reset" method="reset" />
             <argument>null</argument>
             <argument type="service" id="logger" on-invalid="null" />
             <argument>%kernel.debug%</argument>

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -165,7 +165,9 @@ class ExceptionListenerTest extends TestCase
         $event = new GetResponseForExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, new \Exception('foo'));
 
         $listener->onKernelException($event);
+        $this->assertNull($event->getResponse());
 
+        $listener->onKernelException($event);
         $this->assertContains('Whoops, looks like something went wrong.', $event->getResponse()->getContent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27212
| License       | MIT
| Doc PR        | -

#26138 introduced a BC break that is described in the linked issue.
In order to fix it, I propose to postpone generating a response for HTTP exceptions to the exception event that is throw in `terminateWithException()`. This allows providing the target DX (generate 404 for `NotFoundHttpException`) while allowing ppl that have custom listeners or try/catch to keep things working as previously.