### PR TITLE
Update Finder.php

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -668,7 +668,7 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * This method implements the IteratorAggregate interface.
      *
-     * @return \Iterator|SplFileInfo[] An iterator
+     * @return \Iterator|\SplFileInfo[] An iterator
      *
      * @throws \LogicException if the in() method has not been called
      */


### PR DESCRIPTION
Corrected return type which causes following error with [psalm](https://getpsalm.org/)
```
ERROR: PossiblyInvalidArgument - src/Command/Utils/CheckVendorDependencies.php:170:62 - Argument 1 of iterator_to_array expects Traversable, possibly different type array<mixed, Symfony\Component\Finder\SplFileInfo>|Iterator provided $directories = array_map($closure, iterator_to_array($finder->getIterator()));
```

| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | yes (just docblock bug - nothing serious)
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -  <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
