### PR TITLE
[TwigBridge] Fix missing path and separators in loader paths list on debug:twig output

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -151,19 +151,27 @@ EOF
         }
 
         $rows = array();
+        $firstNamespace = true;
+        $prevHasSeparator = false;
         foreach ($this->getLoaderPaths() as $namespace => $paths) {
-            if (count($paths) > 1) {
+            if (!$firstNamespace && !$prevHasSeparator && count($paths) > 1) {
                 $rows[] = array('', '');
             }
+            $firstNamespace = false;
             foreach ($paths as $path) {
-                $rows[] = array($namespace, '- '.$path);
+                $rows[] = array($namespace, $path.DIRECTORY_SEPARATOR);
                 $namespace = '';
             }
             if (count($paths) > 1) {
                 $rows[] = array('', '');
+                $prevHasSeparator = true;
+            } else {
+                $prevHasSeparator = false;
             }
         }
-        array_pop($rows);
+        if ($prevHasSeparator) {
+            array_pop($rows);
+        }
         $io->section('Loader Paths');
         $io->table(array('Namespace', 'Paths'), $rows);
 

--- a/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/DebugCommandTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+class DebugCommandTest extends TestCase
+{
+    public function testDebugCommand()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(array(), array('decorated' => false));
+
+        $this->assertEquals(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains('Functions', trim($tester->getDisplay()));
+    }
+
+    public function testLineSeparatorInLoaderPaths()
+    {
+        // these paths aren't realistic,
+        // they're configured to force the line separator
+        $tester = $this->createCommandTester(array(
+            'Acme' => array('extractor', 'extractor'),
+            '!Acme' => array('extractor', 'extractor'),
+            FilesystemLoader::MAIN_NAMESPACE => array('extractor', 'extractor'),
+        ));
+        $ret = $tester->execute(array(), array('decorated' => false));
+        $ds = DIRECTORY_SEPARATOR;
+        $loaderPaths = <<<TXT
+Loader Paths
+------------
+
+ ----------- ------------ 
+  Namespace   Paths       
+ ----------- ------------ 
+  @Acme       extractor$ds  
+              extractor$ds  
+                          
+  @!Acme      extractor$ds  
+              extractor$ds  
+                          
+  (None)      extractor$ds  
+              extractor$ds  
+ ----------- ------------
+TXT;
+
+        $this->assertEquals(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains($loaderPaths, trim($tester->getDisplay(true)));
+    }
+
+    private function createCommandTester(array $paths = array())
+    {
+        $filesystemLoader = new FilesystemLoader(array(), dirname(__DIR__).'/Fixtures');
+        foreach ($paths as $namespace => $relDirs) {
+            foreach ($relDirs as $relDir) {
+                $filesystemLoader->addPath($relDir, $namespace);
+            }
+        }
+        $command = new DebugCommand(new Environment($filesystemLoader));
+
+        $application = new Application();
+        $application->add($command);
+        $command = $application->find('debug:twig');
+
+        return new CommandTester($command);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

**Reproducer**
```bash
$ composer create-project symfony/skeleton repr
$ cd repr
$ composer req twig
# remove duplicated path on `twig.paths: ['%kernel.project_dir%/templates']` config.
$ bin/console debug:twig
```
See "Loader Paths" section at the end of the output and compare it with `--format=json`. Note that the root `templates` path is present in Twig `loader_paths` because `twig.default_path` config, but it isn't visible on `debug:twig` output.

**Missing path:**

| Before | After |
| --- | --- |
| ![debug_twig_before1](https://user-images.githubusercontent.com/2028198/41908937-9af78274-7913-11e8-91d1-bb48f81031dd.png) | ![debug_twig_after1](https://user-images.githubusercontent.com/2028198/41908969-b5fd3140-7913-11e8-8129-8215f3c09b24.png) |

**Extra Lines separator:**

| Before | After |
| --- | --- |
| ![debug_twig_before2](https://user-images.githubusercontent.com/2028198/41909029-e867fcdc-7913-11e8-91f1-bba0d873495c.png) | ![debug_twig_after2](https://user-images.githubusercontent.com/2028198/41915586-12a6426e-7924-11e8-899f-9ecc7d95b74f.png) |


