### PR TITLE
Serbo-Croatian has Serbian plural rule

### DIFF
--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -144,6 +144,7 @@ class PluralizationRules
             case 'bs':
             case 'hr':
             case 'ru':
+            case 'sh':
             case 'sr':
             case 'uk':
                 return ((1 == $number % 10) && (11 != $number % 100)) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Enable correct plural on Serbo-Croatian translations. Could be safely merged in versions branches.
