### PR TITLE
[Validator] Improve DivisibleBy validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DivisibleByValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DivisibleByValidator.php
@@ -28,20 +28,17 @@ class DivisibleByValidator extends AbstractComparisonValidator
         $epsilon = 0.0000001;
 
         // can't divide by 0
-        if ($value2 < $epsilon)
-        {
+        if ($value2 < $epsilon) {
             return false;
         }
 
         // 0 is divisible by everything
-        if ($value1 < $epsilon)
-        {
+        if ($value1 < $epsilon) {
             return true;
         }
 
         // if the divisor is larger than the dividend, it will never cleanly divide
-        if ($value2 > $value1)
-        {
+        if ($value2 > $value1) {
             return false;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/DivisibleByValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DivisibleByValidator.php
@@ -23,7 +23,29 @@ class DivisibleByValidator extends AbstractComparisonValidator
      */
     protected function compareValues($value1, $value2)
     {
-        return (float) 0 === fmod($value1, $value2);
+        $value1 = \abs($value1);
+        $value2 = \abs($value2);
+        $epsilon = 0.0000001;
+
+        // can't divide by 0
+        if ($value2 < $epsilon)
+        {
+            return false;
+        }
+
+        // 0 is divisible by everything
+        if ($value1 < $epsilon)
+        {
+            return true;
+        }
+
+        // if the divisor is larger than the dividend, it will never cleanly divide
+        if ($value2 > $value1)
+        {
+            return false;
+        }
+
+        return \abs($value1 - round($value1 / $value2) * $value2) < $epsilon;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByValidatorTest.php
@@ -46,6 +46,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
             array(42, 21),
             array(3.25, 0.25),
             array('100', '10'),
+            array(4.1, 0.1),
         );
     }
 
@@ -69,6 +70,7 @@ class DivisibleByValidatorTest extends AbstractComparisonValidatorTestCase
             array(10, '10', 3, '3', 'integer'),
             array(10, '10', 0, '0', 'integer'),
             array(42, '42', INF, 'INF', 'double'),
+            array(4.15, '4.15', 0.1, '0.1', 'double'),
             array('22', '"22"', '10', '"10"', 'string'),
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | —
| License       | MIT
| Doc PR        | —

The newly added `DivisibleBy` validator uses internally `fmod`, which has some issues regarding floating point numbers and numbers with decimals.

For example `fmod(4.1, 0.1) ~= 0.1` and currently fails the validator. See for example this comment in the PHP docs: http://de2.php.net/manual/en/function.fmod.php#122782

This change implements the logic manually ( 😞 ) but should solve more edge cases.
