### PR TITLE
[TwigBridge] Fix translation label in Bootstrap 4 theme

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -120,7 +120,11 @@
         {{- block('form_widget_simple') -}}
         <label for="{{ form.vars.id }}" class="custom-file-label">
             {%- if attr.placeholder is defined -%}
-                {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
+                {%- if translation_domain is same as(false) -%}
+                    {{- attr.placeholder -}}
+                {%- else -%}
+                    {{- attr.placeholder|trans({}, translation_domain) -}}
+                {%- endif -%}
             {%- endif -%}
         </label>
     </{{ element|default('div') }}>
@@ -214,7 +218,14 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}{% block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors %}</{{ element|default('label') }}>
+        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>
+            {%- if translation_domain is same as(false) -%}
+                {{- label -}}
+            {%- else -%}
+                {{- label|trans({}, translation_domain) -}}
+            {%- endif -%}
+            {%- block form_label_errors %}{{- form_errors(form) -}}{% endblock form_label_errors -%}
+        </{{ element|default('label') }}>
     {%- else -%}
         {%- if errors|length > 0 -%}
         <div id="{{ id }}_errors" class="mb-2">
@@ -256,8 +267,14 @@
 
         {{ widget|raw }}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-            {{- label is not same as(false) ? (translation_domain is same as(false) ? label : label|trans({}, translation_domain)) -}}
-            {{- form_errors(form) -}}
+        {%- if label is not same as(false) -%}
+            {%- if translation_domain is same as(false) -%}
+                {{- label -}}
+            {%- else -%}
+                {{- label|trans({}, translation_domain) -}}
+            {%- endif -%}
+        {%- endif -%}
+        {{- form_errors(form) -}}
         </label>
     {%- endif -%}
 {%- endblock checkbox_radio_label %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -267,14 +267,14 @@
 
         {{ widget|raw }}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-        {%- if label is not same as(false) -%}
-            {%- if translation_domain is same as(false) -%}
-                {{- label -}}
-            {%- else -%}
-                {{- label|trans({}, translation_domain) -}}
+            {%- if label is not same as(false) -%}
+                {%- if translation_domain is same as(false) -%}
+                    {{- label -}}
+                {%- else -%}
+                    {{- label|trans({}, translation_domain) -}}
+                {%- endif -%}
             {%- endif -%}
-        {%- endif -%}
-        {{- form_errors(form) -}}
+            {{- form_errors(form) -}}
         </label>
     {%- endif -%}
 {%- endblock checkbox_radio_label %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Actually label translation don't work with the Bootstrap 4 theme, after looking, it appear `label|trans({}, translation_domain)` don't work correctly when called in a ternary. Then, I've just replace ternary conditions per block conditions.
