### PR TITLE
[VarDumper] fix dumping signature of callables

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ClassStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/ClassStub.php
@@ -70,9 +70,6 @@ class ClassStub extends ConstStub
                 } else {
                     $this->value .= $s;
                 }
-                if (isset($this->attr['ellipsis'])) {
-                    $this->attr['ellipsis'] += \strlen($this->value) - \strlen($identifier);
-                }
             }
         } catch (\ReflectionException $e) {
             return;

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -87,16 +87,9 @@ EOTXT
 
     public function testClosureCasterExcludingVerbosity()
     {
-        $var = function () {};
+        $var = function &($a = 5) {};
 
-        $expectedDump = <<<EOTXT
-Closure() {
-  class: "Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest"
-  this: Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest { …}
-}
-EOTXT;
-
-        $this->assertDumpEquals($expectedDump, $var, Caster::EXCLUDE_VERBOSE);
+        $this->assertDumpEquals('Closure&($a = 5) { …6}', $var, Caster::EXCLUDE_VERBOSE);
     }
 
     public function testReflectionParameter()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Adds missing visual hint when returning by reference + makes exclude-verbose mode display only the signature.

E.g. using psysh, before:
![image](https://user-images.githubusercontent.com/243674/45360788-ebe0bf80-b5d0-11e8-8e43-62f954e926af.png)

after:
![image](https://user-images.githubusercontent.com/243674/45360760-d9668600-b5d0-11e8-820a-98cc174ba2ca.png)

(`dump -a` shows the details as usual.)