### PR TITLE
[Serializer] deserialize from json: Fix a collection that contains the only one element

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -310,8 +310,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $class = $collectionValueType->getClassName().'[]';
 
                 // Fix a collection that contains the only one element
-                // This is special to xml format only
-                if ('xml' === $format && !\is_int(key($data))) {
+                // For xml and json format
+                if (('xml' === $format || 'json' === $format) && !\is_int(key($data))) {
                     $data = array($data);
                 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -120,6 +120,48 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[1]);
     }
 
+    public function testDenormalizeCollectionDecodedFromJsonWithOneChild()
+    {
+        $denormalizer = $this->getDenormalizerForDummyCollection();
+
+        $dummyCollection = $denormalizer->denormalize(
+            array(
+                'children' => array(
+                    'bar' => 'first',
+                ),
+            ),
+            DummyCollection::class,
+            'json'
+        );
+
+        $this->assertInstanceOf(DummyCollection::class, $dummyCollection);
+        $this->assertInternalType('array', $dummyCollection->children);
+        $this->assertCount(1, $dummyCollection->children);
+        $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[0]);
+    }
+
+    public function testDenormalizeCollectionDecodedFromJsonWithTwoChildren()
+    {
+        $denormalizer = $this->getDenormalizerForDummyCollection();
+
+        $dummyCollection = $denormalizer->denormalize(
+            array(
+                'children' => array(
+                    array('bar' => 'first'),
+                    array('bar' => 'second'),
+                ),
+            ),
+            DummyCollection::class,
+            'json'
+        );
+
+        $this->assertInstanceOf(DummyCollection::class, $dummyCollection);
+        $this->assertInternalType('array', $dummyCollection->children);
+        $this->assertCount(2, $dummyCollection->children);
+        $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[0]);
+        $this->assertInstanceOf(DummyChild::class, $dummyCollection->children[1]);
+    }
+
     private function getDenormalizerForDummyCollection()
     {
         $extractor = $this->getMockBuilder(PhpDocExtractor::class)->getMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 (be careful when merging)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27279
| License       | MIT
| Doc PR        | 

In xml when parent node (`restaurants`) contains several children nodes with the same tag (`restaurant`) it is clear that the children form a collection:

```
restaurants = {array} [1]
 restaurant = {array} [2]
  0 = {array} [2]
   name = "Some restaurant name"
   type = "Chinese"
  1 = {array} [2]
   name = "Another restaurant name"
   type = "Italian"
```
Afterwards the object denormalizer has no problem to create a collection of restaurants.

But when there is only one child (`restaurant`) the decoded normalized array will not contain a collection:

```
restaurants = {array} [1]
 restaurant = {array} [2]
  name = "Some restaurant name"
  type = "Chinese"
```
In this situation the object denormalizer threw unexpected exception. This PR modifies `AbstractObjectNormalizer` that is it will fill a collection containing the sole element properly.
