### PR TITLE
[PhpUnitBridge] Implement startTest rather than startTestSuite

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV5.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV5.php
@@ -12,8 +12,8 @@
 namespace Symfony\Bridge\PhpUnit\Legacy;
 
 /**
- * CoverageListener adds `@covers <className>` on each test suite when possible
- * to make the code coverage more accurate.
+ * CoverageListener adds `@covers <className>` on each test when possible to
+ * make the code coverage more accurate.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  *

--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV6.php
@@ -15,8 +15,8 @@ use PHPUnit\Framework\BaseTestListener;
 use PHPUnit\Framework\Test;
 
 /**
- * CoverageListener adds `@covers <className>` on each test suite when possible
- * to make the code coverage more accurate.
+ * CoverageListener adds `@covers <className>` on each test when possible to
+ * make the code coverage more accurate.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  *

--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerForV7.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Bridge\PhpUnit\Legacy;
 
+use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
-use PHPUnit\Framework\TestSuite;
 
 /**
- * CoverageListener adds `@covers <className>` on each test suite when possible
- * to make the code coverage more accurate.
+ * CoverageListener adds `@covers <className>` on each test when possible to
+ * make the code coverage more accurate.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  *
@@ -34,8 +34,8 @@ class CoverageListenerForV7 implements TestListener
         $this->trait = new CoverageListenerTrait($sutFqcnResolver, $warningOnSutNotFound);
     }
 
-    public function startTestSuite(TestSuite $suite): void
+    public function startTest(Test $test): void
     {
-        $this->trait->startTest($suite);
+        $this->trait->startTest($test);
     }
 }


### PR DESCRIPTION
Passing a TestSuite instance to CoverageListenerTrait::testStart() will
have no effect.

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Closes #28481