### PR TITLE
[DI] Deprecate non-string default envs

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -21,6 +21,23 @@ Config
 
  * Deprecated using environment variables with `cannotBeEmpty()` if the value is validated with `validate()`
 
+DependencyInjection
+-------------------
+
+ * Deprecated support for non-string default env() parameters
+
+   Before:
+   ```yaml
+   parameters:
+       env(NAME): 1.5
+   ```
+
+   After:
+   ```yaml
+   parameters:
+          env(NAME): '1.5'
+   ```
+
 EventDispatcher
 ---------------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -72,6 +72,23 @@ EventDispatcher
  * The `TraceableEventDispatcherInterface` has been removed.
  * The signature of the `EventDispatcherInterface::dispatch()` method has been updated to `dispatch($event, string $eventName = null)`
 
+DependencyInjection
+-------------------
+
+ * Removed support for non-string default env() parameters
+
+   Before:
+   ```yaml
+   parameters:
+       env(NAME): 1.5
+   ```
+
+   After:
+   ```yaml
+   parameters:
+          env(NAME): '1.5'
+   ```
+
 Filesystem
 ----------
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * added `ReverseContainer`: a container that turns services back to their ids
  * added ability to define an index for a tagged collection
  * added ability to define an index for services in an injected service locator argument
+ * deprecated support for non-string default env() parameters
 
 4.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -49,8 +49,11 @@ class EnvPlaceholderParameterBag extends ParameterBag
             if ($this->has($name)) {
                 $defaultValue = parent::get($name);
 
-                if (null !== $defaultValue && !is_scalar($defaultValue)) {
+                if (null !== $defaultValue && !is_scalar($defaultValue)) { // !is_string in 5.0
+                    //throw new RuntimeException(sprintf('The default value of an env() parameter must be a string or null, but "%s" given to "%s".', \gettype($defaultValue), $name));
                     throw new RuntimeException(sprintf('The default value of an env() parameter must be scalar or null, but "%s" given to "%s".', \gettype($defaultValue), $name));
+                } elseif (is_scalar($defaultValue) && !\is_string($defaultValue)) {
+                    @trigger_error(sprintf('A non-string default value of an env() parameter is deprecated since 4.3, cast "%s" to string instead.', $name), E_USER_DEPRECATED);
                 }
             }
 
@@ -147,9 +150,15 @@ class EnvPlaceholderParameterBag extends ParameterBag
                 continue;
             }
             if (is_numeric($default = $this->parameters[$name])) {
+                if (!\is_string($default)) {
+                    @trigger_error(sprintf('A non-string default value of env parameter "%s" is deprecated since 4.3, cast it to string instead.', $env), E_USER_DEPRECATED);
+                }
                 $this->parameters[$name] = (string) $default;
-            } elseif (null !== $default && !is_scalar($default)) {
+            } elseif (null !== $default && !is_scalar($default)) { // !is_string in 5.0
+                //throw new RuntimeException(sprintf('The default value of env parameter "%s" must be a string or null, %s given.', $env, \gettype($default)));
                 throw new RuntimeException(sprintf('The default value of env parameter "%s" must be scalar or null, %s given.', $env, \gettype($default)));
+            } elseif (is_scalar($default) && !\is_string($default)) {
+                @trigger_error(sprintf('A non-string default value of env parameter "%s" is deprecated since 4.3, cast it to string instead.', $env), E_USER_DEPRECATED);
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -111,12 +111,44 @@ class EnvPlaceholderParameterBagTest extends TestCase
         $this->assertCount(2, $merged[$envName]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation A non-string default value of env parameter "INT_VAR" is deprecated since 4.3, cast it to string instead.
+     */
     public function testResolveEnvCastsIntToString()
     {
         $bag = new EnvPlaceholderParameterBag();
         $bag->get('env(INT_VAR)');
         $bag->set('env(INT_VAR)', 2);
         $bag->resolve();
+        $this->assertSame('2', $bag->all()['env(INT_VAR)']);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation A non-string default value of an env() parameter is deprecated since 4.3, cast "env(INT_VAR)" to string instead.
+     * @expectedDeprecation A non-string default value of env parameter "INT_VAR" is deprecated since 4.3, cast it to string instead.
+     */
+    public function testGetDefaultScalarEnv()
+    {
+        $bag = new EnvPlaceholderParameterBag();
+        $bag->set('env(INT_VAR)', 2);
+        $this->assertStringMatchesFormat('env_%s_INT_VAR_%s', $bag->get('env(INT_VAR)'));
+        $this->assertSame(2, $bag->all()['env(INT_VAR)']);
+        $bag->resolve();
+        $this->assertStringMatchesFormat('env_%s_INT_VAR_%s', $bag->get('env(INT_VAR)'));
+        $this->assertSame('2', $bag->all()['env(INT_VAR)']);
+    }
+
+    public function testGetDefaultEnv()
+    {
+        $bag = new EnvPlaceholderParameterBag();
+        $this->assertStringMatchesFormat('env_%s_INT_VAR_%s', $bag->get('env(INT_VAR)'));
+        $bag->set('env(INT_VAR)', '2');
+        $this->assertStringMatchesFormat('env_%s_INT_VAR_%s', $bag->get('env(INT_VAR)'));
+        $this->assertSame('2', $bag->all()['env(INT_VAR)']);
+        $bag->resolve();
+        $this->assertStringMatchesFormat('env_%s_INT_VAR_%s', $bag->get('env(INT_VAR)'));
         $this->assertSame('2', $bag->all()['env(INT_VAR)']);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes-ish
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes
| Tests pass?   | no    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27680, https://github.com/symfony/symfony/pull/27470#discussion_r196678923
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is a failing test to further clarify the issues raised in #27680 

So given https://github.com/symfony/symfony/issues/27680#issuecomment-399402480

> We should be sure this solves a real-world issue.

I think it solves a real bug :)