### PR TITLE
[WebProfilerBundle] fix wrong url when base path is the index

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -100,7 +100,7 @@ class FileLinkFormatter implements \Serializable
                 }
 
                 return array(
-                    $request->getSchemeAndHttpHost().$request->getBaseUrl().$this->urlFormat,
+                    $request->getSchemeAndHttpHost().$request->getBasePath().$this->urlFormat,
                     $this->baseDir.\DIRECTORY_SEPARATOR, '',
                 );
             }

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
@@ -37,7 +37,6 @@ class FileLinkFormatterTest extends TestCase
     public function testWhenFileLinkFormatAndRequest()
     {
         $file = __DIR__.\DIRECTORY_SEPARATOR.'file.php';
-        $baseDir = __DIR__;
         $requestStack = new RequestStack();
         $request = new Request();
         $requestStack->push($request);
@@ -56,12 +55,12 @@ class FileLinkFormatterTest extends TestCase
 
         $request->server->set('SERVER_NAME', 'www.example.org');
         $request->server->set('SERVER_PORT', 80);
-        $request->server->set('SCRIPT_NAME', '/app.php');
-        $request->server->set('SCRIPT_FILENAME', '/web/app.php');
-        $request->server->set('REQUEST_URI', '/app.php/example');
+        $request->server->set('SCRIPT_NAME', '/index.php');
+        $request->server->set('SCRIPT_FILENAME', '/public/index.php');
+        $request->server->set('REQUEST_URI', '/index.php/example');
 
         $sut = new FileLinkFormatter(null, $requestStack, __DIR__, '/_profiler/open?file=%f&line=%l#line%l');
 
-        $this->assertSame('http://www.example.org/app.php/_profiler/open?file=file.php&line=3#line3', $sut->format($file, 3));
+        $this->assertSame('http://www.example.org/_profiler/open?file=file.php&line=3#line3', $sut->format($file, 3));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | >= 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27846   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

The `FileLinkFormatter` create a wrong url because it's using [getBaseUrl](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Request.php#L870) that render the script filename, the problem is that in this class it's used twice, first time with the [getBaseUrl method](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php#L99) and another time with the [generate method](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php#L77). Just switch to `getBasePath` solve the issue.
WDYT ? 
