### PR TITLE
[PhpUnitBridge] enable DebugClassLoader by default

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestSuite;
 use PHPUnit\Util\Blacklist;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Bridge\PhpUnit\DnsMock;
+use Symfony\Component\Debug\DebugClassLoader;
 
 /**
  * PHP 5.3 compatible trait-like shared implementation.
@@ -52,6 +53,8 @@ class SymfonyTestsListenerTrait
             Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerTrait'] = 2;
         }
 
+        $enableDebugClassLoader = \class_exists('Symfony\Component\Debug\DebugClassLoader');
+
         foreach ($mockedNamespaces as $type => $namespaces) {
             if (!\is_array($namespaces)) {
                 $namespaces = array($namespaces);
@@ -66,6 +69,12 @@ class SymfonyTestsListenerTrait
                     DnsMock::register($ns.'\DummyClass');
                 }
             }
+            if ('debug-class-loader' === $type) {
+                $enableDebugClassLoader = $namespaces && $namespaces[0];
+            }
+        }
+        if ($enableDebugClassLoader) {
+            DebugClassLoader::enable();
         }
         if (self::$globallyEnabled) {
             $this->state = -2;

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -79,9 +79,10 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass implements Repe
         }
     }
 
-    protected function processValue($value, $isRoot = false, bool $inExpression = false)
+    protected function processValue($value, $isRoot = false)
     {
         $lazy = $this->lazy;
+        $inExpression = $this->inExpression();
 
         if ($value instanceof ArgumentInterface) {
             $this->lazy = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/issues/10360

With this PR, the phpunit-bridge will enable `DebugClassLoader` by default, making it do its job: throw deprecation notices at autoloading time. On top of #28329, this made me spot some glitches in the code base, fixed here also.

This can be disabled by configuring the listener in `phpunit.xml.dist` files, adding `<element key="debug-class-loader"><integer>0</integer></element>` next to `<element key="time-sensitive">...`.