### PR TITLE
[Form] Render form errors at the correct position in Bootstrap 4 horizontal layout

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
@@ -14,6 +14,8 @@
     {%- endif -%}
 {%- endblock form_label %}
 
+{% block form_label_errors %}{% endblock %}
+
 {% block form_label_class -%}
 col-sm-2
 {%- endblock form_label_class %}
@@ -28,6 +30,7 @@ col-sm-2
             {{- form_label(form) -}}
             <div class="{{ block('form_group_class') }}">
                 {{- form_widget(form) -}}
+                {{- form_errors(form) -}}
             </div>
     {##}</div>
     {%- endif -%}

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap4HorizontalLayoutTest.php
@@ -31,15 +31,15 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
             '/div
     [
         ./label[@for="name"]
-        [
-            ./span[@class="alert alert-danger d-block"]
+        /following-sibling::div[
+            ./input[@id="name"]
+            /following-sibling::span[@class="alert alert-danger d-block"]
                 [./span[@class="d-block"]
                     [./span[.="[trans]Error[/trans]"]]
                     [./span[.="[trans]Error![/trans]"]]
                 ]
                 [count(./span)=1]
         ]
-        /following-sibling::div[./input[@id="name"]]
     ]
 '
         );
@@ -213,5 +213,12 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
         $html = $this->renderRow($view, array('label' => 'foo'));
 
         $this->assertMatchesXpath($html, '/div[@class="form-group row"]/div[@class="col-sm-2" or @class="col-sm-10"]', 2);
+    }
+
+    public function testErrorWithNoLabel()
+    {
+        // This test doesn't apply to the horizontal form, as here the errors are rendered inside the widget
+        // and the widget can't be empty.
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28086
| License       | MIT
| Doc PR        | — 

In the horizontal form layout for Bootstrap 4, the errors render at a weird position. This PR intends to fix it. Not sure about ordering the form error messages and the help block in 4.1, that needs to be decided by the person, that merges this fix upwards. 🙃 

### Before
![2018-07-07 at 19 18](https://user-images.githubusercontent.com/1032411/42413194-97734f14-821b-11e8-95b7-b77f618f1fc0.png)

### After
![2018-07-07 at 19 18](https://user-images.githubusercontent.com/1032411/42413196-9ce44066-821b-11e8-83a6-14fac7e95ece.png)

**Edit** please note, that the text is in the form label container and wraps pretty early. My example screenshots don't show that too clearly, so here is another one.

![2018-07-07 at 19 27](https://user-images.githubusercontent.com/1032411/42413208-dc489b58-821b-11e8-8a72-625c5006e9a5.png)

vs.

![2018-07-07 at 19 28](https://user-images.githubusercontent.com/1032411/42413211-f5dacde8-821b-11e8-8ee2-c8d6621dedfb.png)
