### PR TITLE
Fix SVGs not scaling in IE9, IE10, and IE11

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -60,6 +60,7 @@
 .sf-toolbarreset svg,
 .sf-toolbarreset img {
     height: 20px;
+    width: 20px;
     display: inline-block;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8 up to 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

Fix scaling issue in IE9, IE10 and IE11

Before change:
[![web profiler before](https://preview.ibb.co/nQ2kDd/web_profiler_before.png)](https://ibb.co/cOBdYd)

After change:
[![web profiler after](https://preview.ibb.co/kCKnRy/web_profiler_after.png)](https://ibb.co/ntcJYd)

No breaking chrome:
[![web profiler chrome](https://preview.ibb.co/dGQ5Dd/web_profiler_chrome.png)](https://ibb.co/fp1dYd)