### PR TITLE
Add `CheckForAnsiColorSupport` trait to symfony contracts

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\PhpUnit;
 
+use Symfony\Contracts\Console\CheckForAnsiColorSupport;
+
 /**
  * Catch deprecation notices and print a summary report at the end of the test suite.
  *
@@ -18,6 +20,8 @@ namespace Symfony\Bridge\PhpUnit;
  */
 class DeprecationErrorHandler
 {
+    use CheckForAnsiColorSupport;
+
     const MODE_WEAK = 'weak';
     const MODE_WEAK_VENDORS = 'weak_vendors';
     const MODE_DISABLED = 'disabled';
@@ -295,44 +299,5 @@ class DeprecationErrorHandler
         register_shutdown_function(function () use ($outputFile, &$deprecations) {
             file_put_contents($outputFile, serialize($deprecations));
         });
-    }
-
-    /**
-     * Returns true if STDOUT is defined and supports colorization.
-     *
-     * Reference: Composer\XdebugHandler\Process::supportsColor
-     * https://github.com/composer/xdebug-handler
-     *
-     * @return bool
-     */
-    private static function hasColorSupport()
-    {
-        if (!defined('STDOUT')) {
-            return false;
-        }
-
-        if ('Hyper' === getenv('TERM_PROGRAM')) {
-            return true;
-        }
-
-        if (DIRECTORY_SEPARATOR === '\\') {
-            return (function_exists('sapi_windows_vt100_support')
-                && sapi_windows_vt100_support(STDOUT))
-                || false !== getenv('ANSICON')
-                || 'ON' === getenv('ConEmuANSI')
-                || 'xterm' === getenv('TERM');
-        }
-
-        if (function_exists('stream_isatty')) {
-            return stream_isatty(STDOUT);
-        }
-
-        if (function_exists('posix_isatty')) {
-            return posix_isatty(STDOUT);
-        }
-
-        $stat = fstat(STDOUT);
-        // Check if formatted mode is S_IFCHR
-        return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=5.3.3 EVEN ON LATEST SYMFONY VERSIONS TO ALLOW USING",
         "php": "THIS BRIDGE WHEN TESTING LOWEST SYMFONY VERSIONS.",
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "symfony/contracts": "^1.0"
     },
     "suggest": {
         "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader",

--- a/src/Symfony/Component/VarDumper/composer.json
+++ b/src/Symfony/Component/VarDumper/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": "^7.1.3",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/polyfill-php72": "~1.5"
+        "symfony/polyfill-php72": "~1.5",
+        "symfony/contracts": "^1.0"
     },
     "require-dev": {
         "ext-iconv": "*",

--- a/src/Symfony/Contracts/Console/CheckForAnsiColorSupport.php
+++ b/src/Symfony/Contracts/Console/CheckForAnsiColorSupport.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Console;
+
+/**
+ * @author Saif Eddin Gmati <saif@azjezz.me>
+ */
+trait CheckForAnsiColorSupport
+{
+    /**
+     * Returns true if STDOUT is defined and supports colorization.
+     *
+     * @return bool
+     */
+    protected static function hasColorSupport(): bool
+    {
+        if (defined('STDOUT')) {
+            return false;
+        }
+
+        return static::streamHasColorSupport(STDOUT);
+    }
+
+    /**
+     * Returns true if the Windows terminal supports true color.
+     *
+     * Note that this does not check an output stream, but relies on environment
+     * variables from known implementations, or a PHP and Windows version that
+     * supports true color.
+     *
+     * @return bool
+     */
+    protected static function isWindowsTrueColor(): bool
+    {
+        $result = 183 <= getenv('ANSICON_VER')
+            || 'ON' === getenv('ConEmuANSI')
+            || 'xterm' === getenv('TERM')
+            || 'Hyper' === getenv('TERM_PROGRAM');
+
+        if (!$result && PHP_VERSION_ID >= 70200) {
+            $version = sprintf(
+                '%s.%s.%s',
+                PHP_WINDOWS_VERSION_MAJOR,
+                PHP_WINDOWS_VERSION_MINOR,
+                PHP_WINDOWS_VERSION_BUILD
+            );
+            $result = $version >= '10.0.15063';
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns true if the stream supports colorization.
+     *
+     * @param mixed $stream A CLI output stream
+     *
+     * @return bool
+     */
+    protected static function streamHasColorSupport($stream): bool
+    {
+        if ('Hyper' === getenv('TERM_PROGRAM')) {
+            return true;
+        }
+
+        if (DIRECTORY_SEPARATOR === '\\') {
+            return (function_exists('sapi_windows_vt100_support')
+                    && sapi_windows_vt100_support($stream))
+                || false !== getenv('ANSICON')
+                || 'ON' === getenv('ConEmuANSI')
+                || 'xterm' === getenv('TERM');
+        }
+
+        if (function_exists('stream_isatty')) {
+            return stream_isatty($stream);
+        }
+
+        $stat = fstat($stream);
+        // Check if formatted mode is S_IFCHR
+        return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes  
| License       | MIT

There's too many check across components for ANSI color support, if we use 1 trait across all components, it would be much better and less code. 
