### PR TITLE
[Lock] Fix SemaphoreStoreTest on OS X

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -50,13 +50,22 @@ class SemaphoreStoreTest extends AbstractStoreTest
 
     private function getOpenedSemaphores()
     {
+        if ('Darwin' === PHP_OS) {
+            $lines = explode(PHP_EOL, trim(`ipcs -s`));
+            if (-1 === $start = array_search('Semaphores:', $lines)) {
+                throw new \Exception('Failed to extract list of opened semaphores. Expected a Semaphore list, got '.implode(PHP_EOL, $lines));
+            }
+
+            return \count(\array_slice($lines, ++$start));
+        }
+
         $lines = explode(PHP_EOL, trim(`LC_ALL=C ipcs -su`));
         if ('------ Semaphore Status --------' !== $lines[0]) {
-            throw new \Exception('Failed to extract list of opend semaphores. Expect a Semaphore status, got '.implode(PHP_EOL, $lines));
+            throw new \Exception('Failed to extract list of opened semaphores. Expected a Semaphore status, got '.implode(PHP_EOL, $lines));
         }
         list($key, $value) = explode(' = ', $lines[1]);
         if ('used arrays' !== $key) {
-            throw new \Exception('Failed to extract list of opend semaphores. Expect a used arrays key, got '.implode(PHP_EOL, $lines));
+            throw new \Exception('Failed to extract list of opened semaphores. Expected a "used arrays" key, got '.implode(PHP_EOL, $lines));
         }
 
         return (int) $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://github.com/symfony/symfony/pull/27755#pullrequestreview-132772372   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

As spotted in https://github.com/symfony/symfony/pull/27755#pullrequestreview-132772372, for OS X.

If other OS X users could give it a try (`/phpunit src/Symfony/Component/Lock/ --filter=SemaphoreStoreTest`), that would be awesome.