### PR TITLE
[ExpressionLanguage] change `evaluate()` docblock return type from string to mixed

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -60,7 +60,7 @@ class ExpressionLanguage
      * @param Expression|string $expression The expression to compile
      * @param array             $values     An array of values
      *
-     * @return string The result of the evaluation of the expression
+     * @return mixed The result of the evaluation of the expression
      */
     public function evaluate($expression, $values = array())
     {


### PR DESCRIPTION
Issue: https://github.com/symfony/symfony/issues/27652