### PR TITLE
[MonologBridge] Add ProcessorInterface, enabling autoconfiguration of monolog processors

### DIFF
--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.2.0
+-----
+
+ * added `ProcessorInterface`: an optional interface to allow autoconfiguration of Monolog processors
+
 4.1.0
 -----
 

--- a/src/Symfony/Bridge/Monolog/Processor/ProcessorInterface.php
+++ b/src/Symfony/Bridge/Monolog/Processor/ProcessorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Processor;
+
+/**
+ * An optional interface to allow autoconfiguration of Monolog processors.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface ProcessorInterface
+{
+    /**
+     * @return array The processed records
+     */
+    public function __invoke(array $records);
+}

--- a/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  *
  * @author Dany Maillard <danymaillard93b@gmail.com>
  */
-class TokenProcessor
+class TokenProcessor implements ProcessorInterface
 {
     private $tokenStorage;
 

--- a/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class WebProcessor extends BaseWebProcessor implements EventSubscriberInterface
+class WebProcessor extends BaseWebProcessor implements EventSubscriberInterface, ProcessorInterface
 {
     public function __construct(array $extraFields = null)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
+use Symfony\Bridge\Monolog\Processor\ProcessorInterface;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -324,6 +325,8 @@ class FrameworkExtension extends Extension
             ->addTag('kernel.event_subscriber');
         $container->registerForAutoconfiguration(ResettableInterface::class)
             ->addTag('kernel.reset', array('method' => 'reset'));
+        $container->registerForAutoconfiguration(ProcessorInterface::class)
+            ->addTag('monolog.processor');
         $container->registerForAutoconfiguration(PropertyListExtractorInterface::class)
             ->addTag('property_info.list_extractor');
         $container->registerForAutoconfiguration(PropertyTypeExtractorInterface::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/9996

Using this, enabling e.g. TokenProcessor or WebProcessor just needs one line in `services.yaml`:
```yaml
services:
    Symfony\Bridge\Monolog\Processor\TokenProcessor: ~
    Symfony\Bridge\Monolog\Processor\WebProcessor: ~
```