### PR TITLE
Renaming internal test class to help auto-completion

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -146,8 +146,8 @@ class ControllerResolverTest extends TestCase
     public function getStaticControllers()
     {
         return array(
-            array(AbstractController::class.'::staticAction', 'foo'),
-            array(array(AbstractController::class, 'staticAction'), 'foo'),
+            array(TestAbstractController::class.'::staticAction', 'foo'),
+            array(array(TestAbstractController::class, 'staticAction'), 'foo'),
             array(PrivateConstructorController::class.'::staticAction', 'bar'),
             array(array(PrivateConstructorController::class, 'staticAction'), 'bar'),
         );
@@ -238,7 +238,7 @@ class InvokableController
     }
 }
 
-abstract class AbstractController
+abstract class TestAbstractController
 {
     public static function staticAction()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes-ish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no->
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not needed

This fixes auto-completion issues in IDE's: when you start typing `AbstractContro...` it gives you two choices. Let's avoid calling test classes the same name as real classes when possible :).
