### PR TITLE
Remove direct dependencies on doctrine/common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
     "require": {
         "php": "^7.1.3",
         "ext-xml": "*",
-        "doctrine/common": "~2.4",
+        "doctrine/collections": "~1.0",
+        "doctrine/event-manager": "~1.0",
+        "doctrine/persistence": "~1.0",
         "fig/link-util": "^1.0",
         "twig/twig": "^1.35|^2.4.4",
         "psr/cache": "~1.0",
@@ -91,6 +93,7 @@
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.4",
         "doctrine/orm": "~2.4,>=2.4.5",
+        "doctrine/reflection": "~1.0",
         "doctrine/doctrine-bundle": "~1.4",
         "monolog/monolog": "~1.11",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",

--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\Form;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\Mapping\MappingException;
+use Doctrine\Common\Persistence\Proxy;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException as LegacyMappingException;
@@ -20,7 +21,6 @@ use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
-use Doctrine\Common\Util\ClassUtils;
 
 class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
 {
@@ -162,7 +162,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     protected function getMetadata($class)
     {
         // normalize class name
-        $class = ClassUtils::getRealClass(ltrim($class, '\\'));
+        $class = self::getRealClass(ltrim($class, '\\'));
 
         if (array_key_exists($class, $this->cache)) {
             return $this->cache[$class];
@@ -178,5 +178,14 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
                 // not an entity or mapped super class, using Doctrine ORM 2.2
             }
         }
+    }
+
+    private static function getRealClass(string $class): string
+    {
+        if (false === $pos = strrpos($class, '\\'.Proxy::MARKER.'\\')) {
+            return $class;
+        }
+
+        return substr($class, $pos + Proxy::MARKER_LENGTH + 2);
     }
 }

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,7 +17,9 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "doctrine/common": "~2.4",
+        "doctrine/collections": "~1.0",
+        "doctrine/event-manager": "~1.0",
+        "doctrine/persistence": "~1.0",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0"
     },
@@ -33,9 +35,12 @@
         "symfony/expression-language": "~3.4|~4.0",
         "symfony/validator": "~3.4|~4.0",
         "symfony/translation": "~3.4|~4.0",
+        "doctrine/annotations": "~1.0",
+        "doctrine/cache": "~1.6",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.4",
-        "doctrine/orm": "^2.4.5"
+        "doctrine/orm": "^2.4.5",
+        "doctrine/reflection": "~1.0"
     },
     "conflict": {
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -25,7 +25,6 @@
         "symfony/expression-language": "~3.4|~4.0",
         "symfony/dependency-injection": "~3.4|~4.0",
         "doctrine/annotations": "~1.0",
-        "doctrine/common": "~2.2",
         "psr/log": "~1.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | ?

Doctrine has recently separated multiple components from doctrine/common:
* [doctrine/event-manager](https://github.com/doctrine/event-manager) [[release notes](https://github.com/doctrine/event-manager/releases/tag/v1.0.0) | [split PR](https://github.com/doctrine/common/pull/842)]
* [doctrine/persistence](https://github.com/doctrine/persistence) [[release notes](https://github.com/doctrine/persistence/releases/tag/v1.0.0) | [split PR](https://github.com/doctrine/common/pull/845)]
* [doctrine/reflection](https://github.com/doctrine/reflection) [[release notes](https://github.com/doctrine/reflection/releases/tag/v1.0.0) | [split PR](https://github.com/doctrine/common/pull/845)]

All of the packages are 100% backward compatible with their counterparts in Common 2.8.

This is a major step to slowly start with [phasing out doctrine/common package](https://github.com/doctrine/common/issues/826) before ORM 3.0 / DBAL 3.0 / ODM 3.0.
Common 2.9.0 will also be composed from these new packages.

Most of the remaining parts in doctrine/common are likely to be deprecated (or already are), please see & discuss in [the PR over in doctrine/common repository](https://github.com/doctrine/common/pull/845).

This PR therefore aims to remove the direct doctrine/common dependency from Symfony, replacing it by specific Doctrine components.