### PR TITLE
[Cache] provider does not respect option maxIdLength with versioning enabled

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MaxIdLengthAdapterTest.php
@@ -34,6 +34,34 @@ class MaxIdLengthAdapterTest extends TestCase
         $cache->hasItem(str_repeat('-', 39));
     }
 
+    public function testLongKeyVersioning()
+    {
+        $cache = $this->getMockBuilder(MaxIdLengthAdapter::class)
+            ->setConstructorArgs(array(str_repeat('-', 26)))
+            ->getMock();
+
+        $reflectionClass = new \ReflectionClass(AbstractAdapter::class);
+
+        $reflectionMethod = $reflectionClass->getMethod('getId');
+        $reflectionMethod->setAccessible(true);
+
+        // No versioning enabled
+        $this->assertEquals('--------------------------:------------', $reflectionMethod->invokeArgs($cache, array(str_repeat('-', 12))));
+        $this->assertLessThanOrEqual(50, strlen($reflectionMethod->invokeArgs($cache, array(str_repeat('-', 12)))));
+        $this->assertLessThanOrEqual(50, strlen($reflectionMethod->invokeArgs($cache, array(str_repeat('-', 23)))));
+        $this->assertLessThanOrEqual(50, strlen($reflectionMethod->invokeArgs($cache, array(str_repeat('-', 40)))));
+
+        $reflectionProperty = $reflectionClass->getProperty('versioningIsEnabled');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($cache, true);
+
+        // Versioning enabled
+        $this->assertEquals('--------------------------:1:------------', $reflectionMethod->invokeArgs($cache, array(str_repeat('-', 12))));
+        $this->assertLessThanOrEqual(50, strlen($reflectionMethod->invokeArgs($cache, array(str_repeat('-', 12)))));
+        $this->assertLessThanOrEqual(50, strlen($reflectionMethod->invokeArgs($cache, array(str_repeat('-', 23)))));
+        $this->assertLessThanOrEqual(50, strlen($reflectionMethod->invokeArgs($cache, array(str_repeat('-', 40)))));
+    }
+
     /**
      * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
      * @expectedExceptionMessage Namespace must be 26 chars max, 40 given ("----------------------------------------")

--- a/src/Symfony/Component/Cache/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractTrait.php
@@ -255,7 +255,7 @@ trait AbstractTrait
             return $this->namespace.$this->namespaceVersion.$key;
         }
         if (\strlen($id = $this->namespace.$this->namespaceVersion.$key) > $this->maxIdLength) {
-            $id = $this->namespace.$this->namespaceVersion.substr_replace(base64_encode(hash('sha256', $key, true)), ':', -22);
+            $id = $this->namespace.$this->namespaceVersion.substr_replace(base64_encode(hash('sha256', $key, true)), ':', -(\strlen($this->namespaceVersion) + 22));
         }
 
         return $id;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #27746 
| License       | MIT
| Doc PR        | 

Component symfony/cache generates cache item ID longer then maxIdLength when versioning is enabled
