### PR TITLE
Fix symfony/console (optional) dependency for MonologBridge

### DIFF
--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -27,11 +27,12 @@
         "symfony/var-dumper": "~3.3|~4.0"
     },
     "conflict": {
+        "symfony/console": "<2.8",
         "symfony/http-foundation": "<3.3"
     },
     "suggest": {
         "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",
-        "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings. You need version ~2.3 of the console for it.",
+        "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings. You need version ^2.8 of the console for it.",
         "symfony/event-dispatcher": "Needed when using log messages in console commands.",
         "symfony/var-dumper": "For using the debugging handlers like the console handler or the log server handler."
      },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Since 278c26f589fa41506e13aa70a15c065d193f04d2, `ConsoleHandler` tries to pass a verbosity level into `Output::write()`. 

In order to make this work, the change 749fba54f91283041ea0d59322ac2016ef38e071 is required which was first released in 2.8.0.

When using MonologBridge ^3.3 with a lower version of symfony/console than 2.8, an `InvalidArgumentException` with the message `Unknown output type given` will be thrown.

Not sure how to add a test for this... 🤷‍♂️ 