### PR TITLE
[WebServerBundle] Add support for Xdebug's Profiler

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
@@ -133,6 +133,9 @@ EOF
             $config = new WebServerConfig($documentRoot, $env, $input->getArgument('addressport'), $input->getOption('router'));
 
             $io->success(sprintf('Server listening on http://%s', $config->getAddress()));
+            if (ini_get('xdebug.profiler_enable_trigger')) {
+                $io->comment('Xdebug profiler trigger enabled.');
+            }
             $io->comment('Quit the server with CONTROL-C.');
 
             $exitCode = $server->run($config, $disableOutput, $callback);

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -144,6 +144,9 @@ EOF
 
             if (WebServer::STARTED === $server->start($config, $input->getOption('pidfile'))) {
                 $io->success(sprintf('Server listening on http://%s', $config->getAddress()));
+                if (ini_get('xdebug.profiler_enable_trigger')) {
+                    $io->comment('Xdebug profiler trigger enabled.');
+                }
             }
         } catch (\Exception $e) {
             $io->error($e->getMessage());

--- a/src/Symfony/Bundle/WebServerBundle/WebServer.php
+++ b/src/Symfony/Bundle/WebServerBundle/WebServer.php
@@ -150,7 +150,9 @@ class WebServer
             throw new \RuntimeException('Unable to find the PHP binary.');
         }
 
-        $process = new Process(array_merge(array($binary), $finder->findArguments(), array('-dvariables_order=EGPCS', '-S', $config->getAddress(), $config->getRouter())));
+        $xdebugArgs = ini_get('xdebug.profiler_enable_trigger') ? array('-dxdebug.profiler_enable_trigger=1') : array();
+
+        $process = new Process(array_merge(array($binary), $finder->findArguments(), $xdebugArgs, array('-dvariables_order=EGPCS', '-S', $config->getAddress(), $config->getRouter())));
         $process->setWorkingDirectory($config->getDocumentRoot());
         $process->setTimeout(null);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

> Xdebug's Profiler is a powerful tool that gives you the ability to analyze your PHP code and determine bottlenecks or generally see which parts of your code are slow and could use a speed boost.

https://xdebug.org/docs/profiler

When we run/start the web server, it would be useful to enable the trigger for the Xdebug's Profiler. That means we could easily trigger the creation of a Xdebug profile and analysing it [thanks to PhpStorm](https://www.jetbrains.com/help/phpstorm/analyzing-xdebug-profiling-data.html) which provides an **Execution Statistics** panel (examine the summary information about execution metrics of every called function) and a **Call Tree** panel (explore the execution paths of all called functions). You can see these two panels in action [here](https://youtu.be/_ua_O01IICg?t=1m22s) for a better understanding.