### PR TITLE
[PropertyInfo] Fix dock block lookup fallback loop

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -75,7 +75,7 @@ Suppose that you have the following security configuration in your application:
 security:
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext
-        AppBundle\Entity\User: bcrypt
+        App\Entity\User: bcrypt
 </comment>
 
 If you execute the command non-interactively, the first available configured
@@ -87,16 +87,16 @@ generated to encode the password:
 Pass the full user class path as the second argument to encode passwords for
 your own entities:
 
-  <info>php %command.full_name% --no-interaction [password] AppBundle\Entity\User</info>
+  <info>php %command.full_name% --no-interaction [password] App\Entity\User</info>
 
 Executing the command interactively allows you to generate a random salt for
 encoding the password:
 
-  <info>php %command.full_name% [password] AppBundle\Entity\User</info>
+  <info>php %command.full_name% [password] App\Entity\User</info>
 
 In case your encoder doesn't require a salt, add the <comment>empty-salt</comment> option:
 
-  <info>php %command.full_name% --empty-salt [password] AppBundle\Entity\User</info>
+  <info>php %command.full_name% --empty-salt [password] App\Entity\User</info>
 
 EOF
             )

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -410,8 +410,8 @@ class MainConfiguration implements ConfigurationInterface
             ->children()
                 ->arrayNode('encoders')
                     ->example(array(
-                        'AppBundle\Entity\User1' => 'bcrypt',
-                        'AppBundle\Entity\User2' => array(
+                        'App\Entity\User1' => 'bcrypt',
+                        'App\Entity\User2' => array(
                             'algorithm' => 'bcrypt',
                             'cost' => 13,
                         ),

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -169,25 +169,21 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
         $ucFirstProperty = ucfirst($property);
 
-        try {
-            switch (true) {
-                case $docBlock = $this->getDocBlockFromProperty($class, $property):
-                    $data = array($docBlock, self::PROPERTY, null);
-                    break;
+        switch (true) {
+            case $docBlock = $this->getDocBlockFromProperty($class, $property):
+                $data = array($docBlock, self::PROPERTY, null);
+                break;
 
-                case list($docBlock) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR):
-                    $data = array($docBlock, self::ACCESSOR, null);
-                    break;
+            case list($docBlock) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR):
+                $data = array($docBlock, self::ACCESSOR, null);
+                break;
 
-                case list($docBlock, $prefix) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR):
-                    $data = array($docBlock, self::MUTATOR, $prefix);
-                    break;
+            case list($docBlock, $prefix) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR):
+                $data = array($docBlock, self::MUTATOR, $prefix);
+                break;
 
-                default:
-                    $data = array(null, null, null);
-            }
-        } catch (\InvalidArgumentException $e) {
-            $data = array(null, null, null);
+            default:
+                $data = array(null, null, null);
         }
 
         return $this->docBlocks[$propertyHash] = $data;
@@ -210,7 +206,11 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             return;
         }
 
-        return $this->docBlockFactory->create($reflectionProperty, $this->contextFactory->createFromReflector($reflectionProperty->getDeclaringClass()));
+        try {
+            return $this->docBlockFactory->create($reflectionProperty, $this->contextFactory->createFromReflector($reflectionProperty->getDeclaringClass()));
+        } catch (\InvalidArgumentException $e) {
+            return null;
+        }
     }
 
     /**
@@ -251,6 +251,10 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             return;
         }
 
-        return array($this->docBlockFactory->create($reflectionMethod, $this->contextFactory->createFromReflector($reflectionMethod)), $prefix);
+        try {
+            return array($this->docBlockFactory->create($reflectionMethod, $this->contextFactory->createFromReflector($reflectionMethod)), $prefix);
+        } catch (\InvalidArgumentException $e) {
+            return null;
+        }
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -184,6 +184,29 @@ class PhpDocExtractorTest extends TestCase
     {
         $this->assertNull($this->extractor->getShortDescription(EmptyDocBlock::class, 'foo'));
     }
+
+    public function dockBlockFallbackTypesProvider()
+    {
+        return array(
+            'pub' => array(
+                'pub', array(new Type(Type::BUILTIN_TYPE_STRING)),
+            ),
+            'protAcc' => array(
+                'protAcc', array(new Type(Type::BUILTIN_TYPE_INT)),
+            ),
+            'protMut' => array(
+                'protMut', array(new Type(Type::BUILTIN_TYPE_BOOL)),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider dockBlockFallbackTypesProvider
+     */
+    public function testDocBlockFallback($property, $types)
+    {
+        $this->assertEquals($types, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DockBlockFallback', $property));
+    }
 }
 
 class EmptyDocBlock

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DockBlockFallback.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DockBlockFallback.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * PhpDocExtractor should fallback from property -> accessor -> mutator when looking up dockblocks.
+ *
+ * @author Martin Rademacher <mano@radebatz.net>
+ */
+class DockBlockFallback
+{
+    /** @var string $pub */
+    public $pub = 'pub';
+
+    protected $protAcc;
+    protected $protMut;
+
+    public function getPub()
+    {
+        return $this->pub;
+    }
+
+    public function setPub($pub)
+    {
+        $this->pub = $pub;
+    }
+
+    /**
+     * @return int
+     */
+    public function getProtAcc()
+    {
+        return $this->protAcc;
+    }
+
+    public function setProt($protAcc)
+    {
+        $this->protAcc = $protAcc;
+    }
+
+    public function getProtMut()
+    {
+        return $this->protMut;
+    }
+
+    /**
+     * @param bool $protMut
+     */
+    public function setProtMut($protMut)
+    {
+        $this->protMut = $protMut;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

`getDocBlock()` in `PhpDocExtractor` implements a fallback loop when trying to lookup a dock block for a property (property, accessor method, mutator method). This relies on the individual lookups to return `null`.

Unfortunately, phpDocumentor will throw an `InvalidArgumentException` exception in case there is no dock block.

Currently the try/catch is wrapping the whole loop which means if the first lookup fails the loop is ended instead of moving on to the next one.

This PR moves the try/catch to each individual call of `$this->docBlockFactory->create()`.