### PR TITLE
[Validator] Allow Validator without the translator component

### DIFF
--- a/src/Symfony/Component/Validator/DependencyInjection/AddValidatorInitializersPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddValidatorInitializersPass.php
@@ -49,11 +49,17 @@ class AddValidatorInitializersPass implements CompilerPassInterface
 
         // @deprecated logic, to be removed in Symfony 5.0
         $builder = $container->getDefinition($this->builderService);
-        $calls = [];
+        $calls = array();
 
         foreach ($builder->getMethodCalls() as list($method, $arguments)) {
             if ('setTranslator' === $method) {
-                $translator = $arguments[0] instanceof Reference ? $container->findDefinition($arguments[0]) : $arguments[0];
+                if (!$arguments[0] instanceof Reference) {
+                    $translator = $arguments[0];
+                } elseif ($container->has($arguments[0])) {
+                    $translator = $container->findDefinition($arguments[0]);
+                } else {
+                    continue;
+                }
 
                 while (!($class = $translator->getClass()) && $translator instanceof ChildDefinition) {
                     $translator = $translator->getParent();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28210
| License       | MIT
| Doc PR        | ø

Validator should be available without the Translator service. #28210 introduced a regression, it was not the case anymore:
```

  You have requested a non-existent service "translator".

```

This fixes it.