### PR TITLE
[FileValidator] Format file size in validation message according to binaryFormat option

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -58,7 +58,7 @@ class FileValidator extends ConstraintValidator
                         $binaryFormat = $constraint->binaryFormat;
                     } else {
                         $limitInBytes = $iniLimitSize;
-                        $binaryFormat = true;
+                        $binaryFormat = null === $constraint->binaryFormat ? true : $constraint->binaryFormat;
                     }
 
                     list($sizeAsString, $limitAsString, $suffix) = $this->factorizeSizes(0, $limitInBytes, $binaryFormat);

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -455,11 +455,17 @@ abstract class FileValidatorTest extends AbstractConstraintValidatorTest
                 '{{ suffix }}' => 'bytes',
             ), '1');
 
+            // access FileValidator::factorizeSizes() private method to format max file size
+            $reflection = new \ReflectionClass(\get_class(new FileValidator()));
+            $method = $reflection->getMethod('factorizeSizes');
+            $method->setAccessible(true);
+            list($sizeAsString, $limit, $suffix) = $method->invokeArgs(new FileValidator(), array(0, UploadedFile::getMaxFilesize(), false));
+
             // it correctly parses the maxSize option and not only uses simple string comparison
             // 1000M should be bigger than the ini value
             $tests[] = array(UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', array(
-                '{{ limit }}' => UploadedFile::getMaxFilesize() / 1048576,
-                '{{ suffix }}' => 'MiB',
+                '{{ limit }}' => $limit,
+                '{{ suffix }}' => $suffix,
             ), '1000M');
 
             // it correctly parses the maxSize option and not only uses simple string comparison


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8 up to master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27682
| License       | MIT
| Doc PR        | 


The binaryFormat option of the constraint is not taken into account if the maxsize limit is defined by the php configuration files.
This patch correct this inconsistent behavior.

If the binaryOption is not set, the unit of measurement used remains in binary because it’s the unit used in php configuration files.