### PR TITLE
[DI] Cleanup unused service_subscriber.locator tag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveServiceSubscribersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveServiceSubscribersPass.php
@@ -35,7 +35,12 @@ class ResolveServiceSubscribersPass extends AbstractRecursivePass
         }
 
         $serviceLocator = $this->serviceLocator;
-        $this->serviceLocator = $value->hasTag('container.service_subscriber.locator') ? $value->getTag('container.service_subscriber.locator')[0]['id'] : null;
+        $this->serviceLocator = null;
+
+        if ($value->hasTag('container.service_subscriber.locator')) {
+            $this->serviceLocator = $value->getTag('container.service_subscriber.locator')[0]['id'];
+            $value->clearTag('container.service_subscriber.locator');
+        }
 
         try {
             return parent::processValue($value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes-ish
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Cleanup internal DI tag `container.service_subscriber.locator` so it's _not_ reported as unused tag, i.e.:

```
Tag "container.service_subscriber.locator" was defined on service(s) "App\Controller\MainController", "translation.warmer", "router.cache_warmer", "twig.cache_warmer", "twig.template_cache_warmer",
but was never used. Did you mean "container.service_subscriber", "container.service_locator"?
```