### PR TITLE
[DomCrawler] Add a way to filter direct children

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -501,14 +501,26 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the children nodes of the current selection.
      *
+     * @param string|null $selector An optional CSS selector to filter children
+     *
      * @return self
      *
      * @throws \InvalidArgumentException When current node is empty
+     * @throws \RuntimeException         If the CssSelector Component is not available and $selector is provided
      */
-    public function children()
+    public function children(/* string $selector = null */)
     {
+        $selector = 0 < \func_num_args() ? func_get_arg(0) : null;
+
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        if (null !== $selector) {
+            $converter = $this->createCssSelectorConverter();
+            $xpath = $converter->toXPath($selector, 'child::');
+
+            return $this->filterRelativeXPath($xpath);
         }
 
         $node = $this->getNode(0)->firstChild;
@@ -691,11 +703,7 @@ class Crawler implements \Countable, \IteratorAggregate
      */
     public function filter($selector)
     {
-        if (!class_exists(CssSelectorConverter::class)) {
-            throw new \RuntimeException('To filter with a CSS selector, install the CssSelector component ("composer require symfony/css-selector"). Or use filterXpath instead.');
-        }
-
-        $converter = new CssSelectorConverter($this->isHtml);
+        $converter = $this->createCssSelectorConverter();
 
         // The CssSelector already prefixes the selector with descendant-or-self::
         return $this->filterRelativeXPath($converter->toXPath($selector));
@@ -1147,5 +1155,17 @@ class Crawler implements \Countable, \IteratorAggregate
         $crawler->namespaces = $this->namespaces;
 
         return $crawler;
+    }
+
+    /**
+     * @throws \RuntimeException If the CssSelector Component is not available
+     */
+    private function createCssSelectorConverter(): CssSelectorConverter
+    {
+        if (!class_exists(CssSelectorConverter::class)) {
+            throw new \RuntimeException('To filter with a CSS selector, install the CssSelector component ("composer require symfony/css-selector"). Or use filterXpath instead.');
+        }
+
+        return new CssSelectorConverter($this->isHtml);
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -1004,6 +1004,37 @@ HTML;
         }
     }
 
+    public function testFilteredChildren()
+    {
+        $html = <<<'HTML'
+<!DOCTYPE html>
+<html lang="en">
+<body>
+    <div id="foo">
+        <div class="lorem">
+            <p class="lorem"></p>
+        </div>
+        <div class="lorem">
+            <span class="lorem"></span>
+        </div>
+        <span class="ipsum"></span>
+    </div>
+</body>
+</html>
+HTML;
+
+        $crawler = new Crawler($html);
+        $foo = $crawler->filter('#foo');
+
+        $this->assertEquals(3, $foo->children()->count());
+        $this->assertEquals(2, $foo->children('.lorem')->count());
+        $this->assertEquals(2, $foo->children('div')->count());
+        $this->assertEquals(2, $foo->children('div.lorem')->count());
+        $this->assertEquals(1, $foo->children('span')->count());
+        $this->assertEquals(1, $foo->children('span.ipsum')->count());
+        $this->assertEquals(1, $foo->children('.ipsum')->count());
+    }
+
     public function testParents()
     {
         $crawler = $this->createTestCrawler()->filterXPath('//li[1]');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28171 
| License       | MIT
| Doc PR        | -

The Dom-Crawler component only has a `filter()` method (to filter the node and all its children) and a `children()` method to return direct children.
**There is currently no way to easily filter (thanks to a selector) the direct children of a node, like jQuery allows so (with a selector passed to the `.children([selector])` method).**

**This PR adds a way to optionally filter direct children thanks to a CSS selector**. Here is an example of the usage:

```php
$html = <<<'HTML'
<html>
    <body>
        <div id="foo">
            <p class="lorem" id="p1"></p>
            <p class="lorem" id="p2"></p>
            <div id="nested">
                <p class="lorem" id="p3"></p>
            </div>
        </div>
    </body>
</html>
HTML;

$crawler = new Crawler($html);
$foo = $crawler->filter('#foo');

$foo->children() // will select `#p1`, `#p2` and `#nested`
$foo->children('p') // will select `#p1` and `p2`
$foo->children('.lorem') // will select `#p1` and `p2`
```
This PR adds only an optional parameter and adds no BC break.