### PR TITLE
[FrameworkBundle] fixed guard event names for transitions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -679,7 +679,9 @@ class FrameworkExtension extends Extension
             $guard = new Definition(Workflow\EventListener\GuardListener::class);
             $guard->setPrivate(true);
             $configuration = array();
-            foreach ($workflow['transitions'] as $transitionName => $config) {
+            foreach ($workflow['transitions'] as $config) {
+                $transitionName = $config['name'];
+
                 if (!isset($config['guard'])) {
                     continue;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.3|4
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Framework yaml configuration support workflow transitions as both indexed and associative array e.g
```yaml
transitions:
    -    name: test
         from: open
         to: test
    -
```
```yaml
transitions:
    test:
         from: open
         to: test
```
Then it's used in foreach loop to register guard event listeners https://github.com/symfony/symfony/blob/4b92b96796d381b225b6665b15160c4c9b06cf41/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L609
Array keys are used as transition names but it's wrong for indexed array so we get event names like these
workflow.workflow_name.guard.transition_index instead of workflow.workflow_name.guard.tranision_name
