### PR TITLE
Form theme that removed custom bootstrap css class from input type file

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -129,8 +129,12 @@
 {% endblock %}
 
 {% block form_widget_simple -%}
+    {% if use_bootstrap_custom is not defined %}
+        {% set use_bootstrap_custom = true %}
+    {% endif %}
+
     {% if type is not defined or type != 'hidden' %}
-        {%- set attr = attr|merge({class: (attr.class|default('') ~ (type|default('') == 'file' ? ' custom-file-input' : ' form-control'))|trim}) -%}
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ (type|default('') == 'file' and use_bootstrap_custom ? ' custom-file-input' : ' form-control'))|trim}) -%}
     {% endif %}
     {%- if type is defined and (type == 'range' or type == 'color') %}
         {# Attribute "required" is not supported #}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_nocustom_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_nocustom_layout.html.twig
@@ -1,0 +1,20 @@
+{% extends "bootstrap_4_layout.html.twig" %}
+
+{% block file_widget -%}
+    <div class="form-group">
+        <{{ element|default('div') }}>
+        {%- set type = type|default('file') -%}
+        {{- block('form_widget_simple') -}}
+        <label for="{{ form.vars.id }}">
+            {%- if attr.placeholder is defined -%}
+                {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
+            {%- endif -%}
+        </label>
+        </{{ element|default('div') }}>
+    </div>
+{% endblock %}
+
+{% block form_widget_simple -%}
+    {% set use_bootstrap_custom = false %}
+    {{- parent() -}}
+{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27477 
| License       | MIT
| Doc PR        | I will create a little info box on the https://github.com/symfony/symfony-docs/blob/master/form/bootstrap4.rst if approved

This will create a new bootstrap theme that removes the custom css class from `<input type="file">` so the user can now see what files that are selected in the input.

I have decided to keep the custom radio/checkbox, as these dont break the functionality.

### Before

![selection_111](https://user-images.githubusercontent.com/20708/42940905-4752d5ce-8b5b-11e8-9d2c-c963acc70d47.png)

### After

![selection_109](https://user-images.githubusercontent.com/20708/42940920-50f6b60e-8b5b-11e8-84cb-8024e5c7c9cc.png)

### Usage

```yaml
twig:
    form_themes: ['bootstrap_4_nocustom_layout.html.twig']
```

This a follow up to #27478 