### PR TITLE
Remove <3.4 conflict rules

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -37,10 +37,6 @@
         "doctrine/dbal": "~2.4",
         "doctrine/orm": "^2.4.5"
     },
-    "conflict": {
-        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-        "symfony/dependency-injection": "<3.4"
-    },
     "suggest": {
         "symfony/form": "",
         "symfony/validator": "",

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -26,9 +26,6 @@
         "symfony/security-core": "~3.4|~4.0",
         "symfony/var-dumper": "~3.4|~4.0"
     },
-    "conflict": {
-        "symfony/http-foundation": "<3.4"
-    },
     "suggest": {
         "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",
         "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings. You need version ~2.3 of the console for it.",

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -24,9 +24,6 @@
         "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader",
         "ext-zip": "Zip support is required when using bin/simple-phpunit"
     },
-    "conflict": {
-        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
-    },
     "autoload": {
         "files": [ "bootstrap.php" ],
         "psr-4": { "Symfony\\Bridge\\PhpUnit\\": "" },

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -41,8 +41,7 @@
         "symfony/workflow": "~3.4|~4.0"
     },
     "conflict": {
-        "symfony/form": "<4.1",
-        "symfony/console": "<3.4"
+        "symfony/form": "<4.1"
     },
     "suggest": {
         "symfony/finder": "",

--- a/src/Symfony/Bundle/DebugBundle/composer.json
+++ b/src/Symfony/Bundle/DebugBundle/composer.json
@@ -27,9 +27,6 @@
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/web-profiler-bundle": "~3.4|~4.0"
     },
-    "conflict": {
-        "symfony/dependency-injection": "<3.4"
-    },
     "suggest": {
         "symfony/config": "For service container configuration",
         "symfony/dependency-injection": "For using as a service from the container"

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -63,14 +63,8 @@
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0",
         "phpdocumentor/type-resolver": "<0.2.1",
-        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-        "symfony/asset": "<3.4",
-        "symfony/console": "<3.4",
         "symfony/form": "<4.1",
-        "symfony/property-info": "<3.4",
         "symfony/serializer": "<4.1",
-        "symfony/stopwatch": "<3.4",
-        "symfony/translation": "<3.4",
         "symfony/validator": "<4.1",
         "symfony/workflow": "<4.1"
     },

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -44,10 +44,7 @@
         "twig/twig": "~1.34|~2.4"
     },
     "conflict": {
-        "symfony/var-dumper": "<3.4",
-        "symfony/event-dispatcher": "<3.4",
-        "symfony/framework-bundle": "<4.1.1",
-        "symfony/console": "<3.4"
+        "symfony/framework-bundle": "<4.1.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\SecurityBundle\\": "" },

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -39,10 +39,6 @@
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0"
     },
-    "conflict": {
-        "symfony/dependency-injection": "<3.4",
-        "symfony/event-dispatcher": "<3.4"
-    },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\TwigBundle\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -29,12 +29,6 @@
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/stopwatch": "~3.4|~4.0"
     },
-    "conflict": {
-        "symfony/config": "<3.4",
-        "symfony/dependency-injection": "<3.4",
-        "symfony/event-dispatcher": "<3.4",
-        "symfony/var-dumper": "<3.4"
-    },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\WebProfilerBundle\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -31,9 +31,6 @@
         "doctrine/dbal": "~2.4",
         "predis/predis": "~1.0"
     },
-    "conflict": {
-        "symfony/var-dumper": "<3.4"
-    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Cache\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -26,9 +26,6 @@
         "symfony/finder": "~3.4|~4.0",
         "symfony/yaml": "~3.4|~4.0"
     },
-    "conflict": {
-        "symfony/finder": "<3.4"
-    },
     "suggest": {
         "symfony/yaml": "To use the yaml reference dumper"
     },

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -33,10 +33,6 @@
         "symfony/process": "",
         "psr/log-implementation": "For using the console logger"
     },
-    "conflict": {
-        "symfony/dependency-injection": "<3.4",
-        "symfony/process": "<3.3"
-    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Console\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Debug/composer.json
+++ b/src/Symfony/Component/Debug/composer.json
@@ -19,9 +19,6 @@
         "php": "^7.1.3",
         "psr/log": "~1.0"
     },
-    "conflict": {
-        "symfony/http-kernel": "<3.4"
-    },
     "require-dev": {
         "symfony/http-kernel": "~3.4|~4.0"
     },

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -32,10 +32,7 @@
         "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
     },
     "conflict": {
-        "symfony/config": "<4.1.1",
-        "symfony/finder": "<3.4",
-        "symfony/proxy-manager-bridge": "<3.4",
-        "symfony/yaml": "<3.4"
+        "symfony/config": "<4.1.1"
     },
     "provide": {
         "psr/container-implementation": "1.0"

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -25,9 +25,6 @@
         "symfony/stopwatch": "~3.4|~4.0",
         "psr/log": "~1.0"
     },
-    "conflict": {
-        "symfony/dependency-injection": "<3.4"
-    },
     "suggest": {
         "symfony/dependency-injection": "",
         "symfony/http-kernel": ""

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -36,14 +36,6 @@
         "symfony/translation": "~3.4|~4.0",
         "symfony/var-dumper": "~3.4|~4.0"
     },
-    "conflict": {
-        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-        "symfony/dependency-injection": "<3.4",
-        "symfony/doctrine-bridge": "<3.4",
-        "symfony/framework-bundle": "<3.4",
-        "symfony/http-kernel": "<3.4",
-        "symfony/twig-bridge": "<3.4.5|<4.0.5,>=4.0"
-    },
     "suggest": {
         "symfony/validator": "For form validation.",
         "symfony/security-csrf": "For protecting forms against CSRF attacks.",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -44,10 +44,8 @@
         "psr/log-implementation": "1.0"
     },
     "conflict": {
-        "symfony/config": "<3.4",
         "symfony/dependency-injection": "<4.2",
-        "symfony/var-dumper": "<4.1",
-        "twig/twig": "<1.34|<2.4,>=2"
+        "symfony/var-dumper": "<4.1"
     },
     "suggest": {
         "symfony/browser-kit": "",

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -35,8 +35,7 @@
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
-        "phpdocumentor/type-resolver": "<0.2.1",
-        "symfony/dependency-injection": "<3.4"
+        "phpdocumentor/type-resolver": "<0.2.1"
     },
     "suggest": {
         "psr/cache-implementation": "To cache results",

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -28,11 +28,6 @@
         "doctrine/common": "~2.2",
         "psr/log": "~1.0"
     },
-    "conflict": {
-        "symfony/config": "<3.4",
-        "symfony/dependency-injection": "<3.4",
-        "symfony/yaml": "<3.4"
-    },
     "suggest": {
         "symfony/http-foundation": "For using a Symfony Request object",
         "symfony/config": "For using the all-in-one router or any loader",

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -22,9 +22,6 @@
     "require-dev": {
         "symfony/http-foundation": "~3.4|~4.0"
     },
-    "conflict": {
-        "symfony/http-foundation": "<3.4"
-    },
     "suggest": {
         "symfony/http-foundation": "For using the class SessionTokenStorage."
     },

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -28,9 +28,6 @@
         "symfony/security-csrf": "^3.4.11|^4.0.11",
         "psr/log": "~1.0"
     },
-    "conflict": {
-        "symfony/security-csrf": "<3.4.11|~4.0,<4.0.11"
-    },
     "suggest": {
         "symfony/security-csrf": "For using tokens to protect authentication/logout attempts",
         "symfony/routing": "For using the HttpUtils class to create sub-requests, redirect the user, and match URLs"

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -33,11 +33,7 @@
         "phpdocumentor/reflection-docblock": "^3.0|^4.0"
     },
     "conflict": {
-        "phpdocumentor/type-resolver": "<0.2.1",
-        "symfony/dependency-injection": "<3.4",
-        "symfony/property-access": "<3.4",
-        "symfony/property-info": "<3.4",
-        "symfony/yaml": "<3.4"
+        "phpdocumentor/type-resolver": "<0.2.1"
     },
     "suggest": {
         "psr/cache-implementation": "For using the metadata cache.",

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -25,13 +25,8 @@
         "symfony/dependency-injection": "~3.4|~4.0",
         "symfony/intl": "~3.4|~4.0",
         "symfony/yaml": "~3.4|~4.0",
-        "symfony/finder": "~2.8|~3.0|~4.0",
+        "symfony/finder": "~3.4|~4.0",
         "psr/log": "~1.0"
-    },
-    "conflict": {
-        "symfony/config": "<3.4",
-        "symfony/dependency-injection": "<3.4",
-        "symfony/yaml": "<3.4"
     },
     "suggest": {
         "symfony/config": "",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -37,11 +37,7 @@
         "egulias/email-validator": "^1.2.8|~2.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-        "symfony/dependency-injection": "<3.4",
-        "symfony/http-kernel": "<3.4",
-        "symfony/intl": "<4.1",
-        "symfony/yaml": "<3.4"
+        "symfony/intl": "<4.1"
     },
     "suggest": {
         "psr/cache-implementation": "For using the metadata cache.",

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -25,10 +25,6 @@
         "symfony/process": "~3.4|~4.0",
         "twig/twig": "~1.34|~2.4"
     },
-    "conflict": {
-        "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-        "symfony/console": "<3.4"
-    },
     "suggest": {
         "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
         "ext-intl": "To show region name in time zone dump",

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -22,9 +22,6 @@
     "require-dev": {
         "symfony/console": "~3.4|~4.0"
     },
-    "conflict": {
-        "symfony/console": "<3.4"
-    },
     "suggest": {
         "symfony/console": "For validating YAML files using the lint command"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As time and versions pass, mentioning old versions in the `conflict` section of our composer.json files has a nasty side effect: it makes composer slower. The reason is that even if these cannot be installed, composer still has to download their package.json file from packagist.org, recursively. This can amount to a significant time at composer startup.

Let's see how this goes.