### PR TITLE
[WebProfilerBundle] Remove useless macro arguments

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -126,7 +126,7 @@
         </h3>
     {% endif %}
 
-    {{ helper.display_timeline('timeline_' ~ token, collector.events, colors) }}
+    {{ helper.display_timeline('timeline_' ~ token, colors) }}
 
     {% if profile.children|length %}
         <p class="help">Note: sections with a striped background correspond to sub-requests.</p>
@@ -140,7 +140,7 @@
                 <small>{{ events.__section__.duration }} ms</small>
             </h4>
 
-            {{ helper.display_timeline('timeline_' ~ child.token, events, colors) }}
+            {{ helper.display_timeline('timeline_' ~ child.token, colors) }}
         {% endfor %}
     {% endif %}
 
@@ -470,12 +470,12 @@
         var requests_data = {
             "max": {{ "%F"|format(collector.events.__section__.endtime) }},
             "requests": [
-{{ helper.dump_request_data(token, profile, collector.events, collector.events.__section__.origin) }}
+{{ helper.dump_request_data(token, collector.events, collector.events.__section__.origin) }}
 
 {% if profile.children|length %}
                 ,
 {% for child in profile.children %}
-{{ helper.dump_request_data(child.token, child, child.getcollector('time').events, collector.events.__section__.origin) }}{{ loop.last ? '' : ',' }}
+{{ helper.dump_request_data(child.token, child.getcollector('time').events, collector.events.__section__.origin) }}{{ loop.last ? '' : ',' }}
 {% endfor %}
 {% endif %}
             ]
@@ -513,7 +513,7 @@
     //]]>{% endautoescape %}</script>
 {% endblock %}
 
-{% macro dump_request_data(token, profile, events, origin) %}
+{% macro dump_request_data(token, events, origin) %}
 {% autoescape 'js' %}
 {% from _self import dump_events %}
                 {
@@ -549,7 +549,7 @@
 {% endautoescape %}
 {% endmacro %}
 
-{% macro display_timeline(id, events, colors) %}
+{% macro display_timeline(id, colors) %}
     <div class="sf-profiler-timeline">
         <div class="legends">
             {% for category, color in colors %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I was digging into the Stopwatch Component and the part of displaying timeline in WebProfilerBundle and found some useless arguments in macro. The code was changed but arguments were abandoned.

Where the problem appeared: https://github.com/symfony/web-profiler-bundle/commit/bfcc5e7392525e795ba94c3160b4a709be1f146b#diff-3651d31bd302da5c7c1ef927e8641c78L294