### PR TITLE
[FrameworkBundle] Don't populate fallback cache on warmup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -31,13 +31,18 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
     private $debug;
 
     /**
-     * @param Reader                 $annotationReader
-     * @param string                 $phpArrayFile     The PHP file where annotations are cached
-     * @param CacheItemPoolInterface $fallbackPool     The pool where runtime-discovered annotations are cached
+     * @param string $phpArrayFile  The PHP file where annotations are cached
+     * @param string $excludeRegexp
+     * @param bool   $debug
      */
-    public function __construct(Reader $annotationReader, string $phpArrayFile, CacheItemPoolInterface $fallbackPool, string $excludeRegexp = null, bool $debug = false)
+    public function __construct(Reader $annotationReader, string $phpArrayFile, $excludeRegexp = null, $debug = false)
     {
-        parent::__construct($phpArrayFile, $fallbackPool);
+        if ($excludeRegexp instanceof CacheItemPoolInterface) {
+            @trigger_error(sprintf('The CacheItemPoolInterface $fallbackPool argument of "%s()" is deprecated since Symfony 4.2, you should not pass it anymore.', __METHOD__), E_USER_DEPRECATED);
+            $excludeRegexp = $debug;
+            $debug = 4 < \func_num_args() && \func_get_arg(4);
+        }
+        parent::__construct($phpArrayFile);
         $this->annotationReader = $annotationReader;
         $this->excludeRegexp = $excludeRegexp;
         $this->debug = $debug;

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
@@ -31,13 +31,15 @@ class SerializerCacheWarmer extends AbstractPhpFileCacheWarmer
     private $loaders;
 
     /**
-     * @param LoaderInterface[]      $loaders      The serializer metadata loaders
-     * @param string                 $phpArrayFile The PHP file where metadata are cached
-     * @param CacheItemPoolInterface $fallbackPool The pool where runtime-discovered metadata are cached
+     * @param LoaderInterface[] $loaders      The serializer metadata loaders
+     * @param string            $phpArrayFile The PHP file where metadata are cached
      */
-    public function __construct(array $loaders, string $phpArrayFile, CacheItemPoolInterface $fallbackPool)
+    public function __construct(array $loaders, string $phpArrayFile)
     {
-        parent::__construct($phpArrayFile, $fallbackPool);
+        if (2 < \func_num_args() && \func_get_arg(2) instanceof CacheItemPoolInterface) {
+            @trigger_error(sprintf('The CacheItemPoolInterface $fallbackPool argument of "%s()" is deprecated since Symfony 4.2, you should not pass it anymore.', __METHOD__), E_USER_DEPRECATED);
+        }
+        parent::__construct($phpArrayFile);
         $this->loaders = $loaders;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
@@ -33,13 +33,14 @@ class ValidatorCacheWarmer extends AbstractPhpFileCacheWarmer
     private $validatorBuilder;
 
     /**
-     * @param ValidatorBuilderInterface $validatorBuilder
-     * @param string                    $phpArrayFile     The PHP file where metadata are cached
-     * @param CacheItemPoolInterface    $fallbackPool     The pool where runtime-discovered metadata are cached
+     * @param string $phpArrayFile The PHP file where metadata are cached
      */
-    public function __construct(ValidatorBuilderInterface $validatorBuilder, string $phpArrayFile, CacheItemPoolInterface $fallbackPool)
+    public function __construct(ValidatorBuilderInterface $validatorBuilder, string $phpArrayFile)
     {
-        parent::__construct($phpArrayFile, $fallbackPool);
+        if (2 < \func_num_args() && \func_get_arg(2) instanceof CacheItemPoolInterface) {
+            @trigger_error(sprintf('The CacheItemPoolInterface $fallbackPool argument of "%s()" is deprecated since Symfony 4.2, you should not pass it anymore.', __METHOD__), E_USER_DEPRECATED);
+        }
+        parent::__construct($phpArrayFile);
         $this->validatorBuilder = $validatorBuilder;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -36,7 +36,6 @@
         <service id="annotations.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer">
             <argument type="service" id="annotations.reader" />
             <argument>%kernel.cache_dir%/annotations.php</argument>
-            <argument type="service" id="cache.annotations" />
             <argument>#^Symfony\\(?:Component\\HttpKernel\\|Bundle\\FrameworkBundle\\Controller\\(?!AbstractController$|Controller$))#</argument>
             <argument>%kernel.debug%</argument>
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -90,7 +90,6 @@
         <service id="serializer.mapping.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer">
             <argument type="collection" /><!-- Loaders injected by the extension -->
             <argument>%serializer.mapping.cache.file%</argument>
-            <argument type="service" id="cache.serializer" />
             <tag name="kernel.cache_warmer" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -35,7 +35,6 @@
         <service id="validator.mapping.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer">
             <argument type="service" id="validator.builder" />
             <argument>%validator.mapping.cache.file%</argument>
-            <argument type="service" id="cache.validator" />
             <tag name="kernel.cache_warmer" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -7,7 +7,6 @@ use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
@@ -37,13 +36,7 @@ class AnnotationsCacheWarmerTest extends TestCase
         file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export(array(__CLASS__), true)));
         $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
         $reader = new AnnotationReader();
-        $fallbackPool = new ArrayAdapter();
-        $warmer = new AnnotationsCacheWarmer(
-            $reader,
-            $cacheFile,
-            $fallbackPool,
-            null
-        );
+        $warmer = new AnnotationsCacheWarmer($reader, $cacheFile);
         $warmer->warmUp($this->cacheDir);
         $this->assertFileExists($cacheFile);
 
@@ -63,14 +56,7 @@ class AnnotationsCacheWarmerTest extends TestCase
         file_put_contents($this->cacheDir.'/annotations.map', sprintf('<?php return %s;', var_export(array(__CLASS__), true)));
         $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
         $reader = new AnnotationReader();
-        $fallbackPool = new ArrayAdapter();
-        $warmer = new AnnotationsCacheWarmer(
-            $reader,
-            $cacheFile,
-            $fallbackPool,
-            null,
-            true
-        );
+        $warmer = new AnnotationsCacheWarmer($reader, $cacheFile, null, true);
         $warmer->warmUp($this->cacheDir);
         $this->assertFileExists($cacheFile);
         // Assert cache is valid

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
 
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
@@ -36,9 +35,7 @@ class SerializerCacheWarmerTest extends TestCase
         $file = sys_get_temp_dir().'/cache-serializer.php';
         @unlink($file);
 
-        $fallbackPool = new ArrayAdapter();
-
-        $warmer = new SerializerCacheWarmer($loaders, $file, $fallbackPool);
+        $warmer = new SerializerCacheWarmer($loaders, $file);
         $warmer->warmUp(\dirname($file));
 
         $this->assertFileExists($file);
@@ -47,13 +44,6 @@ class SerializerCacheWarmerTest extends TestCase
 
         $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person')->isHit());
         $this->assertTrue($arrayPool->getItem('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author')->isHit());
-
-        $values = $fallbackPool->getValues();
-
-        $this->assertInternalType('array', $values);
-        $this->assertCount(2, $values);
-        $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person', $values);
-        $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author', $values);
     }
 
     public function testWarmUpWithoutLoader()
@@ -65,16 +55,9 @@ class SerializerCacheWarmerTest extends TestCase
         $file = sys_get_temp_dir().'/cache-serializer-without-loader.php';
         @unlink($file);
 
-        $fallbackPool = new ArrayAdapter();
-
-        $warmer = new SerializerCacheWarmer(array(), $file, $fallbackPool);
+        $warmer = new SerializerCacheWarmer(array(), $file);
         $warmer->warmUp(\dirname($file));
 
         $this->assertFileExists($file);
-
-        $values = $fallbackPool->getValues();
-
-        $this->assertInternalType('array', $values);
-        $this->assertCount(0, $values);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
 
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -32,9 +31,7 @@ class ValidatorCacheWarmerTest extends TestCase
         $file = sys_get_temp_dir().'/cache-validator.php';
         @unlink($file);
 
-        $fallbackPool = new ArrayAdapter();
-
-        $warmer = new ValidatorCacheWarmer($validatorBuilder, $file, $fallbackPool);
+        $warmer = new ValidatorCacheWarmer($validatorBuilder, $file);
         $warmer->warmUp(\dirname($file));
 
         $this->assertFileExists($file);
@@ -43,13 +40,6 @@ class ValidatorCacheWarmerTest extends TestCase
 
         $this->assertTrue($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Person')->isHit());
         $this->assertTrue($arrayPool->getItem('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Author')->isHit());
-
-        $values = $fallbackPool->getValues();
-
-        $this->assertInternalType('array', $values);
-        $this->assertCount(2, $values);
-        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Person', $values);
-        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Author', $values);
     }
 
     public function testWarmUpWithAnnotations()
@@ -61,9 +51,7 @@ class ValidatorCacheWarmerTest extends TestCase
         $file = sys_get_temp_dir().'/cache-validator-with-annotations.php';
         @unlink($file);
 
-        $fallbackPool = new ArrayAdapter();
-
-        $warmer = new ValidatorCacheWarmer($validatorBuilder, $file, $fallbackPool);
+        $warmer = new ValidatorCacheWarmer($validatorBuilder, $file);
         $warmer->warmUp(\dirname($file));
 
         $this->assertFileExists($file);
@@ -74,13 +62,6 @@ class ValidatorCacheWarmerTest extends TestCase
         $this->assertTrue($item->isHit());
 
         $this->assertInstanceOf(ClassMetadata::class, $item->get());
-
-        $values = $fallbackPool->getValues();
-
-        $this->assertInternalType('array', $values);
-        $this->assertCount(2, $values);
-        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Category', $values);
-        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.SubCategory', $values);
     }
 
     public function testWarmUpWithoutLoader()
@@ -90,16 +71,9 @@ class ValidatorCacheWarmerTest extends TestCase
         $file = sys_get_temp_dir().'/cache-validator-without-loaders.php';
         @unlink($file);
 
-        $fallbackPool = new ArrayAdapter();
-
-        $warmer = new ValidatorCacheWarmer($validatorBuilder, $file, $fallbackPool);
+        $warmer = new ValidatorCacheWarmer($validatorBuilder, $file);
         $warmer->warmUp(\dirname($file));
 
         $this->assertFileExists($file);
-
-        $values = $fallbackPool->getValues();
-
-        $this->assertInternalType('array', $values);
-        $this->assertCount(0, $values);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Since we populate the front PhpArrayCache, there is no need to also populate its fallback pool, since it will never be hit for the warmed up values.
This saves creating a myriad of small cache files and some MB.