### PR TITLE
[DependencyInjection] Adding an exception on circular reference

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Compiler\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Compiler\ResolveEnvPlaceholdersPass;
+use Symfony\Component\DependencyInjection\Exception\ArgumentCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -1015,6 +1016,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     {
         if ($this->isCompiled()) {
             throw new BadMethodCallException('Adding definition to a compiled container is not allowed');
+        }
+
+        if ($definition instanceof ChildDefinition && $id === $definition->getParent()) {
+            throw new ArgumentCircularReferenceException($definition->getParent(), $id);
         }
 
         $id = $this->normalizeId($id);

--- a/src/Symfony/Component/DependencyInjection/Exception/ArgumentCircularReferenceException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/ArgumentCircularReferenceException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+/**
+ * This exception is thrown when a circular reference is detected between services in arguments.
+ *
+ * @author Nicolas LEFEVRE <weblefevre@gmail.com>
+ */
+class ArgumentCircularReferenceException extends RuntimeException
+{
+    private $argument;
+    private $serviceId;
+
+    public function __construct($argument, $serviceId, \Exception $previous = null)
+    {
+        parent::__construct(sprintf('Circular reference detected between service "%s" and parent argument "%s". A "ChildDefinition" can\'t references itself as parent.', $argument, $serviceId), 0, $previous);
+
+        $this->argument = $argument;
+        $this->serviceId = $serviceId;
+    }
+
+    public function getArgument()
+    {
+        return $this->argument;
+    }
+
+    public function getServiceId()
+    {
+        return $this->serviceId;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\CheckCircularReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\Compiler;
@@ -104,6 +105,22 @@ class CheckCircularReferencesPassTest extends TestCase
         $container->register('a')->addArgument(new Reference('b'));
         $container->register('b')->addArgument(new Reference('c'));
         $container->register('c')->addArgument(new Reference('b'));
+
+        $this->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ArgumentCircularReferenceException
+     */
+    public function testProcessDetectCircularReferenceWhenChildDefinitionReferencesItselfAsParent()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('a');
+
+        $definition = new ChildDefinition('a');
+        $definition->setClass('b');
+        $container->setDefinition('a', $definition);
 
         $this->process($container);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28312 
| License       | MIT
| Doc PR        | -

When a `ChildDefinition` references itself as parent (or as ancestor in case of longer cycle), an infinite loop happens in the resolution logic.

It's a try to fix this "bug", thank's for your feedback...
