### PR TITLE
[PhpUnitBridge] Provide debug_backtrace with proper args

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -72,7 +72,7 @@ class DeprecationErrorHandler
             }
 
             $mode = $getMode();
-            $trace = debug_backtrace(true);
+            $trace = debug_backtrace();
             $group = 'other';
 
             $i = \count($trace);


### PR DESCRIPTION
This would fail if we were using strict mode with php 7, because true is
only a valid argument for php < 5.3.6.
This was changed from PHP_VERSION_ID >= 50400 ?
DEBUG_BACKTRACE_IGNORE_ARGS | DEBUG_BACKTRACE_PROVIDE_OBJECT : true in
 #18272, but I do not understand why it was simlified, nor why
DEBUG_BACKTRACE_IGNORE_ARGS was there at that time.

| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Not sure if this qualifies as a bugfix. If not, should I simplify the ternary and target master? My fear is that having the code diverge too much will make it harder to merge subsequent PRs. I know this looks small, but I'm kind of preparing a big PR on the bridge and I'd rather have it smaller and easier to understand by moving everything I can with small patches like this one.