### PR TITLE
[FrameworkBundle] Register an identity translator as fallback

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -17,6 +17,7 @@ use Symfony\Bridge\Twig\TokenParser\TransChoiceTokenParser;
 use Symfony\Bridge\Twig\TokenParser\TransDefaultDomainTokenParser;
 use Symfony\Bridge\Twig\TokenParser\TransTokenParser;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorTrait;
 use Twig\Extension\AbstractExtension;
 use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\TokenParser\AbstractTokenParser;
@@ -29,6 +30,13 @@ use Twig\TwigFilter;
  */
 class TranslationExtension extends AbstractExtension
 {
+    use TranslatorTrait {
+        getLocale as private;
+        setLocale as private;
+        trans as private doTrans;
+        transChoice as private doTransChoice;
+    }
+
     private $translator;
     private $translationNodeVisitor;
 
@@ -91,7 +99,7 @@ class TranslationExtension extends AbstractExtension
     public function trans($message, array $arguments = array(), $domain = null, $locale = null)
     {
         if (null === $this->translator) {
-            return strtr($message, $arguments);
+            return $this->doTrans($message, $arguments, $domain, $locale);
         }
 
         return $this->translator->trans($message, $arguments, $domain, $locale);
@@ -100,7 +108,7 @@ class TranslationExtension extends AbstractExtension
     public function transchoice($message, $count, array $arguments = array(), $domain = null, $locale = null)
     {
         if (null === $this->translator) {
-            return strtr($message, $arguments);
+            return $this->doTransChoice($message, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);
         }
 
         return $this->translator->transChoice($message, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -873,10 +873,6 @@ class FrameworkExtension extends Extension
             } else {
                 $container->removeDefinition('templating.helper.assets');
             }
-
-            if (!$this->translationConfigEnabled) {
-                $container->removeDefinition('templating.helper.translator');
-            }
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -58,7 +58,7 @@
 
         <service id="templating.helper.translator" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper">
             <tag name="templating.helper" alias="translator" />
-            <argument type="service" id="translator" />
+            <argument type="service" id="translator" on-invalid="null" />
         </service>
 
         <service id="templating.helper.form" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper">

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/TranslatorHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/TranslatorHelper.php
@@ -13,15 +13,23 @@ namespace Symfony\Bundle\FrameworkBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorTrait;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class TranslatorHelper extends Helper
 {
+    use TranslatorTrait {
+        getLocale as private;
+        setLocale as private;
+        trans as private doTrans;
+        transChoice as private doTransChoice;
+    }
+
     protected $translator;
 
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator = null)
     {
         $this->translator = $translator;
     }
@@ -31,6 +39,10 @@ class TranslatorHelper extends Helper
      */
     public function trans($id, array $parameters = array(), $domain = 'messages', $locale = null)
     {
+        if (null === $this->translator) {
+            return $this->doTrans($id, $parameters, $domain, $locale);
+        }
+
         return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
@@ -39,6 +51,10 @@ class TranslatorHelper extends Helper
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = 'messages', $locale = null)
     {
+        if (null === $this->translator) {
+            return $this->doTransChoice($id, $number, $parameters, $domain, $locale);
+        }
+
         return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_php_translator_disabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_php_translator_disabled.php
@@ -1,8 +1,0 @@
-<?php
-
-$container->loadFromExtension('framework', array(
-    'translator' => false,
-    'templating' => array(
-        'engines' => array('php'),
-    ),
-));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_php_translator_enabled.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/templating_php_translator_enabled.php
@@ -1,8 +1,0 @@
-<?php
-
-$container->loadFromExtension('framework', array(
-    'translator' => true,
-    'templating' => array(
-        'engines' => array('php'),
-    ),
-));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -701,20 +701,6 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals(array('en', 'fr'), $calls[1][1][0]);
     }
 
-    public function testTranslatorHelperIsRegisteredWhenTranslatorIsEnabled()
-    {
-        $container = $this->createContainerFromFile('templating_php_translator_enabled');
-
-        $this->assertTrue($container->has('templating.helper.translator'));
-    }
-
-    public function testTranslatorHelperIsNotRegisteredWhenTranslatorIsDisabled()
-    {
-        $container = $this->createContainerFromFile('templating_php_translator_disabled');
-
-        $this->assertFalse($container->has('templating.helper.translator'));
-    }
-
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27589
| License       | MIT
| Doc PR        | -

The same approach as https://github.com/symfony/symfony/pull/24358, suggested by @xabbuh here https://github.com/symfony/symfony/issues/27589#issuecomment-421542776

**Templating Engine Context**

The Form component can be used without the Translation component.
However, to be able to use the default form themes provided by the
`FrameworkBundle` you need to have the `translator` helper to be available.

This change ensure that there will always be a `translator` helper which
as a fallback will just return the message key if no translator is present.
