### PR TITLE
[Cache] handle redis cluster creation by dsn

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * added sub-second expiry accuracy for backends that support it
  * added support for phpredis 4 `compression` and `tcp_keepalive` options
  * added automatic table creation when using Doctrine DBAL with PDO-based backends
+ * added support for redis cluster via DSN
  * throw `LogicException` when `CacheItem::tag()` is called on an item coming from a non tag-aware pool
  * deprecated `CacheItem::getPreviousTags()`, use `CacheItem::getMetadata()` instead
  * deprecated the `AbstractAdapter::createSystemCache()` method

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -47,6 +47,7 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
             'compression' => true,
             'tcp_keepalive' => 0,
             'lazy' => false,
+            'cluster' => null,
             'database' => '1',
             'password' => null,
         );

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+
 class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
 {
     public static function setupBeforeClass()
@@ -18,7 +20,8 @@ class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
             self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
-        self::$redis = new \Predis\Client(explode(' ', $hosts), array('cluster' => 'redis'));
+
+        self::$redis = RedisAdapter::createConnection('redis://'.str_replace(' ', ',', $hosts), array('class' => \Predis\Client::class, 'cluster' => 'server'));
     }
 
     public static function tearDownAfterClass()

--- a/src/Symfony/Component/Cache/Traits/RedisClusterProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisClusterProxy.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+/**
+ * @author Alessandro Chitolina <alekitto@gmail.com>
+ *
+ * @internal
+ */
+class RedisClusterProxy
+{
+    private $redis;
+    private $initializer;
+
+    public function __construct(\Closure $initializer)
+    {
+        $this->redis = null;
+        $this->initializer = $initializer;
+    }
+
+    public function __call($method, array $args)
+    {
+        $this->redis ?: $this->redis = $this->initializer->__invoke();
+
+        return \call_user_func_array(array($this->redis, $method), $args);
+    }
+
+    public function hscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
+    {
+        $this->redis ?: $this->redis = $this->initializer->__invoke();
+
+        return $this->redis->hscan($strKey, $iIterator, $strPattern, $iCount);
+    }
+
+    public function scan(&$iIterator, $strPattern = null, $iCount = null)
+    {
+        $this->redis ?: $this->redis = $this->initializer->__invoke();
+
+        return $this->redis->scan($iIterator, $strPattern, $iCount);
+    }
+
+    public function sscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
+    {
+        $this->redis ?: $this->redis = $this->initializer->__invoke();
+
+        return $this->redis->sscan($strKey, $iIterator, $strPattern, $iCount);
+    }
+
+    public function zscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
+    {
+        $this->redis ?: $this->redis = $this->initializer->__invoke();
+
+        return $this->redis->zscan($strKey, $iIterator, $strPattern, $iCount);
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -38,6 +38,7 @@ trait RedisTrait
         'compression' => true,
         'tcp_keepalive' => 0,
         'lazy' => false,
+        'cluster' => null,
     );
     private $redis;
     private $marshaller;
@@ -52,7 +53,7 @@ trait RedisTrait
         if (preg_match('#[^-+_.A-Za-z0-9]#', $namespace, $match)) {
             throw new InvalidArgumentException(sprintf('RedisAdapter namespace contains "%s" but only characters in [-+_.A-Za-z0-9] are allowed.', $match[0]));
         }
-        if (!$redisClient instanceof \Redis && !$redisClient instanceof \RedisArray && !$redisClient instanceof \RedisCluster && !$redisClient instanceof \Predis\Client && !$redisClient instanceof RedisProxy) {
+        if (!$redisClient instanceof \Redis && !$redisClient instanceof \RedisArray && !$redisClient instanceof \RedisCluster && !$redisClient instanceof \Predis\Client && !$redisClient instanceof RedisProxy && !$redisClient instanceof RedisClusterProxy) {
             throw new InvalidArgumentException(sprintf('%s() expects parameter 1 to be Redis, RedisArray, RedisCluster or Predis\Client, %s given', __METHOD__, \is_object($redisClient) ? \get_class($redisClient) : \gettype($redisClient)));
         }
         $this->redis = $redisClient;
@@ -74,49 +75,51 @@ trait RedisTrait
      *
      * @throws InvalidArgumentException when the DSN is invalid
      *
-     * @return \Redis|\Predis\Client According to the "class" option
+     * @return \Redis|\RedisCluster|\Predis\Client According to the "class" option
      */
     public static function createConnection($dsn, array $options = array())
     {
         if (0 !== strpos($dsn, 'redis://')) {
             throw new InvalidArgumentException(sprintf('Invalid Redis DSN: %s does not start with "redis://"', $dsn));
         }
-        $params = preg_replace_callback('#^redis://(?:(?:[^:@]*+:)?([^@]*+)@)?#', function ($m) use (&$auth) {
-            if (isset($m[1])) {
-                $auth = $m[1];
-            }
 
-            return 'file://';
-        }, $dsn);
-        if (false === $params = parse_url($params)) {
+        if (false === $params = parse_url($dsn)) {
             throw new InvalidArgumentException(sprintf('Invalid Redis DSN: %s', $dsn));
         }
+
         if (!isset($params['host']) && !isset($params['path'])) {
             throw new InvalidArgumentException(sprintf('Invalid Redis DSN: %s', $dsn));
         }
+
+        $auth = $params['password'] ?? $params['user'] ?? null;
+        $scheme = isset($params['host']) ? 'tcp' : 'unix';
+
         if (isset($params['path']) && preg_match('#/(\d+)$#', $params['path'], $m)) {
             $params['dbindex'] = $m[1];
             $params['path'] = substr($params['path'], 0, -\strlen($m[0]));
         }
-        if (isset($params['host'])) {
-            $scheme = 'tcp';
-        } else {
-            $scheme = 'unix';
-        }
+
         $params += array(
-            'host' => isset($params['host']) ? $params['host'] : $params['path'],
+            'host' => $params['path'] ?? '',
             'port' => isset($params['host']) ? 6379 : null,
             'dbindex' => 0,
         );
+
         if (isset($params['query'])) {
             parse_str($params['query'], $query);
             $params += $query;
         }
+
         $params += $options + self::$defaultConnectionOptions;
         if (null === $params['class'] && !\extension_loaded('redis') && !class_exists(\Predis\Client::class)) {
             throw new CacheException(sprintf('Cannot find the "redis" extension, and "predis/predis" is not installed: %s', $dsn));
         }
-        $class = null === $params['class'] ? (\extension_loaded('redis') ? \Redis::class : \Predis\Client::class) : $params['class'];
+
+        if (null === $params['class'] && \extension_loaded('redis')) {
+            $class = 'server' === $params['cluster'] ? \RedisCluster::class : \Redis::class;
+        } else {
+            $class = null === $params['class'] ? \Predis\Client::class : $params['class'];
+        }
 
         if (is_a($class, \Redis::class, true)) {
             $connect = $params['persistent'] || $params['persistent_id'] ? 'pconnect' : 'connect';
@@ -124,7 +127,7 @@ trait RedisTrait
 
             $initializer = function ($redis) use ($connect, $params, $dsn, $auth) {
                 try {
-                    @$redis->{$connect}($params['host'], $params['port'], $params['timeout'], $params['persistent_id'], $params['retry_interval']);
+                    @$redis->{$connect}($params['host'], $params['port'], $params['timeout'], (string) $params['persistent_id'], $params['retry_interval']);
                 } catch (\RedisException $e) {
                     throw new InvalidArgumentException(sprintf('Redis connection failed (%s): %s', $e->getMessage(), $dsn));
                 }
@@ -160,6 +163,24 @@ trait RedisTrait
             } else {
                 $initializer($redis);
             }
+        } elseif (is_a($class, \RedisCluster::class, true)) {
+            $initializer = function () use ($class, $params, $dsn, $auth) {
+                $host = $params['host'];
+                if (isset($params['port'])) {
+                    $host .= ':'.$params['port'];
+                }
+
+                try {
+                    /** @var \RedisCluster $redis */
+                    $redis = new $class(null, explode(',', $host), $params['timeout'], $params['read_timeout'], (bool) $params['persistent']);
+                } catch (\RedisClusterException $e) {
+                    throw new InvalidArgumentException(sprintf('Redis connection failed (%s): %s', $e->getMessage(), $dsn));
+                }
+
+                return $redis;
+            };
+
+            $redis = $params['lazy'] ? new RedisClusterProxy($initializer) : $initializer();
         } elseif (is_a($class, \Predis\Client::class, true)) {
             $params['scheme'] = $scheme;
             $params['database'] = $params['dbindex'] ?: null;
@@ -183,9 +204,7 @@ trait RedisTrait
             return array();
         }
 
-        $i = -1;
         $result = array();
-
         if ($this->redis instanceof \Predis\Client) {
             $values = $this->pipeline(function () use ($ids) {
                 foreach ($ids as $id) {
@@ -210,6 +229,11 @@ trait RedisTrait
      */
     protected function doHave($id)
     {
+        if (!\is_string($id)) {
+            // SEGFAULT on \RedisCluster
+            return false;
+        }
+
         return (bool) $this->redis->exists($id);
     }
 
@@ -237,13 +261,14 @@ trait RedisTrait
             foreach ($this->redis->_hosts() as $host) {
                 $hosts[] = $this->redis->_instance($host);
             }
-        } elseif ($this->redis instanceof \RedisCluster) {
+        } elseif ($this->redis instanceof RedisClusterProxy || $this->redis instanceof \RedisCluster) {
             $hosts = array();
             foreach ($this->redis->_masters() as $host) {
                 $hosts[] = $h = new \Redis();
                 $h->connect($host[0], $host[1]);
             }
         }
+
         foreach ($hosts as $host) {
             if (!isset($namespace[0])) {
                 $cleared = $host->flushDb() && $cleared;
@@ -330,7 +355,7 @@ trait RedisTrait
     {
         $ids = array();
 
-        if ($this->redis instanceof \RedisCluster || ($this->redis instanceof \Predis\Client && $this->redis->getConnection() instanceof RedisCluster)) {
+        if ($this->redis instanceof RedisClusterProxy || $this->redis instanceof \RedisCluster || ($this->redis instanceof \Predis\Client && $this->redis->getConnection() instanceof RedisCluster)) {
             // phpredis & predis don't support pipelining with RedisCluster
             // see https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#pipelining
             // see https://github.com/nrk/predis/issues/267#issuecomment-123781423

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
 use Predis\Response\ErrorInterface;
+use Symfony\Component\Cache\Traits\RedisClusterProxy;
 use Symfony\Component\Cache\Traits\RedisProxy;
 
 /**
@@ -45,7 +46,8 @@ class RedisSessionHandler extends AbstractSessionHandler
             !$redis instanceof \RedisArray &&
             !$redis instanceof \RedisCluster &&
             !$redis instanceof \Predis\Client &&
-            !$redis instanceof RedisProxy
+            !$redis instanceof RedisProxy &&
+            !$redis instanceof RedisClusterProxy
         ) {
             throw new \InvalidArgumentException(sprintf('%s() expects parameter 1 to be Redis, RedisArray, RedisCluster or Predis\Client, %s given', __METHOD__, \is_object($redis) ? \get_class($redis) : \gettype($redis)));
         }

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Store;
 
+use Symfony\Component\Cache\Traits\RedisClusterProxy;
 use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
@@ -130,7 +131,12 @@ class RedisStore implements StoreInterface
      */
     private function evaluate(string $script, string $resource, array $args)
     {
-        if ($this->redis instanceof \Redis || $this->redis instanceof \RedisCluster || $this->redis instanceof RedisProxy) {
+        if (
+            $this->redis instanceof \Redis ||
+            $this->redis instanceof \RedisCluster ||
+            $this->redis instanceof RedisProxy ||
+            $this->redis instanceof RedisClusterProxy
+        ) {
             return $this->redis->eval($script, array_merge(array($resource), $args), 1);
         }
 

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Store;
 
+use Symfony\Component\Cache\Traits\RedisClusterProxy;
 use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 
@@ -28,7 +29,14 @@ class StoreFactory
      */
     public static function createStore($connection)
     {
-        if ($connection instanceof \Redis || $connection instanceof \RedisArray || $connection instanceof \RedisCluster || $connection instanceof \Predis\Client || $connection instanceof RedisProxy) {
+        if (
+            $connection instanceof \Redis ||
+            $connection instanceof \RedisArray ||
+            $connection instanceof \RedisCluster ||
+            $connection instanceof \Predis\Client ||
+            $connection instanceof RedisProxy ||
+            $connection instanceof RedisClusterProxy
+        ) {
             return new RedisStore($connection);
         }
         if ($connection instanceof \Memcached) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | TBD

This PR adds support for `\RedisCluster` connection creation via DSN passing `redis+cluster` as protocol (ex: `redis+cluster://redis-server-1:6379,redis-server-2:6379`).

This allow to have the same configuration for different environments and change only the env var containing the connection string.
