### PR TITLE
[WebProfilerBundle] Fixed icon alignment issue using Bootstrap 4.1.2

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -263,6 +263,7 @@ div.sf-toolbar .sf-toolbar-block a:hover {
     border-width: 0;
     position: relative;
     top: 8px;
+    vertical-align: baseline;
 }
 
 .sf-toolbar-block .sf-toolbar-icon img + span,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes?
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Hi,

This PR fixes an issue introduced by Bootstrap 4.1.2: it vertically aligns SVG icons in the middle instead of letting it stay at the baseline.

I'm not sure this PR is relevant but, if I'm not the only Bootstrap user, I guess it will be useful to many and it does not break anything: it enforces what should be default.

[Update] Here is the related PR merged into Bootstrap that causes the issue: https://github.com/twbs/bootstrap/pull/25874

[Update 2] Before the fix:

![fix_before](https://user-images.githubusercontent.com/3929498/42696806-966cfc9e-86b9-11e8-90a9-7a6dc18a1809.png)

After the fix:

![fix_after](https://user-images.githubusercontent.com/3929498/42696821-9df8ef22-86b9-11e8-8c6c-62a4afa752a3.png)
