### PR TITLE
[VarDumper] add caster for MessageFormatter

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/IntlCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/IntlCaster.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class IntlCaster
+{
+    public static function castMessageFormatter(\MessageFormatter $c, array $a, Stub $stub, $isNested)
+    {
+        $a += array(
+            Caster::PREFIX_VIRTUAL.'locale' => $c->getLocale(),
+            Caster::PREFIX_VIRTUAL.'pattern' => $c->getPattern(),
+        );
+
+        if ($errorCode = $c->getErrorCode()) {
+            $a += array(
+                Caster::PREFIX_VIRTUAL.'error_code' => $errorCode,
+                Caster::PREFIX_VIRTUAL.'error_message' => $c->getErrorMessage(),
+            );
+        }
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -117,6 +117,8 @@ abstract class AbstractCloner implements ClonerInterface
 
         'GMP' => array('Symfony\Component\VarDumper\Caster\GmpCaster', 'castGmp'),
 
+        'MessageFormatter' => array('Symfony\Component\VarDumper\Caster\IntlCaster', 'castMessageFormatter'),
+
         ':curl' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castCurl'),
         ':dba' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'),
         ':dba persistent' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'),

--- a/src/Symfony/Component/VarDumper/Tests/Caster/IntlCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/IntlCasterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+/**
+ * @requires extension intl
+ */
+class IntlCasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    public function testArrayIterator()
+    {
+        $var = new \MessageFormatter('en', 'Hello {name}');
+
+        $expected = <<<EOTXT
+MessageFormatter {
+  locale: "en"
+  pattern: "Hello {name}"
+}
+EOTXT;
+        $this->assertDumpEquals($expected, $var);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

There are more classes in intl that could benefit from having a caster, see
http://php.net/manual/en/book.intl.php

Let's start with MessageFormatter.
PRs welcome for adding more.