### PR TITLE
Release v4.0.14

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -7,6 +7,16 @@ in 4.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.0.0...v4.0.1
 
+* 4.0.14 (2018-08-01)
+
+ * security #cve-2018-14774 [HttpKernel] fix trusted headers management in HttpCache and InlineFragmentRenderer (nicolas-grekas)
+ * security #cve-2018-14773 [HttpFoundation] Remove support for legacy and risky HTTP headers (nicolas-grekas)
+ * bug #28003 [HttpKernel] Fixes invalid REMOTE_ADDR in inline subrequest when configuring trusted proxy with subnet (netiul)
+ * bug #28007 [FrameworkBundle] fixed guard event names for transitions (destillat)
+ * bug #28045 [HttpFoundation] Fix Cookie::isCleared (ro0NL)
+ * bug #28080 [HttpFoundation] fixed using _method parameter with invalid type (Phobetor)
+ * bug #28052 [HttpKernel] Fix merging bindings for controllers' locators (nicolas-grekas)
+
 * 4.0.13 (2018-07-23)
 
  * bug #28005 [HttpKernel] Fixed templateExists on parse error of the template name (yceruto)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -63,12 +63,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '4.0.14-DEV';
+    const VERSION = '4.0.14';
     const VERSION_ID = 40014;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 0;
     const RELEASE_VERSION = 14;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '07/2018';
     const END_OF_LIFE = '01/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v4.0.13...v4.0.14)

 * security #cve-2018-14774 [HttpKernel] fix trusted headers management in HttpCache and InlineFragmentRenderer (@nicolas-grekas)
 * security #cve-2018-14773 [HttpFoundation] Remove support for legacy and risky HTTP headers (@nicolas-grekas)
 * bug #28003 [HttpKernel] Fixes invalid REMOTE_ADDR in inline subrequest when configuring trusted proxy with subnet (@netiul)
 * bug #28007 [FrameworkBundle] fixed guard event names for transitions (@destillat)
 * bug #28045 [HttpFoundation] Fix Cookie::isCleared (@ro0NL)
 * bug #28080 [HttpFoundation] fixed using _method parameter with invalid type (@Phobetor)
 * bug #28052 [HttpKernel] Fix merging bindings for controllers' locators (@nicolas-grekas)
