### PR TITLE
[Messenger] Change AmqpExt classes constructor signature

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,11 +4,13 @@ CHANGELOG
 4.2.0
 -----
 
+ * [BC BREAK] The signature of Amqp* classes changed to take a `Connection` as a first argument and an optional
+   `Serializer` as a second argument.
  * [BC BREAK] `SenderLocator` has been renamed to `ContainerSenderLocator`
    Be careful as there is still a `SenderLocator` class, but it does not rely on a `ContainerInterface` to find senders.
    Instead, it accepts the sender instance itself instead of its identifier in the container.
  * [BC BREAK] `MessageSubscriberInterface::getHandledMessages()` return value has changed. The value of an array item
-   needs to be an associative array or the method name. 
+   needs to be an associative array or the method name.
  * `ValidationMiddleware::handle()` and `SendMessageMiddleware::handle()` now require an `Envelope` object
  * `EnvelopeItemInterface` doesn't extend `Serializable` anymore
  * [BC BREAK] The `ConsumeMessagesCommand` class now takes an instance of `Psr\Container\ContainerInterface` 

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
@@ -48,8 +48,8 @@ class AmqpExtIntegrationTest extends TestCase
         $connection->setup();
         $connection->queue()->purge();
 
-        $sender = new AmqpSender($serializer, $connection);
-        $receiver = new AmqpReceiver($serializer, $connection);
+        $sender = new AmqpSender($connection, $serializer);
+        $receiver = new AmqpReceiver($connection, $serializer);
 
         $sender->send($first = Envelope::wrap(new DummyMessage('First')));
         $sender->send($second = Envelope::wrap(new DummyMessage('Second')));
@@ -74,7 +74,7 @@ class AmqpExtIntegrationTest extends TestCase
         $connection->setup();
         $connection->queue()->purge();
 
-        $sender = new AmqpSender($serializer, $connection);
+        $sender = new AmqpSender($connection, $serializer);
         $sender->send(Envelope::wrap(new DummyMessage('Hello')));
 
         $amqpReadTimeout = 30;
@@ -123,7 +123,7 @@ TXT
         $connection->setup();
         $connection->queue()->purge();
 
-        $receiver = new AmqpReceiver($serializer, $connection);
+        $receiver = new AmqpReceiver($connection, $serializer);
 
         $receivedMessages = 0;
         $receiver->receive(function (?Envelope $envelope) use ($receiver, &$receivedMessages) {

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpReceiverTest.php
@@ -44,7 +44,7 @@ class AmqpReceiverTest extends TestCase
 
         $connection->expects($this->once())->method('ack')->with($envelope);
 
-        $receiver = new AmqpReceiver($serializer, $connection);
+        $receiver = new AmqpReceiver($connection, $serializer);
         $receiver->receive(function (?Envelope $envelope) use ($receiver) {
             $this->assertEquals(new DummyMessage('Hi'), $envelope->getMessage());
             $receiver->stop();
@@ -71,7 +71,7 @@ class AmqpReceiverTest extends TestCase
 
         $connection->expects($this->once())->method('nack')->with($envelope);
 
-        $receiver = new AmqpReceiver($serializer, $connection);
+        $receiver = new AmqpReceiver($connection, $serializer);
         $receiver->receive(function () {
             throw new InterruptException('Well...');
         });
@@ -96,7 +96,7 @@ class AmqpReceiverTest extends TestCase
         $connection->method('get')->willReturn($envelope);
         $connection->expects($this->once())->method('reject')->with($envelope);
 
-        $receiver = new AmqpReceiver($serializer, $connection);
+        $receiver = new AmqpReceiver($connection, $serializer);
         $receiver->receive(function () {
             throw new WillNeverWorkException('Well...');
         });

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpSenderTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpSenderTest.php
@@ -34,7 +34,7 @@ class AmqpSenderTest extends TestCase
         $connection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
         $connection->expects($this->once())->method('publish')->with($encoded['body'], $encoded['headers']);
 
-        $sender = new AmqpSender($serializer, $connection);
+        $sender = new AmqpSender($connection, $serializer);
         $sender->send($envelope);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportFactoryTest.php
@@ -38,7 +38,7 @@ class AmqpTransportFactoryTest extends TestCase
             true
         );
 
-        $expectedTransport = new AmqpTransport($serializer, Connection::fromDsn('amqp://localhost', array('foo' => 'bar'), true));
+        $expectedTransport = new AmqpTransport(Connection::fromDsn('amqp://localhost', array('foo' => 'bar'), true), $serializer);
 
         $this->assertEquals($expectedTransport, $factory->createTransport('amqp://localhost', array('foo' => 'bar')));
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportTest.php
@@ -59,6 +59,6 @@ class AmqpTransportTest extends TestCase
         $serializer = $serializer ?: $this->getMockBuilder(SerializerInterface::class)->getMock();
         $connection = $connection ?: $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
 
-        return new AmqpTransport($serializer, $connection);
+        return new AmqpTransport($connection, $serializer);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/Fixtures/long_receiver.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/Fixtures/long_receiver.php
@@ -26,7 +26,7 @@ $serializer = new Serializer(
 );
 
 $connection = Connection::fromDsn(getenv('DSN'));
-$receiver = new AmqpReceiver($serializer, $connection);
+$receiver = new AmqpReceiver($connection, $serializer);
 
 $worker = new Worker($receiver, new class() implements MessageBusInterface {
     public function dispatch($envelope)

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Transport\AmqpExt\Exception\RejectMessageExceptionInterface;
 use Symfony\Component\Messenger\Transport\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
@@ -26,10 +27,10 @@ class AmqpReceiver implements ReceiverInterface
     private $connection;
     private $shouldStop;
 
-    public function __construct(SerializerInterface $serializer, Connection $connection)
+    public function __construct(Connection $connection, SerializerInterface $serializer = null)
     {
-        $this->serializer = $serializer;
         $this->connection = $connection;
+        $this->serializer = $serializer ?? Serializer::create();
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
@@ -25,10 +26,10 @@ class AmqpSender implements SenderInterface
     private $serializer;
     private $connection;
 
-    public function __construct(SerializerInterface $serializer, Connection $connection)
+    public function __construct(Connection $connection, SerializerInterface $serializer = null)
     {
-        $this->serializer = $serializer;
         $this->connection = $connection;
+        $this->serializer = $serializer ?? Serializer::create();
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
@@ -25,10 +26,10 @@ class AmqpTransport implements TransportInterface
     private $receiver;
     private $sender;
 
-    public function __construct(SerializerInterface $serializer, Connection $connection)
+    public function __construct(Connection $connection, SerializerInterface $serializer = null)
     {
-        $this->serializer = $serializer;
         $this->connection = $connection;
+        $this->serializer = $serializer ?? Serializer::create();
     }
 
     /**
@@ -57,11 +58,11 @@ class AmqpTransport implements TransportInterface
 
     private function getReceiver()
     {
-        return $this->receiver = new AmqpReceiver($this->serializer, $this->connection);
+        return $this->receiver = new AmqpReceiver($this->connection, $this->serializer);
     }
 
     private function getSender()
     {
-        return $this->sender = new AmqpSender($this->serializer, $this->connection);
+        return $this->sender = new AmqpSender($this->connection, $this->serializer);
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -23,15 +24,15 @@ class AmqpTransportFactory implements TransportFactoryInterface
     private $serializer;
     private $debug;
 
-    public function __construct(SerializerInterface $serializer, bool $debug)
+    public function __construct(SerializerInterface $serializer = null, bool $debug = false)
     {
-        $this->serializer = $serializer;
+        $this->serializer = $serializer ?? Serializer::create();
         $this->debug = $debug;
     }
 
     public function createTransport(string $dsn, array $options): TransportInterface
     {
-        return new AmqpTransport($this->serializer, Connection::fromDsn($dsn, $options, $this->debug));
+        return new AmqpTransport(Connection::fromDsn($dsn, $options, $this->debug), $this->serializer);
     }
 
     public function supports(string $dsn, array $options): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This pull requests does 2 things:

 * It makes `Connection` a first argument of AmqpExt classes. I think it makes sense as this is the most important argument for those classes.

 * As the `Serializer` is now a second argument, I propose to make it optional and use the default serializer that we've added recently if `null` (`Serializer::create()`)

It makes the component even more user friendly when not using Symfony full stack (and provide good defaults).
