### PR TITLE
Fixed bc break handler in uploaded file constructor

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -65,7 +65,7 @@ class UploadedFile extends File
         $this->originalName = $this->getName($originalName);
         $this->mimeType = $mimeType ?: 'application/octet-stream';
 
-        if (4 < \func_num_args() ? !\is_bool($test) : null !== $error && @filesize($path) === $error) {
+        if (3 < \func_num_args() ? !\is_bool($test) : null !== $error && @filesize($path) === $error) {
             @trigger_error(sprintf('Passing a size as 4th argument to the constructor of "%s" is deprecated since Symfony 4.1.', __CLASS__), E_USER_DEPRECATED);
             $error = $test;
             $test = 5 < \func_num_args() ? func_get_arg(5) : false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Currently the following code:

```php
$uploadedFile = new UploadedFile($path, $name, $mimeType, $size); 
$uploadedFile->getError(); // == $size
```

will set an error.
