### PR TITLE
KernelInterface can return null for getContainer method

### DIFF
--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -139,7 +139,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Gets the current container.
      *
-     * @return ContainerInterface A ContainerInterface instance
+     * @return ContainerInterface|null A ContainerInterface instance or null when the Kernel is shutdown
      */
     public function getContainer();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| License       | MIT

According to [this](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Client.php#L45) a KernelInterface can return null if it is shutdown.
