### PR TITLE
[MonologBridge] Re-add option option to ignore empty context and extra data

### DIFF
--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -69,6 +69,9 @@ class ConsoleFormatter implements FormatterInterface
             if (isset($args[2])) {
                 $options['multiline'] = $args[2];
             }
+            if (isset($args[3])) {
+                $options['ignore_empty_context_and_extra'] = $args[3];
+            }
         }
 
         $this->options = array_replace(array(
@@ -76,6 +79,7 @@ class ConsoleFormatter implements FormatterInterface
             'date_format' => self::SIMPLE_DATE,
             'colors' => true,
             'multiline' => false,
+            'ignore_empty_context_and_extra' => true,
         ), $options);
 
         if (class_exists(VarCloner::class)) {
@@ -116,20 +120,16 @@ class ConsoleFormatter implements FormatterInterface
 
         $levelColor = self::$levelColorMap[$record['level']];
 
-        if ($this->options['multiline']) {
-            $separator = "\n";
+        if (!$this->options['ignore_empty_context_and_extra'] || !empty($record['context'])) {
+            $context = ($this->options['multiline'] ? "\n" : ' ').$this->dumpData($record['context']);
         } else {
-            $separator = ' ';
+            $context = '';
         }
 
-        $context = $this->dumpData($record['context']);
-        if ($context) {
-            $context = $separator.$context;
-        }
-
-        $extra = $this->dumpData($record['extra']);
-        if ($extra) {
-            $extra = $separator.$extra;
+        if (!$this->options['ignore_empty_context_and_extra'] || !empty($record['extra'])) {
+            $extra = ($this->options['multiline'] ? "\n" : ' ').$this->dumpData($record['extra']);
+        } else {
+            $extra = '';
         }
 
         $formatted = strtr($this->options['format'], array(

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -64,9 +64,9 @@ class ConsoleHandlerTest extends TestCase
         $realOutput = $this->getMockBuilder('Symfony\Component\Console\Output\Output')->setMethods(array('doWrite'))->getMock();
         $realOutput->setVerbosity($verbosity);
         if ($realOutput->isDebug()) {
-            $log = "16:21:54 $levelName [app] My info message\n[]\n[]\n";
+            $log = "16:21:54 $levelName [app] My info message\n";
         } else {
-            $log = "16:21:54 $levelName [app] My info message [] []\n";
+            $log = "16:21:54 $levelName [app] My info message\n";
         }
         $realOutput
             ->expects($isHandling ? $this->once() : $this->never())
@@ -149,7 +149,7 @@ class ConsoleHandlerTest extends TestCase
         $output
             ->expects($this->once())
             ->method('write')
-            ->with("16:21:54 <fg=green>INFO     </> <comment>[app]</> My info message\n[]\n[]\n")
+            ->with("16:21:54 <fg=green>INFO     </> <comment>[app]</> My info message\n")
         ;
 
         $handler = new ConsoleHandler(null, false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In #11496, an option was added to `ConsoleFormatter` to ignore empty context and extra data. This setting was even turned on by default.

The `ConsoleHandler` was then overhauled in #21705. During this change, the option got lost.