### PR TITLE
[VarExporter] throw component-specific exceptions

### DIFF
--- a/src/Symfony/Component/VarExporter/Exception/ClassNotFoundException.php
+++ b/src/Symfony/Component/VarExporter/Exception/ClassNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Exception;
+
+class ClassNotFoundException extends \Exception implements ExceptionInterface
+{
+    public function __construct(string $class, \Throwable $previous = null)
+    {
+        parent::__construct(sprintf('Class "%s" not found.', $class), 0, $previous);
+    }
+}

--- a/src/Symfony/Component/VarExporter/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/VarExporter/Exception/ExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Exception;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Symfony/Component/VarExporter/Exception/NotInstantiableTypeException.php
+++ b/src/Symfony/Component/VarExporter/Exception/NotInstantiableTypeException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Exception;
+
+class NotInstantiableTypeException extends \Exception implements ExceptionInterface
+{
+    public function __construct(string $type)
+    {
+        parent::__construct(sprintf('Type "%s" is not instantiable.', $type));
+    }
+}

--- a/src/Symfony/Component/VarExporter/README.md
+++ b/src/Symfony/Component/VarExporter/README.md
@@ -16,7 +16,7 @@ It also provides a few improvements over `var_export()`/`serialize()`:
 
  * the output is PSR-2 compatible;
  * the output can be re-indented without messing up with `\r` or `\n` in the data
- * missing classes throw a `ReflectionException` instead of being unserialized to
+ * missing classes throw a `ClassNotFoundException` instead of being unserialized to
    `PHP_Incomplete_Class` objects;
  * references involving `SplObjectStorage`, `ArrayObject` or `ArrayIterator`
    instances are preserved;

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -21,8 +21,8 @@ class VarExporterTest extends TestCase
     use VarDumperTestTrait;
 
     /**
-     * @expectedException \ReflectionException
-     * @expectedExceptionMessage Class SomeNotExistingClass does not exist
+     * @expectedException \Symfony\Component\VarExporter\Exception\ClassNotFoundException
+     * @expectedExceptionMessage Class "SomeNotExistingClass" not found.
      */
     public function testPhpIncompleteClassesAreForbidden()
     {
@@ -36,8 +36,8 @@ class VarExporterTest extends TestCase
 
     /**
      * @dataProvider provideFailingSerialization
-     * @expectedException \Exception
-     * @expectedExceptionMessageRegexp Serialization of '.*' is not allowed
+     * @expectedException \Symfony\Component\VarExporter\Exception\NotInstantiableTypeException
+     * @expectedExceptionMessageRegexp Type ".*" is not instantiable.
      */
     public function testFailingSerialization($value)
     {

--- a/src/Symfony/Component/VarExporter/VarExporter.php
+++ b/src/Symfony/Component/VarExporter/VarExporter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\VarExporter;
 
+use Symfony\Component\VarExporter\Exception\ExceptionInterface;
 use Symfony\Component\VarExporter\Internal\Exporter;
 use Symfony\Component\VarExporter\Internal\Hydrator;
 use Symfony\Component\VarExporter\Internal\Registry;
@@ -36,7 +37,7 @@ final class VarExporter
      *
      * @return string The value exported as PHP code
      *
-     * @throws \Exception When the provided value cannot be serialized
+     * @throws ExceptionInterface When the provided value cannot be serialized
      */
     public static function export($value, bool &$isStaticValue = null): string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This makes "serializing/unserializing" with the component diverge a bit from native serialize/unserialize (wich can throw plain "Exception" instances), but I think we should still do it.