### PR TITLE
[VarDumper] Allow dd() to be called without arguments

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -32,14 +32,12 @@ if (!function_exists('dump')) {
 }
 
 if (!function_exists('dd')) {
-    function dd($var, ...$moreVars)
+    function dd(...$vars)
     {
-        VarDumper::dump($var);
-
-        foreach ($moreVars as $v) {
+        foreach ($vars as $v) {
             VarDumper::dump($v);
         }
 
-        exit(1);
+        die(1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

**Description**
A while back the `dd()` helper was [added to the VarDumper component](https://github.com/symfony/symfony/pull/26970) which was (i think) inspired by Laravel's `dd()` helper. Laravel has [removed their version of the helper](https://github.com/laravel/framework/pull/25087) in favor of the helper in Symfony.

However, as opposed to the Laravel helper, the Symfony helper requires at least one argument. Calling the Laravel helper with no arguments simply killed the program (and usually showed a white screen), calling the Symfony helper with no arguments throws a `TypeError: Too few arguments to function dd()` exception (which gets rendered by the error handler and fills the whole screen with useless information).

Being able to call the `dd()` helper with no arguments is useful because it is a quick way to tell you if your code reaches a certain point. If it does, you can fill in the `dd()` with variables to keep debugging.

This PR allows the dd helper to be called without arguments. 

This PR also makes the helper call `die` instead of `exit` to better reflect the function name 😄 