### PR TITLE
[HttpFoundation] add tests for FlashBagInterface::setAll()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -124,6 +124,19 @@ class FlashBagTest extends TestCase
         $this->assertEquals(array('notice'), $this->bag->keys());
     }
 
+    public function testSetAll()
+    {
+        $this->bag->add('one_flash', 'Foo');
+        $this->bag->add('another_flash', 'Bar');
+        $this->assertTrue($this->bag->has('one_flash'));
+        $this->assertTrue($this->bag->has('another_flash'));
+        $this->bag->setAll(array('unique_flash' => 'FooBar'));
+        $this->assertFalse($this->bag->has('one_flash'));
+        $this->assertFalse($this->bag->has('another_flash'));
+        $this->assertSame(array('unique_flash' => 'FooBar'), $this->bag->all());
+        $this->assertSame(array(), $this->bag->all());
+    }
+
     public function testPeekAll()
     {
         $this->bag->set('notice', 'Foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~


Adding documentation for the `FlashBagInterface::setAll()` function
