### PR TITLE
[Finder] Allow arrays as parameters of some methods for better fluent experience and code readability

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -107,17 +107,20 @@ class Finder implements \IteratorAggregate, \Countable
      *
      *   $finder->depth('> 1') // the Finder will start matching at level 1.
      *   $finder->depth('< 3') // the Finder will descend at most 3 levels of directories below the starting point.
+     *   $finder->depth(['>= 1', '< 3'])
      *
-     * @param string|int $level The depth level expression
+     * @param string|int|string[]|int[] $levels The depth level expression or an array of depth levels
      *
      * @return $this
      *
      * @see DepthRangeFilterIterator
      * @see NumberComparator
      */
-    public function depth($level)
+    public function depth($levels)
     {
-        $this->depths[] = new Comparator\NumberComparator($level);
+        foreach ((array) $levels as $level) {
+            $this->depths[] = new Comparator\NumberComparator($level);
+        }
 
         return $this;
     }
@@ -131,8 +134,9 @@ class Finder implements \IteratorAggregate, \Countable
      *   $finder->date('until 2 days ago');
      *   $finder->date('> now - 2 hours');
      *   $finder->date('>= 2005-10-15');
+     *   $finder->date(['>= 2005-10-15', '<= 2006-05-27']);
      *
-     * @param string $date A date range string
+     * @param string|string[] $dates A date range string or an array of date ranges
      *
      * @return $this
      *
@@ -140,9 +144,11 @@ class Finder implements \IteratorAggregate, \Countable
      * @see DateRangeFilterIterator
      * @see DateComparator
      */
-    public function date($date)
+    public function date($dates)
     {
-        $this->dates[] = new Comparator\DateComparator($date);
+        foreach ((array) $dates as $date) {
+            $this->dates[] = new Comparator\DateComparator($date);
+        }
 
         return $this;
     }
@@ -155,16 +161,17 @@ class Finder implements \IteratorAggregate, \Countable
      * $finder->name('*.php')
      * $finder->name('/\.php$/') // same as above
      * $finder->name('test.php')
+     * $finder->name(['test.py', 'test.php'])
      *
-     * @param string $pattern A pattern (a regexp, a glob, or a string)
+     * @param string|string[] $patterns A pattern (a regexp, a glob, or a string) or an array of patterns
      *
      * @return $this
      *
      * @see FilenameFilterIterator
      */
-    public function name($pattern)
+    public function name($patterns)
     {
-        $this->names[] = $pattern;
+        $this->names = \array_merge($this->names, (array) $patterns);
 
         return $this;
     }
@@ -172,15 +179,15 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Adds rules that files must not match.
      *
-     * @param string $pattern A pattern (a regexp, a glob, or a string)
+     * @param string|string[] $patterns A pattern (a regexp, a glob, or a string) or an array of patterns
      *
      * @return $this
      *
      * @see FilenameFilterIterator
      */
-    public function notName($pattern)
+    public function notName($patterns)
     {
-        $this->notNames[] = $pattern;
+        $this->notNames = \array_merge($this->notNames, (array) $patterns);
 
         return $this;
     }
@@ -192,16 +199,17 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * $finder->contains('Lorem ipsum')
      * $finder->contains('/Lorem ipsum/i')
+     * $finder->contains(['dolor', '/ipsum/i'])
      *
-     * @param string $pattern A pattern (string or regexp)
+     * @param string|string[] $patterns A pattern (string or regexp) or an array of patterns
      *
      * @return $this
      *
      * @see FilecontentFilterIterator
      */
-    public function contains($pattern)
+    public function contains($patterns)
     {
-        $this->contains[] = $pattern;
+        $this->contains = \array_merge($this->contains, (array) $patterns);
 
         return $this;
     }
@@ -213,16 +221,17 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * $finder->notContains('Lorem ipsum')
      * $finder->notContains('/Lorem ipsum/i')
+     * $finder->notContains(['lorem', '/dolor/i'])
      *
-     * @param string $pattern A pattern (string or regexp)
+     * @param string|string[] $patterns A pattern (string or regexp) or an array of patterns
      *
      * @return $this
      *
      * @see FilecontentFilterIterator
      */
-    public function notContains($pattern)
+    public function notContains($patterns)
     {
-        $this->notContains[] = $pattern;
+        $this->notContains = \array_merge($this->notContains, (array) $patterns);
 
         return $this;
     }
@@ -234,18 +243,19 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * $finder->path('some/special/dir')
      * $finder->path('/some\/special\/dir/') // same as above
+     * $finder->path(['some dir', 'another/dir'])
      *
      * Use only / as dirname separator.
      *
-     * @param string $pattern A pattern (a regexp or a string)
+     * @param string|string[] $patterns A pattern (a regexp or a string) or an array of patterns
      *
      * @return $this
      *
      * @see FilenameFilterIterator
      */
-    public function path($pattern)
+    public function path($patterns)
     {
-        $this->paths[] = $pattern;
+        $this->paths = \array_merge($this->paths, (array) $patterns);
 
         return $this;
     }
@@ -257,18 +267,19 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * $finder->notPath('some/special/dir')
      * $finder->notPath('/some\/special\/dir/') // same as above
+     * $finder->notPath(['some/file.txt', 'another/file.log'])
      *
      * Use only / as dirname separator.
      *
-     * @param string $pattern A pattern (a regexp or a string)
+     * @param string|string[] $patterns A pattern (a regexp or a string) or an array of patterns
      *
      * @return $this
      *
      * @see FilenameFilterIterator
      */
-    public function notPath($pattern)
+    public function notPath($patterns)
     {
-        $this->notPaths[] = $pattern;
+        $this->notPaths = \array_merge($this->notPaths, (array) $patterns);
 
         return $this;
     }
@@ -279,17 +290,20 @@ class Finder implements \IteratorAggregate, \Countable
      * $finder->size('> 10K');
      * $finder->size('<= 1Ki');
      * $finder->size(4);
+     * $finder->size(['> 10K', '< 20K'])
      *
-     * @param string|int $size A size range string or an integer
+     * @param string|int|string[]|int[] $sizes A size range string or an integer or an array of size ranges
      *
      * @return $this
      *
      * @see SizeRangeFilterIterator
      * @see NumberComparator
      */
-    public function size($size)
+    public function size($sizes)
     {
-        $this->sizes[] = new Comparator\NumberComparator($size);
+        foreach ((array) $sizes as $size) {
+            $this->sizes[] = new Comparator\NumberComparator($size);
+        }
 
         return $this;
     }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -95,7 +95,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
     public function testSymlinksNotResolved()
     {
-        if ('\\' === DIRECTORY_SEPARATOR) {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('symlinks are not supported on Windows');
         }
 
@@ -169,6 +169,17 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator(array(), $finder->in(self::$tmpDir)->getIterator());
     }
 
+    public function testDepthWithArrayParam()
+    {
+        $finder = $this->buildFinder();
+        $finder->depth(array('>= 1', '< 2'));
+        $this->assertIterator($this->toAbsolute(array(
+            'foo/bar.tmp',
+            'qux/baz_100_1.py',
+            'qux/baz_1_2.py',
+        )), $finder->in(self::$tmpDir)->getIterator());
+    }
+
     public function testName()
     {
         $finder = $this->buildFinder();
@@ -206,6 +217,13 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         $finder = $this->buildFinder();
         $finder->name('test.p{hp,y}');
+        $this->assertIterator($this->toAbsolute(array('test.php', 'test.py')), $finder->in(self::$tmpDir)->getIterator());
+    }
+
+    public function testNameWithArrayParam()
+    {
+        $finder = $this->buildFinder();
+        $finder->name(array('test.php', 'test.py'));
         $this->assertIterator($this->toAbsolute(array('test.php', 'test.py')), $finder->in(self::$tmpDir)->getIterator());
     }
 
@@ -249,6 +267,19 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator(array(), $finder->in(self::$tmpDir)->getIterator());
     }
 
+    public function testNotNameWithArrayParam()
+    {
+        $finder = $this->buildFinder();
+        $finder->notName(array('*.php', '*.py'));
+        $this->assertIterator($this->toAbsolute(array(
+            'foo',
+            'foo/bar.tmp',
+            'toto',
+            'foo bar',
+            'qux',
+        )), $finder->in(self::$tmpDir)->getIterator());
+    }
+
     /**
      * @dataProvider getRegexNameTestData
      */
@@ -269,10 +300,24 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsolute(array('test.php')), $finder->in(self::$tmpDir)->getIterator());
     }
 
+    public function testSizeWithArrayParam()
+    {
+        $finder = $this->buildFinder();
+        $this->assertSame($finder, $finder->files()->size(array('< 1K', '> 500')));
+        $this->assertIterator($this->toAbsolute(array('test.php')), $finder->in(self::$tmpDir)->getIterator());
+    }
+
     public function testDate()
     {
         $finder = $this->buildFinder();
         $this->assertSame($finder, $finder->files()->date('until last month'));
+        $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php')), $finder->in(self::$tmpDir)->getIterator());
+    }
+
+    public function testDateWithArrayParam()
+    {
+        $finder = $this->buildFinder();
+        $this->assertSame($finder, $finder->files()->date(array('>= 2005-10-15', 'until last month')));
         $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php')), $finder->in(self::$tmpDir)->getIterator());
     }
 
@@ -641,7 +686,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
     public function testFollowLinks()
     {
-        if ('\\' == DIRECTORY_SEPARATOR) {
+        if ('\\' == \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('symlinks are not supported on Windows');
         }
 
@@ -672,15 +717,15 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $iterator = $finder->files()->name('*.php')->depth('< 1')->in(array(self::$tmpDir, __DIR__))->getIterator();
 
         $expected = array(
-            self::$tmpDir.DIRECTORY_SEPARATOR.'test.php',
-            __DIR__.DIRECTORY_SEPARATOR.'FinderTest.php',
-            __DIR__.DIRECTORY_SEPARATOR.'GlobTest.php',
-            self::$tmpDir.DIRECTORY_SEPARATOR.'qux_0_1.php',
-            self::$tmpDir.DIRECTORY_SEPARATOR.'qux_1000_1.php',
-            self::$tmpDir.DIRECTORY_SEPARATOR.'qux_1002_0.php',
-            self::$tmpDir.DIRECTORY_SEPARATOR.'qux_10_2.php',
-            self::$tmpDir.DIRECTORY_SEPARATOR.'qux_12_0.php',
-            self::$tmpDir.DIRECTORY_SEPARATOR.'qux_2_0.php',
+            self::$tmpDir.\DIRECTORY_SEPARATOR.'test.php',
+            __DIR__.\DIRECTORY_SEPARATOR.'FinderTest.php',
+            __DIR__.\DIRECTORY_SEPARATOR.'GlobTest.php',
+            self::$tmpDir.\DIRECTORY_SEPARATOR.'qux_0_1.php',
+            self::$tmpDir.\DIRECTORY_SEPARATOR.'qux_1000_1.php',
+            self::$tmpDir.\DIRECTORY_SEPARATOR.'qux_1002_0.php',
+            self::$tmpDir.\DIRECTORY_SEPARATOR.'qux_10_2.php',
+            self::$tmpDir.\DIRECTORY_SEPARATOR.'qux_12_0.php',
+            self::$tmpDir.\DIRECTORY_SEPARATOR.'qux_2_0.php',
         );
 
         $this->assertIterator($expected, $iterator);
@@ -787,11 +832,11 @@ class FinderTest extends Iterator\RealIteratorTestCase
             'toto',
             'test.py',
             'foo',
-            'foo'.DIRECTORY_SEPARATOR.'bar.tmp',
+            'foo'.\DIRECTORY_SEPARATOR.'bar.tmp',
             'foo bar',
             'qux',
-            'qux'.DIRECTORY_SEPARATOR.'baz_100_1.py',
-            'qux'.DIRECTORY_SEPARATOR.'baz_1_2.py',
+            'qux'.\DIRECTORY_SEPARATOR.'baz_100_1.py',
+            'qux'.\DIRECTORY_SEPARATOR.'baz_1_2.py',
             'qux_0_1.php',
             'qux_1000_1.php',
             'qux_1002_0.php',
@@ -809,7 +854,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testAppendWithAFinder()
     {
         $finder = $this->buildFinder();
-        $finder->files()->in(self::$tmpDir.DIRECTORY_SEPARATOR.'foo');
+        $finder->files()->in(self::$tmpDir.\DIRECTORY_SEPARATOR.'foo');
 
         $finder1 = $this->buildFinder();
         $finder1->directories()->in(self::$tmpDir);
@@ -822,7 +867,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testAppendWithAnArray()
     {
         $finder = $this->buildFinder();
-        $finder->files()->in(self::$tmpDir.DIRECTORY_SEPARATOR.'foo');
+        $finder->files()->in(self::$tmpDir.\DIRECTORY_SEPARATOR.'foo');
 
         $finder->append($this->toAbsolute(array('foo', 'toto')));
 
@@ -837,7 +882,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testAppendDoesNotRequireIn()
     {
         $finder = $this->buildFinder();
-        $finder->in(self::$tmpDir.DIRECTORY_SEPARATOR.'foo');
+        $finder->in(self::$tmpDir.\DIRECTORY_SEPARATOR.'foo');
 
         $finder1 = Finder::create()->append($finder);
 
@@ -858,7 +903,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
     public function testCountFiles()
     {
-        $files = Finder::create()->files()->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $files = Finder::create()->files()->in(__DIR__.\DIRECTORY_SEPARATOR.'Fixtures');
         $i = 0;
 
         foreach ($files as $file) {
@@ -897,7 +942,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testContains($matchPatterns, $noMatchPatterns, $expected)
     {
         $finder = $this->buildFinder();
-        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures')
+        $finder->in(__DIR__.\DIRECTORY_SEPARATOR.'Fixtures')
             ->name('*.txt')->sortByName()
             ->contains($matchPatterns)
             ->notContains($noMatchPatterns);
@@ -960,15 +1005,15 @@ class FinderTest extends Iterator\RealIteratorTestCase
     {
         $locations = array(
             __DIR__.'/Fixtures/one',
-            self::$tmpDir.DIRECTORY_SEPARATOR.'toto',
+            self::$tmpDir.\DIRECTORY_SEPARATOR.'toto',
         );
 
         $finder = $this->buildFinder();
         $finder->in($locations)->depth('< 10')->name('*.neon');
 
         $expected = array(
-            __DIR__.'/Fixtures/one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'c.neon',
-            __DIR__.'/Fixtures/one'.DIRECTORY_SEPARATOR.'b'.DIRECTORY_SEPARATOR.'d.neon',
+            __DIR__.'/Fixtures/one'.\DIRECTORY_SEPARATOR.'b'.\DIRECTORY_SEPARATOR.'c.neon',
+            __DIR__.'/Fixtures/one'.\DIRECTORY_SEPARATOR.'b'.\DIRECTORY_SEPARATOR.'d.neon',
         );
 
         $this->assertIterator($expected, $finder);
@@ -989,10 +1034,10 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testRegexSpecialCharsLocationWithPathRestrictionContainingStartFlag()
     {
         $finder = $this->buildFinder();
-        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'r+e.gex[c]a(r)s')
+        $finder->in(__DIR__.\DIRECTORY_SEPARATOR.'Fixtures'.\DIRECTORY_SEPARATOR.'r+e.gex[c]a(r)s')
             ->path('/^dir/');
 
-        $expected = array('r+e.gex[c]a(r)s'.DIRECTORY_SEPARATOR.'dir', 'r+e.gex[c]a(r)s'.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'bar.dat');
+        $expected = array('r+e.gex[c]a(r)s'.\DIRECTORY_SEPARATOR.'dir', 'r+e.gex[c]a(r)s'.\DIRECTORY_SEPARATOR.'dir'.\DIRECTORY_SEPARATOR.'bar.dat');
         $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
     }
 
@@ -1009,6 +1054,8 @@ class FinderTest extends Iterator\RealIteratorTestCase
             array('lorem', 'foobar', array('lorem.txt')),
             array('', 'lorem', array('dolor.txt', 'ipsum.txt')),
             array('ipsum dolor sit amet', '/^IPSUM/m', array('lorem.txt')),
+            array(array('lorem', 'dolor'), array(), array('lorem.txt', 'ipsum.txt', 'dolor.txt')),
+            array('', array('lorem', 'ipsum'), array('dolor.txt')),
         );
     }
 
@@ -1026,7 +1073,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testPath($matchPatterns, $noMatchPatterns, array $expected)
     {
         $finder = $this->buildFinder();
-        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures')
+        $finder->in(__DIR__.\DIRECTORY_SEPARATOR.'Fixtures')
             ->path($matchPatterns)
             ->notPath($noMatchPatterns);
 
@@ -1038,41 +1085,68 @@ class FinderTest extends Iterator\RealIteratorTestCase
         return array(
             array('', '', array()),
             array('/^A\/B\/C/', '/C$/',
-                array('A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat'),
+                array('A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C'.\DIRECTORY_SEPARATOR.'abc.dat'),
             ),
             array('/^A\/B/', 'foobar',
                 array(
-                    'A'.DIRECTORY_SEPARATOR.'B',
-                    'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C',
-                    'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'ab.dat',
-                    'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat',
+                    'A'.\DIRECTORY_SEPARATOR.'B',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'ab.dat',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C'.\DIRECTORY_SEPARATOR.'abc.dat',
                 ),
             ),
             array('A/B/C', 'foobar',
                 array(
-                    'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C',
-                    'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat',
-                    'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C',
-                    'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat.copy',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C'.\DIRECTORY_SEPARATOR.'abc.dat',
+                    'copy'.\DIRECTORY_SEPARATOR.'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C',
+                    'copy'.\DIRECTORY_SEPARATOR.'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C'.\DIRECTORY_SEPARATOR.'abc.dat.copy',
                 ),
             ),
             array('A/B', 'foobar',
                 array(
                     //dirs
-                    'A'.DIRECTORY_SEPARATOR.'B',
-                    'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C',
-                    'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B',
-                    'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C',
+                    'A'.\DIRECTORY_SEPARATOR.'B',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C',
+                    'copy'.\DIRECTORY_SEPARATOR.'A'.\DIRECTORY_SEPARATOR.'B',
+                    'copy'.\DIRECTORY_SEPARATOR.'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C',
                     //files
-                    'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'ab.dat',
-                    'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat',
-                    'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'ab.dat.copy',
-                    'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat.copy',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'ab.dat',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C'.\DIRECTORY_SEPARATOR.'abc.dat',
+                    'copy'.\DIRECTORY_SEPARATOR.'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'ab.dat.copy',
+                    'copy'.\DIRECTORY_SEPARATOR.'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C'.\DIRECTORY_SEPARATOR.'abc.dat.copy',
                 ),
             ),
             array('/^with space\//', 'foobar',
                 array(
-                    'with space'.DIRECTORY_SEPARATOR.'foo.txt',
+                    'with space'.\DIRECTORY_SEPARATOR.'foo.txt',
+                ),
+            ),
+            array(
+                '/^A/',
+                array('a.dat', 'abc.dat'),
+                array(
+                    'A',
+                    'A'.\DIRECTORY_SEPARATOR.'B',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'ab.dat',
+                ),
+            ),
+            array(
+                array('/^A/', 'one'),
+                'foobar',
+                array(
+                    'A',
+                    'A'.\DIRECTORY_SEPARATOR.'B',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C',
+                    'A'.\DIRECTORY_SEPARATOR.'a.dat',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'ab.dat',
+                    'A'.\DIRECTORY_SEPARATOR.'B'.\DIRECTORY_SEPARATOR.'C'.\DIRECTORY_SEPARATOR.'abc.dat',
+                    'one',
+                    'one'.\DIRECTORY_SEPARATOR.'a',
+                    'one'.\DIRECTORY_SEPARATOR.'b',
+                    'one'.\DIRECTORY_SEPARATOR.'b'.\DIRECTORY_SEPARATOR.'c.neon',
+                    'one'.\DIRECTORY_SEPARATOR.'b'.\DIRECTORY_SEPARATOR.'d.neon',
                 ),
             ),
         );
@@ -1080,7 +1154,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
     public function testAccessDeniedException()
     {
-        if ('\\' === DIRECTORY_SEPARATOR) {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('chmod is not supported on Windows');
         }
 
@@ -1088,7 +1162,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder->files()->in(self::$tmpDir);
 
         // make 'foo' directory non-readable
-        $testDir = self::$tmpDir.DIRECTORY_SEPARATOR.'foo';
+        $testDir = self::$tmpDir.\DIRECTORY_SEPARATOR.'foo';
         chmod($testDir, 0333);
 
         if (false === $couldRead = is_readable($testDir)) {
@@ -1120,7 +1194,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
     public function testIgnoredAccessDeniedException()
     {
-        if ('\\' === DIRECTORY_SEPARATOR) {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('chmod is not supported on Windows');
         }
 
@@ -1128,7 +1202,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder->files()->ignoreUnreadableDirs()->in(self::$tmpDir);
 
         // make 'foo' directory non-readable
-        $testDir = self::$tmpDir.DIRECTORY_SEPARATOR.'foo';
+        $testDir = self::$tmpDir.\DIRECTORY_SEPARATOR.'foo';
         chmod($testDir, 0333);
 
         if (false === ($couldRead = is_readable($testDir))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#10038


Makes the Finder library a little more convenient to use by allowing the use of arrays as parameters of methods that can be called multiple times.

This way of doing things was already present for the `Finder::in()` and `Finder::exclude()` methods, it has been extended to other methods that can be called several times to cumulate their effects.
This allows a better use of fluent methods by avoiding breaking the chaining to iterate on array variables (a little more complexity in the Finder library for less complexity in applications that uses it).


```php
// we could use
$finder = Finder::create()->in($fileRepository)->name($fileList);

// instead of
$finder = Finder::create()->in($fileRepository);
foreach ($fileList as $file) {
    $finder->name($file);
}
```

In `.php_cs` files, this would make the code more readable by separating the configuration of the execution code:

```php
<?php
const RULES = [
    '@Symfony' => true, 
    '@Symfony:risky' => true,
];
const EXCLUDED_DIRS = [
    // directories containing files with content that is autogenerated by `var_export`, which breaks CS in output code
    'Symfony/Component/Cache/Tests/Marshaller/Fixtures',
    'Symfony/Component/DependencyInjection/Tests/Fixtures',
    // ...
];
const EXCLUDED_FILES = [
    // file content autogenerated by `var_export`
    'Symfony/Component/Translation/Tests/fixtures/resources.php',
    // test template
    'Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Custom/_name_entry_label.html.php',
    // ...
];

return PhpCsFixer\Config::create()
    ->setRules(RULES)
    ->setRiskyAllowed(true)
    ->setFinder(
        PhpCsFixer\Finder::create()
            ->in(__DIR__.'/src')
            ->append(array(__FILE__))
            ->exclude(EXCLUDED_DIRS)
            ->notPath(EXCLUDED_FILES)
    )
;
```

TODO
- [x] complete the tests to validate the new syntax on all modified methods
- [x] submit changes to the Finder documentation
