### PR TITLE
[WebProfilerBundle] Prevent toolbar links color override by css

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -150,11 +150,11 @@
     margin-bottom: 0;
 }
 
-.sf-toolbar-block .sf-toolbar-info-piece a {
+div.sf-toolbar .sf-toolbar-block .sf-toolbar-info-piece a {
     color: #99CDD8;
     text-decoration: underline;
 }
-.sf-toolbar-block .sf-toolbar-info-piece a:hover {
+div.sf-toolbar .sf-toolbar-block a:hover {
     text-decoration: none;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27658 
| License       | MIT
| Doc PR        | 

Fixes this issue: https://github.com/symfony/symfony/issues/27658#issuecomment-401008659

Links color in toolbar can be easily override by application css. As this could happens sometimes, this PR set links color with a stronger CSS precedence.
