### PR TITLE
[Serializer] Updates DocBlock to a mixed param type

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -21,7 +21,7 @@ interface NormalizerInterface
     /**
      * Normalizes an object into a set of arrays/scalars.
      *
-     * @param object $object  Object to normalize
+     * @param mixed  $object  Object to normalize
      * @param string $format  Format the normalization result will be encoded as
      * @param array  $context Context options for the normalizer
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      |  Yes
| New feature?  |  No
| BC breaks?    | No
| Deprecations? | Non added.
| Tests pass?   | Yes , no new tests added.
| Fixed tickets | #27457 
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

The JSON serializers make use of the JsonSerializable interface and return arrays to the NormalizerInterface. This PR updates the DocBlock to reflect that.

Moving towards PHP 7.2 and the use of object type-hints would require changes to the [JsonSerializableNormalizer@L41](https://github.com/symfony/symfony/blob/92c37b9711b3e296ad427d590ac49488c73d71b2/src/Symfony/Component/Serializer/Normalizer/JsonSerializableNormalizer.php#L41) at a minimum.

Truly not much of a PR I'm afraid!
