### PR TITLE
[WebLink] Don't preload hinted links when responding to XMLHttpRequest

### DIFF
--- a/src/Symfony/Component/WebLink/EventListener/AddLinkHeaderListener.php
+++ b/src/Symfony/Component/WebLink/EventListener/AddLinkHeaderListener.php
@@ -35,7 +35,7 @@ class AddLinkHeaderListener implements EventSubscriberInterface
 
     public function onKernelResponse(FilterResponseEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMasterRequest() || $event->getRequest()->isXmlHttpRequest()) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | (3.3) 3.4 - master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27797 
| License       | MIT
| Doc PR        | no

When the browser receives a Link header with a `preload` hint, it fetches the resource regardless of wether it has already been downloaded or not.

This changeset prohibits adding a preload hin if the request is an XHR one, to avoid loading and evaluating resources twice. It does not prevent adding a Link header at all.

For a use-case and further explanation, please have a look at the linked issue.