### PR TITLE
[VarDumper] fix using ClassStub with closures in namespaces

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ClassStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/ClassStub.php
@@ -52,9 +52,15 @@ class ClassStub extends ConstStub
             }
 
             if (\is_array($r)) {
-                try {
-                    $r = new \ReflectionMethod($r[0], $r[1]);
-                } catch (\ReflectionException $e) {
+                if (false === strpos($r[1], '{closure}')) {
+                    // if method isn't a closure
+                    try {
+                        $r = new \ReflectionMethod($r[0], $r[1]);
+                    } catch (\ReflectionException $e) {
+                        $r = new \ReflectionClass($r[0]);
+                    }
+                } else {
+                    // if method is a closure
                     $r = new \ReflectionClass($r[0]);
                 }
             }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ClassStubTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ClassStubTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Caster\ClassStub;
+
+require_once \dirname(__DIR__).'/Fixtures/SimpleClass.php';
+
+class ClassStubTest extends TestCase
+{
+    /**
+     * @param $identifier
+     * @param $callable
+     * @param $result
+     *
+     * @dataProvider getIdentifiers
+     */
+    public function testConstruct($identifier, $callable, $result)
+    {
+        $stub = new ClassStub($identifier, $callable);
+
+        $this->assertEquals(serialize($result), $stub->serialize());
+    }
+
+    public function getIdentifiers()
+    {
+        $baseDir = \dirname(__DIR__);
+
+        return array(
+            array('\stdClass', null, array(
+                '',
+                0,
+                0,
+                1,
+                '\stdClass',
+                0,
+                0,
+                array(),
+            )),
+            array('\stdClass::staticMethod()', null, array(
+                '',
+                0,
+                0,
+                1,
+                '\stdClass::staticMethod()',
+                0,
+                0,
+                array(),
+            )),
+            array('\stdClass->classMethod()', null, array(
+                '',
+                0,
+                0,
+                1,
+                '\stdClass->classMethod()',
+                0,
+                0,
+                array(),
+            )),
+            array(\SimpleClass::class.'::staticMethod()', null, array(
+                '',
+                0,
+                0,
+                1,
+                'SimpleClass::staticMethod()',
+                0,
+                0,
+                array(
+                    'file' => $baseDir.'/Fixtures/SimpleClass.php',
+                    'line' => 3,
+                ),
+            )),
+            array(\SimpleClass::class.'->classMethod()', null, array(
+                '',
+                0,
+                0,
+                1,
+                'SimpleClass->classMethod()',
+                0,
+                0,
+                array(
+                    'file' => $baseDir.'/Fixtures/SimpleClass.php',
+                    'line' => 3,
+                ),
+            )),
+            array(\SimpleClass::class.'->'.\SimpleClass::class.'\{closure}', null, array(
+                '',
+                0,
+                0,
+                1,
+                'SimpleClass->SimpleClass\{closure}',
+                0,
+                0,
+                array(
+                    'ellipsis' => 10,
+                    'ellipsis-type' => 'class',
+                    'ellipsis-tail' => 1,
+                    'file' => $baseDir.'/Fixtures/SimpleClass.php',
+                    'line' => 3,
+                ),
+            )),
+        );
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/SimpleClass.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/SimpleClass.php
@@ -1,0 +1,21 @@
+<?php
+
+class SimpleClass
+{
+    public static function staticMethod()
+    {
+        return 'static';
+    }
+
+    public function classMethod()
+    {
+        return 'class';
+    }
+
+    public function getClosure()
+    {
+        return function () {
+            return 'closure';
+        };
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | 

If the `ClassStub` needs to work with a class closure, it will throw a `FatalErrorException`. I got this:

```
FatalErrorExceptionError: __debuginfo() must return an array
--
in ClassStub.php line 56
at ReflectionMethod->__construct('\'eZ\\\\Publish\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\Storage\\\\ExternalStorageRegistryFactory\'', '\'eZ\\\\Publish\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\Storage\\\\{closure}\'') in ClassStub.php line 56
at ClassStub->__construct('identifier' => '\'eZ\\\\Publish\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\Storage\\\\ExternalStorageRegistryFactory->eZ\\\\Publish\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\Storage\\\\{closure}\'', 'callable' => '???') in ExceptionCaster.php line 163
...
```

This bugfix handles this situation.
