### PR TITLE
[SecurityBundle] Make the default value of check_path option the same as login_path

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -65,6 +65,21 @@ class MainConfiguration implements ConfigurationInterface
                     return $v;
                 })
             ->end()
+            ->beforeNormalization()
+                ->ifTrue(function ($v) {
+                    return isset($v['firewalls']);
+                })
+                ->then(function ($v) {
+                    foreach ($v['firewalls'] as $firewallName => $firewallConfig) {
+                        if (isset($firewallConfig['form_login']['login_path']) && !isset($firewallConfig['form_login']['check_path'])) {
+                            $firewallConfig['form_login']['check_path'] = $firewallConfig['form_login']['login_path'];
+                            $v['firewalls'][$firewallName] = $firewallConfig;
+                        }
+                    }
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->scalarNode('access_denied_url')->defaultNull()->example('/foo/error403')->end()
                 ->enumNode('session_fixation_strategy')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27602
| License       | MIT
| Doc PR        | -

This PR simplifies the `form_login` config so when developers build a traditional login form, they don't have to learn or know about the `check_path` option.