### PR TITLE
[PhpUnitBridge] Iterate over tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV7.php
@@ -36,6 +36,8 @@ class CoverageListenerForV7 implements TestListener
 
     public function startTestSuite(TestSuite $suite): void
     {
-        $this->trait->startTest($suite);
+        foreach ($suite->tests() as $test) {
+            $this->trait->startTest($test);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I'm trying to work on a PR for the PHPUnit bridge, but the test suite does not pass when using phpunit 7, so I thought I would start fixing that first.

Calling the trait with a TestSuite argument will have no effect, it will
exit quickly because of a test added in
25e0117152f1297df26567e64e4dd4c7d9115c03, that checks that $suite is a TestCase
instance.
Refs #26612 and #26089

Closes #28495