### PR TITLE
[VarExporter] fix exporting objects that mutate on __sleep()

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -80,6 +80,9 @@ class Exporter
                 // Might throw Exception("Serialization of '...' is not allowed")
                 Registry::getClassReflector($class);
                 serialize(Registry::$prototypes[$class]);
+                if (\method_exists($class, '__sleep')) {
+                    Registry::getClassReflector($class, Registry::$instantiableWithoutConstructor[$class], Registry::$cloneable[$class]);
+                }
             }
             $reflector = Registry::$reflectors[$class];
             $proto = Registry::$prototypes[$class];
@@ -109,6 +112,11 @@ class Exporter
                     trigger_error('serialize(): __sleep should return an array only containing the names of instance-variables to serialize', E_USER_NOTICE);
                     $value = null;
                     goto handle_value;
+                }
+                foreach ($sleep as $name) {
+                    if (\property_exists($value, $name) && !$reflector->hasProperty($name)) {
+                        $arrayValue[$name] = $value->$name;
+                    }
                 }
                 $sleep = array_flip($sleep);
             }

--- a/src/Symfony/Component/VarExporter/Internal/Registry.php
+++ b/src/Symfony/Component/VarExporter/Internal/Registry.php
@@ -74,14 +74,9 @@ class Registry
             }
         }
 
-        if (null !== $cloneable) {
-            self::$prototypes[$class] = $proto;
-            self::$cloneable[$class] = $cloneable;
-
-            return self::$reflectors[$class] = $reflector;
-        }
-
-        if ($proto instanceof \Reflector || $proto instanceof \ReflectionGenerator || $proto instanceof \ReflectionType || $proto instanceof \IteratorIterator || $proto instanceof \RecursiveIteratorIterator) {
+        if (null !== self::$cloneable[$class] = $cloneable) {
+            // no-op
+        } elseif ($proto instanceof \Reflector || $proto instanceof \ReflectionGenerator || $proto instanceof \ReflectionType || $proto instanceof \IteratorIterator || $proto instanceof \RecursiveIteratorIterator) {
             if (!$proto instanceof \Serializable && !\method_exists($proto, '__wakeup')) {
                 throw new \Exception(sprintf("Serialization of '%s' is not allowed", $class));
             }

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/var-on-sleep.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/var-on-sleep.php
@@ -1,0 +1,17 @@
+<?php
+
+return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
+    $o = [
+        clone (\Symfony\Component\VarExporter\Internal\Registry::$prototypes[\Symfony\Component\VarExporter\Tests\GoodNight::class] ?? \Symfony\Component\VarExporter\Internal\Registry::p(\Symfony\Component\VarExporter\Tests\GoodNight::class, true)),
+    ],
+    null,
+    [
+        '*' => [
+            'good' => [
+                'night',
+            ],
+        ],
+    ],
+    $o[0],
+    []
+);

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -72,12 +72,14 @@ class VarExporterTest extends TestCase
      */
     public function testMarshall(string $testName, $value, bool $staticValueExpected = false)
     {
-        $serializedValue = serialize($value);
+        $dumpedValue = $this->getDump($value);
         $isStaticValue = true;
         $marshalledValue = VarExporter::export($value, $isStaticValue);
 
         $this->assertSame($staticValueExpected, $isStaticValue);
-        $this->assertSame($serializedValue, serialize($value));
+        if ('var-on-sleep' !== $testName) {
+            $this->assertDumpEquals($dumpedValue, $value);
+        }
 
         $dump = "<?php\n\nreturn ".$marshalledValue.";\n";
         $dump = str_replace(var_export(__FILE__, true), "\\dirname(__DIR__).\\DIRECTORY_SEPARATOR.'VarExporterTest.php'", $dump);
@@ -165,6 +167,8 @@ class VarExporterTest extends TestCase
         $r->setValue($value, 234);
 
         yield array('error', $value);
+
+        yield array('var-on-sleep', new GoodNight());
     }
 }
 
@@ -246,5 +250,15 @@ class MyArrayObject extends \ArrayObject
     public function setFlags($flags)
     {
         throw new \BadMethodCallException('Calling MyArrayObject::setFlags() is forbidden');
+    }
+}
+
+class GoodNight
+{
+    public function __sleep()
+    {
+        $this->good = 'night';
+
+        return array('good');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28352
| License       | MIT
| Doc PR        | -

