### PR TITLE
Update css for svg files in web profiler toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -70,6 +70,7 @@
 .sf-toolbarreset svg,
 .sf-toolbarreset img {
     height: 20px;
+    width: 20px;
     display: inline-block;
 }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -39,7 +39,7 @@
     -webkit-box-sizing: content-box;
     -moz-box-sizing: content-box;
     box-sizing: content-box;
-    vertical-align: baseline !important;
+    vertical-align: baseline;
     letter-spacing: normal;
     width: auto;
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -39,7 +39,7 @@
     -webkit-box-sizing: content-box;
     -moz-box-sizing: content-box;
     box-sizing: content-box;
-    vertical-align: baseline;
+    vertical-align: baseline !important;
     letter-spacing: normal;
     width: auto;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

Update css for svg files in web profiler toolbar :
- Fix vertical-align (because some reset css like Bootstrap 4.1.2 add `svg:not(:root) {
    overflow: hidden;
    vertical-align: middle;
}`
- Fix scaling issue in IE9, IE10 and IE11 (I know IE is bad but ... :-) )
