### PR TITLE
[Form] Be able to whitelist selected fields in a form

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -123,14 +123,37 @@ class FormValidator extends ConstraintValidator
             }
         }
 
-        // Mark the form with an error if it contains extra fields
+        // Mark the form with an error if it contains non whitelisted extra fields
         if (!$config->getOption('allow_extra_fields') && count($form->getExtraData()) > 0) {
+            // Mark the form with an error, if `allow_extra_fields` is deactivated
             $this->context->setConstraint($constraint);
             $this->context->buildViolation($config->getOption('extra_fields_message'))
                 ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
                 ->setInvalidValue($form->getExtraData())
                 ->setCode(Form::NO_SUCH_FIELD_ERROR)
                 ->addViolation();
+        } elseif (is_array($config->getOption('allow_extra_fields')) && count($form->getExtraData()) > 0) {
+            // Get array of allowed extra fields
+            $allowedExtraFields = $config->getOption('allow_extra_fields');
+            $violatedExtraFields = [];
+
+            // Check extra data to be valid
+            foreach ($form->getExtraData() as $key=>$val) {
+                if (!in_array($key, $allowedExtraFields)) {
+                    $violatedExtraFields[$key] = $val;
+                }
+            }
+
+            // Check if there is invalid extra data
+            if (count($violatedExtraFields) > 0) {
+                // Mark the form with an error, if there are fields not whitelisted by `allow_extra_fields`
+                $this->context->setConstraint($constraint);
+                $this->context->buildViolation($config->getOption('extra_fields_message'))
+                    ->setParameter('{{ extra_fields }}', implode('", "', array_keys($violatedExtraFields)))
+                    ->setInvalidValue($violatedExtraFields)
+                    ->setCode(Form::NO_SUCH_FIELD_ERROR)
+                    ->addViolation();
+            }
         }
     }
 

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -136,7 +136,7 @@ class FormValidator extends ConstraintValidator
             } elseif (is_array($config->getOption('allow_extra_fields'))) {
                 // Get array of allowed extra fields
                 $allowedExtraFields = $config->getOption('allow_extra_fields');
-                $invalidExtraData = [];
+                $invalidExtraData = array();
 
                 // Check extra data to be valid
                 foreach ($form->getExtraData() as $key => $val) {

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -124,35 +124,37 @@ class FormValidator extends ConstraintValidator
         }
 
         // Mark the form with an error if it contains non whitelisted extra fields
-        if (!$config->getOption('allow_extra_fields') && count($form->getExtraData()) > 0) {
-            // Mark the form with an error, if `allow_extra_fields` is deactivated
-            $this->context->setConstraint($constraint);
-            $this->context->buildViolation($config->getOption('extra_fields_message'))
-                ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
-                ->setInvalidValue($form->getExtraData())
-                ->setCode(Form::NO_SUCH_FIELD_ERROR)
-                ->addViolation();
-        } elseif (is_array($config->getOption('allow_extra_fields')) && count($form->getExtraData()) > 0) {
-            // Get array of allowed extra fields
-            $allowedExtraFields = $config->getOption('allow_extra_fields');
-            $violatedExtraFields = [];
-
-            // Check extra data to be valid
-            foreach ($form->getExtraData() as $key=>$val) {
-                if (!in_array($key, $allowedExtraFields)) {
-                    $violatedExtraFields[$key] = $val;
-                }
-            }
-
-            // Check if there is invalid extra data
-            if (count($violatedExtraFields) > 0) {
-                // Mark the form with an error, if there are fields not whitelisted by `allow_extra_fields`
+        if (count($form->getExtraData()) > 0) {
+            if (!$config->getOption('allow_extra_fields')) {
+                // Mark the form with an error, if `allow_extra_fields` is deactivated
                 $this->context->setConstraint($constraint);
                 $this->context->buildViolation($config->getOption('extra_fields_message'))
-                    ->setParameter('{{ extra_fields }}', implode('", "', array_keys($violatedExtraFields)))
-                    ->setInvalidValue($violatedExtraFields)
+                    ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
+                    ->setInvalidValue($form->getExtraData())
                     ->setCode(Form::NO_SUCH_FIELD_ERROR)
                     ->addViolation();
+            } elseif (is_array($config->getOption('allow_extra_fields'))) {
+                // Get array of allowed extra fields
+                $allowedExtraFields = $config->getOption('allow_extra_fields');
+                $invalidExtraData = [];
+
+                // Check extra data to be valid
+                foreach ($form->getExtraData() as $key => $val) {
+                    if (!in_array($key, $allowedExtraFields)) {
+                        $invalidExtraData[$key] = $val;
+                    }
+                }
+
+                // Check if there is invalid extra data
+                if (count($invalidExtraData) > 0) {
+                    // Mark the form with an error, if there are fields not whitelisted by `allow_extra_fields`
+                    $this->context->setConstraint($constraint);
+                    $this->context->buildViolation($config->getOption('extra_fields_message'))
+                        ->setParameter('{{ extra_fields }}', implode('", "', array_keys($invalidExtraData)))
+                        ->setInvalidValue($invalidExtraData)
+                        ->setCode(Form::NO_SUCH_FIELD_ERROR)
+                        ->addViolation();
+                }
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27660
| License       | MIT
| Doc PR        | -

As described in feature request https://github.com/symfony/symfony/issues/27660 I'd like to be able to whitelist selected fields in a form instead of either allow all or none. One use case for this could be the Google reCAPTCHA.

From the feature request:
**Description**  
Currently the Form component in Symfony has the option to allow additional fields by setting `allow_extra_fields` to true (http://symfony.com/doc/current/reference/forms/types/form.html#allow-extra-fields).
As of today, you can only specify a boolean either true or false. I'd propose to, besides having just booleans, also allow passing an array of strings as value. This would work as a mixture of both options, by allowing all fields, whose names are specified in that array, but still forbid all others. This would give devs a finer granularity in what should be allowed in forms and what not.

**Example**  
Currently we can only set a form to accept all or none additional fields. Ex. `$this->createFormBuilder(null, ['allow_extra_fields' => true])`, With this proposal, we could pass something like `$this->createFormBuilder(null, ['allow_extra_fields' => ['foo', 'bar']])`. The form would then accept fields with the name `foo` and `bar` but still reject others, like `baz`.

**Usage**
Only allowing specific additional fields in a form, for example: `g-recaptcha-response` which is used by [reCAPTCHA](https://developers.google.com/recaptcha/docs/verify) but still don't allow arbitrary form inputs to be added
