### PR TITLE
[TwigBundle][DX] Only add the Twig WebLinkExtension if the WebLink component is enabled

### DIFF
--- a/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
+++ b/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig;
 
+use Symfony\Bundle\FullStack;
 use Twig\Error\SyntaxError;
 
 /**
@@ -55,14 +56,21 @@ class UndefinedCallableHandler
         'workflow_marked_places' => 'workflow',
     );
 
+    private static $fullStackEnable = array(
+        'form' => 'enable "framework.form"',
+        'security-core' => 'add the "SecurityBundle"',
+        'security-http' => 'add the "SecurityBundle"',
+        'web-link' => 'enable "framework.web_link"',
+        'workflow' => 'enable "framework.workflows"',
+    );
+
     public static function onUndefinedFilter($name)
     {
         if (!isset(self::$filterComponents[$name])) {
             return false;
         }
 
-        // Twig will append the source context to the message, so that it will end up being like "[...] Unknown filter "%s" in foo.html.twig on line 123."
-        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown filter "%s".', self::$filterComponents[$name], $name));
+        self::onUndefined($name, 'filter', self::$filterComponents[$name]);
     }
 
     public static function onUndefinedFunction($name)
@@ -71,6 +79,15 @@ class UndefinedCallableHandler
             return false;
         }
 
-        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown function "%s".', self::$functionComponents[$name], $name));
+        self::onUndefined($name, 'function', self::$functionComponents[$name]);
+    }
+
+    private static function onUndefined($name, $type, $component)
+    {
+        if (\class_exists(FullStack::class) && isset(self::$fullStackEnable[$component])) {
+            throw new SyntaxError(sprintf('Did you forget to %s? Unknown %s "%s".', self::$fullStackEnable[$component], $type, $name));
+        }
+
+        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown %s "%s".', $component, $type, $name));
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -82,6 +82,10 @@ class ExtensionPass implements CompilerPassInterface
             }
         }
 
+        if ($container->has('web_link.add_link_header_listener')) {
+            $container->getDefinition('twig.extension.weblink')->addTag('twig.extension');
+        }
+
         $twigLoader = $container->getDefinition('twig.loader.native_filesystem');
         if ($container->has('templating')) {
             $loader = $container->getDefinition('twig.loader.filesystem');

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\TwigBundle\DependencyInjection;
 
-use Symfony\Bridge\Twig\Extension\WebLinkExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\Console\Application;
@@ -19,7 +18,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Twig\Extension\ExtensionInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 use Twig\Loader\LoaderInterface;
@@ -58,13 +56,6 @@ class TwigExtension extends Extension
 
         if (!interface_exists('Symfony\Component\Translation\TranslatorInterface')) {
             $container->removeDefinition('twig.translation.extractor');
-        }
-
-        if (class_exists(HttpHeaderSerializer::class)) {
-            $definition = $container->register('twig.extension.weblink', WebLinkExtension::class);
-            $definition->setPublic(false);
-            $definition->addArgument(new Reference('request_stack'));
-            $definition->addTag('twig.extension');
         }
 
         foreach ($configs as $key => $config) {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -114,6 +114,10 @@
 
         <service id="twig.extension.debug" class="Twig\Extension\DebugExtension" />
 
+        <service id="twig.extension.weblink" class="Symfony\Bridge\Twig\Extension\WebLinkExtension">
+            <argument type="service" id="request_stack" />
+        </service>
+
         <service id="twig.translation.extractor" class="Symfony\Bridge\Twig\Translation\TwigExtractor">
             <argument type="service" id="twig" />
             <tag name="translation.extractor" alias="twig" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

While adding https://github.com/elifesciences/journal/pull/990 I was a bit confused why the `preload()` Twig function didn't work initially. Turns out the WebLink component is disabled by default if using the full stack, but the Twig extension is always enabled.

This only adds the Twig extension if the component is enabled, and shows a friendly error message if it's not.