### PR TITLE
[Console] fixed PHPDoc for setArgument/setOption in InputInterface

### DIFF
--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -90,8 +90,8 @@ interface InputInterface
     /**
      * Sets an argument value by name.
      *
-     * @param string $name  The argument name
-     * @param string $value The argument value
+     * @param string          $name  The argument name
+     * @param string|string[] $value The argument value
      *
      * @throws InvalidArgumentException When argument given doesn't exist
      */
@@ -127,8 +127,8 @@ interface InputInterface
     /**
      * Sets an option value by name.
      *
-     * @param string      $name  The option name
-     * @param string|bool $value The option value
+     * @param string               $name  The option name
+     * @param string|string[]|bool $value The option value
      *
      * @throws InvalidArgumentException When option given doesn't exist
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28354
| License       | MIT
| Doc PR        | 

Methods now accept a value of any type except objects not implementing __toString().

**Example use case:** when using array arguments/options I can't set them programmatically without getting errors about type mismatch (from the IDE). With this patch it now works as expected.