### PR TITLE
[Messenger] Add missing typehint on chain sender

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/ChainSender.php
+++ b/src/Symfony/Component/Messenger/Transport/ChainSender.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Messenger\Transport;
 
+use Symfony\Component\Messenger\Envelope;
+
 /**
  * @author Tobias Schultze <http://tobion.de>
  */
@@ -29,7 +31,7 @@ class ChainSender implements SenderInterface
     /**
      * {@inheritdoc}
      */
-    public function send($message): void
+    public function send(Envelope $message): void
     {
         foreach ($this->senders as $sender) {
             $sender->send($message);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

The typehint is part of the `SenderInterface`. Adding it was probably forgotten at some point.