### PR TITLE
Update validators.nl.xlf

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -316,7 +316,7 @@
             </trans-unit>
             <trans-unit id="83">
                 <source>This is not a valid UUID.</source>
-                <target>Deze waarde is geen geldige UUID waarde.</target>
+                <target>Dit is geen geldige UUID.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The original translation does not match intended communication.
`Deze waarde is geen geldige UUID waarde.` reads as `This value is not a valid UUID value`.