### PR TITLE
[FrameworkBundle] show public/private for aliases in debug:container command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -352,7 +352,11 @@ class TextDescriptor extends Descriptor
      */
     protected function describeContainerAlias(Alias $alias, array $options = array(), ContainerBuilder $builder = null)
     {
-        $options['output']->comment(sprintf('This service is an alias for the service <info>%s</info>', (string) $alias));
+        if ($alias->isPublic()) {
+            $options['output']->comment(sprintf('This service is a <info>public</info> alias for the service <info>%s</info>', (string) $alias));
+        } else {
+            $options['output']->comment(sprintf('This service is a <comment>private</comment> alias for the service <info>%s</info>', (string) $alias));
+        }
 
         if (!$builder) {
             return;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_1.txt
@@ -1,3 +1,3 @@
 
-[39;49m // [39;49mThis service is an alias for the service [32mservice_1[39m                                                                  
+[39;49m // [39;49mThis service is a [32mpublic[39m alias for the service [32mservice_1[39m
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_2.txt
@@ -1,3 +1,3 @@
 
-[39;49m // [39;49mThis service is an alias for the service [32m.service_2[39m                                                                  
+[39;49m // [39;49mThis service is a [33mprivate[39m alias for the service [32m.service_2[39m
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
@@ -1,4 +1,4 @@
-[39;49m // [39;49mThis service is an alias for the service [32mservice_1[39m                                                                  
+[39;49m // [39;49mThis service is a [32mpublic[39m alias for the service [32mservice_1[39m                                                            
 
 [33mInformation for Service "[39m[32mservice_1[39m[33m"[39m
 [33m===================================[39m

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
@@ -1,4 +1,4 @@
-[39;49m // [39;49mThis service is an alias for the service [32m.service_2[39m                                                                 
+[39;49m // [39;49mThis service is a [33mprivate[39m alias for the service [32m.service_2[39m                                                          
 
 [33mInformation for Service "[39m[32m.service_2[39m[33m"[39m
 [33m====================================[39m


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | not needed <!-- required for new features -->

It could be helpful to see the public/private status for aliases in `debug:container` command.

Otherwise you need to dive into the code to get the information, because the result only shows the options of the aliased service.

## Look & Feel for public alias
![screenshot 2018-06-08 09 25 50](https://user-images.githubusercontent.com/995707/41144664-f3b50766-6afd-11e8-92d0-ca30513a1afc.png)

_text has slightly changed_

## Look & Feel for private alias
![screenshot 2018-06-08 09 23 31](https://user-images.githubusercontent.com/995707/41144593-b354aad2-6afd-11e8-8ab1-f9196e567f67.png)

_text has slightly changed_

//cc @nicolas-grekas 