### PR TITLE
[Security] Fix accepting null as $uidKey in LdapUserProvider

### DIFF
--- a/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
@@ -35,8 +35,12 @@ class LdapUserProvider implements UserProviderInterface
     private $defaultSearch;
     private $passwordAttribute;
 
-    public function __construct(LdapInterface $ldap, string $baseDn, string $searchDn = null, string $searchPassword = null, array $defaultRoles = array(), string $uidKey = 'sAMAccountName', string $filter = '({uid_key}={username})', string $passwordAttribute = null)
+    public function __construct(LdapInterface $ldap, string $baseDn, string $searchDn = null, string $searchPassword = null, array $defaultRoles = array(), ?string $uidKey = 'sAMAccountName', string $filter = '({uid_key}={username})', string $passwordAttribute = null)
     {
+        if (null === $uidKey) {
+            $uidKey = 'sAMAccountName';
+        }
+
         $this->ldap = $ldap;
         $this->baseDn = $baseDn;
         $this->searchDn = $searchDn;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fixing the hard BC break introduced in https://github.com/symfony/symfony/commit/afeb89fa065be5ebf7f16437551629b028d51f1c#diff-96df7b4cb1c79ec0877d79ae2b61899dL40

