### PR TITLE
[HttpKernel] Preserve security exceptions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -75,6 +75,7 @@
             <argument>%kernel.debug%</argument>
             <argument>%kernel.charset%</argument>
             <argument>%debug.file_link_format%</argument>
+            <argument type="collection" /> <!-- silent ignored exceptions -->
         </service>
 
         <service id="validate_request_listener" class="Symfony\Component\HttpKernel\EventListener\ValidateRequestListener">

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -129,6 +129,9 @@
             <argument>%twig.exception_listener.controller%</argument>
             <argument type="service" id="logger" on-invalid="null" />
             <argument>%kernel.debug%</argument>
+            <argument>%kernel.charset%</argument>
+            <argument>%debug.file_link_format%</argument>
+            <argument type="collection" /> <!-- silent ignored exceptions -->
         </service>
 
         <service id="twig.controller.exception" class="Symfony\Bundle\TwigBundle\Controller\ExceptionController" public="true">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | yes-ish
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27440
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR introduces an approach that allows for skipping certain (origin) exception classes from being logged. In this case the security related ones.