### PR TITLE
[HttpKernel] Make AbstractTestSessionListener compatible with CookieClearingLogoutHandler

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
@@ -71,6 +71,13 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
 
         if ($session instanceof Session ? !$session->isEmpty() || (null !== $this->sessionId && $session->getId() !== $this->sessionId) : $wasStarted) {
             $params = session_get_cookie_params();
+
+            foreach ($event->getResponse()->headers->getCookies() as $cookie) {
+                if ($session->getName() === $cookie->getName() && $params['path'] === $cookie->getPath() && $params['domain'] == $cookie->getDomain()) {
+                    return;
+                }
+            }
+
             $event->getResponse()->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
             $this->sessionId = $session->getId();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

#26157 started to send a new cookie in `AbstractTestSessionListener`, but is incompatible with `CookieClearingLogoutHandler` as it overrides its `Set-Cookie` by setting a new cookie (breaking my test that checked to see that the cookie was removed after a log out).