### PR TITLE
[HttpKernel] Fixes invalid REMOTE_ADDR in inline subrequest when configuring trusted proxy with subnet

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -122,8 +122,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
             // Do nothing
         }
 
-        $trustedProxies = Request::getTrustedProxies();
-        $server['REMOTE_ADDR'] = $trustedProxies ? reset($trustedProxies) : '127.0.0.1';
+        $server['REMOTE_ADDR'] = $this->resolveTrustedProxy();
 
         unset($server['HTTP_IF_MODIFIED_SINCE']);
         unset($server['HTTP_IF_NONE_MATCH']);
@@ -138,6 +137,17 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         }
 
         return $subRequest;
+    }
+
+    private function resolveTrustedProxy()
+    {
+        if (!$trustedProxies = Request::getTrustedProxies()) {
+            return '127.0.0.1';
+        }
+
+        $firstTrustedProxy = reset($trustedProxies);
+
+        return false !== ($i = strpos($firstTrustedProxy, '/')) ? substr($firstTrustedProxy, 0, $i) : $firstTrustedProxy;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -226,6 +226,25 @@ class InlineFragmentRendererTest extends TestCase
         Request::setTrustedProxies(array());
     }
 
+    public function testIpAddressOfRangedTrustedProxyIsSetAsRemote()
+    {
+        $expectedSubRequest = Request::create('/');
+        $expectedSubRequest->headers->set('Surrogate-Capability', 'abc="ESI/1.0"');
+        $expectedSubRequest->server->set('REMOTE_ADDR', '1.1.1.1');
+        $expectedSubRequest->headers->set('x-forwarded-for', array('127.0.0.1'));
+        $expectedSubRequest->server->set('HTTP_X_FORWARDED_FOR', '127.0.0.1');
+
+        Request::setTrustedProxies(array('1.1.1.1/24'));
+
+        $strategy = new InlineFragmentRenderer($this->getKernelExpectingRequest($expectedSubRequest));
+
+        $request = Request::create('/');
+        $request->headers->set('Surrogate-Capability', 'abc="ESI/1.0"');
+        $strategy->render('/', $request);
+
+        Request::setTrustedProxies(array());
+    }
+
     /**
      * Creates a Kernel expecting a request equals to $request
      * Allows delta in comparison in case REQUEST_TIME changed by 1 second.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28000    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | n/a

When trusted proxies are configured including a subnet a subrequest initiated by the InlineFragmentRenderer would contain an invalid REMOTE_ADDR server variable.
