### PR TITLE
FrameworkBundle 4.1 == Messenger 4.1

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -67,6 +67,7 @@
         "symfony/asset": "<3.4",
         "symfony/console": "<3.4",
         "symfony/form": "<4.1",
+        "symfony/messenger": ">=4.2",
         "symfony/property-info": "<3.4",
         "symfony/serializer": "<4.1",
         "symfony/stopwatch": "<3.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

That's the best way to tackle the BC break we've introduced (legitimately) in the consume command in Messenger 4.2.