### PR TITLE
[Validator] Check the BIC country with symfony/intl

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -37,6 +37,14 @@ class BicValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
+    public function testExpectsStringCompatibleType()
+    {
+        $this->validator->validate(new \stdClass(), new Bic());
+    }
+
+    /**
      * @dataProvider getValidBics
      */
     public function testValidBics($bic)
@@ -92,6 +100,7 @@ class BicValidatorTest extends ConstraintValidatorTestCase
             array('DEUT12HH', Bic::INVALID_COUNTRY_CODE_ERROR),
             array('DSBAC6BXSHA', Bic::INVALID_COUNTRY_CODE_ERROR),
             array('DSBA5NBXSHA', Bic::INVALID_COUNTRY_CODE_ERROR),
+            array('DSBAAABXSHA', Bic::INVALID_COUNTRY_CODE_ERROR),
 
             // branch code error
             array('THISSVAL1D]', Bic::INVALID_CHARACTERS_ERROR),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28167
| License       | MIT
| Doc PR        | N/A

Check the BIC country code against the list from Intl component instead of a simple check alphabetical test.

This PR uses the Intl component which is not part of the required dependencies of the Validator component (https://github.com/symfony/validator/blob/master/composer.json): `symfony/intl` is only required for dev. So I'm making a PR against master because it may break existing code.
But `CountryValidator` does the same so it may not be an issue after all.
