### PR TITLE
[Messenger] Add interfaces to be type-hinted even when not using a Container

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/Locator/AbstractHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/AbstractHandlerLocator.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler\Locator;
+
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+
+/**
+ * @author Miha Vrhovnik <miha.vrhovnik@gmail.com>
+ * @author Samuel Roze <samuel.roze@gmail.com>
+ */
+abstract class AbstractHandlerLocator implements HandlerLocatorInterface
+{
+    public function resolve($message): callable
+    {
+        $messageClass = \get_class($message);
+
+        if (null === $handler = $this->resolveFromClass($messageClass)) {
+            throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', $messageClass));
+        }
+
+        return $handler;
+    }
+
+    private function resolveFromClass(string $class): ?callable
+    {
+        if ($handler = $this->getHandler($class)) {
+            return $handler;
+        }
+
+        foreach (class_implements($class, false) as $interface) {
+            if ($handler = $this->getHandler($interface)) {
+                return $handler;
+            }
+        }
+
+        foreach (class_parents($class, false) as $parent) {
+            if ($handler = $this->getHandler($parent)) {
+                return $handler;
+            }
+        }
+
+        return null;
+    }
+
+    abstract protected function getHandler(string $class);
+}

--- a/src/Symfony/Component/Messenger/Handler/Locator/ContainerHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/ContainerHandlerLocator.php
@@ -12,13 +12,12 @@
 namespace Symfony\Component\Messenger\Handler\Locator;
 
 use Psr\Container\ContainerInterface;
-use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 
 /**
  * @author Miha Vrhovnik <miha.vrhovnik@gmail.com>
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-class ContainerHandlerLocator implements HandlerLocatorInterface
+class ContainerHandlerLocator extends AbstractHandlerLocator
 {
     private $container;
 
@@ -27,39 +26,7 @@ class ContainerHandlerLocator implements HandlerLocatorInterface
         $this->container = $container;
     }
 
-    public function resolve($message): callable
-    {
-        $messageClass = \get_class($message);
-
-        if (null === $handler = $this->resolveFromClass($messageClass)) {
-            throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', $messageClass));
-        }
-
-        return $handler;
-    }
-
-    private function resolveFromClass($class): ?callable
-    {
-        if ($handler = $this->getHandler($class)) {
-            return $handler;
-        }
-
-        foreach (class_implements($class, false) as $interface) {
-            if ($handler = $this->getHandler($interface)) {
-                return $handler;
-            }
-        }
-
-        foreach (class_parents($class, false) as $parent) {
-            if ($handler = $this->getHandler($parent)) {
-                return $handler;
-            }
-        }
-
-        return null;
-    }
-
-    private function getHandler($class)
+    protected function getHandler(string $class)
     {
         $handlerKey = 'handler.'.$class;
 

--- a/src/Symfony/Component/Messenger/Handler/Locator/HandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/HandlerLocator.php
@@ -11,12 +11,10 @@
 
 namespace Symfony\Component\Messenger\Handler\Locator;
 
-use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
-
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-class HandlerLocator implements HandlerLocatorInterface
+class HandlerLocator extends AbstractHandlerLocator
 {
     /**
      * Maps a message (its class) to a given handler.
@@ -28,14 +26,8 @@ class HandlerLocator implements HandlerLocatorInterface
         $this->messageToHandlerMapping = $messageToHandlerMapping;
     }
 
-    public function resolve($message): callable
+    protected function getHandler(string $class)
     {
-        $messageKey = \get_class($message);
-
-        if (!isset($this->messageToHandlerMapping[$messageKey])) {
-            throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', $messageKey));
-        }
-
-        return $this->messageToHandlerMapping[$messageKey];
+        return $this->messageToHandlerMapping[$class] ?? null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This a follow-up to #28271. This adds #28271 to the non-container handler locator.
