### PR TITLE
[Serializer] Class discriminator and serialization groups

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -16,6 +16,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Exception\RuntimeException;
+use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
@@ -130,5 +131,25 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         } catch (NoSuchPropertyException $exception) {
             // Properties not found are ignored
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAllowedAttributes($classOrObject, array $context, $attributesAsString = false)
+    {
+        if (false === $allowedAttributes = parent::getAllowedAttributes($classOrObject, $context, $attributesAsString)) {
+            return false;
+        }
+
+        if (null !== $this->classDiscriminatorResolver && null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForMappedObject($classOrObject)) {
+            $allowedAttributes[] = $attributesAsString ? $discriminatorMapping->getTypeProperty() : new AttributeMetadata($discriminatorMapping->getTypeProperty());
+
+            foreach ($discriminatorMapping->getTypesMapping() as $class) {
+                $allowedAttributes = array_merge($allowedAttributes, parent::getAllowedAttributes($class, $context, $attributesAsString));
+            }
+        }
+
+        return $allowedAttributes;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageInterface.php
@@ -15,8 +15,8 @@ use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
 
 /**
  * @DiscriminatorMap(typeProperty="type", mapping={
- *    "first"="Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild",
- *    "second"="Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild"
+ *    "one"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne",
+ *    "two"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo"
  * })
  *
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberTwo.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberTwo.php
@@ -11,17 +11,9 @@
 
 namespace Symfony\Component\Serializer\Tests\Fixtures;
 
-use Symfony\Component\Serializer\Annotation\Groups;
-
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-class DummyMessageNumberOne implements DummyMessageInterface
+class DummyMessageNumberTwo implements DummyMessageInterface
 {
-    public $one;
-
-    /**
-     * @Groups({"two"})
-     */
-    public $two;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27641
| License       | MIT
| Doc PR        | ø

It turns out the discriminator mapping does not work well with the serialization groups. This is fixing it (+ a little bit of cleaning in the tests).