### PR TITLE
link helper does not link Contracts

### DIFF
--- a/link
+++ b/link
@@ -42,6 +42,8 @@ $directories = array_merge(...array_values(array_map(function ($part) {
     return glob(__DIR__.'/src/Symfony/'.$part.'/*', GLOB_ONLYDIR | GLOB_NOSORT);
 }, $braces)));
 
+$directories[] = __DIR__.'/src/Symfony/Contracts';
+
 foreach ($directories as $dir) {
     if ($filesystem->exists($composer = "$dir/composer.json")) {
         $sfPackages[json_decode(file_get_contents($composer))->name] = $dir;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

`link` is great tool in development and while working on another PR, noticed that all `symfony/*` packages are linked except `symfony/contracts`

After this PR this issue will be fixed.
