### PR TITLE
[Debug] Pass previous exception to FatalErrorException

### DIFF
--- a/src/Symfony/Component/Debug/Exception/ClassNotFoundException.php
+++ b/src/Symfony/Component/Debug/Exception/ClassNotFoundException.php
@@ -26,6 +26,9 @@ class ClassNotFoundException extends FatalErrorException
             $previous->getSeverity(),
             $previous->getFile(),
             $previous->getLine(),
+            null,
+            true,
+            null,
             $previous->getPrevious()
         );
         $this->setTrace($previous->getTrace());

--- a/src/Symfony/Component/Debug/Exception/FatalErrorException.php
+++ b/src/Symfony/Component/Debug/Exception/FatalErrorException.php
@@ -35,9 +35,9 @@ use Symfony\Component\HttpKernel\Exception\FatalErrorException as LegacyFatalErr
  */
 class FatalErrorException extends LegacyFatalErrorException
 {
-    public function __construct($message, $code, $severity, $filename, $lineno, $traceOffset = null, $traceArgs = true, array $trace = null)
+    public function __construct($message, $code, $severity, $filename, $lineno, $traceOffset = null, $traceArgs = true, array $trace = null, $previous = null)
     {
-        parent::__construct($message, $code, $severity, $filename, $lineno);
+        parent::__construct($message, $code, $severity, $filename, $lineno, $previous);
 
         if (null !== $trace) {
             if (!$traceArgs) {

--- a/src/Symfony/Component/Debug/Exception/UndefinedFunctionException.php
+++ b/src/Symfony/Component/Debug/Exception/UndefinedFunctionException.php
@@ -26,6 +26,9 @@ class UndefinedFunctionException extends FatalErrorException
             $previous->getSeverity(),
             $previous->getFile(),
             $previous->getLine(),
+            null,
+            true,
+            null,
             $previous->getPrevious()
         );
         $this->setTrace($previous->getTrace());

--- a/src/Symfony/Component/Debug/Exception/UndefinedMethodException.php
+++ b/src/Symfony/Component/Debug/Exception/UndefinedMethodException.php
@@ -26,6 +26,9 @@ class UndefinedMethodException extends FatalErrorException
             $previous->getSeverity(),
             $previous->getFile(),
             $previous->getLine(),
+            null,
+            true,
+            null,
             $previous->getPrevious()
         );
         $this->setTrace($previous->getTrace());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27483 
| License       | MIT

Add a previous parameter to FatalErrorException.
Call \ErrorException with this parameter.
Update parent::__constructor for inherited classes with default parameters and the new one