### PR TITLE
[Messenger] Fix chaining senders with their aliases

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_routing.php
@@ -1,7 +1,9 @@
 <?php
 
 $container->loadFromExtension('framework', array(
+    'serializer' => true,
     'messenger' => array(
+        'serializer' => true,
         'routing' => array(
             'Symfony\Component\Messenger\Tests\Fixtures\DummyMessage' => array('amqp', 'audit'),
             'Symfony\Component\Messenger\Tests\Fixtures\SecondMessage' => array(
@@ -9,6 +11,9 @@ $container->loadFromExtension('framework', array(
                 'send_and_handle' => true,
             ),
             '*' => 'amqp',
+        ),
+        'transports' => array(
+            'amqp' => 'amqp://localhost/%2f/messages',
         ),
     ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_routing.xml
@@ -6,7 +6,9 @@
         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
+        <framework:serializer enabled="true" />
         <framework:messenger>
+            <framework:serializer enabled="true" />
             <framework:routing message-class="Symfony\Component\Messenger\Tests\Fixtures\DummyMessage">
                 <framework:sender service="amqp" />
                 <framework:sender service="audit" />
@@ -18,6 +20,7 @@
             <framework:routing message-class="*">
                 <framework:sender service="amqp" />
             </framework:routing>
+            <framework:transport name="amqp" dsn="amqp://localhost/%2f/messages" />
         </framework:messenger>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_routing.yml
@@ -1,8 +1,12 @@
 framework:
+    serializer: true
     messenger:
+        serializer: true
         routing:
             'Symfony\Component\Messenger\Tests\Fixtures\DummyMessage': [amqp, audit]
             'Symfony\Component\Messenger\Tests\Fixtures\SecondMessage':
                 senders: [amqp, audit]
                 send_and_handle: true
             '*': amqp
+        transports:
+            amqp: 'amqp://localhost/%2f/messages'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -573,6 +573,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertSame($messageToSenderIdsMapping, $senderLocatorDefinition->getArgument(1));
         $this->assertSame($messageToSendAndHandleMapping, $sendMessageMiddlewareDefinition->getArgument(1));
+        $this->assertEquals(array(new Reference('messenger.transport.amqp'), new Reference('audit')), $container->getDefinition('.messenger.chain_sender.'.DummyMessage::class)->getArgument(0));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27908
| License       | MIT
| Doc PR        | ø

Turns out chaining senders when using their alias as the name is broken. This PR fixes it :)