### PR TITLE
[PropertyInfo] Added support for extract type from default value

### DIFF
--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+* Added the ability to extract property type based on its initial value
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyExtended2;
@@ -205,6 +206,25 @@ class ReflectionExtractorTest extends TestCase
             ['bar', [new Type(Type::BUILTIN_TYPE_INT, true)]],
             ['baz', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING))]],
             ['donotexist', null],
+        ];
+    }
+
+    /**
+     * @dataProvider defaultValueProvider
+     */
+    public function testExtractWithDefaultValue($property, $type)
+    {
+        $this->assertEquals($type, $this->extractor->getTypes(DefaultValue::class, $property, []));
+    }
+
+    public function defaultValueProvider()
+    {
+        return [
+            ['defaultInt', [new Type(Type::BUILTIN_TYPE_INT, false)]],
+            ['defaultFloat', [new Type(Type::BUILTIN_TYPE_FLOAT, false)]],
+            ['defaultString', [new Type(Type::BUILTIN_TYPE_STRING, false)]],
+            ['defaultArray', [new Type(Type::BUILTIN_TYPE_ARRAY, false)]],
+            ['defaultNull', null],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DefaultValue.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DefaultValue.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * @author Tales Santos <tales.augusto.santos@gmail.com>
+ */
+class DefaultValue
+{
+    public $defaultInt = 30;
+    public $defaultFloat = 30.5;
+    public $defaultString = 'foo';
+    public $defaultArray = [];
+    public $defaultNull = null;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master |
| Bug fix?      | no
| New feature?  | yes |
| BC breaks?    | no   |
| Deprecations? | no |
| Tests pass?   | yes |
| Fixed tickets | - |
| License       | MIT |
| Doc PR        | - |

Added support for extract type from property's default value.

```php

class Dummy
{
    private $age = 30;
}

$types = $propertyInfo->getTypes('Dummy', 'age');

/*
  Example Result
  --------------
  array(1) {
    [0] =>
    class Symfony\Component\PropertyInfo\Type (6) {
      private $builtinType          => string(3) "int"
      private $nullable             => bool(false)
      private $class                => 'Dummy'
      private $collection           => bool(false)
      private $collectionKeyType    => NULL
      private $collectionValueType  => NULL
    }
  }
*/
```