### PR TITLE
[Process] Add relative path support for PHP_BINARY env var of PhpExecutableFinder

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -37,7 +37,14 @@ class PhpExecutableFinder
     {
         if ($php = getenv('PHP_BINARY')) {
             if (!is_executable($php)) {
-                return false;
+                $command = '\\' === \DIRECTORY_SEPARATOR ? 'where' : 'command -v';
+                if ($php = strtok(exec($command.' '.escapeshellarg($php)), PHP_EOL)) {
+                    if (!is_executable($php)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
             }
 
             return $php;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

At the moment, only the absolute path for PHP_BINARY env var works, for instance :

```
$ PHP_BINARY=/usr/bin/php7.2 php bin/console server:run
[OK] Server listening on http://127.0.0.1:8000

$ PHP_BINARY=php7.2 php bin/console server:run
[ERROR] Unable to find the PHP binary.
```

This PR makes possible the second command. 