### PR TITLE
[Messenger] Fix a bug when having more than one named handler per message subscriber

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -128,11 +128,13 @@ class MessengerPass implements CompilerPassInterface
                     if ('__invoke' !== $method) {
                         $wrapperDefinition = (new Definition('callable'))->addArgument(array(new Reference($serviceId), $method))->setFactory('Closure::fromCallable');
 
-                        $definitions[$serviceId = '.messenger.method_on_object_wrapper.'.ContainerBuilder::hash($messageClass.':'.$messagePriority.':'.$serviceId.':'.$method)] = $wrapperDefinition;
+                        $definitions[$definitionId = '.messenger.method_on_object_wrapper.'.ContainerBuilder::hash($messageClass.':'.$messagePriority.':'.$serviceId.':'.$method)] = $wrapperDefinition;
+                    } else {
+                        $definitionId = $serviceId;
                     }
 
                     foreach ($handlerBuses as $handlerBus) {
-                        $handlersByBusAndMessage[$handlerBus][$messageClass][$messagePriority][] = $serviceId;
+                        $handlersByBusAndMessage[$handlerBus][$messageClass][$messagePriority][] = $definitionId;
                     }
                 }
             }

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -288,7 +288,12 @@ class MessengerPassTest extends TestCase
         $handlerMapping = $handlerLocatorDefinition->getArgument(0);
 
         $this->assertArrayHasKey('handler.'.DummyMessage::class, $handlerMapping);
+        $firstReference = $handlerMapping['handler.'.DummyMessage::class]->getValues()[0];
+        $this->assertEquals(array(new Reference(HandlerWithGenerators::class), 'dummyMethod'), $container->getDefinition($firstReference)->getArgument(0));
+
         $this->assertArrayHasKey('handler.'.SecondMessage::class, $handlerMapping);
+        $secondReference = $handlerMapping['handler.'.SecondMessage::class]->getValues()[0];
+        $this->assertEquals(array(new Reference(HandlerWithGenerators::class), 'secondMessage'), $container->getDefinition($secondReference)->getArgument(0));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

It turns out that when using multiple named handler on the same subscriber class, it wasn't working properly at all. It fixes it and obviously add a test for it :)