### PR TITLE
[Workflow] Fix autofit label in rendering

### DIFF
--- a/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
@@ -28,7 +28,7 @@ class GraphvizDumper implements DumperInterface
 {
     protected static $defaultOptions = array(
         'graph' => array('ratio' => 'compress', 'rankdir' => 'LR'),
-        'node' => array('fontsize' => 9, 'fontname' => 'Arial', 'color' => '#333333', 'fillcolor' => 'lightblue', 'fixedsize' => true, 'width' => 1),
+        'node' => array('fontsize' => 9, 'fontname' => 'Arial', 'color' => '#333333', 'fillcolor' => 'lightblue', 'fixedsize' => 'false', 'width' => 1),
         'edge' => array('fontsize' => 9, 'fontname' => 'Arial', 'color' => '#333333', 'arrowhead' => 'normal', 'arrowsize' => 0.5),
     );
 

--- a/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
@@ -63,7 +63,7 @@ class GraphvizDumperTest extends TestCase
     {
         return 'digraph workflow {
   ratio="compress" rankdir="LR"
-  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="1" width="1"];
+  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="false" width="1"];
   edge [fontsize="9" fontname="Arial" color="#333333" arrowhead="normal" arrowsize="0.5"];
 
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 [label="a", shape=circle, style="filled"];
@@ -101,7 +101,7 @@ class GraphvizDumperTest extends TestCase
     {
         return 'digraph workflow {
   ratio="compress" rankdir="LR"
-  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="1" width="1"];
+  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="false" width="1"];
   edge [fontsize="9" fontname="Arial" color="#333333" arrowhead="normal" arrowsize="0.5"];
 
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 [label="a", shape=circle, style="filled"];
@@ -121,7 +121,7 @@ class GraphvizDumperTest extends TestCase
     {
         return 'digraph workflow {
   ratio="compress" rankdir="LR"
-  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="1" width="1"];
+  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="false" width="1"];
   edge [fontsize="9" fontname="Arial" color="#333333" arrowhead="normal" arrowsize="0.5"];
 
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 [label="a", shape=circle, style="filled"];
@@ -159,7 +159,7 @@ class GraphvizDumperTest extends TestCase
     {
         return 'digraph workflow {
   ratio="compress" rankdir="LR"
-  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="1" width="1"];
+  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="false" width="1"];
   edge [fontsize="9" fontname="Arial" color="#333333" arrowhead="normal" arrowsize="0.5"];
 
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 [label="a", shape=circle, style="filled"];

--- a/src/Symfony/Component/Workflow/Tests/Dumper/StateMachineGraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/StateMachineGraphvizDumperTest.php
@@ -27,7 +27,7 @@ class StateMachineGraphvizDumperTest extends TestCase
         $expected = <<<'EOGRAPH'
 digraph workflow {
   ratio="compress" rankdir="LR"
-  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="1" width="1"];
+  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="false" width="1"];
   edge [fontsize="9" fontname="Arial" color="#333333" arrowhead="normal" arrowsize="0.5"];
 
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 [label="a", shape=circle, style="filled"];
@@ -53,7 +53,7 @@ EOGRAPH;
         $expected = <<<'EOGRAPH'
 digraph workflow {
   ratio="compress" rankdir="LR"
-  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="1" width="1"];
+  node [fontsize="9" fontname="Arial" color="#333333" fillcolor="lightblue" fixedsize="false" width="1"];
   edge [fontsize="9" fontname="Arial" color="#333333" arrowhead="normal" arrowsize="0.5"];
 
   place_86f7e437faa5a7fce15d1ddcb9eaeaea377667b8 [label="a", shape=circle, style="filled"];


### PR DESCRIPTION
Set default to autofit label in place/transition to render long labels properly.

| Q             | A
| ------------- | ---
| Branch?       | master (3.2 to 4.1)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes, not sure how to add a proper test however
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When using long names for `places` or `transitions`, currently this will not be properly rendered it via the `GraphvizDumper`, see below.

![Default truncated](https://cdn.pbrd.co/images/HsAMVK9.png)
![Default autofit](https://cdn.pbrd.co/images/HsANdKx.png)

By setting the default to `fixedsize=false` it will autofit the label in the rendering.

This will also solve the warning when running the `dump` command:
`Warning: node 'place_08b79deda74a924c3babb9b1d0f3e4eed9320989', graph 'workflow' size too small for label`