### PR TITLE
Replaced AppBundle mentions with App

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -75,7 +75,7 @@ Suppose that you have the following security configuration in your application:
 security:
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext
-        AppBundle\Entity\User: bcrypt
+        App\Entity\User: bcrypt
 </comment>
 
 If you execute the command non-interactively, the first available configured
@@ -87,16 +87,16 @@ generated to encode the password:
 Pass the full user class path as the second argument to encode passwords for
 your own entities:
 
-  <info>php %command.full_name% --no-interaction [password] AppBundle\Entity\User</info>
+  <info>php %command.full_name% --no-interaction [password] App\Entity\User</info>
 
 Executing the command interactively allows you to generate a random salt for
 encoding the password:
 
-  <info>php %command.full_name% [password] AppBundle\Entity\User</info>
+  <info>php %command.full_name% [password] App\Entity\User</info>
 
 In case your encoder doesn't require a salt, add the <comment>empty-salt</comment> option:
 
-  <info>php %command.full_name% --empty-salt [password] AppBundle\Entity\User</info>
+  <info>php %command.full_name% --empty-salt [password] App\Entity\User</info>
 
 EOF
             )

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -410,8 +410,8 @@ class MainConfiguration implements ConfigurationInterface
             ->children()
                 ->arrayNode('encoders')
                     ->example(array(
-                        'AppBundle\Entity\User1' => 'bcrypt',
-                        'AppBundle\Entity\User2' => array(
+                        'App\Entity\User1' => 'bcrypt',
+                        'App\Entity\User2' => array(
                             'algorithm' => 'bcrypt',
                             'cost' => 13,
                         ),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Removed some legacy non-test related mentions of AppBundle. Probably this should be done for 4.x only, not >=3.4.