### PR TITLE
[HttpFoundation] fix session

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -191,6 +191,11 @@ class Request
     protected $defaultLocale = 'en';
 
     /**
+     * @var callable
+     */
+    protected $sessionFactory;
+
+    /**
      * @var array
      */
     protected static $formats;
@@ -706,10 +711,14 @@ class Request
      */
     public function getSession()
     {
-        $session = $this->session;
+        if (null === $this->session && \is_callable($this->sessionFactory)) {
+            $session = \call_user_func($this->sessionFactory);
 
-        if (\is_callable($session)) {
-            $this->setSession($session());
+            if (!$session instanceof SessionInterface) {
+                throw new \BadMethodCallException('The sessionFactory must return a SessionInterface');
+            }
+
+            $this->setSession($session);
         }
 
         if (null === $this->session) {
@@ -761,7 +770,7 @@ class Request
      */
     public function setSessionFactory(callable $factory)
     {
-        $this->session = $factory;
+        $this->sessionFactory = $factory;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -707,16 +707,17 @@ class Request
     public function getSession()
     {
         $session = $this->session;
-        if (!$session instanceof SessionInterface && null !== $session) {
-            $this->setSession($session = $session());
+
+        if (\is_callable($session)) {
+            $this->setSession($session());
         }
 
-        if (null === $session) {
+        if (null === $this->session) {
             @trigger_error(sprintf('Calling "%s()" when no session has been set is deprecated since Symfony 4.1 and will throw an exception in 5.0. Use "hasSession()" instead.', __METHOD__), E_USER_DEPRECATED);
             // throw new \BadMethodCallException('Session has not been set');
         }
 
-        return $session;
+        return $this->session;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

`getSession` must not return a callable when using `setSessionFactory`