### PR TITLE
[Serializer] Add support for ignoring comments while XML encoding

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -378,7 +378,9 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
                 } elseif ('#' === $key) {
                     $append = $this->selectNodeType($parentNode, $data);
                 } elseif ('#comment' === $key) {
-                    $append = $this->appendComment($parentNode, $data);
+                    if (!\in_array(XML_COMMENT_NODE, $this->encoderIgnoredNodeTypes, true)) {
+                        $append = $this->appendComment($parentNode, $data);
+                    }
                 } elseif (\is_array($data) && false === is_numeric($key)) {
                     // Is this array fully numeric keys?
                     if (ctype_digit(implode('', array_keys($data)))) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -782,6 +782,21 @@ XML;
         $this->assertEquals($expected, $encoder->encode(array(), 'xml'));
     }
 
+    public function testEncodeWithoutComment()
+    {
+        $encoder = new XmlEncoder('response', null, array(), array(XML_COMMENT_NODE));
+
+        $expected = <<<'XML'
+<?xml version="1.0"?>
+<response/>
+
+XML;
+
+        $data = array('#comment' => ' foo ');
+
+        $this->assertEquals($expected, $encoder->encode($data, 'xml'));
+    }
+
     /**
      * @return XmlEncoder
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

In addition to https://github.com/symfony/symfony/pull/27926 which allowed to ignore XML processing instructions, this PR allows to ignore the XML comments while encoding.