### PR TITLE
[Doctrine Bridge] Fixed usage of wrong variable when tagged subscriber is invalid

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -75,7 +75,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
             $connections = isset($tag['connection']) ? array($tag['connection']) : array_keys($this->connections);
             foreach ($connections as $con) {
                 if (!isset($this->connections[$con])) {
-                    throw new RuntimeException(sprintf('The Doctrine connection "%s" referenced in service "%s" does not exist. Available connections names: %s', $con, $taggedSubscriber, implode(', ', array_keys($this->connections))));
+                    throw new RuntimeException(sprintf('The Doctrine connection "%s" referenced in service "%s" does not exist. Available connections names: %s', $con, $id, implode(', ', array_keys($this->connections))));
                 }
 
                 $this->getEventManagerDef($container, $con)->addMethodCall('addEventSubscriber', array(new Reference($id)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27811
| License       | MIT

This change prevents error when invalid subscriber is being used.

Expected result:
```
The Doctrine connection "root" referenced in service "stof_doctrine_extensions.listener.sluggable" does not exist. Available connections names: default
```

Actual error:
```
Notice: Array to string conversion
```