### PR TITLE
[Controller][ServiceValueResolver] Making method access case insensitive

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -47,6 +47,10 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
             $controller = ltrim($controller, '\\');
         }
 
+        if (!$this->container->has($controller) && false !== $i = strrpos($controller, ':')) {
+            $controller = substr($controller, 0, $i).strtolower(substr($controller, $i));
+        }
+
         return $this->container->has($controller) && $this->container->get($controller)->has($argument->getName());
     }
 
@@ -61,6 +65,11 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
 
         if ('\\' === $controller[0]) {
             $controller = ltrim($controller, '\\');
+        }
+
+        if (!$this->container->has($controller)) {
+            $i = strrpos($controller, ':');
+            $controller = substr($controller, 0, $i).strtolower(substr($controller, $i));
         }
 
         yield $this->container->get($controller)->get($argument->getName());

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
@@ -66,6 +66,24 @@ class ServiceValueResolverTest extends TestCase
         $this->assertYieldEquals(array(new DummyService()), $resolver->resolve($request, $argument));
     }
 
+    public function testExistingControllerWithMethodNameStartUppercase()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator(array(
+            'App\\Controller\\Mine::method' => function () {
+                return new ServiceLocator(array(
+                    'dummy' => function () {
+                        return new DummyService();
+                    },
+                ));
+            },
+        )));
+        $request = $this->requestWithAttributes(array('_controller' => 'App\\Controller\\Mine::Method'));
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+
+        $this->assertTrue($resolver->supports($request, $argument));
+        $this->assertYieldEquals(array(new DummyService()), $resolver->resolve($request, $argument));
+    }
+
     public function testControllerNameIsAnArray()
     {
         $resolver = new ServiceValueResolver(new ServiceLocator(array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28254 
| License       | MIT
| Doc PR        | -

Fix #28254 by making the method access insensitive in `ServiceValueResolver`.