### PR TITLE
[Cache] Added support for Redis igbinary serializer

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -45,6 +45,7 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
             'read_timeout' => 0,
             'retry_interval' => 0,
             'lazy' => false,
+            'serializer' => 0,
             'database' => '1',
             'password' => null,
         );

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -39,6 +39,7 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
         $this->assertInstanceOf(\Redis::class, $redis);
         $this->assertTrue($redis->isConnected());
         $this->assertSame(0, $redis->getDbNum());
+        $this->assertEquals(0, $redis->getOption(\Redis::OPT_SERIALIZER));
 
         $redis = RedisAdapter::createConnection('redis://'.$redisHost.'/2');
         $this->assertSame(2, $redis->getDbNum());
@@ -51,6 +52,9 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
 
         $redis = RedisAdapter::createConnection('redis://'.$redisHost, array('read_timeout' => 5));
         $this->assertEquals(5, $redis->getReadTimeout());
+
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost, array('serializer' => 2));
+        $this->assertEquals(2, $redis->getOption(\Redis::OPT_SERIALIZER));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `3.4`, `4.0`, `4.1`, `master`
| Bug fix?      | no
| New feature?  | yes/no
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes 
| License       | MIT
| Doc PR        | *

Since `Redis` supports `igbinary` serializer it would be great to be able to benefit from it. 
(ref: https://github.com/phpredis/phpredis#setoption)
Using `igbinary` can lower Redis memory usage from 15% to 45% (depends on use case). In our, eZ Platform, case it's a lot because we store a lot of cache data in Redis. 

* docs PR will be provided if the community agrees with the idea shipped with this PR.