### PR TITLE
[TwigBundle] Fixed caching of templates in default path on cache warmup

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -41,6 +41,7 @@
             <argument type="service" id="kernel" />
             <argument>%kernel.root_dir%</argument>
             <argument type="collection" /> <!-- Twig paths -->
+            <argument>%twig.default_path%</argument>
         </service>
 
         <service id="twig.template_cache_warmer" class="Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheWarmer">

--- a/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
+++ b/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
@@ -25,17 +25,20 @@ class TemplateIterator implements \IteratorAggregate
     private $rootDir;
     private $templates;
     private $paths;
+    private $defaultPath;
 
     /**
-     * @param KernelInterface $kernel  A KernelInterface instance
-     * @param string          $rootDir The directory where global templates can be stored
-     * @param array           $paths   Additional Twig paths to warm
+     * @param KernelInterface $kernel      A KernelInterface instance
+     * @param string          $rootDir     The directory where global templates can be stored
+     * @param array           $paths       Additional Twig paths to warm
+     * @param string          $defaultPath The directory where global templates can be stored
      */
-    public function __construct(KernelInterface $kernel, $rootDir, array $paths = array())
+    public function __construct(KernelInterface $kernel, $rootDir, array $paths = array(), $defaultPath = null)
     {
         $this->kernel = $kernel;
         $this->rootDir = $rootDir;
         $this->paths = $paths;
+        $this->defaultPath = $defaultPath;
     }
 
     /**
@@ -47,7 +50,10 @@ class TemplateIterator implements \IteratorAggregate
             return $this->templates;
         }
 
-        $this->templates = $this->findTemplatesInDirectory($this->rootDir.'/Resources/views');
+        $this->templates = array_merge(
+            $this->findTemplatesInDirectory($this->rootDir.'/Resources/views'),
+            $this->findTemplatesInDirectory($this->defaultPath, null, array('bundles'))
+        );
         foreach ($this->kernel->getBundles() as $bundle) {
             $name = $bundle->getName();
             if ('Bundle' === substr($name, -6)) {
@@ -57,7 +63,8 @@ class TemplateIterator implements \IteratorAggregate
             $this->templates = array_merge(
                 $this->templates,
                 $this->findTemplatesInDirectory($bundle->getPath().'/Resources/views', $name),
-                $this->findTemplatesInDirectory($this->rootDir.'/'.$bundle->getName().'/views', $name)
+                $this->findTemplatesInDirectory($this->rootDir.'/'.$bundle->getName().'/views', $name),
+                $this->findTemplatesInDirectory($this->defaultPath.'/bundles/'.$bundle->getName(), $name)
             );
         }
 
@@ -76,14 +83,14 @@ class TemplateIterator implements \IteratorAggregate
      *
      * @return array
      */
-    private function findTemplatesInDirectory($dir, $namespace = null)
+    private function findTemplatesInDirectory($dir, $namespace = null, array $excludeDirs = array())
     {
         if (!is_dir($dir)) {
             return array();
         }
 
         $templates = array();
-        foreach (Finder::create()->files()->followLinks()->in($dir) as $file) {
+        foreach (Finder::create()->files()->followLinks()->in($dir)->exclude($excludeDirs) as $file) {
             $templates[] = (null !== $namespace ? '@'.$namespace.'/' : '').str_replace('\\', '/', $file->getRelativePathname());
         }
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/templates/bundles/BarBundle/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/templates/bundles/BarBundle/layout.html.twig
@@ -1,0 +1,1 @@
+This is a layout

--- a/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
@@ -25,13 +25,14 @@ class TemplateIteratorTest extends TestCase
         $kernel->expects($this->any())->method('getBundles')->will($this->returnValue(array(
             $bundle,
         )));
-        $iterator = new TemplateIterator($kernel, __DIR__.'/Fixtures/templates', array(__DIR__.'/Fixtures/templates/Foo' => 'Foo'));
+        $iterator = new TemplateIterator($kernel, __DIR__.'/Fixtures/templates', array(__DIR__.'/Fixtures/templates/Foo' => 'Foo'), __DIR__.'/DependencyInjection/Fixtures/templates');
 
         $sorted = iterator_to_array($iterator);
         sort($sorted);
         $this->assertEquals(
             array(
                 '@Bar/index.html.twig',
+                '@Bar/layout.html.twig',
                 '@Foo/index.html.twig',
                 'layout.html.twig',
                 'sub/sub.html.twig',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

**Reproducer**
```bash
$ git clone https://github.com/symfony/demo && cd demo
$ bin/console cache:clear
$ find var/cache/dev/twig -printf "%y\n" | awk '/f/{f++}/d/{d++}END{printf "%d directories, %d files\n", d, f}'
...
```
**Before:**
```bash
...
131 directories, 167 files
```
Twig `paths` config:
https://github.com/symfony/symfony/blob/44ce4dd62536037f9cea4db0146541b4ab867d34/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php#L104
`%kernel.root_dir%/Resources/views`:
https://github.com/symfony/symfony/blob/2b01d594818cf872bc481b3a1fe0210da29fab69/src/Symfony/Bundle/TwigBundle/TemplateIterator.php#L50
**After:**
```bash
...
141 directories, 193 files
```
Adding `%twig.default_path%`.