### PR TITLE
[MonologBridge] Prefer PSR-3 to interact with Monolog in tests

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -180,19 +180,19 @@ class ConsoleHandlerTest extends TestCase
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addListener(ConsoleEvents::COMMAND, function () use ($logger) {
-            $logger->addInfo('Before command message.');
+            $logger->info('Before command message.');
         });
         $dispatcher->addListener(ConsoleEvents::TERMINATE, function () use ($logger) {
-            $logger->addInfo('Before terminate message.');
+            $logger->info('Before terminate message.');
         });
 
         $dispatcher->addSubscriber($handler);
 
         $dispatcher->addListener(ConsoleEvents::COMMAND, function () use ($logger) {
-            $logger->addInfo('After command message.');
+            $logger->info('After command message.');
         });
         $dispatcher->addListener(ConsoleEvents::TERMINATE, function () use ($logger) {
-            $logger->addInfo('After terminate message.');
+            $logger->info('After terminate message.');
         });
 
         $event = new ConsoleCommandEvent(new Command('foo'), $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock(), $output);

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -24,7 +24,7 @@ class LoggerTest extends TestCase
         $handler = new TestHandler();
         $logger = new Logger(__METHOD__, array($handler));
 
-        $this->assertTrue($logger->error('error message'));
+        $logger->error('error message');
         $this->assertSame(array(), $logger->getLogs());
     }
 
@@ -33,7 +33,7 @@ class LoggerTest extends TestCase
         $handler = new TestHandler();
         $logger = new Logger(__METHOD__, array($handler));
 
-        $this->assertTrue($logger->error('error message'));
+        $logger->error('error message');
         $this->assertSame(0, $logger->countErrors());
     }
 
@@ -43,7 +43,7 @@ class LoggerTest extends TestCase
         $processor = new DebugProcessor();
         $logger = new Logger(__METHOD__, array($handler), array($processor));
 
-        $this->assertTrue($logger->error('error message'));
+        $logger->error('error message');
         $this->assertCount(1, $logger->getLogs());
     }
 
@@ -53,15 +53,15 @@ class LoggerTest extends TestCase
         $processor = new DebugProcessor();
         $logger = new Logger(__METHOD__, array($handler), array($processor));
 
-        $this->assertTrue($logger->debug('test message'));
-        $this->assertTrue($logger->info('test message'));
-        $this->assertTrue($logger->notice('test message'));
-        $this->assertTrue($logger->warning('test message'));
+        $logger->debug('test message');
+        $logger->info('test message');
+        $logger->notice('test message');
+        $logger->warning('test message');
 
-        $this->assertTrue($logger->error('test message'));
-        $this->assertTrue($logger->critical('test message'));
-        $this->assertTrue($logger->alert('test message'));
-        $this->assertTrue($logger->emergency('test message'));
+        $logger->error('test message');
+        $logger->critical('test message');
+        $logger->alert('test message');
+        $logger->emergency('test message');
 
         $this->assertSame(4, $logger->countErrors());
     }
@@ -72,7 +72,7 @@ class LoggerTest extends TestCase
         $logger = new Logger('test', array($handler));
         $logger->pushProcessor(new DebugProcessor());
 
-        $logger->addInfo('test');
+        $logger->info('test');
         $this->assertCount(1, $logger->getLogs());
         list($record) = $logger->getLogs();
 
@@ -101,7 +101,7 @@ class LoggerTest extends TestCase
         $logger = new Logger('test', array($handler));
         $logger->pushProcessor(new DebugProcessor());
 
-        $logger->addInfo('test');
+        $logger->info('test');
         $logger->clear();
 
         $this->assertEmpty($logger->getLogs());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | part of #27857
| License       | MIT
| Doc PR        | N/A

This PR changes tests in the Monolog bridge:
* Calls to `Logger::addInfo()` are changed to `Logger::info()`.
* The return value of `Logger::debug()`, `Logger::info()`, `Logger::notice()`, `Logger::warning()`, `Logger::error()` etc. is no longer asserted to be `true`.

This way, the tests only use PSR-3 compatible code to interact with the logger, which makes them forward-compatible with the changes in Monolog 2.