### PR TITLE
[SecurityBundle] Add json login ldap

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -10,7 +10,8 @@ CHANGELOG
    custom tokens extend the existing `Symfony\Component\Security\Core\Authentication\Token\AnonymousToken`
    or `Symfony\Component\Security\Core\Authentication\Token\RememberMeToken`.
  * Added `Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass`
-
+ * Added `json_login_ldap` authentication provider to use LDAP authentication with a REST API.
+ 
 4.1.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginLdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginLdapFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * JsonLoginLdapFactory creates services for json login ldap authentication.
+ */
+class JsonLoginLdapFactory extends JsonLoginFactory
+{
+    public function getKey()
+    {
+        return 'json-login-ldap';
+    }
+
+    protected function createAuthProvider(ContainerBuilder $container, $id, $config, $userProviderId)
+    {
+        $provider = 'security.authentication.provider.ldap_bind.'.$id;
+        $definition = $container
+            ->setDefinition($provider, new ChildDefinition('security.authentication.provider.ldap_bind'))
+            ->replaceArgument(0, new Reference($userProviderId))
+            ->replaceArgument(1, new Reference('security.user_checker.'.$id))
+            ->replaceArgument(2, $id)
+            ->replaceArgument(3, new Reference($config['service']))
+            ->replaceArgument(4, $config['dn_string'])
+        ;
+
+        if (!empty($config['query_string'])) {
+            $definition->addMethodCall('setQueryString', array($config['query_string']));
+        }
+
+        return $provider;
+    }
+
+    public function addConfiguration(NodeDefinition $node)
+    {
+        parent::addConfiguration($node);
+
+        $node
+            ->children()
+                ->scalarNode('service')->defaultValue('ldap')->end()
+                ->scalarNode('dn_string')->defaultValue('{username}')->end()
+                ->scalarNode('query_string')->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterCsrfTokenClearingLogoutHandlerPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginLdapFactory;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -47,6 +48,7 @@ class SecurityBundle extends Bundle
         $extension->addSecurityListenerFactory(new FormLoginFactory());
         $extension->addSecurityListenerFactory(new FormLoginLdapFactory());
         $extension->addSecurityListenerFactory(new JsonLoginFactory());
+        $extension->addSecurityListenerFactory(new JsonLoginLdapFactory());
         $extension->addSecurityListenerFactory(new HttpBasicFactory());
         $extension->addSecurityListenerFactory(new HttpBasicLdapFactory());
         $extension->addSecurityListenerFactory(new RememberMeFactory());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginLdapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginLdapTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\HttpKernel\Kernel;
+
+class JsonLoginLdapTest extends WebTestCase
+{
+    public function testKernelBoot()
+    {
+        $kernel = self::createKernel(array('test_case' => 'JsonLoginLdap', 'root_config' => 'config.yml'));
+        $kernel->boot();
+
+        $this->assertInstanceOf(Kernel::class, $kernel);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return array(
+    new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new Symfony\Bundle\TwigBundle\TwigBundle(),
+);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/config.yml
@@ -1,0 +1,39 @@
+imports:
+    - { resource: ./../config/default.yml }
+services:
+    Symfony\Component\Ldap\Ldap:
+        arguments: ['@Symfony\Component\Ldap\Adapter\ExtLdap\Adapter']
+
+    Symfony\Component\Ldap\Adapter\ExtLdap\Adapter:
+        arguments:
+            -   host: 'localhost'
+                port: 389
+                options:
+                    protocol_version: 3
+                    referrals: false
+security:
+    providers:
+        ldap:
+            ldap:
+                service: Symfony\Component\Ldap\Ldap
+                base_dn: 'dc=onfroy,dc=net'
+                search_dn: ''
+                search_password: ''
+                default_roles: ROLE_USER
+                uid_key: uid
+
+    firewalls:
+        main:
+            pattern:  ^/login
+            stateless: true
+            anonymous: true
+            json_login_ldap:
+                check_path: /login
+                require_previous_session: false
+                service: Symfony\Component\Ldap\Ldap
+                dn_string: ''
+                username_path: user.login
+                password_path: user.password
+
+    access_control:
+        - { path: ^/, roles: ROLE_USER }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | yes 
| License       | MIT

Add a simple from_login_ldap on firewall types to let authenticate with ldap with json API
