### PR TITLE
Set serialize_precision explicitly to avoid fancy float rounding

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -16,6 +16,15 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class JsonResponseTest extends TestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (!defined('HHVM_VERSION')) {
+            $this->iniSet('serialize_precision', 14);
+        }
+    }
+
     public function testConstructorEmptyCreatesJsonObject()
     {
         $response = new JsonResponse();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | -

This is fixing some of the test failures I was seeing locally due to increased `serialize_precision` INI setting:
```
2) Symfony\Component\HttpFoundation\Tests\JsonResponseTest::testConstructorWithSimpleTypes
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'0.1'
+'0.10000000000000001'

/www/symfony/symfony/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php:46

3) Symfony\Component\HttpFoundation\Tests\JsonResponseTest::testStaticCreateWithSimpleTypes
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'0.1'
+'0.10000000000000001'
```

The test assertions should not depend on externally configured PHP configuration.

Also default value for this option was changed multiple times: http://php.net/manual/en/ini.core.php#ini.serialize-precision
For compatibility reasons (with PHP <7.x) `-1` can't be used.

https://3v4l.org/HBNsT

HHVM doesn't seem to support this though, how to handle this?