### PR TITLE
[DI] Fix dumping service locators

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -86,4 +86,14 @@ class ProjectServiceContainer extends Container
             'baz' => array('privates', 'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition', 'getCustomDefinitionService', false),
         )))->withContext('foo_service', $this));
     }
+
+    /**
+     * Gets the private 'Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition' shared service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition
+     */
+    protected function getCustomDefinitionService()
+    {
+        return $this->privates['Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes (master only)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28180
| License       | MIT
| Doc PR        | -

Services need to be visited to populate `$this->loadedIds` before using the property decide what needs to be dumped or not.
