### PR TITLE
[Cache] Add ability to configure predis client.

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * added sub-second expiry accuracy for backends that support it
  * added support for phpredis 4 `compression` and `tcp_keepalive` options
  * added automatic table creation when using Doctrine DBAL with PDO-based backends
+ * added support for a `predis_options` array to be passed in the Redis DSN or set in `RedisAdapter` connection options
  * throw `LogicException` when `CacheItem::tag()` is called on an item coming from a non tag-aware pool
  * deprecated `CacheItem::getPreviousTags()`, use `CacheItem::getMetadata()` instead
  * deprecated the `AbstractAdapter::createSystemCache()` method

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Predis\Connection\Aggregate\RedisCluster;
 use Predis\Connection\StreamConnection;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
@@ -51,5 +52,12 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
             'password' => null,
         );
         $this->assertSame($params, $connection->getParameters()->toArray());
+
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'/1', array('class' => \Predis\Client::class, 'timeout' => 3));
+        $this->assertInstanceOf(\Predis\Client::class, $redis);
+
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'?predis_options[cluster]=redis');
+        $this->assertInstanceOf(\Predis\Client::class, $redis);
+        $this->assertInstanceOf(RedisCluster::class, $redis->getOptions()->cluster);
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -73,6 +73,23 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
     }
 
     /**
+     * @dataProvider provideInvalidDSNCreateConnection
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid connection option: "predis_options" provided but provided class "\SomeClass" is not an instance of \Predis\Client
+     */
+    public function testInvalidDSNFailedConnection($dsn)
+    {
+        RedisAdapter::createConnection($dsn);
+    }
+
+    public function provideInvalidDSNCreateConnection()
+    {
+        return array(
+            array('redis://localhost?predis_options[cluster]=redis&class=\SomeClass'),
+        );
+    }
+
+    /**
      * @dataProvider provideInvalidCreateConnection
      * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
      * @expectedExceptionMessage Invalid Redis DSN

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -119,7 +119,20 @@ trait RedisTrait
         if (null === $params['class'] && !\extension_loaded('redis') && !class_exists(\Predis\Client::class)) {
             throw new CacheException(sprintf('Cannot find the "redis" extension, and "predis/predis" is not installed: %s', $dsn));
         }
-        $class = null === $params['class'] ? (\extension_loaded('redis') ? \Redis::class : \Predis\Client::class) : $params['class'];
+
+        if (isset($params['predis_options']) && !class_exists(\Predis\Client::class)) {
+            throw new InvalidArgumentException('Invalid connection option: "predis_options" provided but "predis/predis" is not installed.');
+        }
+
+        if (isset($params['predis_options']) && null !== $params['class'] && !is_a($params['class'], \Predis\Client::class, true)) {
+            throw new InvalidArgumentException(sprintf('Invalid connection option: "predis_options" provided but provided class "%s" is not an instance of \Predis\Client', $params['class']));
+        }
+
+        if (isset($params['predis_options'])) {
+            $class = $params['class'] ?? \Predis\Client::class;
+        } else {
+            $class = $params['class'] ?? (\extension_loaded('redis') ? \Redis::class : \Predis\Client::class);
+        }
 
         if (is_a($class, \Redis::class, true)) {
             $connect = $params['persistent'] || $params['persistent_id'] ? 'pconnect' : 'connect';
@@ -167,7 +180,10 @@ trait RedisTrait
             $params['scheme'] = $scheme;
             $params['database'] = $params['dbindex'] ?: null;
             $params['password'] = $auth;
-            $redis = new $class((new Factory())->create($params));
+
+            $predisOptions = $params['predis_options'] ?? array();
+
+            $redis = new $class((new Factory())->create($params), $predisOptions);
         } elseif (class_exists($class, false)) {
             throw new InvalidArgumentException(sprintf('"%s" is not a subclass of "Redis" or "Predis\Client"', $class));
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

When using `predis/predis`, there is currently no way to set any options as the 2nd parameter in the `Predis\Client` constructor. This merge allows you to define these options with a `predis_options` query parameter in the dsn.

Example:

```
default_redis_provider: 'redis://localhost:6379?predis_options[cluster]=redis&predis_options[profile]=2.8'
```
