### PR TITLE
Fixing redundant requires PHP 7.1 as outlined in #27864

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -16,7 +16,6 @@ CHANGELOG
 * added optional `int[] $ignoredNodeTypes` argument to `XmlEncoder::__construct`. XML decoding now
   ignores comment node types by default.
 * added `ConstraintViolationListNormalizer`
-* removed redundant `@requires PHP 7.1` from `AbstractNormalizerTest.php`
 
 4.0.0
 -----

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
 * added optional `int[] $ignoredNodeTypes` argument to `XmlEncoder::__construct`. XML decoding now
   ignores comment node types by default.
 * added `ConstraintViolationListNormalizer`
+* removed redundant `@requires PHP 7.1` from `AbstractNormalizerTest.php`
 
 4.0.0
 -----

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -121,9 +121,6 @@ class AbstractNormalizerTest extends TestCase
         $this->assertNull($dummy->foo);
     }
 
-    /**
-     * @requires PHP 7.1
-     */
     public function testObjectWithNullableConstructorArgument()
     {
         $normalizer = new ObjectNormalizer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Related tickets | #27864   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

As suggested by @ogizanagi in the sort-of-unrelated ticket #27864 - this annotation is no longer needed as 4.1 now requires PHP 7.1; so I'm submitting my first PR.