### PR TITLE
Revert "bug #26138 [HttpKernel] Catch HttpExceptions when templating is not installed (cilefen)"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -67,16 +67,6 @@
             <argument type="service" id="router" on-invalid="ignore" />
         </service>
 
-        <service id="http_exception_listener" class="Symfony\Component\HttpKernel\EventListener\ExceptionListener">
-            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-256"/>
-            <tag name="monolog.logger" channel="request" />
-            <argument>null</argument>
-            <argument type="service" id="logger" on-invalid="null" />
-            <argument>%kernel.debug%</argument>
-            <argument>%kernel.charset%</argument>
-            <argument>%debug.file_link_format%</argument>
-        </service>
-
         <service id="validate_request_listener" class="Symfony\Component\HttpKernel\EventListener\ValidateRequestListener">
             <tag name="kernel.event_subscriber" />
         </service>

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -12,11 +12,9 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Debug\ExceptionHandler;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -35,16 +33,12 @@ class ExceptionListener implements EventSubscriberInterface
     protected $controller;
     protected $logger;
     protected $debug;
-    private $charset;
-    private $fileLinkFormat;
 
-    public function __construct($controller, LoggerInterface $logger = null, $debug = false, $charset = null, $fileLinkFormat = null)
+    public function __construct($controller, LoggerInterface $logger = null, $debug = false)
     {
         $this->controller = $controller;
         $this->logger = $logger;
         $this->debug = $debug;
-        $this->charset = $charset;
-        $this->fileLinkFormat = $fileLinkFormat;
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
@@ -123,12 +117,8 @@ class ExceptionListener implements EventSubscriberInterface
     protected function duplicateRequest(\Exception $exception, Request $request)
     {
         $attributes = array(
-            'exception' => $exception = FlattenException::create($exception),
-            '_controller' => $this->controller ?: function () use ($exception) {
-                $handler = new ExceptionHandler($this->debug, $this->charset, $this->fileLinkFormat);
-
-                return new Response($handler->getHtml($exception), $exception->getStatusCode(), $exception->getHeaders());
-            },
+            '_controller' => $this->controller,
+            'exception' => FlattenException::create($exception),
             'logger' => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
         );
         $request = $request->duplicate(null, null, $attributes);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -151,23 +151,6 @@ class ExceptionListenerTest extends TestCase
         $this->assertFalse($response->headers->has('content-security-policy'), 'CSP header has been removed');
         $this->assertFalse($dispatcher->hasListeners(KernelEvents::RESPONSE), 'CSP removal listener has been removed');
     }
-
-    public function testNullController()
-    {
-        $listener = new ExceptionListener(null);
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
-        $kernel->expects($this->once())->method('handle')->will($this->returnCallback(function (Request $request) {
-            $controller = $request->attributes->get('_controller');
-
-            return $controller();
-        }));
-        $request = Request::create('/');
-        $event = new GetResponseForExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, new \Exception('foo'));
-
-        $listener->onKernelException($event);
-
-        $this->assertContains('Whoops, looks like something went wrong.', $event->getResponse()->getContent());
-    }
 }
 
 class TestLogger extends Logger implements DebugLoggerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27212
| License       | MIT
| Doc PR        | -

This reverts commit b213c5a758bc8b02375bd388b52b351c7e862f6a, reversing
changes made to 61af0e3a25fbb2d169999a5b550c1f1801f1c0de.

This breaks BC and is more like a new feature, let's move this on master.