### PR TITLE
[EventDispatcher] Clear orphaned events on reset

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -217,6 +217,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     public function reset()
     {
         $this->called = array();
+        $this->orphanedEvents = array();
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -271,6 +271,17 @@ class TraceableEventDispatcherTest extends TestCase
 
         $this->assertCount(1, $eventDispatcher->getListeners('foo'), 'expected listener1 to be removed');
     }
+
+    public function testClearOrphanedEvents()
+    {
+        $tdispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+        $tdispatcher->dispatch('foo');
+        $events = $tdispatcher->getOrphanedEvents();
+        $this->assertCount(1, $events);
+        $tdispatcher->reset();
+        $events = $tdispatcher->getOrphanedEvents();
+        $this->assertCount(0, $events);
+    }
 }
 
 class EventSubscriber implements EventSubscriberInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | NA
| License       | MIT
| Doc PR        | NA

When the Orphaned Events feature was added in #24392 it was forgotten to also clear them when the `reset` method on the `TraceableEventDispatcher` is called. This makes the Orphaned Events tab on the Event profiler an evergrowing list when using PHP-PM (or other event loop implementations).
