### PR TITLE
[Messenger] Remove message from messenger data collector

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/messenger.html.twig
@@ -109,7 +109,7 @@
                 data-toggle-selector="#message-item-{{ discr }}-{{ loop.index0 }}-details"
                 data-toggle-initial="{{ loop.first ? 'display' }}"
             >
-                <span class="dump-inline">{{ profiler_dump(dispatchCall.message.type) }}</span>
+                <span class="dump-inline">{{ profiler_dump(dispatchCall.message) }}</span>
                 {% if showBus %}
                     <span class="label">{{ dispatchCall.bus }}</span>
                 {% endif %}
@@ -154,10 +154,6 @@
                 <td>{{ dispatchCall.bus }}</td>
             </tr>
             {% endif %}
-            <tr>
-                <td class="text-bold">Message</td>
-                <td>{{ profiler_dump(dispatchCall.message.value, maxDepth=2) }}</td>
-            </tr>
             <tr>
                 <td class="text-bold">Envelope items</td>
                 <td>

--- a/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
@@ -91,10 +91,7 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
         $debugRepresentation = array(
             'bus' => $busName,
             'envelopeItems' => $tracedMessage['envelopeItems'] ?? null,
-            'message' => array(
-                'type' => new ClassStub(\get_class($message)),
-                'value' => $message,
-            ),
+            'message' => new ClassStub($message),
             'caller' => $tracedMessage['caller'],
         );
 

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -31,7 +31,7 @@ class TraceableMessageBus implements MessageBusInterface
     {
         $caller = $this->getCaller();
         $callTime = microtime(true);
-        $messageToTrace = $message instanceof Envelope ? $message->getMessage() : $message;
+        $messageToTrace = \get_class($message instanceof Envelope ? $message->getMessage() : $message);
         $envelopeItems = $message instanceof Envelope ? array_values($message->all()) : null;
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [#28350 (comment)](https://github.com/symfony/symfony/issues/28350#issuecomment-419801936)
| License       | MIT
| Doc PR        | 

The messenger data collector currently stores the full message object, which can cause a big increase in memory usage. Based on @nicolas-grekas feedback in [#28350 (comment)](https://github.com/symfony/symfony/issues/28350#issuecomment-419801936), we should store less information. This PR starts by removing the message object from the profiler and to open the conversation about what information is required in the profiler or what can be optimized.

*Before:*
![screen shot 2018-09-10 at 09 44 14](https://user-images.githubusercontent.com/144858/45283429-23227400-b4de-11e8-9c8c-c5a0d87b286f.png)

*After:*
![screen shot 2018-09-10 at 09 41 17](https://user-images.githubusercontent.com/144858/45283447-2e759f80-b4de-11e8-8d48-6136a41a5cc7.png)
