### PR TITLE
No longer allow responses with cookies to be cached

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -57,6 +57,12 @@ Form
    {% endfor %}
    ```
 
+HttpFoundation
+--------------
+
+ * Responses that have any cookies are no longer eligible for caching. This mainly affects how `\Symfony\Component\HttpKernel\HttpCache\HttpCache` works as it will no longer cache any responses
+  that have a cookie, but it might affect third party code as well.
+
 Process
 -------
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -530,6 +530,10 @@ class Response
             return false;
         }
 
+        if (\count($this->headers->getCookies()) > 0) {
+            return false;
+        }
+
         return $this->isValidateable() || $this->isFresh();
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -100,6 +101,13 @@ class ResponseTest extends ResponseTestCase
         $response = new Response();
         $response->setTtl(10);
         $this->assertTrue($response->isCacheable());
+    }
+
+    public function testIsCachableWithCookies()
+    {
+        $response = new Response();
+        $response->headers->setCookie(new Cookie('test'));
+        $this->assertFalse($response->isCacheable());
     }
 
     public function testMustRevalidate()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28305
| License       | MIT
| Doc PR        | N/A

As discussed in #28305, responses with cookies are currently cached in Symfony, which could lead to unwanted behaviour as it might leak personal information to other users. Varnish also doesn't cache any responses with cookies.