### PR TITLE
[Form] Remove extra .form-group wrapper around file widget in bootstrap 4

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -115,17 +115,15 @@
 {%- endblock percent_widget %}
 
 {% block file_widget -%}
-    <div class="form-group">
-        <{{ element|default('div') }} class="custom-file">
-            {%- set type = type|default('file') -%}
-            {{- block('form_widget_simple') -}}
-            <label for="{{ form.vars.id }}" class="custom-file-label">
-                {%- if attr.placeholder is defined -%}
-                    {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
-                {%- endif -%}
-            </label>
-        </{{ element|default('div') }}>
-    </div>
+    <{{ element|default('div') }} class="custom-file">
+        {%- set type = type|default('file') -%}
+        {{- block('form_widget_simple') -}}
+        <label for="{{ form.vars.id }}" class="custom-file-label">
+            {%- if attr.placeholder is defined -%}
+                {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
+            {%- endif -%}
+        </label>
+    </{{ element|default('div') }}>
 {% endblock %}
 
 {% block form_widget_simple -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
@@ -942,17 +942,13 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'n/a', 'attr' => array('class' => 'my&class form-control-file')),
 '/div
-    [@class="form-group"]
+    [@class="custom-file"]
     [
-        ./div
-            [@class="custom-file"]
-            [
-                ./input
-                    [@type="file"]
-                    [@name="name"]
-                /following-sibling::label
-                    [@for="name"]
-            ]
+        ./input
+            [@type="file"]
+            [@name="name"]
+        /following-sibling::label
+            [@for="name"]
     ]
 '
         );
@@ -964,17 +960,13 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'n/a', 'attr' => array('class' => 'my&class form-control-file', 'placeholder' => 'Custom Placeholder')),
 '/div
-    [@class="form-group"]
+    [@class="custom-file"]
     [
-        ./div
-            [@class="custom-file"]
-            [
-                ./input
-                    [@type="file"]
-                    [@name="name"]
-                /following-sibling::label
-                    [@for="name" and text() = "[trans]Custom Placeholder[/trans]"]
-            ]
+        ./input
+            [@type="file"]
+            [@name="name"]
+        /following-sibling::label
+            [@for="name" and text() = "[trans]Custom Placeholder[/trans]"]
     ]
 '
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        |  n/a

This is a follow-up to https://github.com/symfony/symfony/pull/27958 and https://github.com/symfony/symfony/pull/27919 by @apfelbox .

It fixes an extra space between the help text of a FileType widget and the widget itself. The extra space was caused by a `.form-group` wrapper in the `file_widget` block.