### PR TITLE
[Serializer] Supports nested abstract items

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberTwo.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyMessageNumberTwo.php
@@ -22,4 +22,19 @@ class DummyMessageNumberTwo implements DummyMessageInterface
      * @Groups({"two"})
      */
     public $three;
+
+    /**
+     * @var DummyMessageNumberOne
+     */
+    private $nested;
+
+    public function setNested(DummyMessageNumberOne $nested)
+    {
+        $this->nested = $nested;
+    }
+
+    public function getNested(): DummyMessageNumberOne
+    {
+        return $this->nested;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27816, #27641
| License       | MIT
| Doc PR        | ø

This adds support for nested "abstract" objects.