### PR TITLE
[Cache] improve perf when using RedisCluster by reducing roundtrips to the servers

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
+{
+    public static function setupBeforeClass()
+    {
+        if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
+            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
+        }
+        self::$redis = new \Predis\Client(explode(' ', $hosts), array('cluster' => 'redis'));
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$redis = null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Improves perf when using RedisCluster by:
- disabling versioning and replacing by per-master clear/flush
- grouping multiple "get" in one "mget"
- enabling pipelining in PredisCluster mode

~Might need adjustment depending on the answer to https://github.com/nrk/predis/issues/520~