### PR TITLE
[DI] Remove dead code in RemoveUnusedDefinitionsPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
@@ -63,12 +63,7 @@ class RemoveUnusedDefinitionsPass implements RepeatablePassInterface
                 $isReferenced = false;
             }
 
-            if (1 === count($referencingAliases) && false === $isReferenced) {
-                $container->setDefinition((string) reset($referencingAliases), $definition);
-                $definition->setPublic(true);
-                $container->removeDefinition($id);
-                $compiler->addLogMessage($formatter->formatRemoveService($this, $id, 'replaces alias '.reset($referencingAliases)));
-            } elseif (0 === count($referencingAliases) && false === $isReferenced) {
+            if (0 === count($referencingAliases) && false === $isReferenced) {
                 $container->removeDefinition($id);
                 $compiler->addLogMessage($formatter->formatRemoveService($this, $id, 'unused'));
                 $hasChanged = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I don't understand what this code is for. Removing it breaks nothing.
AFAIK `ResolveReferencesToAliasesPass` and `ReplaceAliasByActualDefinitionPass` already resolved all aliases at this point, so that this is dead code.

I'd be happy to add a test case if you think I missed something, that's very possible.

ping @stof @schmittjoh