### PR TITLE
[Console] Fix SymfonyQuestionHelper::askQuestion() with choice value as default

### DIFF
--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -82,7 +82,7 @@ class SymfonyQuestionHelper extends QuestionHelper
 
             case $question instanceof ChoiceQuestion:
                 $choices = $question->getChoices();
-                $text = sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, OutputFormatter::escape($choices[$default]));
+                $text = sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, OutputFormatter::escape(isset($choices[$default]) ? $choices[$default] : $default));
 
                 break;
 

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -75,6 +75,19 @@ class SymfonyQuestionHelperTest extends TestCase
         $this->assertOutputContains('What is your favorite superhero? [Superman, Batman]', $output);
     }
 
+    public function testAskChoiceWithChoiceValueAsDefault()
+    {
+        $questionHelper = new SymfonyQuestionHelper();
+        $helperSet = new HelperSet(array(new FormatterHelper()));
+        $questionHelper->setHelperSet($helperSet);
+        $questionHelper->setInputStream($this->getInputStream("Batman\n"));
+        $question = new ChoiceQuestion('What is your favorite superhero?', array('Superman', 'Batman', 'Spiderman'), 'Batman');
+        $question->setMaxAttempts(1);
+
+        $this->assertSame('Batman', $questionHelper->ask($this->createInputInterfaceMock(), $output = $this->createOutputInterface(), $question));
+        $this->assertOutputContains('What is your favorite superhero? [Batman]', $output);
+    }
+
     public function testAskReturnsNullIfValidatorAllowsIt()
     {
         $questionHelper = new SymfonyQuestionHelper();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/26885
| License       | MIT
| Doc PR        | n/a

There is an inconsistency between `SymfonyStyle::askQuestion(new ChoiceQuestion(...))` and `SymfonyStyle::choice(...)`, the former does not support to have a choice value as default instead of a choice key while the latter handles both. 
This is causing an `undefined index` notice breaking interactive command testing, fixed here.