### PR TITLE
[TwigBundle] Fixed caching of templates in src/Resources/<BundleName>/views on cache warmup

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
+++ b/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
@@ -57,7 +57,7 @@ class TemplateIterator implements \IteratorAggregate
             $this->templates = array_merge(
                 $this->templates,
                 $this->findTemplatesInDirectory($bundle->getPath().'/Resources/views', $name),
-                $this->findTemplatesInDirectory($this->rootDir.'/'.$bundle->getName().'/views', $name)
+                $this->findTemplatesInDirectory($this->rootDir.'/Resources/'.$bundle->getName().'/views', $name)
             );
         }
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
@@ -31,6 +31,7 @@ class TemplateIteratorTest extends TestCase
         sort($sorted);
         $this->assertEquals(
             array(
+                '@Bar/base.html.twig',
                 '@Bar/index.html.twig',
                 '@Foo/index.html.twig',
                 'layout.html.twig',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Same as https://github.com/symfony/symfony/pull/27764, but in this case the convention is wrong.

Corrected according to:
https://github.com/symfony/symfony/blob/992a174470fd557e1cddccd3a35447209602aea3/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php#L165
