### PR TITLE
[Messenger] Allow interfaces to be type-hinted as well

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -114,7 +114,7 @@ class MessengerPass implements CompilerPassInterface
                         $method = $method[0];
                     }
 
-                    if (!\class_exists($messageClass)) {
+                    if (!\class_exists($messageClass) && !\interface_exists($messageClass)) {
                         $messageClassLocation = isset($tag['handles']) ? 'declared in your tag attribute "handles"' : $r->implementsInterface(MessageSubscriberInterface::class) ? sprintf('returned by method "%s::getHandledMessages()"', $r->getName()) : sprintf('used as argument type in method "%s::%s()"', $r->getName(), $method);
 
                         throw new RuntimeException(sprintf('Invalid handler service "%s": message class "%s" %s does not exist.', $serviceId, $messageClass, $messageClassLocation));

--- a/src/Symfony/Component/Messenger/Tests/Asynchronous/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Asynchronous/Middleware/SendMessageMiddlewareTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Messenger\Asynchronous\Middleware\SendMessageMiddleware;
 use Symfony\Component\Messenger\Asynchronous\Routing\SenderLocatorInterface;
 use Symfony\Component\Messenger\Asynchronous\Transport\ReceivedMessage;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Tests\Asynchronous\Routing\ChildDummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Messenger\Transport\SenderInterface;

--- a/src/Symfony/Component/Messenger/Tests/Asynchronous/Routing/SenderLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Asynchronous/Routing/SenderLocatorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Tests\Asynchronous\Routing;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Messenger\Asynchronous\Routing\SenderLocator;
+use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
@@ -87,8 +88,4 @@ class SenderLocatorTest extends TestCase
         $this->assertSame($sender, $locator->getSenderForMessage(new DummyMessage('Hello')));
         $this->assertSame($apiSender, $locator->getSenderForMessage(new SecondMessage()));
     }
-}
-
-class ChildDummyMessage extends DummyMessage
-{
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/ChildDummyMessage.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/ChildDummyMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+class ChildDummyMessage extends DummyMessage
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Handler/Locator/ContainerHandlerLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/Locator/ContainerHandlerLocatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Handler\Locator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Messenger\Handler\Locator\ContainerHandlerLocator;
+use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
+
+class ContainerHandlerLocatorTest extends TestCase
+{
+    public function testItLocatesHandlerUsingTheMessageClass()
+    {
+        $handler = function () {};
+
+        $container = new Container();
+        $container->set('handler.'.DummyMessage::class, $handler);
+
+        $locator = new ContainerHandlerLocator($container);
+        $resolvedHandler = $locator->resolve(new DummyMessage('Hey'));
+
+        $this->assertSame($handler, $resolvedHandler);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Messenger\Exception\NoHandlerForMessageException
+     * @expectedExceptionMessage No handler for message "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage"
+     */
+    public function testThrowsNoHandlerException()
+    {
+        $locator = new ContainerHandlerLocator(new Container());
+        $locator->resolve(new DummyMessage('Hey'));
+    }
+
+    public function testResolveMessageViaTheirInterface()
+    {
+        $handler = function () {};
+
+        $container = new Container();
+        $container->set('handler.'.DummyMessageInterface::class, $handler);
+
+        $locator = new ContainerHandlerLocator($container);
+        $resolvedHandler = $locator->resolve(new DummyMessage('Hey'));
+
+        $this->assertSame($handler, $resolvedHandler);
+    }
+
+    public function testResolveMessageViaTheirParentClass()
+    {
+        $handler = function () {};
+
+        $container = new Container();
+        $container->set('handler.'.DummyMessage::class, $handler);
+
+        $locator = new ContainerHandlerLocator($container);
+        $resolvedHandler = $locator->resolve(new ChildDummyMessage('Hey'));
+
+        $this->assertSame($handler, $resolvedHandler);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27076
| License       | MIT
| Doc PR        | ø

Interfaces can be type-hinted as well for the message handlers.