### PR TITLE
[Security\Http] Restore laziness of listener iterator

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -50,31 +50,38 @@ class Firewall implements EventSubscriberInterface
         // register listeners for this firewall
         $listeners = $this->map->getListeners($event->getRequest());
 
-        $accessListener = null;
-        $authenticationListeners = array();
+        $authenticationListeners = $listeners[0];
+        $exceptionListener = $listeners[1];
+        $logoutListener = isset($listeners[2]) ? $listeners[2] : null;
 
-        foreach ($listeners[0] as $listener) {
-            if ($listener instanceof AccessListener) {
-                $accessListener = $listener;
-            } else {
-                $authenticationListeners[] = $listener;
-            }
-        }
-
-        if (null !== $exceptionListener = $listeners[1]) {
+        if (null !== $exceptionListener) {
             $this->exceptionListeners[$event->getRequest()] = $exceptionListener;
             $exceptionListener->register($this->dispatcher);
         }
 
-        if (null !== $logoutListener = isset($listeners[2]) ? $listeners[2] : null) {
-            $authenticationListeners[] = $logoutListener;
-        }
+        $authenticationListeners = function () use ($authenticationListeners, $logoutListener) {
+            $accessListener = null;
 
-        if (null !== $accessListener) {
-            $authenticationListeners[] = $accessListener;
-        }
+            foreach ($authenticationListeners as $listener) {
+                if ($listener instanceof AccessListener) {
+                    $accessListener = $listener;
 
-        $this->handleRequest($event, $authenticationListeners);
+                    continue;
+                }
+
+                yield $listener;
+            }
+
+            if (null !== $logoutListener) {
+                yield $logoutListener;
+            }
+
+            if (null !== $accessListener) {
+                yield $accessListener;
+            }
+        };
+
+        $this->handleRequest($event, $authenticationListeners());
     }
 
     public function onKernelFinishRequest(FinishRequestEvent $event)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no (never released)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Alternative to #28223

Restores laziness that I broke in merge commit https://github.com/symfony/symfony/commit/2dedacbc046ebfce2d9dc40257f8ce94b2562244#diff-31ca8a8ce837591218082b00363149fc
