### PR TITLE
I removed first blank space

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>


### PR DESCRIPTION
It caused this error during cache:clear
[ERROR 4] Start tag expected, '<' not found (in n/a - line 1, column 1)