### PR TITLE
[FrameworkBundle] fix for allowing single colon controller notation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -94,8 +94,8 @@ class DelegatingLoader extends BaseDelegatingLoader
             }
 
             if (1 === substr_count($controller, ':')) {
-                $controller = str_replace(':', '::', $controller);
-                @trigger_error(sprintf('Referencing controllers with a single colon is deprecated since Symfony 4.1. Use %s instead.', $controller), E_USER_DEPRECATED);
+                $nonDeprecatedNotation = str_replace(':', '::', $controller);
+                @trigger_error(sprintf('Referencing controllers with a single colon is deprecated since Symfony 4.1. Use %s instead.', $nonDeprecatedNotation), E_USER_DEPRECATED);
             }
 
             $route->setDefault('_controller', $controller);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/DelegatingLoaderTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/DelegatingLoaderTest.php
@@ -5,7 +5,11 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Routing;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
 
 class DelegatingLoaderTest extends TestCase
 {
@@ -16,5 +20,49 @@ class DelegatingLoaderTest extends TestCase
             ->getMock();
         new DelegatingLoader($controllerNameParser, new LoaderResolver());
         $this->assertTrue(true, '__construct() takes a ControllerNameParser and LoaderResolverInterface respectively as its first and second argument.');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Referencing controllers with foo:bar:baz is deprecated since Symfony 4.1. Use some_parsed::controller instead.
+     * @expectedDeprecation Referencing controllers with a single colon is deprecated since Symfony 4.1. Use foo::baz instead.
+     */
+    public function testLoad()
+    {
+        $controllerNameParser = $this->getMockBuilder(ControllerNameParser::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $controllerNameParser->expects($this->once())
+            ->method('parse')
+            ->with('foo:bar:baz')
+            ->willReturn('some_parsed::controller');
+
+        $loaderResolver = $this->getMockBuilder(LoaderResolverInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $loader = $this->getMockBuilder(LoaderInterface::class)->getMock();
+
+        $loaderResolver->expects($this->once())
+            ->method('resolve')
+            ->willReturn($loader);
+
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('foo', new Route('/', array('_controller' => 'foo:bar:baz')));
+        $routeCollection->add('bar', new Route('/', array('_controller' => 'foo::baz')));
+        $routeCollection->add('baz', new Route('/', array('_controller' => 'foo:baz')));
+
+        $loader->expects($this->once())
+            ->method('load')
+            ->willReturn($routeCollection);
+
+        $delegatingLoader = new DelegatingLoader($controllerNameParser, $loaderResolver);
+
+        $loadedRouteCollection = $delegatingLoader->load('foo');
+        $this->assertCount(3, $loadedRouteCollection);
+        $this->assertSame('some_parsed::controller', $routeCollection->get('foo')->getDefault('_controller'));
+        $this->assertSame('foo::baz', $routeCollection->get('bar')->getDefault('_controller'));
+        $this->assertSame('foo:baz', $routeCollection->get('baz')->getDefault('_controller'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #27522 
| License       | MIT
| Doc PR        | -

This fixes a BC break introduced in https://github.com/symfony/symfony/pull/26085#pullrequestreview-126370222.

ping @Tobion 