### PR TITLE
[WebServerBundle] Improve the error message when web server is already running

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -135,7 +135,7 @@ EOF
         try {
             $server = new WebServer();
             if ($server->isRunning($input->getOption('pidfile'))) {
-                $io->error(sprintf('The web server is already running (listening on http://%s).', $server->getAddress($input->getOption('pidfile'))));
+                $io->error(sprintf('The web server has already been started. It is currently listening on http://%s. Please stop the web server before you try to start it again.', $server->getAddress($input->getOption('pidfile'))));
 
                 return 1;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | na

I understand that this change seams weird. I've just been in a training where 3 sets of eyes did not figure out why the web server did not start. 

We where faced with the message: 

> The web server is already running (listening on http://127.0.0.1:8000). 

Which I read as: 

> There is already an other service listening on port 8000. 

I know I have myself to blame for not reading properly. But I feel this could be improved some how. So here is a suggestion. I updated the message and I made it a warning. 

