### PR TITLE
[RFC] [Workflow] WIP adding optional timestamp to workflow component

### DIFF
--- a/src/Symfony/Component/Workflow/MarkingStore/MultipleStateMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MultipleStateMarkingStore.php
@@ -26,13 +26,23 @@ use Symfony\Component\Workflow\Marking;
  */
 class MultipleStateMarkingStore implements MarkingStoreInterface
 {
+    /** @var string the marking property name */
     private $property;
+    /** @var \Symfony\Component\PropertyAccess\PropertyAccessor a propertyaccessor to access the marking property */
     private $propertyAccessor;
 
-    public function __construct(string $property = 'marking', PropertyAccessorInterface $propertyAccessor = null)
+    /** @var string the optional timestamp property name */
+    private $timestampProperty;
+    /** @var \Symfony\Component\PropertyAccess\PropertyAccessor|PropertyAccessorInterface a propertyaccessor to access the timestamp field */
+    private $timestampPropertyAccessor;
+
+    public function __construct(string $property = 'marking', PropertyAccessorInterface $propertyAccessor = null, string $timestampProperty = null, PropertyAccessorInterface $timestampPropertyAccessor = null)
     {
         $this->property = $property;
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
+
+        $this->timestampProperty = $timestampProperty;
+        $this->timestampPropertyAccessor = $timestampPropertyAccessor ?? PropertyAccess::createPropertyAccessor();
     }
 
     /**
@@ -49,6 +59,12 @@ class MultipleStateMarkingStore implements MarkingStoreInterface
     public function setMarking($subject, Marking $marking)
     {
         $this->propertyAccessor->setValue($subject, $this->property, $marking->getPlaces());
+
+        // set date / time
+        if (null !== $this->timestampProperty)
+        {
+            $this->timestampPropertyAccessor->setValue($subject, $this->timestampProperty, new \DateTime());
+        }
     }
 
     /**
@@ -59,3 +75,4 @@ class MultipleStateMarkingStore implements MarkingStoreInterface
         return $this->property;
     }
 }
+

--- a/src/Symfony/Component/Workflow/MarkingStore/MultipleStateMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MultipleStateMarkingStore.php
@@ -61,8 +61,7 @@ class MultipleStateMarkingStore implements MarkingStoreInterface
         $this->propertyAccessor->setValue($subject, $this->property, $marking->getPlaces());
 
         // set date / time
-        if (null !== $this->timestampProperty)
-        {
+        if (null !== $this->timestampProperty) {
             $this->timestampPropertyAccessor->setValue($subject, $this->timestampProperty, new \DateTime());
         }
     }
@@ -75,4 +74,3 @@ class MultipleStateMarkingStore implements MarkingStoreInterface
         return $this->property;
     }
 }
-

--- a/src/Symfony/Component/Workflow/MarkingStore/SingleStateMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/SingleStateMarkingStore.php
@@ -25,13 +25,23 @@ use Symfony\Component\Workflow\Marking;
  */
 class SingleStateMarkingStore implements MarkingStoreInterface
 {
+    /** @var string the marking property name */
     private $property;
+    /** @var \Symfony\Component\PropertyAccess\PropertyAccessor a propertyaccessor to access the marking property */
     private $propertyAccessor;
 
-    public function __construct(string $property = 'marking', PropertyAccessorInterface $propertyAccessor = null)
+    /** @var string the optional timestamp property name */
+    private $timestampProperty;
+    /** @var \Symfony\Component\PropertyAccess\PropertyAccessor|PropertyAccessorInterface a propertyaccessor to access the timestamp field */
+    private $timestampPropertyAccessor;
+
+    public function __construct(string $property = 'marking', PropertyAccessorInterface $propertyAccessor = null, string $timestampProperty = null, PropertyAccessorInterface $timestampPropertyAccessor = null)
     {
         $this->property = $property;
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
+
+        $this->timestampProperty = $timestampProperty;
+        $this->timestampPropertyAccessor = $timestampPropertyAccessor ?? PropertyAccess::createPropertyAccessor();
     }
 
     /**
@@ -54,13 +64,20 @@ class SingleStateMarkingStore implements MarkingStoreInterface
     public function setMarking($subject, Marking $marking)
     {
         $this->propertyAccessor->setValue($subject, $this->property, key($marking->getPlaces()));
+
+        // set date / time
+        if (null !== $this->timestampProperty)
+        {
+            $this->timestampPropertyAccessor->setValue($subject, $this->timestampProperty, new \DateTime());
+        }
     }
 
     /**
-     * @return string
+     * @return string the marking property name
      */
     public function getProperty()
     {
         return $this->property;
     }
 }
+

--- a/src/Symfony/Component/Workflow/MarkingStore/SingleStateMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/SingleStateMarkingStore.php
@@ -66,8 +66,7 @@ class SingleStateMarkingStore implements MarkingStoreInterface
         $this->propertyAccessor->setValue($subject, $this->property, key($marking->getPlaces()));
 
         // set date / time
-        if (null !== $this->timestampProperty)
-        {
+        if (null !== $this->timestampProperty) {
             $this->timestampPropertyAccessor->setValue($subject, $this->timestampProperty, new \DateTime());
         }
     }
@@ -80,4 +79,3 @@ class SingleStateMarkingStore implements MarkingStoreInterface
         return $this->property;
     }
 }
-


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | todo    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo <!-- required for new features -->

Adds an optional timestamp that is written to the entity when the state changes. It is defined in the workflow config:

```
            ...
            marking_store:
                type: 'single_state' # 'single_state' or 'multiple_state'
                arguments:
                    - 'currentState'
                    - # optional property accessor for the state column
                    - 'currentStateTimestamp'   # the optional name of the property to write a timestamp to when state changes
            ...
```

where `currentStateTimestamp` is a datetime field. The config looks a little weird because the second parameter of the marking store is an optional PropertyAccessor (but is perfectly useable). Changing the order would be a BC?

