### PR TITLE
[Ldap] Add verbose ext-ldap error if present for easier debugging

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -89,7 +89,12 @@ class Query extends AbstractQuery
         }
 
         if (false === $this->search) {
-            throw new LdapException(sprintf('Could not complete search with dn "%s", query "%s" and filters "%s".', $this->dn, $this->query, implode(',', $this->options['filter'])));
+            $ldapError = '';
+            if ($errno = ldap_errno($con)) {
+                $ldapError = sprintf(' LDAP error was [%d] %s', $errno, ldap_error($con));
+            }
+
+            throw new LdapException(sprintf('Could not complete search with dn "%s", query "%s" and filters "%s".%s', $this->dn, $this->query, implode(',', $this->options['filter']), $ldapError));
         }
 
         return new Collection($this->connection, $this);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (be careful when merging)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | #28149
| License       | MIT
| Doc PR        | 

Added an optional message suffix if ldap_errno is not equals to 0