### PR TITLE
[Routing] Fixed the interface description of the url generator interface

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -73,7 +73,7 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      * @param mixed  $parameters    An array of parameters
      * @param int    $referenceType The type of reference to be generated (one of the constants)
      *
-     * @return string The generated URL
+     * @return string|null The generated URL
      *
      * @throws RouteNotFoundException              If the named route doesn't exist
      * @throws MissingMandatoryParametersException When some parameters are missing that are mandatory for the route


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The `UrlGenerator` has always been able to return `null`. Many tests assert this for many years but the interface actually always only allowed a `string` return.

Examples for tests:

- https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php#L206
- https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php#L217
- https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php#L471

So I think I would not consider this change as a BC break but rather a doc fix because it seems like `null` has always been an accepted return value.