### PR TITLE
[Process] Add feature "wait until callback" to process class

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * added the `Process::fromShellCommandline()` to run commands in a shell wrapper
  * deprecated passing a command as string when creating a `Process` instance
  * deprecated the `Process::setCommandline()` and the `PhpProcess::setPhpBinary()` methods
+ * added the `Process::waitUntil()` method to wait for the process only for a
+   specific output, then continue the normal execution of your application
 
 4.1.0
 -----

--- a/src/Symfony/Component/Process/Tests/KillableProcessWithOutput.php
+++ b/src/Symfony/Component/Process/Tests/KillableProcessWithOutput.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$outputs = array(
+    'First iteration output',
+    'Second iteration output',
+    'One more iteration output',
+    'This took more time',
+    'This one was sooooo slow',
+);
+
+$iterationTime = 10000;
+
+foreach ($outputs as $output) {
+    usleep($iterationTime);
+    $iterationTime *= 10;
+    echo $output."\n";
+}


### PR DESCRIPTION
I often see code like the following:

```php
$process->start();
// wait for the process to be ready
sleep(3);
```

Many times in tests, sometimes in other places. There is a problem with this kind of code because if for any reason the process starts slower than the usual... Your code may fail after that. Also if it's faster, you're losing time for waiting.

So here is my proposal:

```php
$process->start();
$process->waitUntil(function($type, $output) {
    // check the output and return true to stop waiting when you got what you wait
});
```

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | Waiting for feedbacks
