### PR TITLE
Add --dev option to force running web server in dev mode

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
@@ -52,6 +52,7 @@ class ServerRunCommand extends Command
                 new InputArgument('addressport', InputArgument::OPTIONAL, 'The address to listen to (can be address:port, address, or port)'),
                 new InputOption('docroot', 'd', InputOption::VALUE_REQUIRED, 'Document root, usually where your front controllers are stored'),
                 new InputOption('router', 'r', InputOption::VALUE_REQUIRED, 'Path to custom router script'),
+                new InputOption('dev', null, InputOption::VALUE_NONE, 'Ignore environment variables in "bin/console.php" and force running a web server in "dev" mode'),
             ))
             ->setDescription('Runs a local web server')
             ->setHelp(<<<'EOF'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/recipes/pull/467
| License       | MIT
| Doc PR        | -

This `--dev` option will force running Symfony web server in `dev` environment with `bin/console` and allow to preview websites in any environment.

These changes required for https://github.com/symfony/recipes/pull/467