### PR TITLE
Adding a new TargetPathHelper class & service

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -11,6 +11,8 @@ CHANGELOG
    or `Symfony\Component\Security\Core\Authentication\Token\RememberMeToken`.
  * Added `Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass`
  * Added `json_login_ldap` authentication provider to use LDAP authentication with a REST API.
+ * Added a `Symfony\Bundle\SecurityBundle\Security\TargetPathHelper` class
+   and service to help saving or getting the target path from the session.
  
 4.1.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -160,6 +160,13 @@
             <argument />                   <!-- switch_user -->
         </service>
 
+        <service id="security.target_path_helper" class="Symfony\Bundle\SecurityBundle\Security\TargetPathHelper">
+            <argument type="service" id="session" />
+            <argument type="service" id="security.firewall.map" />
+            <argument type="service" id="request_stack" />
+        </service>
+        <service id="Symfony\Bundle\SecurityBundle\Security\TargetPathHelper" alias="security.target_path_helper" />
+
         <service id="security.logout_url_generator" class="Symfony\Component\Security\Http\Logout\LogoutUrlGenerator">
             <argument type="service" id="request_stack" on-invalid="null" />
             <argument type="service" id="router" on-invalid="null" />

--- a/src/Symfony/Bundle/SecurityBundle/Security/TargetPathHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/TargetPathHelper.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Security;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
+
+final class TargetPathHelper
+{
+    use TargetPathTrait;
+
+    private $session;
+
+    private $firewallMap;
+
+    private $requestStack;
+
+    public function __construct(SessionInterface $session, FirewallMap $firewallMap, RequestStack $requestStack)
+    {
+        $this->session = $session;
+        $this->firewallMap = $firewallMap;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * Sets the target path the user should be redirected to after authentication.
+     *
+     * @param string $uri The URI to set as the target path
+     */
+    public function savePath(string $uri)
+    {
+        $this->saveTargetPath($this->session, $this->getProviderKey(), $uri);
+    }
+
+    /**
+     * Returns the URL (if any) the user visited that forced them to login.
+     */
+    public function getPath(): string
+    {
+        return $this->getTargetPath($this->session, $this->getProviderKey());
+    }
+
+    private function getProviderKey(): string
+    {
+        $firewallConfig = $this->firewallMap->getFirewallConfig($this->requestStack->getMasterRequest());
+
+        if (null === $firewallConfig) {
+            throw new \LogicException('Could not find firewall config for the current request');
+        }
+
+        return $firewallConfig->getName();
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/TargetPathHelperTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/TargetPathHelperTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Bundle\SecurityBundle\Security\TargetPathHelper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class TargetPathHelperTest extends TestCase
+{
+    public function testSavePath()
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $firewallMap = $this->createMock(FirewallMap::class);
+        $requestStack = $this->createMock(RequestStack::class);
+        $request = new Request();
+
+        $requestStack->expects($this->once())
+            ->method('getMasterRequest')
+            ->willReturn($request);
+
+        $firewallConfig = new FirewallConfig('firewall_name', '');
+        $firewallMap->expects($this->once())
+            ->method('getFirewallConfig')
+            ->with($request)
+            ->willReturn($firewallConfig);
+
+        $session->expects($this->once())
+            ->method('set')
+            ->with('_security.firewall_name.target_path', '/foo');
+
+        $targetPathHelper = new TargetPathHelper($session, $firewallMap, $requestStack);
+        $targetPathHelper->savePath('/foo');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27835 
| License       | MIT
| Doc PR        | TODO

Hey guys!

If you want to set the redirect "target path" or read it from a controller, it's not so easy because you don't easily have access to your firewall name (unless you hardcode it). This adds a new class & service where you can save/fetch this value without needing any information.

Cheers!