### PR TITLE
[DX] Fix PHPDoc return type

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/GetResponseEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseEvent.php
@@ -29,7 +29,7 @@ class GetResponseEvent extends KernelEvent
     /**
      * Returns the response object.
      *
-     * @return Response
+     * @return Response|null
      */
     public function getResponse()
     {


### PR DESCRIPTION
GetResponseEvent::getResponse() may return null too

| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT

While doing static analysis on my code, I got a false negative for this method, since it may return null, but the PHPDoc says otherwise.