### PR TITLE
PHPDoc block for HttpException constructor

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -23,11 +23,11 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
 
     /**
      * HttpException constructor.
-     * @param int             $statusCode An HTTP response status code
-     * @param string|null     $message    The internal exception message
-     * @param \Exception|null $previous   The previous exception
-     * @param array           $headers
-     * @param int|null        $code       The internal exception code
+     * @param int $statusCode An HTTP response status code
+     * @param string|null $message The internal exception message
+     * @param \Exception|null $previous The previous exception
+     * @param array $headers
+     * @param int $code The internal exception code
      */
     public function __construct($statusCode, $message = null, \Exception $previous = null, array $headers = array(), $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -23,11 +23,11 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
 
     /**
      * HttpException constructor.
-     * @param int $statusCode An HTTP response status code
-     * @param string|null $message The internal exception message
-     * @param \Exception|null $previous The previous exception
+     * @param int               $statusCode An HTTP response status code
+     * @param string|null       $message    The internal exception message
+     * @param \Exception|null   $previous   The previous exception
      * @param array $headers
-     * @param int $code The internal exception code
+     * @param int               $code       The internal exception code
      */
     public function __construct($statusCode, $message = null, \Exception $previous = null, array $headers = array(), $code = 0)
     {

--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -21,6 +21,14 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
     private $statusCode;
     private $headers;
 
+    /**
+     * HttpException constructor.
+     * @param int             $statusCode An HTTP response status code
+     * @param string|null     $message    The internal exception message
+     * @param \Exception|null $previous   The previous exception
+     * @param array           $headers
+     * @param int|null        $code       The internal exception code
+     */
     public function __construct($statusCode, $message = null, \Exception $previous = null, array $headers = array(), $code = 0)
     {
         $this->statusCode = $statusCode;

--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -23,6 +23,7 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
 
     /**
      * HttpException constructor.
+     *
      * @param int               $statusCode An HTTP response status code
      * @param string|null       $message    The internal exception message
      * @param \Exception|null   $previous   The previous exception


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

Difference between `$codeStatus` and `$code`
