### PR TITLE
[WIP][RFC][Console] Deprecate HelperSet

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -265,8 +265,13 @@ class Application
         return $exitCode;
     }
 
+    /**
+     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
+     */
     public function setHelperSet(HelperSet $helperSet)
     {
+        @trigger_error('setHelperSet() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+
         $this->helperSet = $helperSet;
     }
 
@@ -274,9 +279,13 @@ class Application
      * Get the helper set associated with the command.
      *
      * @return HelperSet The HelperSet instance associated with this command
+     *
+     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
      */
     public function getHelperSet()
     {
+        @trigger_error('getHelperSet() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+
         if (!$this->helperSet) {
             $this->helperSet = $this->getDefaultHelperSet();
         }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -266,11 +266,11 @@ class Application
     }
 
     /**
-     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
+     * @deprecated since version 4.2. Use individual helpers instead.
      */
     public function setHelperSet(HelperSet $helperSet)
     {
-        @trigger_error('setHelperSet() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__.'() is deprecated since version 4.2. Use individual helpers instead.', E_USER_DEPRECATED);
 
         $this->helperSet = $helperSet;
     }
@@ -280,12 +280,10 @@ class Application
      *
      * @return HelperSet The HelperSet instance associated with this command
      *
-     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
+     * @deprecated since version 4.2. Use individual helpers instead.
      */
     public function getHelperSet()
     {
-        @trigger_error('getHelperSet() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
-
         if (!$this->helperSet) {
             $this->helperSet = $this->getDefaultHelperSet();
         }

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -98,11 +98,11 @@ class Command
     }
 
     /**
-     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
+     * @deprecated since version 4.2. Use individual helpers instead.
      */
     public function setHelperSet(HelperSet $helperSet)
     {
-        @trigger_error('setHelperSet() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__.'() is deprecated since version 4.2. Use individual helpers instead.', E_USER_DEPRECATED);
 
         $this->helperSet = $helperSet;
     }
@@ -112,11 +112,11 @@ class Command
      *
      * @return HelperSet A HelperSet instance
      *
-     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
+     * @deprecated since version 4.2. Use individual helpers instead.
      */
     public function getHelperSet()
     {
-        @trigger_error('getHelperSet() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__.'() is deprecated since version 4.2. Use individual helpers instead.', E_USER_DEPRECATED);
 
         return $this->helperSet;
     }
@@ -630,11 +630,11 @@ class Command
      * @throws LogicException           if no HelperSet is defined
      * @throws InvalidArgumentException if the helper is not defined
      *
-     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
+     * @deprecated since version 4.2. Use individual helpers instead.
      */
     public function getHelper($name)
     {
-        @trigger_error('getHelper() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__.'() is deprecated since version 4.2. Use individual helpers instead.', E_USER_DEPRECATED);
 
         if (null === $this->helperSet) {
             throw new LogicException(sprintf('Cannot retrieve helper "%s" because there is no HelperSet defined. Did you forget to add your command to the application or to set the application on the command using the setApplication() method? You can also set the HelperSet directly using the setHelperSet() method.', $name));

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -97,8 +97,13 @@ class Command
         }
     }
 
+    /**
+     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
+     */
     public function setHelperSet(HelperSet $helperSet)
     {
+        @trigger_error('setHelperSet() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+
         $this->helperSet = $helperSet;
     }
 
@@ -106,9 +111,13 @@ class Command
      * Gets the helper set.
      *
      * @return HelperSet A HelperSet instance
+     *
+     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
      */
     public function getHelperSet()
     {
+        @trigger_error('getHelperSet() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+
         return $this->helperSet;
     }
 
@@ -620,9 +629,13 @@ class Command
      *
      * @throws LogicException           if no HelperSet is defined
      * @throws InvalidArgumentException if the helper is not defined
+     *
+     * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
      */
     public function getHelper($name)
     {
+        @trigger_error('getHelper() is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+
         if (null === $this->helperSet) {
             throw new LogicException(sprintf('Cannot retrieve helper "%s" because there is no HelperSet defined. Did you forget to add your command to the application or to set the application on the command using the setApplication() method? You can also set the HelperSet directly using the setHelperSet() method.', $name));
         }

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -54,12 +54,12 @@ class FormatterHelper extends Helper
         foreach ($messages as $message) {
             $message = OutputFormatter::escape($message);
             $lines[] = sprintf($large ? '  %s  ' : ' %s ', $message);
-            $len = max($this->strlen($message) + ($large ? 4 : 2), $len);
+            $len = max(TextHelper::strlen($message) + ($large ? 4 : 2), $len);
         }
 
         $messages = $large ? array(str_repeat(' ', $len)) : array();
         for ($i = 0; isset($lines[$i]); ++$i) {
-            $messages[] = $lines[$i].str_repeat(' ', $len - $this->strlen($lines[$i]));
+            $messages[] = $lines[$i].str_repeat(' ', $len - TextHelper::strlen($lines[$i]));
         }
         if ($large) {
             $messages[] = str_repeat(' ', $len);
@@ -83,9 +83,9 @@ class FormatterHelper extends Helper
      */
     public function truncate($message, $length, $suffix = '...')
     {
-        $computedLength = $length - $this->strlen($suffix);
+        $computedLength = $length - TextHelper::strlen($suffix);
 
-        if ($computedLength > $this->strlen($message)) {
+        if ($computedLength > TextHelper::strlen($message)) {
             return $message;
         }
 

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Console\Helper;
 
-@trigger_error('The '.__NAMESPACE__.'\Helper class is deprecated since version 4.2 and will be removed in 5.0.', E_USER_DEPRECATED);
-
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 
 /**
@@ -20,7 +18,7 @@ use Symfony\Component\Console\Formatter\OutputFormatterInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @deprecated since version 4.2, to be removed in 5.0.
+ * @deprecated since version 4.2
  */
 abstract class Helper implements HelperInterface
 {
@@ -31,6 +29,8 @@ abstract class Helper implements HelperInterface
      */
     public function setHelperSet(HelperSet $helperSet = null)
     {
+        @trigger_error('The '.__NAMESPACE__.'\Helper class is deprecated since version 4.2.', E_USER_DEPRECATED);
+
         $this->helperSet = $helperSet;
     }
 
@@ -39,6 +39,8 @@ abstract class Helper implements HelperInterface
      */
     public function getHelperSet()
     {
+        @trigger_error('The '.__NAMESPACE__.'\Helper class is deprecated since version 4.2.', E_USER_DEPRECATED);
+
         return $this->helperSet;
     }
 
@@ -51,6 +53,8 @@ abstract class Helper implements HelperInterface
      */
     public static function strlen($string)
     {
+        @trigger_error('The '.__NAMESPACE__.'\Helper class is deprecated since version 4.2. Use TextHelper instead.', E_USER_DEPRECATED);
+
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
             return \strlen($string);
         }
@@ -69,6 +73,8 @@ abstract class Helper implements HelperInterface
      */
     public static function substr($string, $from, $length = null)
     {
+        @trigger_error('The '.__NAMESPACE__.'\Helper class is deprecated since version 4.2. Use TextHelper instead.', E_USER_DEPRECATED);
+
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
             return substr($string, $from, $length);
         }
@@ -78,6 +84,8 @@ abstract class Helper implements HelperInterface
 
     public static function formatTime($secs)
     {
+        @trigger_error('The '.__NAMESPACE__.'\Helper class is deprecated since version 4.2. Use TextHelper instead.', E_USER_DEPRECATED);
+
         static $timeFormats = array(
             array(0, '< 1 sec'),
             array(1, '1 sec'),
@@ -107,6 +115,8 @@ abstract class Helper implements HelperInterface
 
     public static function formatMemory($memory)
     {
+        @trigger_error('The '.__NAMESPACE__.'\Helper class is deprecated since version 4.2. Use TextHelper instead.', E_USER_DEPRECATED);
+
         if ($memory >= 1024 * 1024 * 1024) {
             return sprintf('%.1f GiB', $memory / 1024 / 1024 / 1024);
         }
@@ -129,6 +139,8 @@ abstract class Helper implements HelperInterface
 
     public static function removeDecoration(OutputFormatterInterface $formatter, $string)
     {
+        @trigger_error('The '.__NAMESPACE__.'\Helper class is deprecated since version 4.2. Use TextHelper instead.', E_USER_DEPRECATED);
+
         $isDecorated = $formatter->isDecorated();
         $formatter->setDecorated(false);
         // remove <...> formatting

--- a/src/Symfony/Component/Console/Helper/HelperInterface.php
+++ b/src/Symfony/Component/Console/Helper/HelperInterface.php
@@ -11,21 +11,21 @@
 
 namespace Symfony\Component\Console\Helper;
 
-@trigger_error('The '.__NAMESPACE__.'\HelperInterface class is deprecated since version 4.2 and will be removed in 5.0.', E_USER_DEPRECATED);
+@trigger_error('The '.__NAMESPACE__.'\HelperInterface class is deprecated since version 4.2.', E_USER_DEPRECATED);
 
 /**
  * HelperInterface is the interface all helpers must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @deprecated since version 4.2, to be removed in 5.0.
+ * @deprecated since version 4.2
  */
 interface HelperInterface
 {
     /**
      * Sets the helper set associated with this helper.
      *
-     * @deprecated since version 4.2, to be removed in 5.0.
+     * @deprecated since version 4.2
      */
     public function setHelperSet(HelperSet $helperSet = null);
 
@@ -34,7 +34,7 @@ interface HelperInterface
      *
      * @return HelperSet A HelperSet instance
      *
-     * @deprecated since version 4.2, to be removed in 5.0.
+     * @deprecated since version 4.2
      */
     public function getHelperSet();
 
@@ -43,7 +43,7 @@ interface HelperInterface
      *
      * @return string The canonical name
      *
-     * @deprecated since version 4.2, to be removed in 5.0.
+     * @deprecated since version 4.2
      */
     public function getName();
 }

--- a/src/Symfony/Component/Console/Helper/HelperInterface.php
+++ b/src/Symfony/Component/Console/Helper/HelperInterface.php
@@ -11,15 +11,21 @@
 
 namespace Symfony\Component\Console\Helper;
 
+@trigger_error('The '.__NAMESPACE__.'\HelperInterface class is deprecated since version 4.2 and will be removed in 5.0.', E_USER_DEPRECATED);
+
 /**
  * HelperInterface is the interface all helpers must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 4.2, to be removed in 5.0.
  */
 interface HelperInterface
 {
     /**
      * Sets the helper set associated with this helper.
+     *
+     * @deprecated since version 4.2, to be removed in 5.0.
      */
     public function setHelperSet(HelperSet $helperSet = null);
 
@@ -27,6 +33,8 @@ interface HelperInterface
      * Gets the helper set associated with this helper.
      *
      * @return HelperSet A HelperSet instance
+     *
+     * @deprecated since version 4.2, to be removed in 5.0.
      */
     public function getHelperSet();
 
@@ -34,6 +42,8 @@ interface HelperInterface
      * Returns the canonical name of this helper.
      *
      * @return string The canonical name
+     *
+     * @deprecated since version 4.2, to be removed in 5.0.
      */
     public function getName();
 }

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Helper;
 
+@trigger_error('The '.__NAMESPACE__.'\HelperSet class is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 
@@ -18,6 +20,8 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
  * HelperSet represents a set of helpers to be used with a command.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
  */
 class HelperSet implements \IteratorAggregate
 {

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Console\Helper;
 
-@trigger_error('The '.__NAMESPACE__.'\HelperSet class is deprecated since version 4.2 and will be removed in 5.0. Use individual helpers instead.', E_USER_DEPRECATED);
+@trigger_error('The '.__NAMESPACE__.'\HelperSet class is deprecated since version 4.2. Use individual helpers instead.', E_USER_DEPRECATED);
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @deprecated since version 4.2, to be removed in 5.0. Use individual helpers instead.
+ * @deprecated since version 4.2. Use individual helpers instead.
  */
 class HelperSet implements \IteratorAggregate
 {

--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -25,6 +25,13 @@ use Symfony\Component\Process\Process;
  */
 class ProcessHelper extends Helper
 {
+    private $formatter;
+
+    public function __construct()
+    {
+        $this->formatter = new DebugFormatterHelper();
+    }
+
     /**
      * Runs an external process.
      *
@@ -42,8 +49,6 @@ class ProcessHelper extends Helper
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();
         }
-
-        $formatter = $this->getHelperSet()->get('debug_formatter');
 
         if ($cmd instanceof Process) {
             $cmd = array($cmd);
@@ -65,7 +70,7 @@ class ProcessHelper extends Helper
         }
 
         if ($verbosity <= $output->getVerbosity()) {
-            $output->write($formatter->start(spl_object_hash($process), $this->escapeString($process->getCommandLine())));
+            $output->write($this->formatter->start(spl_object_hash($process), $this->escapeString($process->getCommandLine())));
         }
 
         if ($output->isDebug()) {
@@ -76,7 +81,7 @@ class ProcessHelper extends Helper
 
         if ($verbosity <= $output->getVerbosity()) {
             $message = $process->isSuccessful() ? 'Command ran successfully' : sprintf('%s Command did not run successfully', $process->getExitCode());
-            $output->write($formatter->stop(spl_object_hash($process), $message, $process->isSuccessful()));
+            $output->write($this->formatter->stop(spl_object_hash($process), $message, $process->isSuccessful()));
         }
 
         if (!$process->isSuccessful() && null !== $error) {
@@ -130,10 +135,8 @@ class ProcessHelper extends Helper
             $output = $output->getErrorOutput();
         }
 
-        $formatter = $this->getHelperSet()->get('debug_formatter');
-
-        return function ($type, $buffer) use ($output, $process, $callback, $formatter) {
-            $output->write($formatter->progress(spl_object_hash($process), $this->escapeString($buffer), Process::ERR === $type));
+        return function ($type, $buffer) use ($output, $process, $callback) {
+            $output->write($this->formatter->progress(spl_object_hash($process), $this->escapeString($buffer), Process::ERR === $type));
 
             if (null !== $callback) {
                 \call_user_func($callback, $type, $buffer);

--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -27,7 +27,10 @@ class ProcessHelper extends Helper
 {
     private $formatter;
 
-    public function __construct()
+    /**
+     * @param object $formatter A helper that formats output of the external process
+     */
+    public function __construct($formatter = null)
     {
         $this->formatter = new DebugFormatterHelper();
     }

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -300,7 +300,7 @@ final class ProgressBar
     {
         $this->format = null;
         $this->max = max(0, $max);
-        $this->stepWidth = $this->max ? Helper::strlen((string) $this->max) : 4;
+        $this->stepWidth = $this->max ? TextHelper::strlen((string) $this->max) : 4;
     }
 
     /**
@@ -378,7 +378,7 @@ final class ProgressBar
         if ($this->overwrite) {
             if (!$this->firstRun) {
                 if ($this->output instanceof ConsoleSectionOutput) {
-                    $lines = floor(Helper::strlen($message) / $this->terminal->getWidth()) + $this->formatLineCount + 1;
+                    $lines = floor(TextHelper::strlen($message) / $this->terminal->getWidth()) + $this->formatLineCount + 1;
                     $this->output->clear($lines);
                 } else {
                     // Move the cursor to the beginning of the line
@@ -424,14 +424,14 @@ final class ProgressBar
                 $completeBars = floor($bar->getMaxSteps() > 0 ? $bar->getProgressPercent() * $bar->getBarWidth() : $bar->getProgress() % $bar->getBarWidth());
                 $display = str_repeat($bar->getBarCharacter(), $completeBars);
                 if ($completeBars < $bar->getBarWidth()) {
-                    $emptyBars = $bar->getBarWidth() - $completeBars - Helper::strlenWithoutDecoration($output->getFormatter(), $bar->getProgressCharacter());
+                    $emptyBars = $bar->getBarWidth() - $completeBars - TextHelper::strlenWithoutDecoration($output->getFormatter(), $bar->getProgressCharacter());
                     $display .= $bar->getProgressCharacter().str_repeat($bar->getEmptyBarCharacter(), $emptyBars);
                 }
 
                 return $display;
             },
             'elapsed' => function (ProgressBar $bar) {
-                return Helper::formatTime(time() - $bar->getStartTime());
+                return TextHelper::formatTime(time() - $bar->getStartTime());
             },
             'remaining' => function (ProgressBar $bar) {
                 if (!$bar->getMaxSteps()) {
@@ -444,7 +444,7 @@ final class ProgressBar
                     $remaining = round((time() - $bar->getStartTime()) / $bar->getProgress() * ($bar->getMaxSteps() - $bar->getProgress()));
                 }
 
-                return Helper::formatTime($remaining);
+                return TextHelper::formatTime($remaining);
             },
             'estimated' => function (ProgressBar $bar) {
                 if (!$bar->getMaxSteps()) {
@@ -457,10 +457,10 @@ final class ProgressBar
                     $estimated = round((time() - $bar->getStartTime()) / $bar->getProgress() * $bar->getMaxSteps());
                 }
 
-                return Helper::formatTime($estimated);
+                return TextHelper::formatTime($estimated);
             },
             'memory' => function (ProgressBar $bar) {
-                return Helper::formatMemory(memory_get_usage(true));
+                return TextHelper::formatMemory(memory_get_usage(true));
             },
             'current' => function (ProgressBar $bar) {
                 return str_pad($bar->getProgress(), $bar->getStepWidth(), ' ', STR_PAD_LEFT);
@@ -513,7 +513,7 @@ final class ProgressBar
 
         // gets string length for each sub line with multiline format
         $linesLength = array_map(function ($subLine) {
-            return Helper::strlenWithoutDecoration($this->output->getFormatter(), rtrim($subLine, "\r"));
+            return TextHelper::strlenWithoutDecoration($this->output->getFormatter(), rtrim($subLine, "\r"));
         }, explode("\n", $line));
 
         $linesWidth = max($linesLength);

--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -245,10 +245,10 @@ class ProgressIndicator
                 return $indicator->message;
             },
             'elapsed' => function (ProgressIndicator $indicator) {
-                return Helper::formatTime(time() - $indicator->startTime);
+                return TextHelper::formatTime(time() - $indicator->startTime);
             },
             'memory' => function () {
-                return Helper::formatMemory(memory_get_usage(true));
+                return TextHelper::formatMemory(memory_get_usage(true));
             },
         );
     }

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -161,11 +161,9 @@ class QuestionHelper extends Helper
      */
     protected function writeError(OutputInterface $output, \Exception $error)
     {
-        if (null !== $this->getHelperSet() && $this->getHelperSet()->has('formatter')) {
-            $message = $this->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error');
-        } else {
-            $message = '<error>'.$error->getMessage().'</error>';
-        }
+        $formatter = new FormatterHelper();
+
+        $message = $formatter->formatBlock($error->getMessage(), 'error');
 
         $output->writeln($message);
     }

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -29,8 +29,17 @@ use Symfony\Component\Console\Question\Question;
 class QuestionHelper extends Helper
 {
     private $inputStream;
+    private $errorFormatter;
     private static $shell;
     private static $stty;
+
+    /**
+     * @param object $errorFormatter A helper that formats the output of error messages
+     */
+    public function __construct($errorFormatter = null)
+    {
+        $this->errorFormatter = new FormatterHelper();
+    }
 
     /**
      * Asks a question to the user.
@@ -161,9 +170,7 @@ class QuestionHelper extends Helper
      */
     protected function writeError(OutputInterface $output, \Exception $error)
     {
-        $formatter = new FormatterHelper();
-
-        $message = $formatter->formatBlock($error->getMessage(), 'error');
+        $message = $this->errorFormatter->formatBlock($error->getMessage(), 'error');
 
         $output->writeln($message);
     }

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -473,7 +473,7 @@ class Table
             return sprintf($style->getBorderFormat(), str_repeat($style->getBorderChars()[2], $width));
         }
 
-        $width += Helper::strlen($cell) - Helper::strlenWithoutDecoration($this->output->getFormatter(), $cell);
+        $width += TextHelper::strlen($cell) - TextHelper::strlenWithoutDecoration($this->output->getFormatter(), $cell);
         $content = sprintf($style->getCellRowContentFormat(), $cell);
 
         return sprintf($cellFormat, str_pad($content, $width, $style->getPaddingChar(), $style->getPadType()));
@@ -678,8 +678,8 @@ class Table
 
                 foreach ($row as $i => $cell) {
                     if ($cell instanceof TableCell) {
-                        $textContent = Helper::removeDecoration($this->output->getFormatter(), $cell);
-                        $textLength = Helper::strlen($textContent);
+                        $textContent = TextHelper::removeDecoration($this->output->getFormatter(), $cell);
+                        $textLength = TextHelper::strlen($textContent);
                         if ($textLength > 0) {
                             $contentColumns = str_split($textContent, ceil($textLength / $cell->getColspan()));
                             foreach ($contentColumns as $position => $content) {
@@ -707,7 +707,7 @@ class Table
 
         if (isset($row[$column])) {
             $cell = $row[$column];
-            $cellWidth = Helper::strlenWithoutDecoration($this->output->getFormatter(), $cell);
+            $cellWidth = TextHelper::strlenWithoutDecoration($this->output->getFormatter(), $cell);
         }
 
         $columnWidth = isset($this->columnWidths[$column]) ? $this->columnWidths[$column] : 0;

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -434,7 +434,6 @@ class Table
      * Example:
      *
      *     | 9971-5-0210-0 | A Tale of Two Cities  | Charles Dickens  |
-     *
      */
     private function renderRow(array $row, string $cellFormat)
     {

--- a/src/Symfony/Component/Console/Helper/TextHelper.php
+++ b/src/Symfony/Component/Console/Helper/TextHelper.php
@@ -76,17 +76,19 @@ final class TextHelper
         );
 
         foreach ($timeFormats as $index => $format) {
-            if ($secs >= $format[0]) {
-                if ((isset($timeFormats[$index + 1]) && $secs < $timeFormats[$index + 1][0])
-                    || $index == count($timeFormats) - 1
-                ) {
-                    if (2 == count($format)) {
-                        return $format[1];
-                    }
-
-                    return floor($secs / $format[2]).' '.$format[1];
-                }
+            if ($secs < $format[0]) {
+                continue;
             }
+
+            if (isset($timeFormats[$index + 1]) && $secs >= $timeFormats[$index + 1][0]) {
+                continue;
+            }
+
+            if (2 == count($format)) {
+                return $format[1];
+            }
+
+            return floor($secs / $format[2]).' '.$format[1];
         }
     }
 

--- a/src/Symfony/Component/Console/Helper/TextHelper.php
+++ b/src/Symfony/Component/Console/Helper/TextHelper.php
@@ -30,7 +30,7 @@ final class TextHelper
     public static function strlen(string $string): int
     {
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
-            return strlen($string);
+            return \strlen($string);
         }
 
         return mb_strwidth($string, $encoding);
@@ -84,7 +84,7 @@ final class TextHelper
                 continue;
             }
 
-            if (2 == count($format)) {
+            if (2 == \count($format)) {
                 return $format[1];
             }
 

--- a/src/Symfony/Component/Console/Helper/TextHelper.php
+++ b/src/Symfony/Component/Console/Helper/TextHelper.php
@@ -11,37 +11,15 @@
 
 namespace Symfony\Component\Console\Helper;
 
-@trigger_error('The '.__NAMESPACE__.'\Helper class is deprecated since version 4.2 and will be removed in 5.0.', E_USER_DEPRECATED);
-
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 
 /**
- * Helper is the base class for all helper classes.
+ * The TextHelper provides helpers for text formatting.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @deprecated since version 4.2, to be removed in 5.0.
  */
-abstract class Helper implements HelperInterface
+final class TextHelper
 {
-    protected $helperSet = null;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setHelperSet(HelperSet $helperSet = null)
-    {
-        $this->helperSet = $helperSet;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getHelperSet()
-    {
-        return $this->helperSet;
-    }
-
     /**
      * Returns the length of a string, using mb_strwidth if it is available.
      *
@@ -52,7 +30,7 @@ abstract class Helper implements HelperInterface
     public static function strlen($string)
     {
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
-            return \strlen($string);
+            return strlen($string);
         }
 
         return mb_strwidth($string, $encoding);
@@ -93,9 +71,9 @@ abstract class Helper implements HelperInterface
         foreach ($timeFormats as $index => $format) {
             if ($secs >= $format[0]) {
                 if ((isset($timeFormats[$index + 1]) && $secs < $timeFormats[$index + 1][0])
-                    || $index == \count($timeFormats) - 1
+                    || $index == count($timeFormats) - 1
                 ) {
-                    if (2 == \count($format)) {
+                    if (2 == count($format)) {
                         return $format[1];
                     }
 

--- a/src/Symfony/Component/Console/Helper/TextHelper.php
+++ b/src/Symfony/Component/Console/Helper/TextHelper.php
@@ -27,7 +27,7 @@ final class TextHelper
      *
      * @return int The length of the string
      */
-    public static function strlen($string)
+    public static function strlen(string $string): int
     {
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
             return strlen($string);
@@ -45,7 +45,7 @@ final class TextHelper
      *
      * @return string The string subset
      */
-    public static function substr($string, $from, $length = null)
+    public static function substr(string $string, int $from, int $length = null): string
     {
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
             return substr($string, $from, $length);
@@ -54,7 +54,14 @@ final class TextHelper
         return mb_substr($string, $from, $length, $encoding);
     }
 
-    public static function formatTime($secs)
+    /**
+     * Returns a time difference in a human-readable format.
+     *
+     * @param int $secs Amount of seconds
+     *
+     * @return string The time difference
+     */
+    public static function formatTime(int $secs): string
     {
         static $timeFormats = array(
             array(0, '< 1 sec'),
@@ -83,7 +90,14 @@ final class TextHelper
         }
     }
 
-    public static function formatMemory($memory)
+    /**
+     * Returns an amount of memory bytes in a human-readable format.
+     *
+     * @param int $memory Amount of bytes
+     *
+     * @return string The amount of memory
+     */
+    public static function formatMemory(int $memory): string
     {
         if ($memory >= 1024 * 1024 * 1024) {
             return sprintf('%.1f GiB', $memory / 1024 / 1024 / 1024);
@@ -100,12 +114,27 @@ final class TextHelper
         return sprintf('%d B', $memory);
     }
 
-    public static function strlenWithoutDecoration(OutputFormatterInterface $formatter, $string)
+    /**
+     * Returns the length of a string, stripped of its console decoration characters.
+     *
+     * @param string $string The string to check its length
+     *
+     * @return int The length of the string
+     */
+    public static function strlenWithoutDecoration(OutputFormatterInterface $formatter, string $string): string
     {
         return self::strlen(self::removeDecoration($formatter, $string));
     }
 
-    public static function removeDecoration(OutputFormatterInterface $formatter, $string)
+    /**
+     * Returns a string, stripped of its console decoration characters.
+     *
+     * @param OutputFormatterInterface $formatter
+     * @param string                   $string
+     *
+     * @return string The string without console decoration characters
+     */
+    public static function removeDecoration(OutputFormatterInterface $formatter, string $string): string
     {
         $isDecorated = $formatter->isDecorated();
         $formatter->setDecorated(false);

--- a/src/Symfony/Component/Console/Tests/Helper/TextHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TextHelperTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\TextHelper;
+
+class TextHelperTest extends TestCase
+{
+    public function formatTimeProvider()
+    {
+        return array(
+            array(0,      '< 1 sec'),
+            array(1,      '1 sec'),
+            array(2,      '2 secs'),
+            array(59,     '59 secs'),
+            array(60,     '1 min'),
+            array(61,     '1 min'),
+            array(119,    '1 min'),
+            array(120,    '2 mins'),
+            array(121,    '2 mins'),
+            array(3599,   '59 mins'),
+            array(3600,   '1 hr'),
+            array(7199,   '1 hr'),
+            array(7200,   '2 hrs'),
+            array(7201,   '2 hrs'),
+            array(86399,  '23 hrs'),
+            array(86400,  '1 day'),
+            array(86401,  '1 day'),
+            array(172799, '1 day'),
+            array(172800, '2 days'),
+            array(172801, '2 days'),
+        );
+    }
+
+    /**
+     * @dataProvider formatTimeProvider
+     *
+     * @param int    $secs
+     * @param string $expectedFormat
+     */
+    public function testFormatTime($secs, $expectedFormat)
+    {
+        $this->assertEquals($expectedFormat, TextHelper::formatTime($secs));
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/TextHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TextHelperTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Helper\TextHelper;
 
 class TextHelperTest extends TestCase
 {
-    public function formatTimeProvider()
+    public function formatTimeProvider(): array
     {
         return array(
             array(0,      '< 1 sec'),
@@ -44,11 +44,8 @@ class TextHelperTest extends TestCase
 
     /**
      * @dataProvider formatTimeProvider
-     *
-     * @param int    $secs
-     * @param string $expectedFormat
      */
-    public function testFormatTime($secs, $expectedFormat)
+    public function testFormatTime(int $secs, string $expectedFormat)
     {
         $this->assertEquals($expectedFormat, TextHelper::formatTime($secs));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #21417
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

This PR deprecates the [Helper](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Helper/Helper.php), [HelperInterface](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Helper/HelperInterface.php) and [HelperSet](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Helper/HelperSet.php) classes and introduces a new class `TextHelper` that replaces the base methods of the original Helper class.

The reason for these deprecations is that newer helpers (like `ProgressBar` and `Table`) have not been using these base classes and other helpers have seen problems due to being stateful while being used across multiple commands (see #21417). `HelperSet` was used as a way to make helpers interchangeable, but I'd argue it's better to explicitly use a helper class instead of relying on a helper container to return the correct helper. Since all helpers have different methods this abstraction is just conceptual anyway. There is the use case of helpers relying on other helpers, this could be solved through optional setter injection.