### PR TITLE
Add a ProfileStorage based on PSR Cache

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/AbstractProfileStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/AbstractProfileStorage.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Profiler;
+
+abstract class AbstractProfileStorage implements ProfilerStorageInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function read($token)
+    {
+        if (!$token) {
+            return false;
+        }
+
+        $data = $this->readProfileData($token);
+        if (!$data) {
+            return false;
+        }
+
+        return $this->createProfileFromData($token, $data);
+    }
+
+    abstract public function readProfileData($token);
+
+    /**
+     * Create a profile from serializable data.
+     *
+     * @param string $token
+     * @param array  $data
+     * @param string $parent
+     *
+     * @return Profile
+     */
+    protected function createProfileFromData($token, $data, $parent = null)
+    {
+        $profile = new Profile($token);
+        $profile->setIp($data['ip']);
+        $profile->setMethod($data['method']);
+        $profile->setUrl($data['url']);
+        $profile->setTime($data['time']);
+        $profile->setStatusCode($data['status_code']);
+        $profile->setCollectors($data['data']);
+
+        if (!$parent && $data['parent']) {
+            $parent = $this->read($data['parent']);
+        }
+
+        if ($parent) {
+            $profile->setParent($parent);
+        }
+
+        foreach ($data['children'] as $childToken) {
+            $childProfileData = $this->readProfileData($childToken);
+            if (!$childProfileData) {
+                continue;
+            }
+            $profile->addChild($this->createProfileFromData($childToken, $childProfileData, $profile));
+        }
+
+        return $profile;
+    }
+
+    /**
+     * Creates a serializable version of the profile.
+     *
+     * @param Profile $profile
+     *
+     * @return array
+     */
+    protected function getProfileData(Profile $profile)
+    {
+        $profileToken = $profile->getToken();
+        // when there are errors in sub-requests, the parent and/or children tokens
+        // may equal the profile token, resulting in infinite loops
+        $parentToken = $profile->getParentToken() !== $profileToken ? $profile->getParentToken() : null;
+        $childrenToken = array_filter(
+            array_map(
+                function (Profile $p) use ($profileToken) {
+                    return $profileToken !== $p->getToken() ? $p->getToken() : null;
+                },
+                $profile->getChildren()
+            )
+        );
+
+        // Store profile
+        $data = array(
+            'token' => $profileToken,
+            'parent' => $parentToken,
+            'children' => $childrenToken,
+            'data' => $profile->getCollectors(),
+            'ip' => $profile->getIp(),
+            'method' => $profile->getMethod(),
+            'url' => $profile->getUrl(),
+            'time' => $profile->getTime(),
+            'status_code' => $profile->getStatusCode(),
+        );
+
+        return $data;
+    }
+
+    /**
+     * Creates an array for storing in the index.
+     *
+     * @return array
+     */
+    protected function getProfileIndexItem(Profile $profile)
+    {
+        return array(
+            $profile->getToken(),
+            $profile->getIp(),
+            $profile->getMethod(),
+            $profile->getUrl(),
+            $profile->getTime(),
+            $profile->getParentToken(),
+            $profile->getStatusCode(),
+        );
+    }
+
+    /**
+     * Checks if the index item matches the filters.
+     */
+    protected function checkIndexItem($indexItem, $ip, $url, $method, $start, $end, $statusCode)
+    {
+        list($csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode) = $indexItem;
+        $csvTime = (int) $csvTime;
+
+        if ($ip && false === strpos($csvIp, $ip) || $url && false === strpos($csvUrl, $url) || $method && false === strpos($csvMethod, $method) || $statusCode && false === strpos($csvStatusCode, $statusCode)) {
+            return;
+        }
+
+        if (!empty($start) && $csvTime < $start) {
+            return;
+        }
+
+        if (!empty($end) && $csvTime > $end) {
+            return;
+        }
+
+        return array(
+            'token' => $csvToken,
+            'ip' => $csvIp,
+            'method' => $csvMethod,
+            'url' => $csvUrl,
+            'time' => $csvTime,
+            'parent' => $csvParent,
+            'status_code' => $csvStatusCode,
+        );
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Profiler/CacheProfileStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/CacheProfileStorage.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Profiler;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+class CacheProfileStorage extends AbstractProfileStorage
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    public function __construct(CacheItemPoolInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($ip, $url, $limit, $method, $start = null, $end = null, $statusCode = null)
+    {
+        $item = $this->cache->getItem('index');
+        if (!$item->isHit()) {
+            return array();
+        }
+
+        $result = array();
+        foreach ($item->get() as $values) {
+            if (\count($result) >= $limit) {
+                break;
+            }
+
+            $checked = $this->checkIndexItem($values, $ip, $url, $method, $start, $end, $statusCode);
+            if (!$checked) {
+                continue;
+            }
+
+            $result[$checked['token']] = $checked;
+        }
+
+        return array_values($result);
+    }
+
+    public function readProfileData($token)
+    {
+        if (!$token) {
+            return false;
+        }
+
+        $item = $this->cache->getItem($token);
+        if (!$item->isHit()) {
+            return false;
+        }
+
+        return $item->get();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write(Profile $profile)
+    {
+        $this->addToIndex($profile);
+
+        $item = $this->cache->getItem($profile->getToken());
+        $item->set($this->getProfileData($profile));
+
+        return $this->cache->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function purge()
+    {
+        $this->cache->clear();
+    }
+
+    /**
+     * Stores the profile in the index.
+     */
+    private function addToIndex(Profile $profile)
+    {
+        $item = $this->cache->getItem('index');
+        if ($item->isHit()) {
+            $index = $item->get();
+        } else {
+            $index = array();
+        }
+        $index[] = $this->getProfileIndexItem($profile);
+
+        $item->set($index);
+        $this->cache->save($item);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | Coming if needed

Makes it easy to use different backends for profile storage. This is appealing when running multiple server or to avoid disk use and use a backend such as redis.

I have moved some code from `FileProfilerStorage` into a `AbstractProfileStorage` because otherwise would have been copied and pasted.

It would be tempted to replace `FileProfilerStorage` completely with a `CacheProfileStorage` that uses the filesystem cache provider, but would break BC and add dependency on cache bundle - but maybe would make sense?

I haven't added any tests at this point - I'd rather get some feedback and see if there is any interest in adding such a feature to Symfony.

