### PR TITLE
[HttpFoundation] Ensure RedisSessionHandler::updateTimestamp returns a boolean

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -100,6 +100,6 @@ class RedisSessionHandler extends AbstractSessionHandler
      */
     public function updateTimestamp($sessionId, $data)
     {
-        return $this->redis->expire($this->prefix.$sessionId, (int) ini_get('session.gc_maxlifetime'));
+        return (bool) $this->redis->expire($this->prefix.$sessionId, (int) ini_get('session.gc_maxlifetime'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Since v1.1.0 predis doesn't return the result of `EXPIRE` as a boolean, thus breaking `updateTimestamp` implementation.

Maybe it's worth mentioning error messages were useless here:

- Symfony: `User Warning: session_write_close(): Failed to write session data with Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler handler`
- PHP: `session_write_close(): Session callback expects true/false return value`