### PR TITLE
[Translation] fix perf of lint:xliff command

### DIFF
--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -130,10 +130,10 @@ EOF
         $document->schemaValidate(__DIR__.'/../Resources/schemas/xliff-core-1.2-strict.xsd');
         foreach (libxml_get_errors() as $xmlError) {
             $errors[] = array(
-                    'line' => $xmlError->line,
-                    'column' => $xmlError->column,
-                    'message' => trim($xmlError->message),
-                );
+                'line' => $xmlError->line,
+                'column' => $xmlError->column,
+                'message' => trim($xmlError->message),
+            );
         }
 
         libxml_clear_errors();

--- a/src/Symfony/Component/Translation/Resources/schemas/xliff-core-1.2-strict.xsd
+++ b/src/Symfony/Component/Translation/Resources/schemas/xliff-core-1.2-strict.xsd
@@ -30,7 +30,7 @@ Jan-10-2006
 -->
 <xsd:schema xmlns:xlf="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:oasis:names:tc:xliff:document:1.2" xml:lang="en">
   <!-- Import for xml:lang and xml:space -->
-  <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../../Loader/schema/dic/xliff-core/xml.xsd"/>
   <!-- Attributes Lists -->
   <xsd:simpleType name="XTend">
     <xsd:restriction base="xsd:string">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27564
| License       | MIT
| Doc PR        | -

#27653 has been merged on master as an improvement, but the perf issue is a killer.
Our CI spends 1 minutes on just a few translation test cases.
Only 4.1 has this behavior. That's a bug.