### PR TITLE
Release v4.1.3

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -7,6 +7,18 @@ in 4.1 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.1.0...v4.1.1
 
+* 4.1.3 (2018-08-01)
+
+ * security #cve-2018-14774 [HttpKernel] fix trusted headers management in HttpCache and InlineFragmentRenderer (nicolas-grekas)
+ * security #cve-2018-14773 [HttpFoundation] Remove support for legacy and risky HTTP headers (nicolas-grekas)
+ * bug #28003 [HttpKernel] Fixes invalid REMOTE_ADDR in inline subrequest when configuring trusted proxy with subnet (netiul)
+ * bug #28007 [FrameworkBundle] fixed guard event names for transitions (destillat)
+ * bug #28045 [HttpFoundation] Fix Cookie::isCleared (ro0NL)
+ * bug #28080 [HttpFoundation] fixed using _method parameter with invalid type (Phobetor)
+ * bug #28059 [Messenger] Fix error message on undefined message class for non-subscriber handler (chalasr)
+ * bug #28052 [HttpKernel] Fix merging bindings for controllers' locators (nicolas-grekas)
+ * bug #28014 [Messenger] Fix chaining senders with their aliases (sroze)
+
 * 4.1.2 (2018-07-23)
 
  * bug #28005 [HttpKernel] Fixed templateExists on parse error of the template name (yceruto)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -63,12 +63,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '4.1.3-DEV';
+    const VERSION = '4.1.3';
     const VERSION_ID = 40103;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 1;
     const RELEASE_VERSION = 3;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2019';
     const END_OF_LIFE = '07/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v4.1.2...v4.1.3)

 * security #cve-2018-14774 [HttpKernel] fix trusted headers management in HttpCache and InlineFragmentRenderer (@nicolas-grekas)
 * security #cve-2018-14773 [HttpFoundation] Remove support for legacy and risky HTTP headers (@nicolas-grekas)
 * bug #28003 [HttpKernel] Fixes invalid REMOTE_ADDR in inline subrequest when configuring trusted proxy with subnet (@netiul)
 * bug #28007 [FrameworkBundle] fixed guard event names for transitions (@destillat)
 * bug #28045 [HttpFoundation] Fix Cookie::isCleared (@ro0NL)
 * bug #28080 [HttpFoundation] fixed using _method parameter with invalid type (@Phobetor)
 * bug #28059 [Messenger] Fix error message on undefined message class for non-subscriber handler (@chalasr)
 * bug #28052 [HttpKernel] Fix merging bindings for controllers' locators (@nicolas-grekas)
 * bug #28014 [Messenger] Fix chaining senders with their aliases (@sroze)
