### PR TITLE
[HttpFoundation] fix session tracking counter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SessionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SessionController.php
@@ -43,6 +43,14 @@ class SessionController implements ContainerAwareInterface
         return new Response(sprintf('Welcome back %s, nice to meet you.', $name));
     }
 
+    public function cacheableAction()
+    {
+        $response = new Response('all good');
+        $response->setSharedMaxAge(100);
+
+        return $response;
+    }
+
     public function logoutAction(Request $request)
     {
         $request->getSession()->invalidate();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -2,6 +2,10 @@ session_welcome:
     path:     /session
     defaults: { _controller: TestBundle:Session:welcome }
 
+session_cacheable:
+    path:     /cacheable
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SessionController::cacheableAction }
+
 session_welcome_name:
     path:     /session/{name}
     defaults: { _controller: TestBundle:Session:welcome }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
@@ -126,6 +126,22 @@ class SessionTest extends WebTestCase
         $this->assertContains('Welcome back client2, nice to meet you.', $crawler2->text());
     }
 
+    /**
+     * @dataProvider getConfigs
+     */
+    public function testCorrectCacheControlHeadersForCacheableAction($config, $insulate)
+    {
+        $client = $this->createClient(array('test_case' => 'Session', 'root_config' => $config));
+        if ($insulate) {
+            $client->insulate();
+        }
+
+        $client->request('GET', '/cacheable');
+
+        $response = $client->getResponse();
+        $this->assertSame('public, s-maxage=100', $response->headers->get('cache-control'));
+    }
+
     public function getConfigs()
     {
         return array(

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -160,7 +160,9 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function isEmpty()
     {
-        ++$this->usageIndex;
+        if ($this->isStarted()) {
+            ++$this->usageIndex;
+        }
         foreach ($this->data as &$data) {
             if (!empty($data)) {
                 return false;
@@ -185,8 +187,6 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function migrate($destroy = false, $lifetime = null)
     {
-        ++$this->usageIndex;
-
         return $this->storage->regenerate($destroy, $lifetime);
     }
 
@@ -195,8 +195,6 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function save()
     {
-        ++$this->usageIndex;
-
         $this->storage->save();
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -54,8 +54,6 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function start()
     {
-        ++$this->usageIndex;
-
         return $this->storage->start();
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
@@ -44,8 +44,6 @@ final class SessionBagProxy implements SessionBagInterface
      */
     public function isEmpty()
     {
-        ++$this->usageIndex;
-
         return empty($this->data[$this->bag->getStorageKey()]);
     }
 
@@ -81,8 +79,6 @@ final class SessionBagProxy implements SessionBagInterface
      */
     public function clear()
     {
-        ++$this->usageIndex;
-
         return $this->bag->clear();
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionBagProxy.php
@@ -44,6 +44,11 @@ final class SessionBagProxy implements SessionBagInterface
      */
     public function isEmpty()
     {
+        if (!isset($this->data[$this->bag->getStorageKey()])) {
+            return true;
+        }
+        ++$this->usageIndex;
+
         return empty($this->data[$this->bag->getStorageKey()]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As just discussed with @nicolas-grekas I found this issue today while upgrading my app to 3.4.12. Somehow its not possible anymore to set caching headers correctly since this commit: https://github.com/symfony/symfony/commit/146e01cb4442fbcb3b05dd8ae2569d9894374044#diff-5350dc763df30ada9d00563c115f6652
