### PR TITLE
[Stopwatch] Support more memory profiling info

### DIFF
--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Stopwatch;
  * Represents an Event managed by Stopwatch.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Adamo Crespi <hello@aerendir.me>
  */
 class StopwatchEvent
 {
@@ -194,7 +195,9 @@ class StopwatchEvent
     }
 
     /**
-     * Gets the max memory usage of all periods.
+     * Of all periods, gets the max memory amount assigned to PHP.
+     *
+     * Very similar to StopwatchEvent::getMemoryPeak().
      *
      * @return int The memory usage (in bytes)
      */
@@ -208,6 +211,59 @@ class StopwatchEvent
         }
 
         return $memory;
+    }
+
+    /**
+     * Of all periods, gets the max amount of memory used by the script.
+     *
+     * Very similar to StopwatchEvent::getMemoryPeakEmalloc().
+     *
+     * @return int The memory usage (in bytes)
+     */
+    public function getMemoryCurrent()
+    {
+        $memoryCurrent = 0;
+        foreach ($this->periods as $period) {
+            if ($period->getMemoryCurrent() > $memoryCurrent) {
+                $memoryCurrent = $period->getMemoryCurrent();
+            }
+        }
+
+        return $memoryCurrent;
+    }
+
+    /**
+     * Of all periods, gets the max amount of memory assigned to PHP.
+     *
+     * @return int The memory usage (in bytes)
+     */
+    public function getMemoryPeak()
+    {
+        $memoryPeak = 0;
+        foreach ($this->periods as $period) {
+            if ($period->getMemoryPeak() > $memoryPeak) {
+                $memoryPeak = $period->getMemoryPeak();
+            }
+        }
+
+        return $memoryPeak;
+    }
+
+    /**
+     * Of all periods, gets the max amount of memory assigned to PHP and used by emalloc().
+     *
+     * @return int The memory usage (in bytes)
+     */
+    public function getMemoryPeakEmalloc()
+    {
+        $memoryPeakCurrent = 0;
+        foreach ($this->periods as $period) {
+            if ($period->getMemoryPeakEmalloc() > $memoryPeakCurrent) {
+                $memoryPeakCurrent = $period->getMemoryPeakEmalloc();
+            }
+        }
+
+        return $memoryPeakCurrent;
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchPeriod.php
@@ -15,12 +15,27 @@ namespace Symfony\Component\Stopwatch;
  * Represents an Period for an Event.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Adamo Crespi <hello@aerendir.me>
  */
 class StopwatchPeriod
 {
+    /** @var float|int $start */
     private $start;
+
+    /** @var float|int $end */
     private $end;
+
+    /** @var int $memory The amount of memory assigned to PHP */
     private $memory;
+
+    /** @var int $memoryCurrent Of the memory assigned to PHP, the amount of memory currently consumed by the script */
+    private $memoryCurrent;
+
+    /** @var int $memoryPeak The max amount of memory assigned to PHP */
+    private $memoryPeak;
+
+    /** @var int $memoryPeakEmalloc The max amount of memory assigned to PHP and used by emalloc() */
+    private $memoryPeakEmalloc;
 
     /**
      * @param int|float $start         The relative time of the start of the period (in milliseconds)
@@ -32,6 +47,9 @@ class StopwatchPeriod
         $this->start = $morePrecision ? (float) $start : (int) $start;
         $this->end = $morePrecision ? (float) $end : (int) $end;
         $this->memory = memory_get_usage(true);
+        $this->memoryCurrent = memory_get_usage();
+        $this->memoryPeak = memory_get_peak_usage(true);
+        $this->memoryPeakEmalloc = memory_get_peak_usage();
     }
 
     /**
@@ -65,12 +83,42 @@ class StopwatchPeriod
     }
 
     /**
-     * Gets the memory usage.
+     * Gets the memory assigned to PHP.
      *
      * @return int The memory usage (in bytes)
      */
     public function getMemory()
     {
         return $this->memory;
+    }
+
+    /**
+     * Of the memory assigned to PHP, gets the amount of memory currently used by the script.
+     *
+     * @return int
+     */
+    public function getMemoryCurrent(): int
+    {
+        return $this->memoryCurrent;
+    }
+
+    /**
+     * Gets the max amount of memory assigned to PHP.
+     *
+     * @return int
+     */
+    public function getMemoryPeak(): int
+    {
+        return $this->memoryPeak;
+    }
+
+    /**
+     * Gets the max amount of memory used by emalloc().
+     *
+     * @return int
+     */
+    public function getMemoryPeakEmalloc(): int
+    {
+        return $this->memoryPeakEmalloc;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27693
| License       | MIT
| Doc PR        | symfony/symfony-docs#

Add support for `memory_get_usage()`, `memory_get_peak_usage(true)` and `memory_get_peak_usage()`.
