### PR TITLE
[Cache] added support for phpredis 4 `compression` and `tcp_keepalive` options

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added `CacheInterface`, which provides stampede protection via probabilistic early expiration and should become the preferred way to use a cache
  * added sub-second expiry accuracy for backends that support it
+ * added support for phpredis 4 `compression` and `tcp_keepalive` options
  * throw `LogicException` when `CacheItem::tag()` is called on an item coming from a non tag-aware pool
  * deprecated `CacheItem::getPreviousTags()`, use `CacheItem::getMetadata()` instead
  * deprecated the `AbstractAdapter::createSystemCache()` method

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -44,6 +44,8 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
             'persistent_id' => null,
             'read_timeout' => 0,
             'retry_interval' => 0,
+            'compression' => true,
+            'tcp_keepalive' => 0,
             'lazy' => false,
             'database' => '1',
             'password' => null,

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -34,6 +34,8 @@ trait RedisTrait
         'timeout' => 30,
         'read_timeout' => 0,
         'retry_interval' => 0,
+        'compression' => true,
+        'tcp_keepalive' => 0,
         'lazy' => false,
     );
     private $redis;
@@ -140,6 +142,13 @@ trait RedisTrait
                 ) {
                     $e = preg_replace('/^ERR /', '', $redis->getLastError());
                     throw new InvalidArgumentException(sprintf('Redis connection failed (%s): %s', $e, $dsn));
+                }
+
+                if (0 < $params['tcp_keepalive'] && \defined('Redis::OPT_TCP_KEEPALIVE')) {
+                    $redis->setOption(\Redis::OPT_TCP_KEEPALIVE, $params['tcp_keepalive']);
+                }
+                if ($params['compression'] && \defined('Redis::COMPRESSION_LZF')) {
+                    $redis->setOption(\Redis::OPT_COMPRESSION, \Redis::COMPRESSION_LZF);
                 }
 
                 return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

See https://pecl.php.net/package-changelog.php?package=redis