### PR TITLE
[DI] Avoid leaking unused env placeholders

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
@@ -84,6 +84,8 @@ class ValidateEnvPlaceholdersPass implements CompilerPassInterface
         } finally {
             BaseNode::resetPlaceholders();
         }
+
+        $resolvingBag->clearUnusedEnvPlaceholders();
     }
 
     private static function getType($value): string

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -87,6 +87,11 @@ class EnvPlaceholderParameterBag extends ParameterBag
         return $this->unusedEnvPlaceholders;
     }
 
+    public function clearUnusedEnvPlaceholders()
+    {
+        $this->unusedEnvPlaceholders = array();
+    }
+
     /**
      * Merges the env placeholders of another EnvPlaceholderParameterBag.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27486
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR avoids leaking out unused env placeholders, those are not resolved in `resolveEnvPlaceholders()` and such. As a result they are dumped as-is.

cc @nicolas-grekas 