### PR TITLE
Using $value, which at this point, is identical to the previous code

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -104,7 +104,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
             }
         } catch (RuntimeException $e) {
             $this->errorMessages[] = $e->getMessage();
-            $this->container->getDefinition($this->currentId)->addError($e->getMessage());
+            $value->addError($e->getMessage());
 
             return parent::processValue($value, $isRoot);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no->
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/27088/files#r200171296
| License       | MIT
| Doc PR        | not needed

Hi guys! `$value` IS the Definition object at this point. I double-checked this in a real project to be absolutely sure.

Cheers!