### PR TITLE
[Lock] use 'r+' for fopen (fixes issue on Solaris)

### DIFF
--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -79,12 +79,12 @@ class FlockStore implements StoreInterface
 
         // Silence error reporting
         set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
-        if (!$handle = fopen($fileName, 'r')) {
+        if (!$handle = fopen($fileName, 'r+') ?: fopen($fileName, 'r')) {
             if ($handle = fopen($fileName, 'x')) {
                 chmod($fileName, 0444);
-            } elseif (!$handle = fopen($fileName, 'r')) {
+            } elseif (!$handle = fopen($fileName, 'r+') ?: fopen($fileName, 'r')) {
                 usleep(100); // Give some time for chmod() to complete
-                $handle = fopen($fileName, 'r');
+                $handle = fopen($fileName, 'r+') ?: fopen($fileName, 'r');
             }
         }
         restore_error_handler();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 (also applicable to _LockHandler_ in 2.8 and 3.3)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes [1]
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

We discovered a curious case on a specific hosting environment: the `FlockStorage` (or `LockHandler` in previous Symfony versions) could never get a file lock on **existing files**. So if you run a script for the first time and the lock file did not exist yet, the `FlockStorage` could get a lock on that file just fine. However on the second and subsequent runs, `FlockStorage` could _never_ get a file lock anymore. You can follow the discussion [here](https://github.com/contao/core-bundle/issues/1551) (if you speak German).

We have been using this little script to confirm the issue on the hosting environment:
```php
$fileName = __DIR__ . '/file.lock';

if (!$handle = @fopen($fileName, 'r')) {
    $handle = fopen($fileName, 'x');
}

if (!$handle) {
    echo "Could not open $fileName\n";
    exit;
}

if (flock($handle, LOCK_EX | LOCK_NB)) {
    echo "Got a lock on $fileName\n";
    flock($handle, LOCK_UN | LOCK_NB);
} else {
    echo "Could not get a lock on $fileName\n";
}
```
Whenever `file.lock` already existed prior to running the script, a lock could not be made.

After contacting the hosting provider's support on this they confirmed the issue and told us they are using **Solaris** instead of a Linux environment. And this is supposedly why it does not work. Instead you have to use `'r+'` instead of `'r'` for `fopen`.

I was able to confirm that changing from `'r'` to `'r+'` fixes the issue. However I am wondering who's actually at fault here. Is it Solaris? PHP? The compiled PHP version under Solaris? The hosting provider's operating system configuration?

### System information
```
uname -a
SunOS vlek 5.11 11.3 i86pc i386 i86pc Solaris
```
```
phpinfo:
SunOS localhost 5.10 Generic_150401-49 i86pc 
```
```
php -v
PHP 7.2.5 (cli) (built: May  4 2018 12:57:43) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
```

### Footnotes

[1] Previously one failed test on the first run and two failing tests on the second run with the proposed changes:
```
1) Symfony\Component\Lock\Tests\Store\FlockStoreTest::testSaveSanitizeName
Symfony\Component\Lock\Exception\LockStorageException: fopen(C:\Users\[…]\AppData\Local\Temp/sf.-php-echo-hello-word-.Sz2dDSf.lock)
: failed to open stream: Permission denied
```
```
2) Symfony\Component\Lock\Tests\Store\FlockStoreTest::testSaveWithDifferentKeysOnSameResources
Symfony\Component\Lock\Exception\LockStorageException: fopen(C:\Users\[…]\AppData\Local\Temp/sf.Symfony-Component-Lock-Tests-Store-
AbstractStoreTest-testSaveWithDifferentKeysOnSameResources5b2b5f00872538.64807920.2u9bH+a.lock): failed to open stream: Permission denied
```
The latter failed both on the first run and on the second run.

After the [proposed changes](https://github.com/symfony/symfony/pull/27668#discussion_r197054198) from @nicolas-grekas everything works fine 👍 