### PR TITLE
[Form] Add help texts for checkboxes in horizontal bootstrap 4 forms

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
@@ -81,6 +81,7 @@ col-sm-10
         <div class="{{ block('form_label_class') }}"></div>{#--#}
         <div class="{{ block('form_group_class') }}">
             {{- form_widget(form) -}}
+            {{- form_help(form) -}}
             {{- form_errors(form) -}}
         </div>{#--#}
     </div>

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTest.php
@@ -214,4 +214,24 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
 
         $this->assertMatchesXpath($html, '/div[@class="form-group row"]/div[@class="col-sm-2" or @class="col-sm-10"]', 2);
     }
+
+    public function testCheckboxRowWithHelp()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType');
+        $view = $form->createView();
+        $html = $this->renderRow($view, array('label' => 'foo', 'help' => 'really helpful text'));
+
+        $this->assertMatchesXpath($html,
+'/div
+    [@class="form-group row"]
+    [
+        ./div[@class="col-sm-2" or @class="col-sm-10"]
+        /following-sibling::div[@class="col-sm-2" or @class="col-sm-10"]
+        [
+            ./small[text() = "[trans]really helpful text[/trans]"]
+        ]
+    ]
+'
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | —
| License       | MIT
| Doc PR        | —

Bootstrap 4 horizontal forms override the `{% block checkbox_form %}` but didn't include the help text. Regular (vertical) Bootstrap 4 are not affected, as they use the default `form_row`, which includes the `form_help()` call.

### Before
![before](https://user-images.githubusercontent.com/1032411/43576420-9a1051ee-9649-11e8-8c1e-89502e5a79bd.png)

### After
![after](https://user-images.githubusercontent.com/1032411/43576423-9dfe5620-9649-11e8-8bce-74ec82d83729.png)
