### PR TITLE
[HttpFoundation] Allow reuse of Session between requests if ID did not change

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -178,7 +178,9 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
      */
     public function setId($id)
     {
-        $this->storage->setId($id);
+        if ($this->storage->getId() !== $id) {
+            $this->storage->setId($id);
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -70,6 +70,27 @@ class SessionTest extends TestCase
         $this->assertEquals('0123456789abcdef', $this->session->getId());
     }
 
+    public function testSetIdAfterStart()
+    {
+        $this->session->start();
+        $id = $this->session->getId();
+
+        $e = null;
+        try {
+            $this->session->setId($id);
+        } catch (\Exception $e) {
+        }
+
+        $this->assertNull($e);
+
+        try {
+            $this->session->setId('different');
+        } catch (\Exception $e) {
+        }
+
+        $this->assertInstanceOf('\LogicException', $e);
+    }
+
     public function testSetName()
     {
         $this->assertEquals('MOCKSESSID', $this->session->getName());

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockArraySessionStorageTest.php
@@ -48,7 +48,7 @@ class MockArraySessionStorageTest extends TestCase
         $this->data = array(
             $this->attributes->getStorageKey() => array('foo' => 'bar'),
             $this->flashes->getStorageKey() => array('notice' => 'hello'),
-            );
+        );
 
         $this->storage = new MockArraySessionStorage();
         $this->storage->registerBag($this->flashes);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13450
| License       | MIT
| Doc PR        | -

I stumbled upon the issue from https://github.com/symfony/symfony/issues/13450 in a more simple case than what was exposed in the issue. From my understanding, the problem arises when the session is used between an access to the session and a functional test request: because the session was accessed (usually using the container directly), the session has started and the following request fails.

This PR checks whether the ID was actually regenerated before throwing (if a setId is called with the same ID, it is the same request context, it shouldn't throw IMO).

Not sure I understood everything correctly though, feel free to fix it for me if needed.