### PR TITLE
Fix `!important` in VarDumper stylesheet

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/css/htmlDescriptor.css
+++ b/src/Symfony/Component/VarDumper/Resources/css/htmlDescriptor.css
@@ -102,7 +102,7 @@ pre.sf-dump {
     margin-bottom: 0;
 }
 .hidden {
-    display: none; !important
+    display: none !important;
 }
 .dumped-tag > .sf-dump {
     display: inline-block;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

Recreate new PR to fix tiny thing. Previous PR #28107 

Before

```css
.hidden {
    display: none; !important
}
```

After

```css
.hidden {
    display: none !important;
}
```
