### PR TITLE
[MonologBridge] Monolog 2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "doctrine/reflection": "~1.0",
         "doctrine/doctrine-bundle": "^1.5|^2.0",
         "masterminds/html5": "^2.6",
-        "monolog/monolog": "~1.11",
+        "monolog/monolog": "^1.11|^2",
         "nyholm/psr7": "^1.0",
         "ocramius/proxy-manager": "^2.1",
         "php-http/httplug": "^1.0|^2.0",

--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * The methods `DebugProcessor::getLogs()`, `DebugProcessor::countErrors()`, `Logger::getLogs()` and `Logger::countErrors()` have a new `$request` argument.
+ * Added support for Monolog 2.
 
 4.4.0
 -----

--- a/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
@@ -57,7 +57,7 @@ class ChromePhpHandler extends BaseChromePhpHandler
     /**
      * {@inheritdoc}
      */
-    protected function sendHeader($header, $content)
+    protected function sendHeader($header, $content): void
     {
         if (!$this->sendHeaders) {
             return;

--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Monolog\Handler;
 
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
@@ -74,7 +75,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     /**
      * {@inheritdoc}
      */
-    public function isHandling(array $record)
+    public function isHandling(array $record): bool
     {
         return $this->updateLevel() && parent::isHandling($record);
     }
@@ -82,7 +83,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     /**
      * {@inheritdoc}
      */
-    public function handle(array $record)
+    public function handle(array $record): bool
     {
         // we have to update the logging level each time because the verbosity of the
         // console output might have changed in the meantime (it is not immutable)
@@ -100,7 +101,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     /**
      * Disables the output.
      */
-    public function close()
+    public function close(): void
     {
         $this->output = null;
 
@@ -143,7 +144,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     /**
      * {@inheritdoc}
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         // at this point we've determined for sure that we want to output the record, so use the output's own verbosity
         $this->output->write((string) $record['formatted'], false, $this->output->getVerbosity());
@@ -152,7 +153,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultFormatter()
+    protected function getDefaultFormatter(): FormatterInterface
     {
         if (!class_exists(CliDumper::class)) {
             return new LineFormatter();

--- a/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/HttpCodeActivationStrategy.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/HttpCodeActivationStrategy.php
@@ -45,7 +45,7 @@ class HttpCodeActivationStrategy extends ErrorLevelActivationStrategy
         $this->exclusions = $exclusions;
     }
 
-    public function isHandlerActivated(array $record)
+    public function isHandlerActivated(array $record): bool
     {
         $isActivated = parent::isHandlerActivated($record);
 

--- a/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/NotFoundActivationStrategy.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FingersCrossed/NotFoundActivationStrategy.php
@@ -34,7 +34,7 @@ class NotFoundActivationStrategy extends ErrorLevelActivationStrategy
         $this->blacklist = '{('.implode('|', $excludedUrls).')}i';
     }
 
-    public function isHandlerActivated(array $record)
+    public function isHandlerActivated(array $record): bool
     {
         $isActivated = parent::isHandlerActivated($record);
 

--- a/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
@@ -59,7 +59,7 @@ class FirePHPHandler extends BaseFirePHPHandler
     /**
      * {@inheritdoc}
      */
-    protected function sendHeader($header, $content)
+    protected function sendHeader($header, $content): void
     {
         if (!self::$sendHeaders) {
             return;

--- a/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
@@ -39,7 +39,7 @@ class ServerLogHandler extends AbstractHandler
     /**
      * {@inheritdoc}
      */
-    public function handle(array $record)
+    public function handle(array $record): bool
     {
         if (!$this->isHandling($record)) {
             return false;

--- a/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
@@ -52,7 +52,7 @@ class SwiftMailerHandler extends BaseSwiftMailerHandler
     /**
      * {@inheritdoc}
      */
-    protected function send($content, array $records)
+    protected function send($content, array $records): void
     {
         parent::send($content, $records);
 

--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -59,7 +59,7 @@ class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->clear();
 

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2.9",
-        "monolog/monolog": "~1.19",
+        "monolog/monolog": "^1.19|^2",
         "symfony/service-contracts": "^1.1",
         "symfony/http-kernel": "^4.4|^5.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27857
| License       | MIT
| Doc PR        | N/A

See #27857 for the discussion.

This PR adds return types to methods that need to have one in Monolog 2.

Notes:
* The PR will break userland handlers that extend handlers from Monolog Bridge.
* I was unable to come up with a php 7.1 compatible version of `SwiftMailerHandler` that works with Monolog 1 and Monolog 2 because a method we're overriding now has a `string` type-hint on a parameter that wasn't there before. I've „solved“ this with a version switch, but I feel dirty doing this. 🙈  If you have a better solution, please enlighten me.