### PR TITLE
Added different protocols to be allowed as asset base_url

### DIFF
--- a/src/Symfony/Component/Asset/CHANGELOG.md
+++ b/src/Symfony/Component/Asset/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.2.0
+-----
+
+ * added different protocols to be allowed as asset base_urls
+
 3.4.0
 -----
 

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -33,21 +33,28 @@ class UrlPackageTest extends TestCase
             array('http://example.net', '', 'http://example.com/foo', 'http://example.com/foo'),
             array('http://example.net', '', 'https://example.com/foo', 'https://example.com/foo'),
             array('http://example.net', '', '//example.com/foo', '//example.com/foo'),
+            array('file:///example/net', '', 'file:///example/com/foo', 'file:///example/com/foo'),
+            array('ftp://example.net', '', 'ftp://example.com', 'ftp://example.com'),
 
             array('http://example.com', '', '/foo', 'http://example.com/foo?v1'),
             array('http://example.com', '', 'foo', 'http://example.com/foo?v1'),
             array('http://example.com/', '', 'foo', 'http://example.com/foo?v1'),
             array('http://example.com/foo', '', 'foo', 'http://example.com/foo/foo?v1'),
             array('http://example.com/foo/', '', 'foo', 'http://example.com/foo/foo?v1'),
+            array('file:///example/com/foo/', '', 'foo', 'file:///example/com/foo/foo?v1'),
 
             array(array('http://example.com'), '', '/foo', 'http://example.com/foo?v1'),
             array(array('http://example.com', 'http://example.net'), '', '/foo', 'http://example.com/foo?v1'),
             array(array('http://example.com', 'http://example.net'), '', '/fooa', 'http://example.net/fooa?v1'),
+            array(array('file:///example/com', 'file:///example/net'), '', '/foo', 'file:///example/com/foo?v1'),
+            array(array('ftp://example.com', 'ftp://example.net'), '', '/fooa', 'ftp://example.net/fooa?v1'),
 
             array('http://example.com', 'version-%2$s/%1$s', '/foo', 'http://example.com/version-v1/foo'),
             array('http://example.com', 'version-%2$s/%1$s', 'foo', 'http://example.com/version-v1/foo'),
             array('http://example.com', 'version-%2$s/%1$s', 'foo/', 'http://example.com/version-v1/foo/'),
             array('http://example.com', 'version-%2$s/%1$s', '/foo/', 'http://example.com/version-v1/foo/'),
+            array('file:///example/com', 'version-%2$s/%1$s', '/foo/', 'file:///example/com/version-v1/foo/'),
+            array('ftp://example.com', 'version-%2$s/%1$s', '/foo/', 'ftp://example.com/version-v1/foo/'),
         );
     }
 
@@ -97,11 +104,21 @@ class UrlPackageTest extends TestCase
     }
 
     /**
+     * @dataProvider getWrongBaseUrlConfig
+     *
      * @expectedException \Symfony\Component\Asset\Exception\InvalidArgumentException
      */
-    public function testWrongBaseUrl()
+    public function testWrongBaseUrl($baseUrls)
     {
-        new UrlPackage(array('not-a-url'), new EmptyVersionStrategy());
+        new UrlPackage($baseUrls, new EmptyVersionStrategy());
+    }
+
+    public function getWrongBaseUrlConfig()
+    {
+        return array(
+            array('not-a-url'),
+            array('not-a-url-with-query?query=://'),
+        );
     }
 
     private function getContext($secure)

--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -129,7 +129,7 @@ class UrlPackage extends Package
         foreach ($urls as $url) {
             if ('https://' === substr($url, 0, 8) || '//' === substr($url, 0, 2)) {
                 $sslUrls[] = $url;
-            } elseif ('http://' !== substr($url, 0, 7)) {
+            } elseif (null === parse_url($url, PHP_URL_SCHEME)) {
                 throw new InvalidArgumentException(sprintf('"%s" is not a valid URL', $url));
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | fixes #28238
| License       | MIT
| Doc PR        | symfony/symfony-docs#10347

In some cases you want to use the `file://` as base_url when you are for example generating pdf and want to avoid network requests to improve the pdf generation performance:

```yaml
framework:
    assets:
        packages:
            pdf:
                base_url: "file://%kernel.project_dir%/public"
```

usage:

```twig
{{ asset('image.jpg', 'pdf' }}
```