### PR TITLE
[DI] configure inlined services before injecting when dumping the container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -56,7 +56,9 @@ class PhpDumper extends Dumper
     private $definitionVariables;
     private $referenceVariables;
     private $variableCount;
-    private $reservedVariables = array('instance', 'class');
+    private $inlinedDefinitions;
+    private $serviceCalls;
+    private $reservedVariables = array('instance', 'class', 'this');
     private $expressionLanguage;
     private $targetDirRegex;
     private $targetDirMaxMatches;
@@ -301,59 +303,6 @@ EOF;
         return $this->proxyDumper;
     }
 
-    private function addServiceLocalTempVariables(string $cId, Definition $definition, \SplObjectStorage $inlinedDefinitions, array $serviceCalls, bool $preInstance = false): string
-    {
-        $calls = array();
-
-        foreach ($inlinedDefinitions as $def) {
-            if ($preInstance && !$inlinedDefinitions[$def][1]) {
-                continue;
-            }
-            $this->getServiceCallsFromArguments(array($def->getArguments(), $def->getFactory()), $calls, $preInstance, $cId);
-            if ($def !== $definition) {
-                $arguments = array($def->getProperties(), $def->getMethodCalls(), $def->getConfigurator());
-                $this->getServiceCallsFromArguments($arguments, $calls, $preInstance && !$this->hasReference($cId, $arguments, true), $cId);
-            }
-        }
-        if (!isset($inlinedDefinitions[$definition])) {
-            $arguments = array($definition->getProperties(), $definition->getMethodCalls(), $definition->getConfigurator());
-            $this->getServiceCallsFromArguments($arguments, $calls, false, $cId);
-        }
-
-        $code = '';
-        foreach ($calls as $id => list($callCount)) {
-            if ('service_container' === $id || $id === $cId || isset($this->referenceVariables[$id])) {
-                continue;
-            }
-            if ($callCount <= 1 && $serviceCalls[$id][0] <= 1) {
-                continue;
-            }
-
-            $name = $this->getNextVariableName();
-            $this->referenceVariables[$id] = new Variable($name);
-
-            $reference = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $serviceCalls[$id][1] ? new Reference($id, $serviceCalls[$id][1]) : null;
-            $code .= sprintf("        \$%s = %s;\n", $name, $this->getServiceCall($id, $reference));
-        }
-
-        if ('' !== $code) {
-            if ($preInstance) {
-                $code .= sprintf(<<<'EOTXT'
-
-        if (isset($this->%s['%s'])) {
-            return $this->%1$s['%2$s'];
-        }
-
-EOTXT
-                , $definition->isPublic() ? 'services' : 'privates', $cId);
-            }
-
-            $code .= "\n";
-        }
-
-        return $code;
-    }
-
     private function analyzeCircularReferences(array $edges, &$checkedNodes, &$currentPath)
     {
         foreach ($edges as $edge) {
@@ -433,19 +382,19 @@ EOTXT
         }
     }
 
-    private function addServiceInclude(string $cId, Definition $definition, \SplObjectStorage $inlinedDefinitions, array $serviceCalls): string
+    private function addServiceInclude(string $cId, Definition $definition): string
     {
         $code = '';
 
         if ($this->inlineRequires && !$this->isHotPath($definition)) {
             $lineage = array();
-            foreach ($inlinedDefinitions as $def) {
+            foreach ($this->inlinedDefinitions as $def) {
                 if (!$def->isDeprecated() && \is_string($class = \is_array($factory = $def->getFactory()) && \is_string($factory[0]) ? $factory[0] : $def->getClass())) {
                     $this->collectLineage($class, $lineage);
                 }
             }
 
-            foreach ($serviceCalls as $id => list($callCount, $behavior)) {
+            foreach ($this->serviceCalls as $id => list($callCount, $behavior)) {
                 if ('service_container' !== $id && $id !== $cId
                     && ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE !== $behavior
                     && $this->container->has($id)
@@ -461,64 +410,13 @@ EOTXT
             }
         }
 
-        foreach ($inlinedDefinitions as $def) {
+        foreach ($this->inlinedDefinitions as $def) {
             if ($file = $def->getFile()) {
                 $code .= sprintf("        include_once %s;\n", $this->dumpValue($file));
             }
         }
 
         if ('' !== $code) {
-            $code .= "\n";
-        }
-
-        return $code;
-    }
-
-    /**
-     * Generates the inline definition of a service.
-     *
-     * @throws RuntimeException                  When the factory definition is incomplete
-     * @throws ServiceCircularReferenceException When a circular reference is detected
-     */
-    private function addServiceInlinedDefinitions(string $id, Definition $definition, \SplObjectStorage $inlinedDefinitions, bool &$isSimpleInstance, bool $preInstance = false): string
-    {
-        $code = '';
-
-        foreach ($inlinedDefinitions as $def) {
-            if ($definition === $def || isset($this->definitionVariables[$def])) {
-                continue;
-            }
-            if ($inlinedDefinitions[$def][0] <= 1 && !$def->getMethodCalls() && !$def->getProperties() && !$def->getConfigurator() && false === strpos($this->dumpValue($def->getClass()), '$')) {
-                continue;
-            }
-            if ($preInstance && !$inlinedDefinitions[$def][1]) {
-                continue;
-            }
-
-            $name = $this->getNextVariableName();
-            $this->definitionVariables[$def] = new Variable($name);
-
-            // a construct like:
-            // $a = new ServiceA(ServiceB $b); $b = new ServiceB(ServiceA $a);
-            // this is an indication for a wrong implementation, you can circumvent this problem
-            // by setting up your service structure like this:
-            // $b = new ServiceB();
-            // $a = new ServiceA(ServiceB $b);
-            // $b->setServiceA(ServiceA $a);
-            if (isset($inlinedDefinitions[$definition]) && $this->hasReference($id, array($def->getArguments(), $def->getFactory()))) {
-                throw new ServiceCircularReferenceException($id, array($id, '...', $id));
-            }
-
-            $code .= $this->addNewInstance($def, '$'.$name, ' = ', $id);
-
-            if (!$this->hasReference($id, array($def->getProperties(), $def->getMethodCalls(), $def->getConfigurator()), true, $inlinedDefinitions)) {
-                $code .= $this->addServiceProperties($def, $name);
-                $code .= $this->addServiceMethodCalls($def, $name);
-                $code .= $this->addServiceConfigurator($def, $name);
-            } else {
-                $isSimpleInstance = false;
-            }
-
             $code .= "\n";
         }
 
@@ -553,14 +451,7 @@ EOTXT
             $instantiation .= ' = ';
         }
 
-        $code = $this->addNewInstance($definition, $return, $instantiation, $id);
-        $this->referenceVariables[$id] = new Variable('instance');
-
-        if (!$isSimpleInstance) {
-            $code .= "\n";
-        }
-
-        return $code;
+        return $this->addNewInstance($definition, $return, $instantiation, $id);
     }
 
     private function isTrivialInstance(Definition $definition): bool
@@ -620,41 +511,11 @@ EOTXT
         return $calls;
     }
 
-    private function addServiceProperties(Definition $definition, $variableName = 'instance')
+    private function addServiceProperties(Definition $definition, string $variableName = 'instance')
     {
         $code = '';
         foreach ($definition->getProperties() as $name => $value) {
             $code .= sprintf("        \$%s->%s = %s;\n", $variableName, $name, $this->dumpValue($value));
-        }
-
-        return $code;
-    }
-
-    /**
-     * @throws ServiceCircularReferenceException when the container contains a circular reference
-     */
-    private function addServiceInlinedDefinitionsSetup(string $id, Definition $definition, \SplObjectStorage $inlinedDefinitions, bool $isSimpleInstance): string
-    {
-        $code = '';
-        foreach ($inlinedDefinitions as $def) {
-            if ($definition === $def || !$this->hasReference($id, array($def->getProperties(), $def->getMethodCalls(), $def->getConfigurator()), true, $inlinedDefinitions)) {
-                continue;
-            }
-
-            // if the instance is simple, the return statement has already been generated
-            // so, the only possible way to get there is because of a circular reference
-            if ($isSimpleInstance) {
-                throw new ServiceCircularReferenceException($id, array($id, '...', $id));
-            }
-
-            $name = (string) $this->definitionVariables[$def];
-            $code .= $this->addServiceProperties($def, $name);
-            $code .= $this->addServiceMethodCalls($def, $name);
-            $code .= $this->addServiceConfigurator($def, $name);
-        }
-
-        if ('' !== $code && ($definition->getProperties() || $definition->getMethodCalls() || $definition->getConfigurator())) {
-            $code .= "\n";
         }
 
         return $code;
@@ -693,6 +554,7 @@ EOTXT
         $this->definitionVariables = new \SplObjectStorage();
         $this->referenceVariables = array();
         $this->variableCount = 0;
+        $this->definitionVariables[$definition] = $this->referenceVariables[$id] = new Variable('instance');
 
         $return = array();
 
@@ -758,26 +620,10 @@ EOF;
             return $asFile ? substr($code, 8).$e : $code.'        '.$e."    }\n";
         }
 
-        $inlinedDefinitions = $this->getDefinitionsFromArguments(array($definition));
-        $constructorDefinitions = $this->getDefinitionsFromArguments(array($definition->getArguments(), $definition->getFactory()));
-        unset($constructorDefinitions[$definition]); // ensures $definition will be last
-        $otherDefinitions = new \SplObjectStorage();
-        $serviceCalls = array();
+        $this->serviceCalls = array();
+        $this->inlinedDefinitions = $this->getDefinitionsFromArguments(array($definition), null, $this->serviceCalls);
 
-        foreach ($inlinedDefinitions as $def) {
-            if ($def === $definition || isset($constructorDefinitions[$def])) {
-                $constructorDefinitions[$def] = $inlinedDefinitions[$def];
-            } else {
-                $otherDefinitions[$def] = $inlinedDefinitions[$def];
-            }
-            $arguments = array($def->getArguments(), $def->getFactory(), $def->getProperties(), $def->getMethodCalls(), $def->getConfigurator());
-            $this->getServiceCallsFromArguments($arguments, $serviceCalls, false, $id);
-        }
-
-        $isSimpleInstance = !$definition->getProperties() && !$definition->getMethodCalls() && !$definition->getConfigurator();
-        $preInstance = isset($this->circularReferences[$id]) && !$this->getProxyDumper()->isProxyCandidate($definition) && $definition->isShared();
-
-        $code .= $this->addServiceInclude($id, $definition, $inlinedDefinitions, $serviceCalls);
+        $code .= $this->addServiceInclude($id, $definition);
 
         if ($this->getProxyDumper()->isProxyCandidate($definition)) {
             $factoryCode = $asFile ? "\$this->load('%s.php', false)" : '$this->%s(false)';
@@ -788,20 +634,22 @@ EOF;
             $code .= sprintf("        @trigger_error(%s, E_USER_DEPRECATED);\n\n", $this->export($definition->getDeprecationMessage($id)));
         }
 
-        $code .=
-            $this->addServiceLocalTempVariables($id, $definition, $constructorDefinitions, $serviceCalls, $preInstance).
-            $this->addServiceInlinedDefinitions($id, $definition, $constructorDefinitions, $isSimpleInstance, $preInstance).
-            $this->addServiceInstance($id, $definition, $isSimpleInstance).
-            $this->addServiceLocalTempVariables($id, $definition, $constructorDefinitions->offsetUnset($definition) ?: $constructorDefinitions, $serviceCalls).
-            $this->addServiceLocalTempVariables($id, $definition, $otherDefinitions, $serviceCalls).
-            $this->addServiceInlinedDefinitions($id, $definition, $constructorDefinitions, $isSimpleInstance).
-            $this->addServiceInlinedDefinitions($id, $definition, $otherDefinitions, $isSimpleInstance).
-            $this->addServiceInlinedDefinitionsSetup($id, $definition, $inlinedDefinitions, $isSimpleInstance).
-            $this->addServiceProperties($definition).
-            $this->addServiceMethodCalls($definition).
-            $this->addServiceConfigurator($definition).
-            (!$isSimpleInstance ? "\n        return \$instance;\n" : '')
-        ;
+        $head = $tail = '';
+        $arguments = array($definition->getArguments(), $definition->getFactory());
+        $this->addInlineVariables($head, $tail, $id, $arguments, true);
+        $code .= '' !== $head ? $head."\n" : '';
+
+        if ($arguments = array_filter(array($definition->getProperties(), $definition->getMethodCalls(), $definition->getConfigurator()))) {
+            $this->addInlineVariables($tail, $tail, $id, $arguments, false);
+
+            $tail .= '' !== $tail ? "\n" : '';
+            $tail .= $this->addServiceProperties($definition);
+            $tail .= $this->addServiceMethodCalls($definition);
+            $tail .= $this->addServiceConfigurator($definition);
+        }
+
+        $code .= $this->addServiceInstance($id, $definition, '' === $tail)
+            .('' !== $tail ? "\n".$tail."\n        return \$instance;\n" : '');
 
         if ($asFile) {
             $code = implode("\n", array_map(function ($line) { return $line ? substr($line, 8) : $line; }, explode("\n", $code)));
@@ -809,10 +657,106 @@ EOF;
             $code .= "    }\n";
         }
 
-        $this->definitionVariables = null;
-        $this->referenceVariables = null;
+        $this->definitionVariables = $this->inlinedDefinitions = null;
+        $this->referenceVariables = $this->serviceCalls = null;
 
         return $code;
+    }
+
+    private function addInlineVariables(string &$head, string &$tail, string $id, array $arguments, bool $forConstructor): bool
+    {
+        $hasSelfRef = false;
+
+        foreach ($arguments as $argument) {
+            if (\is_array($argument)) {
+                $hasSelfRef = $this->addInlineVariables($head, $tail, $id, $argument, $forConstructor) || $hasSelfRef;
+            } elseif ($argument instanceof Reference) {
+                $hasSelfRef = $this->addInlineReference($head, $tail, $id, (string) $argument, $forConstructor) || $hasSelfRef;
+            } elseif ($argument instanceof Definition) {
+                $hasSelfRef = $this->addInlineService($head, $tail, $id, $argument, $forConstructor) || $hasSelfRef;
+            }
+        }
+
+        return $hasSelfRef;
+    }
+
+    private function addInlineReference(string &$head, string &$tail, string $id, string $targetId, bool $forConstructor): bool
+    {
+        if ('service_container' === $targetId || isset($this->referenceVariables[$targetId])) {
+            return isset($this->circularReferences[$id][$targetId]);
+        }
+
+        list($callCount, $behavior) = $this->serviceCalls[$targetId];
+
+        if (2 > $callCount && (!$forConstructor || !isset($this->circularReferences[$id][$targetId]))) {
+            return isset($this->circularReferences[$id][$targetId]);
+        }
+
+        $name = $this->getNextVariableName();
+        $this->referenceVariables[$targetId] = new Variable($name);
+
+        $reference = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $behavior ? new Reference($targetId, $behavior) : null;
+        $code = sprintf("        \$%s = %s;\n", $name, $this->getServiceCall($targetId, $reference));
+
+        if (!isset($this->circularReferences[$id][$targetId])) {
+            $head .= $code;
+
+            return false;
+        }
+
+        if (!$forConstructor) {
+            $tail .= $code;
+
+            return true;
+        }
+
+        $head .= $code.sprintf(<<<'EOTXT'
+
+        if (isset($this->%s['%s'])) {
+            return $this->%1$s['%2$s'];
+        }
+
+EOTXT
+            ,
+            $this->container->getDefinition($id)->isPublic() ? 'services' : 'privates',
+            $id
+        );
+
+        return false;
+    }
+
+    private function addInlineService(string &$head, string &$tail, string $id, Definition $definition, bool $forConstructor): bool
+    {
+        if (isset($this->definitionVariables[$definition])) {
+            return false;
+        }
+
+        $arguments = array($definition->getArguments(), $definition->getFactory());
+
+        if (2 > $this->inlinedDefinitions[$definition] && !$definition->getMethodCalls() && !$definition->getProperties() && !$definition->getConfigurator() && false === strpos($this->dumpValue($definition->getClass()), '$')) {
+            return $this->addInlineVariables($head, $tail, $id, $arguments, $forConstructor);
+        }
+
+        $name = $this->getNextVariableName();
+        $this->definitionVariables[$definition] = new Variable($name);
+
+        $code = '';
+        $hasSelfRef = $this->addInlineVariables($code, $tail, $id, $arguments, $forConstructor);
+        $code .= $this->addNewInstance($definition, '$'.$name, ' = ', $id);
+        $hasSelfRef ? $tail .= ('' !== $tail ? "\n" : '').$code : $head .= ('' !== $head ? "\n" : '').$code;
+
+        $code = '';
+        $arguments = array($definition->getProperties(), $definition->getMethodCalls(), $definition->getConfigurator());
+        $hasSelfRef = $this->addInlineVariables($code, $tail, $id, $arguments, false) || $hasSelfRef;
+
+        $code .= $this->addServiceProperties($definition, $name);
+        $code .= $this->addServiceMethodCalls($definition, $name);
+        $code .= $this->addServiceConfigurator($definition, $name);
+        if ('' !== $code) {
+            $hasSelfRef ? $tail .= ('' !== $tail ? "\n" : '').$code : $head .= ('' !== $head ? "\n" : '').$code;
+        }
+
+        return $hasSelfRef;
     }
 
     private function addServices(): string
@@ -1377,26 +1321,7 @@ EOF;
         return implode(' && ', $conditions);
     }
 
-    private function getServiceCallsFromArguments(array $arguments, array &$calls, bool $preInstance, string $callerId)
-    {
-        foreach ($arguments as $argument) {
-            if (\is_array($argument)) {
-                $this->getServiceCallsFromArguments($argument, $calls, $preInstance, $callerId);
-            } elseif ($argument instanceof Reference) {
-                $id = (string) $argument;
-
-                if (!isset($calls[$id])) {
-                    $calls[$id] = array((int) ($preInstance && isset($this->circularReferences[$callerId][$id])), $argument->getInvalidBehavior());
-                } else {
-                    $calls[$id][1] = min($calls[$id][1], $argument->getInvalidBehavior());
-                }
-
-                ++$calls[$id][0];
-            }
-        }
-    }
-
-    private function getDefinitionsFromArguments(array $arguments, bool $isConstructorArgument = true, \SplObjectStorage $definitions = null): \SplObjectStorage
+    private function getDefinitionsFromArguments(array $arguments, \SplObjectStorage $definitions = null, array &$calls = array()): \SplObjectStorage
     {
         if (null === $definitions) {
             $definitions = new \SplObjectStorage();
@@ -1404,76 +1329,29 @@ EOF;
 
         foreach ($arguments as $argument) {
             if (\is_array($argument)) {
-                $this->getDefinitionsFromArguments($argument, $isConstructorArgument, $definitions);
+                $this->getDefinitionsFromArguments($argument, $definitions, $calls);
+            } elseif ($argument instanceof Reference) {
+                $id = (string) $argument;
+
+                if (!isset($calls[$id])) {
+                    $calls[$id] = array(0, $argument->getInvalidBehavior());
+                } else {
+                    $calls[$id][1] = min($calls[$id][1], $argument->getInvalidBehavior());
+                }
+
+                ++$calls[$id][0];
             } elseif (!$argument instanceof Definition) {
                 // no-op
             } elseif (isset($definitions[$argument])) {
-                $def = $definitions[$argument];
-                $definitions[$argument] = array(1 + $def[0], $isConstructorArgument || $def[1]);
+                $definitions[$argument] = 1 + $definitions[$argument];
             } else {
-                $definitions[$argument] = array(1, $isConstructorArgument);
-                $this->getDefinitionsFromArguments($argument->getArguments(), $isConstructorArgument, $definitions);
-                $this->getDefinitionsFromArguments(array($argument->getFactory()), $isConstructorArgument, $definitions);
-                $this->getDefinitionsFromArguments($argument->getProperties(), false, $definitions);
-                $this->getDefinitionsFromArguments($argument->getMethodCalls(), false, $definitions);
-                $this->getDefinitionsFromArguments(array($argument->getConfigurator()), false, $definitions);
-                // move current definition last in the list
-                $def = $definitions[$argument];
-                unset($definitions[$argument]);
-                $definitions[$argument] = $def;
+                $definitions[$argument] = 1;
+                $arguments = array($argument->getArguments(), $argument->getFactory(), $argument->getProperties(), $argument->getMethodCalls(), $argument->getConfigurator());
+                $this->getDefinitionsFromArguments($arguments, $definitions, $calls);
             }
         }
 
         return $definitions;
-    }
-
-    private function hasReference(string $id, array $arguments, bool $deep = false, \SplObjectStorage $inlinedDefinitions = null, array &$visited = array()): bool
-    {
-        if (!isset($this->circularReferences[$id])) {
-            return false;
-        }
-
-        foreach ($arguments as $argument) {
-            if (\is_array($argument)) {
-                if ($this->hasReference($id, $argument, $deep, $inlinedDefinitions, $visited)) {
-                    return true;
-                }
-
-                continue;
-            } elseif ($argument instanceof Reference) {
-                $argumentId = (string) $argument;
-                if ($id === $argumentId) {
-                    return true;
-                }
-
-                if (!$deep || isset($visited[$argumentId]) || !isset($this->circularReferences[$argumentId])) {
-                    continue;
-                }
-
-                $visited[$argumentId] = true;
-
-                $service = $this->container->getDefinition($argumentId);
-            } elseif ($argument instanceof Definition) {
-                if (isset($inlinedDefinitions[$argument])) {
-                    return true;
-                }
-                $service = $argument;
-            } else {
-                continue;
-            }
-
-            // if the proxy manager is enabled, disable searching for references in lazy services,
-            // as these services will be instantiated lazily and don't have direct related references.
-            if ($service->isLazy() && !$this->getProxyDumper() instanceof NullDumper) {
-                continue;
-            }
-
-            if ($this->hasReference($id, array($service->getArguments(), $service->getFactory(), $service->getProperties(), $service->getMethodCalls(), $service->getConfigurator()), $deep, $inlinedDefinitions, $visited)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -1492,7 +1370,7 @@ EOF;
 
             return sprintf('array(%s)', implode(', ', $code));
         } elseif ($value instanceof ArgumentInterface) {
-            $scope = array($this->definitionVariables, $this->referenceVariables, $this->variableCount);
+            $scope = array($this->definitionVariables, $this->referenceVariables);
             $this->definitionVariables = $this->referenceVariables = null;
 
             try {
@@ -1540,7 +1418,7 @@ EOF;
                     return implode("\n", $code);
                 }
             } finally {
-                list($this->definitionVariables, $this->referenceVariables, $this->variableCount) = $scope;
+                list($this->definitionVariables, $this->referenceVariables) = $scope;
             }
         } elseif ($value instanceof Definition) {
             if (null !== $this->definitionVariables && $this->definitionVariables->contains($value)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -890,7 +890,14 @@ class PhpDumperTest extends TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
 
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_deep_graph.php', $dumper->dump());
+        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_deep_graph.php', $dumper->dump(array('class' => 'Symfony_DI_PhpDumper_Test_Deep_Graph')));
+
+        require self::$fixturesPath.'/php/services_deep_graph.php';
+
+        $container = new \Symfony_DI_PhpDumper_Test_Deep_Graph();
+
+        $this->assertInstanceOf(FooForDeepGraph::class, $container->get('foo'));
+        $this->assertEquals((object) array('p2' => (object) array('p3' => (object) array())), $container->get('foo')->bClone);
     }
 
     public function testHotPathOptimizations()
@@ -1039,5 +1046,16 @@ class Rot13EnvVarProcessor implements EnvVarProcessorInterface
     public static function getProvidedTypes()
     {
         return array('rot13' => 'string');
+    }
+}
+
+class FooForDeepGraph
+{
+    public $bClone;
+
+    public function __construct(\stdClass $a, \stdClass $b)
+    {
+        // clone to verify that $b has been fully initialized before
+        $this->bClone = clone $b;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -67,6 +67,7 @@ class ProjectServiceContainer extends Container
     protected function getBarService()
     {
         $a = new \stdClass();
+
         $a->add($this);
 
         return $this->services['bar'] = new \stdClass($a);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -75,6 +75,7 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 $this->services['configured_service'] = $instance = new \stdClass();
 
 $a = new \ConfClass();
+
 $a->setFoo(($this->services['baz'] ?? $this->load('getBazService.php')));
 
 $a->configureStdClass($instance);
@@ -294,6 +295,7 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 // Returns the public 'new_factory_service' shared service.
 
 $a = new \FactoryClass();
+
 $a->foo = 'bar';
 
 $this->services['new_factory_service'] = $instance = $a->getInstance();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -171,6 +171,7 @@ class ProjectServiceContainer extends Container
         $this->services['configured_service'] = $instance = new \stdClass();
 
         $a = new \ConfClass();
+
         $a->setFoo(($this->services['baz'] ?? $this->getBazService()));
 
         $a->configureStdClass($instance);
@@ -365,6 +366,7 @@ class ProjectServiceContainer extends Container
     protected function getNewFactoryServiceService()
     {
         $a = new \FactoryClass();
+
         $a->foo = 'bar';
 
         $this->services['new_factory_service'] = $instance = $a->getInstance();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -125,6 +125,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
         $this->services['connection'] = $instance = new \stdClass($a, $b);
 
         $a->subscriber = ($this->services['subscriber'] ?? $this->getSubscriberService());
+
         $b->logger = ($this->services['logger'] ?? $this->getLoggerService());
 
         return $instance;
@@ -139,17 +140,19 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     {
         $a = new \stdClass();
 
-        $b = new \stdClass();
+        $c = new \stdClass();
 
-        $this->services['connection2'] = $instance = new \stdClass($a, $b);
+        $this->services['connection2'] = $instance = new \stdClass($a, $c);
 
-        $c = ($this->services['manager2'] ?? $this->getManager2Service());
+        $b = ($this->services['manager2'] ?? $this->getManager2Service());
+
+        $a->subscriber2 = new \stdClass($b);
 
         $d = new \stdClass($instance);
 
-        $a->subscriber2 = new \stdClass($c);
-        $d->handler2 = new \stdClass($c);
-        $b->logger2 = $d;
+        $d->handler2 = new \stdClass($b);
+
+        $c->logger2 = $d;
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -173,6 +173,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
         $c = new \stdClass($instance);
 
         $c->handler2 = new \stdClass(($this->services['manager2'] ?? $this->getManager2Service()));
+
         $b->logger2 = $c;
 
         return $instance;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  *
  * @final since Symfony 3.3
  */
-class ProjectServiceContainer extends Container
+class Symfony_DI_PhpDumper_Test_Deep_Graph extends Container
 {
     private $parameters;
     private $targetDirs = array();
@@ -62,13 +62,13 @@ class ProjectServiceContainer extends Container
     /**
      * Gets the public 'bar' shared service.
      *
-     * @return \c5
+     * @return \stdClass
      */
     protected function getBarService()
     {
-        $this->services['bar'] = $instance = new \c5();
+        $this->services['bar'] = $instance = new \stdClass();
 
-        $instance->p5 = new \c6(($this->services['foo'] ?? $this->getFooService()));
+        $instance->p5 = new \stdClass(($this->services['foo'] ?? $this->getFooService()));
 
         return $instance;
     }
@@ -76,7 +76,7 @@ class ProjectServiceContainer extends Container
     /**
      * Gets the public 'foo' shared service.
      *
-     * @return \c1
+     * @return \Symfony\Component\DependencyInjection\Tests\Dumper\FooForDeepGraph
      */
     protected function getFooService()
     {
@@ -86,15 +86,13 @@ class ProjectServiceContainer extends Container
             return $this->services['foo'];
         }
 
-        $b = new \c2();
+        $b = new \stdClass();
 
-        $this->services['foo'] = $instance = new \c1($a, $b);
+        $c = new \stdClass();
 
-        $c = new \c3();
-
-        $c->p3 = new \c4();
+        $c->p3 = new \stdClass();
         $b->p2 = $c;
 
-        return $instance;
+        return $this->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Dumper\FooForDeepGraph($a, $b);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -171,6 +171,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
         $this->services['configured_service'] = $instance = new \stdClass();
 
         $a = new \ConfClass();
+
         $a->setFoo(($this->services['baz'] ?? $this->getBazService()));
 
         $a->configureStdClass($instance);
@@ -365,6 +366,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
     protected function getNewFactoryServiceService()
     {
         $a = new \FactoryClass();
+
         $a->foo = 'bar';
 
         $this->services['new_factory_service'] = $instance = $a->getInstance();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_requires.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_requires.php
@@ -101,8 +101,8 @@ class ProjectServiceContainer extends Container
      */
     protected function getC2Service()
     {
-        include_once $this->targetDirs[1].'/includes/HotPath/C3.php';
         include_once $this->targetDirs[1].'/includes/HotPath/C2.php';
+        include_once $this->targetDirs[1].'/includes/HotPath/C3.php';
 
         return $this->services['Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2(new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3());
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_deep_graph.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_deep_graph.yml
@@ -1,24 +1,24 @@
 
 services:
     foo:
-        class: c1
+        class: Symfony\Component\DependencyInjection\Tests\Dumper\FooForDeepGraph
         public: true
         arguments:
             - '@bar'
             - !service
-                class: c2
+                class: stdClass
                 properties:
                     p2: !service
-                        class: c3
+                        class: stdClass
                         properties:
                             p3: !service
-                                class: c4
+                                class: stdClass
 
     bar:
-        class: c5
+        class: stdClass
         public: true
         properties:
             p5: !service
-                class: c6
+                class: stdClass
                 arguments: ['@foo']
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 (WIP on 4.1 for now)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28304
| License       | MIT
| Doc PR        | -

#28060 introduced a change in the way inline services are dumped: these instances could end up being configured *after* being injected. This breaks e.g. using Doctrine's Configuration instances, which are expected to be fully defined before being injected into their consumers.

Fixing this required a significant refactorization because I was just unable to reason with the heavily scrambled logic in place right now. The new logic is still non-trivial, but at least it's manageable, thus easier to get correct.

(I'll see if I can figure out a way to remove the whitespace differences also.)

To be retargeted at 3.4 once validated.