### PR TITLE
[Messenger] Adding support for record messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -34,6 +34,11 @@
             <argument type="service" id="validator" />
         </service>
 
+        <service id="messenger.middleware.record_messages" class="Symfony\Component\Messenger\Middleware\HandleRecordedMessageMiddleware" abstract="true">
+            <argument /> <!-- Message bus -->
+            <argument type="service" id="messenger.recorder" />
+        </service>
+
         <!-- Logging -->
         <service id="messenger.middleware.logging" class="Symfony\Component\Messenger\Middleware\LoggingMiddleware" abstract="true">
             <argument type="service" id="logger" />
@@ -62,5 +67,11 @@
 
             <tag name="messenger.transport_factory" />
         </service>
+
+        <!-- Message recorder -->
+        <service id="messenger.recorder" class="Symfony\Component\Messenger\MessageRecorder">
+            <tag name="kernel.reset" method="reset" />
+        </service>
+        <service id="Symfony\Component\Messenger\MessageRecorderInterface" alias="messenger.recorder" />
     </services>
 </container>

--- a/src/Symfony/Component/Messenger/Exception/MessageHandlingException.php
+++ b/src/Symfony/Component/Messenger/Exception/MessageHandlingException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * When handling messages, some handlers caused an exception. This exception
+ * contains all those handler exceptions.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class MessageHandlingException extends \RuntimeException implements ExceptionInterface
+{
+    private $exceptions = array();
+
+    public function __construct(array $exceptions)
+    {
+        $message = sprintf(
+            "Some handlers for recorded messages threw an exception. Their messages were: \n\n%s",
+            implode(", \n", array_map(function (\Throwable $e) {
+                return $e->getMessage();
+            }, $exceptions))
+        );
+
+        $this->exceptions = $exceptions;
+        parent::__construct($message);
+    }
+
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+}

--- a/src/Symfony/Component/Messenger/MessageRecorder.php
+++ b/src/Symfony/Component/Messenger/MessageRecorder.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger;
+
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Matthias Noback <matthiasnoback@gmail.com>
+ */
+class MessageRecorder implements MessageRecorderInterface, RecordedMessageCollectionInterface, ResetInterface
+{
+    private $messages = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRecordedMessages(): array
+    {
+        return $this->messages;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resetRecordedMessages(): void
+    {
+        $this->reset();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->messages = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function record($message): void
+    {
+        $this->messages[] = $message;
+    }
+}

--- a/src/Symfony/Component/Messenger/MessageRecorderInterface.php
+++ b/src/Symfony/Component/Messenger/MessageRecorderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Matthias Noback <matthiasnoback@gmail.com>
+ */
+interface MessageRecorderInterface
+{
+    /**
+     * Record a message.
+     *
+     * @param object $message
+     */
+    public function record($message);
+}

--- a/src/Symfony/Component/Messenger/Middleware/HandleRecordedMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleRecordedMessageMiddleware.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Exception\MessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\RecordedMessageCollectionInterface;
+
+/**
+ * A middleware that takes all recorded messages and dispatch them to the bus.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Matthias Noback <matthiasnoback@gmail.com>
+ */
+class HandleRecordedMessageMiddleware implements MiddlewareInterface
+{
+    private $messageRecorder;
+    private $messageBus;
+
+    public function __construct(MessageBusInterface $messageBus, RecordedMessageCollectionInterface $messageRecorder)
+    {
+        $this->messageRecorder = $messageRecorder;
+        $this->messageBus = $messageBus;
+    }
+
+    public function handle($message, callable $next)
+    {
+        // Make sure the recorder is empty before we begin
+        $this->messageRecorder->resetRecordedMessages();
+
+        try {
+            $returnData = $next($message);
+        } catch (\Throwable $exception) {
+            $this->messageRecorder->resetRecordedMessages();
+
+            throw $exception;
+        }
+
+        $exceptions = array();
+        while (!empty($recordedMessages = $this->messageRecorder->getRecordedMessages())) {
+            $this->messageRecorder->resetRecordedMessages();
+            // Assert: The message recorder is empty, all messages are in $recordedMessages
+
+            foreach ($recordedMessages as $recordedMessage) {
+                try {
+                    $this->messageBus->dispatch($recordedMessage);
+                } catch (\Throwable $exception) {
+                    $exceptions[] = $exception;
+                }
+            }
+        }
+
+        if (!empty($exceptions)) {
+            if (1 === \count($exceptions)) {
+                throw $exceptions[0];
+            }
+            throw new MessageHandlingException($exceptions);
+        }
+
+        return $returnData;
+    }
+}

--- a/src/Symfony/Component/Messenger/RecordedMessageCollectionInterface.php
+++ b/src/Symfony/Component/Messenger/RecordedMessageCollectionInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Matthias Noback <matthiasnoback@gmail.com>
+ */
+interface RecordedMessageCollectionInterface
+{
+    /**
+     * Fetch recorded messages.
+     *
+     * @return object[]
+     */
+    public function getRecordedMessages(): array;
+
+    /**
+     * Remove all recorded messages.
+     */
+    public function resetRecordedMessages(): void;
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleRecordedMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleRecordedMessageMiddlewareTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Exception\MessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\MessageRecorder;
+use Symfony\Component\Messenger\MessageRecorderInterface;
+use Symfony\Component\Messenger\Middleware\HandleRecordedMessageMiddleware;
+use Symfony\Component\Messenger\RecordedMessageCollectionInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+class HandleRecordedMessageMiddlewareTest extends TestCase
+{
+    public function testResetRecorderOnException()
+    {
+        $message = new DummyMessage('Hello');
+        $messageBus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+        $recorder = new MessageRecorder();
+        $next = new class($recorder) {
+            private $recorder;
+
+            public function __construct(MessageRecorderInterface $recorder)
+            {
+                $this->recorder = $recorder;
+            }
+
+            public function __invoke()
+            {
+                $this->recorder->record(new \stdClass());
+                throw new \LogicException();
+            }
+        };
+
+        $middleware = new HandleRecordedMessageMiddleware($messageBus, $recorder);
+        try {
+            $middleware->handle($message, $next);
+        } catch (\LogicException $e) {
+        }
+
+        $this->assertEmpty($recorder->getRecordedMessages());
+    }
+
+    public function testResetRecorderOnStart()
+    {
+        $message = new DummyMessage('Hello');
+        $recorder = new MessageRecorder();
+        $recorder->record(new \stdClass());
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next->expects($this->once())->method('__invoke')->willReturn('World');
+        $messageBus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+        $messageBus->expects($this->exactly(0))->method('dispatch');
+
+        $middleware = new HandleRecordedMessageMiddleware($messageBus, $recorder);
+        $middleware->handle($message, $next);
+        $this->assertEmpty($recorder->getRecordedMessages());
+    }
+
+    public function testDispatchMessageToBus()
+    {
+        $message = new DummyMessage('Hello');
+        $recorder = new MessageRecorder();
+        $messageBus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+        $messageBus->expects($this->exactly(3))->method('dispatch')->willReturnCallback(function ($a) use ($recorder) {
+            if (2 === $a->idx) {
+                $message = new \stdClass();
+                $message->idx = 3;
+                $recorder->record($message);
+            }
+
+            return;
+        });
+
+        $next = new class($recorder) {
+            private $recorder;
+
+            public function __construct(MessageRecorderInterface $recorder)
+            {
+                $this->recorder = $recorder;
+            }
+
+            public function __invoke()
+            {
+                $message = new \stdClass();
+                $message->idx = 1;
+                $this->recorder->record($message);
+
+                $message = new \stdClass();
+                $message->idx = 2;
+                $this->recorder->record($message);
+            }
+        };
+
+        $middleware = new HandleRecordedMessageMiddleware($messageBus, $recorder);
+        $middleware->handle($message, $next);
+        $this->assertEmpty($recorder->getRecordedMessages(), 'RecordedMessageContainerInterface should be empty after execution of HandleRecordedMessageMiddleware.');
+    }
+
+    public function testCatchExceptions()
+    {
+        $message = new DummyMessage('Hello');
+        $recorder = new MessageRecorder();
+        $messageBus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+        $messageBus->expects($this->exactly(2))->method('dispatch')->willThrowException(new \LogicException('Foo'));
+
+        $next = new class($recorder) {
+            private $recorder;
+
+            public function __construct(MessageRecorderInterface $recorder)
+            {
+                $this->recorder = $recorder;
+            }
+
+            public function __invoke()
+            {
+                $message = new \stdClass();
+                $message->idx = 1;
+                $this->recorder->record($message);
+
+                $message = new \stdClass();
+                $message->idx = 2;
+                $this->recorder->record($message);
+            }
+        };
+
+        $middleware = new HandleRecordedMessageMiddleware($messageBus, $recorder);
+        $this->expectException(MessageHandlingException::class);
+        $this->expectExceptionMessage('Some handlers for recorded messages threw an exception. Their messages were: 
+
+Foo, 
+Foo');
+        $middleware->handle($message, $next);
+    }
+
+    public function testItReturnsData()
+    {
+        $message = new DummyMessage('Hello');
+
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next->method('__invoke')->willReturn('World');
+
+        $messageBus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+        $recorder = $this->getMockBuilder(RecordedMessageCollectionInterface::class)->getMock();
+
+        $middleware = new HandleRecordedMessageMiddleware($messageBus, $recorder);
+
+        $result = $middleware->handle($message, $next);
+
+        $this->assertEquals('World', $result);
+    }
+}

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -21,6 +21,7 @@
     "require-dev": {
         "psr/log": "~1.0",
         "symfony/console": "~3.4|~4.0",
+        "symfony/contracts": "^1.0",
         "symfony/dependency-injection": "~3.4.6|~4.0",
         "symfony/http-kernel": "~3.4|~4.0",
         "symfony/process": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10015

With inspiration from [this blog post](https://matthiasnoback.nl/2015/01/collecting-events-and-the-events-aware-command-bus/), I created a message recorder. This is needed when you handle messages in the same doctrine transaction. Ie, you have a `Command` and the `CommandHandler` dispatches `Events`. Those events should be handled in a new doctrine transaction. 

### Scenario

If the command handler creates a User with uuid X and dispatches `UserCreated` event. If they are handled in the same transaction then this code will find nothing: 

```php
$this->em->getRepository(User::class)->findOneBy(['uuid'=>X]);
```

---------

Example configuration:

```yaml

framework:
    messenger:
        default_bus: messenger.bus.command
        buses:
            messenger.bus.command:
                middleware:
                    # Make sure recorded events are handled by the event bus. You may also configure the message recorder with a second parameter. 
                    - app.messenger.middleware.record_messages
                    - doctrine_transaction_middleware: ['default']
        # -- more buses

services: 
    app.messenger.middleware.record_messages:
        parent: messenger.middleware.record_messages
        arguments: ['@messenger.bus.event']
```

