### PR TITLE
Display validation errors underneath the form widget instead of underneath the label

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
@@ -33,6 +33,7 @@ col-sm-2
             <div class="{{ block('form_group_class') }}">
                 {{- form_widget(form, widget_attr) -}}
                 {{- form_help(form) -}}
+                {{- form_errors(form) -}}
             </div>
     {##}</div>
     {%- endif -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -216,7 +216,7 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}{% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}</{{ element|default('label') }}>
+        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</{{ element|default('label') }}>
     {%- else -%}
         {%- if errors|length > 0 -%}
         <div id="{{ id }}_errors" class="mb-2">
@@ -278,6 +278,7 @@
         {{- form_label(form) -}}
         {{- form_widget(form, widget_attr) -}}
         {{- form_help(form) -}}
+        {{- form_errors(form) -}}
     </{{ element|default('div') }}>
 {%- endblock form_row %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes  
| Fixed tickets | #28086  
| License       | MIT
| Doc PR        | ~

The changes in this PR make the validation errors display underneath the actual form widget instead of underneath the label. This ensures that it matches the official documentation found [here](https://getbootstrap.com/docs/4.1/components/forms/#server-side).

Old layout:
![image](https://user-images.githubusercontent.com/3764924/43369946-e7007aae-9376-11e8-909d-26474325eba6.png)

New (correct) layout:
![image](https://user-images.githubusercontent.com/3764924/43391224-68c91464-93f0-11e8-991d-96839c1b658f.png)