### PR TITLE
[RFC][Routing] Add warnings to "debug:router" command.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -48,10 +48,10 @@ class TextDescriptor extends Descriptor
         foreach ($routes->all() as $name => $route) {
             $row = array(
                 $name,
-                $this->describeMethods($route->getMethods()),
+                $this->describeRouteMethods($route->getMethods()),
                 $route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY',
                 '' !== $route->getHost() ? $route->getHost() : 'ANY',
-                $this->describePath($route->getPath()),
+                $this->describeRoutePath($route->getPath()),
             );
 
             if ($showControllers) {
@@ -471,7 +471,7 @@ class TextDescriptor extends Descriptor
         );
     }
 
-    private function describeMethods(array $methods)
+    private function describeRouteMethods(array $methods)
     {
         if (!$methods) {
             return '<info>ANY</info>';
@@ -498,7 +498,7 @@ class TextDescriptor extends Descriptor
         return rtrim($methodDescription, '|');
     }
 
-    private function describePath(string $path)
+    private function describeRoutePath(string $path)
     {
         if ('' === $path || '/' === $path) {
             return $path; // cheap short cuts

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -473,7 +473,7 @@ class TextDescriptor extends Descriptor
 
     private function describeMethods(array $methods)
     {
-        if (0 === count($methods)) {
+        if (!$methods) {
             return '<info>ANY</info>';
         }
 
@@ -491,11 +491,7 @@ class TextDescriptor extends Descriptor
 
         $methodDescription = '';
         foreach ($methods as $method) {
-            $methodDescription .= isset($knownMethods[$method])
-                ? $method
-                : '<error>'.$method.'</error>'
-            ;
-
+            $methodDescription .= isset($knownMethods[$method]) ? $method : '<error>'.$method.'</error>';
             $methodDescription .= '|';
         }
 
@@ -515,7 +511,7 @@ class TextDescriptor extends Descriptor
             ((?:\# (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?) # a fragment (optional)
         $~ixu';
 
-        if (1 !== preg_match($pattern, preg_replace('#\{\w+\}#', 'X', $path), $matches)) {
+        if (!preg_match($pattern, preg_replace('#\{\w+\}#', 'X', $path), $matches)) {
             return '<error>'.$path.'</error>';
         }
 
@@ -534,8 +530,7 @@ class TextDescriptor extends Descriptor
         }
 
         // while a valid path it is still likely a typo
-        $doubleSlashIndex = strpos($path, '//');
-        if (false !== $doubleSlashIndex) {
+        if (false !== $doubleSlashIndex = strpos($path, '//')) {
             return substr($path, 0, $doubleSlashIndex).'<error>'.substr($path, $doubleSlashIndex).'</error>';
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -496,7 +496,7 @@ class TextDescriptor extends Descriptor
             return 'ANY';
         }
 
-        $knownMethods = [
+        $knownMethods = array(
             'CONNECT' => true,
             'DELETE' => true,
             'GET' => true,
@@ -506,7 +506,7 @@ class TextDescriptor extends Descriptor
             'POST' => true,
             'PUT' => true,
             'TRACE' => true,
-        ];
+        );
 
         $methodDescription = '';
         foreach ($methods as $method) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -504,7 +504,7 @@ class TextDescriptor extends Descriptor
 
     private function describePath(string $path)
     {
-        if ($path === '' || $path === '/') {
+        if ('' === $path || '/' === $path) {
             return $path; // cheap short cuts
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -485,6 +485,7 @@ class TextDescriptor extends Descriptor
             'OPTIONS' => true,
             'PATCH' => true,
             'POST' => true,
+            'PURGE' => true,
             'PUT' => true,
             'TRACE' => true,
         );
@@ -501,7 +502,7 @@ class TextDescriptor extends Descriptor
     private function describeRoutePath(string $path)
     {
         if ('' === $path || '/' === $path) {
-            return $path; // cheap short cuts
+            return $path;
         }
 
         // this pattern has been derived from `Symfony\Component\Validator\Constraints\UrlValidator`

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -27,8 +27,7 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~3.4|~4.0",
         "symfony/finder": "~3.4|~4.0",
-        "symfony/routing": "^4.1",
-        "symfony/validator": "^4.1"
+        "symfony/routing": "^4.1"
     },
     "require-dev": {
         "doctrine/cache": "~1.0",
@@ -50,6 +49,7 @@
         "symfony/stopwatch": "~3.4|~4.0",
         "symfony/translation": "~3.4|~4.0",
         "symfony/templating": "~3.4|~4.0",
+        "symfony/validator": "^4.1",
         "symfony/var-dumper": "~3.4|~4.0",
         "symfony/workflow": "^4.1",
         "symfony/yaml": "~3.4|~4.0",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -27,7 +27,8 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~3.4|~4.0",
         "symfony/finder": "~3.4|~4.0",
-        "symfony/routing": "^4.1"
+        "symfony/routing": "^4.1",
+        "symfony/validator": "^4.1"
     },
     "require-dev": {
         "doctrine/cache": "~1.0",
@@ -49,7 +50,6 @@
         "symfony/stopwatch": "~3.4|~4.0",
         "symfony/translation": "~3.4|~4.0",
         "symfony/templating": "~3.4|~4.0",
-        "symfony/validator": "^4.1",
         "symfony/var-dumper": "~3.4|~4.0",
         "symfony/workflow": "^4.1",
         "symfony/yaml": "~3.4|~4.0",

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -22,9 +22,14 @@ class DirectoryResourceTest extends TestCase
     {
         $this->directory = sys_get_temp_dir().DIRECTORY_SEPARATOR.'symfonyDirectoryIterator';
         if (!file_exists($this->directory)) {
-            mkdir($this->directory);
+            if (false === mkdir($this->directory)) {
+                throw new \RuntimeException(sprintf('Failed to create tmp directory to test with @ "%s".', $this->directory));
+            }
         }
-        touch($this->directory.'/tmp.xml');
+
+        if (false === touch($this->directory.'/tmp.xml')) {
+            throw new \RuntimeException(sprintf('Failed to create tmp file to test with @ "%s".', $this->directory.'/tmp.xml'));
+        }
     }
 
     protected function tearDown()

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -21,13 +21,11 @@ class DirectoryResourceTest extends TestCase
     protected function setUp()
     {
         $this->directory = sys_get_temp_dir().DIRECTORY_SEPARATOR.'symfonyDirectoryIterator';
-        if (!file_exists($this->directory)) {
-            if (false === mkdir($this->directory)) {
-                throw new \RuntimeException(sprintf('Failed to create tmp directory to test with @ "%s".', $this->directory));
-            }
+        if (!file_exists($this->directory) && !mkdir($this->directory)) {
+            throw new \RuntimeException(sprintf('Failed to create tmp directory to test with @ "%s".', $this->directory));
         }
 
-        if (false === touch($this->directory.'/tmp.xml')) {
+        if (!touch($this->directory.'/tmp.xml')) {
             throw new \RuntimeException(sprintf('Failed to create tmp file to test with @ "%s".', $this->directory.'/tmp.xml'));
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | we'll see ^_^
| License       | MIT
| Doc PR        | no update needed

When using `debug:router`; this adds colors to warn a user about possible typo's in the routing setup.
This is only done on the text format as to not break any BC.

I thought a picture might be more useful than a full description:

![debug_router](https://user-images.githubusercontent.com/10462973/41347381-c05ed77e-6f09-11e8-8670-13f31cd474e7.png)
