### PR TITLE
Add color support for Hyper terminal .

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -231,7 +231,8 @@ class DeprecationErrorHandler
                 && sapi_windows_vt100_support(STDOUT))
                 || false !== getenv('ANSICON')
                 || 'ON' === getenv('ConEmuANSI')
-                || 'xterm' === getenv('TERM');
+                || 'xterm' === getenv('TERM')
+                || 'Hyper' === getenv('TERM_PROGRAM');
         }
 
         if (function_exists('stream_isatty')) {

--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -98,7 +98,8 @@ class StreamOutput extends Output
                 && @sapi_windows_vt100_support($this->stream))
                 || false !== getenv('ANSICON')
                 || 'ON' === getenv('ConEmuANSI')
-                || 'xterm' === getenv('TERM');
+                || 'xterm' === getenv('TERM')
+                || 'Hyper' === getenv('TERM_PROGRAM');
         }
 
         if (function_exists('stream_isatty')) {

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -271,7 +271,7 @@ class SymfonyStyle extends OutputStyle
     {
         $progressBar = parent::createProgressBar($max);
 
-        if ('\\' !== DIRECTORY_SEPARATOR) {
+        if ('\\' !== DIRECTORY_SEPARATOR ||  'Hyper' === getenv('TERM_PROGRAM')) {
             $progressBar->setEmptyBarCharacter('░'); // light shade character \u2591
             $progressBar->setProgressCharacter('');
             $progressBar->setBarCharacter('▓'); // dark shade character \u2593

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -484,7 +484,8 @@ class CliDumper extends AbstractDumper
                 && @sapi_windows_vt100_support($stream))
                 || false !== getenv('ANSICON')
                 || 'ON' === getenv('ConEmuANSI')
-                || 'xterm' === getenv('TERM');
+                || 'xterm' === getenv('TERM')
+                || 'Hyper' === getenv('TERM_PROGRAM');
         }
 
         if (function_exists('stream_isatty')) {
@@ -513,7 +514,8 @@ class CliDumper extends AbstractDumper
     {
         $result = 183 <= getenv('ANSICON_VER')
             || 'ON' === getenv('ConEmuANSI')
-            || 'xterm' === getenv('TERM');
+            || 'xterm' === getenv('TERM')
+            || 'Hyper' === getenv('TERM_PROGRAM');
 
         if (!$result && PHP_VERSION_ID >= 70200) {
             $version = sprintf(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes    
| License       | MIT

Added color support for [Hyper terminal](https://hyper.is), also shade characters support for progress bar. 

![image](https://user-images.githubusercontent.com/29315886/42135797-6edb8492-7d50-11e8-968b-2dd19981dcdd.png)
