### PR TITLE
[Form/Profiler] Massively reducing memory footprint of form profiling pages...

### DIFF
--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
 use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\VarDumper\Caster\CutStub;
 
 /**
  * Default implementation of {@link FormDataExtractorInterface}.
@@ -155,6 +156,10 @@ class FormDataExtractor implements FormDataExtractorInterface
         );
 
         foreach ($view->vars as $varName => $value) {
+            // Removing redundant variable from view variables
+            if ('form' === $varName) {
+                $value = new CutStub($value);
+            }
             $data['view_vars'][$varName] = $value;
         }
 


### PR DESCRIPTION
… by removing redundant 'form' variable from view variables.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

## Problem
When trying to profile large forms in web profiler, the page can get so big that the memory footprint of the web browser excedes 1Gb making everything unusable and sometimes crashing the browser.

This is especially true for "deep" forms as every node of the form also contains its children in the debugging infos.

## Solution
When removing the "form" view variable that actually contains duplicated contents of everything already displayed in the page, the memory footprint massively decrease making the page usable again even form very complex and deep forms.

By using CutStub, we keep a necessary level of information by providing the information that the variable is indeed here but not directly accessible in the dump.