### PR TITLE
[HttpFoundation] fix support for SplTempFileObject in BinaryFileResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -87,22 +87,12 @@ class BinaryFileResponse extends Response
     {
         if (!$file instanceof File) {
             if ($file instanceof \SplTempFileObject) {
-                static $method = null;
-                static $params = null;
-                if (null === $method) {
-                    $method = 'fread';
-                    $params = array(1024);
-                    if (!method_exists('SplTempFileObject', $method)) {
-                        $method = 'fgets';
-                        $params = array();
-                    }
-                }
                 $file->fflush();
                 $file->rewind();
                 $path = tempnam(sys_get_temp_dir(), 'symfony-temp-file-object');
                 $tmpFile = new \SplFileObject($path, 'wb');
                 while ($file->valid()) {
-                    $tmpFile->fwrite(call_user_func_array(array($file, $method), $params));
+                    $tmpFile->fwrite($file->fgets());
                 }
                 $tmpFile->fflush();
                 $tmpFile = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -45,6 +45,16 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertSame('fööö.html', $response->getFile()->getFilename());
     }
 
+    public function testConstructWithSplTempFileObject()
+    {
+        $file = new \SplTempFileObject();
+        $file->fwrite('foobar');
+        $response = new BinaryFileResponse($file);
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\BinaryFileResponse', $response);
+        $this->expectOutputString('foobar');
+        $response->sendContent();
+    }
+
     /**
      * @expectedException \LogicException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | #14969
| License       | MIT
| Doc PR        | ~

Adding support for using `SplTempFileObject` when using `BinaryFileResponse` see
issue #14969

The patch uses `SplFileObject::fread` when it is available (PHP 5.5.11) or falls back
to using `SplFileObject::fgets` for older version of PHP
