### PR TITLE
[Security] Deprecate returning stringish objects from Security::getUser

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -94,6 +94,7 @@ Security
    custom anonymous and remember me token classes is deprecated. To
    use custom tokens, extend the existing `Symfony\Component\Security\Core\Authentication\Token\AnonymousToken`
    or `Symfony\Component\Security\Core\Authentication\Token\RememberMeToken`.
+ * Accessing the user object that is not an instance of `UserInterface` from `Security::getUser()` is deprecated.
 
 SecurityBundle
 --------------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -126,6 +126,7 @@ Security
  * The `FirewallMapInterface::getListeners()` method must return an array of 3 elements,
    the 3rd one must be either a `LogoutListener` instance or `null`.
  * The `AuthenticationTrustResolver` constructor arguments have been removed.
+ * A user object that is not an instance of `UserInterface` cannot be accessed from `Security::getUser()` anymore and returns `null` instead.
 
 SecurityBundle
 --------------

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
   use custom tokens, extend the existing `Symfony\Component\Security\Core\Authentication\Token\AnonymousToken`
   or `Symfony\Component\Security\Core\Authentication\Token\RememberMeToken`.
 * allow passing null as $filter in LdapUserProvider to get the default filter
+* accessing the user object that is not an instance of `UserInterface` from `Security::getUser()` is deprecated
 
 4.1.0
 -----

--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -46,6 +46,11 @@ final class Security
             return null;
         }
 
+        if (!$user instanceof UserInterface) {
+            @trigger_error(sprintf('Accessing the user object "%s" that is not an instance of "%s" from "%s()" is deprecated since Symfony 4.2, use "getToken()->getUser()" instead.', get_class($user), UserInterface::class, __METHOD__), E_USER_DEPRECATED);
+            //return null; // 5.0 behavior
+        }
+
         return $user;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes-ish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

`$user` can also be an object implementing `__ toString`. Here we want only true user objects...