### PR TITLE
4.1

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -256,7 +256,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 continue;
             }
 
-            $value = $this->validateAndDenormalize(\get_class($class), $attribute, $value, $format, $context);
+            $value = $this->validateAndDenormalize(\get_class($object), $attribute, $value, $format, $context);
             try {
                 $this->setAttributeValue($object, $attribute, $value, $format, $context);
             } catch (InvalidArgumentException $e) {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -256,7 +256,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 continue;
             }
 
-            $value = $this->validateAndDenormalize($class, $attribute, $value, $format, $context);
+            $value = $this->validateAndDenormalize(\get_class($class), $attribute, $value, $format, $context);
             try {
                 $this->setAttributeValue($object, $attribute, $value, $format, $context);
             } catch (InvalidArgumentException $e) {

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -142,14 +142,24 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             return false;
         }
 
-        if (null !== $this->classDiscriminatorResolver && null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForMappedObject($classOrObject)) {
-            $allowedAttributes[] = $attributesAsString ? $discriminatorMapping->getTypeProperty() : new AttributeMetadata($discriminatorMapping->getTypeProperty());
+        $discriminatorMapping = $this->classDiscriminatorResolver ? $this->classDiscriminatorResolver->getMappingForMappedObject($classOrObject) : null;
 
-            foreach ($discriminatorMapping->getTypesMapping() as $class) {
-                $allowedAttributes = array_merge($allowedAttributes, parent::getAllowedAttributes($class, $context, $attributesAsString));
-            }
+        if (!$discriminatorMapping) {
+            return $allowedAttributes;
         }
 
-        return $allowedAttributes;
+        $allowedAttributes[] = $attributesAsString ? $discriminatorMapping->getTypeProperty() : new AttributeMetadata($discriminatorMapping->getTypeProperty());
+
+        $reflectionClass = new \ReflectionClass($classOrObject);
+
+        if (!$reflectionClass->isAbstract() && !$reflectionClass->isInterface()) {
+            return $allowedAttributes;
+        }
+
+        foreach ($discriminatorMapping->getTypesMapping() as $class) {
+            $allowedAttributes = \array_merge($allowedAttributes, parent::getAllowedAttributes($class, $context, $attributesAsString));
+        }
+
+        return \array_unique($allowedAttributes);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27641
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixing this bugs:

1. https://github.com/voodoo-dn/serializer-bug/commit/0aa4a57a5eecc0a9fb34736715deb6d81d29dbde
On normalization trying get property from class which not exists(because merged whole attribute list from class discriminator map)

2. https://github.com/voodoo-dn/serializer-bug/commit/41ae6e89ce77335316fed9c1513112fe3db61738
Associated objects are not deserialized
For example: DummyA has association with DummyB, but on deserialization(json string for example) instead of passing DummyB object via DummyA::setDummyB(), array passed to this method.
