### PR TITLE
[Config] show proposals when unsupported option is provided

### DIFF
--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -37,6 +37,31 @@ class ArrayNodeTest extends TestCase
         $node->normalize(array('foo' => 'bar'));
     }
 
+    /**
+     * @expectedException        \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Did you mean "alpha1", "alpha2"?
+     */
+    public function testNormalizeWithProposals()
+    {
+        $node = new ArrayNode('root');
+        $node->addChild(new ArrayNode('alpha1'));
+        $node->addChild(new ArrayNode('alpha2'));
+        $node->addChild(new ArrayNode('beta'));
+        $node->normalize(array('alpha3' => 'foo'));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Available options are "alpha1", "alpha2".
+     */
+    public function testNormalizeWithoutProposals()
+    {
+        $node = new ArrayNode('root');
+        $node->addChild(new ArrayNode('alpha1'));
+        $node->addChild(new ArrayNode('alpha2'));
+        $node->normalize(array('beta' => 'foo'));
+    }
+
     public function ignoreAndRemoveMatrixProvider()
     {
         $unrecognizedOptionException = new InvalidConfigurationException('Unrecognized option "foo" under "root"');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28075 
| License       | MIT
| Doc PR        | none

In case of proposals match with the provided option, all proposals are displayed.
In case of no pertinent proposal is available, all options are displayed in alpha order. 
