### PR TITLE
Redesigned the default error page in production

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/error.html.twig
@@ -3,14 +3,22 @@
     <head>
         <meta charset="{{ _charset }}" />
         <title>An Error Occurred: {{ status_text }}</title>
+        <style>
+            body { background-color: #fff; color: #222; font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; margin: 0; }
+            .container { margin: 30px; max-width: 600px; }
+            h1 { color: #dc3545; font-size: 24px; }
+            h2 { font-size: 18px; }
+        </style>
     </head>
     <body>
-        <h1>Oops! An Error Occurred</h1>
-        <h2>The server returned a "{{ status_code }} {{ status_text }}".</h2>
+        <div class="container">
+            <h1>Oops! An Error Occurred</h1>
+            <h2>The server returned a "{{ status_code }} {{ status_text }}".</h2>
 
-        <div>
-            Something is broken. Please let us know what you were doing when this error occurred.
-            We will fix it as soon as possible. Sorry for any inconvenience caused.
+            <p>
+                Something is broken. Please let us know what you were doing when this error occurred.
+                We will fix it as soon as possible. Sorry for any inconvenience caused.
+            </p>
         </div>
     </body>
 </html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22964
| License       | MIT
| Doc PR        | -

This continues the work done in #27071.

Before/After comparison:

![before-after-prod-error-pages](https://user-images.githubusercontent.com/73419/41844084-6e132208-786f-11e8-97c9-53602395e231.png)
