### PR TITLE
[Yaml] Skip parser test with root user

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2099,6 +2099,10 @@ YAML;
             $this->markTestSkipped('chmod is not supported on Windows');
         }
 
+        if (!getenv('USER') || 'root' === getenv('USER')) {
+            $this->markTestSkipped('This test will fail if run under superuser');
+        }
+
         $file = __DIR__.'/Fixtures/not_readable.yml';
         chmod($file, 0200);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28478
| License       | MIT
| Doc PR        | -

This PR fix a test failure in YAML Component when running from a php docker container.
By defaut, root user is used to run phpunit. It means permission checking will fail (Root user is always allowed to read files)
