### PR TITLE
[HttpFoundation] make cookies auto-secure when passing them $secure=null + plan to make it and samesite=lax the defaults in 5.0

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -72,6 +72,13 @@ Form
    {% endfor %}
    ```
 
+HttpFoundation
+--------------
+
+ * The default value of the "$secure" and "$samesite" arguments of Cookie's constructor
+   will respectively change from "false" to "null" and from "null" to "lax" in Symfony
+   5.0, you should define their values explicitly or use "Cookie::create()" instead.
+
 Process
 -------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -117,6 +117,8 @@ HttpFoundation
  * The `$size` argument of the `UploadedFile` constructor has been removed.
  * The `getClientSize()` method of the `UploadedFile` class has been removed.
  * The `getSession()` method of the `Request` class throws an exception when session is null.
+ * The default value of the "$secure" and "$samesite" arguments of Cookie's constructor
+   changed respectively from "false" to "null" and from "null" to "lax".
 
 Monolog
 -------

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -199,6 +199,9 @@ class FrameworkExtension extends Extension
         if ($this->isConfigEnabled($container, $config['session'])) {
             $this->sessionConfigEnabled = true;
             $this->registerSessionConfiguration($config['session'], $container, $loader);
+            if (!empty($config['test'])) {
+                $container->getDefinition('test.session.listener')->setArgument(1, '%session.storage.options%');
+            }
         }
 
         if ($this->isConfigEnabled($container, $config['request'])) {

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 -----
 
  * added `getAcceptableFormats()` for reading acceptable formats based on Accept header
+ * the default value of the "$secure" and "$samesite" arguments of Cookie's constructor
+   will respectively change from "false" to "null" and from "null" to "lax" in Symfony
+   5.0, you should define their values explicitly or use "Cookie::create()" instead.
 
 4.1.3
 -----

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -313,6 +313,12 @@ class Response
 
         $this->ensureIEOverSSLCompatibility($request);
 
+        if ($request->isSecure()) {
+            foreach ($headers->getCookies() as $cookie) {
+                $cookie->setSecureDefault(true);
+            }
+        }
+
         return $this;
     }
 

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -247,7 +247,7 @@ class ResponseHeaderBag extends HeaderBag
      */
     public function clearCookie($name, $path = '/', $domain = null, $secure = false, $httpOnly = true)
     {
-        $this->setCookie(new Cookie($name, null, 1, $path, $domain, $secure, $httpOnly));
+        $this->setCookie(new Cookie($name, null, 1, $path, $domain, $secure, $httpOnly, false, null));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -128,7 +128,9 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
                 if (\PHP_VERSION_ID < 70300) {
                     setcookie($this->sessionName, '', 0, ini_get('session.cookie_path'), ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'));
                 } else {
-                    setcookie($this->sessionName, '', 0, ini_get('session.cookie_path'), ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'), ini_get('session.cookie_samesite'));
+                    $params = session_get_cookie_params();
+                    unset($params['lifetime']);
+                    setcookie($this->sessionName, '', $params);
                 }
             }
         }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -153,7 +153,7 @@ class NativeSessionStorage implements SessionStorageInterface
         if (null !== $this->emulateSameSite) {
             $originalCookie = SessionUtils::popSessionCookie(session_name(), session_id());
             if (null !== $originalCookie) {
-                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite));
+                header(sprintf('%s; samesite=%s', $originalCookie, $this->emulateSameSite));
             }
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -45,7 +45,7 @@ class CookieTest extends TestCase
      */
     public function testInstantiationThrowsExceptionIfCookieNameContainsInvalidCharacters($name)
     {
-        new Cookie($name);
+        Cookie::create($name);
     }
 
     /**
@@ -53,12 +53,12 @@ class CookieTest extends TestCase
      */
     public function testInvalidExpiration()
     {
-        new Cookie('MyCookie', 'foo', 'bar');
+        Cookie::create('MyCookie', 'foo', 'bar');
     }
 
     public function testNegativeExpirationIsNotPossible()
     {
-        $cookie = new Cookie('foo', 'bar', -100);
+        $cookie = Cookie::create('foo', 'bar', -100);
 
         $this->assertSame(0, $cookie->getExpiresTime());
     }
@@ -66,32 +66,32 @@ class CookieTest extends TestCase
     public function testGetValue()
     {
         $value = 'MyValue';
-        $cookie = new Cookie('MyCookie', $value);
+        $cookie = Cookie::create('MyCookie', $value);
 
         $this->assertSame($value, $cookie->getValue(), '->getValue() returns the proper value');
     }
 
     public function testGetPath()
     {
-        $cookie = new Cookie('foo', 'bar');
+        $cookie = Cookie::create('foo', 'bar');
 
         $this->assertSame('/', $cookie->getPath(), '->getPath() returns / as the default path');
     }
 
     public function testGetExpiresTime()
     {
-        $cookie = new Cookie('foo', 'bar');
+        $cookie = Cookie::create('foo', 'bar');
 
         $this->assertEquals(0, $cookie->getExpiresTime(), '->getExpiresTime() returns the default expire date');
 
-        $cookie = new Cookie('foo', 'bar', $expire = time() + 3600);
+        $cookie = Cookie::create('foo', 'bar', $expire = time() + 3600);
 
         $this->assertEquals($expire, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
     }
 
     public function testGetExpiresTimeIsCastToInt()
     {
-        $cookie = new Cookie('foo', 'bar', 3600.9);
+        $cookie = Cookie::create('foo', 'bar', 3600.9);
 
         $this->assertSame(3600, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date as an integer');
     }
@@ -99,7 +99,7 @@ class CookieTest extends TestCase
     public function testConstructorWithDateTime()
     {
         $expire = new \DateTime();
-        $cookie = new Cookie('foo', 'bar', $expire);
+        $cookie = Cookie::create('foo', 'bar', $expire);
 
         $this->assertEquals($expire->format('U'), $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
     }
@@ -107,7 +107,7 @@ class CookieTest extends TestCase
     public function testConstructorWithDateTimeImmutable()
     {
         $expire = new \DateTimeImmutable();
-        $cookie = new Cookie('foo', 'bar', $expire);
+        $cookie = Cookie::create('foo', 'bar', $expire);
 
         $this->assertEquals($expire->format('U'), $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
     }
@@ -115,7 +115,7 @@ class CookieTest extends TestCase
     public function testGetExpiresTimeWithStringValue()
     {
         $value = '+1 day';
-        $cookie = new Cookie('foo', 'bar', $value);
+        $cookie = Cookie::create('foo', 'bar', $value);
         $expire = strtotime($value);
 
         $this->assertEquals($expire, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date', 1);
@@ -123,99 +123,99 @@ class CookieTest extends TestCase
 
     public function testGetDomain()
     {
-        $cookie = new Cookie('foo', 'bar', 0, '/', '.myfoodomain.com');
+        $cookie = Cookie::create('foo', 'bar', 0, '/', '.myfoodomain.com');
 
         $this->assertEquals('.myfoodomain.com', $cookie->getDomain(), '->getDomain() returns the domain name on which the cookie is valid');
     }
 
     public function testIsSecure()
     {
-        $cookie = new Cookie('foo', 'bar', 0, '/', '.myfoodomain.com', true);
+        $cookie = Cookie::create('foo', 'bar', 0, '/', '.myfoodomain.com', true);
 
         $this->assertTrue($cookie->isSecure(), '->isSecure() returns whether the cookie is transmitted over HTTPS');
     }
 
     public function testIsHttpOnly()
     {
-        $cookie = new Cookie('foo', 'bar', 0, '/', '.myfoodomain.com', false, true);
+        $cookie = Cookie::create('foo', 'bar', 0, '/', '.myfoodomain.com', false, true);
 
         $this->assertTrue($cookie->isHttpOnly(), '->isHttpOnly() returns whether the cookie is only transmitted over HTTP');
     }
 
     public function testCookieIsNotCleared()
     {
-        $cookie = new Cookie('foo', 'bar', time() + 3600 * 24);
+        $cookie = Cookie::create('foo', 'bar', time() + 3600 * 24);
 
         $this->assertFalse($cookie->isCleared(), '->isCleared() returns false if the cookie did not expire yet');
     }
 
     public function testCookieIsCleared()
     {
-        $cookie = new Cookie('foo', 'bar', time() - 20);
+        $cookie = Cookie::create('foo', 'bar', time() - 20);
 
         $this->assertTrue($cookie->isCleared(), '->isCleared() returns true if the cookie has expired');
 
-        $cookie = new Cookie('foo', 'bar');
+        $cookie = Cookie::create('foo', 'bar');
 
         $this->assertFalse($cookie->isCleared());
 
-        $cookie = new Cookie('foo', 'bar', 0);
+        $cookie = Cookie::create('foo', 'bar');
 
         $this->assertFalse($cookie->isCleared());
 
-        $cookie = new Cookie('foo', 'bar', -1);
+        $cookie = Cookie::create('foo', 'bar', -1);
 
         $this->assertFalse($cookie->isCleared());
     }
 
     public function testToString()
     {
-        $cookie = new Cookie('foo', 'bar', $expire = strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true);
+        $cookie = Cookie::create('foo', 'bar', $expire = strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true, true, false, null);
         $this->assertEquals('foo=bar; expires=Fri, 20-May-2011 15:25:52 GMT; Max-Age=0; path=/; domain=.myfoodomain.com; secure; httponly', (string) $cookie, '->__toString() returns string representation of the cookie');
 
-        $cookie = new Cookie('foo', 'bar with white spaces', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true);
+        $cookie = Cookie::create('foo', 'bar with white spaces', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true, true, false, null);
         $this->assertEquals('foo=bar%20with%20white%20spaces; expires=Fri, 20-May-2011 15:25:52 GMT; Max-Age=0; path=/; domain=.myfoodomain.com; secure; httponly', (string) $cookie, '->__toString() encodes the value of the cookie according to RFC 3986 (white space = %20)');
 
-        $cookie = new Cookie('foo', null, 1, '/admin/', '.myfoodomain.com');
+        $cookie = Cookie::create('foo', null, 1, '/admin/', '.myfoodomain.com', false, true, false, null);
         $this->assertEquals('foo=deleted; expires='.gmdate('D, d-M-Y H:i:s T', $expire = time() - 31536001).'; Max-Age=0; path=/admin/; domain=.myfoodomain.com; httponly', (string) $cookie, '->__toString() returns string representation of a cleared cookie if value is NULL');
 
-        $cookie = new Cookie('foo', 'bar', 0, '/', '');
-        $this->assertEquals('foo=bar; path=/; httponly', (string) $cookie);
+        $cookie = Cookie::create('foo', 'bar');
+        $this->assertEquals('foo=bar; path=/; httponly; samesite=lax', (string) $cookie);
     }
 
     public function testRawCookie()
     {
-        $cookie = new Cookie('foo', 'b a r', 0, '/', null, false, false);
+        $cookie = Cookie::create('foo', 'b a r', 0, '/', null, false, false, false, null);
         $this->assertFalse($cookie->isRaw());
         $this->assertEquals('foo=b%20a%20r; path=/', (string) $cookie);
 
-        $cookie = new Cookie('foo', 'b+a+r', 0, '/', null, false, false, true);
+        $cookie = Cookie::create('foo', 'b+a+r', 0, '/', null, false, false, true, null);
         $this->assertTrue($cookie->isRaw());
         $this->assertEquals('foo=b+a+r; path=/', (string) $cookie);
     }
 
     public function testGetMaxAge()
     {
-        $cookie = new Cookie('foo', 'bar');
+        $cookie = Cookie::create('foo', 'bar');
         $this->assertEquals(0, $cookie->getMaxAge());
 
-        $cookie = new Cookie('foo', 'bar', $expire = time() + 100);
+        $cookie = Cookie::create('foo', 'bar', $expire = time() + 100);
         $this->assertEquals($expire - time(), $cookie->getMaxAge());
 
-        $cookie = new Cookie('foo', 'bar', $expire = time() - 100);
+        $cookie = Cookie::create('foo', 'bar', $expire = time() - 100);
         $this->assertEquals(0, $cookie->getMaxAge());
     }
 
     public function testFromString()
     {
         $cookie = Cookie::fromString('foo=bar; expires=Fri, 20-May-2011 15:25:52 GMT; path=/; domain=.myfoodomain.com; secure; httponly');
-        $this->assertEquals(new Cookie('foo', 'bar', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true, true, true), $cookie);
+        $this->assertEquals(Cookie::create('foo', 'bar', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true, true, true, null), $cookie);
 
         $cookie = Cookie::fromString('foo=bar', true);
-        $this->assertEquals(new Cookie('foo', 'bar', 0, '/', null, false, false), $cookie);
+        $this->assertEquals(Cookie::create('foo', 'bar', 0, '/', null, false, false, false, null), $cookie);
 
         $cookie = Cookie::fromString('foo', true);
-        $this->assertEquals(new Cookie('foo', null, 0, '/', null, false, false), $cookie);
+        $this->assertEquals(Cookie::create('foo', null, 0, '/', null, false, false, false, null), $cookie);
     }
 
     public function testFromStringWithHttpOnly()
@@ -227,9 +227,27 @@ class CookieTest extends TestCase
         $this->assertFalse($cookie->isHttpOnly());
     }
 
-    public function testSameSiteAttributeIsCaseInsensitive()
+    public function testSameSiteAttribute()
     {
         $cookie = new Cookie('foo', 'bar', 0, '/', null, false, true, false, 'Lax');
         $this->assertEquals('lax', $cookie->getSameSite());
+
+        $cookie = new Cookie('foo', 'bar', 0, '/', null, false, true, false, '');
+        $this->assertNull($cookie->getSameSite());
+    }
+
+    public function testSetSecureDefault()
+    {
+        $cookie = Cookie::create('foo', 'bar');
+
+        $this->assertFalse($cookie->isSecure());
+
+        $cookie->setSecureDefault(true);
+
+        $this->assertTrue($cookie->isSecure());
+
+        $cookie->setSecureDefault(false);
+
+        $this->assertFalse($cookie->isSecure());
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.php
@@ -4,7 +4,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 
 $r = require __DIR__.'/common.inc';
 
-$r->headers->setCookie(new Cookie('foo', 'bar', 253402310800, '', null, false, false));
+$r->headers->setCookie(new Cookie('foo', 'bar', 253402310800, '', null, false, false, false, null));
 $r->sendHeaders();
 
 setcookie('foo2', 'bar', 253402310800, '/');

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_raw_urlencode.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_raw_urlencode.php
@@ -6,7 +6,7 @@ $r = require __DIR__.'/common.inc';
 
 $str = '?*():@&+$/%#[]';
 
-$r->headers->setCookie(new Cookie($str, $str, 0, '/', null, false, false, true));
+$r->headers->setCookie(new Cookie($str, $str, 0, '/', null, false, false, true, null));
 $r->sendHeaders();
 
 setrawcookie($str, $str, 0, '/', null, false, false);

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_urlencode.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_urlencode.php
@@ -6,7 +6,7 @@ $r = require __DIR__.'/common.inc';
 
 $str = '?*():@&+$/%#[]';
 
-$r->headers->setCookie(new Cookie($str, $str, 0, '', null, false, false));
+$r->headers->setCookie(new Cookie($str, $str, 0, '', null, false, false, false, null));
 $r->sendHeaders();
 
 setcookie($str, $str, 0, '/');

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/invalid_cookie_name.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/invalid_cookie_name.php
@@ -5,7 +5,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 $r = require __DIR__.'/common.inc';
 
 try {
-    $r->headers->setCookie(new Cookie('Hello + world', 'hodor'));
+    $r->headers->setCookie(Cookie::create('Hello + world', 'hodor'));
 } catch (\InvalidArgumentException $e) {
     echo $e->getMessage();
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -110,9 +110,9 @@ class ResponseHeaderBagTest extends TestCase
     public function testToStringIncludesCookieHeaders()
     {
         $bag = new ResponseHeaderBag(array());
-        $bag->setCookie(new Cookie('foo', 'bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar'));
 
-        $this->assertSetCookieHeader('foo=bar; path=/; httponly', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/; httponly; samesite=lax', $bag);
 
         $bag->clearCookie('foo');
 
@@ -154,24 +154,24 @@ class ResponseHeaderBagTest extends TestCase
     public function testCookiesWithSameNames()
     {
         $bag = new ResponseHeaderBag();
-        $bag->setCookie(new Cookie('foo', 'bar', 0, '/path/foo', 'foo.bar'));
-        $bag->setCookie(new Cookie('foo', 'bar', 0, '/path/bar', 'foo.bar'));
-        $bag->setCookie(new Cookie('foo', 'bar', 0, '/path/bar', 'bar.foo'));
-        $bag->setCookie(new Cookie('foo', 'bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar', 0, '/path/foo', 'foo.bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar', 0, '/path/bar', 'foo.bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar', 0, '/path/bar', 'bar.foo'));
+        $bag->setCookie(Cookie::create('foo', 'bar'));
 
         $this->assertCount(4, $bag->getCookies());
-        $this->assertEquals('foo=bar; path=/path/foo; domain=foo.bar; httponly', $bag->get('set-cookie'));
+        $this->assertEquals('foo=bar; path=/path/foo; domain=foo.bar; httponly; samesite=lax', $bag->get('set-cookie'));
         $this->assertEquals(array(
-            'foo=bar; path=/path/foo; domain=foo.bar; httponly',
-            'foo=bar; path=/path/bar; domain=foo.bar; httponly',
-            'foo=bar; path=/path/bar; domain=bar.foo; httponly',
-            'foo=bar; path=/; httponly',
+            'foo=bar; path=/path/foo; domain=foo.bar; httponly; samesite=lax',
+            'foo=bar; path=/path/bar; domain=foo.bar; httponly; samesite=lax',
+            'foo=bar; path=/path/bar; domain=bar.foo; httponly; samesite=lax',
+            'foo=bar; path=/; httponly; samesite=lax',
         ), $bag->get('set-cookie', null, false));
 
-        $this->assertSetCookieHeader('foo=bar; path=/path/foo; domain=foo.bar; httponly', $bag);
-        $this->assertSetCookieHeader('foo=bar; path=/path/bar; domain=foo.bar; httponly', $bag);
-        $this->assertSetCookieHeader('foo=bar; path=/path/bar; domain=bar.foo; httponly', $bag);
-        $this->assertSetCookieHeader('foo=bar; path=/; httponly', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/path/foo; domain=foo.bar; httponly; samesite=lax', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/path/bar; domain=foo.bar; httponly; samesite=lax', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/path/bar; domain=bar.foo; httponly; samesite=lax', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/; httponly; samesite=lax', $bag);
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
 
@@ -186,8 +186,8 @@ class ResponseHeaderBagTest extends TestCase
         $bag = new ResponseHeaderBag();
         $this->assertFalse($bag->has('set-cookie'));
 
-        $bag->setCookie(new Cookie('foo', 'bar', 0, '/path/foo', 'foo.bar'));
-        $bag->setCookie(new Cookie('bar', 'foo', 0, '/path/bar', 'foo.bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar', 0, '/path/foo', 'foo.bar'));
+        $bag->setCookie(Cookie::create('bar', 'foo', 0, '/path/bar', 'foo.bar'));
         $this->assertTrue($bag->has('set-cookie'));
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
@@ -209,8 +209,8 @@ class ResponseHeaderBagTest extends TestCase
     public function testRemoveCookieWithNullRemove()
     {
         $bag = new ResponseHeaderBag();
-        $bag->setCookie(new Cookie('foo', 'bar', 0));
-        $bag->setCookie(new Cookie('bar', 'foo', 0));
+        $bag->setCookie(Cookie::create('foo', 'bar'));
+        $bag->setCookie(Cookie::create('bar', 'foo'));
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
         $this->assertArrayHasKey('/', $cookies['']);
@@ -228,12 +228,12 @@ class ResponseHeaderBagTest extends TestCase
     {
         $bag = new ResponseHeaderBag();
         $bag->set('set-cookie', 'foo=bar');
-        $this->assertEquals(array(new Cookie('foo', 'bar', 0, '/', null, false, false, true)), $bag->getCookies());
+        $this->assertEquals(array(Cookie::create('foo', 'bar', 0, '/', null, false, false, true, null)), $bag->getCookies());
 
         $bag->set('set-cookie', 'foo2=bar2', false);
         $this->assertEquals(array(
-            new Cookie('foo', 'bar', 0, '/', null, false, false, true),
-            new Cookie('foo2', 'bar2', 0, '/', null, false, false, true),
+            Cookie::create('foo', 'bar', 0, '/', null, false, false, true, null),
+            Cookie::create('foo2', 'bar2', 0, '/', null, false, false, true, null),
         ), $bag->getCookies());
 
         $bag->remove('set-cookie');

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -571,6 +572,24 @@ class ResponseTest extends ResponseTestCase
         $response->prepare($request);
         $this->assertFalse($response->headers->has('pragma'));
         $this->assertFalse($response->headers->has('expires'));
+    }
+
+    public function testPrepareSetsCookiesSecure()
+    {
+        $cookie = Cookie::create('foo', 'bar');
+
+        $response = new Response('foo');
+        $response->headers->setCookie($cookie);
+
+        $request = Request::create('/', 'GET');
+        $response->prepare($request);
+
+        $this->assertFalse($cookie->isSecure());
+
+        $request = Request::create('https://localhost/', 'GET');
+        $response->prepare($request);
+
+        $this->assertTrue($cookie->isSecure());
     }
 
     public function testSetCache()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/with_samesite.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/with_samesite.expected
@@ -11,6 +11,6 @@ Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
     [1] => Cache-Control: max-age=0, private, must-revalidate
-    [2] => Set-Cookie: sid=random_session_id; path=/; secure; HttpOnly; SameSite=lax
+    [2] => Set-Cookie: sid=random_session_id; path=/; secure; HttpOnly; samesite=lax
 )
 shutdown

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -165,7 +165,8 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                     'controller' => $this->parseController($request->attributes->get('_controller')),
                     'status_code' => $statusCode,
                     'status_text' => Response::$statusTexts[(int) $statusCode],
-                ))
+                )),
+                0, '/', null, $request->isSecure(), true, false, 'lax'
             ));
         }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
@@ -24,9 +24,10 @@ class TestSessionListener extends AbstractTestSessionListener
 {
     private $container;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, array $sessionOptions = array())
     {
         $this->container = $container;
+        parent::__construct($sessionOptions);
     }
 
     protected function getSession()

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -61,13 +61,13 @@ class ClientTest extends TestCase
         $m->setAccessible(true);
 
         $response = new Response();
-        $response->headers->setCookie($cookie1 = new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true));
+        $response->headers->setCookie($cookie1 = new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true, false, null));
         $domResponse = $m->invoke($client, $response);
         $this->assertSame((string) $cookie1, $domResponse->getHeader('Set-Cookie'));
 
         $response = new Response();
-        $response->headers->setCookie($cookie1 = new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true));
-        $response->headers->setCookie($cookie2 = new Cookie('foo1', 'bar1', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true));
+        $response->headers->setCookie($cookie1 = new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true, false, null));
+        $response->headers->setCookie($cookie2 = new Cookie('foo1', 'bar1', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true, false, null));
         $domResponse = $m->invoke($client, $response);
         $this->assertSame((string) $cookie1, $domResponse->getHeader('Set-Cookie'));
         $this->assertSame(array((string) $cookie1, (string) $cookie2), $domResponse->getHeader('Set-Cookie', false));

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -274,9 +274,9 @@ class RequestDataCollectorTest extends TestCase
         $response->setStatusCode(200);
         $response->headers->set('Content-Type', 'application/json');
         $response->headers->set('X-Foo-Bar', null);
-        $response->headers->setCookie(new Cookie('foo', 'bar', 1, '/foo', 'localhost', true, true));
-        $response->headers->setCookie(new Cookie('bar', 'foo', new \DateTime('@946684800')));
-        $response->headers->setCookie(new Cookie('bazz', 'foo', '2000-12-12'));
+        $response->headers->setCookie(new Cookie('foo', 'bar', 1, '/foo', 'localhost', true, true, false, null));
+        $response->headers->setCookie(new Cookie('bar', 'foo', new \DateTime('@946684800'), '/', null, false, true, false, null));
+        $response->headers->setCookie(new Cookie('bazz', 'foo', '2000-12-12', '/', null, false, true, false, null));
 
         return $response;
     }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
@@ -24,7 +24,7 @@ class ResponseListenerTest extends TestCase
 {
     public function testRememberMeCookieIsSentWithResponse()
     {
-        $cookie = new Cookie('rememberme');
+        $cookie = new Cookie('rememberme', null, 0, '/', null, false, true, false, null);
 
         $request = $this->getRequest(array(
             RememberMeServicesInterface::COOKIE_ATTR_NAME => $cookie,
@@ -39,7 +39,7 @@ class ResponseListenerTest extends TestCase
 
     public function testRememberMeCookieIsNotSendWithResponseForSubRequests()
     {
-        $cookie = new Cookie('rememberme');
+        $cookie = new Cookie('rememberme', null, 0, '/', null, false, true, false, null);
 
         $request = $this->getRequest(array(
             RememberMeServicesInterface::COOKIE_ATTR_NAME => $cookie,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #26731
| License       | MIT
| Doc PR        | -

By creating Cookie instances using `null` for the `$secure` argument, this PR allows making cookies inherit their "secure" attribute from the request.

This PR also adds a forward to make $secure=null and samesite=lax the defaults in Symfony 5.0:
- either define all constructor's arguments explicitly
- or use the new `Cookie::create()` factory