### PR TITLE
[Form] Add translation_parameters option to base form type

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1366,6 +1366,64 @@ class EntityTypeTest extends BaseTypeTest
         $this->assertNull($view['child']->vars['translation_domain']);
     }
 
+    public function testPassTranslationParametersToView()
+    {
+        $view = $this->factory->create(static::TESTED_TYPE, null, array(
+            'translation_parameters' => array('%param%' => 'value'),
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+        ))
+            ->createView();
+
+        $this->assertSame(array('%param%' => 'value'), $view->vars['translation_parameters']);
+    }
+
+    public function testInheritTranslationParametersFromParent()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
+                'translation_parameters' => array('%param%' => 'value'),
+            ))
+            ->add('child', static::TESTED_TYPE, array(
+                'em' => 'default',
+                'class' => self::SINGLE_IDENT_CLASS,
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals(array('%param%' => 'value'), $view['child']->vars['translation_parameters']);
+    }
+
+    public function testPreferOwnTranslationParameters()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
+                'translation_parameters' => array('%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'),
+            ))
+            ->add('child', static::TESTED_TYPE, array(
+                'translation_parameters' => array('%override_param%' => 'child_value'),
+                'em' => 'default',
+                'class' => self::SINGLE_IDENT_CLASS,
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals(array('%parent_param%' => 'parent_value', '%override_param%' => 'child_value'), $view['child']->vars['translation_parameters']);
+    }
+
+    public function testDefaultTranslationParameters()
+    {
+        $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
+            ->add('child', static::TESTED_TYPE, array(
+                'em' => 'default',
+                'class' => self::SINGLE_IDENT_CLASS,
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals(array(), $view['child']->vars['translation_parameters']);
+    }
+
     public function testPassLabelToView()
     {
         $view = $this->factory->createNamed('__test___field', static::TESTED_TYPE, null, array(

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -181,7 +181,7 @@
             {%- if translation_domain is same as(false) -%}
                 {{- help -}}
             {%- else -%}
-                {{- help|trans({}, translation_domain) -}}
+                {{- help|trans(translation_parameters, translation_domain) -}}
             {%- endif -%}
         </span>
     {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -204,7 +204,7 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}{% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}</{{ element|default('label') }}>
+        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans(translation_parameters, translation_domain) }}{% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}</{{ element|default('label') }}>
     {%- else -%}
         {%- if errors|length > 0 -%}
         <div id="{{ id }}_errors" class="mb-2">
@@ -300,7 +300,7 @@
             {%- if translation_domain is same as(false) -%}
                 {{- help -}}
             {%- else -%}
-                {{- help|trans({}, translation_domain) -}}
+                {{- help|trans(translation_parameters, translation_domain) -}}
             {%- endif -%}
         </small>
     {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -279,7 +279,7 @@
             {%- if translation_domain is same as(false) -%}
                 {{- label -}}
             {%- else -%}
-                {{- label|trans({}, translation_domain) -}}
+                {{- label|trans(translation_parameters, translation_domain) -}}
             {%- endif -%}
         </{{ element|default('label') }}>
     {%- endif -%}
@@ -295,7 +295,7 @@
             {%- if translation_domain is same as(false) -%}
                 {{- help -}}
             {%- else -%}
-                {{- help|trans({}, translation_domain) -}}
+                {{- help|trans(translation_parameters, translation_domain) -}}
             {%- endif -%}
         </p>
     {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -232,7 +232,7 @@
             {% set label = name|humanize %}
         {%- endif -%}
     {%- endif -%}
-    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</button>
+    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ translation_domain is same as(false) ? label : label|trans(translation_parameters, translation_domain) }}</button>
 {%- endblock button_widget -%}
 
 {%- block submit_widget -%}
@@ -424,7 +424,7 @@
     {%- for attrname, attrvalue in attr -%}
         {{- " " -}}
         {%- if attrname in ['placeholder', 'title'] -%}
-            {{- attrname }}="{{ translation_domain is same as(false) ? attrvalue : attrvalue|trans({}, translation_domain) }}"
+            {{- attrname }}="{{ translation_domain is same as(false) ? attrvalue : attrvalue|trans(translation_parameters, translation_domain) }}"
         {%- elseif attrvalue is same as(true) -%}
             {{- attrname }}="{{ attrname }}"
         {%- elseif attrvalue is not same as(false) -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
@@ -17,7 +17,7 @@ class StubTranslator implements TranslatorInterface
 {
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
-        return '[trans]'.$id.'[/trans]';
+        return '[trans]'.strtr($id, $parameters).'[/trans]';
     }
 
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/custom_widgets.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/custom_widgets.html.twig
@@ -11,7 +11,7 @@
     {% if label is empty %}
         {% set label = name|humanize %}
     {% endif %}
-    <label>Custom label: {{ label|trans({}, translation_domain) }}</label>
+    <label>Custom label: {{ label|trans(translation_parameters, translation_domain) }}</label>
 {% endspaceless %}
 {% endblock _names_entry_label %}
 
@@ -20,6 +20,6 @@
     {% if label is empty %}
         {% set label = name|humanize %}
     {% endif %}
-    <label>Custom name label: {{ label|trans({}, translation_domain) }}</label>
+    <label>Custom name label: {{ label|trans(translation_parameters, translation_domain) }}</label>
 {% endspaceless %}
 {% endblock _name_c_entry_label %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/attributes.html.php
@@ -1,6 +1,6 @@
 <?php foreach ($attr as $k => $v): ?>
 <?php if ('placeholder' === $k || 'title' === $k): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape(false !== $translation_domain ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
+<?php printf('%s="%s" ', $view->escape($k), $view->escape(false !== $translation_domain ? $view['translator']->trans($v, $translation_parameters, $translation_domain) : $v)) ?>
 <?php elseif (true === $v): ?>
 <?php printf('%s="%s" ', $view->escape($k), $view->escape($k)) ?>
 <?php elseif (false !== $v): ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/button_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/button_widget.html.php
@@ -1,4 +1,4 @@
 <?php if (!$label) { $label = isset($label_format)
     ? strtr($label_format, array('%name%' => $name, '%id%' => $id))
     : $view['form']->humanize($name); } ?>
-<button type="<?php echo isset($type) ? $view->escape($type) : 'button' ?>" <?php echo $view['form']->block($form, 'button_attributes') ?>><?php echo $view->escape(false !== $translation_domain ? $view['translator']->trans($label, array(), $translation_domain) : $label) ?></button>
+<button type="<?php echo isset($type) ? $view->escape($type) : 'button' ?>" <?php echo $view['form']->block($form, 'button_attributes') ?>><?php echo $view->escape(false !== $translation_domain ? $view['translator']->trans($label, $translation_parameters, $translation_domain) : $label) ?></button>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_help.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_help.html.php
@@ -1,3 +1,3 @@
 <?php if (!empty($help)): ?>
-    <p id="<?php echo $view->escape($id); ?>_help" class="help-text"><?php echo $view->escape(false !== $translation_domain ? $view['translator']->trans($help, array(), $translation_domain) : $help); ?></p>
+    <p id="<?php echo $view->escape($id); ?>_help" class="help-text"><?php echo $view->escape(false !== $translation_domain ? $view['translator']->trans($help, $translation_parameters, $translation_domain) : $help); ?></p>
 <?php endif; ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
@@ -4,5 +4,5 @@
 <?php if (!$label) { $label = isset($label_format)
     ? strtr($label_format, array('%name%' => $name, '%id%' => $id))
     : $view['form']->humanize($name); } ?>
-<label<?php if ($label_attr) { echo ' '.$view['form']->block($form, 'attributes', array('attr' => $label_attr)); } ?>><?php echo $view->escape(false !== $translation_domain ? $view['translator']->trans($label, array(), $translation_domain) : $label) ?></label>
+<label<?php if ($label_attr) { echo ' '.$view['form']->block($form, 'attributes', array('attr' => $label_attr)); } ?>><?php echo $view->escape(false !== $translation_domain ? $view['translator']->trans($label, $translation_parameters, $translation_domain) : $label) ?></label>
 <?php endif ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTranslator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTranslator.php
@@ -17,7 +17,7 @@ class StubTranslator implements TranslatorInterface
 {
     public function trans($id, array $parameters = array(), $domain = null, $locale = null)
     {
-        return '[trans]'.$id.'[/trans]';
+        return '[trans]'.strtr($id, $parameters).'[/trans]';
     }
 
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -44,6 +44,7 @@ abstract class BaseType extends AbstractType
         $name = $form->getName();
         $blockName = $options['block_name'] ?: $form->getName();
         $translationDomain = $options['translation_domain'];
+        $translationParameters = $options['translation_parameters'];
         $labelFormat = $options['label_format'];
 
         if ($view->parent) {
@@ -60,6 +61,8 @@ abstract class BaseType extends AbstractType
             if (null === $translationDomain) {
                 $translationDomain = $view->parent->vars['translation_domain'];
             }
+
+            $translationParameters = array_merge($view->parent->vars['translation_parameters'], $translationParameters);
 
             if (!$labelFormat) {
                 $labelFormat = $view->parent->vars['label_format'];
@@ -94,6 +97,7 @@ abstract class BaseType extends AbstractType
             'block_prefixes' => $blockPrefixes,
             'unique_block_prefix' => $uniqueBlockPrefix,
             'translation_domain' => $translationDomain,
+            'translation_parameters' => $translationParameters,
             // Using the block name here speeds up performance in collection
             // forms, where each entry has the same full block name.
             // Including the type is important too, because if rows of a
@@ -114,6 +118,7 @@ abstract class BaseType extends AbstractType
             'disabled' => false,
             'label' => null,
             'label_format' => null,
+            'translation_parameters' => array(),
             'attr' => array(),
             'translation_domain' => null,
             'auto_initialize' => true,

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2581,7 +2581,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             'help' => 'for company %company%',
             'translation_parameters' => array(
                 '%company%' => 'ACME Ltd.',
-            )
+            ),
         ));
         $html = $this->renderHelp($form->createView());
 

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2596,10 +2596,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testAttributesWithTranslationParameters()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
-            'attr' => [
+            'attr' => array(
                 'title' => 'Message to %company%',
                 'placeholder' => 'Enter a message to %company%',
-            ],
+            ),
             'translation_parameters' => array(
                 '%company%' => 'ACME Ltd.',
             ),

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2558,7 +2558,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         );
     }
 
-    public function testLabelWithTranslationLabel()
+    public function testLabelWithTranslationParameters()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
         $html = $this->renderLabel($form->createView(), 'Address is %address%', array(
@@ -2575,7 +2575,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         );
     }
 
-    public function testHelpWithTranslationLabel()
+    public function testHelpWithTranslationParameters()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
             'help' => 'for company %company%',
@@ -2589,6 +2589,47 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             '/*
     [@id="name_help"]
     [.="[trans]for company ACME Ltd.[/trans]"]
+'
+        );
+    }
+
+    public function testAttributesWithTranslationParameters()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
+            'attr' => [
+                'title' => 'Message to %company%',
+                'placeholder' => 'Enter a message to %company%',
+            ],
+            'translation_parameters' => array(
+                '%company%' => 'ACME Ltd.',
+            ),
+        ));
+        $html = $this->renderWidget($form->createView());
+
+        $this->assertMatchesXpath($html,
+            '/input
+    [@title="[trans]Message to ACME Ltd.[/trans]"]
+    [@placeholder="[trans]Enter a message to ACME Ltd.[/trans]"]
+'
+        );
+    }
+
+    public function testButtonWithTranslationParameters()
+    {
+        $form = $this->factory->createNamedBuilder('myform')
+            ->add('mybutton', 'Symfony\Component\Form\Extension\Core\Type\ButtonType', array(
+                'label' => 'Submit to %company%',
+                'translation_parameters' => array(
+                    '%company%' => 'ACME Ltd.',
+                ),
+            ))
+            ->getForm();
+        $view = $form->get('mybutton')->createView();
+        $html = $this->renderWidget($view, array('label_format' => 'form.%name%'));
+
+        $this->assertMatchesXpath($html,
+            '/button
+    [.="[trans]Submit to ACME Ltd.[/trans]"]
 '
         );
     }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2557,4 +2557,39 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 '
         );
     }
+
+    public function testLabelWithTranslationLabel()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $html = $this->renderLabel($form->createView(), 'Address is %address%', array(
+            'translation_parameters' => array(
+                '%address%' => 'Paris, rue de la Paix',
+            ),
+        ));
+
+        $this->assertMatchesXpath($html,
+            '/label
+    [@for="name"]
+    [.="[trans]Address is Paris, rue de la Paix[/trans]"]
+'
+        );
+    }
+
+    public function testHelpWithTranslationLabel()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, array(
+            'help' => 'for company %company%',
+            'translation_parameters' => array(
+                '%company%' => 'ACME Ltd.',
+            )
+        ));
+        $html = $this->renderHelp($form->createView());
+
+        $this->assertMatchesXpath($html,
+            '/*
+    [@id="name_help"]
+    [.="[trans]for company ACME Ltd.[/trans]"]
+'
+        );
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -119,6 +119,54 @@ abstract class BaseTypeTest extends TypeTestCase
         $this->assertNull($view['child']->vars['translation_domain']);
     }
 
+    public function testPassTranslationParametersToView()
+    {
+        $view = $this->factory->create($this->getTestedType(), null, array(
+            'translation_parameters' => ['%param%' => 'value'],
+        ))
+            ->createView();
+
+        $this->assertSame(['%param%' => 'value'], $view->vars['translation_parameters']);
+    }
+
+    public function testInheritTranslationParametersFromParent()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
+                'translation_parameters' => ['%param%' => 'value'],
+            ))
+            ->add('child', $this->getTestedType())
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals(['%param%' => 'value'], $view['child']->vars['translation_parameters']);
+    }
+
+    public function testPreferOwnTranslationParameters()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
+                'translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
+            ))
+            ->add('child', $this->getTestedType(), array(
+                'translation_parameters' => ['%override_param%' => 'child_value'],
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals(['%parent_param%' => 'parent_value', '%override_param%' => 'child_value'], $view['child']->vars['translation_parameters']);
+    }
+
+    public function testDefaultTranslationParameters()
+    {
+        $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
+            ->add('child', $this->getTestedType())
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals([], $view['child']->vars['translation_parameters']);
+    }
+
     public function testPassLabelToView()
     {
         $view = $this->factory->createNamed('__test___field', $this->getTestedType(), null, array('label' => 'My label'))

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -122,39 +122,39 @@ abstract class BaseTypeTest extends TypeTestCase
     public function testPassTranslationParametersToView()
     {
         $view = $this->factory->create($this->getTestedType(), null, array(
-            'translation_parameters' => ['%param%' => 'value'],
+            'translation_parameters' => array('%param%' => 'value'),
         ))
             ->createView();
 
-        $this->assertSame(['%param%' => 'value'], $view->vars['translation_parameters']);
+        $this->assertSame(array('%param%' => 'value'), $view->vars['translation_parameters']);
     }
 
     public function testInheritTranslationParametersFromParent()
     {
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
-                'translation_parameters' => ['%param%' => 'value'],
+                'translation_parameters' => array('%param%' => 'value'),
             ))
             ->add('child', $this->getTestedType())
             ->getForm()
             ->createView();
 
-        $this->assertEquals(['%param%' => 'value'], $view['child']->vars['translation_parameters']);
+        $this->assertEquals(array('%param%' => 'value'), $view['child']->vars['translation_parameters']);
     }
 
     public function testPreferOwnTranslationParameters()
     {
         $view = $this->factory
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, array(
-                'translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
+                'translation_parameters' => array('%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'),
             ))
             ->add('child', $this->getTestedType(), array(
-                'translation_parameters' => ['%override_param%' => 'child_value'],
+                'translation_parameters' => array('%override_param%' => 'child_value'),
             ))
             ->getForm()
             ->createView();
 
-        $this->assertEquals(['%parent_param%' => 'parent_value', '%override_param%' => 'child_value'], $view['child']->vars['translation_parameters']);
+        $this->assertEquals(array('%parent_param%' => 'parent_value', '%override_param%' => 'child_value'), $view['child']->vars['translation_parameters']);
     }
 
     public function testDefaultTranslationParameters()
@@ -164,7 +164,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ->getForm()
             ->createView();
 
-        $this->assertEquals([], $view['child']->vars['translation_parameters']);
+        $this->assertEquals(array(), $view['child']->vars['translation_parameters']);
     }
 
     public function testPassLabelToView()

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -45,6 +45,7 @@
                 "property_path",
                 "required",
                 "translation_domain",
+                "translation_parameters",
                 "upload_max_size_message"
             ]
         },

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -25,6 +25,7 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
                                                    property_path                                    
                                                    required                                         
                                                    translation_domain                               
+                                                   translation_parameters                           
                                                    upload_max_size_message                          
  --------------------------- -------------------- ------------------------- ----------------------- 
 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
@@ -25,6 +25,7 @@
             "property_path",
             "required",
             "translation_domain",
+            "translation_parameters",
             "trim",
             "upload_max_size_message"
         ],

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
@@ -27,6 +27,7 @@ Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")
   property_path            
   required                 
   translation_domain       
+  translation_parameters   
   trim                     
   upload_max_size_message  
  ------------------------- 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes. Travis-ci isn't green because it tests the components separately. Fabbot.io requires license headers in files where they were not present before.
| Fixed tickets | #27698
| License       | MIT
| Doc PR        | symfony/symfony-docs/pull/10065

In forms it would be very nice if there is a way to provide translation parameters for `label` and `help` optons. Consider this example :

```yaml
#messages.en.yml
form:
  order_list:
    id: Identifier of the order to %company%
    first: First position is to send to %address%
    second: Second position is to send to %address%
    second_help: This must be %item%
```

```yaml
#messages.fr.yml
form:
  order_list:
    id: Identifiant de la commande pour la société %company%
    first: Première position est à envoyer à %address%
    second: Seconde position est à envoyer à %address%
    second_help: Ce doit être %item%
```

```php
class OrderListType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('id', TextType::class, [
                'label' => 'form.order_list.id',
                'translation_parameters' => [
                    '%company%' => 'Webnet'
                ]
            ])
            ->add('list', FormType::class, [
                'translation_parameters' => [
                    '%address%' => 'Sèvres, 92310'
                ]
            ])
        ;

        // Add list's children to demonstrate translation_parameters inheritance.
        $builder->get('list')
            ->add('first', TextType::class, [
                'label' => 'form.order_list.first',
                'translation_parameters' => [
                    // "Paris, 75010" (a value particular to this field) will overwrite "Sèvres, 92310"
                    '%address%' => 'Paris, 75010' 
                ]
            ])
            ->add('second', TextType::class, [
                'label' => 'form.order_list.second',
                'help' => 'form.order_list.second_help',
                'translation_parameters' => [
                    // Inherit %address% from parent => 'Sèvres, 92310',
                    // "item" parameter is used in help message.
                    '%item%' => 'DIN5555'
                ],
            ])
        ;
    }
}
```

Here is a result with translation parameters :
![With parameters](https://github.com/webnet-fr/symfony/raw/form_translation_parameters_images/img/after.png)

and without them :
![With parameters](https://github.com/webnet-fr/symfony/raw/form_translation_parameters_images/img/before.png)



