### PR TITLE
[3.4] - Bug Fix - Fix global dump function return value for PHP7

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -19,8 +19,8 @@ if (!function_exists('dump')) {
     {
         VarDumper::dump($var);
 
-        foreach ($moreVars as $var) {
-            VarDumper::dump($var);
+        foreach ($moreVars as $more) {
+            VarDumper::dump($more);
         }
 
         if (1 < func_num_args()) {

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Dumper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+class FunctionsTest extends TestCase
+{
+    public function testDumpReturnsFirstArg()
+    {
+        $this->setupVarDumper();
+
+        $var1 = 'a';
+
+        ob_start();
+        $return = dump($var1);
+        $out = ob_get_clean();
+
+        $this->assertEquals($var1, $return);
+    }
+
+    public function testDumpReturnsAllArgsInArray()
+    {
+        $this->setupVarDumper();
+
+        $var1 = 'a';
+        $var2 = 'b';
+        $var3 = 'c';
+
+        ob_start();
+        $return = dump($var1, $var2, $var3);
+        $out = ob_get_clean();
+
+        $this->assertEquals(array($var1, $var2, $var3), $return);
+    }
+
+    protected function setupVarDumper()
+    {
+        $cloner = new VarCloner();
+        $dumper = new CliDumper('php://output');
+        VarDumper::setHandler(function ($var) use ($cloner, $dumper) {
+            $dumper->dump($cloner->cloneVar($var));
+        });
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In 3.4, the global `dump()` helper function in the VarDumper component was updated to return the arguments passed in to it. However, in 4.0, the way the variables are dumped was updated, and it introduced a bug in PHP7 in the return value of the function.

With the update made in 4.0, the variable used in the `foreach` loop overwrites the value passed in by the first argument. In PHP5, this is okay. In PHP7, even though the argument is passed by value, the value returned by `func_get_args()` is affected by changes to the arguments inside the function. This is a change from PHP5.

From the documentation for [`func_get_args()`](http://php.net/manual/en/function.func-get-args.php):

> If the arguments are passed by reference, any changes to the arguments will be reflected in the values returned by this function. As of PHP 7 the current values will also be returned if the arguments are passed by value.

This PR simply changes the name of the variable used in the `foreach` loop. It also adds a test file to test the return value of the global `dump()` function.

This is my first contribution to Symfony, so please let me know if the issue should be resolved in a different manner, or if the test should be modified in any way.

Thanks,
Patrick