### PR TITLE
[WebProfilerBundle] Limit width of toolbar item

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -86,6 +86,7 @@
     height: 36px;
     margin-right: 0;
     white-space: nowrap;
+    max-width: 15%;
 }
 .sf-toolbar-block > a,
 .sf-toolbar-block > a:hover {
@@ -252,6 +253,8 @@
     display: block;
     height: 36px;
     padding: 0 7px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 .sf-toolbar-block-request .sf-toolbar-icon {
     padding-left: 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28105 
| License       | MIT
| Doc PR        | 

before
![screenshot from 2018-08-17 22-06-46](https://user-images.githubusercontent.com/496233/44287443-2d4dab80-a26d-11e8-9e28-e4f7764ed428.png)
after:
![screenshot from 2018-08-17 22-07-04](https://user-images.githubusercontent.com/496233/44287452-33438c80-a26d-11e8-8efe-539f7a1dae8d.png)

Tested on master and 2.8. 
IMO should be treated as bug fix, there are no conflicts.