### PR TITLE
[Serializer] Fix the XML comments encoding

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 * `AbstractNormalizer::handleCircularReference` is now final, and receives two optional extra arguments: the format and the context
+* added support for XML comment encoding (encoding `['#comment' => ' foo ']` results `<!-- foo -->`)
 
 4.1.0
 -----

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -22,6 +22,7 @@ use Symfony\Component\Serializer\SerializerAwareTrait;
  * @author John Wards <jwards@whiteoctober.co.uk>
  * @author Fabian Vogler <fabian@equivalence.ch>
  * @author Kévin Dunglas <dunglas@gmail.com>
+ * @author Dany Maillard <danymaillard93b@gmail.com>
  */
 class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwareInterface, SerializerAwareInterface
 {
@@ -226,6 +227,13 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         return false;
     }
 
+    final protected function appendComment(\DOMNode $node, string $data): bool
+    {
+        $node->appendChild($this->dom->createComment($data));
+
+        return true;
+    }
+
     /**
      * Checks the name is a valid xml element name.
      */
@@ -366,6 +374,8 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
                     $parentNode->setAttribute($attributeName, $data);
                 } elseif ('#' === $key) {
                     $append = $this->selectNodeType($parentNode, $data);
+                } elseif ('#comment' === $key) {
+                    $append = $this->appendComment($parentNode, $data);
                 } elseif (\is_array($data) && false === is_numeric($key)) {
                     // Is this array fully numeric keys?
                     if (ctype_digit(implode('', array_keys($data)))) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -760,6 +760,19 @@ XML;
         $this->assertEquals($this->createXmlWithDateTimeField(), $actualXml);
     }
 
+    public function testEncodeComment()
+    {
+        $expected = <<<'XML'
+<?xml version="1.0"?>
+<response><!-- foo --></response>
+
+XML;
+
+        $data = array('#comment' => ' foo ');
+
+        $this->assertEquals($expected, $this->encoder->encode($data, 'xml'));
+    }
+
     /**
      * @return XmlEncoder
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

When we decode a XML comment, we get `['#comment' => ' foo ']`. But when we encode this same content, the result is not the expected one.

```php
$encoder->encode(['#comment' => ' foo '], 'xml');
```
```
Expected:
<response>
    <!-- foo -->
</response>

Actual:
<response>
  <item key="#comment"> foo </item>
</response>
```