### PR TITLE
[Cache][Contracts] We must save the item or the trait does not have any effect

### DIFF
--- a/src/Symfony/Contracts/Cache/GetForCacheItemPoolTrait.php
+++ b/src/Symfony/Contracts/Cache/GetForCacheItemPoolTrait.php
@@ -36,6 +36,7 @@ trait GetForCacheItemPoolTrait
         if (INF === $beta || !$item->isHit()) {
             $value = $callback($item);
             $item->set($value);
+            $this->save($item);
         }
 
         return $item->get();

--- a/src/Symfony/Contracts/Tests/Cache/GetForCacheItemPoolTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Cache/GetForCacheItemPoolTraitTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Tests\Cache;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Symfony\Contracts\Cache\GetForCacheItemPoolTrait;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class GetForCacheItemPoolTraitTest extends TestCase
+{
+    public function testSave()
+    {
+        $item = $this->getMockBuilder(CacheItemInterface::class)->getMock();
+        $item->method('isHit')
+            ->willReturn(false);
+
+        $item->expects($this->once())
+            ->method('set')
+            ->with('computed data');
+
+        $cache = $this->getMockBuilder(ClassUsingTrait::class)
+            ->setMethods(array('getItem', 'save'))
+            ->getMock();
+        $cache->expects($this->once())
+            ->method('getItem')
+            ->with('key')
+            ->willReturn($item);
+        $cache->expects($this->once())
+            ->method('save');
+
+        $callback = function (CacheItemInterface $item) {
+            return 'computed data';
+        };
+
+        $cache->get('key', $callback);
+    }
+
+    public function testNoCallbackCallOnHit()
+    {
+        $item = $this->getMockBuilder(CacheItemInterface::class)->getMock();
+        $item->method('isHit')
+            ->willReturn(true);
+
+        $item->expects($this->never())
+            ->method('set');
+
+        $cache = $this->getMockBuilder(ClassUsingTrait::class)
+            ->setMethods(array('getItem', 'save'))
+            ->getMock();
+
+        $cache->expects($this->once())
+            ->method('getItem')
+            ->with('key')
+            ->willReturn($item);
+        $cache->expects($this->never())
+            ->method('save');
+
+        $callback = function (CacheItemInterface $item) {
+            $this->assertTrue(false, 'This code should never be reached');
+        };
+
+        $cache->get('key', $callback);
+    }
+
+    public function testRecomputeOnBetaInf()
+    {
+        $item = $this->getMockBuilder(CacheItemInterface::class)->getMock();
+        $item->method('isHit')
+            // We want to recompute even if it is a hit
+            ->willReturn(true);
+
+        $item->expects($this->once())
+            ->method('set')
+            ->with('computed data');
+
+        $cache = $this->getMockBuilder(ClassUsingTrait::class)
+            ->setMethods(array('getItem', 'save'))
+            ->getMock();
+
+        $cache->expects($this->once())
+            ->method('getItem')
+            ->with('key')
+            ->willReturn($item);
+        $cache->expects($this->once())
+            ->method('save');
+
+        $callback = function (CacheItemInterface $item) {
+            return 'computed data';
+        };
+
+        $cache->get('key', $callback, INF);
+    }
+
+    public function testExceptionOnNegativeBeta()
+    {
+        $cache = $this->getMockBuilder(ClassUsingTrait::class)
+            ->setMethods(array('getItem', 'save'))
+            ->getMock();
+
+        $callback = function (CacheItemInterface $item) {
+            return 'computed data';
+        };
+
+        $this->expectException(\InvalidArgumentException::class);
+        $cache->get('key', $callback, -2);
+    }
+}
+
+class ClassUsingTrait
+{
+    use GetForCacheItemPoolTrait;
+
+    public function getItem($key)
+    {
+    }
+
+    public function save(CacheItemInterface $item)
+    {
+    }
+}

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -19,6 +19,7 @@
         "php": "^7.1.3"
     },
     "require-dev": {
+        "psr/cache": "^1.0",
         "psr/container": "^1.0"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | 

Using the trait must result in that items gets saved. 

We could use `saveDeferred` instead, it might be a performance improvement but you also may have side-effects. Say you are using two cache pool objects for the same storage.


Example use of the trait: 

```php
use Psr\Cache\CacheItemInterface;
use Psr\Cache\CacheItemPoolInterface;
use Symfony\Contracts\Cache\CacheInterface;
use Symfony\Contracts\Cache\GetForCacheItemPoolTrait;

class AcmeCache implements CacheInterface
{
    use GetForCacheItemPoolTrait;
    private $cache;

    public function __construct(CacheItemPoolInterface $cache)
    {
        $this->cache = $cache;
    }

    public function getItem(string $key): CacheItemInterface
    {
       return $this->cache->getItem($key);
    }


    public function save(CacheItemInterface $item): bool
    {
       return $this->cache->save($item);
    }
}

```