### PR TITLE
[ProxyManagerBridge] Fixed support of private services

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -57,7 +57,7 @@ class ProxyDumper implements DumperInterface
         $instantiation = 'return';
 
         if ($definition->isShared()) {
-            $instantiation .= " \$this->services['$id'] =";
+            $instantiation .= sprintf(' $this->%s[\'%s\'] =', $definition->isPublic() && !$definition->isPrivate() ? 'services' : 'privates', $id);
         }
 
         if (null === $factoryCode) {

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -84,6 +84,34 @@ class ProxyDumperTest extends TestCase
     }
 
     /**
+     * @dataProvider getPrivatePublicDefinitions
+     */
+    public function testCorrectAssigning(Definition $definition, $access)
+    {
+        $definition->setLazy(true);
+
+        $code = $this->dumper->getProxyFactoryCode($definition, 'foo', '$this->getFoo2Service(false)');
+
+        $this->assertStringMatchesFormat('%A$this->'.$access.'[\'foo\'] = %A', $code);
+    }
+
+    public function getPrivatePublicDefinitions()
+    {
+        return array(
+            array(
+                (new Definition(__CLASS__))
+                    ->setPublic(false),
+                'privates',
+            ),
+            array(
+                (new Definition(__CLASS__))
+                    ->setPublic(true),
+                'services',
+            ),
+        );
+    }
+
+    /**
      * @group legacy
      */
     public function testLegacyGetProxyFactoryCode()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #...
| License       | MIT
| Doc PR        | 

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

Fixed lazy loading of private services, that was broken since Symfony 4.0 release because of renaming 
addObjectResource
https://github.com/symfony/symfony/blame/fa022f05be75aacc8afcdc11b63333685c719e13/src/Symfony/Component/DependencyInjection/CHANGELOG.md#L114
