### PR TITLE
[Console] correctly return parameter's default value on "--"

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -306,7 +306,7 @@ class ArgvInput extends Input
         while (0 < count($tokens)) {
             $token = array_shift($tokens);
             if ($onlyParams && '--' === $token) {
-                return false;
+                return $default;
             }
 
             foreach ($values as $value) {

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -81,7 +81,7 @@ class ArrayInput extends Input
 
         foreach ($this->parameters as $k => $v) {
             if ($onlyParams && ('--' === $k || (is_int($k) && '--' === $v))) {
-                return false;
+                return $default;
             }
 
             if (is_int($k)) {

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -395,25 +395,26 @@ class ArgvInputTest extends TestCase
     /**
      * @dataProvider provideGetParameterOptionValues
      */
-    public function testGetParameterOptionEqualSign($argv, $key, $onlyParams, $expected)
+    public function testGetParameterOptionEqualSign($argv, $key, $default, $onlyParams, $expected)
     {
         $input = new ArgvInput($argv);
-        $this->assertEquals($expected, $input->getParameterOption($key, false, $onlyParams), '->getParameterOption() returns the expected value');
+        $this->assertEquals($expected, $input->getParameterOption($key, $default, $onlyParams), '->getParameterOption() returns the expected value');
     }
 
     public function provideGetParameterOptionValues()
     {
         return array(
-            array(array('app/console', 'foo:bar', '-e', 'dev'), '-e', false, 'dev'),
-            array(array('app/console', 'foo:bar', '--env=dev'), '--env', false, 'dev'),
-            array(array('app/console', 'foo:bar', '-e', 'dev'), array('-e', '--env'), false, 'dev'),
-            array(array('app/console', 'foo:bar', '--env=dev'), array('-e', '--env'), false, 'dev'),
-            array(array('app/console', 'foo:bar', '--env=dev', '--en=1'), array('--en'), false, '1'),
-            array(array('app/console', 'foo:bar', '--env=dev', '', '--en=1'), array('--en'), false, '1'),
-            array(array('app/console', 'foo:bar', '--env', 'val'), '--env', false, 'val'),
-            array(array('app/console', 'foo:bar', '--env', 'val', '--dummy'), '--env', false, 'val'),
-            array(array('app/console', 'foo:bar', '--', '--env=dev'), '--env', false, 'dev'),
-            array(array('app/console', 'foo:bar', '--', '--env=dev'), '--env', true, false),
+            array(array('app/console', 'foo:bar'), '-e', 'default', false, 'default'),
+            array(array('app/console', 'foo:bar', '-e', 'dev'), '-e', 'default', false, 'dev'),
+            array(array('app/console', 'foo:bar', '--env=dev'), '--env', 'default', false, 'dev'),
+            array(array('app/console', 'foo:bar', '-e', 'dev'), array('-e', '--env'), 'default', false, 'dev'),
+            array(array('app/console', 'foo:bar', '--env=dev'), array('-e', '--env'), 'default', false, 'dev'),
+            array(array('app/console', 'foo:bar', '--env=dev', '--en=1'), array('--en'), 'default', false, '1'),
+            array(array('app/console', 'foo:bar', '--env=dev', '', '--en=1'), array('--en'), 'default', false, '1'),
+            array(array('app/console', 'foo:bar', '--env', 'val'), '--env', 'default', false, 'val'),
+            array(array('app/console', 'foo:bar', '--env', 'val', '--dummy'), '--env', 'default', false, 'val'),
+            array(array('app/console', 'foo:bar', '--', '--env=dev'), '--env', 'default', false, 'dev'),
+            array(array('app/console', 'foo:bar', '--', '--env=dev'), '--env', 'default', true, 'default'),
         );
     }
 

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -47,14 +47,14 @@ class ArrayInputTest extends TestCase
     {
         $input = new ArrayInput(array('name' => 'Fabien', '--foo' => 'bar'));
         $this->assertEquals('bar', $input->getParameterOption('--foo'), '->getParameterOption() returns the option of specified name');
-        $this->assertFalse($input->getParameterOption('--bar'), '->getParameterOption() returns the default if an option is not present in the passed parameters');
+        $this->assertEquals('default', $input->getParameterOption('--bar', 'default'), '->getParameterOption() returns the default value if an option is not present in the passed parameters');
 
         $input = new ArrayInput(array('Fabien', '--foo' => 'bar'));
         $this->assertEquals('bar', $input->getParameterOption('--foo'), '->getParameterOption() returns the option of specified name');
 
         $input = new ArrayInput(array('--foo', '--', '--bar' => 'woop'));
         $this->assertEquals('woop', $input->getParameterOption('--bar'), '->getParameterOption() returns the correct value if an option is present in the passed parameters');
-        $this->assertFalse($input->getParameterOption('--bar', false, true), '->getParameterOption() returns false if an option is present in the passed parameters after an end of options signal');
+        $this->assertEquals('default', $input->getParameterOption('--bar', 'default', true), '->getParameterOption() returns the default value if an option is present in the passed parameters after an end of options signal');
     }
 
     public function testParseArguments()


### PR DESCRIPTION
Fixes #27916

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27916
| License       | MIT
| Doc PR        | n/a

The tests have been adjusted to use a default value different from the one in `A*Input::getParameterOption()`'s signature. This would have detected the bug in the first place and should prevent future regressions.