### PR TITLE
[FrameworkBundle] fix compatibility with older Cache versions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -25,6 +25,8 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+use Symfony\Component\Cache\ResettableInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\DirectoryResource;
@@ -326,6 +328,12 @@ class FrameworkExtension extends Extension
             ->addTag('kernel.event_subscriber');
         $container->registerForAutoconfiguration(ResetInterface::class)
             ->addTag('kernel.reset', array('method' => 'reset'));
+
+        if (!interface_exists(MarshallerInterface::class)) {
+            $container->registerForAutoconfiguration(ResettableInterface::class)
+                ->addTag('kernel.reset', array('method' => 'reset'));
+        }
+
         $container->registerForAutoconfiguration(ProcessorInterface::class)
             ->addTag('monolog.processor');
         $container->registerForAutoconfiguration(PropertyListExtractorInterface::class)

--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -4,4 +4,4 @@ CHANGELOG
 1.0.0
 -----
 
- * added `Service\ResetInterface` to provides a way to reset an object to its initial state
+ * added `Service\ResetInterface` to provide a way to reset an object to its initial state

--- a/src/Symfony/Contracts/README.md
+++ b/src/Symfony/Contracts/README.md
@@ -22,7 +22,7 @@ FAQ
 
 The abstractions in this package are useful to achieve loose coupling and
 interoperability. By using the provided interfaces as type hints, you are able
-to reuse any implementations that match their contracts. It could be a Symfony
+to reuse any implementation that matches their contracts. It could be a Symfony
 component, or another one provided by the PHP community at large.
 
 Depending on their semantics, some interfaces can be combined with autowiring to
@@ -34,12 +34,12 @@ any other means provided by your framework.)
 
 ### How is this different from PHP-FIG's PSRs?
 
-When applicable, the provided contracts are built on top of PHP-FIG's PSR. We
+When applicable, the provided contracts are built on top of PHP-FIG's PSRs. We
 encourage relying on them and won't duplicate the effort. Still, the FIG has
 different goals and different processes. Here, we don't need to seek universal
 standards. Instead, we're providing abstractions that are compatible with the
 implementations provided by Symfony. This should actually also contribute
-positively to the PHP-FIG (from which Symfony is a member), by hinting the group
+positively to the PHP-FIG (of which Symfony is a member), by hinting the group
 at some abstractions the PHP world might like to take inspiration from.
 
 ### Why isn't this package split into several packages?


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

FrameworkBundle 4.2 will be compatible with older versions of the Cache
component. In those versions adapters don't implement `ResetInterface`.
For backwards compatibility they still need to be tagged.