### PR TITLE
4.1

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
@@ -65,7 +65,7 @@ class ValidateEnvPlaceholdersPass implements CompilerPassInterface
             $processor = new Processor();
 
             foreach ($extensions as $name => $extension) {
-                if (!$extension instanceof ConfigurationExtensionInterface || !$config = $container->getExtensionConfig($name)) {
+                if (!$extension instanceof ConfigurationExtensionInterface || !$config = array_filter($container->getExtensionConfig($name))) {
                     // this extension has no semantic configuration or was not called
                     continue;
                 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/default_option_with_normalizer.txt
@@ -15,9 +15,9 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (choice_translation_domain
  ---------------- --------------------%s 
   Allowed values   -                  %s 
  ---------------- --------------------%s 
-  Normalizer       Closure%s{         %s 
+  Normalizer       Closure%s{%w
                      parameters: 2    %s 
-                     file: "%s%eExtension%eCore%eType%eChoiceType.php"  
+                     file: "%s%eExtension%eCore%eType%eChoiceType.php"%w
                      line: "%s to %s" %s 
                    }                  %s 
  ---------------- --------------------%s 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/overridden_option_with_default_closures.txt
@@ -8,14 +8,14 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (empty_data)
   Default          Value: null          %s 
                                         %s 
                    Closure(s): [        %s 
-                     Closure%s{         %s 
+                     Closure%s{%w
                        parameters: 1    %s 
-                       file: "%s%eExtension%eCore%eType%eFormType.php"                     
+                       file: "%s%eExtension%eCore%eType%eFormType.php"%w
                        line: "%s to %s" %s 
                      },                 %s 
-                     Closure%s{         %s 
+                     Closure%s{%w
                        parameters: 2    %s 
-                       file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"  
+                       file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"%w
                        line: "%s to %s" %s 
                      }                  %s 
                    ]                    %s 

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/required_option_with_allowed_values.txt
@@ -16,9 +16,9 @@ Symfony\Component\Form\Tests\Console\Descriptor\FooType (foo)
                      "baz"            %s 
                    ]                  %s 
  ---------------- --------------------%s 
-  Normalizer       Closure%s{         %s 
+  Normalizer       Closure%s{%w
                      parameters: 2    %s 
-                     file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"  
+                     file: "%s%eTests%eConsole%eDescriptor%eAbstractDescriptorTest.php"%w
                      line: "%s to %s" %s 
                    }                  %s 
  ---------------- --------------------%s 

--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -50,13 +50,22 @@ class SemaphoreStoreTest extends AbstractStoreTest
 
     private function getOpenedSemaphores()
     {
+        if ('Darwin' === PHP_OS) {
+            $lines = explode(PHP_EOL, trim(`ipcs -s`));
+            if (-1 === $start = array_search('Semaphores:', $lines)) {
+                throw new \Exception('Failed to extract list of opened semaphores. Expected a Semaphore list, got '.implode(PHP_EOL, $lines));
+            }
+
+            return \count(\array_slice($lines, ++$start));
+        }
+
         $lines = explode(PHP_EOL, trim(`LC_ALL=C ipcs -su`));
         if ('------ Semaphore Status --------' !== $lines[0]) {
-            throw new \Exception('Failed to extract list of opend semaphores. Expect a Semaphore status, got '.implode(PHP_EOL, $lines));
+            throw new \Exception('Failed to extract list of opened semaphores. Expected a Semaphore status, got '.implode(PHP_EOL, $lines));
         }
         list($key, $value) = explode(' = ', $lines[1]);
         if ('used arrays' !== $key) {
-            throw new \Exception('Failed to extract list of opend semaphores. Expect a used arrays key, got '.implode(PHP_EOL, $lines));
+            throw new \Exception('Failed to extract list of opened semaphores. Expected a "used arrays" key, got '.implode(PHP_EOL, $lines));
         }
 
         return (int) $value;

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -256,7 +256,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 continue;
             }
 
-            $value = $this->validateAndDenormalize($class, $attribute, $value, $format, $context);
+            $value = $this->validateAndDenormalize(\get_class($class), $attribute, $value, $format, $context);
             try {
                 $this->setAttributeValue($object, $attribute, $value, $format, $context);
             } catch (InvalidArgumentException $e) {

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -16,6 +16,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Exception\RuntimeException;
+use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
@@ -130,5 +131,25 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         } catch (NoSuchPropertyException $exception) {
             // Properties not found are ignored
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAllowedAttributes($classOrObject, array $context, $attributesAsString = false)
+    {
+        if (false === $allowedAttributes = parent::getAllowedAttributes($classOrObject, $context, $attributesAsString)) {
+            return false;
+        }
+
+        if (null !== $this->classDiscriminatorResolver && null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForMappedObject($classOrObject)) {
+            $allowedAttributes[] = $attributesAsString ? $discriminatorMapping->getTypeProperty() : new AttributeMetadata($discriminatorMapping->getTypeProperty());
+
+            foreach ($discriminatorMapping->getTypesMapping() as $class) {
+                $allowedAttributes = array_merge($allowedAttributes, parent::getAllowedAttributes($class, $context, $attributesAsString));
+            }
+        }
+
+        return $allowedAttributes;
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -142,14 +142,24 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             return false;
         }
 
-        if (null !== $this->classDiscriminatorResolver && null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForMappedObject($classOrObject)) {
-            $allowedAttributes[] = $attributesAsString ? $discriminatorMapping->getTypeProperty() : new AttributeMetadata($discriminatorMapping->getTypeProperty());
+        $discriminatorMapping = $this->classDiscriminatorResolver ? $this->classDiscriminatorResolver->getMappingForMappedObject($classOrObject) : null;
 
-            foreach ($discriminatorMapping->getTypesMapping() as $class) {
-                $allowedAttributes = array_merge($allowedAttributes, parent::getAllowedAttributes($class, $context, $attributesAsString));
-            }
+        if (!$discriminatorMapping) {
+            return $allowedAttributes;
         }
 
-        return $allowedAttributes;
+        $allowedAttributes[] = $attributesAsString ? $discriminatorMapping->getTypeProperty() : new AttributeMetadata($discriminatorMapping->getTypeProperty());
+
+        $reflectionClass = new \ReflectionClass($classOrObject);
+
+        if (!$reflectionClass->isAbstract() && !$reflectionClass->isInterface()) {
+            return $allowedAttributes;
+        }
+
+        foreach ($discriminatorMapping->getTypesMapping() as $class) {
+            $allowedAttributes = \array_merge($allowedAttributes, parent::getAllowedAttributes($class, $context, $attributesAsString));
+        }
+
+        return \array_unique($allowedAttributes);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageInterface.php
@@ -15,8 +15,8 @@ use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
 
 /**
  * @DiscriminatorMap(typeProperty="type", mapping={
- *    "first"="Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild",
- *    "second"="Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild"
+ *    "one"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberOne",
+ *    "two"="Symfony\Component\Serializer\Tests\Fixtures\DummyMessageNumberTwo"
  * })
  *
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberTwo.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberTwo.php
@@ -11,17 +11,9 @@
 
 namespace Symfony\Component\Serializer\Tests\Fixtures;
 
-use Symfony\Component\Serializer\Annotation\Groups;
-
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-class DummyMessageNumberOne implements DummyMessageInterface
+class DummyMessageNumberTwo implements DummyMessageInterface
 {
-    public $one;
-
-    /**
-     * @Groups({"two"})
-     */
-    public $two;
 }

--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -30,10 +30,10 @@ class Event extends BaseEvent
     private $workflowName;
 
     /**
-     * @param object     $subject
-     * @param Marking    $marking
-     * @param Transition $transition
-     * @param Workflow   $workflow
+     * @param object            $subject
+     * @param Marking           $marking
+     * @param Transition        $transition
+     * @param WorkflowInterface $workflow
      */
     public function __construct($subject, Marking $marking, Transition $transition, $workflow = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27641
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixing this bugs:

1. https://github.com/voodoo-dn/serializer-bug/commit/0aa4a57a5eecc0a9fb34736715deb6d81d29dbde
On normalization trying get property from class which not exists(because merged whole attribute list from class discriminator map)

2. https://github.com/voodoo-dn/serializer-bug/commit/41ae6e89ce77335316fed9c1513112fe3db61738
Associated objects are not deserialized
For example: DummyA has association with DummyB, but on deserialization(json string for example) instead of passing DummyB object via DummyA::setDummyB(), array passed to this method.
