### PR TITLE
[Security] Make statefull pages NOT turn responses private when the token is not used

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/TokenProcessor.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bridge\Monolog\Processor;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface;
 
 /**
  * Adds the current security token to the log entry.
@@ -24,13 +26,13 @@ class TokenProcessor implements ProcessorInterface
 
     public function __construct(TokenStorageInterface $tokenStorage)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->tokenStorage = $tokenStorage instanceof UsageTrackingTokenStorageInterface ? $tokenStorage : new UsageTrackingTokenStorage($tokenStorage);
     }
 
     public function __invoke(array $records)
     {
         $records['extra']['token'] = null;
-        if (null !== $token = $this->tokenStorage->getToken()) {
+        if (null !== $token = $this->tokenStorage->getToken(false)) {
             $records['extra']['token'] = array(
                 'username' => $token->getUsername(),
                 'authenticated' => $token->isAuthenticated(),

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Bridge\Monolog\Tests\Processor;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
@@ -26,8 +26,8 @@ class TokenProcessorTest extends TestCase
     public function testProcessor()
     {
         $token = new UsernamePasswordToken('user', 'password', 'provider', array('ROLE_USER'));
-        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
-        $tokenStorage->method('getToken')->willReturn($token);
+        $tokenStorage = $this->getMockBuilder(UsageTrackingTokenStorageInterface::class)->getMock();
+        $tokenStorage->method('getToken')->with(false)->willReturn($token);
 
         $processor = new TokenProcessor($tokenStorage);
         $record = array('extra' => array());

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -24,11 +24,12 @@
     "require-dev": {
         "symfony/console": "~3.4|~4.0",
         "symfony/event-dispatcher": "~3.4|~4.0",
-        "symfony/security-core": "~3.4|~4.0",
+        "symfony/security-core": "~4.2",
         "symfony/var-dumper": "~3.4|~4.0"
     },
     "conflict": {
-        "symfony/http-foundation": "<3.4"
+        "symfony/http-foundation": "<3.4",
+        "symfony/security-core": "<4.2"
     },
     "suggest": {
         "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
 use Symfony\Component\Security\Core\Role\Role;
@@ -44,7 +46,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
     public function __construct(TokenStorageInterface $tokenStorage = null, RoleHierarchyInterface $roleHierarchy = null, LogoutUrlGenerator $logoutUrlGenerator = null, AccessDecisionManagerInterface $accessDecisionManager = null, FirewallMapInterface $firewallMap = null, TraceableFirewallListener $firewall = null)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->tokenStorage = null === $tokenStorage || $tokenStorage instanceof UsageTrackingTokenStorageInterface ? $tokenStorage : new UsageTrackingTokenStorage($tokenStorage);
         $this->roleHierarchy = $roleHierarchy;
         $this->logoutUrlGenerator = $logoutUrlGenerator;
         $this->accessDecisionManager = $accessDecisionManager;
@@ -73,7 +75,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                 'inherited_roles' => array(),
                 'supports_role_hierarchy' => null !== $this->roleHierarchy,
             );
-        } elseif (null === $token = $this->tokenStorage->getToken()) {
+        } elseif (null === $token = $this->tokenStorage->getToken(false)) {
             $this->data = array(
                 'enabled' => true,
                 'authenticated' => false,

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -21,10 +21,11 @@
         </service>
         <service id="Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface" alias="security.authorization_checker" />
 
-        <service id="security.token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage" public="true">
+        <service id="security.token_storage" class="Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage" public="true">
             <tag name="kernel.reset" method="setToken" />
         </service>
         <service id="Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface" alias="security.token_storage" />
+        <service id="Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface" alias="security.token_storage" />
 
         <service id="security.helper" class="Symfony\Component\Security\Core\Security">
             <argument type="service_locator">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -19,7 +19,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
@@ -51,7 +51,8 @@ class SecurityDataCollectorTest extends TestCase
 
     public function testCollectWhenAuthenticationTokenIsNull()
     {
-        $tokenStorage = new TokenStorage();
+        $tokenStorage = new UsageTrackingTokenStorage();
+        $tokenStorage->setToken(null, \Closure::fromCallable(array($this, 'fail')));
         $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy());
         $collector->collect($this->getRequest(), $this->getResponse());
 
@@ -71,8 +72,8 @@ class SecurityDataCollectorTest extends TestCase
     /** @dataProvider provideRoles */
     public function testCollectAuthenticationTokenAndRoles(array $roles, array $normalizedRoles, array $inheritedRoles)
     {
-        $tokenStorage = new TokenStorage();
-        $tokenStorage->setToken(new UsernamePasswordToken('hhamon', 'P4$$w0rD', 'provider', $roles));
+        $tokenStorage = new UsageTrackingTokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken('hhamon', 'P4$$w0rD', 'provider', $roles), \Closure::fromCallable(array($this, 'fail')));
 
         $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy());
         $collector->collect($this->getRequest(), $this->getResponse());
@@ -99,8 +100,8 @@ class SecurityDataCollectorTest extends TestCase
             new SwitchUserRole('ROLE_PREVIOUS_ADMIN', $adminToken),
         );
 
-        $tokenStorage = new TokenStorage();
-        $tokenStorage->setToken(new UsernamePasswordToken('hhamon', 'P4$$w0rD', 'provider', $userRoles));
+        $tokenStorage = new UsageTrackingTokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken('hhamon', 'P4$$w0rD', 'provider', $userRoles), \Closure::fromCallable(array($this, 'fail')));
 
         $collector = new SecurityDataCollector($tokenStorage, $this->getRoleHierarchy());
         $collector->collect($this->getRequest(), $this->getResponse());

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -146,7 +146,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      *
      * @internal
      */
-    public function getUsageIndex()
+    public function &getUsageIndex()
     {
         return $this->usageIndex;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token\Storage;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * A token storage that optionally calls a closure when the token is accessed.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class UsageTrackingTokenStorage implements UsageTrackingTokenStorageInterface
+{
+    private $storage;
+    private $usageTracker;
+
+    public function __construct(TokenStorageInterface $storage = null)
+    {
+        $this->storage = $storage ?? new TokenStorage();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getToken(bool $trackUsage = true): ?TokenInterface
+    {
+        if ($trackUsage && $usageTracker = $this->usageTracker) {
+            $usageTracker();
+        }
+
+        return $this->storage->getToken();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setToken(TokenInterface $token = null, \Closure $usageTracker = null): void
+    {
+        $this->usageTracker = $usageTracker;
+        $this->storage->setToken($token);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorageInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorageInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token\Storage;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * A token storage that optionally calls a closure when the token is accessed.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface UsageTrackingTokenStorageInterface extends TokenStorageInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getToken(bool $trackUsage = true): ?TokenInterface;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setToken(TokenInterface $token = null, \Closure $usageTracker = null): void;
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authentication\Token\Storage;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+
+class UsageTrackingTokenStorageTest extends TestCase
+{
+    public function testGetSetToken()
+    {
+        $counter = 0;
+        $usageTracker = function () use (&$counter) { ++$counter; };
+
+        $tokenStorage = new UsageTrackingTokenStorage();
+        $this->assertNull($tokenStorage->getToken());
+        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+
+        $tokenStorage->setToken($token);
+        $this->assertSame($token, $tokenStorage->getToken());
+
+        $tokenStorage->setToken($token, $usageTracker);
+        $this->assertSame($token, $tokenStorage->getToken(false));
+        $this->assertSame(0, $counter);
+        $this->assertSame($token, $tokenStorage->getToken());
+        $this->assertSame(1, $counter);
+
+        $tokenStorage->setToken(null, $usageTracker);
+        $this->assertNull($tokenStorage->getToken(false));
+        $this->assertSame(1, $counter);
+        $this->assertNull($tokenStorage->getToken());
+        $this->assertSame(2, $counter);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
@@ -33,7 +35,7 @@ class AnonymousAuthenticationListener implements ListenerInterface
 
     public function __construct(TokenStorageInterface $tokenStorage, string $secret, LoggerInterface $logger = null, AuthenticationManagerInterface $authenticationManager = null)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->tokenStorage = $tokenStorage instanceof UsageTrackingTokenStorageInterface ? $tokenStorage : new UsageTrackingTokenStorage($tokenStorage);
         $this->secret = $secret;
         $this->authenticationManager = $authenticationManager;
         $this->logger = $logger;
@@ -44,7 +46,7 @@ class AnonymousAuthenticationListener implements ListenerInterface
      */
     public function handle(GetResponseEvent $event)
     {
-        if (null !== $this->tokenStorage->getToken()) {
+        if (null !== $this->tokenStorage->getToken(false)) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -16,6 +16,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
@@ -40,7 +42,7 @@ class RememberMeListener implements ListenerInterface
 
     public function __construct(TokenStorageInterface $tokenStorage, RememberMeServicesInterface $rememberMeServices, AuthenticationManagerInterface $authenticationManager, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, bool $catchExceptions = true, SessionAuthenticationStrategyInterface $sessionStrategy = null)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->tokenStorage = $tokenStorage instanceof UsageTrackingTokenStorageInterface ? $tokenStorage : new UsageTrackingTokenStorage($tokenStorage);
         $this->rememberMeServices = $rememberMeServices;
         $this->authenticationManager = $authenticationManager;
         $this->logger = $logger;
@@ -54,7 +56,7 @@ class RememberMeListener implements ListenerInterface
      */
     public function handle(GetResponseEvent $event)
     {
-        if (null !== $this->tokenStorage->getToken()) {
+        if (null !== $this->tokenStorage->getToken(false)) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -22,6 +22,8 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverIn
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
@@ -53,7 +55,7 @@ class SimplePreAuthenticationListener implements ListenerInterface
             throw new \InvalidArgumentException('$providerKey must not be empty.');
         }
 
-        $this->tokenStorage = $tokenStorage;
+        $this->tokenStorage = $tokenStorage instanceof UsageTrackingTokenStorageInterface ? $tokenStorage : new UsageTrackingTokenStorage($tokenStorage);
         $this->authenticationManager = $authenticationManager;
         $this->providerKey = $providerKey;
         $this->simpleAuthenticator = $simpleAuthenticator;
@@ -83,7 +85,7 @@ class SimplePreAuthenticationListener implements ListenerInterface
             $this->logger->info('Attempting SimplePreAuthentication.', array('key' => $this->providerKey, 'authenticator' => \get_class($this->simpleAuthenticator)));
         }
 
-        if ((null !== $token = $this->tokenStorage->getToken()) && !$this->trustResolver->isAnonymous($token)) {
+        if ((null !== $token = $this->tokenStorage->getToken(false)) && !$this->trustResolver->isAnonymous($token)) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -183,6 +183,41 @@ class AccessListenerTest extends TestCase
         $listener->handle($event);
     }
 
+    public function testHandleWhenAccessMapReturnsEmptyAttributes()
+    {
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+
+        $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
+        $accessMap
+            ->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->will($this->returnValue(array(array(), null)))
+        ;
+
+        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        $tokenStorage
+            ->expects($this->never())
+            ->method('getToken')
+        ;
+
+        $listener = new AccessListener(
+            $tokenStorage,
+            $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock(),
+            $accessMap,
+            $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock()
+        );
+
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->will($this->returnValue($request))
+        ;
+
+        $listener->handle($event);
+    }
+
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException
      */
@@ -195,14 +230,29 @@ class AccessListenerTest extends TestCase
             ->will($this->returnValue(null))
         ;
 
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->disableOriginalConstructor()->disableOriginalClone()->getMock();
+
+        $accessMap = $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock();
+        $accessMap
+            ->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->will($this->returnValue(array(array('foo' => 'bar'), null)))
+        ;
+
         $listener = new AccessListener(
             $tokenStorage,
             $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')->getMock(),
-            $this->getMockBuilder('Symfony\Component\Security\Http\AccessMapInterface')->getMock(),
+            $accessMap,
             $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock()
         );
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->will($this->returnValue($request))
+        ;
 
         $listener->handle($event);
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -13,16 +13,18 @@ namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface;
 use Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener;
 
 class AnonymousAuthenticationListenerTest extends TestCase
 {
     public function testHandleWithTokenStorageHavingAToken()
     {
-        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        $tokenStorage = $this->getMockBuilder(UsageTrackingTokenStorageInterface::class)->getMock();
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()))
         ;
         $tokenStorage
@@ -42,10 +44,11 @@ class AnonymousAuthenticationListenerTest extends TestCase
 
     public function testHandleWithTokenStorageHavingNoToken()
     {
-        $tokenStorage = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        $tokenStorage = $this->getMockBuilder(UsageTrackingTokenStorageInterface::class)->getMock();
         $tokenStorage
             ->expects($this->any())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue(null))
         ;
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Firewall\RememberMeListener;
 use Symfony\Component\Security\Http\SecurityEvents;
@@ -26,6 +27,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()))
         ;
 
@@ -44,6 +46,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue(null))
         ;
 
@@ -72,6 +75,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue(null))
         ;
 
@@ -114,6 +118,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue(null))
         ;
 
@@ -152,6 +157,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue(null))
         ;
 
@@ -189,6 +195,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue(null))
         ;
 
@@ -228,6 +235,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue(null))
         ;
 
@@ -293,6 +301,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue(null))
         ;
 
@@ -356,6 +365,7 @@ class RememberMeListenerTest extends TestCase
         $tokenStorage
             ->expects($this->once())
             ->method('getToken')
+            ->with(false)
             ->will($this->returnValue(null))
         ;
 
@@ -440,7 +450,7 @@ class RememberMeListenerTest extends TestCase
 
     protected function getTokenStorage()
     {
-        return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')->getMock();
+        return $this->getMockBuilder(UsageTrackingTokenStorageInterface::class)->getMock();
     }
 
     protected function getDispatcher()

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Firewall\SimplePreAuthenticationListener;
@@ -91,6 +92,25 @@ class SimplePreAuthenticationListenerTest extends TestCase
         $listener = new SimplePreAuthenticationListener($this->tokenStorage, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);
 
         $listener->handle($this->event);
+    }
+
+    public function testHandleWithTokenStorageHavingAToken()
+    {
+        $tokenStorage = $this->getMockBuilder(UsageTrackingTokenStorageInterface::class)->getMock();
+        $tokenStorage
+            ->expects($this->any())
+            ->method('getToken')
+            ->with(false)
+            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()))
+        ;
+        $tokenStorage
+            ->expects($this->never())
+            ->method('setToken')
+        ;
+        $simpleAuthenticator = $this->getMockBuilder('Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface')->getMock();
+
+        $listener = new SimplePreAuthenticationListener($tokenStorage, $this->authenticationManager, 'secured_area', $simpleAuthenticator, $this->logger, $this->dispatcher);
+        $listener->handle($this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock());
     }
 
     protected function setUp()

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/security-core": "~3.4|~4.0",
+        "symfony/security-core": "~4.2",
         "symfony/event-dispatcher": "~3.4|~4.0",
         "symfony/http-foundation": "~3.4|~4.0",
         "symfony/http-kernel": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #26769 *et al.*
| License       | MIT
| Doc PR        | -

Replaces #27817
By taking over session usage tracking and replacing it with token usage tracking, we can prevent responses that don't actually use the token from turning responses private without changing anything to the lifecycle of security listeners. This makes the behavior much more seamless, allowing to still log the user with the monolog processor, and display it in the profiler toolbar.