### PR TITLE
[Translation] Rename IntlMessageFormat to IcuMessageFormat

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -32,9 +32,9 @@
         <service id="translator.formatter.symfony" class="Symfony\Component\Translation\Formatter\MessageFormatter">
             <argument type="service" id="identity_translator" />
         </service>
-        <service id="translator.formatter.intl" class="Symfony\Component\Translation\Formatter\IntlMessageFormatter" public="false" />
+        <service id="translator.formatter.icu" class="Symfony\Component\Translation\Formatter\IcuMessageFormatter" public="false" />
         <service id="translator.formatter.fallback" class="Symfony\Component\Translation\Formatter\FallbackFormatter" public="false">
-            <argument type="service" id="translator.formatter.intl" />
+            <argument type="service" id="translator.formatter.icu" />
             <argument type="service" id="translator.formatter.symfony" />
         </service>
         <service id="translator.formatter.default" alias="translator.formatter.fallback" />

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Started using ICU parent locales as fallback locales.
  * deprecated `TranslatorInterface` in favor of `Symfony\Contracts\Translation\TranslatorInterface`
  * deprecated `MessageSelector`, `Interval` and `PluralizationRules`; use `IdentityTranslator` instead
- * Added `IntlMessageFormatter` and `FallbackMessageFormatter`
+ * Added `IcuMessageFormatter` and `FallbackMessageFormatter`
  * added support for multiple files and directories in `XliffLintCommand`
 
 4.1.0

--- a/src/Symfony/Component/Translation/Formatter/IcuMessageFormatter.php
+++ b/src/Symfony/Component/Translation/Formatter/IcuMessageFormatter.php
@@ -17,7 +17,7 @@ use Symfony\Component\Translation\Exception\InvalidArgumentException;
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
  */
-class IntlMessageFormatter implements MessageFormatterInterface
+class IcuMessageFormatter implements MessageFormatterInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Translation/Tests/Formatter/IcuMessageFormatterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Formatter/IcuMessageFormatterTest.php
@@ -12,9 +12,9 @@
 namespace Symfony\Component\Translation\Tests\Formatter;
 
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
-use Symfony\Component\Translation\Formatter\IntlMessageFormatter;
+use Symfony\Component\Translation\Formatter\IcuMessageFormatter;
 
-class IntlMessageFormatterTest extends \PHPUnit\Framework\TestCase
+class IcuMessageFormatterTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {
@@ -28,13 +28,13 @@ class IntlMessageFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormat($expected, $message, $arguments)
     {
-        $this->assertEquals($expected, trim((new IntlMessageFormatter())->format($message, 'en', $arguments)));
+        $this->assertEquals($expected, trim((new IcuMessageFormatter())->format($message, 'en', $arguments)));
     }
 
     public function testInvalidFormat()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new IntlMessageFormatter())->format('{foo', 'en', array(2));
+        (new IcuMessageFormatter())->format('{foo', 'en', array(2));
     }
 
     public function testFormatWithNamedArguments()
@@ -62,7 +62,7 @@ class IntlMessageFormatterTest extends \PHPUnit\Framework\TestCase
      other {{host} invites {guest} as one of the # people invited to their party.}}}}
 _MSG_;
 
-        $message = (new IntlMessageFormatter())->format($chooseMessage, 'en', array(
+        $message = (new IcuMessageFormatter())->format($chooseMessage, 'en', array(
             'gender_of_host' => 'male',
             'num_guests' => 10,
             'host' => 'Fabien',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (it is not released yet)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When researching this new message format. I found that Yahoo has a javascript library called [IntlMessageFormat](https://github.com/yahoo/intl-messageformat). In their readme it says: 

> Uses industry standards: [ICU Message syntax](http://userguide.icu-project.org/formatparse/messages) and [CLDR locale data](http://cldr.unicode.org/).

The standard they are following is this: http://userguide.icu-project.org/formatparse/messages

> The ICU MessageFormat class uses message "pattern" ....

So the message format is called ICU. 

--------

The YII framework is calling their class `MessageFormatter` with a comment: 

> https://github.com/yiisoft/yii2/blob/master/framework/i18n/MessageFormatter.php#L73

------

The [PHP docs](https://secure.php.net/manual/en/class.messageformatter.php) for `\MessageFormat` does not mention ICU except in the "read more" section. 

------

Question: Do we create a `IntlMessageFormatter` (which is a made up class name) or are we doing a `IcuMessageFormatter` (which has a clear definition what it suppose to do). 