### PR TITLE
[Console] Fixes multiselect choice question defaults in non-interactive mode

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -46,13 +46,23 @@ class QuestionHelper extends Helper
         }
 
         if (!$input->isInteractive()) {
-            if ($question instanceof ChoiceQuestion) {
+            $default = $question->getDefault();
+
+            if (null !== $default && $question instanceof ChoiceQuestion) {
                 $choices = $question->getChoices();
 
-                return $choices[$question->getDefault()];
+                if (!$question->isMultiselect()) {
+                    return isset($choices[$default]) ? $choices[$default] : $default;
+                }
+
+                $default = explode(',', $default);
+                foreach ($default as $k => $v) {
+                    $v = trim($v);
+                    $default[$k] = isset($choices[$v]) ? $choices[$v] : $v;
+                }
             }
 
-            return $question->getDefault();
+            return $default;
         }
 
         if (!$question->getValidator()) {

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -90,6 +90,63 @@ class QuestionHelperTest extends TestCase
         $this->assertEquals('Superman', $questionHelper->ask($this->createInputInterfaceMock(true), $this->createOutputInterface(), $question));
     }
 
+    public function testAskChoiceNonInteractive()
+    {
+        $questionHelper = new QuestionHelper();
+
+        $helperSet = new HelperSet(array(new FormatterHelper()));
+        $questionHelper->setHelperSet($helperSet);
+        $questionHelper->setInputStream($this->getInputStream("\n1\n  1  \nFabien\n1\nFabien\n1\n0,2\n 0 , 2  \n\n\n"));
+
+        $heroes = array('Superman', 'Batman', 'Spiderman');
+
+        $question = new ChoiceQuestion('What is your favorite superhero?', $heroes, '0');
+
+        $this->assertSame('Superman', $questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question));
+
+        $question = new ChoiceQuestion('What is your favorite superhero?', $heroes, 'Batman');
+        $this->assertSame('Batman', $questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question));
+
+        $question = new ChoiceQuestion('What is your favorite superhero?', $heroes, null);
+        $this->assertNull($questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question));
+
+        $question = new ChoiceQuestion('What is your favorite superhero?', $heroes, '0');
+        $question->setValidator(null);
+        $this->assertSame('Superman', $questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question));
+
+        try {
+            $question = new ChoiceQuestion('What is your favorite superhero?', $heroes, null);
+            $questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question);
+        } catch (\InvalidArgumentException $e) {
+            $this->assertSame('Value "" is invalid', $e->getMessage());
+        }
+
+        $question = new ChoiceQuestion('Who are your favorite superheros?', $heroes, '0, 1');
+        $question->setMultiselect(true);
+        $this->assertSame(array('Superman', 'Batman'), $questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question));
+
+        $question = new ChoiceQuestion('Who are your favorite superheros?', $heroes, '0, 1');
+        $question->setMultiselect(true);
+        $question->setValidator(null);
+        $this->assertSame(array('Superman', 'Batman'), $questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question));
+
+        $question = new ChoiceQuestion('Who are your favorite superheros?', $heroes, '0, Batman');
+        $question->setMultiselect(true);
+        $this->assertSame(array('Superman', 'Batman'), $questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question));
+
+        $question = new ChoiceQuestion('Who are your favorite superheros?', $heroes, null);
+        $question->setMultiselect(true);
+        $this->assertNull($questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question));
+
+        try {
+            $question = new ChoiceQuestion('Who are your favorite superheros?', $heroes, '');
+            $question->setMultiselect(true);
+            $questionHelper->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question);
+        } catch (\InvalidArgumentException $e) {
+            $this->assertSame('Value "" is invalid', $e->getMessage());
+        }
+    }
+
     public function testAsk()
     {
         $dialog = new QuestionHelper();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | >4.1.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 


[This commit](https://github.com/symfony/symfony/commit/41ffc69fa091ecb04bd8b4c70c0f96c09819b470) introduced a warning in multiselect mode:

```
PHP Notice:  Undefined index:  in /tmp/vendor/symfony/console/Helper/QuestionHelper.php on line 52
PHP Stack trace:
PHP   1. {main}() /tmp/vendor/phpro/grumphp/bin/grumphp:0
PHP   2. GrumPHP\Console\Application->run() /tmp/vendor/phpro/grumphp/bin/grumphp:31
PHP   3. GrumPHP\Console\Application->run() /tmp/vendor/phpro/grumphp/src/Console/Application.php:240
PHP   4. GrumPHP\Console\Application->doRun() /tmp/vendor/symfony/console/Application.php:145
PHP   5. GrumPHP\Console\Application->doRunCommand() /tmp/vendor/symfony/console/Application.php:262
PHP   6. GrumPHP\Console\Command\ConfigureCommand->run() /tmp/vendor/symfony/console/Application.php:904
PHP   7. GrumPHP\Console\Command\ConfigureCommand->execute() /tmp/vendor/symfony/console/Command/Command.php:251
PHP   8. GrumPHP\Console\Command\ConfigureCommand->buildConfiguration() /tmp/vendor/phpro/grumphp/src/Console/Command/ConfigureCommand.php:95
PHP   9. Symfony\Component\Console\Helper\QuestionHelper->ask() /tmp/vendor/phpro/grumphp/src/Console/Command/ConfigureCommand.php:156

Notice: Undefined index:  in /tmp/vendor/symfony/console/Helper/QuestionHelper.php on line 52
```

This PR fixes this issue by parsing the default value using the built-in validator if available. (which most likely is ...)