### PR TITLE
[Validator] New `DivisibleBy` constraint for testing divisibility

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DivisibleBy.php
+++ b/src/Symfony/Component/Validator/Constraints/DivisibleBy.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Colin O'Dell <colinodell@gmail.com>
+ */
+class DivisibleBy extends AbstractComparison
+{
+    const NOT_DIVISIBLE_BY = '6d99d6c3-1464-4ccf-bdc7-14d083cf455c';
+
+    protected static $errorNames = array(
+        self::NOT_DIVISIBLE_BY => 'NOT_DIVISIBLE_BY',
+    );
+
+    public $message = 'This value should be a multiple of {{ compared_value }}.';
+}

--- a/src/Symfony/Component/Validator/Constraints/DivisibleByValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DivisibleByValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * Validates that values are a multiple of the given number.
+ *
+ * @author Colin O'Dell <colinodell@gmail.com>
+ */
+class DivisibleByValidator extends AbstractComparisonValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function compareValues($value1, $value2)
+    {
+        return (float) 0 === fmod($value1, $value2);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getErrorCode()
+    {
+        return DivisibleBy::NOT_DIVISIBLE_BY;
+    }
+}

--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -322,6 +322,10 @@
                 <source>This is not a valid UUID.</source>
                 <target>Dies ist keine gültige UUID.</target>
             </trans-unit>
+            <trans-unit id="84">
+                <source>This value should be a multiple of {{ compared_value }}.</source>
+                <target>Dieser Wert sollte ein Vielfaches von {{ compared_value }} sein.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -322,6 +322,10 @@
                 <source>This is not a valid UUID.</source>
                 <target>This is not a valid UUID.</target>
             </trans-unit>
+            <trans-unit id="84">
+                <source>This value should be a multiple of {{ compared_value }}.</source>
+                <target>This value should be a multiple of {{ compared_value }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -322,6 +322,10 @@
                 <source>This is not a valid UUID.</source>
                 <target>Este valor no es un UUID válido.</target>
             </trans-unit>
+            <trans-unit id="84">
+                <source>This value should be a multiple of {{ compared_value }}.</source>
+                <target>Este valor debería ser un múltiplo de {{ compared_value }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -322,6 +322,10 @@
                 <source>This is not a valid UUID.</source>
                 <target>Ceci n'est pas un UUID valide.</target>
             </trans-unit>
+            <trans-unit id="84">
+                <source>This value should be a multiple of {{ compared_value }}.</source>
+                <target>Cette valeur doit être un multiple de {{ compared_value }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -318,6 +318,10 @@
                 <source>This is not a valid UUID.</source>
                 <target>Deze waarde is geen geldige UUID waarde.</target>
             </trans-unit>
+            <trans-unit id="84">
+                <source>This value should be a multiple of {{ compared_value }}.</source>
+                <target>Deze waarde moet een veelvoud zijn van {{ compared_value }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\DivisibleBy;
+use Symfony\Component\Validator\Constraints\DivisibleByValidator;
+
+/**
+ * @author Colin O'Dell <colinodell@gmail.com>
+ */
+class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new DivisibleByValidator();
+    }
+
+    protected function createConstraint(array $options = null)
+    {
+        return new DivisibleBy($options);
+    }
+
+    protected function getErrorCode()
+    {
+        return DivisibleBy::NOT_DIVISIBLE_BY;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideValidComparisons()
+    {
+        return array(
+            array(-7, 1),
+            array(0, 3.1415),
+            array(42, 42),
+            array(42, 21),
+            array(3.25, 0.25),
+            array('100', '10'),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideValidComparisonsToPropertyPath()
+    {
+        return array(
+            array(25),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return array(
+            array(1, '1', 2, '2', 'integer'),
+            array(10, '10', 3, '3', 'integer'),
+            array(10, '10', 0, '0', 'integer'),
+            array(42, '42', INF, 'INF', 'double'),
+            array('22', '"22"', '10', '"10"', 'string'),
+        );
+    }
+}


### PR DESCRIPTION
This introduces a new ~`MultipleOf`~ `DivisibleBy` constraint which checks whether one number is a multiple of (aka "divisible by") some other number.  Useful for enforcing specific increments on a number.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10121

See https://github.com/symfony/symfony-docs/pull/10121 for examples of this constraint in action.