### PR TITLE
[Finder] Added a way to inverse a previous sorting

### DIFF
--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added $useNaturalSort option to Finder::sortByName() method
+ * added `Finder::reverseSorting` to reverse the sorting
 
 4.0.0
 -----

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -48,6 +48,7 @@ class Finder implements \IteratorAggregate, \Countable
     private $depths = array();
     private $sizes = array();
     private $followLinks = false;
+    private $reverseSorting = false;
     private $sort = false;
     private $ignore = 0;
     private $dirs = array();
@@ -461,6 +462,18 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Reverses the sorting.
+     *
+     * @return $this
+     */
+    public function reverseSorting()
+    {
+        $this->reverseSorting = true;
+
+        return $this;
+    }
+
+    /**
      * Sorts files and directories by the last inode changed time.
      *
      * This is the time that the inode information was last modified (permissions, owner, group or other metadata).
@@ -736,6 +749,11 @@ class Finder implements \IteratorAggregate, \Countable
 
         if ($this->sort) {
             $iteratorAggregate = new Iterator\SortableIterator($iterator, $this->sort);
+            $iterator = $iteratorAggregate->getIterator();
+        }
+
+        if ($this->reverseSorting) {
+            $iteratorAggregate = new Iterator\ReverseSortingIterator($iterator);
             $iterator = $iteratorAggregate->getIterator();
         }
 

--- a/src/Symfony/Component/Finder/Iterator/ReverseSortingIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ReverseSortingIterator.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Iterator;
+
+/**
+ * Reverse the order of a previous iterator.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class ReverseSortingIterator implements \IteratorAggregate
+{
+    private $iterator;
+
+    public function __construct(\Traversable $iterator)
+    {
+        $this->iterator = $iterator;
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator(array_reverse(iterator_to_array($this->iterator, true)));
+    }
+}

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -611,6 +611,30 @@ class FinderTest extends Iterator\RealIteratorTestCase
         )), $finder->in(self::$tmpDir)->getIterator());
     }
 
+    public function testReverseSorting()
+    {
+        $finder = $this->buildFinder();
+        $this->assertSame($finder, $finder->sortByName());
+        $this->assertSame($finder, $finder->reverseSorting());
+        $this->assertOrderedIteratorInForeach($this->toAbsolute(array(
+            'toto',
+            'test.py',
+            'test.php',
+            'qux_2_0.php',
+            'qux_12_0.php',
+            'qux_10_2.php',
+            'qux_1002_0.php',
+            'qux_1000_1.php',
+            'qux_0_1.php',
+            'qux/baz_1_2.py',
+            'qux/baz_100_1.py',
+            'qux',
+            'foo/bar.tmp',
+            'foo bar',
+            'foo',
+        )), $finder->in(self::$tmpDir)->getIterator());
+    }
+
     public function testSortByNameNatural()
     {
         $finder = $this->buildFinder();

--- a/src/Symfony/Component/Finder/Tests/Iterator/ReverseSortingIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/ReverseSortingIteratorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Tests\Iterator;
+
+use Symfony\Component\Finder\Iterator\ReverseSortingIterator;
+
+class ReverseSortingIteratorTest extends IteratorTestCase
+{
+    public function test()
+    {
+        $iterator = new ReverseSortingIterator(new MockFileListIterator(array(
+            'a.txt',
+            'b.yaml',
+            'c.php',
+        )));
+
+        $result = iterator_to_array($iterator);
+        $this->assertCount(3, $iterator);
+        $this->assertSame('c.php', $result[0]->getFilename());
+        $this->assertSame('b.yaml', $result[1]->getFilename());
+        $this->assertSame('a.txt', $result[2]->getFilename());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

---

Sometimes, it's useful to inverse the previous sorting.
For exemple when you want to display the most recent uploaded files