### PR TITLE
[Translation] SimpleIntlMessageFormatter for users with no icu extension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -699,7 +699,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue(array('en'))
                         ->end()
                         ->booleanNode('logging')->defaultValue(false)->end()
-                        ->scalarNode('formatter')->defaultValue(class_exists(\MessageFormatter::class) ? 'translator.formatter.default' : 'translator.formatter.symfony')->end()
+                        ->scalarNode('formatter')->defaultValue('translator.formatter.default')->end()
                         ->scalarNode('default_path')
                             ->info('The default path used to load translations')
                             ->defaultValue('%kernel.project_dir%/translations')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -92,6 +92,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Translation\Command\XliffLintCommand as BaseXliffLintCommand;
+use Symfony\Component\Translation\Formatter\FallbackFormatter;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\ObjectInitializerInterface;
@@ -993,6 +994,11 @@ class FrameworkExtension extends Extension
 
         $container->setParameter('translator.logging', $config['logging']);
         $container->setParameter('translator.default_path', $config['default_path']);
+
+        if (!class_exists(\MessageFormatter::class)) {
+            $container->getDefinition(FallbackFormatter::class)
+                ->replaceArgument(1, new Reference('translator.formatter.intl_simple'));
+        }
 
         // Discover translation directories
         $dirs = array();

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -33,6 +33,7 @@
             <argument type="service" id="identity_translator" />
         </service>
         <service id="translator.formatter.intl" class="Symfony\Component\Translation\Formatter\IntlMessageFormatter" public="false" />
+        <service id="translator.formatter.intl_simple" class="Symfony\Component\Translation\Formatter\IntlSimpleMessageFormatter" public="false" />
         <service id="translator.formatter.fallback" class="Symfony\Component\Translation\Formatter\FallbackFormatter" public="false">
             <argument type="service" id="translator.formatter.intl" />
             <argument type="service" id="translator.formatter.symfony" />

--- a/src/Symfony/Component/Translation/Formatter/IntlSimpleMessageFormatter.php
+++ b/src/Symfony/Component/Translation/Formatter/IntlSimpleMessageFormatter.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Formatter;
+
+/**
+ * A Polyfill for IntlMessageFormatter for users that do not have the icu extension installed.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class IntlSimpleMessageFormatter implements MessageFormatterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function format($message, $locale, array $parameters = array())
+    {
+        $message = $this->handlePlural($message, $parameters);
+        $message = $this->handleSelect($message, $parameters);
+        $message = $this->replaceParameters($message, $parameters);
+
+        return $message;
+    }
+
+    private function handlePlural(string $message, array $parameters): string
+    {
+        $lookupMap = array(0 => 'zero', 1 => 'one', 2 => 'two', 3 => 'few');
+
+        foreach ($parameters as $key => $value) {
+            $regex = '|{ ?'.$key.', plural,(.*)|sm';
+            if (preg_match($regex, $message, $match)) {
+                $blockContent = $this->findBlock($match[1]);
+                $fullBlock = substr($match[0], 0, strpos($match[0], $blockContent) + \strlen($blockContent) + 1);
+
+                $lookup = array();
+                if (\is_int($value)) {
+                    $lookup[] = '='.$value;
+                }
+                if (isset($lookupMap[$value])) {
+                    $lookup[] = $lookupMap[$value];
+                } elseif ($value > 3) {
+                    $lookup[] = 'many';
+                }
+                $lookup[] = 'other';
+
+                foreach ($lookup as $l) {
+                    if (preg_match('|'.$l.' ?{(.*)|sm', $blockContent, $blockMatch)) {
+                        $result = $this->findBlock($blockMatch[1]);
+                        $blockReplacement = str_replace('#', $value, $result);
+
+                        return str_replace($fullBlock, $blockReplacement, $message);
+                    }
+                }
+            }
+        }
+
+        return $message;
+    }
+
+    private function handleSelect(string $message, array $parameters): string
+    {
+        $regex = '|{ ?([a-zA-Z]+), select,(.*)|sm';
+        if (preg_match($regex, $message, $match)) {
+            $blockContent = $this->findBlock($match[2]);
+            $fullBlock = substr($match[0], 0, strpos($match[0], $blockContent) + \strlen($blockContent) + 1);
+            foreach ($parameters as $key => $value) {
+                if ($match[1] === $key) {
+                    if (preg_match('|'.$value.' ?{(.*)|sm', $blockContent, $blockMatch)) {
+                        $result = $this->findBlock($blockMatch[1]);
+
+                        return str_replace($fullBlock, $result, $message);
+                    }
+                }
+            }
+
+            // If no match
+            if (preg_match('|other ?{(.*)|sm', $blockContent, $blockMatch)) {
+                $result = $this->findBlock($blockMatch[1]);
+
+                return str_replace($fullBlock, $result, $message);
+            }
+        }
+
+        return $message;
+    }
+
+    private function replaceParameters(string $message, array $parameters): string
+    {
+        $updatedParameters = array();
+        foreach ($parameters as $key => $value) {
+            $updatedParameters[sprintf('{%s}', $key)] = $value;
+        }
+
+        return strtr($message, $updatedParameters);
+    }
+
+    private function findBlock(string $input): string
+    {
+        // How may open curly brackets ({) do we got?
+        $open = 1;
+        $block = '';
+        for ($i = 0; $i < \strlen($input); ++$i) {
+            if ('{' === $input[$i]) {
+                ++$open;
+            } elseif ('}' === $input[$i]) {
+                --$open;
+            }
+            if (0 === $open) {
+                $block = substr($input, 0, $i);
+                break;
+            }
+        }
+
+        return $block;
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Formatter/IntlSimpleMessageFormatterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/IntlSimpleMessageFormatterTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Formatter\IntlSimpleMessageFormatter;
+
+class IntlSimpleMessageFormatterTest extends TestCase
+{
+    /**
+     * @dataProvider getTestStrings
+     */
+    public function testFormat(string $input, string $expected, array $params = array(), string $locale = 'en')
+    {
+        $formatter = new IntlSimpleMessageFormatter();
+        $result = $formatter->format($input, 'en', $params, $locale);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function getTestStrings()
+    {
+        $apples = '{ COUNT, plural,
+        =0 {{name}, there are no apples}
+        =1 {{name}, there is one apple}
+        other {{name}, there are # apples}
+        }';
+
+        yield array('foobar', 'foobar');
+        yield array('foo {name} bar', 'foo test bar', array('name' => 'test'));
+        yield array($apples, 'Foo, there are no apples', array('COUNT' => 0, 'name' => 'Foo'));
+        yield array($apples, 'Foo, there is one apple', array('COUNT' => 1, 'name' => 'Foo'));
+        yield array($apples, 'Foo, there are 2 apples', array('COUNT' => 2, 'name' => 'Foo'));
+        yield array('Hello {name}. There are {COUNT, plural, zero{no apples} other{some apples}} in the basket', 'Hello Foo. There are no apples in the basket', array('COUNT' => 0, 'name' => 'Foo'));
+        yield array('Hello {name}. There are {COUNT, plural, zero{no apples} other{some apples}} in the basket', 'Hello Foo. There are some apples in the basket', array('COUNT' => 3, 'name' => 'Foo'));
+
+        // Test select
+        $gender = 'I think { GENDER, select,
+       male {he}
+       female {she}
+       other {they}
+   } liked this.';
+        yield array($gender, 'I think he liked this.', array('GENDER' => 'male'));
+        yield array($gender, 'I think she liked this.', array('GENDER' => 'female'));
+        yield array($gender, 'I think they liked this.', array());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | comming

In #27399 we added a IntlMessageFormatter. That only works for users with icu extension installed. Here is a simple implementation of a IntlMessageFormatter. It does not use the icu extension. It is (obviously) not feature complete. I've also chosen to not do it locale specific. 
