### PR TITLE
[HttpFoundation] Fixed phpdoc for get method of HeaderBag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -101,11 +101,11 @@ class HeaderBag implements \IteratorAggregate, \Countable
     /**
      * Returns a header value by name.
      *
-     * @param string          $key     The header name
-     * @param string|string[] $default The default value
-     * @param bool            $first   Whether to return the first value or all header values
+     * @param string               $key     The header name
+     * @param string|string[]|null $default The default value
+     * @param bool                 $first   Whether to return the first value or all header values
      *
-     * @return string|string[] The first header value or default value if $first is true, an array of values otherwise
+     * @return string|string[]|null The first header value or default value if $first is true, an array of values otherwise
      */
     public function get($key, $default = null, $first = true)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Method `\Symfony\Component\HttpFoundation\HeaderBag::get` return type was declared only as `string|string[]` but there is also possibility of returning of `null` value since the `null` is the default value for second parameter.
