### PR TITLE
[Messenger] Add a simple serializer

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -13,6 +13,10 @@ namespace Symfony\Component\Messenger\Transport\Serialization;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -29,6 +33,15 @@ class Serializer implements DecoderInterface, EncoderInterface
         $this->serializer = $serializer;
         $this->format = $format;
         $this->context = $context;
+    }
+
+    public static function create(): self
+    {
+        $encoders = array(new XmlEncoder(), new JsonEncoder());
+        $normalizers = array(new ObjectNormalizer());
+        $serializer = new SymfonySerializer($normalizers, $encoders);
+
+        return new self($serializer);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | #...

When using the Messenger component without Symfony full stack, it helps to use a simple Serializer configured with the bare minimum (this bare minimum is up to the discussion).
