### PR TITLE
[HttpKernel] fix argument's error messages in ServiceValueResolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -68,7 +68,7 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
             yield $this->container->get($controller)->get($argument->getName());
         } catch (RuntimeException $e) {
             $what = sprintf('argument $%s of "%s()"', $argument->getName(), $controller);
-            $message = preg_replace('/service "service_locator\.[^"]++"/', $what, $e->getMessage());
+            $message = preg_replace('/service "\.service_locator\.[^"]++"/', $what, $e->getMessage());
 
             if ($e->getMessage() === $message) {
                 $message = sprintf('Cannot resolve %s: %s', $what, $message);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
@@ -12,10 +12,12 @@
 namespace Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ServiceValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\DependencyInjection\RegisterControllerArgumentLocatorsPass;
 
 class ServiceValueResolverTest extends TestCase
 {
@@ -85,6 +87,25 @@ class ServiceValueResolverTest extends TestCase
         $this->assertYieldEquals(array(new DummyService()), $resolver->resolve($request, $argument));
     }
 
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage Cannot autowire argument $dummy of "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyController::index()": it references class "Symfony\Component\HttpKernel\Tests\Controller\ArgumentResolver\DummyService" but no such service exists.
+     */
+    public function testErrorIsTruncated()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new RegisterControllerArgumentLocatorsPass());
+
+        $container->register('argument_resolver.service', ServiceValueResolver::class)->addArgument(null)->setPublic(true);
+        $container->register(DummyController::class)->addTag('controller.service_arguments')->setPublic(true);
+
+        $container->compile();
+
+        $request = $this->requestWithAttributes(array('_controller' => array(DummyController::class, 'index')));
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+        $container->get('argument_resolver.service')->resolve($request, $argument)->current();
+    }
+
     private function requestWithAttributes(array $attributes)
     {
         $request = Request::create('/');
@@ -109,4 +130,11 @@ class ServiceValueResolverTest extends TestCase
 
 class DummyService
 {
+}
+
+class DummyController
+{
+    public function index(DummyService $dummy)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27625
| License       | MIT
| Doc PR        | -

Forgotten while renamed to hidden services.