### PR TITLE
[DX] Log potential redirect loops caused by forced HTTPS

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -46,7 +46,13 @@ class ChannelListener implements ListenerInterface
 
         if ('https' === $channel && !$request->isSecure()) {
             if (null !== $this->logger) {
-                $this->logger->info('Redirecting to HTTPS.');
+                if ('https' === $request->headers->get('X-Forwarded-Proto')) {
+                    $this->logger->info('Redirecting to HTTPS. ("X-Forwarded-Proto" header is set to "https" - did you set "trusted_proxies" correctly?)');
+                } elseif (false !== strpos($request->headers->get('Forwarded'), 'proto=https')) {
+                    $this->logger->info('Redirecting to HTTPS. ("Forwarded" header is set to "proto=https" - did you set "trusted_proxies" correctly?)');
+                } else {
+                    $this->logger->info('Redirecting to HTTPS.');
+                }
             }
 
             $response = $this->authenticationEntryPoint->start($request);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27603 
| License       | MIT
| Doc PR        | n/a

If the developer forgets/fails to set "trusted_proxies" properly, forcing the
https channel can cause infinite redirect loops. This change will hopefully
help them identify the problem faster.

See https://github.com/symfony/symfony/issues/27603