### PR TITLE
[Serializer] deprecated normalizers and encoders who dont implement the base interfaces

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -13,6 +13,12 @@ CHANGELOG
    the format and the context in a name converter
  * the `AbstractNormalizer::handleCircularReference()` method will have two new `$format`
    and `$context` arguments in version 5.0, not defining them is deprecated
+ * deprecated creating a `Serializer` with normalizers which do not implement
+   either `NormalizerInterface` or `DenormalizerInterface`
+ * deprecated creating a `Serializer` with normalizers which do not implement
+   either `NormalizerInterface` or `DenormalizerInterface`
+ * deprecated creating a `Serializer` with encoders which do not implement
+   either `EncoderInterface` or `DecoderInterface`
 
 4.1.0
 -----

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -64,6 +64,10 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
     private $denormalizerCache = array();
     private $normalizerCache = array();
 
+    /**
+     * @param (NormalizerInterface|DenormalizerInterface)[] $normalizers
+     * @param (EncoderInterface|DecoderInterface)[]         $encoders
+     */
     public function __construct(array $normalizers = array(), array $encoders = array())
     {
         foreach ($normalizers as $normalizer) {
@@ -77,6 +81,11 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
 
             if ($normalizer instanceof NormalizerAwareInterface) {
                 $normalizer->setNormalizer($this);
+            }
+
+            if (!($normalizer instanceof NormalizerInterface || $normalizer instanceof DenormalizerInterface)) {
+                @trigger_error(\sprintf('Passing normalizers ("%s") which do not implement either "%s" or "%s" has been deprecated since Symfony 4.2.', \get_class($normalizer), NormalizerInterface::class, DenormalizerInterface::class), E_USER_DEPRECATED);
+                // throw new \InvalidArgumentException(\sprintf('The class "%s" does not implement "%s" or "%s".', \get_class($normalizer), NormalizerInterface::class, DenormalizerInterface::class));
             }
         }
         $this->normalizers = $normalizers;
@@ -92,6 +101,11 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             }
             if ($encoder instanceof EncoderInterface) {
                 $realEncoders[] = $encoder;
+            }
+
+            if (!($encoder instanceof EncoderInterface || $encoder instanceof DecoderInterface)) {
+                @trigger_error(\sprintf('Passing encoders ("%s") which do not implement either "%s" or "%s" has been deprecated since Symfony 4.2.', \get_class($encoder), EncoderInterface::class, DecoderInterface::class), E_USER_DEPRECATED);
+                // throw new \InvalidArgumentException(\sprintf('The class "%s" does not implement "%s" or "%s".', \get_class($normalizer), EncoderInterface::class, DecoderInterface::class));
             }
         }
         $this->encoder = new ChainEncoder($realEncoders);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -56,6 +56,24 @@ class SerializerTest extends TestCase
     }
 
     /**
+     * @expectedDeprecation Passing normalizers ("stdClass") which do not implement either "Symfony\Component\Serializer\Normalizer\NormalizerInterface" or "Symfony\Component\Serializer\Normalizer\DenormalizerInterface" has been deprecated since Symfony 4.2.
+     * @group legacy
+     */
+    public function testDeprecationErrorOnInvalidNormalizer()
+    {
+        new Serializer(array(new \stdClass()));
+    }
+
+    /**
+     * @expectedDeprecation Passing encoders ("stdClass") which do not implement either "Symfony\Component\Serializer\Encoder\EncoderInterface" or "Symfony\Component\Serializer\Encoder\DecoderInterface" has been deprecated since Symfony 4.2.
+     * @group legacy
+     */
+    public function testDeprecationErrorOnInvalidEncoder()
+    {
+        new Serializer(array(), array(new \stdClass()));
+    }
+
+    /**
      * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
      */
     public function testNormalizeNoMatch()
@@ -334,7 +352,7 @@ class SerializerTest extends TestCase
 
     public function testNormalizerAware()
     {
-        $normalizerAware = $this->getMockBuilder(NormalizerAwareInterface::class)->getMock();
+        $normalizerAware = $this->getMockBuilder(array(NormalizerAwareInterface::class, NormalizerInterface::class))->getMock();
         $normalizerAware->expects($this->once())
             ->method('setNormalizer')
             ->with($this->isInstanceOf(NormalizerInterface::class));
@@ -344,7 +362,7 @@ class SerializerTest extends TestCase
 
     public function testDenormalizerAware()
     {
-        $denormalizerAware = $this->getMockBuilder(DenormalizerAwareInterface::class)->getMock();
+        $denormalizerAware = $this->getMockBuilder(array(DenormalizerAwareInterface::class, DenormalizerInterface::class))->getMock();
         $denormalizerAware->expects($this->once())
             ->method('setDenormalizer')
             ->with($this->isInstanceOf(DenormalizerInterface::class));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | None
| License       | MIT
| Doc PR        | None

Currently the `Serializer` can be constructed with any object regardless of whether or not it implements `NormalizerInterface` or `DenormalizerInterface`. This object will then be ignored when getting a normalizer/denormalizer, so in effect silently ignored for serializer operations.

This change throws an exception on construct if a given normalizer object does not implement one of these interfaces - are there use cases where this would not be true?