### PR TITLE
[HttpFoundation] update phpdoc of FlashBagInterface::add()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBagInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBagInterface.php
@@ -24,7 +24,7 @@ interface FlashBagInterface extends SessionBagInterface
      * Adds a flash message for type.
      *
      * @param string $type
-     * @param string $message
+     * @param mixed  $message
      */
     public function add($type, $message);
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -74,6 +74,18 @@ class FlashBagTest extends TestCase
         $this->assertEquals(array('A previous flash message'), $this->bag->peek('notice'));
     }
 
+    public function testAdd()
+    {
+        $tab = array('bar' => 'baz');
+        $this->bag->add('string_message', 'lorem');
+        $this->bag->add('object_message', new \stdClass());
+        $this->bag->add('array_message', $tab);
+
+        $this->assertEquals(array('lorem'), $this->bag->get('string_message'));
+        $this->assertEquals(array(new \stdClass()), $this->bag->get('object_message'));
+        $this->assertEquals(array($tab), $this->bag->get('array_message'));
+    }
+
     public function testGet()
     {
         $this->assertEquals(array(), $this->bag->get('non_existing'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

**Reason why I propose to change the docblock like this: **
The `FlashBagInterface::add()` function does not work only with the `string` type in second parameter

