### PR TITLE
[Intl] JSON config - Croatian dinar doesn't exist

### DIFF
--- a/src/Symfony/Component/Intl/Resources/data/currencies/en.json
+++ b/src/Symfony/Component/Intl/Resources/data/currencies/en.json
@@ -461,10 +461,6 @@
             "HNL",
             "Honduran Lempira"
         ],
-        "HRD": [
-            "HRD",
-            "Croatian Dinar"
-        ],
         "HRK": [
             "HRK",
             "Croatian Kuna"


### PR DESCRIPTION
Q | A
-- | --
Branch? | master
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Tests pass? | yes
Fixed tickets | -
License | MIT
Doc PR | -

We have only one currency, that is Croatian kuna. Croatian dinnar doesn't exist