### PR TITLE
[DX] Resolve env values in debug:config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -84,7 +84,7 @@ EOF
 
         $this->validateConfiguration($extension, $configuration);
 
-        $configs = $container->resolveEnvPlaceholders($container->getParameterBag()->resolveValue($configs));
+        $configs = $container->resolveEnvPlaceholders($container->getParameterBag()->resolveValue($configs), true);
 
         $processor = new Processor();
         $config = $container->resolveEnvPlaceholders($container->getParameterBag()->resolveValue($processor->processConfiguration($configuration, $configs)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | maybe
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

As `debug:config` only resolved back to original placeholders these could then fail validation if present. For example if using this in a bundle configuration:
```php
          ->scalarNode('my_api_url')
              ->isRequired()
              ->validate()
                  ->ifTrue(function ($val) { return !preg_match('#^https?://[^\s]+$#', $val); })
                  ->thenInvalid('"%s" must be a valid URL with http/https scheme')
              ->end()
          ->end()
```
And then configuring this as:
```
  my_api_url: "%env(MY_API_URL)%"
```
The `debug:config` would crash:
```
  Invalid configuration for path "mybundle.my_api_url": ""%env(MY_API_URL)  
  %"" must be a valid URL with http/http scheme           
```
Even if the value was present in `$_ENV` and/or `.env` file. With this patch the actual values are used if available, and otherwise `null`, which in reality does better mimic the config that will be used at runtime anyway than leaving unresolved env vars, which is the purpose of the debug command. At worst it will crash the same as before.

I'd first like to foureye whether this fix is really as easy as it seems (it fixes my issues), I can add some tests after that. Also I consciously didn't patch the `resolveEnvPlaceholders` call 3 lines below because that one would imply runtime knowledge.

Refs https://github.com/symfony/symfony/issues/20684#issuecomment-401500703