### PR TITLE
[Dotenv] use array instead of variadic in Dotenv::doLoad()

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -47,7 +47,7 @@ final class Dotenv
      */
     public function load(string $path, string ...$paths): void
     {
-        $this->doLoad(false, $path, ...$paths);
+        $this->doLoad(false, $path, $paths);
     }
 
     /**
@@ -61,7 +61,7 @@ final class Dotenv
      */
     public function overload(string $path, string ...$paths): void
     {
-        $this->doLoad(true, $path, ...$paths);
+        $this->doLoad(true, $path, $paths);
     }
 
     /**
@@ -405,7 +405,7 @@ final class Dotenv
         return new FormatException($message, new FormatExceptionContext($this->data, $this->path, $this->lineno, $this->cursor));
     }
 
-    private function doLoad(bool $overrideExistingVars, string $path, string ...$paths): void
+    private function doLoad(bool $overrideExistingVars, string $path, array $paths): void
     {
         array_unshift($paths, $path);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT

According to comments done after merge in #26859.
