### PR TITLE
[Messenger] Don't make EnvelopeItemInterface extend Serializable

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -87,6 +87,7 @@ FrameworkBundle
 Messenger
 ---------
 
+ * `EnvelopeItemInterface` doesn't extend `Serializable` anymore
  * The `handle` method of the `Symfony\Component\Messenger\Middleware\ValidationMiddleware` and `Symfony\Component\Messenger\Asynchronous\Middleware\SendMessageMiddleware` middlewares now requires an `Envelope` object to be given (because they implement the `EnvelopeAwareInterface`). When using these middleware with the provided `MessageBus`, you will not have to do anything. If you use the middlewares any other way, you can use `Envelope::wrap($message)` to create an envelope for your message.
 
 Security

--- a/src/Symfony/Component/Messenger/Asynchronous/Transport/ReceivedMessage.php
+++ b/src/Symfony/Component/Messenger/Asynchronous/Transport/ReceivedMessage.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\EnvelopeItemInterface;
 
 /**
  * Marker config for a received message.
+ *
  * This is mainly used by the `SendMessageMiddleware` middleware to identify
  * a message should not be sent if it was just received.
  *
@@ -25,13 +26,4 @@ use Symfony\Component\Messenger\EnvelopeItemInterface;
  */
 final class ReceivedMessage implements EnvelopeItemInterface
 {
-    public function serialize()
-    {
-        return '';
-    }
-
-    public function unserialize($serialized)
-    {
-        // noop
-    }
 }

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,0 +1,8 @@
+CHANGELOG
+=========
+
+4.2.0
+-----
+
+ * `ValidationMiddleware::handle()` and `SendMessageMiddleware::handle()` now require an `Envelope` object
+ * `EnvelopeItemInterface` doesn't extend `Serializable` anymore

--- a/src/Symfony/Component/Messenger/EnvelopeItemInterface.php
+++ b/src/Symfony/Component/Messenger/EnvelopeItemInterface.php
@@ -13,12 +13,13 @@ namespace Symfony\Component\Messenger;
 
 /**
  * An envelope item related to a message.
+ *
  * This item must be serializable for transport.
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  *
  * @experimental in 4.1
  */
-interface EnvelopeItemInterface extends \Serializable
+interface EnvelopeItemInterface
 {
 }

--- a/src/Symfony/Component/Messenger/Middleware/Configuration/ValidationConfiguration.php
+++ b/src/Symfony/Component/Messenger/Middleware/Configuration/ValidationConfiguration.php
@@ -35,24 +35,4 @@ final class ValidationConfiguration implements EnvelopeItemInterface
     {
         return $this->groups;
     }
-
-    public function serialize()
-    {
-        $isGroupSequence = $this->groups instanceof GroupSequence;
-
-        return serialize(array(
-            'groups' => $isGroupSequence ? $this->groups->groups : $this->groups,
-            'is_group_sequence' => $isGroupSequence,
-        ));
-    }
-
-    public function unserialize($serialized)
-    {
-        list(
-            'groups' => $groups,
-            'is_group_sequence' => $isGroupSequence
-        ) = unserialize($serialized, array('allowed_classes' => false));
-
-        $this->__construct($isGroupSequence ? new GroupSequence($groups) : $groups);
-    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Asynchronous/Transport/Serialization/SerializerConfigurationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Asynchronous/Transport/Serialization/SerializerConfigurationTest.php
@@ -24,7 +24,6 @@ class SerializerConfigurationTest extends TestCase
     {
         $config = new SerializerConfiguration(array(ObjectNormalizer::GROUPS => array('Default', 'Extra')));
 
-        $this->assertTrue(is_subclass_of(SerializerConfiguration::class, \Serializable::class, true));
         $this->assertEquals($config, unserialize(serialize($config)));
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/AnEnvelopeItem.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/AnEnvelopeItem.php
@@ -15,19 +15,4 @@ use Symfony\Component\Messenger\EnvelopeItemInterface;
 
 class AnEnvelopeItem implements EnvelopeItemInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function serialize()
-    {
-        return '';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function unserialize($serialized)
-    {
-        // noop
-    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/Configuration/ValidationConfigurationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/Configuration/ValidationConfigurationTest.php
@@ -31,7 +31,6 @@ class ValidationConfigurationTest extends TestCase
 
     public function testSerializable()
     {
-        $this->assertTrue(is_subclass_of(ValidationConfiguration::class, \Serializable::class, true));
         $this->assertEquals($config = new ValidationConfiguration(array('Default', 'Extra')), unserialize(serialize($config)));
         $this->assertEquals($config = new ValidationConfiguration(new GroupSequence(array('Default', 'Then'))), unserialize(serialize($config)));
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -98,6 +98,6 @@ class SerializerTest extends TestCase
         $this->assertArrayHasKey('type', $encoded['headers']);
         $this->assertEquals(DummyMessage::class, $encoded['headers']['type']);
         $this->assertArrayHasKey('X-Message-Envelope-Items', $encoded['headers']);
-        $this->assertSame('a:2:{s:75:"Symfony\Component\Messenger\Transport\Serialization\SerializerConfiguration";C:75:"Symfony\Component\Messenger\Transport\Serialization\SerializerConfiguration":59:{a:1:{s:7:"context";a:1:{s:6:"groups";a:1:{i:0;s:3:"foo";}}}}s:76:"Symfony\Component\Messenger\Middleware\Configuration\ValidationConfiguration";C:76:"Symfony\Component\Messenger\Middleware\Configuration\ValidationConfiguration":82:{a:2:{s:6:"groups";a:2:{i:0;s:3:"foo";i:1;s:3:"bar";}s:17:"is_group_sequence";b:0;}}}', $encoded['headers']['X-Message-Envelope-Items']);
+        $this->assertSame('a:2:{s:75:"Symfony\Component\Messenger\Transport\Serialization\SerializerConfiguration";O:75:"Symfony\Component\Messenger\Transport\Serialization\SerializerConfiguration":1:{s:84:"'."\0".'Symfony\Component\Messenger\Transport\Serialization\SerializerConfiguration'."\0".'context";a:1:{s:6:"groups";a:1:{i:0;s:3:"foo";}}}s:76:"Symfony\Component\Messenger\Middleware\Configuration\ValidationConfiguration";O:76:"Symfony\Component\Messenger\Middleware\Configuration\ValidationConfiguration":1:{s:84:"'."\0".'Symfony\Component\Messenger\Middleware\Configuration\ValidationConfiguration'."\0".'groups";a:2:{i:0;s:3:"foo";i:1;s:3:"bar";}}}', $encoded['headers']['X-Message-Envelope-Items']);
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SerializerConfiguration.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SerializerConfiguration.php
@@ -31,16 +31,4 @@ final class SerializerConfiguration implements EnvelopeItemInterface
     {
         return $this->context;
     }
-
-    public function serialize()
-    {
-        return serialize(array('context' => $this->context));
-    }
-
-    public function unserialize($serialized)
-    {
-        list('context' => $context) = unserialize($serialized, array('allowed_classes' => false));
-
-        $this->__construct($context);
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes (on experimental API)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

`Serializable` is a broken interface, see e.g. https://externals.io/message/98834
I don't think we should force ppl to implement it anywhere.
Actually, it isn't required to be able to serialize an object, and it doesn't enforce making a class serializable (as the `serialize()` method can throw).

What was the purpose of the removed logic? ping @sroze @ogizanagi 