### PR TITLE
[travis][appveyor] use symfony/flex to accelerate builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
 
       if [[ $TRAVIS_PHP_VERSION = 5.* || $TRAVIS_PHP_VERSION = hhvm* ]]; then
           composer () {
-              $HOME/.phpenv/versions/7.1/bin/composer config platform.php $(echo ' <?php echo preg_replace("/-.*/", "", PHP_VERSION);' | php /dev/stdin)
+              $HOME/.phpenv/versions/7.1/bin/php $HOME/.phpenv/versions/7.1/bin/composer config platform.php $(echo ' <?php echo preg_replace("/-.*/", "", PHP_VERSION);' | php /dev/stdin)
               $HOME/.phpenv/versions/7.1/bin/php $HOME/.phpenv/versions/7.1/bin/composer $*
           }
           export -f composer
@@ -187,6 +187,15 @@ install:
       else
           SYMFONY_VERSION=$(cat composer.json | grep '^ *"dev-master". *"[1-9]' | grep -o '[0-9.]*')
       fi
+
+    - |
+      # Install symfony/flex
+      if [[ $deps = low ]]; then
+          export SYMFONY_REQUIRE='>=2.3'
+      else
+          export SYMFONY_REQUIRE=">=$SYMFONY_VERSION"
+      fi
+      composer global require symfony/flex dev-master
 
     - |
       # Legacy tests are skipped when deps=high and when the current branch version has not the same major version number than the next one

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ init:
     - SET PATH=c:\php;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
     - SET SYMFONY_DEPRECATIONS_HELPER=strict
+    - SET "SYMFONY_REQUIRE=>=2.8"
     - SET ANSICON=121x90 (121x90)
     - SET SYMFONY_PHPUNIT_VERSION=4.8
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v DelayedExpansion /t REG_DWORD /d 1 /f
@@ -51,9 +52,10 @@ install:
     - copy /Y php.ini-min php.ini
     - echo extension=php_openssl.dll >> php.ini
     - cd c:\projects\symfony
-    - IF NOT EXIST composer.phar (appveyor DownloadFile https://getcomposer.org/download/1.3.0/composer.phar)
+    - IF NOT EXIST composer.phar (appveyor DownloadFile https://github.com/composer/composer/releases/download/1.7.1/composer.phar)
     - php composer.phar self-update
     - copy /Y .composer\* %APPDATA%\Composer\
+    - php composer.phar global require --no-progress symfony/flex dev-master
     - php .github/build-packages.php "HEAD^" src\Symfony\Bridge\PhpUnit
     - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
     - php composer.phar config platform.php 5.3.9


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Playing with https://github.com/symfony/flex/pull/409

The optimization is required because appveyor is transiently failing with OOM errors, see e.g.
https://ci.appveyor.com/project/fabpot/symfony/build/1.0.39377