### PR TITLE
[Security] Update user phpdoc on tokens

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -77,14 +77,7 @@ abstract class AbstractToken implements TokenInterface
     }
 
     /**
-     * Sets the user in the token.
-     *
-     * The user can be a UserInterface instance, or an object implementing
-     * a __toString method or the username as a regular string.
-     *
-     * @param string|object $user The user
-     *
-     * @throws \InvalidArgumentException
+     * {@inheritdoc}
      */
     public function setUser($user)
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -47,17 +47,22 @@ interface TokenInterface extends \Serializable
     /**
      * Returns a user representation.
      *
-     * @return mixed Can be a UserInterface instance, an object implementing a __toString method,
-     *               or the username as a regular string
+     * @return string|object Can be a UserInterface instance, an object implementing a __toString method,
+     *                       or the username as a regular string
      *
      * @see AbstractToken::setUser()
      */
     public function getUser();
 
     /**
-     * Sets a user.
+     * Sets the user in the token.
      *
-     * @param mixed $user
+     * The user can be a UserInterface instance, or an object implementing
+     * a __toString method or the username as a regular string.
+     *
+     * @param string|object $user The user
+     *
+     * @throws \InvalidArgumentException
      */
     public function setUser($user);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
 
As implemented here:

https://github.com/symfony/symfony/blob/1e16a8b979683a7136d30e37eec7b401586ad940/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php#L78-L88

Note IMHO `string|object` is intended, and used consistently elsewhere, e.g.: https://github.com/symfony/symfony/blob/f80376217d33490fcb9592262c5ac5a08519a7f9/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php#L27