### PR TITLE
[HttpFoundation] Suppress side effects in 'get' and 'has' methods of NamespacedAttributeBag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
@@ -124,7 +124,13 @@ class NamespacedAttributeBag extends AttributeBag
 
         foreach ($parts as $part) {
             if (null !== $array && !array_key_exists($part, $array)) {
-                $array[$part] = $writeContext ? array() : null;
+                if (!$writeContext) {
+                    $null = null;
+
+                    return $null;
+                }
+
+                $array[$part] = array();
             }
 
             $array = &$array[$part];

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/NamespacedAttributeBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/NamespacedAttributeBagTest.php
@@ -85,6 +85,17 @@ class NamespacedAttributeBagTest extends TestCase
     /**
      * @dataProvider attributesProvider
      */
+    public function testHasNoSideEffect($key, $value, $expected)
+    {
+        $expected = json_encode($this->bag->all());
+        $this->bag->has($key);
+
+        $this->assertEquals($expected, json_encode($this->bag->all()));
+    }
+
+    /**
+     * @dataProvider attributesProvider
+     */
     public function testGet($key, $value, $expected)
     {
         $this->assertEquals($value, $this->bag->get($key));
@@ -94,6 +105,17 @@ class NamespacedAttributeBagTest extends TestCase
     {
         $this->assertNull($this->bag->get('user2.login'));
         $this->assertEquals('default', $this->bag->get('user2.login', 'default'));
+    }
+
+    /**
+     * @dataProvider attributesProvider
+     */
+    public function testGetNoSideEffect($key, $value, $expected)
+    {
+        $expected = json_encode($this->bag->all());
+        $this->bag->get($key);
+
+        $this->assertEquals($expected, json_encode($this->bag->all()));
     }
 
     /**


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27912 
| License       | MIT
| Doc PR        | -

As @Gemineye reported there was a bug in `get` and `has` methods of NamespacedAttributeBag. These methods accept composite names as an argument (like 'foo/bar' or 'foo/bar/baz') to reach the elements of stored arrays. Up to now these methods erroneously created entries (`->get('foo/bar')` created `['foo' => null]`, `->get('foo/bar/baz')` created `['foo' => ['bar' => null]]`).


