### PR TITLE
[FrameworkBundle] [Command] TranslationUpdate change default output to xlf

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -67,7 +67,7 @@ class TranslationUpdateCommand extends Command
                 new InputArgument('locale', InputArgument::REQUIRED, 'The locale'),
                 new InputArgument('bundle', InputArgument::OPTIONAL, 'The bundle name or directory where to load the messages, defaults to app/Resources folder'),
                 new InputOption('prefix', null, InputOption::VALUE_OPTIONAL, 'Override the default prefix', '__'),
-                new InputOption('output-format', null, InputOption::VALUE_OPTIONAL, 'Override the default output format', 'yml'),
+                new InputOption('output-format', null, InputOption::VALUE_OPTIONAL, 'Override the default output format', 'xlf'),
                 new InputOption('dump-messages', null, InputOption::VALUE_NONE, 'Should the messages be dumped in the console'),
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Should the update be done'),
                 new InputOption('no-backup', null, InputOption::VALUE_NONE, 'Should backup be disabled'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | Not applicable
| License | MIT
| Doc PR | Not applicable



Simple modification on the default output for the translation: update command to XLIFF (xlf)
It's to be in agreement with the documentation

![image](https://user-images.githubusercontent.com/2004449/42637935-a91dcabc-85ec-11e8-86db-9c8bea5e710b.png)

Link to the documentation : 
https://symfony.com/doc/master/translation.html#translation-resource-file-names-and-locations
