### PR TITLE
Removed dead code in Kernel

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -244,19 +244,10 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
         $isResource = 0 === strpos($path, 'Resources') && null !== $dir;
         $overridePath = substr($path, 9);
-        $resourceBundle = null;
         $bundle = $this->getBundle($bundleName);
         $files = array();
 
         if ($isResource && file_exists($file = $dir.'/'.$bundle->getName().$overridePath)) {
-            if (null !== $resourceBundle) {
-                throw new \RuntimeException(sprintf('"%s" resource is hidden by a resource from the "%s" derived bundle. Create a "%s" file to override the bundle resource.',
-                    $file,
-                    $resourceBundle,
-                    $dir.'/'.$bundle->getName().$overridePath
-                ));
-            }
-
             $files[] = $file;
         }
 
@@ -265,7 +256,6 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                 return $file;
             }
             $files[] = $file;
-            $resourceBundle = $bundle->getName();
         }
 
         if (\count($files) > 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| License       | MIT

While navigating in `src/Symfony/Component/HttpKernel/Kernel` I saw some **dead** codes. 
