### PR TITLE
[Form] Fix fixtures for forward compat

### DIFF
--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
@@ -15,9 +15,9 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (choice_translation_domain
  ---------------- --------------------%s 
   Allowed values   -                  %s 
  ---------------- --------------------%s 
-  Normalizer       Closure%s{         %s 
+  Normalizer       Closure%s{%w
                      parameters: 2    %s 
-                     file: "%s%eExtension%eCore%eType%eChoiceType.php"  
+                     file: "%s%eExtension%eCore%eType%eChoiceType.php"%w
                      line: "%s to %s" %s 
                    }                  %s 
  ---------------- --------------------%s 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
@@ -8,14 +8,14 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (empty_data)
   Default          Value: null          %s 
                                         %s 
                    Closure(s): [        %s 
-                     Closure%s{         %s 
+                     Closure%s{%w
                        parameters: 1    %s 
-                       file: "%s%eExtension%eCore%eType%eFormType.php"                     
+                       file: "%s%eExtension%eCore%eType%eFormType.php"%w
                        line: "%s to %s" %s 
                      },                 %s 
-                     Closure%s{         %s 
+                     Closure%s{%w
                        parameters: 2    %s 
-                       file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"  
+                       file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"%w
                        line: "%s to %s" %s 
                      }                  %s 
                    ]                    %s 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
@@ -16,9 +16,9 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (foo)
                      "baz"            %s 
                    ]                  %s 
  ---------------- --------------------%s 
-  Normalizer       Closure%s{         %s 
+  Normalizer       Closure%s{%w
                      parameters: 2    %s 
-                     file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"  
+                     file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"%w
                      line: "%s to %s" %s 
                    }                  %s 
  ---------------- --------------------%s 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://travis-ci.org/symfony/symfony/jobs/398533738#L4394-L4407   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Completes https://github.com/symfony/symfony/pull/27771 in order to fix https://travis-ci.org/symfony/symfony/jobs/398533738#L4394-L4407. As the Closure signature is variable, we cannot assume the exact number of whitespaces after it, nor if it will or not overtake the length of the `file:` line. So let's just assume an undetermined nb of whitespaces.