### PR TITLE
[HttpKernel] Log/Collect exceptions at prio 0

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * added orphaned events support to `EventDataCollector`
- * `ExceptionListener` now logs and collects exceptions at priority `2048` (previously logged at `-128` and collected at `0`)
+ * `ExceptionListener` now logs exceptions at priority `0` (previously logged at `-128`)
  * Deprecated `service:action` syntax with a single colon to reference controllers. Use `service::method` instead.
  * Added the ability to profile individual argument value resolvers via the
    `Symfony\Component\HttpKernel\Controller\ArgumentResolver\TraceableValueResolver`

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -44,7 +44,6 @@ class ExceptionListener implements EventSubscriberInterface
     public function logKernelException(GetResponseForExceptionEvent $event)
     {
         $exception = $event->getException();
-        $request = $event->getRequest();
 
         $this->logException($exception, sprintf('Uncaught PHP Exception %s: "%s" at %s line %s', get_class($exception), $exception->getMessage(), $exception->getFile(), $exception->getLine()));
     }
@@ -90,7 +89,7 @@ class ExceptionListener implements EventSubscriberInterface
     {
         return array(
             KernelEvents::EXCEPTION => array(
-                array('logKernelException', 2048),
+                array('logKernelException', 0),
                 array('onKernelException', -128),
             ),
         );

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -121,7 +121,7 @@ class ProfilerListener implements EventSubscriberInterface
     {
         return array(
             KernelEvents::RESPONSE => array('onKernelResponse', -100),
-            KernelEvents::EXCEPTION => array('onKernelException', 2048),
+            KernelEvents::EXCEPTION => array('onKernelException', 0),
             KernelEvents::TERMINATE => array('onKernelTerminate', -1024),
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no, fixes one
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27440
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

So that it runs after the security exception listener, which runs at prio 1.

Im not sure what to do with the (wrong) changelog entry for 4.1.0 at this point.. should we add a new entry for 4.1.1?