### PR TITLE
[Debug] Fixed remark about debug class loader in docblock of Debug::enable()

### DIFF
--- a/src/Symfony/Component/Debug/Debug.php
+++ b/src/Symfony/Component/Debug/Debug.php
@@ -23,10 +23,7 @@ class Debug
     /**
      * Enables the debug tools.
      *
-     * This method registers an error handler and an exception handler.
-     *
-     * If the Symfony ClassLoader component is available, a special
-     * class loader is also registered.
+     * This method registers an error handler, an exception handler and a special class loader.
      *
      * @param int  $errorReportingLevel The level of error reporting you want
      * @param bool $displayErrors       Whether to display errors (for development) or just log them (for production)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The docblock of the `Debug::enable()` method states that "a special class loader" is registered if the ClassLoader component is available. In fact, that class loader has been moved to the Debug component a long time ago, which is why it is always loaded.

The docblock is clearly lying and I thought we should fix that. ☝️🤓 