### PR TITLE
[HttpFoundation] add set body on request

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1545,6 +1545,11 @@ class Request
         return $this->content;
     }
 
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+
     /**
      * Gets the Etags.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Add a convenient way to inject data into the body of the request or replace it.

```
$request->initialize(
    iterator_to_array($request->query->getIterator()),
    iterator_to_array($request->request->getIterator()),
    iterator_to_array($request->attributes->getIterator()),
    iterator_to_array($request->cookies->getIterator()),
    iterator_to_array($request->files->getIterator()),
    iterator_to_array($request->server->getIterator()),
    json_encode($data)
);
```
=>
```
$request->setContent($data);
```
