### PR TITLE
[Serializer] CsvEncoder::AS_COLLECTION_KEY constant

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -28,6 +28,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
     const KEY_SEPARATOR_KEY = 'csv_key_separator';
     const HEADERS_KEY = 'csv_headers';
     const ESCAPE_FORMULAS_KEY = 'csv_escape_formulas';
+    const AS_COLLECTION_KEY = 'as_collection';
 
     private $delimiter;
     private $enclosure;
@@ -157,7 +158,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         }
         fclose($handle);
 
-        if ($context['as_collection'] ?? false) {
+        if ($context[self::AS_COLLECTION_KEY] ?? false) {
             return $result;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -324,7 +324,7 @@ foo
 a
 
 CSV
-            , 'csv', array('as_collection' => true)));
+            , 'csv', array(CsvEncoder::AS_COLLECTION_KEY => true)));
     }
 
     public function testDecodeToManyRelation()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | not really <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

We use public constants for context options. For 4.1 IMHO as a consistency fix.