### PR TITLE
[Cache] fix Memcached tests

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -22,6 +22,7 @@ class MemcachedAdapterTest extends AdapterTestCase
     );
 
     protected static $client;
+    protected static $enableVersioning = false;
 
     public static function setupBeforeClass()
     {
@@ -41,7 +42,23 @@ class MemcachedAdapterTest extends AdapterTestCase
     {
         $client = $defaultLifetime ? AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST')) : self::$client;
 
-        return new MemcachedAdapter($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+        $adapter = new MemcachedAdapter($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+
+        if (self::$enableVersioning) {
+            $adapter->enableVersioning();
+        }
+
+        return $adapter;
+    }
+
+    public function testClear()
+    {
+        self::$enableVersioning = true;
+        try {
+            parent::testClear();
+        } finally {
+            self::$enableVersioning = false;
+        }
     }
 
     public function testOptions()

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -23,6 +23,7 @@ class MemcachedCacheTest extends CacheTestCase
     );
 
     protected static $client;
+    protected static $enableVersioning = false;
 
     public static function setupBeforeClass()
     {
@@ -42,7 +43,23 @@ class MemcachedCacheTest extends CacheTestCase
     {
         $client = $defaultLifetime ? AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'), array('binary_protocol' => false)) : self::$client;
 
-        return new MemcachedCache($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+        $adapter = new MemcachedCache($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+
+        if (self::$enableVersioning) {
+            $adapter->enableVersioning();
+        }
+
+        return $adapter;
+    }
+
+    public function testClear()
+    {
+        self::$enableVersioning = true;
+        try {
+            parent::testClear();
+        } finally {
+            self::$enableVersioning = false;
+        }
     }
 
     public function testCreatePersistentConnectionShouldNotDupServerList()

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
@@ -20,6 +20,12 @@ class MemcachedCacheTextModeTest extends MemcachedCacheTest
     {
         $client = AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'), array('binary_protocol' => false));
 
-        return new MemcachedCache($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+        $adapter = new MemcachedCache($client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+
+        if (self::$enableVersioning) {
+            $adapter->enableVersioning();
+        }
+
+        return $adapter;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Clearing a memcached pool works only when versioning is enabled. Dunno why this has not be caught before, but it's making tests fail now.