### PR TITLE
Remove all usages of call_user_func_array()

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -146,7 +146,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
 
         if ($sortedTags) {
             krsort($sortedTags);
-            $sortedTags = \call_user_func_array('array_merge', $sortedTags);
+            $sortedTags = array_merge(...$sortedTags);
         }
 
         return $sortedTags;

--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -17,8 +17,6 @@ use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
- * Logger.
- *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
@@ -29,7 +27,7 @@ class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
     public function getLogs(/* Request $request = null */)
     {
         if ($logger = $this->getDebugLogger()) {
-            return \call_user_func_array(array($logger, 'getLogs'), \func_get_args());
+            return $logger->getLogs(...\func_get_args());
         }
 
         return array();
@@ -41,7 +39,7 @@ class Logger extends BaseLogger implements DebugLoggerInterface, ResetInterface
     public function countErrors(/* Request $request = null */)
     {
         if ($logger = $this->getDebugLogger()) {
-            return \call_user_func_array(array($logger, 'countErrors'), \func_get_args());
+            return $logger->countErrors(...\func_get_args());
         }
 
         return 0;

--- a/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/DumpExtensionTest.php
@@ -76,7 +76,7 @@ class DumpExtensionTest extends TestCase
         array_unshift($args, $context);
         array_unshift($args, $twig);
 
-        $dump = \call_user_func_array(array($extension, 'dump'), $args);
+        $dump = $extension->dump(...$args);
 
         if ($debug) {
             $this->assertStringStartsWith('<script>', $dump);

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/StopwatchHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/StopwatchHelper.php
@@ -37,7 +37,7 @@ class StopwatchHelper extends Helper
     {
         if (null !== $this->stopwatch) {
             if (method_exists($this->stopwatch, $method)) {
-                return \call_user_func_array(array($this->stopwatch, $method), $arguments);
+                return $this->stopwatch->{$method}(...$arguments);
             }
 
             throw new \BadMethodCallException(sprintf('Method "%s" of Stopwatch does not exist', $method));

--- a/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/WrappedListener.php
@@ -53,7 +53,7 @@ final class WrappedListener implements ListenerInterface
      */
     public function __call($method, $arguments)
     {
-        return \call_user_func_array(array($this->listener, $method), $arguments);
+        return $this->listener->{$method}(...$arguments);
     }
 
     public function getWrappedListener(): ListenerInterface

--- a/src/Symfony/Component/Cache/Traits/RedisProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisProxy.php
@@ -32,7 +32,7 @@ class RedisProxy
     {
         $this->ready ?: $this->ready = $this->initializer->__invoke($this->redis);
 
-        return \call_user_func_array(array($this->redis, $method), $args);
+        return $this->redis->{$method}(...$args);
     }
 
     public function hscan($strKey, &$iIterator, $strPattern = null, $iCount = null)

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -336,13 +336,13 @@ trait RedisTrait
             // see https://github.com/nrk/predis/issues/267#issuecomment-123781423
             $results = array();
             foreach ($generator() as $command => $args) {
-                $results[] = \call_user_func_array(array($this->redis, $command), $args);
+                $results[] = $this->redis->{$command}(...$args);
                 $ids[] = $args[0];
             }
         } elseif ($this->redis instanceof \Predis\Client) {
             $results = $this->redis->pipeline(function ($redis) use ($generator, &$ids) {
                 foreach ($generator() as $command => $args) {
-                    \call_user_func_array(array($redis, $command), $args);
+                    $redis->{$command}(...$args);
                     $ids[] = $args[0];
                 }
             });
@@ -353,7 +353,7 @@ trait RedisTrait
                     $connections[$h] = array($this->redis->_instance($h), -1);
                     $connections[$h][0]->multi(\Redis::PIPELINE);
                 }
-                \call_user_func_array(array($connections[$h][0], $command), $args);
+                $connections[$h][0]->{$command}(...$args);
                 $results[] = array($h, ++$connections[$h][1]);
                 $ids[] = $args[0];
             }
@@ -366,7 +366,7 @@ trait RedisTrait
         } else {
             $this->redis->multi(\Redis::PIPELINE);
             foreach ($generator() as $command => $args) {
-                \call_user_func_array(array($this->redis, $command), $args);
+                $this->redis->{$command}(...$args);
                 $ids[] = $args[0];
             }
             $results = $this->redis->exec();

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -43,7 +43,7 @@ class ArrayNodeDefinitionTest extends TestCase
     {
         $node = new ArrayNodeDefinition('root');
 
-        \call_user_func_array(array($node, $method), $args);
+        $node->{$method}(...$args);
 
         $node->getNode();
     }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1114,7 +1114,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         if (null !== $factory) {
-            $service = \call_user_func_array($factory, $arguments);
+            $service = $factory(...$arguments);
 
             if (!$definition->isDeprecated() && \is_array($factory) && \is_string($factory[0])) {
                 $r = new \ReflectionClass($factory[0]);
@@ -1563,7 +1563,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             }
         }
 
-        \call_user_func_array(array($service, $call[0]), $this->doResolveServices($this->getParameterBag()->unescapeValue($this->getParameterBag()->resolveValue($call[1])), $inlineServices));
+        $service->{$call[0]}(...$this->doResolveServices($this->getParameterBag()->unescapeValue($this->getParameterBag()->resolveValue($call[1])), $inlineServices));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -28,7 +28,7 @@ abstract class AbstractConfigurator
     public function __call($method, $args)
     {
         if (method_exists($this, 'set'.$method)) {
-            return \call_user_func_array(array($this, 'set'.$method), $args);
+            return $this->{'set'.$method}(...$args);
         }
 
         throw new \BadMethodCallException(sprintf('Call to undefined method %s::%s()', \get_class($this), $method));

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -230,7 +230,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
      */
     public function __call($method, $arguments)
     {
-        return \call_user_func_array(array($this->dispatcher, $method), $arguments);
+        return $this->dispatcher->{$method}(...$arguments);
     }
 
     /**

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionFunction.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionFunction.php
@@ -90,9 +90,7 @@ class ExpressionFunction
         };
 
         $evaluator = function () use ($phpFunctionName) {
-            $args = \func_get_args();
-
-            return \call_user_func_array($phpFunctionName, array_splice($args, 1));
+            return $phpFunctionName(...\array_slice(\func_get_args(), 1));
         };
 
         return new self($expressionFunctionName ?: end($parts), $compiler, $evaluator);

--- a/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
@@ -37,7 +37,7 @@ class FunctionNode extends Node
 
         $function = $compiler->getFunction($this->attributes['name']);
 
-        $compiler->raw(\call_user_func_array($function['compiler'], $arguments));
+        $compiler->raw($function['compiler'](...$arguments));
     }
 
     public function evaluate($functions, $values)
@@ -47,7 +47,7 @@ class FunctionNode extends Node
             $arguments[] = $node->evaluate($functions, $values);
         }
 
-        return \call_user_func_array($functions[$this->attributes['name']]['evaluator'], $arguments);
+        return $functions[$this->attributes['name']]['evaluator'](...$arguments);
     }
 
     public function toArray()

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -86,7 +86,7 @@ class GetAttrNode extends Node
                     throw new \RuntimeException(sprintf('Unable to call method "%s" of object "%s".', $this->nodes['attribute']->attributes['value'], \get_class($obj)));
                 }
 
-                return \call_user_func_array($toCall, $this->nodes['arguments']->evaluate($functions, $values));
+                return $toCall(...array_values($this->nodes['arguments']->evaluate($functions, $values)));
 
             case self::ARRAY_CALL:
                 $array = $this->nodes['node']->evaluate($functions, $values);

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -744,7 +744,7 @@ class Filesystem
         self::$lastError = null;
         \set_error_handler(__CLASS__.'::handleError');
         try {
-            $result = \call_user_func_array($func, \array_slice(\func_get_args(), 1));
+            $result = $func(...\array_slice(\func_get_args(), 1));
             \restore_error_handler();
 
             return $result;

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -147,7 +147,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         $arguments = $event->getArguments();
 
         // call controller
-        $response = \call_user_func_array($controller, $arguments);
+        $response = $controller(...$arguments);
 
         // view
         if (!$response instanceof Response) {

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -88,7 +88,7 @@ class FragmentHandlerTest extends TestCase
         ;
 
         if ($arguments) {
-            \call_user_func_array(array($e, 'with'), $arguments);
+            $e->with(...$arguments);
         }
 
         $handler = new FragmentHandler($this->requestStack);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -234,7 +234,7 @@ class EsiTest extends TestCase
         if (\is_array($response)) {
             $cache->expects($this->any())
                   ->method('handle')
-                  ->will(\call_user_func_array(array($this, 'onConsecutiveCalls'), $response))
+                  ->will($this->onConsecutiveCalls(...$response))
             ;
         } else {
             $cache->expects($this->any())

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/SsiTest.php
@@ -201,7 +201,7 @@ class SsiTest extends TestCase
         if (\is_array($response)) {
             $cache->expects($this->any())
                   ->method('handle')
-                  ->will(\call_user_func_array(array($this, 'onConsecutiveCalls'), $response))
+                  ->will($this->onConsecutiveCalls(...$response))
             ;
         } else {
             $cache->expects($this->any())

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -227,8 +227,8 @@ class HttpKernelTest extends TestCase
         $first = $e->getTrace()[0];
 
         // `file` index the array starting at 0, and __FILE__ starts at 1
-        $line = file($first['file'])[$first['line'] - 1];
-        $this->assertContains('call_user_func_array', $line);
+        $line = file($first['file'])[$first['line'] - 2];
+        $this->assertContains('// call controller', $line);
     }
 
     public function testHandleWhenTheControllerDoesNotReturnAResponseButAViewIsRegistered()
@@ -274,7 +274,7 @@ class HttpKernelTest extends TestCase
             $oldArguments = $event->getArguments();
 
             $newController = function ($id) use ($oldController, $oldArguments) {
-                $response = \call_user_func_array($oldController, $oldArguments);
+                $response = $oldController(...$oldArguments);
 
                 $response->headers->set('X-Id', $id);
 

--- a/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Intl\Tests\Locale;
 
+use Symfony\Component\Intl\Locale\Locale;
+
 class LocaleTest extends AbstractLocaleTest
 {
     /**
@@ -172,6 +174,6 @@ class LocaleTest extends AbstractLocaleTest
     {
         $args = \array_slice(\func_get_args(), 1);
 
-        return \call_user_func_array(array('Symfony\Component\Intl\Locale\Locale', $methodName), $args);
+        return Locale::{$methodName}(...$args);
     }
 }

--- a/src/Symfony/Component/Intl/Tests/Locale/Verification/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/Verification/LocaleTest.php
@@ -33,6 +33,6 @@ class LocaleTest extends AbstractLocaleTest
     {
         $args = \array_slice(\func_get_args(), 1);
 
-        return \call_user_func_array(array('Locale', $methodName), $args);
+        return \Locale::{$methodName}(...$args);
     }
 }

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -139,7 +139,7 @@ class RedisStore implements StoreInterface
         }
 
         if ($this->redis instanceof \Predis\Client) {
-            return \call_user_func_array(array($this->redis, 'eval'), array_merge(array($script, 1, $resource), $args));
+            return $this->redis->eval(...array_merge(array($script, 1, $resource), $args));
         }
 
         throw new InvalidArgumentException(sprintf('%s() expects being initialized with a Redis, RedisArray, RedisCluster or Predis\Client, %s given', __METHOD__, \is_object($this->redis) ? \get_class($this->redis) : \gettype($this->redis)));

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -99,7 +99,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
             $serializedArguments = serialize($arguments);
         } catch (\Exception $exception) {
             // If arguments are not serializable, skip the cache
-            return \call_user_func_array(array($this->propertyInfoExtractor, $method), $arguments);
+            return $this->propertyInfoExtractor->{$method}(...$arguments);
         }
 
         // Calling rawurlencode escapes special characters not allowed in PSR-6's keys
@@ -115,7 +115,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
             return $this->arrayCache[$key] = $item->get();
         }
 
-        $value = \call_user_func_array(array($this->propertyInfoExtractor, $method), $arguments);
+        $value = $this->propertyInfoExtractor->{$method}(...$arguments);
         $item->set($value);
         $this->cacheItemPool->save($item);
 

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -106,8 +106,7 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     private function extract(iterable $extractors, string $method, array $arguments)
     {
         foreach ($extractors as $extractor) {
-            $value = \call_user_func_array(array($extractor, $method), $arguments);
-            if (null !== $value) {
+            if (null !== $value = $extractor->{$method}(...$arguments)) {
                 return $value;
             }
         }

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -108,7 +108,7 @@ class DataCollectorTranslator implements LegacyTranslatorInterface, TranslatorBa
      */
     public function __call($method, $args)
     {
-        return \call_user_func_array(array($this->translator, $method), $args);
+        return $this->translator->{$method}(...$args);
     }
 
     /**

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -107,7 +107,7 @@ class LoggingTranslator implements LegacyTranslatorInterface, TranslatorBagInter
      */
     public function __call($method, $args)
     {
-        return \call_user_func_array(array($this->translator, $method), $args);
+        return $this->translator->{$method}(...$args);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Because it's cleaner :) (and it saves creating one extra dummy array)