### PR TITLE
Release v3.3.18

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -7,6 +7,11 @@ in 3.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.3.0...v3.3.1
 
+* 3.3.18 (2018-08-01)
+
+ * security #cve-2018-14774 [HttpKernel] fix trusted headers management in HttpCache and InlineFragmentRenderer (nicolas-grekas)
+ * security #cve-2018-14773 [HttpFoundation] Remove support for legacy and risky HTTP headers (nicolas-grekas)
+
 * 3.3.17 (2018-05-25)
 
  * security #cve-2018-11407 [Ldap] cast to string when checking empty passwords

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -61,11 +61,11 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
     private $projectDir;
 
-    const VERSION = '3.3.17';
-    const VERSION_ID = 30317;
+    const VERSION = '3.3.18';
+    const VERSION_ID = 30318;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 3;
-    const RELEASE_VERSION = 17;
+    const RELEASE_VERSION = 18;
     const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2018';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v3.3.17...v3.3.18)

 * security #cve-2018-14774 [HttpKernel] fix trusted headers management in HttpCache and InlineFragmentRenderer (@nicolas-grekas)
 * security #cve-2018-14773 [HttpFoundation] Remove support for legacy and risky HTTP headers (@nicolas-grekas)
