### PR TITLE
[Cache] prevent getting older entries when the version key is evicted

### DIFF
--- a/src/Symfony/Component/Cache/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractTrait.php
@@ -106,14 +106,7 @@ trait AbstractTrait
     {
         $this->deferred = array();
         if ($cleared = $this->versioningIsEnabled) {
-            $namespaceVersion = 2;
-            try {
-                foreach ($this->doFetch(array('@'.$this->namespace)) as $v) {
-                    $namespaceVersion = 1 + (int) $v;
-                }
-            } catch (\Exception $e) {
-            }
-            $namespaceVersion .= ':';
+            $namespaceVersion = substr_replace(base64_encode(pack('V', mt_rand())), ':', 5);
             try {
                 $cleared = $this->doSave(array('@'.$this->namespace => $namespaceVersion), 0);
             } catch (\Exception $e) {
@@ -246,6 +239,10 @@ trait AbstractTrait
             try {
                 foreach ($this->doFetch(array('@'.$this->namespace)) as $v) {
                     $this->namespaceVersion = $v;
+                }
+                if ('1:' === $this->namespaceVersion) {
+                    $this->namespaceVersion = substr_replace(base64_encode(pack('V', time())), ':', 5);
+                    $this->doSave(array('@'.$this->namespace => $this->namespaceVersion), 0);
                 }
             } catch (\Exception $e) {
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28445
| License       | MIT
| Doc PR        | -

As described in linked issue, using a strategy described in
https://github.com/memcached/memcached/wiki/ProgrammingTricks#deleting-by-namespace
