### PR TITLE
WIP: [Messenger] Infinite Loop Receiver

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Enhancers/InfiniteLoopReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Enhancers/InfiniteLoopReceiverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\Enhancers;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Transport\ReceiverInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\CallbackReceiver;
+use Symfony\Component\Messenger\Transport\Enhancers\InfiniteLoopReceiver;
+
+class InfiniteLoopReceiverTest extends TestCase
+{
+    public function testReceiverReceivesUntilStopIsCalled()
+    {
+        $i = 0;
+        $decoratedReceiver = null;
+        $receiver = new CallbackReceiver(function ($handler) use (&$i, &$decoratedReceiver) {
+            $i += 1;
+            if ($i === 3) {
+                $decoratedReceiver->stop();
+            }
+        });
+
+        $decoratedReceiver = new InfiniteLoopReceiver($receiver);
+        $decoratedReceiver->receive(function() {});
+        $this->assertEquals(3, $i);
+    }
+
+    public function testReceiverDelegatesStopToInnerReceiver()
+    {
+        $decoratedReceiver = null;
+        $receiver = new class($decoratedReceiver) implements ReceiverInterface {
+            public $wasStopped = 0;
+            private $decoratedReceiver;
+
+            public function __construct(&$decoratedReceiver) {
+                $this->decoratedReceiver = &$decoratedReceiver;
+            }
+
+            public function receive(callable $handle): void {
+                $this->decoratedReceiver->stop();
+            }
+            public function stop(): void {
+                $this->wasStopped += 1;
+            }
+        };
+        $decoratedReceiver = new InfiniteLoopReceiver($receiver);
+        $decoratedReceiver->receive(function() {});
+        $this->assertEquals(1, $receiver->wasStopped);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage test
+     */
+    public function testReceiverRethrowsAnyExceptions()
+    {
+        $decoratedReceiver = null;
+        $receiver = new CallbackReceiver(function ($handler) {
+            throw new \Exception('test');
+        });
+
+        $decoratedReceiver = new InfiniteLoopReceiver($receiver);
+        $decoratedReceiver->receive(function() {});
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Enhancers\InfiniteLoopReceiver;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -58,7 +59,7 @@ class AmqpTransport implements TransportInterface
 
     private function getReceiver()
     {
-        return $this->receiver = new AmqpReceiver($this->connection, $this->serializer);
+        return $this->receiver = new InfiniteLoopReceiver(new AmqpReceiver($this->connection, $this->serializer));
     }
 
     private function getSender()

--- a/src/Symfony/Component/Messenger/Transport/Enhancers/InfiniteLoopReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/Enhancers/InfiniteLoopReceiver.php
@@ -18,7 +18,6 @@ class InfiniteLoopReceiver implements ReceiverInterface
         $this->shouldStop = false;
     }
 
-
     public function receive(callable $handler): void
     {
         while (!$this->shouldStop) {
@@ -36,10 +35,9 @@ class InfiniteLoopReceiver implements ReceiverInterface
         }
     }
 
-    /**
-     * Stop receiving some messages.
-     */
-    public function stop(): void {
+    public function stop(): void
+    {
         $this->shouldStop = true;
+        $this->receiver->stop();
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Enhancers/InfiniteLoopReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/Enhancers/InfiniteLoopReceiver.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Symfony\Component\Messenger\Transport\Enhancers;
+
+use Symfony\Component\Messenger\Transport\ReceiverInterface;
+
+/**
+ * @author RJ Garcia <rj@bighead.net>
+ */
+class InfiniteLoopReceiver implements ReceiverInterface
+{
+    private $receiver;
+    private $shouldStop;
+
+    public function __construct(ReceiverInterface $receiver)
+    {
+        $this->receiver = $receiver;
+        $this->shouldStop = false;
+    }
+
+
+    public function receive(callable $handler): void
+    {
+        while (!$this->shouldStop) {
+            try {
+                $this->receiver->receive($handler);
+            } catch (\Throwable $t) {}
+
+            if (\function_exists('pcntl_signal_dispatch')) {
+                \pcntl_signal_dispatch();
+            }
+
+            if ($t ?? null) {
+                throw $t;
+            }
+        }
+    }
+
+    /**
+     * Stop receiving some messages.
+     */
+    public function stop(): void {
+        $this->shouldStop = true;
+    }
+}


### PR DESCRIPTION
- Add a receiver decorator for standardizing the infinite
  looping format
- Updated the AMQP transport to utilize the infinite looping
  receiver to simply design


Signed-off-by: RJ Garcia <rj@bighead.net>

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | not yet    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The AMQP looping and pcntl_signal structure is actually pretty common among other receivers like Redis or SQS. This WIP PR abstracts out that logic into a decorator to simplify the design of the AMQP receiver and to also prevent the duplication of code across the third party receivers.

It's WIP because I haven't added or updated tests yet, I wanted to create this first to see if you guys (@sroze) even approve of this change before I make the effort to get this ready for merge.

Thanks!