### PR TITLE
[HttpKernel] Fixed templateExists on parse error of the template name

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -135,7 +135,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
         if ($this->templating instanceof EngineInterface) {
             try {
                 return $this->templating->exists($template);
-            } catch (\InvalidArgumentException $e) {
+            } catch (\Exception $e) {
                 return false;
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
@@ -86,4 +86,17 @@ class HIncludeFragmentRendererTest extends TestCase
         $strategy = new HIncludeFragmentRenderer($engine);
         $this->assertEquals('<hx:include src="/foo">default</hx:include>', $strategy->render('/foo', Request::create('/'), array('default' => 'default'))->getContent());
     }
+
+    public function testRenderWithEngineAndDefaultText()
+    {
+        $engine = $this->getMockBuilder('Symfony\\Component\\Templating\\EngineInterface')->getMock();
+        $engine->expects($this->once())
+            ->method('exists')
+            ->with('loading...')
+            ->will($this->throwException(new \RuntimeException()));
+
+        // only default
+        $strategy = new HIncludeFragmentRenderer($engine);
+        $this->assertEquals('<hx:include src="/foo">loading...</hx:include>', $strategy->render('/foo', Request::create('/'), array('default' => 'loading...'))->getContent());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28001 
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/blob/9bfa971bc5662a6f90408b58a7b2453d7dae4f83/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php#L49-L51