### PR TITLE
Allow autowire of fragment handler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
@@ -17,6 +17,7 @@
             <argument type="service" id="request_stack" />
             <argument>%kernel.debug%</argument>
         </service>
+        <service id="Symfony\Component\HttpKernel\DependencyInjection\LazyLoadingFragmentHandler" alias="fragment.handler" />
 
         <service id="fragment.renderer.inline" class="Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer">
             <tag name="kernel.fragment_renderer" alias="inline" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

Autowiring the fragment handler throws a deprecation notice and won't work anymore in Symfony 4.

> Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "fragment.handler" service to "Symfony\Component\HttpKernel\DependencyInjection\LazyLoadingFragmentHandler" instead.

Note: I'm not entirely sure if we need to do the same for `Symfony\Component\HttpKernel\Fragment\FragmentHandler`?