### PR TITLE
[Form] Removed .mb-0 in errors.

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -268,7 +268,7 @@
     {%- if errors|length > 0 -%}
         <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block">
             {%- for error in errors -%}
-                <span class="mb-0 d-block">
+                <span class="d-block">
                     <span class="form-error-icon badge badge-danger text-uppercase">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span>
                 </span>
             {%- endfor -%}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
         "symfony/asset": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",
-        "symfony/form": "^3.4.9|^4.0.9",
+        "symfony/form": "^3.4.13|~4.0.13|^4.1.2",
         "symfony/http-foundation": "^3.3.11|~4.0",
         "symfony/http-kernel": "~3.2|~4.0",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -41,7 +41,7 @@
         "symfony/workflow": "~3.3|~4.0"
     },
     "conflict": {
-        "symfony/form": "<3.4.9|<4.0.9,>=4.0",
+        "symfony/form": "<3.4.13|>=4.0,<4.0.13|>=4.1,<4.1.2",
         "symfony/console": "<3.4"
     },
     "suggest": {

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
@@ -33,7 +33,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
         ./label[@for="name"]
         [
             ./span[@class="alert alert-danger d-block"]
-                [./span[@class="mb-0 d-block"]
+                [./span[@class="d-block"]
                     [./span[.="[trans]Error[/trans]"]]
                     [./span[.="[trans]Error![/trans]"]]
                 ]

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4LayoutTest.php
@@ -42,7 +42,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./label[@for="name"]
         [
             ./span[@class="alert alert-danger d-block"]
-                [./span[@class="mb-0 d-block"]
+                [./span[@class="d-block"]
                     [./span[.="[trans]Error[/trans]"]]
                     [./span[.="[trans]Error![/trans]"]]
                 ]
@@ -172,11 +172,11 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 '/span
     [@class="alert alert-danger d-block"]
     [
-        ./span[@class="mb-0 d-block"]
+        ./span[@class="d-block"]
             [./span[.="[trans]Error[/trans]"]]
             [./span[.="[trans]Error 1[/trans]"]]
 
-        /following-sibling::span[@class="mb-0 d-block"]
+        /following-sibling::span[@class="d-block"]
             [./span[.="[trans]Error[/trans]"]]
             [./span[.="[trans]Error 2[/trans]"]]
     ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

`<span class="d-block">` will never have a margin on its own, so `.mb-0` is needless.