### PR TITLE
[VarDumper] Fix dumping ArrayObject and ArrayIterator instances

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -29,30 +29,12 @@ class SplCaster
 
     public static function castArrayObject(\ArrayObject $c, array $a, Stub $stub, $isNested)
     {
-        $prefix = Caster::PREFIX_VIRTUAL;
-        $class = $stub->class;
-        $flags = $c->getFlags();
+        return self::castSplArray($c, $a, $stub, $isNested);
+    }
 
-        $b = array(
-            $prefix.'flag::STD_PROP_LIST' => (bool) ($flags & \ArrayObject::STD_PROP_LIST),
-            $prefix.'flag::ARRAY_AS_PROPS' => (bool) ($flags & \ArrayObject::ARRAY_AS_PROPS),
-            $prefix.'iteratorClass' => $c->getIteratorClass(),
-            $prefix.'storage' => $c->getArrayCopy(),
-        );
-
-        if ('ArrayObject' === $class) {
-            $a = $b;
-        } else {
-            if (!($flags & \ArrayObject::STD_PROP_LIST)) {
-                $c->setFlags(\ArrayObject::STD_PROP_LIST);
-                $a = Caster::castObject($c, new \ReflectionClass($class));
-                $c->setFlags($flags);
-            }
-
-            $a += $b;
-        }
-
-        return $a;
+    public static function castArrayIterator(\ArrayIterator $c, array $a, Stub $stub, $isNested)
+    {
+        return self::castSplArray($c, $a, $stub, $isNested);
     }
 
     public static function castHeap(\Iterator $c, array $a, Stub $stub, $isNested)
@@ -182,7 +164,7 @@ class SplCaster
 
         $clone = clone $c;
         foreach ($clone as $obj) {
-            $storage[spl_object_hash($obj)] = array(
+            $storage[] = array(
                 'object' => $obj,
                 'info' => $clone->getInfo(),
              );
@@ -198,6 +180,29 @@ class SplCaster
     public static function castOuterIterator(\OuterIterator $c, array $a, Stub $stub, $isNested)
     {
         $a[Caster::PREFIX_VIRTUAL.'innerIterator'] = $c->getInnerIterator();
+
+        return $a;
+    }
+
+    private static function castSplArray($c, array $a, Stub $stub, $isNested)
+    {
+        $prefix = Caster::PREFIX_VIRTUAL;
+        $class = $stub->class;
+        $flags = $c->getFlags();
+
+        if (!($flags & \ArrayObject::STD_PROP_LIST)) {
+            $c->setFlags(\ArrayObject::STD_PROP_LIST);
+            $a = Caster::castObject($c, new \ReflectionClass($class));
+            $c->setFlags($flags);
+        }
+        $a += array(
+            $prefix.'flag::STD_PROP_LIST' => (bool) ($flags & \ArrayObject::STD_PROP_LIST),
+            $prefix.'flag::ARRAY_AS_PROPS' => (bool) ($flags & \ArrayObject::ARRAY_AS_PROPS),
+        );
+        if ($c instanceof \ArrayObject) {
+            $a[$prefix.'iteratorClass'] = $c->getIteratorClass();
+        }
+        $a[$prefix.'storage'] = $c->getArrayCopy();
 
         return $a;
     }

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -89,6 +89,7 @@ abstract class AbstractCloner implements ClonerInterface
         'AMQPEnvelope' => 'Symfony\Component\VarDumper\Caster\AmqpCaster::castEnvelope',
 
         'ArrayObject' => 'Symfony\Component\VarDumper\Caster\SplCaster::castArrayObject',
+        'ArrayIterator' => 'Symfony\Component\VarDumper\Caster\SplCaster::castArrayIterator',
         'SplDoublyLinkedList' => 'Symfony\Component\VarDumper\Caster\SplCaster::castDoublyLinkedList',
         'SplFileInfo' => 'Symfony\Component\VarDumper\Caster\SplCaster::castFileInfo',
         'SplFileObject' => 'Symfony\Component\VarDumper\Caster\SplCaster::castFileObject',

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
@@ -160,4 +160,51 @@ EOTXT;
 
         $this->assertDumpMatchesFormat('%ADateTime%A', $var);
     }
+
+    public function testCastArrayObject()
+    {
+        if (\defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM as different internal details.');
+        }
+        $var = new \ArrayObject(array(123));
+        $var->foo = 234;
+
+        $expected = <<<EOTXT
+ArrayObject {
+  +"foo": 234
+  flag::STD_PROP_LIST: false
+  flag::ARRAY_AS_PROPS: false
+  iteratorClass: "ArrayIterator"
+  storage: array:1 [
+    0 => 123
+  ]
+}
+EOTXT;
+        $this->assertDumpEquals($expected, $var);
+    }
+
+    public function testArrayIterator()
+    {
+        if (\defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM as different internal details.');
+        }
+        $var = new MyArrayIterator(array(234));
+
+        $expected = <<<EOTXT
+Symfony\Component\VarDumper\Tests\Caster\MyArrayIterator {
+  -foo: 123
+  flag::STD_PROP_LIST: false
+  flag::ARRAY_AS_PROPS: false
+  storage: array:1 [
+    0 => 234
+  ]
+}
+EOTXT;
+        $this->assertDumpEquals($expected, $var);
+    }
+}
+
+class MyArrayIterator extends \ArrayIterator
+{
+    private $foo = 123;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Properties added on child classes of `ArrayObject` and `ArrayIterator`, or dynamic properties added on instances of them were now properly dumped. This fixes it.

![image](https://user-images.githubusercontent.com/243674/41349429-2660cbc6-6f10-11e8-8015-a3d6ad8b0c9c.png)
