### PR TITLE
[DI] Don't show internal service id on binding errors

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -117,9 +117,11 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 }
             }
 
+            $definition->setBindings($bindings);
+
             // reset fields with "merge" behavior
             $abstract
-                ->setBindings($bindings)
+                ->setBindings(array())
                 ->setArguments(array())
                 ->setMethodCalls(array())
                 ->setDecoratedService(null)

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
@@ -249,5 +250,19 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $this->assertNull($abstract->getDecoratedService());
         $this->assertEmpty($abstract->getTags());
         $this->assertTrue($abstract->isAbstract());
+    }
+
+    public function testBindings()
+    {
+        $container = new ContainerBuilder();
+        $def = $container->register('foo', self::class)->setBindings(array('$toto' => 123));
+        $def->setInstanceofConditionals(array(parent::class => new ChildDefinition('')));
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $bindings = $container->getDefinition('foo')->getBindings();
+        $this->assertSame(array('$toto'), array_keys($bindings));
+        $this->assertInstanceOf(BoundArgument::class, $bindings['$toto']);
+        $this->assertSame(123, $bindings['$toto']->getValues()[0]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Will throw
    Unused binding "$variableName" in service "App\Twig\AppExtension".
instead of the current
    Unused binding "$variableName" in service ".abstract.instanceof.App\Twig\AppExtension".
