### PR TITLE
Deprecate getRootDir and promote getProjectDir instead

### DIFF
--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -120,9 +120,18 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Gets the application root dir (path of the project's Kernel class).
      *
+     * @deprecated since Symfony 4.2, use getProjectDir() instead
+     *
      * @return string The Kernel root dir
      */
     public function getRootDir();
+
+    /**
+     * Gets the application root dir (path of the project's composer file).
+     *
+     * @return string The project root dir
+     */
+    public function getProjectDir();
 
     /**
      * Gets the current container.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #22315   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
* Method getProjectDir not covered in Interface
* Deprecate getRootDir in favor of getProjectDir

To deprecate in 4.2?

Related to [22315](https://github.com/symfony/symfony/pull/22315).