### PR TITLE
[VarDumper][HttpKernel] Add context to all dumps

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
@@ -51,8 +51,7 @@ class DumpListenerTest extends TestCase
 
             VarDumper::dump('foo');
             VarDumper::dump('bar');
-
-            $this->assertSame('+foo-+bar-', ob_get_clean());
+            $this->assertSame('+'.__FILE__.' on line '.(__LINE__ - 2).':-+foo-+'.__FILE__.' on line '.(__LINE__ - 1).':-+bar-', ob_get_clean());
         } catch (\Exception $exception) {
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Following some discussion in https://github.com/symfony/symfony/pull/28317, I think it would be nice if the default `VarDumper` handler would add where the `dump` calls comes from. This is the case when the `DebugBundle` is enabled on html dumps. The behavior I added is exactly the same.

I also added it for cli dumps, but for those one I think it's actually better to display the file path instead of just the class name as sometimes you have multiple classes with the same name. This is not a problem for html dumps since there is a title attribute on the span or on the link.