### PR TITLE
[Routing] Fixing == & != operators

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -240,9 +240,9 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
 
         if ((self::ABSOLUTE_URL === $referenceType || self::NETWORK_PATH === $referenceType) && !empty($host)) {
             $port = '';
-            if ('http' === $scheme && 80 != $this->context->getHttpPort()) {
+            if ('http' === $scheme && 80 !== $this->context->getHttpPort()) {
                 $port = ':'.$this->context->getHttpPort();
-            } elseif ('https' === $scheme && 443 != $this->context->getHttpsPort()) {
+            } elseif ('https' === $scheme && 443 !== $this->context->getHttpsPort()) {
                 $port = ':'.$this->context->getHttpsPort();
             }
 

--- a/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
@@ -50,7 +50,7 @@ abstract class ObjectRouteLoader extends Loader
         }
 
         $parts = explode('::', $resource);
-        if (2 != \count($parts)) {
+        if (2 !== \count($parts)) {
             throw new \InvalidArgumentException(sprintf('Invalid resource "%s" passed to the "service" route loader: use the format "service::method"', $resource));
         }
 

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -252,8 +252,8 @@ class RouteCompiler implements RouteCompilerInterface
      */
     private static function findNextSeparator(string $pattern, bool $useUtf8): string
     {
-        if ('' == $pattern) {
-            // return empty string if pattern is empty or false (false which can be returned by substr)
+        if ('' === $pattern) {
+            // return empty string if pattern is empty
             return '';
         }
         // first remove all placeholders from the pattern so we can find the next real static character
@@ -295,7 +295,7 @@ class RouteCompiler implements RouteCompilerInterface
                     // matched the optional subpattern is not passed back.
                     $regexp = "(?:$regexp";
                     $nbTokens = \count($tokens);
-                    if ($nbTokens - 1 == $index) {
+                    if ($nbTokens - 1 === $index) {
                         // Close the optional subpatterns
                         $regexp .= str_repeat(')?', $nbTokens - $firstOptional - (0 === $firstOptional ? 1 : 0));
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | possibly
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | none

Fixing some `==` & `!=` operators with `===` & `!==` operators. Since they would become deprecated.
Cf. https://github.com/php/php-src/compare/master...Majkl578:deprecate-equals-operator

There is still: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Generator/UrlGenerator.php#L261, but this one is strongly based on `==` behavior so not sure if I should find a workaround or keep it like this.