### PR TITLE
[Routing][FrameworkBundle] Allow configurable query encoding type in UrlGenerator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * Allowed configuring query encoding type passed to `http_build_query` in `Symfony\Component\Routing\Generator\UrlGenerator` via a new `framework.router.query_encoding_type` option
+
 4.2.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -468,6 +468,21 @@ class Configuration implements ConfigurationInterface
                             ->defaultTrue()
                         ->end()
                         ->booleanNode('utf8')->defaultFalse()->end()
+                        ->scalarNode('query_encoding_type')
+                            ->validate()
+                                ->ifNotInArray(array(PHP_QUERY_RFC1738, PHP_QUERY_RFC3986))
+                                ->thenInvalid(
+                                    'The value %s is not allowed for path "framework.router.query_encoding_type". '.
+                                    "Permissible values are PHP_QUERY_RFC1738 and PHP_QUERY_RFC3986, entered as a constant: '!php/const PHP_QUERY_RFC1738'"
+                                )
+                            ->end()
+                            ->info(
+                                "This value defaults to PHP_QUERY_RFC3986, which makes the UrlGenerator percent-encode spaces (%20) when building query strings.\n".
+                                "It can be set to PHP_QUERY_RFC1738 to make the UrlGenerator encode spaces as plus signs (+) instead.\n".
+                                "It should be declared as a constant, like '!php/const PHP_QUERY_RFC1738'"
+                            )
+                            ->defaultValue(PHP_QUERY_RFC3986)
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -743,6 +743,9 @@ class FrameworkExtension extends Extension
         if (isset($config['type'])) {
             $argument['resource_type'] = $config['type'];
         }
+        if (isset($config['query_encoding_type'])) {
+            $argument['query_encoding_type'] = $config['query_encoding_type'];
+        }
         $router->replaceArgument(2, $argument);
 
         $container->setParameter('request_listener.http_port', $config['http_port']);

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~3.4|~4.0",
         "symfony/finder": "~3.4|~4.0",
-        "symfony/routing": "^4.1"
+        "symfony/routing": "^4.3"
     },
     "require-dev": {
         "doctrine/cache": "~1.0",

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * Added a `query_encoding_type` configuration option for `UrlGenerator` to allow encoding query strings according to RFC 1738. 
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -55,12 +55,14 @@ class {$options['class']} extends {$options['base_class']}
 {
     private static \$declaredRoutes;
     private \$defaultLocale;
-
-    public function __construct(RequestContext \$context, LoggerInterface \$logger = null, string \$defaultLocale = null)
+    protected \$queryEncodingType;
+    
+    public function __construct(RequestContext \$context, LoggerInterface \$logger = null, string \$defaultLocale = null, int \$queryEncodingType = PHP_QUERY_RFC3986)
     {
         \$this->context = \$context;
         \$this->logger = \$logger;
         \$this->defaultLocale = \$defaultLocale;
+        \$this->queryEncodingType = \$queryEncodingType;
         if (null === self::\$declaredRoutes) {
             self::\$declaredRoutes = {$this->generateDeclaredRoutes()};
         }

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -35,6 +35,15 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
      */
     protected $strictRequirements = true;
 
+    /**
+     * By default, http_build_query() uses PHP_QUERY_RFC1738 as its fourth
+     * parameter. This implementation passes PHP_QUERY_RFC3986 as its preferred
+     * encoding type, but it can be configured to use PHP_QUERY_RFC1738.
+     *
+     * @var int
+     */
+    protected $queryEncodingType = PHP_QUERY_RFC3986;
+
     protected $logger;
 
     private $defaultLocale;
@@ -67,12 +76,13 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         '%7C' => '|',
     );
 
-    public function __construct(RouteCollection $routes, RequestContext $context, LoggerInterface $logger = null, string $defaultLocale = null)
+    public function __construct(RouteCollection $routes, RequestContext $context, LoggerInterface $logger = null, string $defaultLocale = null, int $queryEncodingType = PHP_QUERY_RFC3986)
     {
         $this->routes = $routes;
         $this->context = $context;
         $this->logger = $logger;
         $this->defaultLocale = $defaultLocale;
+        $this->queryEncodingType = $queryEncodingType;
     }
 
     /**
@@ -269,7 +279,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
             unset($extra['_fragment']);
         }
 
-        if ($extra && $query = http_build_query($extra, '', '&', PHP_QUERY_RFC3986)) {
+        if ($extra && $query = http_build_query($extra, '', '&', $this->queryEncodingType)) {
             // "/" and "?" can be left decoded for better user experience, see
             // http://tools.ietf.org/html/rfc3986#section-3.4
             $url .= '?'.strtr($query, array('%2F' => '/'));

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -117,6 +117,7 @@ class Router implements RouterInterface, RequestMatcherInterface
      *   * resource_type:          Type hint for the main resource (optional)
      *   * strict_requirements:    Configure strict requirement checking for generators
      *                             implementing ConfigurableRequirementsInterface (default is true)
+     *   * query_encoding_type:    Configure the encoding type passed by generators to http_build_query
      *
      * @param array $options An array of options
      *
@@ -137,6 +138,7 @@ class Router implements RouterInterface, RequestMatcherInterface
             'matcher_cache_class' => 'ProjectUrlMatcher',
             'resource_type' => null,
             'strict_requirements' => true,
+            'query_encoding_type' => PHP_QUERY_RFC3986,
         );
 
         // check option names and live merge, if errors are encountered Exception will be thrown
@@ -321,7 +323,7 @@ class Router implements RouterInterface, RequestMatcherInterface
         }
 
         if (null === $this->options['cache_dir'] || null === $this->options['generator_cache_class']) {
-            $this->generator = new $this->options['generator_class']($this->getRouteCollection(), $this->context, $this->logger);
+            $this->generator = new $this->options['generator_class']($this->getRouteCollection(), $this->context, $this->logger, null, $this->options['query_encoding_type']);
         } else {
             $cache = $this->getConfigCacheFactory()->cache($this->options['cache_dir'].'/'.$this->options['generator_cache_class'].'.php',
                 function (ConfigCacheInterface $cache) {
@@ -340,7 +342,7 @@ class Router implements RouterInterface, RequestMatcherInterface
                 require_once $cache->getPath();
             }
 
-            $this->generator = new $this->options['generator_cache_class']($this->context, $this->logger);
+            $this->generator = new $this->options['generator_cache_class']($this->context, $this->logger, null, $this->options['query_encoding_type']);
         }
 
         if ($this->generator instanceof ConfigurableRequirementsInterface) {

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -253,4 +253,32 @@ class PhpGeneratorDumperTest extends TestCase
         $this->assertEquals('https://localhost/app.php/testing', $absoluteUrl);
         $this->assertEquals('/app.php/testing', $relativeUrl);
     }
+
+    public function testDumpWithDefaultQueryEncoding()
+    {
+        $this->routeCollection->add('Test1', new Route('/with space'));
+
+        file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump(array('class' => 'Rfc3986UrlGenerator')));
+        include $this->testTmpFilepath;
+
+        $rfc3986UrlGenerator = new \Rfc3986UrlGenerator(new RequestContext());
+
+        $url = $rfc3986UrlGenerator->generate('Test1', array('query' => 'with space', '_fragment' => 'with space'));
+
+        $this->assertEquals('/with%20space?query=with%20space#with%20space', $url);
+    }
+
+    public function testDumpWithRfc1738QueryEncoding()
+    {
+        $this->routeCollection->add('Test1', new Route('/with space'));
+
+        file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump(array('class' => 'Rfc1738UrlGenerator')));
+        include $this->testTmpFilepath;
+
+        $rfc1738UrlGenerator = new \Rfc1738UrlGenerator(new RequestContext(), null, null, PHP_QUERY_RFC1738);
+
+        $url = $rfc1738UrlGenerator->generate('Test1', array('query' => 'with space', '_fragment' => 'with space'));
+
+        $this->assertEquals('/with%20space?query=with+space#with%20space', $url);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | symfony/symfony-docs#10073

This PR introduces a change that makes it very easy for developers to use RFC 1738 if they choose.

I have seen #19625, but I believe there are cases when PHP_QUERY_RFC1738 may be preferred even if the generator is not used in a form context, strictly speaking. One such case is search — it can begin with an actual form, but subsequent facet and pagination links can simply be generated. Pagination and related search links in Google use RFC 1738, as do pagination and “Pro Tip!” recommendation links on GitHub.

While we could simply replace `%20` with `+` after generating facet URLs, it becomes much more complicated to accomplish the same effect in pagination links if you are using a bundle like KnpPaginatorBundle.

Extending the generator class seems excessive, as it would require copying over 150 lines of code to override the `doGenerate` method just to change one parameter. 
