### PR TITLE
[Form] Remove duplicate .form-group in bootstrap 4 file field

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -115,17 +115,15 @@
 {%- endblock percent_widget %}
 
 {% block file_widget -%}
-    <div class="form-group">
-        <{{ element|default('div') }} class="custom-file">
-            {%- set type = type|default('file') -%}
-            {{- block('form_widget_simple') -}}
-            <label for="{{ form.vars.id }}" class="custom-file-label">
-                {%- if attr.placeholder is defined -%}
-                    {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
-                {%- endif -%}
-            </label>
-        </{{ element|default('div') }}>
-    </div>
+    <{{ element|default('div') }} class="custom-file">
+        {%- set type = type|default('file') -%}
+        {{- block('form_widget_simple') -}}
+        <label for="{{ form.vars.id }}" class="custom-file-label">
+            {%- if attr.placeholder is defined -%}
+                {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
+            {%- endif -%}
+        </label>
+    </{{ element|default('div') }}>
 {% endblock %}
 
 {% block form_widget_simple -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
@@ -942,17 +942,13 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'n/a', 'attr' => array('class' => 'my&class form-control-file')),
 '/div
-    [@class="form-group"]
+    [@class="custom-file"]
     [
-        ./div
-            [@class="custom-file"]
-            [
-                ./input
-                    [@type="file"]
-                    [@name="name"]
-                /following-sibling::label
-                    [@for="name"]
-            ]
+        ./input
+            [@type="file"]
+            [@name="name"]
+        /following-sibling::label
+            [@for="name"]
     ]
 '
         );
@@ -964,17 +960,13 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
         $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'n/a', 'attr' => array('class' => 'my&class form-control-file', 'placeholder' => 'Custom Placeholder')),
 '/div
-    [@class="form-group"]
+    [@class="custom-file"]
     [
-        ./div
-            [@class="custom-file"]
-            [
-                ./input
-                    [@type="file"]
-                    [@name="name"]
-                /following-sibling::label
-                    [@for="name" and text() = "[trans]Custom Placeholder[/trans]"]
-            ]
+        ./input
+            [@type="file"]
+            [@name="name"]
+        /following-sibling::label
+            [@for="name" and text() = "[trans]Custom Placeholder[/trans]"]
     ]
 '
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes/no
| New feature?  | /no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://github.com/symfony/symfony/pull/27919#issuecomment-409888807
| License       | MIT
| Doc PR        | —

When reworking the bootstrap 4 file field (in https://github.com/symfony/symfony/pull/27919) I added the `.form-group` div twice. 
We can safely remove it in the `file_widget`, as the widget is already wrapped in a `.form-group` in the [`form_row`](https://github.com/symfony/symfony/blob/3cd2eef6e680c60d4d1d1e8ecd759f5806513698/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig#L277)

Thanks to @MrMitch for the report 👍 