### PR TITLE
Remove the HTML5 validation from the profiler URL search form

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
@@ -22,7 +22,7 @@
 
         <div class="form-group">
             <label for="url">URL</label>
-            <input type="url" name="url" id="url" value="{{ url }}">
+            <input type="text" name="url" id="url" value="{{ url }}">
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28157
| License       | MIT
| Doc PR        | N/A

We do not have to write a complete URL to do a search.

Only some keywords are necessary.