### PR TITLE
Avoid calling eval when there is no script embedded in the toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -419,9 +419,10 @@
                     function(xhr, el) {
 
                         /* Evaluate in global scope scripts embedded inside the toolbar */
-                        eval.call({}, ([].slice.call(el.querySelectorAll('script')).map(function (script) {
-                          return script.firstChild.nodeValue;
-                        }).join(';\n')));
+                        var i, scripts = [].slice.call(el.querySelectorAll('script'));
+                        for (i = 0; i < scripts.length; ++i) {
+                            eval.call({}, scripts[i].firstChild.nodeValue);
+                        }
 
                         el.style.display = -1 !== xhr.responseText.indexOf('sf-toolbarreset') ? 'block' : 'none';
 
@@ -440,7 +441,7 @@
                         }
 
                         /* Handle toolbar-info position */
-                        var i, toolbarBlocks = [].slice.call(el.querySelectorAll('.sf-toolbar-block'));
+                        var toolbarBlocks = [].slice.call(el.querySelectorAll('.sf-toolbar-block'));
                         for (i = 0; i < toolbarBlocks.length; ++i) {
                             toolbarBlocks[i].onmouseover = function () {
                                 var toolbarInfo = this.querySelectorAll('.sf-toolbar-info')[0];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #27583
| License       | MIT
| Doc PR        | n/a

#27189 changed the way embedded scripts were eval'd for the toolbar. But it also refactored the code in a way triggering `eval` all the time, even when there is no embedded script, which was reported several times as an issue with CSP.

While the debug panel (showing dumps) still requires having `unsafe-eval` in the CSP header (due to embedding scripts that we eval), this PR reverts back to the behavior of Symfony 4.0 and older, where only toolbars actually embedding scripts have this CSP compat issue.
