### PR TITLE
[Validator] Checking a BIC along with an IBAN

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added options `iban` and `ibanPropertyPath` to Bic constraint
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Intl;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\LogicException;
 
 /**
@@ -28,6 +30,7 @@ class Bic extends Constraint
     const INVALID_BANK_CODE_ERROR = '00559357-6170-4f29-aebd-d19330aa19cf';
     const INVALID_COUNTRY_CODE_ERROR = '1ce76f8d-3c1f-451c-9e62-fe9c3ed486ae';
     const INVALID_CASE_ERROR = '11884038-3312-4ae5-9d04-699f782130c7';
+    const INVALID_IBAN_COUNTRY_CODE_ERROR = '29a2c3bb-587b-4996-b6f5-53081364cea5';
 
     protected static $errorNames = array(
         self::INVALID_LENGTH_ERROR => 'INVALID_LENGTH_ERROR',
@@ -38,12 +41,23 @@ class Bic extends Constraint
     );
 
     public $message = 'This is not a valid Business Identifier Code (BIC).';
+    public $ibanMessage = 'This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.';
+    public $iban;
+    public $ibanPropertyPath;
 
     public function __construct($options = null)
     {
         if (!class_exists(Intl::class)) {
             // throw new LogicException(sprintf('The "symfony/intl" component is required to use the "%s" constraint.', __CLASS__));
             @trigger_error(sprintf('Using the "%s" constraint without the "symfony/intl" component installed is deprecated since Symfony 4.2.', __CLASS__), E_USER_DEPRECATED);
+        }
+
+        if (isset($options['iban']) && isset($options['ibanPropertyPath'])) {
+            throw new ConstraintDefinitionException(sprintf('The "iban" and "ibanPropertyPath" options of the Iban constraint cannot be used at the same time.', self::class));
+        }
+
+        if (isset($options['ibanPropertyPath']) && !class_exists(PropertyAccess::class)) {
+            throw new LogicException(sprintf('The "symfony/property-access" component is required to use the "%s" constraint with the "ibanPropertyPath" option.', self::class));
         }
 
         parent::__construct($options);

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -326,6 +326,10 @@
                 <source>This value should be a multiple of {{ compared_value }}.</source>
                 <target>This value should be a multiple of {{ compared_value }}.</target>
             </trans-unit>
+            <trans-unit id="85">
+                <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
+                <target>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -326,6 +326,10 @@
                 <source>This value should be a multiple of {{ compared_value }}.</source>
                 <target>Cette valeur doit être un multiple de {{ compared_value }}.</target>
             </trans-unit>
+            <trans-unit id="85">
+                <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
+                <target>Ce BIC n'est pas associé à l'IBAN {{ iban }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BicValidatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Bic;
 use Symfony\Component\Validator\Constraints\BicValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class BicValidatorTest extends ConstraintValidatorTestCase
@@ -34,6 +35,113 @@ class BicValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate('', new Bic());
 
         $this->assertNoViolation();
+    }
+
+    public function testValidComparisonToPropertyPath()
+    {
+        $constraint = new Bic(array('ibanPropertyPath' => 'value'));
+
+        $object = new BicComparisonTestClass('FR14 2004 1010 0505 0001 3M02 606');
+
+        $this->setObject($object);
+
+        $this->validator->validate('SOGEFRPP', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidComparisonToPropertyPathOnArray()
+    {
+        $constraint = new Bic(array('ibanPropertyPath' => '[root][value]'));
+
+        $this->setObject(array('root' => array('value' => 'FR14 2004 1010 0505 0001 3M02 606')));
+
+        $this->validator->validate('SOGEFRPP', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidComparisonToPropertyPath()
+    {
+        $constraint = new Bic(array('ibanPropertyPath' => 'value'));
+        $constraint->ibanMessage = 'Constraint Message';
+
+        $object = new BicComparisonTestClass('FR14 2004 1010 0505 0001 3M02 606');
+
+        $this->setObject($object);
+
+        $this->validator->validate('UNCRIT2B912', $constraint);
+
+        $this->buildViolation('Constraint Message')
+            ->setParameter('{{ value }}', '"UNCRIT2B912"')
+            ->setParameter('{{ iban }}', 'FR14 2004 1010 0505 0001 3M02 606')
+            ->setCode(Bic::INVALID_IBAN_COUNTRY_CODE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testValidComparisonToValue()
+    {
+        $constraint = new Bic(array('iban' => 'FR14 2004 1010 0505 0001 3M02 606'));
+        $constraint->ibanMessage = 'Constraint Message';
+
+        $this->validator->validate('SOGEFRPP', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidComparisonToValue()
+    {
+        $constraint = new Bic(array('iban' => 'FR14 2004 1010 0505 0001 3M02 606'));
+        $constraint->ibanMessage = 'Constraint Message';
+
+        $this->validator->validate('UNCRIT2B912', $constraint);
+
+        $this->buildViolation('Constraint Message')
+            ->setParameter('{{ value }}', '"UNCRIT2B912"')
+            ->setParameter('{{ iban }}', 'FR14 2004 1010 0505 0001 3M02 606')
+            ->setCode(Bic::INVALID_IBAN_COUNTRY_CODE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testNoViolationOnNullObjectWithPropertyPath()
+    {
+        $constraint = new Bic(array('ibanPropertyPath' => 'propertyPath'));
+
+        $this->setObject(null);
+
+        $this->validator->validate('UNCRIT2B912', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "iban" and "ibanPropertyPath" options of the Iban constraint cannot be used at the same time
+     */
+    public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
+    {
+        new Bic(array(
+            'iban' => 'value',
+            'ibanPropertyPath' => 'propertyPath',
+        ));
+    }
+
+    public function testInvalidValuePath()
+    {
+        $constraint = new Bic(array('ibanPropertyPath' => 'foo'));
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException(ConstraintDefinitionException::class);
+            $this->expectExceptionMessage(sprintf('Invalid property path "foo" provided to "%s" constraint', \get_class($constraint)));
+        } else {
+            $this->setExpectedException(ConstraintDefinitionException::class, sprintf('Invalid property path "foo" provided to "%s" constraint', \get_class($constraint)));
+        }
+
+        $object = new BicComparisonTestClass(5);
+
+        $this->setObject($object);
+
+        $this->validator->validate('UNCRIT2B912', $constraint);
     }
 
     /**
@@ -112,5 +220,25 @@ class BicValidatorTest extends ConstraintValidatorTestCase
             array('DeutAT2LXXX', Bic::INVALID_CASE_ERROR),
             array('DEUTAT2lxxx', Bic::INVALID_CASE_ERROR),
         );
+    }
+}
+
+class BicComparisonTestClass
+{
+    protected $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->value;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28166 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10349

A BIC comes usually with an IBAN so it's better to check that they are associated. This PR provides an `iban` option to `Symfony\Component\Validator\Constraints\Bic` to check the BIC against an IBAN.

It also provides an `ibanPropertyPath` to retrieves the IBAN using the property accessor like with comparison constraints. 