### PR TITLE
[Cache] ArrayAdapter and NullAdapter don't need stampede protection

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -14,15 +14,12 @@ namespace Symfony\Component\Cache\Adapter;
 use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\CacheInterface;
 use Symfony\Component\Cache\CacheItem;
-use Symfony\Component\Cache\Traits\GetTrait;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
 class NullAdapter implements AdapterInterface, CacheInterface
 {
-    use GetTrait;
-
     private $createCacheItem;
 
     public function __construct()
@@ -38,6 +35,14 @@ class NullAdapter implements AdapterInterface, CacheInterface
             $this,
             CacheItem::class
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(string $key, callable $callback, float $beta = null)
+    {
+        return $callback(($this->createCacheItem)());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | probably
| Fixed tickets | #27734 #27731
| License       | MIT

Cf. issues.