### PR TITLE
[Serializer] Update changelog about the new $encoderIgnoredNodeTypes arg in XmlEncoder contrustor

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
 * `AbstractNormalizer::handleCircularReference` is now final, and receives two optional extra arguments: the format and the context
 * added support for XML comment encoding (encoding `['#comment' => ' foo ']` results `<!-- foo -->`)
+* added optional `int[] $encoderIgnoredNodeTypes` argument to `XmlEncoder::__construct` to configure node types to be
+  ignored during encoding.
 
 4.1.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/27926
| License       | MIT
| Doc PR        | /