### PR TITLE
[Form] Added a cause on when a Csrf Error has occurred on CsrfValidationListener

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -55,6 +55,9 @@ Finder
 Form
 ----
 
+ * The `scale` option of the `IntegerType` is deprecated.
+ * The `$scale` argument of the `IntegerToLocalizedStringTransformer` is deprecated.
+
  * Deprecated calling `FormRenderer::searchAndRenderBlock` for fields which were already rendered.
    Instead of expecting such calls to return empty strings, check if the field has already been rendered.
 
@@ -72,24 +75,12 @@ Form
    {% endfor %}
    ```
 
-Process
--------
+HttpFoundation
+--------------
 
- * Deprecated the `Process::setCommandline()` and the `PhpProcess::setPhpBinary()` methods.
- * Deprecated passing commands as strings when creating a `Process` instance.
-
-   Before:
-   ```php
-   $process = new Process('ls -l');
-   ```
-
-   After:
-   ```php
-   $process = new Process(array('ls', '-l'));
-
-   // alternatively, when a shell wrapper is required
-   $process = Process::fromShellCommandline('ls -l');
-   ```
+ * The default value of the "$secure" and "$samesite" arguments of Cookie's constructor
+   will respectively change from "false" to "null" and from "null" to "lax" in Symfony
+   5.0, you should define their values explicitly or use "Cookie::create()" instead.
 
 FrameworkBundle
 ---------------
@@ -164,6 +155,25 @@ Monolog
 
  * The methods `DebugProcessor::getLogs()`, `DebugProcessor::countErrors()`, `Logger::getLogs()` and `Logger::countErrors()` will have a new `$request` argument in version 5.0, not defining it is deprecated.
 
+Process
+-------
+
+ * Deprecated the `Process::setCommandline()` and the `PhpProcess::setPhpBinary()` methods.
+ * Deprecated passing commands as strings when creating a `Process` instance.
+
+   Before:
+   ```php
+   $process = new Process('ls -l');
+   ```
+
+   After:
+   ```php
+   $process = new Process(array('ls', '-l'));
+
+   // alternatively, when a shell wrapper is required
+   $process = Process::fromShellCommandline('ls -l');
+   ```
+
 Security
 --------
 
@@ -206,3 +216,4 @@ Validator
  * The component is now decoupled from `symfony/translation` and uses `Symfony\Contracts\Translation\TranslatorInterface` instead
  * The `ValidatorBuilderInterface` has been deprecated and `ValidatorBuilder` made final
  * Deprecated validating instances of `\DateTimeInterface` in `DateTimeValidator`, `DateValidator` and `TimeValidator`. Use `Type` instead or remove the constraint if the underlying model is type hinted to `\DateTimeInterface` already.
+ * Using the `Bic` constraint without `symfony/intl` is deprecated

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -69,6 +69,12 @@ Finder
 
  * The `Finder::sortByName()` method has a new `$useNaturalSort` argument.
 
+Form
+----
+
+ * The `scale` option was removed from the `IntegerType`.
+ * The `$scale` argument of the `IntegerToLocalizedStringTransformer` was removed.
+
 FrameworkBundle
 ---------------
 
@@ -117,6 +123,8 @@ HttpFoundation
  * The `$size` argument of the `UploadedFile` constructor has been removed.
  * The `getClientSize()` method of the `UploadedFile` class has been removed.
  * The `getSession()` method of the `Request` class throws an exception when session is null.
+ * The default value of the "$secure" and "$samesite" arguments of Cookie's constructor
+   changed respectively from "false" to "null" and from "null" to "lax".
 
 Monolog
 -------
@@ -191,6 +199,7 @@ Validator
  * The component is now decoupled from `symfony/translation` and uses `Symfony\Contracts\Translation\TranslatorInterface` instead
  * The `ValidatorBuilderInterface` has been removed and `ValidatorBuilder` is now final
  * Removed support for validating instances of `\DateTimeInterface` in `DateTimeValidator`, `DateValidator` and `TimeValidator`. Use `Type` instead or remove the constraint if the underlying model is type hinted to `\DateTimeInterface` already.
+ * The `symfony/intl` component is now required for using the `Bic` constraint
 
 Workflow
 --------

--- a/src/Symfony/Bridge/Monolog/CHANGELOG.md
+++ b/src/Symfony/Bridge/Monolog/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * added `ProcessorInterface`: an optional interface to allow autoconfiguration of Monolog processors
  * The methods `DebugProcessor::getLogs()`, `DebugProcessor::countErrors()`, `Logger::getLogs()`
    and `Logger::countErrors()` will have a new `$request` argument in version 5.0, not defining
-   it is deprecated since Symfony 4.2.
+   it is deprecated
 
 4.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
@@ -144,7 +145,16 @@ EOF
         $options['show_hidden'] = $input->getOption('show-hidden');
         $options['raw_text'] = $input->getOption('raw');
         $options['output'] = $io;
-        $helper->describe($io, $object, $options);
+
+        try {
+            $helper->describe($io, $object, $options);
+        } catch (ServiceNotFoundException $e) {
+            if ('' !== $e->getId() && '@' === $e->getId()[0]) {
+                throw new ServiceNotFoundException($e->getId(), $e->getSourceId(), null, array(substr($e->getId(), 1)));
+            }
+
+            throw $e;
+        }
 
         if (!$input->getArgument('name') && !$input->getOption('tag') && !$input->getOption('parameter') && $input->isInteractive()) {
             if ($input->getOption('tags')) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
@@ -133,7 +133,7 @@ class CachePoolPass implements CompilerPassInterface
     {
         $container->resolveEnvPlaceholders($name, null, $usedEnvs);
 
-        if ($usedEnvs || preg_match('#^[a-z]++://#', $name)) {
+        if ($usedEnvs || preg_match('#^[a-z]++:#', $name)) {
             $dsn = $name;
 
             if (!$container->hasDefinition($name = '.cache_connection.'.ContainerBuilder::hash($dsn))) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -199,6 +199,9 @@ class FrameworkExtension extends Extension
         if ($this->isConfigEnabled($container, $config['session'])) {
             $this->sessionConfigEnabled = true;
             $this->registerSessionConfiguration($config['session'], $container, $loader);
+            if (!empty($config['test'])) {
+                $container->getDefinition('test.session.listener')->setArgument(1, '%session.storage.options%');
+            }
         }
 
         if ($this->isConfigEnabled($container, $config['request'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -23,7 +23,7 @@ abstract class WebTestCase extends KernelTestCase
     /**
      * Creates a Client.
      *
-     * @param array $options An array of options to pass to the createKernel class
+     * @param array $options An array of options to pass to the createKernel method
      * @param array $server  An array of server parameters
      *
      * @return Client A Client instance

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,11 +6,13 @@ CHANGELOG
 
  * Using the `security.authentication.trust_resolver.anonymous_class` and 
    `security.authentication.trust_resolver.rememberme_class` parameters to define
-   the token classes is deprecated. To use
-   custom tokens extend the existing `Symfony\Component\Security\Core\Authentication\Token\AnonymousToken`
+   the token classes is deprecated. To use custom tokens extend the existing
+   `Symfony\Component\Security\Core\Authentication\Token\AnonymousToken`.
    or `Symfony\Component\Security\Core\Authentication\Token\RememberMeToken`.
  * Added `Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddExpressionLanguageProvidersPass`
  * Added `json_login_ldap` authentication provider to use LDAP authentication with a REST API.
+ * Made remember-me cookies inherit their default config from `framework.session.cookie_*`
+   and added an "auto" mode to their "secure" config option to make them secure on HTTPS automatically.
  
 4.1.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\Cookie;
 
 class RememberMeFactory implements SecurityFactoryInterface
 {
@@ -140,7 +141,11 @@ class RememberMeFactory implements SecurityFactoryInterface
         ;
 
         foreach ($this->options as $name => $value) {
-            if (\is_bool($value)) {
+            if ('secure' === $name) {
+                $builder->enumNode($name)->values(array(true, false, 'auto'))->defaultValue('auto' === $value ? null : $value);
+            } elseif ('samesite' === $name) {
+                $builder->enumNode($name)->values(array(null, Cookie::SAMESITE_LAX, Cookie::SAMESITE_STRICT))->defaultValue($value);
+            } elseif (\is_bool($value)) {
                 $builder->booleanNode($name)->defaultValue($value);
             } else {
                 $builder->scalarNode($name)->defaultValue($value);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
@@ -26,6 +26,7 @@ class LogoutTest extends WebTestCase
         $cookieJar->expire(session_name());
 
         $this->assertNotNull($cookieJar->get('REMEMBERME'));
+        $this->assertSame('lax', $cookieJar->get('REMEMBERME')->getSameSite());
 
         $client->request('GET', '/logout');
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeLogout/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeLogout/config.yml
@@ -1,6 +1,11 @@
 imports:
     - { resource: ./../config/framework.yml }
 
+framework:
+    session:
+        cookie_secure: auto
+        cookie_samesite: lax
+
 security:
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "symfony/asset": "~3.4|~4.0",
-        "symfony/browser-kit": "~3.4|~4.0",
+        "symfony/browser-kit": "~4.2",
         "symfony/console": "~3.4|~4.0",
         "symfony/css-selector": "~3.4|~4.0",
         "symfony/dom-crawler": "~3.4|~4.0",
@@ -48,6 +48,7 @@
         "twig/twig": "~1.34|~2.4"
     },
     "conflict": {
+        "symfony/browser-kit": "<4.2",
         "symfony/var-dumper": "<3.4",
         "symfony/event-dispatcher": "<3.4",
         "symfony/framework-bundle": "<4.2",

--- a/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
+++ b/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
@@ -63,7 +63,7 @@ class TemplateIterator implements \IteratorAggregate
             $this->templates = array_merge(
                 $this->templates,
                 $this->findTemplatesInDirectory($bundle->getPath().'/Resources/views', $name),
-                $this->findTemplatesInDirectory($this->rootDir.'/'.$bundle->getName().'/views', $name),
+                $this->findTemplatesInDirectory($this->rootDir.'/Resources/'.$bundle->getName().'/views', $name),
                 $this->findTemplatesInDirectory($this->defaultPath.'/bundles/'.$bundle->getName(), $name)
             );
         }

--- a/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
@@ -31,6 +31,7 @@ class TemplateIteratorTest extends TestCase
         sort($sorted);
         $this->assertEquals(
             array(
+                '@Bar/base.html.twig',
                 '@Bar/index.html.twig',
                 '@Bar/layout.html.twig',
                 '@Foo/index.html.twig',

--- a/src/Symfony/Bundle/WebProfilerBundle/README.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/README.md
@@ -1,6 +1,12 @@
 WebProfilerBundle
 =================
 
+The Web profiler bundle is a **development tool** that gives detailed
+information about the execution of any request.
+
+**Never** enable it on production servers as it will lead to major security
+vulnerabilities in your project.
+
 Resources
 ---------
 

--- a/src/Symfony/Bundle/WebProfilerBundle/WebProfilerBundle.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/WebProfilerBundle.php
@@ -14,10 +14,14 @@ namespace Symfony\Bundle\WebProfilerBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Bundle.
- *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class WebProfilerBundle extends Bundle
 {
+    public function boot()
+    {
+        if ('prod' === $this->container->getParameter('kernel.environment')) {
+            @trigger_error('Using WebProfilerBundle in production is not supported and puts your project at risk, disable it.', E_USER_WARNING);
+        }
+    }
 }

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -5,7 +5,8 @@ CHANGELOG
 -----
 
  * The method `Client::submit()` will have a new `$serverParameters` argument 
-   in version 5.0, not defining it is deprecated since version 4.2
+   in version 5.0, not defining it is deprecated
+ * Added ability to read the "samesite" attribute of cookies using `Cookie::getSameSite()`
 
 3.4.0
 -----

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -118,7 +118,7 @@ abstract class Client
     public function insulate($insulated = true)
     {
         if ($insulated && !class_exists('Symfony\\Component\\Process\\Process')) {
-            throw new \RuntimeException('Unable to isolate requests as the Symfony Process Component is not installed.');
+            throw new \LogicException('Unable to isolate requests as the Symfony Process Component is not installed.');
         }
 
         $this->insulated = (bool) $insulated;
@@ -297,7 +297,11 @@ abstract class Client
      */
     public function clickLink(string $linkText): Crawler
     {
-        return $this->click($this->getCrawler()->selectLink($linkText)->link());
+        if (null === $this->crawler) {
+            throw new BadMethodCallException(sprintf('The "request()" method must be called before "%s()".', __METHOD__));
+        }
+
+        return $this->click($this->crawler->selectLink($linkText)->link());
     }
 
     /**
@@ -332,7 +336,11 @@ abstract class Client
      */
     public function submitForm(string $button, array $fieldValues = array(), string $method = 'POST', array $serverParameters = array()): Crawler
     {
-        $buttonNode = $this->getCrawler()->selectButton($button);
+        if (null === $this->crawler) {
+            throw new BadMethodCallException(sprintf('The "request()" method must be called before "%s()".', __METHOD__));
+        }
+
+        $buttonNode = $this->crawler->selectButton($button);
         $form = $buttonNode->form($fieldValues, $method);
 
         return $this->submit($form, array(), $serverParameters);

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -40,6 +40,7 @@ class Cookie
     protected $secure;
     protected $httponly;
     protected $rawValue;
+    private $samesite;
 
     /**
      * Sets a cookie.
@@ -52,8 +53,9 @@ class Cookie
      * @param bool        $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
      * @param bool        $httponly     The cookie httponly flag
      * @param bool        $encodedValue Whether the value is encoded or not
+     * @param string|null $samesite     The cookie samesite attribute
      */
-    public function __construct(string $name, ?string $value, string $expires = null, string $path = null, string $domain = '', bool $secure = false, bool $httponly = true, bool $encodedValue = false)
+    public function __construct(string $name, ?string $value, string $expires = null, string $path = null, string $domain = '', bool $secure = false, bool $httponly = true, bool $encodedValue = false, string $samesite = null)
     {
         if ($encodedValue) {
             $this->value = urldecode($value);
@@ -67,6 +69,7 @@ class Cookie
         $this->domain = $domain;
         $this->secure = $secure;
         $this->httponly = $httponly;
+        $this->samesite = $samesite;
 
         if (null !== $expires) {
             $timestampAsDateTime = \DateTime::createFromFormat('U', $expires);
@@ -106,6 +109,10 @@ class Cookie
             $cookie .= '; httponly';
         }
 
+        if (null !== $this->samesite) {
+            $str .= '; samesite='.$this->samesite;
+        }
+
         return $cookie;
     }
 
@@ -138,6 +145,7 @@ class Cookie
             'secure' => false,
             'httponly' => false,
             'passedRawValue' => true,
+            'samesite' => null,
         );
 
         if (null !== $url) {
@@ -186,7 +194,8 @@ class Cookie
             $values['domain'],
             $values['secure'],
             $values['httponly'],
-            $values['passedRawValue']
+            $values['passedRawValue'],
+            $values['samesite']
         );
     }
 
@@ -297,5 +306,15 @@ class Cookie
     public function isExpired()
     {
         return null !== $this->expires && 0 != $this->expires && $this->expires < time();
+    }
+
+    /**
+     * Gets the samesite attribute of the cookie.
+     *
+     * @return string|null The cookie samesite attribute
+     */
+    public function getSameSite(): ?string
+    {
+        return $this->samesite;
     }
 }

--- a/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
@@ -202,4 +202,13 @@ class CookieTest extends TestCase
     {
         $cookie = new Cookie('foo', 'bar', 'string');
     }
+
+    public function testSameSite()
+    {
+        $cookie = new Cookie('foo', 'bar');
+        $this->assertNull($cookie->getSameSite());
+
+        $cookie = new Cookie('foo', 'bar', 0, '/', 'foo.com', false, true, false, 'lax');
+        $this->assertSame('lax', $cookie->getSameSite());
+    }
 }

--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -151,7 +151,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
         if (0 === strpos($dsn, 'redis://')) {
             return RedisAdapter::createConnection($dsn, $options);
         }
-        if (0 === strpos($dsn, 'memcached://')) {
+        if (0 === strpos($dsn, 'memcached:')) {
             return MemcachedAdapter::createConnection($dsn, $options);
         }
 

--- a/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
@@ -100,7 +100,7 @@ class ChainAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
             if ($adapter instanceof CacheInterface) {
                 $value = $adapter->get($key, $callback, $beta);
             } else {
-                $value = $this->doGet($adapter, $key, $callback, $beta ?? 1.0);
+                $value = $this->doGet($adapter, $key, $callback, $beta);
             }
             if (null !== $item) {
                 ($this->syncItem)($lastItem = $lastItem ?? $item, $item);

--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -93,7 +93,7 @@ class PhpArrayAdapter implements AdapterInterface, CacheInterface, PruneableInte
                 return $this->pool->get($key, $callback, $beta);
             }
 
-            return $this->doGet($this->pool, $key, $callback, $beta ?? 1.0);
+            return $this->doGet($this->pool, $key, $callback, $beta);
         }
         $value = $this->values[$this->keys[$key]];
 

--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -94,7 +94,7 @@ class ProxyAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
     public function get(string $key, callable $callback, float $beta = null)
     {
         if (!$this->pool instanceof CacheInterface) {
-            return $this->doGet($this, $key, $callback, $beta ?? 1.0);
+            return $this->doGet($this, $key, $callback, $beta);
         }
 
         return $this->pool->get($this->getId($key), function ($innerItem) use ($key, $callback) {

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.2.0
 -----
 
+ * added support for configuring multiple Memcached servers in one DSN
  * added `MarshallerInterface` and `DefaultMarshaller` to allow changing the serializer and provide one that automatically uses igbinary when available
  * added `CacheInterface`, which provides stampede protection via probabilistic early expiration and should become the preferred way to use a cache
  * added sub-second expiry accuracy for backends that support it

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -192,4 +192,46 @@ class MemcachedAdapterTest extends AdapterTestCase
             array(\Memcached::OPT_SOCKET_RECV_SIZE => 1, \Memcached::OPT_SOCKET_SEND_SIZE => 2, \Memcached::OPT_RETRY_TIMEOUT => 8),
         );
     }
+
+    public function testMultiServerDsn()
+    {
+        $dsn = 'memcached:?host[localhost]&host[localhost:12345]&host[/some/memcached.sock:]=3';
+        $client = MemcachedAdapter::createConnection($dsn);
+
+        $expected = array(
+            0 => array(
+                'host' => 'localhost',
+                'port' => 11211,
+                'type' => 'TCP',
+            ),
+            1 => array(
+                'host' => 'localhost',
+                'port' => 12345,
+                'type' => 'TCP',
+            ),
+            2 => array(
+                'host' => '/some/memcached.sock',
+                'port' => 0,
+                'type' => 'SOCKET',
+            ),
+        );
+        $this->assertSame($expected, $client->getServerList());
+
+        $dsn = 'memcached://localhost?host[foo.bar]=3';
+        $client = MemcachedAdapter::createConnection($dsn);
+
+        $expected = array(
+            0 => array(
+                'host' => 'localhost',
+                'port' => 11211,
+                'type' => 'TCP',
+            ),
+            1 => array(
+                'host' => 'foo.bar',
+                'port' => 11211,
+                'type' => 'TCP',
+            ),
+        );
+        $this->assertSame($expected, $client->getServerList());
+    }
 }

--- a/src/Symfony/Component/Cache/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractTrait.php
@@ -107,14 +107,7 @@ trait AbstractTrait
     {
         $this->deferred = array();
         if ($cleared = $this->versioningIsEnabled) {
-            $namespaceVersion = 2;
-            try {
-                foreach ($this->doFetch(array('/'.$this->namespace)) as $v) {
-                    $namespaceVersion = 1 + (int) $v;
-                }
-            } catch (\Exception $e) {
-            }
-            $namespaceVersion .= '/';
+            $namespaceVersion = substr_replace(base64_encode(pack('V', mt_rand())), ':', 5);
             try {
                 $cleared = $this->doSave(array('/'.$this->namespace => $namespaceVersion), 0);
             } catch (\Exception $e) {
@@ -253,6 +246,10 @@ trait AbstractTrait
             try {
                 foreach ($this->doFetch(array('/'.$this->namespace)) as $v) {
                     $this->namespaceVersion = $v;
+                }
+                if ('1:' === $this->namespaceVersion) {
+                    $this->namespaceVersion = substr_replace(base64_encode(pack('V', time())), ':', 5);
+                    $this->doSave(array('@'.$this->namespace => $this->namespaceVersion), 0);
                 }
             } catch (\Exception $e) {
             }

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -47,7 +47,7 @@ class XmlUtils
     public static function parse($content, $schemaOrCallable = null)
     {
         if (!\extension_loaded('dom')) {
-            throw new \RuntimeException('Extension DOM is required.');
+            throw new \LogicException('Extension DOM is required.');
         }
 
         $internalErrors = libxml_use_internal_errors(true);

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -159,6 +159,8 @@ class Application
             } else {
                 $exitCode = 1;
             }
+
+            return $exitCode;
         } finally {
             // if the exception handler changed, keep it
             // otherwise, unregister $renderException

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
    pass it the command as an array of its arguments instead
  * made the `ProcessHelper` class final
  * added `WrappableOutputFormatterInterface::formatAndWrap()` (implemented in `OutputFormatter`)
+ * added `capture_stderr_separately` option to `CommandTester::execute()`
 
 4.1.0
 -----

--- a/src/Symfony/Component/Console/Command/LockableTrait.php
+++ b/src/Symfony/Component/Console/Command/LockableTrait.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Console\Command;
 
 use Symfony\Component\Console\Exception\LogicException;
-use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\Store\FlockStore;
@@ -36,7 +35,7 @@ trait LockableTrait
     private function lock($name = null, $blocking = false)
     {
         if (!class_exists(SemaphoreStore::class)) {
-            throw new RuntimeException('To enable the locking feature you must install the symfony/lock component.');
+            throw new LogicException('To enable the locking feature you must install the symfony/lock component.');
         }
 
         if (null !== $this->lock) {

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Console\Tester;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * Eases the testing of console applications.
@@ -33,7 +31,6 @@ class ApplicationTester
     private $application;
     private $input;
     private $statusCode;
-    private $captureStreamsIndependently = false;
 
     public function __construct(Application $application)
     {
@@ -69,65 +66,12 @@ class ApplicationTester
             putenv('SHELL_INTERACTIVE=1');
         }
 
-        $this->captureStreamsIndependently = array_key_exists('capture_stderr_separately', $options) && $options['capture_stderr_separately'];
-        if (!$this->captureStreamsIndependently) {
-            $this->output = new StreamOutput(fopen('php://memory', 'w', false));
-            if (isset($options['decorated'])) {
-                $this->output->setDecorated($options['decorated']);
-            }
-            if (isset($options['verbosity'])) {
-                $this->output->setVerbosity($options['verbosity']);
-            }
-        } else {
-            $this->output = new ConsoleOutput(
-                isset($options['verbosity']) ? $options['verbosity'] : ConsoleOutput::VERBOSITY_NORMAL,
-                isset($options['decorated']) ? $options['decorated'] : null
-            );
-
-            $errorOutput = new StreamOutput(fopen('php://memory', 'w', false));
-            $errorOutput->setFormatter($this->output->getFormatter());
-            $errorOutput->setVerbosity($this->output->getVerbosity());
-            $errorOutput->setDecorated($this->output->isDecorated());
-
-            $reflectedOutput = new \ReflectionObject($this->output);
-            $strErrProperty = $reflectedOutput->getProperty('stderr');
-            $strErrProperty->setAccessible(true);
-            $strErrProperty->setValue($this->output, $errorOutput);
-
-            $reflectedParent = $reflectedOutput->getParentClass();
-            $streamProperty = $reflectedParent->getProperty('stream');
-            $streamProperty->setAccessible(true);
-            $streamProperty->setValue($this->output, fopen('php://memory', 'w', false));
-        }
+        $this->initOutput($options);
 
         $this->statusCode = $this->application->run($this->input, $this->output);
 
         putenv($shellInteractive ? "SHELL_INTERACTIVE=$shellInteractive" : 'SHELL_INTERACTIVE');
 
         return $this->statusCode;
-    }
-
-    /**
-     * Gets the output written to STDERR by the application.
-     *
-     * @param bool $normalize Whether to normalize end of lines to \n or not
-     *
-     * @return string
-     */
-    public function getErrorOutput($normalize = false)
-    {
-        if (!$this->captureStreamsIndependently) {
-            throw new \LogicException('The error output is not available when the tester is run without "capture_stderr_separately" option set.');
-        }
-
-        rewind($this->output->getErrorOutput()->getStream());
-
-        $display = stream_get_contents($this->output->getErrorOutput()->getStream());
-
-        if ($normalize) {
-            $display = str_replace(PHP_EOL, "\n", $display);
-        }
-
-        return $display;
     }
 }

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Console\Tester;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * Eases the testing of console commands.
@@ -39,9 +38,10 @@ class CommandTester
      *
      * Available execution options:
      *
-     *  * interactive: Sets the input interactive flag
-     *  * decorated:   Sets the output decorated flag
-     *  * verbosity:   Sets the output verbosity flag
+     *  * interactive:               Sets the input interactive flag
+     *  * decorated:                 Sets the output decorated flag
+     *  * verbosity:                 Sets the output verbosity flag
+     *  * capture_stderr_separately: Make output of stdOut and stdErr separately available
      *
      * @param array $input   An array of command arguments and options
      * @param array $options An array of execution options
@@ -68,11 +68,11 @@ class CommandTester
             $this->input->setInteractive($options['interactive']);
         }
 
-        $this->output = new StreamOutput(fopen('php://memory', 'w', false));
-        $this->output->setDecorated(isset($options['decorated']) ? $options['decorated'] : false);
-        if (isset($options['verbosity'])) {
-            $this->output->setVerbosity($options['verbosity']);
+        if (!isset($options['decorated'])) {
+            $options['decorated'] = false;
         }
+
+        $this->initOutput($options);
 
         return $this->statusCode = $this->command->run($this->input, $this->output);
     }

--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -12,19 +12,19 @@
 namespace Symfony\Component\Console\Tester;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
- *
- * @internal
  */
 trait TesterTrait
 {
     /** @var StreamOutput */
     private $output;
     private $inputs = array();
+    private $captureStreamsIndependently = false;
 
     /**
      * Gets the display returned by the last execution of the command or application.
@@ -38,6 +38,30 @@ trait TesterTrait
         rewind($this->output->getStream());
 
         $display = stream_get_contents($this->output->getStream());
+
+        if ($normalize) {
+            $display = str_replace(PHP_EOL, "\n", $display);
+        }
+
+        return $display;
+    }
+
+    /**
+     * Gets the output written to STDERR by the application.
+     *
+     * @param bool $normalize Whether to normalize end of lines to \n or not
+     *
+     * @return string
+     */
+    public function getErrorOutput($normalize = false)
+    {
+        if (!$this->captureStreamsIndependently) {
+            throw new \LogicException('The error output is not available when the tester is run without "capture_stderr_separately" option set.');
+        }
+
+        rewind($this->output->getErrorOutput()->getStream());
+
+        $display = stream_get_contents($this->output->getErrorOutput()->getStream());
 
         if ($normalize) {
             $display = str_replace(PHP_EOL, "\n", $display);
@@ -89,6 +113,49 @@ trait TesterTrait
         $this->inputs = $inputs;
 
         return $this;
+    }
+
+    /**
+     * Initializes the output property.
+     *
+     * Available options:
+     *
+     *  * decorated:                 Sets the output decorated flag
+     *  * verbosity:                 Sets the output verbosity flag
+     *  * capture_stderr_separately: Make output of stdOut and stdErr separately available
+     */
+    private function initOutput(array $options)
+    {
+        $this->captureStreamsIndependently = array_key_exists('capture_stderr_separately', $options) && $options['capture_stderr_separately'];
+        if (!$this->captureStreamsIndependently) {
+            $this->output = new StreamOutput(fopen('php://memory', 'w', false));
+            if (isset($options['decorated'])) {
+                $this->output->setDecorated($options['decorated']);
+            }
+            if (isset($options['verbosity'])) {
+                $this->output->setVerbosity($options['verbosity']);
+            }
+        } else {
+            $this->output = new ConsoleOutput(
+                isset($options['verbosity']) ? $options['verbosity'] : ConsoleOutput::VERBOSITY_NORMAL,
+                isset($options['decorated']) ? $options['decorated'] : null
+            );
+
+            $errorOutput = new StreamOutput(fopen('php://memory', 'w', false));
+            $errorOutput->setFormatter($this->output->getFormatter());
+            $errorOutput->setVerbosity($this->output->getVerbosity());
+            $errorOutput->setDecorated($this->output->isDecorated());
+
+            $reflectedOutput = new \ReflectionObject($this->output);
+            $strErrProperty = $reflectedOutput->getProperty('stderr');
+            $strErrProperty->setAccessible(true);
+            $strErrProperty->setValue($this->output, $errorOutput);
+
+            $reflectedParent = $reflectedOutput->getParentClass();
+            $streamProperty = $reflectedParent->getProperty('stream');
+            $streamProperty->setAccessible(true);
+            $streamProperty->setValue($this->output, fopen('php://memory', 'w', false));
+        }
     }
 
     private static function createStream(array $inputs)

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -985,6 +985,31 @@ class ApplicationTest extends TestCase
         $this->assertSame(4, $exitCode, '->run() returns integer exit code extracted from raised exception');
     }
 
+    public function testRunDispatchesIntegerExitCode()
+    {
+        $passedRightValue = false;
+
+        // We can assume here that some other test asserts that the event is dispatched at all
+        $dispatcher = new EventDispatcher();
+        $self = $this;
+        $dispatcher->addListener('console.terminate', function (ConsoleTerminateEvent $event) use ($self, &$passedRightValue) {
+            $passedRightValue = (4 === $event->getExitCode());
+        });
+
+        $application = new Application();
+        $application->setDispatcher($dispatcher);
+        $application->setAutoExit(false);
+
+        $application->register('test')->setCode(function (InputInterface $input, OutputInterface $output) {
+            throw new \Exception('', 4);
+        });
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'test'));
+
+        $this->assertTrue($passedRightValue, '-> exit code 4 was passed in the console.terminate event');
+    }
+
     public function testRunReturnsExitCodeOneForExceptionCodeZero()
     {
         $exception = new \Exception('', 0);
@@ -998,6 +1023,31 @@ class ApplicationTest extends TestCase
         $exitCode = $application->run(new ArrayInput(array()), new NullOutput());
 
         $this->assertSame(1, $exitCode, '->run() returns exit code 1 when exception code is 0');
+    }
+
+    public function testRunDispatchesExitCodeOneForExceptionCodeZero()
+    {
+        $passedRightValue = false;
+
+        // We can assume here that some other test asserts that the event is dispatched at all
+        $dispatcher = new EventDispatcher();
+        $self = $this;
+        $dispatcher->addListener('console.terminate', function (ConsoleTerminateEvent $event) use ($self, &$passedRightValue) {
+            $passedRightValue = (1 === $event->getExitCode());
+        });
+
+        $application = new Application();
+        $application->setDispatcher($dispatcher);
+        $application->setAutoExit(false);
+
+        $application->register('test')->setCode(function (InputInterface $input, OutputInterface $output) {
+            throw new \Exception();
+        });
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'test'));
+
+        $this->assertTrue($passedRightValue, '-> exit code 1 was passed in the console.terminate event');
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
@@ -90,4 +90,24 @@ class ApplicationTesterTest extends TestCase
     {
         $this->assertSame(0, $this->tester->getStatusCode(), '->getStatusCode() returns the status code');
     }
+
+    public function testErrorOutput()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->register('foo')
+            ->addArgument('foo')
+            ->setCode(function ($input, $output) {
+                $output->getErrorOutput()->write('foo');
+            })
+        ;
+
+        $tester = new ApplicationTester($application);
+        $tester->run(
+            array('command' => 'foo', 'foo' => 'bar'),
+            array('capture_stderr_separately' => true)
+        );
+
+        $this->assertSame('foo', $tester->getErrorOutput());
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -160,4 +160,23 @@ class CommandTesterTest extends TestCase
 
         $this->assertEquals(0, $tester->getStatusCode());
     }
+
+    public function testErrorOutput()
+    {
+        $command = new Command('foo');
+        $command->addArgument('command');
+        $command->addArgument('foo');
+        $command->setCode(function ($input, $output) {
+            $output->getErrorOutput()->write('foo');
+        }
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(
+            array('foo' => 'bar'),
+            array('capture_stderr_separately' => true)
+        );
+
+        $this->assertSame('foo', $tester->getErrorOutput());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\ExpressionLanguage;
 use Symfony\Component\DependencyInjection\Reference;
@@ -197,7 +198,7 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
     {
         if (null === $this->expressionLanguage) {
             if (!class_exists(ExpressionLanguage::class)) {
-                throw new RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+                throw new LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
 
             $providers = $this->container->getExpressionLanguageProviders();
@@ -208,7 +209,7 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
                     $arg = $this->processValue(new Reference($id));
                     $this->inExpression = false;
                     if (!$arg instanceof Reference) {
-                        throw new RuntimeException(sprintf('"%s::processValue()" must return a Reference when processing an expression, %s returned for service("%s").', \get_class($this), \is_object($arg) ? \get_class($arg) : \gettype($arg)));
+                        throw new RuntimeException(sprintf('"%s::processValue()" must return a Reference when processing an expression, %s returned for service("%s").', \get_class($this), \is_object($arg) ? \get_class($arg) : \gettype($arg), $id));
                     }
                     $arg = sprintf('"%s"', $arg);
                 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -53,8 +54,12 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
             $seenAliasTargets[$targetId] = true;
             try {
                 $definition = $container->getDefinition($targetId);
-            } catch (InvalidArgumentException $e) {
-                throw new InvalidArgumentException(sprintf('Unable to replace alias "%s" with actual definition "%s".', $definitionId, $targetId), null, $e);
+            } catch (ServiceNotFoundException $e) {
+                if ('' !== $e->getId() && '@' === $e->getId()[0]) {
+                    throw new ServiceNotFoundException($e->getId(), $e->getSourceId(), null, array(substr($e->getId(), 1)));
+                }
+
+                throw $e;
             }
             if ($definition->isPublic()) {
                 continue;

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1587,7 +1587,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     {
         if (null === $this->expressionLanguage) {
             if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
-                throw new RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+                throw new LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
             $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders);
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1692,7 +1692,7 @@ EOF;
     {
         if (null === $this->expressionLanguage) {
             if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
-                throw new RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+                throw new LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
             $providers = $this->container->getExpressionLanguageProviders();
             $this->expressionLanguage = new ExpressionLanguage(null, $providers, function ($arg) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
@@ -45,7 +46,7 @@ class YamlDumper extends Dumper
     public function dump(array $options = array())
     {
         if (!class_exists('Symfony\Component\Yaml\Dumper')) {
-            throw new RuntimeException('Unable to dump the container as the Symfony Yaml Component is not installed.');
+            throw new LogicException('Unable to dump the container as the Symfony Yaml Component is not installed.');
         }
 
         if (null === $this->dumper) {

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection;
 
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
@@ -180,7 +181,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
     private static function phpize($value)
     {
         if (!class_exists(XmlUtils::class)) {
-            throw new RuntimeException('The Symfony Config component is required to cast env vars to "bool", "int" or "float".');
+            throw new LogicException('The Symfony Config component is required to cast env vars to "bool", "int" or "float".');
         }
 
         return XmlUtils::phpize($value);

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
 * The `$currentUri` constructor argument of the `AbstractUriElement`, `Link` and
   `Image` classes is now optional.
 * The `Crawler::children()` method will have a new `$selector` argument in version 5.0, 
-  not defining it is deprecated since version 4.2.
+  not defining it is deprecated.
 
 3.1.0
 -----

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1166,7 +1166,7 @@ class Crawler implements \Countable, \IteratorAggregate
     private function createCssSelectorConverter(): CssSelectorConverter
     {
         if (!\class_exists(CssSelectorConverter::class)) {
-            throw new \RuntimeException('To filter with a CSS selector, install the CssSelector component ("composer require symfony/css-selector"). Or use filterXpath instead.');
+            throw new \LogicException('To filter with a CSS selector, install the CssSelector component ("composer require symfony/css-selector"). Or use filterXpath instead.');
         }
 
         return new CssSelectorConverter($this->isHtml);

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -50,6 +50,10 @@ class FilesystemTest extends FilesystemTestCase
             $this->markTestSkipped('This test cannot run on Windows.');
         }
 
+        if (!getenv('USER') || 'root' === getenv('USER')) {
+            $this->markTestSkipped('This test will fail if run under superuser');
+        }
+
         $sourceFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_source_file';
         $targetFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_target_file';
 
@@ -122,6 +126,10 @@ class FilesystemTest extends FilesystemTestCase
         // skip test on Windows; PHP can't easily set file as unwritable on Windows
         if ('\\' === \DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('This test cannot run on Windows.');
+        }
+
+        if (!getenv('USER') || 'root' === getenv('USER')) {
+            $this->markTestSkipped('This test will fail if run under superuser');
         }
 
         $sourceFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'copy_source_file';

--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -5,8 +5,8 @@ CHANGELOG
 -----
 
  * added $useNaturalSort option to Finder::sortByName() method
- * The `Finder::sortByName()` method will have a new `$useNaturalSort` 
-   argument in version 5.0, not defining it is deprecated since version 4.2.
+ * the `Finder::sortByName()` method will have a new `$useNaturalSort`
+   argument in version 5.0, not defining it is deprecated
 
 4.0.0
 -----

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,8 +4,11 @@ CHANGELOG
 4.2.0
 -----
 
+ * deprecated the `$scale` argument of the `IntegerToLocalizedStringTransformer`
  * added `Symfony\Component\Form\ClearableErrorsInterface`
  * deprecated calling `FormRenderer::searchAndRenderBlock` for fields which were already rendered
+ * added a cause when a CSRF error has occurred
+ * deprecated the `scale` option of the `IntegerType`
 
 4.1.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
@@ -22,12 +22,18 @@ class IntegerToLocalizedStringTransformer extends NumberToLocalizedStringTransfo
     /**
      * Constructs a transformer.
      *
-     * @param int  $scale        Unused
      * @param bool $grouping     Whether thousands should be grouped
      * @param int  $roundingMode One of the ROUND_ constants in this class
      */
-    public function __construct(?int $scale = 0, ?bool $grouping = false, int $roundingMode = self::ROUND_DOWN)
+    public function __construct($grouping = false, $roundingMode = self::ROUND_DOWN)
     {
+        if (\is_int($grouping) || \is_bool($roundingMode) || 2 < \func_num_args()) {
+            @trigger_error(sprintf('Passing a precision as the first value to %s::__construct() is deprecated since Symfony 4.2 and support for it will be dropped in 5.0.', __CLASS__), E_USER_DEPRECATED);
+
+            $grouping = $roundingMode;
+            $roundingMode = 2 < \func_num_args() ? func_get_arg(2) : self::ROUND_DOWN;
+        }
+
         parent::__construct(0, $grouping, $roundingMode);
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
+use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -41,6 +42,10 @@ class CountryType extends AbstractType implements ChoiceLoaderInterface
     {
         $resolver->setDefaults(array(
             'choice_loader' => function (Options $options) {
+                if (!class_exists(Intl::class)) {
+                    throw new LogicException(sprintf('The "symfony/intl" component is required to use "%s".', static::class));
+                }
+
                 $choiceTranslationLocale = $options['choice_translation_locale'];
 
                 return new IntlCallbackChoiceLoader(function () use ($choiceTranslationLocale) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
+use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -41,6 +42,10 @@ class CurrencyType extends AbstractType implements ChoiceLoaderInterface
     {
         $resolver->setDefaults(array(
             'choice_loader' => function (Options $options) {
+                if (!class_exists(Intl::class)) {
+                    throw new LogicException(sprintf('The "symfony/intl" component is required to use "%s".', static::class));
+                }
+
                 $choiceTranslationLocale = $options['choice_translation_locale'];
 
                 return new IntlCallbackChoiceLoader(function () use ($choiceTranslationLocale) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
@@ -23,12 +23,7 @@ class IntegerType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addViewTransformer(
-            new IntegerToLocalizedStringTransformer(
-                $options['scale'],
-                $options['grouping'],
-                $options['rounding_mode']
-        ));
+        $builder->addViewTransformer(new IntegerToLocalizedStringTransformer($options['grouping'], $options['rounding_mode']));
     }
 
     /**
@@ -37,8 +32,6 @@ class IntegerType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            // default scale is locale specific (usually around 3)
-            'scale' => null,
             'grouping' => false,
             // Integer cast rounds towards 0, so do the same when displaying fractions
             'rounding_mode' => IntegerToLocalizedStringTransformer::ROUND_DOWN,
@@ -55,7 +48,9 @@ class IntegerType extends AbstractType
             IntegerToLocalizedStringTransformer::ROUND_CEILING,
         ));
 
+        $resolver->setDefined('scale');
         $resolver->setAllowedTypes('scale', array('null', 'int'));
+        $resolver->setDeprecated('scale');
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
+use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -41,6 +42,10 @@ class LanguageType extends AbstractType implements ChoiceLoaderInterface
     {
         $resolver->setDefaults(array(
             'choice_loader' => function (Options $options) {
+                if (!class_exists(Intl::class)) {
+                    throw new LogicException(sprintf('The "symfony/intl" component is required to use "%s".', static::class));
+                }
+
                 $choiceTranslationLocale = $options['choice_translation_locale'];
 
                 return new IntlCallbackChoiceLoader(function () use ($choiceTranslationLocale) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
+use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -41,6 +42,10 @@ class LocaleType extends AbstractType implements ChoiceLoaderInterface
     {
         $resolver->setDefaults(array(
             'choice_loader' => function (Options $options) {
+                if (!class_exists(Intl::class)) {
+                    throw new LogicException(sprintf('The "symfony/intl" component is required to use "%s".', static::class));
+                }
+
                 $choiceTranslationLocale = $options['choice_translation_locale'];
 
                 return new IntlCallbackChoiceLoader(function () use ($choiceTranslationLocale) {

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -59,14 +59,15 @@ class CsrfValidationListener implements EventSubscriberInterface
         if ($form->isRoot() && $form->getConfig()->getOption('compound') && !$postRequestSizeExceeded) {
             $data = $event->getData();
 
-            if (!isset($data[$this->fieldName]) || !$this->tokenManager->isTokenValid(new CsrfToken($this->tokenId, $data[$this->fieldName]))) {
+            $csrfToken = new CsrfToken($this->tokenId, $data[$this->fieldName] ?? null);
+            if (!isset($data[$this->fieldName]) || !$this->tokenManager->isTokenValid($csrfToken)) {
                 $errorMessage = $this->errorMessage;
 
                 if (null !== $this->translator) {
                     $errorMessage = $this->translator->trans($errorMessage, array(), $this->translationDomain);
                 }
 
-                $form->addError(new FormError($errorMessage));
+                $form->addError(new FormError($errorMessage, $errorMessage, array(), null, $csrfToken));
             }
 
             if (\is_array($data)) {

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -137,7 +137,7 @@ class FormValidator extends ConstraintValidator
     /**
      * Returns the validation groups of the given form.
      *
-     * @return array The validation groups
+     * @return string|GroupSequence|(string|GroupSequence)[] The validation groups
      */
     private static function getValidationGroups(FormInterface $form)
     {
@@ -172,10 +172,10 @@ class FormValidator extends ConstraintValidator
     /**
      * Post-processes the validation groups option for a given form.
      *
-     * @param array|callable $groups The validation groups
-     * @param FormInterface  $form   The validated form
+     * @param string|GroupSequence|(string|GroupSequence)[]|callable $groups The validation groups
+     * @param FormInterface                                          $form   The validated form
      *
-     * @return array The validation groups
+     * @return (string|GroupSequence)[] The validation groups
      */
     private static function resolveValidationGroups($groups, FormInterface $form)
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -80,6 +80,18 @@ class IntegerToLocalizedStringTransformerTest extends TestCase
      */
     public function testTransformWithRounding($input, $output, $roundingMode)
     {
+        $transformer = new IntegerToLocalizedStringTransformer(null, $roundingMode);
+
+        $this->assertEquals($output, $transformer->transform($input));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a precision as the first value to %s::__construct() is deprecated since Symfony 4.2 and support for it will be dropped in 5.0.
+     * @dataProvider transformWithRoundingProvider
+     */
+    public function testTransformWithRoundingUsingLegacyConstructorSignature($input, $output, $roundingMode)
+    {
         $transformer = new IntegerToLocalizedStringTransformer(null, null, $roundingMode);
 
         $this->assertEquals($output, $transformer->transform($input));
@@ -108,6 +120,25 @@ class IntegerToLocalizedStringTransformerTest extends TestCase
     }
 
     public function testReverseTransformWithGrouping()
+    {
+        // Since we test against "de_DE", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_DE');
+
+        $transformer = new IntegerToLocalizedStringTransformer(true);
+
+        $this->assertEquals(1234, $transformer->reverseTransform('1.234,5'));
+        $this->assertEquals(12345, $transformer->reverseTransform('12.345,912'));
+        $this->assertEquals(1234, $transformer->reverseTransform('1234,5'));
+        $this->assertEquals(12345, $transformer->reverseTransform('12345,912'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a precision as the first value to %s::__construct() is deprecated since Symfony 4.2 and support for it will be dropped in 5.0.
+     */
+    public function testReverseTransformWithGroupingUsingLegacyConstructorSignature()
     {
         // Since we test against "de_DE", we need the full implementation
         IntlTestHelper::requireFullIntl($this, false);
@@ -177,6 +208,18 @@ class IntegerToLocalizedStringTransformerTest extends TestCase
      * @dataProvider reverseTransformWithRoundingProvider
      */
     public function testReverseTransformWithRounding($input, $output, $roundingMode)
+    {
+        $transformer = new IntegerToLocalizedStringTransformer(null, $roundingMode);
+
+        $this->assertEquals($output, $transformer->reverseTransform($input));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a precision as the first value to %s::__construct() is deprecated since Symfony 4.2 and support for it will be dropped in 5.0.
+     * @dataProvider reverseTransformWithRoundingProvider
+     */
+    public function testReverseTransformWithRoundingUsingLegacyConstructorSignature($input, $output, $roundingMode)
     {
         $transformer = new IntegerToLocalizedStringTransformer(null, null, $roundingMode);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -365,9 +365,10 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
 
     public function testsTranslateCustomErrorMessage()
     {
+        $csrfToken = new CsrfToken('TOKEN_ID', 'token');
         $this->tokenManager->expects($this->once())
             ->method('isTokenValid')
-            ->with(new CsrfToken('TOKEN_ID', 'token'))
+            ->with($csrfToken)
             ->will($this->returnValue(false));
 
         $this->translator->expects($this->once())
@@ -390,7 +391,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         ));
 
         $errors = $form->getErrors();
-        $expected = new FormError('[trans]Foobar[/trans]');
+        $expected = new FormError('[trans]Foobar[/trans]', null, array(), null, $csrfToken);
         $expected->setOrigin($form);
 
         $this->assertGreaterThan(0, \count($errors));

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -219,8 +219,8 @@ class BinaryFileResponse extends Response
                 // Do X-Accel-Mapping substitutions.
                 // @link http://wiki.nginx.org/X-accel#X-Accel-Redirect
                 $parts = HeaderUtils::split($request->headers->get('X-Accel-Mapping', ''), ',=');
-                $mappings = HeaderUtils::combine($parts);
-                foreach ($mappings as $pathPrefix => $location) {
+                foreach ($parts as $part) {
+                    list($pathPrefix, $location) = $part;
                     if (substr($path, 0, \strlen($pathPrefix)) === $pathPrefix) {
                         $path = $location.substr($path, \strlen($pathPrefix));
                         break;

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 -----
 
  * added `getAcceptableFormats()` for reading acceptable formats based on Accept header
+ * the default value of the "$secure" and "$samesite" arguments of Cookie's constructor
+   will respectively change from "false" to "null" and from "null" to "lax" in Symfony
+   5.0, you should define their values explicitly or use "Cookie::create()" instead.
 
 4.1.3
 -----

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1332,7 +1332,7 @@ class Request
      *  * _format request attribute
      *  * $default
      *
-     * @param string $default The default format
+     * @param string|null $default The default format
      *
      * @return string The request format
      */

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -313,6 +313,12 @@ class Response
 
         $this->ensureIEOverSSLCompatibility($request);
 
+        if ($request->isSecure()) {
+            foreach ($headers->getCookies() as $cookie) {
+                $cookie->setSecureDefault(true);
+            }
+        }
+
         return $this;
     }
 

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -247,7 +247,7 @@ class ResponseHeaderBag extends HeaderBag
      */
     public function clearCookie($name, $path = '/', $domain = null, $secure = false, $httpOnly = true)
     {
-        $this->setCookie(new Cookie($name, null, 1, $path, $domain, $secure, $httpOnly));
+        $this->setCookie(new Cookie($name, null, 1, $path, $domain, $secure, $httpOnly, false, null));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -128,7 +128,9 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
                 if (\PHP_VERSION_ID < 70300) {
                     setcookie($this->sessionName, '', 0, ini_get('session.cookie_path'), ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'));
                 } else {
-                    setcookie($this->sessionName, '', 0, ini_get('session.cookie_path'), ini_get('session.cookie_domain'), ini_get('session.cookie_secure'), ini_get('session.cookie_httponly'), ini_get('session.cookie_samesite'));
+                    $params = session_get_cookie_params();
+                    unset($params['lifetime']);
+                    setcookie($this->sessionName, '', $params);
                 }
             }
         }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -153,7 +153,7 @@ class NativeSessionStorage implements SessionStorageInterface
         if (null !== $this->emulateSameSite) {
             $originalCookie = SessionUtils::popSessionCookie(session_name(), session_id());
             if (null !== $originalCookie) {
-                header(sprintf('%s; SameSite=%s', $originalCookie, $this->emulateSameSite));
+                header(sprintf('%s; samesite=%s', $originalCookie, $this->emulateSameSite));
             }
         }
 
@@ -241,28 +241,21 @@ class NativeSessionStorage implements SessionStorageInterface
             unset($_SESSION[$key]);
         }
 
-        // Register custom error handler to catch a possible failure warning during session write
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, E_WARNING, $errfile, $errline);
-        }, E_WARNING);
+        // Register error handler to add information about the current save handler
+        $previousHandler = set_error_handler(function ($type, $msg, $file, $line) use (&$previousHandler) {
+            if (E_WARNING === $type && 0 === strpos($msg, 'session_write_close():')) {
+                $handler = $this->saveHandler instanceof SessionHandlerProxy ? $this->saveHandler->getHandler() : $this->saveHandler;
+                $msg = sprintf('session_write_close(): Failed to write session data with "%s" handler', \get_class($handler));
+            }
+
+            return $previousHandler ? $previousHandler($type, $msg, $file, $line) : false;
+        });
 
         try {
-            $e = null;
             session_write_close();
-        } catch (\ErrorException $e) {
         } finally {
             restore_error_handler();
             $_SESSION = $session;
-        }
-        if (null !== $e) {
-            // The default PHP error message is not very helpful, as it does not give any information on the current save handler.
-            // Therefore, we catch this error and trigger a warning with a better error message
-            $handler = $this->getSaveHandler();
-            if ($handler instanceof SessionHandlerProxy) {
-                $handler = $handler->getHandler();
-            }
-
-            trigger_error(sprintf('session_write_close(): Failed to write session data with %s handler', \get_class($handler)), E_USER_WARNING);
         }
 
         $this->closed = true;

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -337,7 +337,8 @@ class BinaryFileResponseTest extends ResponseTestCase
     {
         return array(
             array('/var/www/var/www/files/foo.txt', '/var/www/=/files/', '/files/var/www/files/foo.txt'),
-            array('/home/foo/bar.txt', '/var/www/=/files/,/home/foo/=/baz/', '/baz/bar.txt'),
+            array('/home/Foo/bar.txt', '/var/www/=/files/,/home/Foo/=/baz/', '/baz/bar.txt'),
+            array('/home/Foo/bar.txt', '"/var/www/"="/files/", "/home/Foo/"="/baz/"', '/baz/bar.txt'),
         );
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -45,7 +45,7 @@ class CookieTest extends TestCase
      */
     public function testInstantiationThrowsExceptionIfCookieNameContainsInvalidCharacters($name)
     {
-        new Cookie($name);
+        Cookie::create($name);
     }
 
     /**
@@ -53,12 +53,12 @@ class CookieTest extends TestCase
      */
     public function testInvalidExpiration()
     {
-        new Cookie('MyCookie', 'foo', 'bar');
+        Cookie::create('MyCookie', 'foo', 'bar');
     }
 
     public function testNegativeExpirationIsNotPossible()
     {
-        $cookie = new Cookie('foo', 'bar', -100);
+        $cookie = Cookie::create('foo', 'bar', -100);
 
         $this->assertSame(0, $cookie->getExpiresTime());
     }
@@ -66,32 +66,32 @@ class CookieTest extends TestCase
     public function testGetValue()
     {
         $value = 'MyValue';
-        $cookie = new Cookie('MyCookie', $value);
+        $cookie = Cookie::create('MyCookie', $value);
 
         $this->assertSame($value, $cookie->getValue(), '->getValue() returns the proper value');
     }
 
     public function testGetPath()
     {
-        $cookie = new Cookie('foo', 'bar');
+        $cookie = Cookie::create('foo', 'bar');
 
         $this->assertSame('/', $cookie->getPath(), '->getPath() returns / as the default path');
     }
 
     public function testGetExpiresTime()
     {
-        $cookie = new Cookie('foo', 'bar');
+        $cookie = Cookie::create('foo', 'bar');
 
         $this->assertEquals(0, $cookie->getExpiresTime(), '->getExpiresTime() returns the default expire date');
 
-        $cookie = new Cookie('foo', 'bar', $expire = time() + 3600);
+        $cookie = Cookie::create('foo', 'bar', $expire = time() + 3600);
 
         $this->assertEquals($expire, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
     }
 
     public function testGetExpiresTimeIsCastToInt()
     {
-        $cookie = new Cookie('foo', 'bar', 3600.9);
+        $cookie = Cookie::create('foo', 'bar', 3600.9);
 
         $this->assertSame(3600, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date as an integer');
     }
@@ -99,7 +99,7 @@ class CookieTest extends TestCase
     public function testConstructorWithDateTime()
     {
         $expire = new \DateTime();
-        $cookie = new Cookie('foo', 'bar', $expire);
+        $cookie = Cookie::create('foo', 'bar', $expire);
 
         $this->assertEquals($expire->format('U'), $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
     }
@@ -107,7 +107,7 @@ class CookieTest extends TestCase
     public function testConstructorWithDateTimeImmutable()
     {
         $expire = new \DateTimeImmutable();
-        $cookie = new Cookie('foo', 'bar', $expire);
+        $cookie = Cookie::create('foo', 'bar', $expire);
 
         $this->assertEquals($expire->format('U'), $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
     }
@@ -115,7 +115,7 @@ class CookieTest extends TestCase
     public function testGetExpiresTimeWithStringValue()
     {
         $value = '+1 day';
-        $cookie = new Cookie('foo', 'bar', $value);
+        $cookie = Cookie::create('foo', 'bar', $value);
         $expire = strtotime($value);
 
         $this->assertEquals($expire, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date', 1);
@@ -123,99 +123,99 @@ class CookieTest extends TestCase
 
     public function testGetDomain()
     {
-        $cookie = new Cookie('foo', 'bar', 0, '/', '.myfoodomain.com');
+        $cookie = Cookie::create('foo', 'bar', 0, '/', '.myfoodomain.com');
 
         $this->assertEquals('.myfoodomain.com', $cookie->getDomain(), '->getDomain() returns the domain name on which the cookie is valid');
     }
 
     public function testIsSecure()
     {
-        $cookie = new Cookie('foo', 'bar', 0, '/', '.myfoodomain.com', true);
+        $cookie = Cookie::create('foo', 'bar', 0, '/', '.myfoodomain.com', true);
 
         $this->assertTrue($cookie->isSecure(), '->isSecure() returns whether the cookie is transmitted over HTTPS');
     }
 
     public function testIsHttpOnly()
     {
-        $cookie = new Cookie('foo', 'bar', 0, '/', '.myfoodomain.com', false, true);
+        $cookie = Cookie::create('foo', 'bar', 0, '/', '.myfoodomain.com', false, true);
 
         $this->assertTrue($cookie->isHttpOnly(), '->isHttpOnly() returns whether the cookie is only transmitted over HTTP');
     }
 
     public function testCookieIsNotCleared()
     {
-        $cookie = new Cookie('foo', 'bar', time() + 3600 * 24);
+        $cookie = Cookie::create('foo', 'bar', time() + 3600 * 24);
 
         $this->assertFalse($cookie->isCleared(), '->isCleared() returns false if the cookie did not expire yet');
     }
 
     public function testCookieIsCleared()
     {
-        $cookie = new Cookie('foo', 'bar', time() - 20);
+        $cookie = Cookie::create('foo', 'bar', time() - 20);
 
         $this->assertTrue($cookie->isCleared(), '->isCleared() returns true if the cookie has expired');
 
-        $cookie = new Cookie('foo', 'bar');
+        $cookie = Cookie::create('foo', 'bar');
 
         $this->assertFalse($cookie->isCleared());
 
-        $cookie = new Cookie('foo', 'bar', 0);
+        $cookie = Cookie::create('foo', 'bar');
 
         $this->assertFalse($cookie->isCleared());
 
-        $cookie = new Cookie('foo', 'bar', -1);
+        $cookie = Cookie::create('foo', 'bar', -1);
 
         $this->assertFalse($cookie->isCleared());
     }
 
     public function testToString()
     {
-        $cookie = new Cookie('foo', 'bar', $expire = strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true);
+        $cookie = Cookie::create('foo', 'bar', $expire = strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true, true, false, null);
         $this->assertEquals('foo=bar; expires=Fri, 20-May-2011 15:25:52 GMT; Max-Age=0; path=/; domain=.myfoodomain.com; secure; httponly', (string) $cookie, '->__toString() returns string representation of the cookie');
 
-        $cookie = new Cookie('foo', 'bar with white spaces', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true);
+        $cookie = Cookie::create('foo', 'bar with white spaces', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true, true, false, null);
         $this->assertEquals('foo=bar%20with%20white%20spaces; expires=Fri, 20-May-2011 15:25:52 GMT; Max-Age=0; path=/; domain=.myfoodomain.com; secure; httponly', (string) $cookie, '->__toString() encodes the value of the cookie according to RFC 3986 (white space = %20)');
 
-        $cookie = new Cookie('foo', null, 1, '/admin/', '.myfoodomain.com');
+        $cookie = Cookie::create('foo', null, 1, '/admin/', '.myfoodomain.com', false, true, false, null);
         $this->assertEquals('foo=deleted; expires='.gmdate('D, d-M-Y H:i:s T', $expire = time() - 31536001).'; Max-Age=0; path=/admin/; domain=.myfoodomain.com; httponly', (string) $cookie, '->__toString() returns string representation of a cleared cookie if value is NULL');
 
-        $cookie = new Cookie('foo', 'bar', 0, '/', '');
-        $this->assertEquals('foo=bar; path=/; httponly', (string) $cookie);
+        $cookie = Cookie::create('foo', 'bar');
+        $this->assertEquals('foo=bar; path=/; httponly; samesite=lax', (string) $cookie);
     }
 
     public function testRawCookie()
     {
-        $cookie = new Cookie('foo', 'b a r', 0, '/', null, false, false);
+        $cookie = Cookie::create('foo', 'b a r', 0, '/', null, false, false, false, null);
         $this->assertFalse($cookie->isRaw());
         $this->assertEquals('foo=b%20a%20r; path=/', (string) $cookie);
 
-        $cookie = new Cookie('foo', 'b+a+r', 0, '/', null, false, false, true);
+        $cookie = Cookie::create('foo', 'b+a+r', 0, '/', null, false, false, true, null);
         $this->assertTrue($cookie->isRaw());
         $this->assertEquals('foo=b+a+r; path=/', (string) $cookie);
     }
 
     public function testGetMaxAge()
     {
-        $cookie = new Cookie('foo', 'bar');
+        $cookie = Cookie::create('foo', 'bar');
         $this->assertEquals(0, $cookie->getMaxAge());
 
-        $cookie = new Cookie('foo', 'bar', $expire = time() + 100);
+        $cookie = Cookie::create('foo', 'bar', $expire = time() + 100);
         $this->assertEquals($expire - time(), $cookie->getMaxAge());
 
-        $cookie = new Cookie('foo', 'bar', $expire = time() - 100);
+        $cookie = Cookie::create('foo', 'bar', $expire = time() - 100);
         $this->assertEquals(0, $cookie->getMaxAge());
     }
 
     public function testFromString()
     {
         $cookie = Cookie::fromString('foo=bar; expires=Fri, 20-May-2011 15:25:52 GMT; path=/; domain=.myfoodomain.com; secure; httponly');
-        $this->assertEquals(new Cookie('foo', 'bar', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true, true, true), $cookie);
+        $this->assertEquals(Cookie::create('foo', 'bar', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true, true, true, null), $cookie);
 
         $cookie = Cookie::fromString('foo=bar', true);
-        $this->assertEquals(new Cookie('foo', 'bar', 0, '/', null, false, false), $cookie);
+        $this->assertEquals(Cookie::create('foo', 'bar', 0, '/', null, false, false, false, null), $cookie);
 
         $cookie = Cookie::fromString('foo', true);
-        $this->assertEquals(new Cookie('foo', null, 0, '/', null, false, false), $cookie);
+        $this->assertEquals(Cookie::create('foo', null, 0, '/', null, false, false, false, null), $cookie);
     }
 
     public function testFromStringWithHttpOnly()
@@ -227,9 +227,27 @@ class CookieTest extends TestCase
         $this->assertFalse($cookie->isHttpOnly());
     }
 
-    public function testSameSiteAttributeIsCaseInsensitive()
+    public function testSameSiteAttribute()
     {
         $cookie = new Cookie('foo', 'bar', 0, '/', null, false, true, false, 'Lax');
         $this->assertEquals('lax', $cookie->getSameSite());
+
+        $cookie = new Cookie('foo', 'bar', 0, '/', null, false, true, false, '');
+        $this->assertNull($cookie->getSameSite());
+    }
+
+    public function testSetSecureDefault()
+    {
+        $cookie = Cookie::create('foo', 'bar');
+
+        $this->assertFalse($cookie->isSecure());
+
+        $cookie->setSecureDefault(true);
+
+        $this->assertTrue($cookie->isSecure());
+
+        $cookie->setSecureDefault(false);
+
+        $this->assertFalse($cookie->isSecure());
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.php
@@ -4,7 +4,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 
 $r = require __DIR__.'/common.inc';
 
-$r->headers->setCookie(new Cookie('foo', 'bar', 253402310800, '', null, false, false));
+$r->headers->setCookie(new Cookie('foo', 'bar', 253402310800, '', null, false, false, false, null));
 $r->sendHeaders();
 
 setcookie('foo2', 'bar', 253402310800, '/');

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_raw_urlencode.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_raw_urlencode.php
@@ -6,7 +6,7 @@ $r = require __DIR__.'/common.inc';
 
 $str = '?*():@&+$/%#[]';
 
-$r->headers->setCookie(new Cookie($str, $str, 0, '/', null, false, false, true));
+$r->headers->setCookie(new Cookie($str, $str, 0, '/', null, false, false, true, null));
 $r->sendHeaders();
 
 setrawcookie($str, $str, 0, '/', null, false, false);

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_urlencode.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_urlencode.php
@@ -6,7 +6,7 @@ $r = require __DIR__.'/common.inc';
 
 $str = '?*():@&+$/%#[]';
 
-$r->headers->setCookie(new Cookie($str, $str, 0, '', null, false, false));
+$r->headers->setCookie(new Cookie($str, $str, 0, '', null, false, false, false, null));
 $r->sendHeaders();
 
 setcookie($str, $str, 0, '/');

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/invalid_cookie_name.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/invalid_cookie_name.php
@@ -5,7 +5,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 $r = require __DIR__.'/common.inc';
 
 try {
-    $r->headers->setCookie(new Cookie('Hello + world', 'hodor'));
+    $r->headers->setCookie(Cookie::create('Hello + world', 'hodor'));
 } catch (\InvalidArgumentException $e) {
     echo $e->getMessage();
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -110,9 +110,9 @@ class ResponseHeaderBagTest extends TestCase
     public function testToStringIncludesCookieHeaders()
     {
         $bag = new ResponseHeaderBag(array());
-        $bag->setCookie(new Cookie('foo', 'bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar'));
 
-        $this->assertSetCookieHeader('foo=bar; path=/; httponly', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/; httponly; samesite=lax', $bag);
 
         $bag->clearCookie('foo');
 
@@ -154,24 +154,24 @@ class ResponseHeaderBagTest extends TestCase
     public function testCookiesWithSameNames()
     {
         $bag = new ResponseHeaderBag();
-        $bag->setCookie(new Cookie('foo', 'bar', 0, '/path/foo', 'foo.bar'));
-        $bag->setCookie(new Cookie('foo', 'bar', 0, '/path/bar', 'foo.bar'));
-        $bag->setCookie(new Cookie('foo', 'bar', 0, '/path/bar', 'bar.foo'));
-        $bag->setCookie(new Cookie('foo', 'bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar', 0, '/path/foo', 'foo.bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar', 0, '/path/bar', 'foo.bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar', 0, '/path/bar', 'bar.foo'));
+        $bag->setCookie(Cookie::create('foo', 'bar'));
 
         $this->assertCount(4, $bag->getCookies());
-        $this->assertEquals('foo=bar; path=/path/foo; domain=foo.bar; httponly', $bag->get('set-cookie'));
+        $this->assertEquals('foo=bar; path=/path/foo; domain=foo.bar; httponly; samesite=lax', $bag->get('set-cookie'));
         $this->assertEquals(array(
-            'foo=bar; path=/path/foo; domain=foo.bar; httponly',
-            'foo=bar; path=/path/bar; domain=foo.bar; httponly',
-            'foo=bar; path=/path/bar; domain=bar.foo; httponly',
-            'foo=bar; path=/; httponly',
+            'foo=bar; path=/path/foo; domain=foo.bar; httponly; samesite=lax',
+            'foo=bar; path=/path/bar; domain=foo.bar; httponly; samesite=lax',
+            'foo=bar; path=/path/bar; domain=bar.foo; httponly; samesite=lax',
+            'foo=bar; path=/; httponly; samesite=lax',
         ), $bag->get('set-cookie', null, false));
 
-        $this->assertSetCookieHeader('foo=bar; path=/path/foo; domain=foo.bar; httponly', $bag);
-        $this->assertSetCookieHeader('foo=bar; path=/path/bar; domain=foo.bar; httponly', $bag);
-        $this->assertSetCookieHeader('foo=bar; path=/path/bar; domain=bar.foo; httponly', $bag);
-        $this->assertSetCookieHeader('foo=bar; path=/; httponly', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/path/foo; domain=foo.bar; httponly; samesite=lax', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/path/bar; domain=foo.bar; httponly; samesite=lax', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/path/bar; domain=bar.foo; httponly; samesite=lax', $bag);
+        $this->assertSetCookieHeader('foo=bar; path=/; httponly; samesite=lax', $bag);
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
 
@@ -186,8 +186,8 @@ class ResponseHeaderBagTest extends TestCase
         $bag = new ResponseHeaderBag();
         $this->assertFalse($bag->has('set-cookie'));
 
-        $bag->setCookie(new Cookie('foo', 'bar', 0, '/path/foo', 'foo.bar'));
-        $bag->setCookie(new Cookie('bar', 'foo', 0, '/path/bar', 'foo.bar'));
+        $bag->setCookie(Cookie::create('foo', 'bar', 0, '/path/foo', 'foo.bar'));
+        $bag->setCookie(Cookie::create('bar', 'foo', 0, '/path/bar', 'foo.bar'));
         $this->assertTrue($bag->has('set-cookie'));
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
@@ -209,8 +209,8 @@ class ResponseHeaderBagTest extends TestCase
     public function testRemoveCookieWithNullRemove()
     {
         $bag = new ResponseHeaderBag();
-        $bag->setCookie(new Cookie('foo', 'bar', 0));
-        $bag->setCookie(new Cookie('bar', 'foo', 0));
+        $bag->setCookie(Cookie::create('foo', 'bar'));
+        $bag->setCookie(Cookie::create('bar', 'foo'));
 
         $cookies = $bag->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
         $this->assertArrayHasKey('/', $cookies['']);
@@ -228,12 +228,12 @@ class ResponseHeaderBagTest extends TestCase
     {
         $bag = new ResponseHeaderBag();
         $bag->set('set-cookie', 'foo=bar');
-        $this->assertEquals(array(new Cookie('foo', 'bar', 0, '/', null, false, false, true)), $bag->getCookies());
+        $this->assertEquals(array(Cookie::create('foo', 'bar', 0, '/', null, false, false, true, null)), $bag->getCookies());
 
         $bag->set('set-cookie', 'foo2=bar2', false);
         $this->assertEquals(array(
-            new Cookie('foo', 'bar', 0, '/', null, false, false, true),
-            new Cookie('foo2', 'bar2', 0, '/', null, false, false, true),
+            Cookie::create('foo', 'bar', 0, '/', null, false, false, true, null),
+            Cookie::create('foo2', 'bar2', 0, '/', null, false, false, true, null),
         ), $bag->getCookies());
 
         $bag->remove('set-cookie');

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -571,6 +572,24 @@ class ResponseTest extends ResponseTestCase
         $response->prepare($request);
         $this->assertFalse($response->headers->has('pragma'));
         $this->assertFalse($response->headers->has('expires'));
+    }
+
+    public function testPrepareSetsCookiesSecure()
+    {
+        $cookie = Cookie::create('foo', 'bar');
+
+        $response = new Response('foo');
+        $response->headers->setCookie($cookie);
+
+        $request = Request::create('/', 'GET');
+        $response->prepare($request);
+
+        $this->assertFalse($cookie->isSecure());
+
+        $request = Request::create('https://localhost/', 'GET');
+        $response->prepare($request);
+
+        $this->assertTrue($cookie->isSecure());
     }
 
     public function testSetCache()

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/with_samesite.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/with_samesite.expected
@@ -11,6 +11,6 @@ Array
 (
     [0] => Content-Type: text/plain; charset=utf-8
     [1] => Cache-Control: max-age=0, private, must-revalidate
-    [2] => Set-Cookie: sid=random_session_id; path=/; secure; HttpOnly; SameSite=lax
+    [2] => Set-Cookie: sid=random_session_id; path=/; secure; HttpOnly; samesite=lax
 )
 shutdown

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -165,7 +165,8 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                     'controller' => $this->parseController($request->attributes->get('_controller')),
                     'status_code' => $statusCode,
                     'status_text' => Response::$statusTexts[(int) $statusCode],
-                ))
+                )),
+                0, '/', null, $request->isSecure(), true, false, 'lax'
             ));
         }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
@@ -24,9 +24,10 @@ class TestSessionListener extends AbstractTestSessionListener
 {
     private $container;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, array $sessionOptions = array())
     {
         $this->container = $container;
+        parent::__construct($sessionOptions);
     }
 
     protected function getSession()

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -125,6 +125,13 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         }
         $setSession($subRequest, $request);
 
+        if ($request->get('_format')) {
+            $subRequest->attributes->set('_format', $request->get('_format'));
+        }
+        if ($request->getDefaultLocale() !== $request->getLocale()) {
+            $subRequest->setLocale($request->getLocale());
+        }
+
         return $subRequest;
     }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
@@ -14,6 +14,14 @@ namespace Symfony\Component\HttpKernel\Profiler;
 /**
  * ProfilerStorageInterface.
  *
+ * This interface exists for historical reasons. The only supported
+ * implementation is FileProfilerStorage.
+ *
+ * As the profiler must only be used on non-production servers, the file storage
+ * is more than enough and no other implementations will ever be supported.
+ *
+ * @internal since 4.2
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 interface ProfilerStorageInterface

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -61,13 +61,13 @@ class ClientTest extends TestCase
         $m->setAccessible(true);
 
         $response = new Response();
-        $response->headers->setCookie($cookie1 = new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true));
+        $response->headers->setCookie($cookie1 = new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true, false, null));
         $domResponse = $m->invoke($client, $response);
         $this->assertSame((string) $cookie1, $domResponse->getHeader('Set-Cookie'));
 
         $response = new Response();
-        $response->headers->setCookie($cookie1 = new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true));
-        $response->headers->setCookie($cookie2 = new Cookie('foo1', 'bar1', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true));
+        $response->headers->setCookie($cookie1 = new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true, false, null));
+        $response->headers->setCookie($cookie2 = new Cookie('foo1', 'bar1', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true, false, null));
         $domResponse = $m->invoke($client, $response);
         $this->assertSame((string) $cookie1, $domResponse->getHeader('Set-Cookie'));
         $this->assertSame(array((string) $cookie1, (string) $cookie2), $domResponse->getHeader('Set-Cookie', false));

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -225,6 +225,8 @@ class RequestDataCollectorTest extends TestCase
         $cookie = $this->getCookieByName($response, 'sf_redirect');
 
         $this->assertNotEmpty($cookie->getValue());
+        $this->assertSame('lax', $cookie->getSameSite());
+        $this->assertFalse($cookie->isSecure());
     }
 
     public function testItCollectsTheRedirectionAndClearTheCookie()
@@ -274,9 +276,9 @@ class RequestDataCollectorTest extends TestCase
         $response->setStatusCode(200);
         $response->headers->set('Content-Type', 'application/json');
         $response->headers->set('X-Foo-Bar', null);
-        $response->headers->setCookie(new Cookie('foo', 'bar', 1, '/foo', 'localhost', true, true));
-        $response->headers->setCookie(new Cookie('bar', 'foo', new \DateTime('@946684800')));
-        $response->headers->setCookie(new Cookie('bazz', 'foo', '2000-12-12'));
+        $response->headers->setCookie(new Cookie('foo', 'bar', 1, '/foo', 'localhost', true, true, false, null));
+        $response->headers->setCookie(new Cookie('bar', 'foo', new \DateTime('@946684800'), '/', null, false, true, false, null));
+        $response->headers->setCookie(new Cookie('bazz', 'foo', '2000-12-12', '/', null, false, true, false, null));
 
         return $response;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -145,6 +145,26 @@ class InlineFragmentRendererTest extends TestCase
         $this->assertEquals('Foo', ob_get_clean());
     }
 
+    public function testLocaleAndFormatAreIsKeptInSubrequest()
+    {
+        $expectedSubRequest = Request::create('/');
+        $expectedSubRequest->attributes->set('_format', 'foo');
+        $expectedSubRequest->setLocale('fr');
+        if (Request::HEADER_X_FORWARDED_FOR & Request::getTrustedHeaderSet()) {
+            $expectedSubRequest->headers->set('x-forwarded-for', array('127.0.0.1'));
+            $expectedSubRequest->server->set('HTTP_X_FORWARDED_FOR', '127.0.0.1');
+        }
+        $expectedSubRequest->headers->set('forwarded', array('for="127.0.0.1";host="localhost";proto=http'));
+        $expectedSubRequest->server->set('HTTP_FORWARDED', 'for="127.0.0.1";host="localhost";proto=http');
+
+        $strategy = new InlineFragmentRenderer($this->getKernelExpectingRequest($expectedSubRequest));
+
+        $request = Request::create('/');
+        $request->attributes->set('_format', 'foo');
+        $request->setLocale('fr');
+        $strategy->render('/', $request);
+    }
+
     public function testESIHeaderIsKeptInSubrequest()
     {
         $expectedSubRequest = Request::create('/');

--- a/src/Symfony/Component/Messenger/Exception/LogicException.php
+++ b/src/Symfony/Component/Messenger/Exception/LogicException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Messenger\Transport\Serialization;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
-use Symfony\Component\Messenger\Exception\RuntimeException;
+use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -39,7 +39,7 @@ class Serializer implements SerializerInterface
     public static function create(): self
     {
         if (!class_exists(SymfonySerializer::class)) {
-            throw new RuntimeException(sprintf('The default Messenger Serializer requires Symfony\'s Serializer component. Try running "composer require symfony/serializer".'));
+            throw new LogicException(sprintf('The default Messenger Serializer requires Symfony\'s Serializer component. Try running "composer require symfony/serializer".'));
         }
 
         $encoders = array(new XmlEncoder(), new JsonEncoder());

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -140,7 +140,7 @@ class Process implements \IteratorAggregate
     public function __construct($command, string $cwd = null, array $env = null, $input = null, ?float $timeout = 60)
     {
         if (!\function_exists('proc_open')) {
-            throw new RuntimeException('The Process class relies on proc_open, which is not available on your PHP installation.');
+            throw new LogicException('The Process class relies on proc_open, which is not available on your PHP installation.');
         }
 
         if (!\is_array($command)) {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -788,7 +788,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     public static function createCache($namespace, $defaultLifetime, $version, LoggerInterface $logger = null)
     {
         if (!class_exists('Symfony\Component\Cache\Adapter\ApcuAdapter')) {
-            throw new \RuntimeException(sprintf('The Symfony Cache component must be installed to use %s().', __METHOD__));
+            throw new \LogicException(sprintf('The Symfony Cache component must be installed to use %s().', __METHOD__));
         }
 
         if (!ApcuAdapter::isSupported()) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -54,7 +54,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     public function __construct(DocBlockFactoryInterface $docBlockFactory = null, array $mutatorPrefixes = null, array $accessorPrefixes = null, array $arrayMutatorPrefixes = null)
     {
         if (!class_exists(DocBlockFactory::class)) {
-            throw new \RuntimeException(sprintf('Unable to use the "%s" class as the "phpdocumentor/reflection-docblock" package is not installed.', __CLASS__));
+            throw new \LogicException(sprintf('Unable to use the "%s" class as the "phpdocumentor/reflection-docblock" package is not installed.', __CLASS__));
         }
 
         $this->docBlockFactory = $docBlockFactory ?: DocBlockFactory::createInstance();

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -32,7 +32,7 @@ class AnnotationFileLoader extends FileLoader
     public function __construct(FileLocatorInterface $locator, AnnotationClassLoader $loader)
     {
         if (!\function_exists('token_get_all')) {
-            throw new \RuntimeException('The Tokenizer extension is required for the routing annotation loaders.');
+            throw new \LogicException('The Tokenizer extension is required for the routing annotation loaders.');
         }
 
         parent::__construct($locator);

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -724,7 +724,7 @@ EOF;
     {
         if (null === $this->expressionLanguage) {
             if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
-                throw new \RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+                throw new \LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
             $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders);
         }

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -246,7 +246,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
     {
         if (null === $this->expressionLanguage) {
             if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
-                throw new \RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+                throw new \LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
             $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders);
         }

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -101,6 +101,13 @@ class HttpUtils
             $newRequest->attributes->set(Security::LAST_USERNAME, $request->attributes->get(Security::LAST_USERNAME));
         }
 
+        if ($request->get('_format')) {
+            $newRequest->attributes->set('_format', $request->get('_format'));
+        }
+        if ($request->getDefaultLocale() !== $request->getLocale()) {
+            $newRequest->setLocale($request->getLocale());
+        }
+
         return $newRequest;
     }
 

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -271,7 +271,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             $this->logger->debug('Clearing remember-me cookie.', array('name' => $this->options['name']));
         }
 
-        $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie($this->options['name'], null, 1, $this->options['path'], $this->options['domain'], $this->options['secure'], $this->options['httponly'], false, $this->options['samesite'] ?? null));
+        $request->attributes->set(self::COOKIE_ATTR_NAME, new Cookie($this->options['name'], null, 1, $this->options['path'], $this->options['domain'], $this->options['secure'] ?? $request->isSecure(), $this->options['httponly'], false, $this->options['samesite'] ?? null));
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
@@ -83,7 +83,7 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
                 time() + $this->options['lifetime'],
                 $this->options['path'],
                 $this->options['domain'],
-                $this->options['secure'],
+                $this->options['secure'] ?? $request->isSecure(),
                 $this->options['httponly'],
                 false,
                 $this->options['samesite'] ?? null
@@ -118,7 +118,7 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
                 time() + $this->options['lifetime'],
                 $this->options['path'],
                 $this->options['domain'],
-                $this->options['secure'],
+                $this->options['secure'] ?? $request->isSecure(),
                 $this->options['httponly'],
                 false,
                 $this->options['samesite'] ?? null

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -80,7 +80,7 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
                 $expires,
                 $this->options['path'],
                 $this->options['domain'],
-                $this->options['secure'],
+                $this->options['secure'] ?? $request->isSecure(),
                 $this->options['httponly'],
                 false,
                 $this->options['samesite'] ?? null

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
@@ -24,7 +24,7 @@ class ResponseListenerTest extends TestCase
 {
     public function testRememberMeCookieIsSentWithResponse()
     {
-        $cookie = new Cookie('rememberme');
+        $cookie = new Cookie('rememberme', null, 0, '/', null, false, true, false, null);
 
         $request = $this->getRequest(array(
             RememberMeServicesInterface::COOKIE_ATTR_NAME => $cookie,
@@ -39,7 +39,7 @@ class ResponseListenerTest extends TestCase
 
     public function testRememberMeCookieIsNotSendWithResponseForSubRequests()
     {
-        $cookie = new Cookie('rememberme');
+        $cookie = new Cookie('rememberme', null, 0, '/', null, false, true, false, null);
 
         $request = $this->getRequest(array(
             RememberMeServicesInterface::COOKIE_ATTR_NAME => $cookie,

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -13,6 +13,12 @@ CHANGELOG
    the format and the context in a name converter
  * the `AbstractNormalizer::handleCircularReference()` method will have two new `$format`
    and `$context` arguments in version 5.0, not defining them is deprecated
+ * deprecated creating a `Serializer` with normalizers which do not implement
+   either `NormalizerInterface` or `DenormalizerInterface`
+ * deprecated creating a `Serializer` with normalizers which do not implement
+   either `NormalizerInterface` or `DenormalizerInterface`
+ * deprecated creating a `Serializer` with encoders which do not implement
+   either `EncoderInterface` or `DecoderInterface`
 
 4.1.0
 -----

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
-use Symfony\Component\Serializer\Exception\RuntimeException;
+use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -33,7 +33,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
     public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyAccessorInterface $propertyAccessor = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null)
     {
         if (!\class_exists(PropertyAccess::class)) {
-            throw new RuntimeException('The ObjectNormalizer class requires the "PropertyAccess" component. Install "symfony/property-access" to use it.');
+            throw new LogicException('The ObjectNormalizer class requires the "PropertyAccess" component. Install "symfony/property-access" to use it.');
         }
 
         parent::__construct($classMetadataFactory, $nameConverter, $propertyTypeExtractor, $classDiscriminatorResolver);

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -64,6 +64,10 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
     private $denormalizerCache = array();
     private $normalizerCache = array();
 
+    /**
+     * @param (NormalizerInterface|DenormalizerInterface)[] $normalizers
+     * @param (EncoderInterface|DecoderInterface)[]         $encoders
+     */
     public function __construct(array $normalizers = array(), array $encoders = array())
     {
         foreach ($normalizers as $normalizer) {
@@ -77,6 +81,11 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
 
             if ($normalizer instanceof NormalizerAwareInterface) {
                 $normalizer->setNormalizer($this);
+            }
+
+            if (!($normalizer instanceof NormalizerInterface || $normalizer instanceof DenormalizerInterface)) {
+                @trigger_error(\sprintf('Passing normalizers ("%s") which do not implement either "%s" or "%s" has been deprecated since Symfony 4.2.', \get_class($normalizer), NormalizerInterface::class, DenormalizerInterface::class), E_USER_DEPRECATED);
+                // throw new \InvalidArgumentException(\sprintf('The class "%s" does not implement "%s" or "%s".', \get_class($normalizer), NormalizerInterface::class, DenormalizerInterface::class));
             }
         }
         $this->normalizers = $normalizers;
@@ -92,6 +101,11 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             }
             if ($encoder instanceof EncoderInterface) {
                 $realEncoders[] = $encoder;
+            }
+
+            if (!($encoder instanceof EncoderInterface || $encoder instanceof DecoderInterface)) {
+                @trigger_error(\sprintf('Passing encoders ("%s") which do not implement either "%s" or "%s" has been deprecated since Symfony 4.2.', \get_class($encoder), EncoderInterface::class, DecoderInterface::class), E_USER_DEPRECATED);
+                // throw new \InvalidArgumentException(\sprintf('The class "%s" does not implement "%s" or "%s".', \get_class($normalizer), EncoderInterface::class, DecoderInterface::class));
             }
         }
         $this->encoder = new ChainEncoder($realEncoders);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -56,6 +56,24 @@ class SerializerTest extends TestCase
     }
 
     /**
+     * @expectedDeprecation Passing normalizers ("stdClass") which do not implement either "Symfony\Component\Serializer\Normalizer\NormalizerInterface" or "Symfony\Component\Serializer\Normalizer\DenormalizerInterface" has been deprecated since Symfony 4.2.
+     * @group legacy
+     */
+    public function testDeprecationErrorOnInvalidNormalizer()
+    {
+        new Serializer(array(new \stdClass()));
+    }
+
+    /**
+     * @expectedDeprecation Passing encoders ("stdClass") which do not implement either "Symfony\Component\Serializer\Encoder\EncoderInterface" or "Symfony\Component\Serializer\Encoder\DecoderInterface" has been deprecated since Symfony 4.2.
+     * @group legacy
+     */
+    public function testDeprecationErrorOnInvalidEncoder()
+    {
+        new Serializer(array(), array(new \stdClass()));
+    }
+
+    /**
      * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
      */
     public function testNormalizeNoMatch()
@@ -334,7 +352,7 @@ class SerializerTest extends TestCase
 
     public function testNormalizerAware()
     {
-        $normalizerAware = $this->getMockBuilder(NormalizerAwareInterface::class)->getMock();
+        $normalizerAware = $this->getMockBuilder(array(NormalizerAwareInterface::class, NormalizerInterface::class))->getMock();
         $normalizerAware->expects($this->once())
             ->method('setNormalizer')
             ->with($this->isInstanceOf(NormalizerInterface::class));
@@ -344,7 +362,7 @@ class SerializerTest extends TestCase
 
     public function testDenormalizerAware()
     {
-        $denormalizerAware = $this->getMockBuilder(DenormalizerAwareInterface::class)->getMock();
+        $denormalizerAware = $this->getMockBuilder(array(DenormalizerAwareInterface::class, DenormalizerInterface::class))->getMock();
         $denormalizerAware->expects($this->once())
             ->method('setDenormalizer')
             ->with($this->isInstanceOf(DenormalizerInterface::class));

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * made `ValidatorBuilder` final
  * marked `format` the default option in `DateTime` constraint
  * deprecated validating instances of `\DateTimeInterface` in `DateTimeValidator`, `DateValidator` and `TimeValidator`.
+ * deprecated using the `Bic` constraint without `symfony/intl`
 
 4.1.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Intl\Intl;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\LogicException;
 
 /**
  * @Annotation
@@ -36,4 +38,14 @@ class Bic extends Constraint
     );
 
     public $message = 'This is not a valid Business Identifier Code (BIC).';
+
+    public function __construct($options = null)
+    {
+        if (!class_exists(Intl::class)) {
+            // throw new LogicException(sprintf('The "symfony/intl" component is required to use the "%s" constraint.', __CLASS__));
+            @trigger_error(sprintf('Using the "%s" constraint without the "symfony/intl" component installed is deprecated since Symfony 4.2.', __CLASS__), E_USER_DEPRECATED);
+        }
+
+        parent::__construct($options);
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -15,7 +15,7 @@ use Egulias\EmailValidator\Validation\EmailValidation;
 use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Exception\RuntimeException;
+use Symfony\Component\Validator\Exception\LogicException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
@@ -100,7 +100,7 @@ class EmailValidator extends ConstraintValidator
 
         if (Email::VALIDATION_MODE_STRICT === $constraint->mode) {
             if (!class_exists('\Egulias\EmailValidator\EmailValidator')) {
-                throw new RuntimeException('Strict email validation requires egulias/email-validator ~1.2|~2.0');
+                throw new LogicException('Strict email validation requires egulias/email-validator ~1.2|~2.0');
             }
 
             $strictValidator = new \Egulias\EmailValidator\EmailValidator();

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Exception\RuntimeException;
+use Symfony\Component\Validator\Exception\LogicException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
@@ -55,7 +55,7 @@ class ExpressionValidator extends ConstraintValidator
     {
         if (null === $this->expressionLanguage) {
             if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
-                throw new RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+                throw new LogicException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
             }
             $this->expressionLanguage = new ExpressionLanguage();
         }

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
-use Symfony\Component\Validator\Exception\RuntimeException;
+use Symfony\Component\Validator\Exception\LogicException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
@@ -218,7 +218,7 @@ class ImageValidator extends FileValidator
 
         if ($constraint->detectCorrupted) {
             if (!\function_exists('imagecreatefromstring')) {
-                throw new RuntimeException('Corrupted images detection requires installed and enabled GD extension');
+                throw new LogicException('Corrupted images detection requires installed and enabled GD extension');
             }
 
             $resource = @imagecreatefromstring(file_get_contents($value));

--- a/src/Symfony/Component/Validator/GroupSequenceProviderInterface.php
+++ b/src/Symfony/Component/Validator/GroupSequenceProviderInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator;
 
+use Symfony\Component\Validator\Constraints\GroupSequence;
+
 /**
  * Defines the interface for a group sequence provider.
  */
@@ -20,7 +22,7 @@ interface GroupSequenceProviderInterface
      * Returns which validation groups should be used for a certain state
      * of the object.
      *
-     * @return array An array of validation groups
+     * @return string[]|GroupSequence An array of validation groups
      */
     public function getGroupSequence();
 }

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -392,7 +392,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
     /**
      * Sets the default group sequence for this class.
      *
-     * @param array $groupSequence An array of group names
+     * @param string[]|GroupSequence $groupSequence An array of group names
      *
      * @return $this
      *

--- a/src/Symfony/Component/Validator/Validator/ContextualValidatorInterface.php
+++ b/src/Symfony/Component/Validator/Validator/ContextualValidatorInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Validator;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
@@ -39,12 +40,9 @@ interface ContextualValidatorInterface
      * If no constraint is passed, the constraint
      * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
      *
-     * @param mixed                   $value       The value to validate
-     * @param Constraint|Constraint[] $constraints The constraint(s) to validate
-     *                                             against
-     * @param array|null              $groups      The validation groups to
-     *                                             validate. If none is given,
-     *                                             "Default" is assumed
+     * @param mixed                                              $value       The value to validate
+     * @param Constraint|Constraint[]                            $constraints The constraint(s) to validate against
+     * @param string|GroupSequence|(string|GroupSequence)[]|null $groups      The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return $this
      */
@@ -54,10 +52,9 @@ interface ContextualValidatorInterface
      * Validates a property of an object against the constraints specified
      * for this property.
      *
-     * @param object     $object       The object
-     * @param string     $propertyName The name of the validated property
-     * @param array|null $groups       The validation groups to validate. If
-     *                                 none is given, "Default" is assumed
+     * @param object                                             $object       The object
+     * @param string                                             $propertyName The name of the validated property
+     * @param string|GroupSequence|(string|GroupSequence)[]|null $groups       The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return $this
      */
@@ -67,12 +64,10 @@ interface ContextualValidatorInterface
      * Validates a value against the constraints specified for an object's
      * property.
      *
-     * @param object|string $objectOrClass The object or its class name
-     * @param string        $propertyName  The name of the property
-     * @param mixed         $value         The value to validate against the
-     *                                     property's constraints
-     * @param array|null    $groups        The validation groups to validate. If
-     *                                     none is given, "Default" is assumed
+     * @param object|string                                      $objectOrClass The object or its class name
+     * @param string                                             $propertyName  The name of the property
+     * @param mixed                                              $value         The value to validate against the property's constraints
+     * @param string|GroupSequence|(string|GroupSequence)[]|null $groups        The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return $this
      */

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -272,9 +272,9 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
     /**
      * Normalizes the given group or list of groups to an array.
      *
-     * @param mixed $groups The groups to normalize
+     * @param string|GroupSequence|(string|GroupSequence)[] $groups The groups to normalize
      *
-     * @return array A group array
+     * @return (string|GroupSequence)[] A group array
      */
     protected function normalizeGroups($groups)
     {
@@ -295,7 +295,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
      *
      * @param object                    $object            The object to cascade
      * @param string                    $propertyPath      The current property path
-     * @param string[]                  $groups            The validated groups
+     * @param (string|GroupSequence)[]  $groups            The validated groups
      * @param int                       $traversalStrategy The strategy for traversing the
      *                                                     cascaded object
      * @param ExecutionContextInterface $context           The current execution context
@@ -355,10 +355,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
      * objects are iterated as well. Nested arrays are always iterated,
      * regardless of the value of $recursive.
      *
-     * @param iterable                  $collection   The collection
-     * @param string                    $propertyPath The current property path
-     * @param string[]                  $groups       The validated groups
-     * @param ExecutionContextInterface $context      The current execution context
+     * @param iterable                  $collection    The collection
+     * @param string                    $propertyPath  The current property path
+     * @param (string|GroupSequence)[]  $groups        The validated groups
+     * @param ExecutionContextInterface $context       The current execution context
      *
      * @see ClassNode
      * @see CollectionNode
@@ -424,7 +424,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
      *                                                     the object
      * @param string                    $propertyPath      The property path leading
      *                                                     to the object
-     * @param string[]                  $groups            The groups in which the
+     * @param (string|GroupSequence)[]  $groups            The groups in which the
      *                                                     object should be validated
      * @param string[]|null             $cascadedGroups    The groups in which
      *                                                     cascaded objects should
@@ -608,7 +608,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
      *                                                     value
      * @param string                    $propertyPath      The property path leading
      *                                                     to the value
-     * @param string[]                  $groups            The groups in which the
+     * @param (string|GroupSequence)[]  $groups            The groups in which the
      *                                                     value should be validated
      * @param string[]|null             $cascadedGroups    The groups in which
      *                                                     cascaded objects should

--- a/src/Symfony/Component/Validator/Validator/ValidatorInterface.php
+++ b/src/Symfony/Component/Validator/Validator/ValidatorInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Validator;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
@@ -29,12 +30,9 @@ interface ValidatorInterface extends MetadataFactoryInterface
      * If no constraint is passed, the constraint
      * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
      *
-     * @param mixed                   $value       The value to validate
-     * @param Constraint|Constraint[] $constraints The constraint(s) to validate
-     *                                             against
-     * @param array|null              $groups      The validation groups to
-     *                                             validate. If none is given,
-     *                                             "Default" is assumed
+     * @param mixed                                              $value       The value to validate
+     * @param Constraint|Constraint[]                            $constraints The constraint(s) to validate against
+     * @param string|GroupSequence|(string|GroupSequence)[]|null $groups      The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return ConstraintViolationListInterface A list of constraint violations
      *                                          If the list is empty, validation
@@ -46,10 +44,9 @@ interface ValidatorInterface extends MetadataFactoryInterface
      * Validates a property of an object against the constraints specified
      * for this property.
      *
-     * @param object     $object       The object
-     * @param string     $propertyName The name of the validated property
-     * @param array|null $groups       The validation groups to validate. If
-     *                                 none is given, "Default" is assumed
+     * @param object                                             $object       The object
+     * @param string                                             $propertyName The name of the validated property
+     * @param string|GroupSequence|(string|GroupSequence)[]|null $groups       The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return ConstraintViolationListInterface A list of constraint violations
      *                                          If the list is empty, validation
@@ -61,12 +58,10 @@ interface ValidatorInterface extends MetadataFactoryInterface
      * Validates a value against the constraints specified for an object's
      * property.
      *
-     * @param object|string $objectOrClass The object or its class name
-     * @param string        $propertyName  The name of the property
-     * @param mixed         $value         The value to validate against the
-     *                                     property's constraints
-     * @param array|null    $groups        The validation groups to validate. If
-     *                                     none is given, "Default" is assumed
+     * @param object|string                                      $objectOrClass The object or its class name
+     * @param string                                             $propertyName  The name of the property
+     * @param mixed                                              $value         The value to validate against the property's constraints
+     * @param string|GroupSequence|(string|GroupSequence)[]|null $groups        The validation groups to validate. If none is given, "Default" is assumed
      *
      * @return ConstraintViolationListInterface A list of constraint violations
      *                                          If the list is empty, validation

--- a/src/Symfony/Component/VarDumper/Caster/IntlCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/IntlCaster.php
@@ -106,6 +106,57 @@ class IntlCaster
         return self::castError($c, $a);
     }
 
+    public static function castIntlTimeZone(\IntlTimeZone $c, array $a, Stub $stub, $isNested)
+    {
+        $a += array(
+            Caster::PREFIX_VIRTUAL.'display_name' => $c->getDisplayName(),
+            Caster::PREFIX_VIRTUAL.'id' => $c->getID(),
+            Caster::PREFIX_VIRTUAL.'raw_offset' => $c->getRawOffset(),
+        );
+
+        if ($c->useDaylightTime()) {
+            $a += array(
+                Caster::PREFIX_VIRTUAL.'dst_savings' => $c->getDSTSavings(),
+            );
+        }
+
+        return self::castError($c, $a);
+    }
+
+    public static function castIntlCalendar(\IntlCalendar $c, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        $a += array(
+            Caster::PREFIX_VIRTUAL.'type' => $c->getType(),
+            Caster::PREFIX_VIRTUAL.'first_day_of_week' => $c->getFirstDayOfWeek(),
+            Caster::PREFIX_VIRTUAL.'minimal_days_in_first_week' => $c->getMinimalDaysInFirstWeek(),
+            Caster::PREFIX_VIRTUAL.'repeated_wall_time_option' => $c->getRepeatedWallTimeOption(),
+            Caster::PREFIX_VIRTUAL.'skipped_wall_time_option' => $c->getSkippedWallTimeOption(),
+            Caster::PREFIX_VIRTUAL.'time' => $c->getTime(),
+            Caster::PREFIX_VIRTUAL.'type' => $c->getType(),
+            Caster::PREFIX_VIRTUAL.'in_daylight_time' => $c->inDaylightTime(),
+            Caster::PREFIX_VIRTUAL.'is_lenient' => $c->isLenient(),
+            Caster::PREFIX_VIRTUAL.'time_zone' => ($filter & Caster::EXCLUDE_VERBOSE) ? new CutStub($c->getTimeZone()) : $c->getTimeZone(),
+        );
+
+        return self::castError($c, $a);
+    }
+
+    public static function castIntlDateFormatter(\IntlDateFormatter $c, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        $a += array(
+            Caster::PREFIX_VIRTUAL.'locale' => $c->getLocale(),
+            Caster::PREFIX_VIRTUAL.'pattern' => $c->getPattern(),
+            Caster::PREFIX_VIRTUAL.'calendar' => $c->getCalendar(),
+            Caster::PREFIX_VIRTUAL.'time_zone_id' => $c->getTimeZoneId(),
+            Caster::PREFIX_VIRTUAL.'time_type' => $c->getTimeType(),
+            Caster::PREFIX_VIRTUAL.'date_type' => $c->getDateType(),
+            Caster::PREFIX_VIRTUAL.'calendar_object' => ($filter & Caster::EXCLUDE_VERBOSE) ? new CutStub($c->getCalendarObject()) : $c->getCalendarObject(),
+            Caster::PREFIX_VIRTUAL.'time_zone' => ($filter & Caster::EXCLUDE_VERBOSE) ? new CutStub($c->getTimeZone()) : $c->getTimeZone(),
+        );
+
+        return self::castError($c, $a);
+    }
+
     private static function castError($c, array $a): array
     {
         if ($errorCode = $c->getErrorCode()) {

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -119,6 +119,9 @@ abstract class AbstractCloner implements ClonerInterface
 
         'MessageFormatter' => array('Symfony\Component\VarDumper\Caster\IntlCaster', 'castMessageFormatter'),
         'NumberFormatter' => array('Symfony\Component\VarDumper\Caster\IntlCaster', 'castNumberFormatter'),
+        'IntlTimeZone' => array('Symfony\Component\VarDumper\Caster\IntlCaster', 'castIntlTimeZone'),
+        'IntlCalendar' => array('Symfony\Component\VarDumper\Caster\IntlCaster', 'castIntlCalendar'),
+        'IntlDateFormatter' => array('Symfony\Component\VarDumper\Caster\IntlCaster', 'castIntlDateFormatter'),
 
         ':curl' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castCurl'),
         ':dba' => array('Symfony\Component\VarDumper\Caster\ResourceCaster', 'castDba'),

--- a/src/Symfony/Component/VarDumper/Tests/Caster/IntlCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/IntlCasterTest.php
@@ -150,4 +150,150 @@ NumberFormatter {
 EOTXT;
         $this->assertDumpEquals($expected, $var);
     }
+
+    public function testCastIntlTimeZoneWithDST()
+    {
+        $var = \IntlTimeZone::createTimeZone('America/Los_Angeles');
+
+        $expectedDisplayName = $var->getDisplayName();
+        $expectedDSTSavings = $var->getDSTSavings();
+        $expectedID = $var->getID();
+        $expectedRawOffset = $var->getRawOffset();
+
+        $expected = <<<EOTXT
+IntlTimeZone {
+  display_name: "$expectedDisplayName"
+  id: "$expectedID"
+  raw_offset: $expectedRawOffset
+  dst_savings: $expectedDSTSavings
+}
+EOTXT;
+        $this->assertDumpEquals($expected, $var);
+    }
+
+    public function testCastIntlTimeZoneWithoutDST()
+    {
+        $var = \IntlTimeZone::createTimeZone('Asia/Bangkok');
+
+        $expectedDisplayName = $var->getDisplayName();
+        $expectedID = $var->getID();
+        $expectedRawOffset = $var->getRawOffset();
+
+        $expected = <<<EOTXT
+IntlTimeZone {
+  display_name: "$expectedDisplayName"
+  id: "$expectedID"
+  raw_offset: $expectedRawOffset
+}
+EOTXT;
+        $this->assertDumpEquals($expected, $var);
+    }
+
+    public function testCastIntlCalendar()
+    {
+        $var = \IntlCalendar::createInstance('America/Los_Angeles', 'en');
+
+        $expectedType = $var->getType();
+        $expectedFirstDayOfWeek = $var->getFirstDayOfWeek();
+        $expectedMinimalDaysInFirstWeek = $var->getMinimalDaysInFirstWeek();
+        $expectedRepeatedWallTimeOption = $var->getRepeatedWallTimeOption();
+        $expectedSkippedWallTimeOption = $var->getSkippedWallTimeOption();
+        $expectedTime = $var->getTime().'.0';
+        $expectedInDaylightTime = $var->inDaylightTime() ? 'true' : 'false';
+        $expectedIsLenient = $var->isLenient() ? 'true' : 'false';
+
+        $expectedTimeZone = $var->getTimeZone();
+        $expectedTimeZoneDisplayName = $expectedTimeZone->getDisplayName();
+        $expectedTimeZoneID = $expectedTimeZone->getID();
+        $expectedTimeZoneRawOffset = $expectedTimeZone->getRawOffset();
+        $expectedTimeZoneDSTSavings = $expectedTimeZone->getDSTSavings();
+
+        $expected = <<<EOTXT
+IntlGregorianCalendar {
+  type: "$expectedType"
+  first_day_of_week: $expectedFirstDayOfWeek
+  minimal_days_in_first_week: $expectedMinimalDaysInFirstWeek
+  repeated_wall_time_option: $expectedRepeatedWallTimeOption
+  skipped_wall_time_option: $expectedSkippedWallTimeOption
+  time: $expectedTime
+  in_daylight_time: $expectedInDaylightTime
+  is_lenient: $expectedIsLenient
+  time_zone: IntlTimeZone {
+    display_name: "$expectedTimeZoneDisplayName"
+    id: "$expectedTimeZoneID"
+    raw_offset: $expectedTimeZoneRawOffset
+    dst_savings: $expectedTimeZoneDSTSavings
+  }
+}
+EOTXT;
+        $this->assertDumpEquals($expected, $var);
+    }
+
+    public function testCastDateFormatter()
+    {
+        $var = new \IntlDateFormatter('en', \IntlDateFormatter::TRADITIONAL, \IntlDateFormatter::TRADITIONAL);
+
+        $expectedLocale = $var->getLocale();
+        $expectedPattern = $var->getPattern();
+        $expectedCalendar = $var->getCalendar();
+        $expectedTimeZoneId = $var->getTimeZoneId();
+        $expectedTimeType = $var->getTimeType();
+        $expectedDateType = $var->getDateType();
+
+        $expectedCalendarObject = $var->getCalendarObject();
+        $expectedCalendarObjectType = $expectedCalendarObject->getType();
+        $expectedCalendarObjectFirstDayOfWeek = $expectedCalendarObject->getFirstDayOfWeek();
+        $expectedCalendarObjectMinimalDaysInFirstWeek = $expectedCalendarObject->getMinimalDaysInFirstWeek();
+        $expectedCalendarObjectRepeatedWallTimeOption = $expectedCalendarObject->getRepeatedWallTimeOption();
+        $expectedCalendarObjectSkippedWallTimeOption = $expectedCalendarObject->getSkippedWallTimeOption();
+        $expectedCalendarObjectTime = $expectedCalendarObject->getTime().'.0';
+        $expectedCalendarObjectInDaylightTime = $expectedCalendarObject->inDaylightTime() ? 'true' : 'false';
+        $expectedCalendarObjectIsLenient = $expectedCalendarObject->isLenient() ? 'true' : 'false';
+
+        $expectedCalendarObjectTimeZone = $expectedCalendarObject->getTimeZone();
+        $expectedCalendarObjectTimeZoneDisplayName = $expectedCalendarObjectTimeZone->getDisplayName();
+        $expectedCalendarObjectTimeZoneID = $expectedCalendarObjectTimeZone->getID();
+        $expectedCalendarObjectTimeZoneRawOffset = $expectedCalendarObjectTimeZone->getRawOffset();
+        $expectedCalendarObjectTimeZoneDSTSavings = $expectedCalendarObjectTimeZone->getDSTSavings();
+
+        $expectedTimeZone = $var->getTimeZone();
+        $expectedTimeZoneDisplayName = $expectedTimeZone->getDisplayName();
+        $expectedTimeZoneID = $expectedTimeZone->getID();
+        $expectedTimeZoneRawOffset = $expectedTimeZone->getRawOffset();
+        $expectedTimeZoneDSTSavings = $expectedTimeZone->getDSTSavings();
+
+        $expected = <<<EOTXT
+IntlDateFormatter {
+  locale: "$expectedLocale"
+  pattern: "$expectedPattern"
+  calendar: $expectedCalendar
+  time_zone_id: "$expectedTimeZoneId"
+  time_type: $expectedTimeType
+  date_type: $expectedDateType
+  calendar_object: IntlGregorianCalendar {
+    type: "$expectedCalendarObjectType"
+    first_day_of_week: $expectedCalendarObjectFirstDayOfWeek
+    minimal_days_in_first_week: $expectedCalendarObjectMinimalDaysInFirstWeek
+    repeated_wall_time_option: $expectedCalendarObjectRepeatedWallTimeOption
+    skipped_wall_time_option: $expectedCalendarObjectSkippedWallTimeOption
+    time: $expectedCalendarObjectTime
+    in_daylight_time: $expectedCalendarObjectInDaylightTime
+    is_lenient: $expectedCalendarObjectIsLenient
+    time_zone: IntlTimeZone {
+      display_name: "$expectedCalendarObjectTimeZoneDisplayName"
+      id: "$expectedCalendarObjectTimeZoneID"
+      raw_offset: $expectedCalendarObjectTimeZoneRawOffset
+      dst_savings: $expectedCalendarObjectTimeZoneDSTSavings
+    }
+  }
+  time_zone: IntlTimeZone {
+    display_name: "$expectedTimeZoneDisplayName"
+    id: "$expectedTimeZoneID"
+    raw_offset: $expectedTimeZoneRawOffset
+    dst_savings: $expectedTimeZoneDSTSavings
+  }
+}
+EOTXT;
+        $this->assertDumpEquals($expected, $var);
+    }
 }

--- a/src/Symfony/Component/VarExporter/Instantiator.php
+++ b/src/Symfony/Component/VarExporter/Instantiator.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter;
+
+use Symfony\Component\VarExporter\Exception\ExceptionInterface;
+use Symfony\Component\VarExporter\Exception\NotInstantiableTypeException;
+use Symfony\Component\VarExporter\Internal\Hydrator;
+use Symfony\Component\VarExporter\Internal\Registry;
+
+/**
+ * A utility class to create objects without calling their constructor.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class Instantiator
+{
+    /**
+     * Creates an object and sets its properties without calling its constructor nor any other methods.
+     *
+     * For example:
+     *
+     *     // creates an empty instance of Foo
+     *     Instantiator::instantiate(Foo::class);
+     *
+     *     // creates a Foo instance and sets one of its properties
+     *     Instantiator::instantiate(Foo::class, ['propertyName' => $propertyValue]);
+     *
+     *     // creates a Foo instance and sets a private property defined on its parent Bar class
+     *     Instantiator::instantiate(Foo::class, [], [
+     *         Bar::class => ['privateBarProperty' => $propertyValue],
+     *     ]);
+     *
+     * Instances of ArrayObject, ArrayIterator and SplObjectHash can be created
+     * by using the special "\0" property name to define their internal value:
+     *
+     *     // creates an SplObjectHash where $info1 is attached to $obj1, etc.
+     *     Instantiator::instantiate(SplObjectStorage::class, ["\0" => [$obj1, $info1, $obj2, $info2...]]);
+     *
+     *     // creates an ArrayObject populated with $inputArray
+     *     Instantiator::instantiate(ArrayObject::class, ["\0" => [$inputArray]]);
+     *
+     * @param string $class             The class of the instance to create
+     * @param array  $properties        The properties to set on the instance
+     * @param array  $privateProperties The private properties to set on the instance,
+     *                                  keyed by their declaring class
+     *
+     * @return object The created instance
+     *
+     * @throws ExceptionInterface When the instance cannot be created
+     */
+    public static function instantiate(string $class, array $properties = array(), array $privateProperties = array())
+    {
+        $reflector = Registry::$reflectors[$class] ?? Registry::getClassReflector($class);
+
+        if (Registry::$cloneable[$class]) {
+            $wrappedInstance = array(clone Registry::$prototypes[$class]);
+        } elseif (Registry::$instantiableWithoutConstructor[$class]) {
+            $wrappedInstance = array($reflector->newInstanceWithoutConstructor());
+        } elseif (null === Registry::$prototypes[$class]) {
+            throw new NotInstantiableTypeException($class);
+        } elseif ($reflector->implementsInterface('Serializable')) {
+            $wrappedInstance = array(unserialize('C:'.\strlen($class).':"'.$class.'":0:{}'));
+        } else {
+            $wrappedInstance = array(unserialize('O:'.\strlen($class).':"'.$class.'":0:{}'));
+        }
+
+        if ($properties) {
+            $privateProperties[$class] = isset($privateProperties[$class]) ? $properties + $privateProperties[$class] : $properties;
+        }
+
+        foreach ($privateProperties as $class => $properties) {
+            if (!$properties) {
+                continue;
+            }
+            foreach ($properties as $name => $value) {
+                // because they're also used for "unserialization", hydrators
+                // deal with array of instances, so we need to wrap values
+                $properties[$name] = array($value);
+            }
+            (Hydrator::$hydrators[$class] ?? Hydrator::getHydrator($class))($properties, $wrappedInstance);
+        }
+
+        return $wrappedInstance[0];
+    }
+}

--- a/src/Symfony/Component/VarExporter/README.md
+++ b/src/Symfony/Component/VarExporter/README.md
@@ -5,6 +5,9 @@ The VarExporter component allows exporting any serializable PHP data structure t
 plain PHP code. While doing so, it preserves all the semantics associated with
 the serialization mechanism of PHP (`__wakeup`, `__sleep`, `Serializable`).
 
+It also provides an instantiator that allows creating and populating objects
+without calling their constructor nor any other methods.
+
 The reason to use this component *vs* `serialize()` or
 [igbinary](https://github.com/igbinary/igbinary) is performance: thanks to
 OPcache, the resulting code is significantly faster and more memory efficient

--- a/src/Symfony/Component/VarExporter/Tests/InstantiatorTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/InstantiatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarExporter\Instantiator;
+
+class InstantiatorTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\VarExporter\Exception\ClassNotFoundException
+     * @expectedExceptionMessage Class "SomeNotExistingClass" not found.
+     */
+    public function testNotFoundClass()
+    {
+        Instantiator::instantiate('SomeNotExistingClass');
+    }
+
+    /**
+     * @dataProvider provideFailingInstantiation
+     * @expectedException \Symfony\Component\VarExporter\Exception\NotInstantiableTypeException
+     * @expectedExceptionMessageRegexp Type ".*" is not instantiable.
+     */
+    public function testFailingInstantiation(string $class)
+    {
+        Instantiator::instantiate($class);
+    }
+
+    public function provideFailingInstantiation()
+    {
+        yield array('ReflectionClass');
+        yield array('SplHeap');
+        yield array('Throwable');
+        yield array('Closure');
+        yield array('SplFileInfo');
+    }
+
+    public function testInstantiate()
+    {
+        $this->assertEquals((object) array('p' => 123), Instantiator::instantiate('stdClass', array('p' => 123)));
+        $this->assertEquals((object) array('p' => 123), Instantiator::instantiate('STDcLASS', array('p' => 123)));
+        $this->assertEquals(new \ArrayObject(array(123)), Instantiator::instantiate(\ArrayObject::class, array("\0" => array(array(123)))));
+
+        $expected = array(
+            "\0".__NAMESPACE__."\Bar\0priv" => 123,
+            "\0".__NAMESPACE__."\Foo\0priv" => 234,
+        );
+
+        $this->assertSame($expected, (array) Instantiator::instantiate(Bar::class, array('priv' => 123), array(Foo::class => array('priv' => 234))));
+
+        $e = Instantiator::instantiate('Exception', array('foo' => 123, 'trace' => array(234)));
+
+        $this->assertSame(123, $e->foo);
+        $this->assertSame(array(234), $e->getTrace());
+    }
+}
+
+class Foo
+{
+    private $priv;
+}
+
+class Bar extends Foo
+{
+    private $priv;
+}

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1945,6 +1945,10 @@ YAML;
             $this->markTestSkipped('chmod is not supported on Windows');
         }
 
+        if (!getenv('USER') || 'root' === getenv('USER')) {
+            $this->markTestSkipped('This test will fail if run under superuser');
+        }
+
         $file = __DIR__.'/Fixtures/not_readable.yml';
         chmod($file, 0200);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #28427 
| License       | MIT
| Doc PR        | symfony/symfony-docs

The Csrf error that it is added as a `FormError` does not have a cause making it hard to filter it out.

1. I am not sure if this is a bug or a feature.
2. @xabbuh on the issue you said something about `CsrfValidationError`. I didn't quite get that. In the current PR you can see what I was thinking about. Let me know your thoughts and continue the discussion here.
