### PR TITLE
[Security] check request scheme in HttpUtils::checkRequestPath

### DIFF
--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -113,7 +113,7 @@ class HttpUtils
                     $parameters = $this->urlMatcher->match($request->getPathInfo());
                 }
 
-                return isset($parameters['_route']) && $path === $parameters['_route'];
+                return isset($parameters['_route']) && $path === $parameters['_route'] && (!isset($parameters['scheme']) || $request->getScheme() === $parameters['scheme']);
             } catch (MethodNotAllowedException $e) {
                 return false;
             } catch (ResourceNotFoundException $e) {

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -284,6 +284,29 @@ class HttpUtilsTest extends TestCase
         $this->assertEquals('/foo/bar', $utils->generateUri(new Request(), 'route_name'));
     }
 
+    public function testCheckRequestPathWithNotMatchingScheme()
+    {
+        $request = $this->getRequest();
+        $urlMatcher = $this->getMockBuilder('Symfony\Component\Routing\Matcher\RequestMatcherInterface')->getMock();
+        $urlMatcher
+            ->expects($this->any())
+            ->method('matchRequest')
+            ->with($request)
+            ->will($this->returnValue(array(
+                '_route' => 'foobar',
+                '_controller' => 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction',
+                'path' => '/foo/bar',
+                'permanent' => true,
+                'scheme' => 'https',
+                'httpPort' => 80,
+                'httpsPortand' => 443,
+            )))
+        ;
+
+        $utils = new HttpUtils(null, $urlMatcher);
+        $this->assertFalse($utils->checkRequestPath($request, 'foobar'));
+    }
+
     /**
      * @expectedException \LogicException
      * @expectedExceptionMessage You must provide a UrlGeneratorInterface instance to be able to use routes.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8<!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #22097    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

This PR checks the request `scheme` to be matched with route configuration when security listeners need to match the current request with some actions like logout path or check login.