### PR TITLE
[Serializer] Add a manual class discriminator configuration

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorConfiguration.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorConfiguration.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Mapping;
+
+/**
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ */
+class ClassDiscriminatorConfiguration implements ClassDiscriminatorResolverInterface
+{
+    use ClassDiscriminatorConfigurationTrait;
+
+    private $mapping;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMappingForClass(string $class): ?ClassDiscriminatorMapping
+    {
+        return $this->mapping[$class] ?? null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMappingForMappedObject($object): ?ClassDiscriminatorMapping
+    {
+        $class = \is_object($object) ? \get_class($object) : $object;
+
+        return $this->getMappingForClass($class) ?: $this->resolveMappingForMappedObject($object);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeForMappedObject($object): ?string
+    {
+        if (null === $mapping = $this->getMappingForMappedObject($object)) {
+            return null;
+        }
+
+        return $mapping->getMappedObjectType($object);
+    }
+
+    /**
+     * Configure the class discriminator for the given class.
+     */
+    public function setClassMapping(string $className, ClassDiscriminatorMapping $mapping)
+    {
+        $this->mapping[$className] = $mapping;
+    }
+}

--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorConfigurationTrait.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorConfigurationTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Mapping;
+
+/**
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ */
+trait ClassDiscriminatorConfigurationTrait
+{
+    private function resolveMappingForMappedObject($object)
+    {
+        $reflectionClass = new \ReflectionClass($object);
+        if ($parentClass = $reflectionClass->getParentClass()) {
+            return $this->getMappingForMappedObject($parentClass->getName());
+        }
+
+        foreach ($reflectionClass->getInterfaceNames() as $interfaceName) {
+            if (null !== ($interfaceMapping = $this->getMappingForMappedObject($interfaceName))) {
+                return $interfaceMapping;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorFromClassMetadata.php
@@ -18,6 +18,8 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
  */
 class ClassDiscriminatorFromClassMetadata implements ClassDiscriminatorResolverInterface
 {
+    use ClassDiscriminatorConfigurationTrait;
+
     /**
      * @var ClassMetadataFactoryInterface
      */
@@ -72,21 +74,5 @@ class ClassDiscriminatorFromClassMetadata implements ClassDiscriminatorResolverI
         }
 
         return $mapping->getMappedObjectType($object);
-    }
-
-    private function resolveMappingForMappedObject($object)
-    {
-        $reflectionClass = new \ReflectionClass($object);
-        if ($parentClass = $reflectionClass->getParentClass()) {
-            return $this->getMappingForMappedObject($parentClass->getName());
-        }
-
-        foreach ($reflectionClass->getInterfaceNames() as $interfaceName) {
-            if (null !== ($interfaceMapping = $this->getMappingForMappedObject($interfaceName))) {
-                return $interfaceMapping;
-            }
-        }
-
-        return null;
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassDiscriminatorMapping.php
@@ -47,7 +47,7 @@ class ClassDiscriminatorMapping
     public function getMappedObjectType($object): ?string
     {
         foreach ($this->typesMapping as $type => $typeClass) {
-            if (is_a($object, $typeClass)) {
+            if ($object === $typeClass || is_a($object, $typeClass)) {
                 return $type;
             }
         }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/ClassDiscriminatorConfigurationTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/ClassDiscriminatorConfigurationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Mapping;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorConfiguration;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
+use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild;
+use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild;
+use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
+
+class ClassDiscriminatorConfigurationTest extends TestCase
+{
+    public function testItConfiguresAClassWithMultipleMappings()
+    {
+        $resolver = new ClassDiscriminatorConfiguration();
+        $resolver->setClassMapping(AbstractDummy::class, $abstractDummyMapping = new ClassDiscriminatorMapping('type', array(
+            'first' => AbstractDummyFirstChild::class,
+            'second' => AbstractDummySecondChild::class,
+        )));
+
+        $this->assertEquals($abstractDummyMapping, $resolver->getMappingForClass(AbstractDummy::class));
+        $this->assertNull($resolver->getMappingForClass(Dummy::class));
+
+        $this->assertEquals($abstractDummyMapping, $resolver->getMappingForMappedObject(AbstractDummy::class));
+        $this->assertEquals($abstractDummyMapping, $resolver->getMappingForMappedObject(AbstractDummyFirstChild::class));
+        $this->assertEquals($abstractDummyMapping, $resolver->getMappingForMappedObject(AbstractDummySecondChild::class));
+
+        $this->assertEquals('first', $resolver->getTypeForMappedObject(new AbstractDummyFirstChild()));
+        $this->assertEquals('second', $resolver->getTypeForMappedObject(new AbstractDummySecondChild()));
+        $this->assertEquals('first', $resolver->getTypeForMappedObject(AbstractDummyFirstChild::class));
+        $this->assertEquals('second', $resolver->getTypeForMappedObject(AbstractDummySecondChild::class));
+        $this->assertNull($resolver->getTypeForMappedObject(Dummy::class));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony-docs/issues/10250
| License       | MIT
| Doc PR        | ø

It turns out that at the moment (while the documentation says otherwise) it is impossible to configure the discriminator mapping any other way than using the XML/Yaml/Annotation configuration because the only resolver is the class metadata factory based. 

This pull request adds a `ClassDiscriminatorConfiguration` class, so that the serializer can be actually used without the class metadata factory:
```php
$discriminatorConfiguration = new ClassDiscriminatorConfiguration();
$discriminatorConfiguration->addClassMapping(CodeRepository::class, new ClassDiscriminatorMapping('type', [
    'github' => GitHubCodeRepository::class,
    'bitbucket' => BitBucketCodeRepository::class,
]));

$serializer = new Serializer(
    array(new ObjectNormalizer(null, null, null, null, $discriminatorConfiguration)),
    array('json' => new JsonEncoder())
);
```