### PR TITLE
[FrameworkBundle] add conflict for non-compatible TwigBridge version

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -71,6 +71,7 @@
         "symfony/serializer": "<4.1",
         "symfony/stopwatch": "<3.4",
         "symfony/translation": "<3.4",
+        "symfony/twig-bridge": "<4.1.1",
         "symfony/validator": "<4.1",
         "symfony/workflow": "<4.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27713
| License       | MIT
| Doc PR        | 

The argument was dropped in #27454.