### PR TITLE
[Console] display commands list when name matches NS

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -536,7 +536,7 @@ class Application
      */
     public function getNamespaces()
     {
-        if ($this->namespaces !== null) {
+        if (null !== $this->namespaces) {
             return $this->namespaces;
         }
 

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -65,7 +65,6 @@ EOF
         return $this->createDefinition();
     }
 
-
     public function setNamespace(string $namespace): void
     {
         $this->namespace = $namespace;

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -25,6 +25,8 @@ use Symfony\Component\Console\Input\InputDefinition;
  */
 class ListCommand extends Command
 {
+    private $namespace;
+
     /**
      * {@inheritdoc}
      */
@@ -63,6 +65,12 @@ EOF
         return $this->createDefinition();
     }
 
+
+    public function setNamespace(string $namespace): void
+    {
+        $this->namespace = $namespace;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -72,8 +80,10 @@ EOF
         $helper->describe($output, $this->getApplication(), array(
             'format' => $input->getOption('format'),
             'raw_text' => $input->getOption('raw'),
-            'namespace' => $input->getArgument('namespace'),
+            'namespace' => $this->namespace ?: $input->getArgument('namespace'),
         ));
+
+        $this->namespace = null;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\CommandLoader\FactoryCommandLoader;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
 use Symfony\Component\Console\Exception\NamespaceNotFoundException;
@@ -304,10 +305,6 @@ class ApplicationTest extends TestCase
         $application->findNamespace('bar');
     }
 
-    /**
-     * @expectedException        \Symfony\Component\Console\Exception\CommandNotFoundException
-     * @expectedExceptionMessage Command "foo1" is not defined
-     */
     public function testFindUniqueNameButNamespaceName()
     {
         $application = new Application();
@@ -315,7 +312,21 @@ class ApplicationTest extends TestCase
         $application->add(new \Foo1Command());
         $application->add(new \Foo2Command());
 
-        $application->find($commandName = 'foo1');
+        $output = $application->find($commandName = 'foo1');
+        $this->assertInstanceOf(ListCommand::class, $output);
+        $this->assertAttributeSame('foo1', 'namespace', $output);
+    }
+
+    public function testFindNamespaceNameWithNamespaceSeparator()
+    {
+        $application = new Application();
+        $application->add(new \FooCommand());
+        $application->add(new \Foo1Command());
+        $application->add(new \Foo2Command());
+
+        $output = $application->find($commandName = 'foo:');
+        $this->assertInstanceOf(ListCommand::class, $output);
+        $this->assertAttributeSame('foo', 'namespace', $output);
     }
 
     public function testFind()
@@ -655,13 +666,13 @@ class ApplicationTest extends TestCase
         );
 
         try {
-            $application->find('foo');
+            $application->find('bar');
             $this->fail('->find() throws a CommandNotFoundException if command is not defined');
         } catch (\Exception $e) {
             $this->assertInstanceOf('Symfony\Component\Console\Exception\CommandNotFoundException', $e, '->find() throws a CommandNotFoundException if command is not defined');
             $this->assertSame($expectedAlternatives, $e->getAlternatives());
 
-            $this->assertRegExp('/Command "foo" is not defined\..*Did you mean one of these\?.*/Ums', $e->getMessage());
+            $this->assertRegExp('/Command "bar" is not defined\..*Did you mean one of these\?.*/Ums', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27473
| License       | MIT


As described in the ticket this makes console component display list of available commands in namespace when called command name matches existing namespace name.
Now when you call `bin/console make` or `bin/console make:` you will get the same view as you would call `bin/console list make`. The help is not triggered when namespace with part of an existing command is typed, e.g. `bin/console make:v` - this will display usual message about ambiguous command with list of commands.
If the command names exactly like namespace is defined command will be run instead of the help.

This change introduces small BC break, which shouldn't affect anyone. Previously when `bin/console make` was called the call was returning `1` output code - now (since we call `list` internally instead of throwing) it returns `0`.
```
$ bin/console make: > /dev/null 2>&1 ; echo $?
0
$ bin/console stranger: > /dev/null 2>&1 ; echo $?
1
$ bin/console make:v > /dev/null 2>&1 ; echo $?
1
```