### PR TITLE
[Ldap] Use shut up operator on connection errors at ldap_start_tls

### DIFF
--- a/src/Symfony/Component/Ldap/LdapClient.php
+++ b/src/Symfony/Component/Ldap/LdapClient.php
@@ -136,7 +136,7 @@ class LdapClient implements LdapClientInterface
             ldap_set_option($this->connection, LDAP_OPT_REFERRALS, $this->optReferrals);
 
             if ($this->useStartTls) {
-                ldap_start_tls($this->connection);
+                @ldap_start_tls($this->connection);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28426 
| License       | MIT
| Doc PR        | n/a

Added shut-up operator to php function `ldap_start_tls()` so connection errors are ignored.