### PR TITLE
[SecurityBundle] Dont throw if "security.http_utils" is not found

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSessionDomainConstraintPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSessionDomainConstraintPass.php
@@ -26,7 +26,7 @@ class AddSessionDomainConstraintPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasParameter('session.storage.options')) {
+        if (!$container->hasParameter('session.storage.options') || !$container->has('security.http_utils')) {
             return;
         }
 
@@ -34,7 +34,6 @@ class AddSessionDomainConstraintPass implements CompilerPassInterface
         $domainRegexp = empty($sessionOptions['cookie_domain']) ? '%s' : sprintf('(?:%%s|(?:.+\.)?%s)', preg_quote(trim($sessionOptions['cookie_domain'], '.')));
         $domainRegexp = (empty($sessionOptions['cookie_secure']) ? 'https?://' : 'https://').$domainRegexp;
 
-        // if the service doesn't exist, an exception must be thrown - ignoring would put security at risk
         $container->findDefinition('security.http_utils')->addArgument(sprintf('{^%s$}i', $domainRegexp));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -96,19 +96,6 @@ class AddSessionDomainConstraintPassTest extends TestCase
         $this->assertTrue($utils->createRedirectResponse($request, 'http://pirate.com/foo')->isRedirect('http://pirate.com/foo'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage You have requested a non-existent service "security.http_utils".
-     */
-    public function testNoHttpUtils()
-    {
-        $container = new ContainerBuilder();
-        $container->setParameter('session.storage.options', array());
-
-        $pass = new AddSessionDomainConstraintPass();
-        $pass->process($container);
-    }
-
     private function createContainer($sessionStorageOptions)
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27445
| License       | MIT
| Doc PR        | -

The comment + test were misleading, the actual important thing is wiring `AddSessionDomainConstraintPass` before removing passes, which is already the case already.