### PR TITLE
[PhpUnitBridge] Add missing stderr redirection

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -16,7 +16,7 @@ class CoverageListenerTest extends TestCase
             $this->markTestSkipped('This test cannot be run on HHVM.');
         }
 
-        exec('type phpdbg', $output, $returnCode);
+        exec('type phpdbg 2> /dev/null', $output, $returnCode);
 
         if (\PHP_VERSION_ID >= 70000 && 0 === $returnCode) {
             $php = 'phpdbg -qrr';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This seems to have been overlooked in
6c0e6af47a5f36b906892537f5b2fbf15dab30b2, and results in the test suite
being polluted on machines where phpdbg is not installed.
I updated the code to mimic other occurences of exec in this file.