### PR TITLE
[Console] Added Parallelization trait

### DIFF
--- a/src/Symfony/Component/Console/Parallelization/Parallelization.php
+++ b/src/Symfony/Component/Console/Parallelization/Parallelization.php
@@ -1,0 +1,475 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Parallelization;
+
+use Exception;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
+
+/**
+ * Adds parallelization capabilities to console commands.
+ *
+ * Make sure to call configureParallelization() in your configure() method!
+ *
+ * You must implement the following methods in your command:
+ *
+ *  * fetchElements(): Returns all the elements that you want to process as
+ *    strings. Typically, you will return IDs of database objects here.
+ *  * runSingleCommand(): Executes the command for a single element.
+ *  * getElementName(): Returns a human readable name of the processed things
+ *
+ * You can improve the performance of your command by making use of batching.
+ * Batching allows you to process multiple elements together, for example to
+ * persist them in a batch to reduce the number of I/O operations.
+ *
+ * To enable batching, you will typically implement runAfterBatch() and persist
+ * the changes done in multiple calls of runSingleCommand().
+ *
+ * The batch size is determined by getBatchSize() and defaults to the segment
+ * size. The segment size is the number of elements a worker (child) process
+ * consumes before it dies. This means that, by default, a child process will
+ * process all its elements, persist them in a batch and then die. If you want
+ * to improve the performance of your command, try to tweak getSegmentSize()
+ * first. Optionally, you can tweak getBatchSize() to process multiple batches
+ * in each child process.
+ */
+trait Parallelization
+{
+    /**
+     * Returns the symbol for communicating progress from the child to the
+     * main process.
+     *
+     * @return string A single character
+     */
+    private static function getProgressSymbol()
+    {
+        return chr(254);
+    }
+
+    /**
+     * Detects the path of the PHP interpreter.
+     *
+     * @throws RuntimeException If PHP could not be found
+     *
+     * @return string The absolute path to the PHP interpreter
+     */
+    private static function detectPhpExecutable(): string
+    {
+        $executableFinder = new PhpExecutableFinder();
+
+        $php = $executableFinder->find();
+
+        if (false === $php) {
+            throw new RuntimeException('Cannot find php executable');
+        }
+
+        return $php;
+    }
+
+    /**
+     * Returns the environment variables that are passed to the child processes.
+     *
+     * @param ContainerInterface $container The service containers
+     *
+     * @return string[] A list of environment variable names and values
+     */
+    private static function getEnvironmentVariables(ContainerInterface $container): array
+    {
+        return [
+            'PATH' => getenv('PATH'),
+            'HOME' => getenv('HOME'),
+            'SYMFONY_DEBUG' => $container->getParameter('kernel.debug'),
+            'SYMFONY_ENV' => $container->getParameter('kernel.environment'),
+        ];
+    }
+
+    /**
+     * Returns the working directory for the child process.
+     *
+     * @param ContainerInterface $container The service container
+     *
+     * @return string The absolute path to the working directory
+     */
+    private static function getWorkingDirectory(ContainerInterface $container): string
+    {
+        return dirname($container->getParameter('kernel.root_dir'));
+    }
+
+    /**
+     * Provided by Symfony Command class.
+     *
+     * @return string The command name
+     */
+    abstract public function getName();
+
+    /**
+     * Provided by Symfony Command class.
+     *
+     * @return ContainerInterface The service container
+     */
+    abstract protected function getContainer();
+
+    /**
+     * Provided by Symfony Command class.
+     *
+     * @return Application The console application
+     */
+    abstract protected function getApplication();
+
+    /**
+     * Fetches the elements that should be processed.
+     *
+     * Typically, you will fetch all the elements of the database objects that you
+     * you want to process here. These will be passed to runSingleCommand().
+     *
+     * This method is called exactly once in the main process.
+     *
+     * @param InputInterface $input The console input
+     *
+     * @return string[] The elements to process
+     */
+    abstract protected function fetchElements(InputInterface $input): iterable;
+
+    /**
+     * Processes an element in the child process.
+     *
+     * @param string          $element The element to process
+     * @param InputInterface  $input   The console input
+     * @param OutputInterface $output  The console output
+     */
+    abstract protected function runSingleCommand(string $element, InputInterface $input, OutputInterface $output);
+
+    /**
+     * Returns the name of each element in lowercase letters.
+     *
+     * For example, this method could return "contact" if the count is one and
+     * "contacts" otherwise.
+     *
+     * @param int $count The number of elements
+     *
+     * @return string The name of the element in the correct plurality
+     */
+    abstract protected function getElementName(int $count);
+
+    /**
+     * Can be overridden to execute logic in the very beginning.
+     *
+     * This method is always executed in the main process.
+     *
+     * @param InputInterface  $input  The console input
+     * @param OutputInterface $output The console output
+     */
+    protected function runBeforeFirstCommand(InputInterface $input, OutputInterface $output)
+    {
+    }
+
+    /**
+     * Can be overridden to execute logic in the very end.
+     *
+     * This method is always executed in the main process.
+     *
+     * @param InputInterface  $input  The console input
+     * @param OutputInterface $output The console output
+     */
+    protected function runAfterLastCommand(InputInterface $input, OutputInterface $output)
+    {
+    }
+
+    /**
+     * Can be overridden to execute logic before every batch.
+     *
+     * @param InputInterface  $input  The console input
+     * @param OutputInterface $output The console output
+     */
+    protected function runBeforeBatch(InputInterface $input, OutputInterface $output)
+    {
+    }
+
+    /**
+     * Can be overridden to execute logic after every batch.
+     *
+     * @param InputInterface  $input  The console input
+     * @param OutputInterface $output The console output
+     */
+    protected function runAfterBatch(InputInterface $input, OutputInterface $output)
+    {
+    }
+
+    /**
+     * Returns the number of elements to process per child process.
+     *
+     * You can override this method to tweak the performance of your
+     * parallelized command.
+     *
+     * @return int The number of elements to process per child process
+     */
+    protected function getSegmentSize(): int
+    {
+        return 50;
+    }
+
+    /**
+     * Returns the number of elements to process in a batch.
+     *
+     * Batches allow you to persist multiple elements at once. Add
+     * your persistence logic to runAfterBatch().
+     *
+     * @return int The number of elements to process in a batch
+     */
+    protected function getBatchSize(): int
+    {
+        return $this->getSegmentSize();
+    }
+
+    /**
+     * Executes the parallelized command.
+     *
+     * @param InputInterface  $input  The console input
+     * @param OutputInterface $output The console output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getOption('child')) {
+            return $this->executeChildProcess($input, $output);
+        }
+
+        $this->executeMainProcess($input, $output);
+    }
+
+    /**
+     * Adds the command configuration specific to parallelization.
+     *
+     * Call this method in your configure() method.
+     */
+    protected function configureParallelization()
+    {
+        $this
+            ->addArgument(
+                'element',
+                InputArgument::OPTIONAL,
+                'The element to process'
+            )
+            ->addOption(
+                'processes',
+                'p',
+                InputOption::VALUE_OPTIONAL,
+                'The number of parallel processes to run',
+                1
+            )
+            ->addOption(
+                'child',
+                null,
+                InputOption::VALUE_NONE,
+                'Set on child processes'
+            )
+        ;
+    }
+
+    /**
+     * Executes the main process.
+     *
+     * The main process spawns as many child processes as set in the
+     * "--processes" option. Each of the child processes receives a segment of
+     * items of the processed data set and terminates. As long as there is data
+     * left to process, new child processes are spawned automatically.
+     *
+     * @param InputInterface  $input  The console input
+     * @param OutputInterface $output The console output
+     */
+    protected function executeMainProcess(InputInterface $input, OutputInterface $output)
+    {
+        $this->runBeforeFirstCommand($input, $output);
+
+        $numberOfProcesses = (int) $input->getOption('processes');
+        $elements = $input->getArgument('element') ? [$input->getArgument('element')] : $this->fetchElements($input);
+        $count = count($elements);
+        $segmentSize = 1 === $numberOfProcesses ? $count : $this->getSegmentSize();
+        $batchSize = $this->getBatchSize();
+        $rounds = 1 === $numberOfProcesses ? 1 : ceil($count * 1.0 / $segmentSize);
+        $batches = ceil($segmentSize * 1.0 / $batchSize) * $rounds;
+
+        if (0 === $numberOfProcesses) {
+            throw new InvalidArgumentException(sprintf('Requires at least one process, "%s" given.', $input->getOption('processes')));
+        }
+
+        $output->writeln(sprintf(
+            'Processing %d %s in segments of %d, batches of %d, %d %s, %d %s in %d %s',
+            $count,
+            $this->getElementName($count),
+            $segmentSize,
+            $batchSize,
+            $rounds,
+            1 === $rounds ? 'round' : 'rounds',
+            $batches,
+            1 === $batches ? 'batch' : 'batches',
+            $numberOfProcesses,
+            1 === $numberOfProcesses ? 'process' : 'processes'
+        ));
+        $output->writeln('');
+
+        $progressBar = new ProgressBar($output, $count);
+        $progressBar->setFormat('debug');
+        $progressBar->start();
+
+        if ($count <= $segmentSize || 1 === $numberOfProcesses) {
+            $i = 0;
+
+            // Run in main process if we have only one segment
+            foreach ($elements as $element) {
+                if (0 === $i) {
+                    $this->runBeforeBatch($input, $output);
+                }
+
+                $this->runTolerantSingleCommand($element, $input, $output);
+
+                $progressBar->advance();
+                ++$i;
+
+                if ($i >= $this->getBatchSize()) {
+                    $this->runAfterBatch($input, $output);
+                    $i = 0;
+                }
+            }
+
+            if (0 !== $i) {
+                $this->runAfterBatch($input, $output);
+            }
+        } else {
+            // Distribute if we have multiple segments
+            $commandTemplate = sprintf('%s bin/console %s %s --child --env=%s --verbose --no-debug',
+                self::detectPhpExecutable(),
+                $this->getName(),
+                implode(' ', array_slice($input->getArguments(), 1)),
+                $input->getOption('env')
+            );
+            $terminalWidth = current($this->getApplication()->getTerminalDimensions());
+
+            $processLauncher = new ProcessLauncher(
+                $commandTemplate,
+                self::getWorkingDirectory($this->getContainer()),
+                self::getEnvironmentVariables($this->getContainer()),
+                $numberOfProcesses,
+                $segmentSize,
+                $this->getContainer()->get('logger'),
+                function (string $type, string $buffer) use ($progressBar, $output, $terminalWidth) {
+                    $this->processChildOutput($buffer, $progressBar, $output, $terminalWidth);
+                }
+            );
+
+            $processLauncher->run($elements);
+        }
+
+        $progressBar->finish();
+        $output->writeln('');
+        $output->writeln('');
+        $output->writeln(sprintf(
+            'Processed %d %s.',
+            $count,
+            $this->getElementName($count)
+        ));
+
+        $this->runAfterLastCommand($input, $output);
+    }
+
+    /**
+     * Executes the child process.
+     *
+     * This method reads the elements from the standard input that the main process
+     * piped into the process. These elements are passed to runSingleCommand() one
+     * by one.
+     *
+     * @param InputInterface  $input  The console input
+     * @param OutputInterface $output The console output
+     */
+    protected function executeChildProcess(InputInterface $input, OutputInterface $output)
+    {
+        $advancementChar = self::getProgressSymbol();
+        $handle = fopen('php://stdin', 'r');
+        $i = 0;
+
+        while (false !== $line = fgets($handle)) {
+            if (0 === $i) {
+                $this->runBeforeBatch($input, $output);
+            }
+
+            $this->runTolerantSingleCommand($line, $input, $output);
+
+            // Communicate progress to the main process
+            $output->write($advancementChar);
+
+            ++$i;
+
+            if ($i >= $this->getBatchSize()) {
+                $this->runAfterBatch($input, $output);
+                $i = 0;
+            }
+        }
+
+        if (0 !== $i) {
+            $this->runAfterBatch($input, $output);
+        }
+
+        fclose($handle);
+    }
+
+    /**
+     * Called whenever data is received in the main process from a child process.
+     *
+     * @param string          $buffer        The received data
+     * @param ProgressBar     $progressBar   The progress bar
+     * @param OutputInterface $output        The output of the main process
+     * @param int             $terminalWidth The width of the terminal window
+     *                                       in characters
+     */
+    private function processChildOutput(string $buffer, ProgressBar $progressBar, OutputInterface $output, int $terminalWidth)
+    {
+        $advancementChar = $this->getProgressSymbol();
+        $chars = mb_substr_count($buffer, $advancementChar);
+
+        // Display unexpected output
+        if ($chars !== mb_strlen($buffer)) {
+            $output->writeln('');
+            $output->writeln(sprintf(
+                '<comment>%s</comment>',
+                str_pad(' Process Output ', $terminalWidth, '=', STR_PAD_BOTH)
+            ));
+            $output->writeln(str_replace($advancementChar, '', $buffer));
+            $output->writeln('');
+        }
+
+        $progressBar->advance($chars);
+    }
+
+    private function runTolerantSingleCommand(string $element, InputInterface $input, OutputInterface $output): void
+    {
+        try {
+            $this->runSingleCommand(trim($element), $input, $output);
+        } catch (Exception $exception) {
+            $output->writeln(sprintf(
+                "Failed to process \"%s\": %s\n%s",
+                trim($element),
+                $exception->getMessage(),
+                $exception->getTraceAsString()
+            ));
+
+            $this->getContainer()->reset();
+        }
+    }
+}

--- a/src/Symfony/Component/Console/Parallelization/ProcessLauncher.php
+++ b/src/Symfony/Component/Console/Parallelization/ProcessLauncher.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Parallelization;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\InputStream;
+use Symfony\Component\Process\Process;
+
+/**
+ * Launches a number of processes and distributes data among these processes.
+ *
+ * The distributed data set is passed to run(). The launcher spawns as many
+ * processes as configured in the constructor. Each process receives a share
+ * of the data set via its standard input, separated by newlines. The size
+ * of this share can be configured in the constructor (the segment size).
+ */
+class ProcessLauncher
+{
+    /**
+     * @var string
+     */
+    private $command;
+
+    /**
+     * @var string
+     */
+    private $workingDirectory;
+
+    /**
+     * @var array
+     */
+    private $environmentVariables;
+
+    /**
+     * @var int
+     */
+    private $processLimit;
+
+    /**
+     * @var int
+     */
+    private $segmentSize;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Process[]
+     */
+    private $runningProcesses = [];
+
+    /**
+     * @var callable
+     */
+    private $callback;
+
+    /**
+     * Creates the process launcher.
+     *
+     * @param string          $command              The console command to run
+     * @param string          $workingDirectory     The working directory to run
+     *                                              the command in
+     * @param array           $environmentVariables The environment variables
+     *                                              passed to the command
+     * @param int             $processLimit         The maximum number of
+     *                                              processes that should be
+     *                                              executed at the same time
+     * @param int             $segmentSize          The size of the data set
+     *                                              each process receives
+     * @param LoggerInterface $logger               A logger for debug output
+     * @param callable        $callback             The callback that receives
+     *                                              the output of the child
+     *                                              processes
+     */
+    public function __construct(
+        string $command,
+        string $workingDirectory,
+        array $environmentVariables,
+        int $processLimit,
+        int $segmentSize,
+        LoggerInterface $logger,
+        callable $callback
+    ) {
+        $this->command = $command;
+        $this->workingDirectory = $workingDirectory;
+        $this->environmentVariables = $environmentVariables;
+        $this->processLimit = $processLimit;
+        $this->segmentSize = $segmentSize;
+        $this->logger = $logger;
+        $this->callback = $callback;
+    }
+
+    /**
+     * Runs child processes to process the given elements.
+     *
+     * @param string[] $elements The elements to process. None of the elements
+     *                           must contain newlines
+     */
+    public function run(iterable $elements): void
+    {
+        $currentInputStream = null;
+        $numberOfStreamedElements = 0;
+
+        foreach ($elements as $element) {
+            // Close the input stream if the segment is full
+            if (null !== $currentInputStream && $numberOfStreamedElements >= $this->segmentSize) {
+                $currentInputStream->close();
+
+                $currentInputStream = null;
+                $numberOfStreamedElements = 0;
+            }
+
+            // Wait until we can launch a new process
+            while (null === $currentInputStream) {
+                $this->freeTerminatedProcesses();
+
+                if (count($this->runningProcesses) < $this->processLimit) {
+                    // Start a new process
+                    $currentInputStream = new InputStream();
+                    $numberOfStreamedElements = 0;
+
+                    $this->startProcess($currentInputStream);
+
+                    break;
+                }
+
+                // 100ms
+                usleep(100000);
+            }
+
+            // Stream the data segment to the process' input stream
+            $currentInputStream->write($element."\n");
+
+            ++$numberOfStreamedElements;
+        }
+
+        if (null !== $currentInputStream) {
+            $currentInputStream->close();
+        }
+
+        while (count($this->runningProcesses) > 0) {
+            $this->freeTerminatedProcesses();
+
+            // 100ms
+            usleep(100000);
+        }
+    }
+
+    /**
+     * Starts a single process reading from the given input stream.
+     *
+     * @param InputStream $inputStream The input stream
+     */
+    private function startProcess(InputStream $inputStream): void
+    {
+        $process = new Process(
+            $this->command,
+            $this->workingDirectory,
+            $this->environmentVariables,
+            null,
+            null
+        );
+
+        $process->setInput($inputStream);
+        $process->start($this->callback);
+
+        $this->logger->debug('Command started');
+
+        $this->runningProcesses[] = $process;
+    }
+
+    /**
+     * Searches for terminated processes and removes them from memory to make
+     * space for new processes.
+     */
+    private function freeTerminatedProcesses(): void
+    {
+        foreach ($this->runningProcesses as $key => $process) {
+            if (!$process->isRunning()) {
+                $this->logger->debug('Command finished');
+
+                unset($this->runningProcesses[$key]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8454 ?
| License       | MIT
| Doc PR        | TODO

I propose to add a `Parallelization` trait that we use internally for a while now to the core Console component.

## What's it about

The `Parallelization` trait adds parallelization capabilities to Console commands in a very simple but efficient manner. These commands can then be launched with a `--processes` argument to determine in how many processes the command should be executed.

## How to use

1. Add the `Parallelization` trait to your command
2. Implement `configure()` and call `configureParallelization()`
3. Implement `fetchElements()` to return an iterable of strings (e.g. database IDs)
4. Implement `runSingleCommand()` to process the workload for a single element
5. Implement `getElementName()` to return the human readable name of one element

## Example (simple)

```php
class ImportContactsCommand
{
    use Parallelization;

    protected function configure()
    {
        $this->setName('import:contacts');

        $this->configureParallelization();
    }

    protected function fetchElements(InputInterface $input): iterable
    {
        // I am executed in the master process
        $sheet = $this->openExcelSheet();
        
        foreach ($sheet as $row) {
            yield serialize($row);
        }
    }

    protected function runSingleCommand(string $element, InputInterface $input, OutputInterface $output)
    {
        // I am executed in the child process when using parallelization
        // I am executed in the master process when not using parallelization
        $row = unserialize($row);
        
        $this->importContact($row);
    }

    protected function getElementName(int $count)
    {
        return 1 === $count ? 'contact' : 'contacts';
    }

    // ...
}
```

By default, this command is executed in a single processes like a regular Symfony command. However, it can be changed to use multiple processes if that speeds up performance:

```
bin/console import:contacts --processes 4
```

Now the same workload is distributed among 4 processes.

## Segments and batches

When distributing a workload among processes, each process receives a *segment* of the processed data. The size of that segment can be configured by overriding `getSegmentSize()`. Depending on the task, different segment sizes may be optimal.

Within a process, the work is distributed in *batches*. You can override `runBeforeBatch()` or `runAfterBatch()` in order to prepare or finish the batch, for example in order to flush the database only after a batch has been completed.

By default, the batch size is the segment size, hence each process also processes a single batch. For very large segment sizes (e.g. 1000), it might make sense to reduce the batch size (e.g. 100) to improve memory usage and IO throughput. You can do that by overriding `getBatchSize()`.

## Example (advanced)

```php
class ImportContactsCommandWithBatchFlush
{
    use Parallelization;

    protected function configure()
    {
        $this->setName('import:contacts');

        $this->configureParallelization();
    }

    protected function fetchElements(InputInterface $input): iterable
    {
        $sheet = $this->openExcelSheet();

        foreach ($sheet as $row) {
            yield serialize($row);
        }
    }

    protected function runSingleCommand(string $element, InputInterface $input, OutputInterface $output)
    {
        $em = $this->getContainer()->get('doctrine')->getManagerForClass(Contact::class);
        
        $row = unserialize($row);

        $contact = $this->createContact($row);
        
        $em->persist($contact);
    }
    
    protected function runAfterBatch(InputInterface $input, OutputInterface $output)
    {
        $em = $this->getContainer()->get('doctrine')->getManagerForClass(Contact::class);

        // Persist in a batch
        $em->flush();
        $em->clear();
    }

    protected function getElementName(int $count)
    {
        return 1 === $count ? 'contact' : 'contacts';
    }
}
```

## Hooks

* `runBeforeFirstCommand()` - executed in the master process at the very beginning
* `runAfterLastCommand()` - executed in the master process at the very beginning
* `runBeforeBatch()` - executed in the child process before a batch
* `runAfterBatch()` - executed in the child process after a batch

## Pending decision

Before we proceed with CS details, implementation feedback etc.: Is there any interest to add this to core?