### PR TITLE
[Lock] fix locale dependent test case

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -50,7 +50,7 @@ class SemaphoreStoreTest extends AbstractStoreTest
 
     private function getOpenedSemaphores()
     {
-        $lines = explode(PHP_EOL, trim(`ipcs -su`));
+        $lines = explode(PHP_EOL, trim(`LC_ALL=C ipcs -su`));
         if ('------ Semaphore Status --------' !== $lines[0]) {
             throw new \Exception('Failed to extract list of opend semaphores. Expect a Semaphore status, got '.implode(PHP_EOL, $lines));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Right now, I get a failure with `Exception: Failed to extract list of opend semaphores. Expect a Semaphore status, got ------ États des sémaphores --------` :)