### PR TITLE
[Messenger] Fixed MessengerPass::guessHandledClasses return type

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -185,7 +185,7 @@ class MessengerPass implements CompilerPassInterface
         }
     }
 
-    private function guessHandledClasses(\ReflectionClass $handlerClass, string $serviceId): array
+    private function guessHandledClasses(\ReflectionClass $handlerClass, string $serviceId): iterable
     {
         if ($handlerClass->implementsInterface(MessageSubscriberInterface::class)) {
             if (!$handledMessages = $handlerClass->getName()::getHandledMessages()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Good evening! Thanks for this amazing project.
I've searched over issues and PRs and I didn't find anything about this bug I found. Excuse me if this is a duplicate.

If you create an implementation of `MessageSubscriberInterface` and yield results from `getHandledMessages` method, a TypeError (like the following) will be raised:

```TypeError: Return value of Symfony\Component\Messenger\DependencyInjection\MessengerPass::guessHandledClasses() must be of the type array, object returned```

`MessengerPass::guessHandledClasses` return type declared is `array`, when `MessageSubscriberInterface::guessHandledClasses()`'s return type is `iterable`.

In this PR I have fixed the return type and wrote a simple test for it.


I am looking forward your review. Thank you.
Massimiliano