### PR TITLE
[Form] Removed .form-control-label class.

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -187,7 +187,7 @@
             {%- set element = 'legend' -%}
             {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' col-form-label')|trim}) -%}
         {%- else -%}
-            {%- set label_attr = label_attr|merge({for: id, class: (label_attr.class|default('') ~ ' form-control-label')|trim}) -%}
+            {%- set label_attr = label_attr|merge({for: id}) -%}
         {%- endif -%}
         {% if required -%}
             {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
         "symfony/asset": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
-        "symfony/form": "^3.4.9|^4.0.9",
+        "symfony/form": "^3.4.13|~4.0.13|^4.1.2",
         "symfony/http-foundation": "^3.3.11|~4.0",
         "symfony/http-kernel": "~3.2|~4.0",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -41,7 +41,7 @@
         "symfony/workflow": "~3.3|~4.0"
     },
     "conflict": {
-        "symfony/form": "<3.4.9|<4.0.9,>=4.0",
+        "symfony/form": "<3.4.13|>=4.0,<4.0.13|>=4.1,<4.1.2",
         "symfony/console": "<3.4"
     },
     "suggest": {

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
@@ -72,7 +72,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="col-form-label col-sm-2 form-control-label required"]
+    [@class="col-form-label col-sm-2 required"]
 '
         );
     }
@@ -89,7 +89,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="my&class col-form-label col-sm-2 form-control-label required"]
+    [@class="my&class col-form-label col-sm-2 required"]
 '
         );
     }
@@ -106,7 +106,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="my&class col-form-label col-sm-2 form-control-label required"]
+    [@class="my&class col-form-label col-sm-2 required"]
     [.="[trans]Custom label[/trans]"]
 '
         );
@@ -126,7 +126,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="my&class col-form-label col-sm-2 form-control-label required"]
+    [@class="my&class col-form-label col-sm-2 required"]
     [.="[trans]Custom label[/trans]"]
 '
         );

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
@@ -81,7 +81,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="form-control-label required"]
+    [@class="required"]
 '
         );
     }
@@ -98,7 +98,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="my&class form-control-label required"]
+    [@class="my&class required"]
 '
         );
     }
@@ -115,7 +115,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="my&class form-control-label required"]
+    [@class="my&class required"]
     [.="[trans]Custom label[/trans]"]
 '
         );
@@ -135,7 +135,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         $this->assertMatchesXpath($html,
 '/label
     [@for="name"]
-    [@class="my&class form-control-label required"]
+    [@class="my&class required"]
     [.="[trans]Custom label[/trans]"]
 '
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

There is no such a class neither in [bootstrap 4.0](https://getbootstrap.com/docs/4.0/components/forms/#form-controls) nor in [bootstrap 4.1](https://getbootstrap.com/docs/4.1/components/forms/#form-controls).