### PR TITLE
Add "dump to server" function

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\ServerDumper;
 use Symfony\Component\VarDumper\VarDumper;
 
 if (!function_exists('dump')) {
@@ -41,5 +43,29 @@ if (!function_exists('dd')) {
         }
 
         exit(1);
+    }
+}
+
+if (!function_exists('dumps')) {
+    function dumps($var, ...$moreVars)
+    {
+        $cloner = new VarCloner();
+        $dumper = new ServerDumper($_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912');
+        $handler = function ($var) use ($cloner, $dumper) {
+            $dumper->dump($cloner->cloneVar($var));
+        };
+        VarDumper::setHandler($handler);
+
+        VarDumper::dump($var);
+
+        foreach ($moreVars as $var) {
+           VarDumper::dump($var);
+        }
+
+        if (1 < func_num_args()) {
+            return func_get_args();
+        }
+
+        return $var;
     }
 }

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -54,13 +54,17 @@ if (!function_exists('dumps')) {
         $handler = function ($var) use ($cloner, $dumper) {
             $dumper->dump($cloner->cloneVar($var));
         };
-        VarDumper::setHandler($handler);
+        $originalHandler = VarDumper::setHandler($handler);
 
         VarDumper::dump($var);
 
         foreach ($moreVars as $var) {
            VarDumper::dump($var);
         }
+
+        // Make sure that any subsequent call to dump would then go to the
+        // server rather than to the previously configured handler.
+        VarDumper::setHandler($originalHandler);
 
         if (1 < func_num_args()) {
             return func_get_args();

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -62,8 +62,8 @@ if (!function_exists('dumps')) {
            VarDumper::dump($var);
         }
 
-        // Make sure that any subsequent call to dump would then go to the
-        // server rather than to the previously configured handler.
+        // Make sure that any subsequent call would go to the previously
+        // configured handler rather than to the server.
         VarDumper::setHandler($originalHandler);
 
         if (1 < func_num_args()) {

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -62,8 +62,8 @@ if (!function_exists('dumps')) {
            VarDumper::dump($var);
         }
 
-        // Make sure that any subsequent call would go to the previously
-        // configured handler rather than to the server.
+        // Make sure that any subsequent call go to the previously configured
+        // handler rather than to the server.
         VarDumper::setHandler($originalHandler);
 
         if (1 < func_num_args()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR adds new `dumps` function which can be used to send variables to VarDumper server.
