### PR TITLE
[WebProfilerBundle] Add server timing

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\DependencyInjection;
 
+use Symfony\Bundle\WebProfilerBundle\EventListener\ServerTimingListener;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -53,6 +54,13 @@ class WebProfilerExtension extends Extension
             $container->getDefinition('web_profiler.debug_toolbar')->replaceArgument(4, $config['excluded_ajax_paths']);
             $container->setParameter('web_profiler.debug_toolbar.intercept_redirects', $config['intercept_redirects']);
             $container->setParameter('web_profiler.debug_toolbar.mode', $config['toolbar'] ? WebDebugToolbarListener::ENABLED : WebDebugToolbarListener::DISABLED);
+        }
+
+        if ($config['server_timing']) {
+            $container->register('web_profiler.server_timing', ServerTimingListener::class)
+                ->addArgument(new Reference('debug.stopwatch'))
+                ->setPrivate(true)
+                ->addTag('kernel.event_subscriber');
         }
 
         if (Kernel::VERSION_ID >= 40008 || (Kernel::VERSION_ID >= 30408 && Kernel::VERSION_ID < 40000)) {

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/ServerTimingListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/ServerTimingListener.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Stopwatch\Section;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\Stopwatch\StopwatchPeriod;
+
+/**
+ * ServerTimingListener exposes collected metrics in the response's headers following the server timing specifications.
+ *
+ * @see https://www.w3.org/TR/server-timing/
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class ServerTimingListener implements EventSubscriberInterface
+{
+    private $stopwatch;
+
+    public function __construct(Stopwatch $stopwatch = null)
+    {
+        $this->stopwatch = $stopwatch;
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (null === $this->stopwatch || !$event->isMasterRequest()) {
+            return;
+        }
+        $response = $event->getResponse();
+        $durationByCategory = $this->computeTiming();
+
+        $timing = array();
+        \arsort($durationByCategory);
+        $i = 0;
+        foreach ($durationByCategory as $name => $duration) {
+            // prefix the metric's name with a counter to force browser to keep the order
+            $timing[] = sprintf('%s;dur=%.3f;desc="%s"', sprintf('%\'.03d-%s', $i++, \preg_replace('/[^a-z0-9#_!#$%&\'*+.^_`|~-]/i', '-', $name)), $duration, \addslashes($name));
+        }
+
+        $response->headers->set('Server-Timing', implode(',', $timing));
+    }
+
+    protected function computeTiming()
+    {
+        // Collect list of periods per category
+        $periodsByCategory = array();
+        foreach ($this->stopwatch->getSections() as $section) {
+            $periodsByCategory = \array_merge_recursive($periodsByCategory, $this->collectPeriods($section));
+        }
+
+        $durationByCategory = array();
+        // Remove dupplicate period in the same time frame and compute duration
+        foreach ($periodsByCategory as $category => $periods) {
+            $duration = 0;
+            \usort($periods, function (StopwatchPeriod $a, StopwatchPeriod $b) {
+                return array($a->getStartTime(), $a->getEndTime()) <=> array($b->getStartTime(), $b->getEndTime());
+            });
+            $lastPeriod = null;
+            foreach ($periods as $period) {
+                if (null !== $lastPeriod && $lastPeriod->getEndTime() > $period->getStartTime()) {
+                    if ($period->getEndTime() <= $lastPeriod->getEndTime()) {
+                        continue;
+                    }
+
+                    $period = new StopwatchPeriod($lastPeriod->getEndTime(), $period->getEndTime(), true);
+                }
+
+                $duration += $period->getDuration();
+                $lastPeriod = $period;
+            }
+            $durationByCategory[$category] = $duration;
+        }
+
+        return $durationByCategory;
+    }
+
+    private function collectPeriods(Section $section)
+    {
+        $periods = array();
+        foreach ($section->getEvents() as $event) {
+            if (!isset($periods[$category = $event->getCategory()])) {
+                $periods[$category] = $event->getPeriods();
+            } else {
+                $periods[$category] = array_merge($periods[$event->getCategory()], $event->getPeriods());
+            }
+        }
+
+        foreach ($section->getChildren() as $child) {
+            $periods = \array_merge_recursive($periods, $this->collectPeriods($child));
+        }
+
+        return $periods;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => array('onKernelResponse', -128),
+        );
+    }
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/ServerTimingListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/ServerTimingListenerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\WebProfilerBundle\EventListener\ServerTimingListener;
+use Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * @group time-sensitive
+ */
+class ServerTimingListenerTest extends TestCase
+{
+    /**
+     * @dataProvider getInjectHeaderTests
+     */
+    public function testInjectHeader(array $events, $expected)
+    {
+        $stopWatch = new Stopwatch();
+        $listener = new ServerTimingListener($stopWatch);
+
+        $request = new Request();
+        $response = new Response();
+
+        foreach ($events as list($category, $duration)) {
+            $stopWatch->start($category, $category);
+            \usleep($duration * 1000);
+            $stopWatch->stop($category);
+        }
+
+        $listener->onKernelResponse(new FilterResponseEvent($this->getMockBuilder(KernelInterface::class)->getMock(), $request, HttpKernelInterface::MASTER_REQUEST, $response));
+
+        $this->assertEquals($expected, $response->headers->get('Server-Timing'));
+    }
+
+    public function getInjectHeaderTests()
+    {
+        return array(
+            array(array(), ''),
+            array(array(array('foo', 10)), '000-foo;dur=10.000;desc="foo"'),
+            array(array(array('foo', 10), array('bar', 20)), '000-bar;dur=20.000;desc="bar",001-foo;dur=10.000;desc="foo"'),
+            array(array(array('foo', 10), array('bar', 20), array('foo', 5)), '000-bar;dur=20.000;desc="bar",001-foo;dur=15.000;desc="foo"'),
+        );
+    }
+}

--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -70,6 +70,16 @@ class Section
     }
 
     /**
+     * Returns the children from this section.
+     *
+     * @return Section[]
+     */
+    public function getChildren()
+    {
+        return $this->children;
+    }
+
+    /**
      * Creates or re-opens a child section.
      *
      * @param string|null $id Null to create a new section, the identifier to re-open an existing one


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21585
| License       | MIT
| Doc PR        | NA

This PR Exposes data collected by the StopWatch component to the browser through the server timing feature


![screenshot from 2017-02-11 12-09-24](https://cloud.githubusercontent.com/assets/578547/22853295/fc743b78-f052-11e6-8d97-eea2ff40a534.png)
