### PR TITLE
[FrameworkBundle] Register the messenger data collector only when the profiler is enabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -52,5 +52,9 @@
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
             <tag name="data_collector" template="@WebProfiler/Collector/router.html.twig" id="router" priority="285" />
         </service>
+
+        <service id="data_collector.messenger" class="Symfony\Component\Messenger\DataCollector\MessengerDataCollector">
+            <tag name="data_collector" template="@WebProfiler/Collector/messenger.html.twig" id="messenger" priority="100" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -34,15 +34,11 @@
             <argument type="service" id="validator" />
         </service>
 
-        <!-- Logging & Debug -->
+        <!-- Logging -->
         <service id="messenger.middleware.logging" class="Symfony\Component\Messenger\Middleware\LoggingMiddleware" abstract="true">
             <argument type="service" id="logger" />
 
             <tag name="monolog.logger" channel="messenger" />
-        </service>
-
-        <service id="messenger.data_collector" class="Symfony\Component\Messenger\DataCollector\MessengerDataCollector">
-            <tag name="data_collector" template="@WebProfiler/Collector/messenger.html.twig" id="messenger" priority="100" />
         </service>
 
         <!-- Discovery -->

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -64,7 +64,7 @@ class MessengerPass implements CompilerPassInterface
                 $container->getParameterBag()->remove($busMiddlewareParameter);
             }
 
-            if ($container->hasDefinition('messenger.data_collector')) {
+            if ($container->hasDefinition('data_collector.messenger')) {
                 $this->registerBusToCollector($container, $busId);
             }
         }
@@ -276,7 +276,7 @@ class MessengerPass implements CompilerPassInterface
             (new Definition(TraceableMessageBus::class, array(new Reference($tracedBusId.'.inner'))))->setDecoratedService($busId)
         );
 
-        $container->getDefinition('messenger.data_collector')->addMethodCall('registerBus', array($busId, new Reference($tracedBusId)));
+        $container->getDefinition('data_collector.messenger')->addMethodCall('registerBus', array($busId, new Reference($tracedBusId)));
     }
 
     private function registerBusMiddleware(ContainerBuilder $container, string $busId, array $middlewareCollection)

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -435,14 +435,14 @@ class MessengerPassTest extends TestCase
         $dataCollector = $this->getMockBuilder(MessengerDataCollector::class)->getMock();
 
         $container = $this->getContainerBuilder($fooBusId = 'messenger.bus.foo');
-        $container->register('messenger.data_collector', $dataCollector);
+        $container->register('data_collector.messenger', $dataCollector);
         $container->setParameter('kernel.debug', true);
 
         (new MessengerPass())->process($container);
 
         $this->assertTrue($container->hasDefinition($debuggedFooBusId = 'debug.traced.'.$fooBusId));
         $this->assertSame(array($fooBusId, null, 0), $container->getDefinition($debuggedFooBusId)->getDecoratedService());
-        $this->assertEquals(array(array('registerBus', array($fooBusId, new Reference($debuggedFooBusId)))), $container->getDefinition('messenger.data_collector')->getMethodCalls());
+        $this->assertEquals(array(array('registerBus', array($fooBusId, new Reference($debuggedFooBusId)))), $container->getDefinition('data_collector.messenger')->getMethodCalls());
     }
 
     public function testRegistersMiddlewareFromServices()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28350
| License       | MIT
| Doc PR        | N/A

The data collector for the messenger is currently unconditionally registered, which causes increased memory usage even in production. Instead, it should only be registered along with the rest of the data collectors only when the profiler is enabled
