### PR TITLE
[FrameworkBundle] Deprecate ContainerAwareCommand

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -102,6 +102,8 @@ FrameworkBundle
            serializer:
                id: your_messenger_service_id
    ```
+ * The `ContainerAwareCommand` class has been deprecated, use `Symfony\Component\Console\Command\Command`
+   with dependency injection instead.
 
 Messenger
 ---------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -93,6 +93,8 @@ FrameworkBundle
  * The `RequestDataCollector` class has been removed. Use the `Symfony\Component\HttpKernel\DataCollector\RequestDataCollector` class instead.
  * Removed `Symfony\Bundle\FrameworkBundle\Controller\Controller`. Use `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` instead.
  * Added support for the SameSite attribute for session cookies. It is highly recommended to set this setting (`framework.session.cookie_samesite`) to `lax` for increased security against CSRF attacks.
+ * The `ContainerAwareCommand` class has been removed, use `Symfony\Component\Console\Command\Command`
+   with dependency injection instead.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,8 +11,9 @@ CHANGELOG
  * Deprecated the `Symfony\Bundle\FrameworkBundle\Controller\Controller` class in favor of `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`.
  * Enabled autoconfiguration for `Psr\Log\LoggerAwareInterface`
  * Added new "auto" mode for `framework.session.cookie_secure` to turn it on when HTTPS is used
- * Removed the `framework.messenger.encoder` and `framework.messenger.decoder` options. Use the `framework.messenger.serializer.id` option to replace the Messenger serializer.
- 
+ * Removed the `framework.messenger.encoder` and `framework.messenger.decoder` options. Use the `framework.messenger.serializer.id` option to replace the Messenger serializer. 
+ * Deprecated the `ContainerAwareCommand` class in favor of `Symfony\Component\Console\Command\Command`
+
 4.1.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
@@ -15,10 +15,14 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.2, use "%s" with dependency injection instead.', ContainerAwareCommand::class, Command::class), E_USER_DEPRECATED);
+
 /**
  * Command.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 4.2, use {@see Command} instead.
  */
 abstract class ContainerAwareCommand extends Command implements ContainerAwareInterface
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -101,6 +101,10 @@ class ApplicationTest extends TestCase
         $this->assertSame($command, $application->find('alias'));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The "Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand" class is deprecated since Symfony 4.2, use "Symfony\Component\Console\Command\Command" with dependency injection instead.
+     */
     public function testBundleCommandsHaveRightContainer()
     {
         $command = $this->getMockForAbstractClass('Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand', array('foo'), '', true, true, true, array('setContainer'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10307

Follow up of the recent `Controller` deprecation.

I think people are widely used to register their commands as services and use proper dependency injection, we made the move for core commands in 3.4, let's deprecate `ContainerAwareCommand` for 4.2.