### PR TITLE
[FrameworkBundle] decouple some cache-warmer's test from internal details

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
@@ -41,12 +43,10 @@ class SerializerCacheWarmerTest extends TestCase
 
         $this->assertFileExists($file);
 
-        $values = require $file;
+        $arrayPool = new PhpArrayAdapter($file, new NullAdapter());
 
-        $this->assertInternalType('array', $values);
-        $this->assertCount(2, $values);
-        $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person', $values);
-        $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author', $values);
+        $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person')->isHit());
+        $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author')->isHit());
 
         $values = $fallbackPool->getValues();
 
@@ -71,11 +71,6 @@ class SerializerCacheWarmerTest extends TestCase
         $warmer->warmUp(dirname($file));
 
         $this->assertFileExists($file);
-
-        $values = require $file;
-
-        $this->assertInternalType('array', $values);
-        $this->assertCount(0, $values);
 
         $values = $fallbackPool->getValues();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -