### PR TITLE
[Console] changed warning verbosity; fixes typo

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -220,7 +220,10 @@ class Command
             if (function_exists('cli_set_process_title')) {
                 if (!@cli_set_process_title($this->processTitle)) {
                     if ('Darwin' === PHP_OS) {
-                        $output->writeln('<comment>Running "cli_get_process_title" as an unprivileged user is not supported on MacOS.</comment>');
+                        $output->writeln(
+                            '<comment>Running "cli_set_process_title" as an unprivileged user is not supported on MacOS.</comment>',
+                            OutputInterface::VERBOSITY_VERY_VERBOSE
+                        );
                     } else {
                         cli_set_process_title($this->processTitle);
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes*
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

* Tests pass, but I do not have an installation of MacOS to run tests on.  Tests should be unaffected (the test is simply [skipped on MacOS](https://github.com/symfony/console/blob/master/Tests/Command/CommandTest.php#L345)).

When a Console Command fails to change the process title on MacOS, a warning is issued to output.  This warning is relevant to developers of Console applications, but to end users is largely meaningless and potentially confusing.

This PR changes the verbosity of the warning to "very verbose" so it does not interrupt normal usage.
I've also fixed a typo in the message ("get" vs. "set").