### PR TITLE
Mock date() in ClockMock

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\PhpUnit;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ * @author Dominic Tubach <dominic.tubach@to.com>
  */
 class ClockMock
 {
@@ -69,6 +70,15 @@ class ClockMock
         return sprintf('%0.6f %d', self::$now - (int) self::$now, (int) self::$now);
     }
 
+    public static function date($format, $timestamp = null)
+    {
+        if (null === $timestamp) {
+            $timestamp = self::time();
+        }
+
+        return \date($format, $timestamp);
+    }
+
     public static function register($class)
     {
         $self = get_called_class();
@@ -105,6 +115,11 @@ function sleep(\$s)
 function usleep(\$us)
 {
     return \\$self::usleep(\$us);
+}
+
+function date(\$format, \$timestamp = null)
+{
+    return \\$self::date(\$format, \$timestamp);
 }
 
 EOPHP

--- a/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
+
+/**
+ * @author Dominic Tubach <dominic.tubach@to.com>
+ *
+ * @covers \Symfony\Bridge\PhpUnit\ClockMock
+ */
+class ClockMockTest extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        ClockMock::register(__CLASS__);
+    }
+
+    protected function setUp()
+    {
+        ClockMock::withClockMock(1234567890.125);
+    }
+
+    public function testTime()
+    {
+        $this->assertSame(1234567890, time());
+    }
+
+    public function testSleep()
+    {
+        sleep(2);
+        $this->assertSame(1234567892, time());
+    }
+
+    public function testMicrotime()
+    {
+        $this->assertSame('0.125000 1234567890', microtime());
+    }
+
+    public function testMicrotimeAsFloat()
+    {
+        $this->assertSame(1234567890.125, microtime(true));
+    }
+
+    public function testUsleep()
+    {
+        usleep(2);
+        $this->assertSame(1234567890.125002, microtime(true));
+    }
+
+    public function testDate()
+    {
+        $this->assertSame('1234567890', date('U'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no (In case `date()` is mocked in some other way execution would fail because of redeclaration. Could be avoided with an extra `function_exists()` check. WDYT?)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

As to the [PHP documentation](https://secure.php.net/manual/en/function.date.php) `date()` uses the value of `time()` as timestamp if none is given. `date()` has to be mocked in ClockMock as well for this still being true, otherwise `\time()` is used as default.

BTW: The msec part of `microtime()` has 8 fractional digits on my system, ClockMock returns only 6...