### PR TITLE
[HttpFoundation] Fix unprepared BinaryFileResponse sends empty file

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -31,8 +31,8 @@ class BinaryFileResponse extends Response
      * @var File
      */
     protected $file;
-    protected $offset;
-    protected $maxlen;
+    protected $offset = 0;
+    protected $maxlen = -1;
     protected $deleteFileAfterSend = false;
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -206,6 +206,19 @@ class BinaryFileResponseTest extends ResponseTestCase
         );
     }
 
+    public function testUnpreparedResponseSendsFullFile()
+    {
+        $response = BinaryFileResponse::create(__DIR__.'/File/Fixtures/test.gif', 200);
+
+        $data = file_get_contents(__DIR__.'/File/Fixtures/test.gif');
+
+        $this->expectOutputString($data);
+        $response = clone $response;
+        $response->sendContent();
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
     /**
      * @dataProvider provideInvalidRanges
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes, with the exception of preexisting, unrelated failures
| Fixed tickets | #28237 
| License       | MIT
| Doc PR        | 

When you call `BinaryFileResponse#sendContent()` without first calling `prepare()` the response is sent but the contents are empty. `prepare()` properly initializes the `$maxlen` and `$offset` properties. However, `sendContent()` doesn't do any sanity checking, and so, uses the uninitialized properties. This causes `stream_copy_to_stream()` to copy empty contents and the file that is sent, to contain nothing.

This change initializes the properties at definition instead of in `prepare()`.

> Additionally:
> - Bug fixes must be submitted against the lowest branch where they apply

~I'm not sure how early this bug exists, or how far back to go. I'll check to see if 2.7 and 2.8 are affected and report back.~
