### PR TITLE
[Security] add "lazy_authentication" mode to firewalls

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterForAutoconfigurationPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterForAutoconfigurationPass.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
+
+use Symfony\Bridge\Monolog\Processor\ProcessorInterface;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Adds a rule to bind "security.actual_token_storage" to ProcessorInterface instances.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class RegisterForAutoconfigurationPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->has('security.actual_token_storage')) {
+            $processorAutoconfiguration = $container->registerForAutoconfiguration(ProcessorInterface::class);
+            $processorAutoconfiguration->setBindings($processorAutoconfiguration->getBindings() + array(
+                TokenStorageInterface::class => new BoundArgument(new Reference('security.actual_token_storage'), false),
+            ));
+        }
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -196,6 +196,7 @@ class MainConfiguration implements ConfigurationInterface
             ->scalarNode('entry_point')->end()
             ->scalarNode('provider')->end()
             ->booleanNode('stateless')->defaultFalse()->end()
+            ->booleanNode('lazy_authentication')->defaultFalse()->end()
             ->scalarNode('context')->cannotBeEmpty()->end()
             ->booleanNode('logout_on_user_change')
                 ->defaultTrue()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -204,7 +204,8 @@ class SecurityExtension extends Extension
             list($matcher, $listeners, $exceptionListener, $logoutListener) = $this->createFirewall($container, $name, $firewall, $authenticationProviders, $providerIds, $configId);
 
             $contextId = 'security.firewall.map.context.'.$name;
-            $context = $container->setDefinition($contextId, new ChildDefinition('security.firewall.context'));
+            $context = new ChildDefinition($firewall['stateless'] || !$firewall['lazy_authentication'] ? 'security.firewall.context' : 'security.firewall.lazy_context');
+            $context = $container->setDefinition($contextId, $context);
             $context
                 ->replaceArgument(0, new IteratorArgument($listeners))
                 ->replaceArgument(1, $exceptionListener)
@@ -374,7 +375,9 @@ class SecurityExtension extends Extension
         }
 
         // Access listener
-        $listeners[] = new Reference('security.access_listener');
+        if ($firewall['stateless'] || !$firewall['lazy_authentication']) {
+            $listeners[] = new Reference('security.access_listener');
+        }
 
         // Exception listener
         $exceptionListener = new Reference($this->createExceptionListener($container, $firewall, $id, $configuredEntryPoint ?: $defaultEntryPoint, $firewall['stateless']));

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
@@ -9,7 +9,7 @@
 
         <service id="data_collector.security" class="Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector">
             <tag name="data_collector" template="@Security/Collector/security.html.twig" id="security" priority="270" />
-            <argument type="service" id="security.token_storage" on-invalid="ignore" />
+            <argument type="service" id="security.actual_token_storage" />
             <argument type="service" id="security.role_hierarchy" />
             <argument type="service" id="security.logout_url_generator" />
             <argument type="service" id="security.access.decision_manager" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -21,10 +21,13 @@
         </service>
         <service id="Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface" alias="security.authorization_checker" />
 
-        <service id="security.token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" public="true">
+        <service id="security.token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\LazyTokenStorage" public="true">
             <tag name="kernel.reset" method="setToken" />
+            <argument type="service" id="security.actual_token_storage" />
         </service>
         <service id="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface" alias="security.token_storage" />
+
+        <service id="security.actual_token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" />
 
         <service id="security.helper" class="Symfony\Component\Security\Core\Security">
             <argument type="service_locator">
@@ -143,6 +146,14 @@
             <argument type="service" id="security.exception_listener" />
             <argument />  <!-- LogoutListener -->
             <argument />  <!-- FirewallConfig -->
+        </service>
+
+        <service id="security.firewall.lazy_context" class="Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext" abstract="true">
+            <argument type="collection" />
+            <argument type="service" id="security.exception_listener" />
+            <argument />  <!-- LogoutListener -->
+            <argument />  <!-- FirewallConfig -->
+            <argument type="service" id="security.lazy_access_listener" />
         </service>
 
         <service id="security.firewall.config" class="Symfony\Bundle\SecurityBundle\Security\FirewallConfig" abstract="true">

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -242,5 +242,13 @@
             <argument type="service" id="security.access_map" />
             <argument type="service" id="security.authentication.manager" />
         </service>
+
+        <service id="security.lazy_access_listener" class="Symfony\Component\Security\Http\Firewall\LazyAccessListener">
+            <tag name="monolog.logger" channel="security" />
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.access.decision_manager" />
+            <argument type="service" id="security.access_map" />
+            <argument type="service" id="security.authentication.manager" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/LazyFirewallContext.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Security;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\Exception\LazyResponseException;
+use Symfony\Component\Security\Http\Event\LazyResponseEvent;
+use Symfony\Component\Security\Http\Firewall\ExceptionListener;
+use Symfony\Component\Security\Http\Firewall\LazyAccessListener;
+use Symfony\Component\Security\Http\Firewall\ListenerInterface;
+use Symfony\Component\Security\Http\Firewall\LogoutListener;
+
+/**
+ * Lazily calls authentication listeners when actually required by the access listener.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class LazyFirewallContext extends FirewallContext implements ListenerInterface
+{
+    private $accessListener;
+
+    public function __construct(iterable $listeners, ?ExceptionListener $exceptionListener, ?LogoutListener $logoutListener, ?FirewallConfig $config, LazyAccessListener $accessListener)
+    {
+        parent::__construct($listeners, $exceptionListener, $logoutListener, $config);
+
+        $this->accessListener = $accessListener;
+    }
+
+    public function getListeners(): iterable
+    {
+        return array($this);
+    }
+
+    public function handle(GetResponseEvent $event)
+    {
+        $this->accessListener->getTokenStorage()->setInitializer(function () use ($event) {
+            $event = new LazyResponseEvent($event);
+            foreach (parent::getListeners() as $listener) {
+                $listener->handle($event);
+            }
+        });
+
+        try {
+            $this->accessListener->handle($event);
+        } catch (LazyResponseException $e) {
+            $event->setResponse($e->getResponse());
+        }
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddExpressionLang
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSessionDomainConstraintPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterCsrfTokenClearingLogoutHandlerPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterForAutoconfigurationPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginLdapFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\GuardAuthenticationFactory;
@@ -64,5 +65,6 @@ class SecurityBundle extends Bundle
         $container->addCompilerPass(new AddSecurityVotersPass());
         $container->addCompilerPass(new AddSessionDomainConstraintPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new RegisterCsrfTokenClearingLogoutHandlerPass());
+        $container->addCompilerPass(new RegisterForAutoconfigurationPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/LazyTokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/LazyTokenStorage.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token\Storage;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Lazily populates a token storage.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @final
+ */
+class LazyTokenStorage implements TokenStorageInterface
+{
+    private $storage;
+    private $initializer;
+
+    public function __construct(TokenStorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    public function setInitializer(\Closure $initializer)
+    {
+        $this->initializer = $initializer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getToken()
+    {
+        if ($initializer = $this->initializer) {
+            $this->initializer = null;
+            $initializer();
+        }
+
+        return $this->storage->getToken();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setToken(TokenInterface $token = null)
+    {
+        $this->initializer = null;
+        $this->storage->setToken($token);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Exception/LazyResponseException.php
+++ b/src/Symfony/Component/Security/Core/Exception/LazyResponseException.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Exception;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Wraps a lazily computed response in a signaling exception.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class LazyResponseException extends \Exception implements ExceptionInterface
+{
+    private $response;
+
+    public function __construct(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\Exception\LazyResponseException;
+
+/**
+ * Wraps a lazily computed response in a signaling exception.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @final
+ */
+class LazyResponseEvent extends GetResponseEvent
+{
+    private $event;
+
+    public function __construct(parent $event)
+    {
+        $this->event = $event;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setResponse(Response $response)
+    {
+        $this->stopPropagation();
+        $this->event->stopPropagation();
+
+        throw new LazyResponseException($response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getKernel()
+    {
+        return $this->event->getKernel();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequest()
+    {
+        return $this->event->getRequest();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequestType()
+    {
+        return $this->event->getRequestType();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMasterRequest()
+    {
+        return $this->event->isMasterRequest();
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -25,6 +25,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\InsufficientAuthenticationException;
+use Symfony\Component\Security\Core\Exception\LazyResponseException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
@@ -92,6 +93,8 @@ class ExceptionListener
                 return $this->handleAuthenticationException($event, $exception);
             } elseif ($exception instanceof AccessDeniedException) {
                 return $this->handleAccessDeniedException($event, $exception);
+            } elseif ($exception instanceof LazyResponseException) {
+                return $event->setResponse($exception->getResponse());
             } elseif ($exception instanceof LogoutException) {
                 return $this->handleLogoutException($exception);
             }

--- a/src/Symfony/Component/Security/Http/Firewall/LazyAccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LazyAccessListener.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Firewall;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\LazyTokenStorage;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Http\AccessMapInterface;
+
+/**
+ * Enforces access control rules while allowing unauthenticated access when no attributes are found.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class LazyAccessListener extends AccessListener
+{
+    private $tokenStorage;
+    private $map;
+
+    public function __construct(LazyTokenStorage $tokenStorage, AccessDecisionManagerInterface $accessDecisionManager, AccessMapInterface $map, AuthenticationManagerInterface $authManager)
+    {
+        parent::__construct($tokenStorage, $accessDecisionManager, $map, $authManager);
+        $this->tokenStorage = $tokenStorage;
+        $this->map = $map;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(GetResponseEvent $event)
+    {
+        list($attributes) = $this->map->getPatterns($event->getRequest());
+
+        if ($attributes) {
+            return parent::handle($event);
+        }
+    }
+
+    public function getTokenStorage(): LazyTokenStorage
+    {
+        return $this->tokenStorage;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26769 *et al.*
| License       | MIT
| Doc PR        | -

Wouhou, here is my first significant PR on the Security component :)

This PR is aimed at allowing unauthenticated access to resources that don't read the user token. It applies to stateful firewalls only. Right now, when a stateful firewall is configured, a user token is always hydrated from the session. This has the effect of making the response uncacheable.

When access control defines no specific roles for a resource and when no further `is_granted()` checks are made when computing it, one doesn't really need statefulness.

This PR allows differentiating the "anonymous" mode from the "unauthenticated" one: "anonymous" is stateful and allows e.g. tracking the journey of a user on a website even if we don't know who this is. "unauthenticated" on the other end is anonymous+stateless - i.e. we don't track navigation.

When "lazy_authentication" is enabled, all security listeners are called lazily only when the user token is actually read from the token storage.

A visible side effect is that ESI fragments can be more easily cached (see linked issue). Another one is that the debug toolbar will report as "unauthenticated" when browsing such a page. And a last one is that once #27806 is merged, `TokenProcessor` won't add the username on the logs when a resource didn't start the authentication stack.

The next step should be to enable this rule by default in https://github.com/symfony/recipes/blob/master/symfony/security-bundle/3.3/config/packages/security.yaml:

```yaml
security:
    firewalls:
        main:
            anonymous: true
            lazy_authentication: true
```

TODO:
- [ ] add tests
- [ ] doc PR

WDYT?