### PR TITLE
[FrameworkBundle] give access to non-shared services when using test.service_container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TestServiceContainerRefPassesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TestServiceContainerRefPassesTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerWeakRefPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerRealRefPass;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TestServiceContainerRefPassesTest extends TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container->register('test.private_services_locator', ServiceLocator::class)
+            ->setPublic(true)
+            ->addArgument(0, array());
+
+        $container->addCompilerPass(new TestServiceContainerWeakRefPass(), PassConfig::TYPE_BEFORE_REMOVING, -32);
+        $container->addCompilerPass(new TestServiceContainerRealRefPass(), PassConfig::TYPE_AFTER_REMOVING);
+
+        $container->register('Test\public_service')
+            ->setPublic(true)
+            ->addArgument(new Reference('Test\private_used_shared_service'))
+            ->addArgument(new Reference('Test\private_used_non_shared_service'))
+        ;
+
+        $container->register('Test\private_used_shared_service');
+        $container->register('Test\private_unused_shared_service');
+        $container->register('Test\private_used_non_shared_service')->setShared(false);
+        $container->register('Test\private_unused_non_shared_service')->setShared(false);
+
+        $container->compile();
+
+        $expected = array(
+            'Test\private_used_shared_service' => new ServiceClosureArgument(new Reference('Test\private_used_shared_service')),
+            'Test\private_used_non_shared_service' => new ServiceClosureArgument(new Reference('Test\private_used_non_shared_service')),
+            'Psr\Container\ContainerInterface' => new ServiceClosureArgument(new Reference('service_container')),
+            'Symfony\Component\DependencyInjection\ContainerInterface' => new ServiceClosureArgument(new Reference('service_container')),
+        );
+        $this->assertEquals($expected, $container->getDefinition('test.private_services_locator')->getArgument(0));
+        $this->assertSame($container, $container->get('test.private_services_locator')->get('Psr\Container\ContainerInterface'));
+        $this->assertFalse($container->getDefinition('Test\private_used_non_shared_service')->isShared());
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.1.3",
         "ext-xml": "*",
         "symfony/cache": "~3.4|~4.0",
-        "symfony/dependency-injection": "^4.1",
+        "symfony/dependency-injection": "^4.1.1",
         "symfony/config": "~3.4|~4.0",
         "symfony/event-dispatcher": "^4.1",
         "symfony/http-foundation": "^4.1",

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -93,6 +93,12 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
         }
 
         if (!$definition->isShared()) {
+            foreach ($graph->getNode($id)->getInEdges() as $edge) {
+                if ($edge->isWeak()) {
+                    return false;
+                }
+            }
+
             return true;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27488
| License       | MIT
| Doc PR        | -

