### PR TITLE
[FrameworkBundle] Ignore backslashes in service ids when using debug:container and debug:autowiring

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Added new "auto" mode for `framework.session.cookie_secure` to turn it on when HTTPS is used
  * Removed the `framework.messenger.encoder` and `framework.messenger.decoder` options. Use the `framework.messenger.serializer.id` option to replace the Messenger serializer. 
  * Deprecated the `ContainerAwareCommand` class in favor of `Symfony\Component\Console\Command\Command`
+ * Made `debug:container` and `debug:autowiring` ignore backslashes in service ids
 
 4.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -219,23 +219,27 @@ EOF
             throw new InvalidArgumentException(sprintf('No services found that match "%s".', $name));
         }
 
-        $default = 1 === \count($matchingServices) ? $matchingServices[0] : null;
+        if (1 === \count($matchingServices)) {
+            return $matchingServices[0];
+        }
 
-        return $io->choice('Select one of the following services to display its information', $matchingServices, $default);
+        return $io->choice('Select one of the following services to display its information', $matchingServices);
     }
 
     private function findServiceIdsContaining(ContainerBuilder $builder, $name)
     {
         $serviceIds = $builder->getServiceIds();
-        $foundServiceIds = array();
+        $foundServiceIds = $foundServiceIdsIgnoringBackslashes = array();
         foreach ($serviceIds as $serviceId) {
-            if (false === stripos($serviceId, $name)) {
-                continue;
+            if (false !== stripos(str_replace('\\', '', $serviceId), $name)) {
+                $foundServiceIdsIgnoringBackslashes[] = $serviceId;
             }
-            $foundServiceIds[] = $serviceId;
+            if (false !== stripos($serviceId, $name)) {
+                $foundServiceIds[] = $serviceId;
+            }
         }
 
-        return $foundServiceIds;
+        return $foundServiceIds ?: $foundServiceIdsIgnoringBackslashes;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -66,7 +66,7 @@ EOF
 
         if ($search = $input->getArgument('search')) {
             $serviceIds = array_filter($serviceIds, function ($serviceId) use ($search) {
-                return false !== stripos($serviceId, $search);
+                return false !== stripos(str_replace('\\', '', $serviceId), $search);
             });
 
             if (empty($serviceIds)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/BackslashClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/BackslashClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class BackslashClass
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\BackslashClass;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
 /**
@@ -62,5 +63,28 @@ class ContainerDebugCommandTest extends WebTestCase
         $tester->run(array('command' => 'debug:container'));
         $this->assertContains('public', $tester->getDisplay());
         $this->assertContains('private_alias', $tester->getDisplay());
+    }
+
+    /**
+     * @dataProvider provideIgnoreBackslashWhenFindingService
+     */
+    public function testIgnoreBackslashWhenFindingService(string $validServiceId)
+    {
+        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'debug:container', 'name' => $validServiceId));
+        $this->assertNotContains('No services found', $tester->getDisplay());
+    }
+
+    public function provideIgnoreBackslashWhenFindingService()
+    {
+        return array(
+            array(BackslashClass::class),
+            array('FixturesBackslashClass'),
+        );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -47,6 +47,18 @@ class DebugAutowiringCommandTest extends WebTestCase
         $this->assertNotContains('Symfony\Component\Routing\RouterInterface', $tester->getDisplay());
     }
 
+    public function testSearchIgnoreBackslashWhenFindingService()
+    {
+        static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'debug:autowiring', 'search' => 'HttpKernelHttpKernelInterface'));
+        $this->assertContains('Symfony\Component\HttpKernel\HttpKernelInterface', $tester->getDisplay());
+    }
+
     public function testSearchNoResults()
     {
         static::bootKernel(array('test_case' => 'ContainerDebug', 'root_config' => 'config.yml'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
@@ -8,3 +8,5 @@ services:
     private_alias:
         alias: public
         public: false
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\BackslashClass:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\BackslashClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28143 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
