### PR TITLE
[FrameworkBundle] Deprecate `Symfony\Bundle\FrameworkBundle\Controller\Controller`

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -91,6 +91,7 @@ FrameworkBundle
  * Removed `Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser`.
  * Warming up a router in `RouterCacheWarmer` that does not implement the `WarmableInterface` is not supported anymore.
  * The `RequestDataCollector` class has been removed. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
+ * Removed `Symfony\Bundle\FrameworkBundle\Controller\Controller`. Use `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` instead.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allowed configuring PDO-based cache pools via a new `cache.adapter.pdo` abstract service
  * Deprecated auto-injection of the container in AbstractController instances, register them as service subscribers instead
  * Deprecated processing of services tagged `security.expression_language_provider` in favor of a new `AddExpressionLanguageProvidersPass` in SecurityBundle.
+ * Deprecated the `Symfony\Bundle\FrameworkBundle\Controller\Controller` class in favor of `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`.
  * Enabled autoconfiguration for `Psr\Log\LoggerAwareInterface`
 
 4.1.0

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -14,10 +14,14 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.2, use %s instead.', Controller::class, AbstractController::class), E_USER_DEPRECATED);
+
 /**
  * Controller is a simple implementation of a Controller.
  *
  * It provides methods to common features needed in controllers.
+ *
+ * @deprecated since Symfony 4.2, use {@see AbstractController} instead.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -18,7 +18,6 @@ use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bridge\Monolog\Processor\ProcessorInterface;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
@@ -296,7 +295,6 @@ class FrameworkExtension extends Extension
 
             // Added explicitly so that we don't rely on the class map being dumped to make it work
             'Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController',
-            'Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller',
         ));
 
         $container->registerForAutoconfiguration(Command::class)
@@ -313,7 +311,7 @@ class FrameworkExtension extends Extension
             ->addTag('controller.argument_value_resolver');
         $container->registerForAutoconfiguration(AbstractController::class)
             ->addTag('controller.service_arguments');
-        $container->registerForAutoconfiguration(Controller::class)
+        $container->registerForAutoconfiguration('Symfony\Bundle\FrameworkBundle\Controller\Controller')
             ->addTag('controller.service_arguments');
         $container->registerForAutoconfiguration(DataCollectorInterface::class)
             ->addTag('data_collector');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -11,17 +11,13 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-
+/**
+ * @group legacy
+ */
 class ControllerTest extends ControllerTraitTest
 {
     protected function createController()
     {
         return new TestController();
     }
-}
-
-class TestController extends Controller
-{
-    use TestControllerTrait;
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TestController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TestController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class TestController extends Controller
+{
+    use TestControllerTrait;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      |  no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #28215
| License       | MIT
| Doc PR        | ø

Time to deprecate `Controller`, youpi !! 🎉 
