### PR TITLE
[FrameworkBundle] remove dead code in CachePoolClearerPass

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolClearerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolClearerPass.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -37,23 +36,6 @@ final class CachePoolClearerPass implements CompilerPassInterface
                 }
             }
             $clearer->replaceArgument(0, $pools);
-        }
-
-        if (!$container->has('cache.annotations')) {
-            return;
-        }
-        $factory = array(AbstractAdapter::class, 'createSystemCache');
-        $annotationsPool = $container->findDefinition('cache.annotations');
-        if ($factory !== $annotationsPool->getFactory() || 4 !== count($annotationsPool->getArguments())) {
-            return;
-        }
-        if ($container->has('monolog.logger.cache')) {
-            $annotationsPool->addArgument(new Reference('monolog.logger.cache'));
-        } elseif ($container->has('cache.system')) {
-            $systemPool = $container->findDefinition('cache.system');
-            if ($factory === $systemPool->getFactory() && 5 <= count($systemArgs = $systemPool->getArguments())) {
-                $annotationsPool->addArgument($systemArgs[4]);
-            }
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This code had been removed in #21381, I don't know why it's still there but this is dead code, as the `cache.annotations` service inherits a logger from the parent `cache.system` service.