### PR TITLE
Use an empty string as default for assertEquals

### DIFF
--- a/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -138,7 +138,7 @@ class ClassMapGeneratorTest extends TestCase
         ), ClassMapGenerator::createMap($finder));
     }
 
-    protected function assertEqualsNormalized($expected, $actual, $message = null)
+    protected function assertEqualsNormalized($expected, $actual, $message = '')
     {
         foreach ($expected as $ns => $path) {
             $expected[$ns] = str_replace('\\', '/', $path);

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -1027,7 +1027,7 @@ HTML;
     /**
      * @dataProvider getBaseTagData
      */
-    public function testBaseTag($baseValue, $linkValue, $expectedUri, $currentUri = null, $description = null)
+    public function testBaseTag($baseValue, $linkValue, $expectedUri, $currentUri = null, $description = '')
     {
         $crawler = new Crawler('<html><base href="'.$baseValue.'"><a href="'.$linkValue.'"></a></html>', $currentUri);
         $this->assertEquals($expectedUri, $crawler->filterXPath('//a')->link()->getUri(), $description);

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -73,7 +73,7 @@ class StopwatchEventTest extends TestCase
         $event->start();
         usleep(200000);
         $event->stop();
-        $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
+        $this->assertEquals(200, $event->getDuration(), '', self::DELTA);
 
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->start();
@@ -83,7 +83,7 @@ class StopwatchEventTest extends TestCase
         $event->start();
         usleep(100000);
         $event->stop();
-        $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
+        $this->assertEquals(200, $event->getDuration(), '', self::DELTA);
     }
 
     public function testDurationBeforeStop()
@@ -91,7 +91,7 @@ class StopwatchEventTest extends TestCase
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->start();
         usleep(200000);
-        $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
+        $this->assertEquals(200, $event->getDuration(), '', self::DELTA);
 
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->start();
@@ -100,7 +100,7 @@ class StopwatchEventTest extends TestCase
         usleep(50000);
         $event->start();
         usleep(100000);
-        $this->assertEquals(100, $event->getDuration(), null, self::DELTA);
+        $this->assertEquals(100, $event->getDuration(), '', self::DELTA);
     }
 
     /**
@@ -134,7 +134,7 @@ class StopwatchEventTest extends TestCase
         $event->start();
         usleep(100000);
         $event->ensureStopped();
-        $this->assertEquals(300, $event->getDuration(), null, self::DELTA);
+        $this->assertEquals(300, $event->getDuration(), '', self::DELTA);
     }
 
     public function testStartTime()
@@ -151,7 +151,7 @@ class StopwatchEventTest extends TestCase
         $event->start();
         usleep(100000);
         $event->stop();
-        $this->assertEquals(0, $event->getStartTime(), null, self::DELTA);
+        $this->assertEquals(0, $event->getStartTime(), '', self::DELTA);
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -79,7 +79,7 @@ class StopwatchTest extends TestCase
         $event = $stopwatch->stop('foo');
 
         $this->assertInstanceOf('Symfony\Component\Stopwatch\StopwatchEvent', $event);
-        $this->assertEquals(200, $event->getDuration(), null, self::DELTA);
+        $this->assertEquals(200, $event->getDuration(), '', self::DELTA);
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/escapedCharacters.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/escapedCharacters.yml
@@ -4,7 +4,7 @@ yaml: |
 php: |
     "\\0 \\ \\a \\b \\n"
 ---
-test: null
+test: 'null'
 yaml: |
     "\0"
 php: |


### PR DESCRIPTION
Make sure it isn’t interpreted as a type NULL, making the test fail with PHPUnit 7.2.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This shouldn’t break the existing tests, but will also make them work with recent PHPUnit.