### PR TITLE
[DomCrawler] return empty string on `Crawler::text()` and `Crawler::html()` instead of an exception

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 * Added return of element name (`_name`) in `extract()` method.
+* Added ability to return a default value in `text()` and `html()` instead of throwing an exception when node is empty.
 
 4.2.0
 -----

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -570,13 +570,19 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the node value of the first node of the list.
      *
+     * @param mixed $default When provided and the current node is empty, this value is returned and no exception is thrown
+     *
      * @return string The node value
      *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function text()
+    public function text(/* $default = null */)
     {
         if (!$this->nodes) {
+            if (0 < \func_num_args()) {
+                return \func_get_arg(0);
+            }
+
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
@@ -586,13 +592,19 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the first node of the list as HTML.
      *
+     * @param mixed $default When provided and the current node is empty, this value is returned and no exception is thrown
+     *
      * @return string The node html
      *
      * @throws \InvalidArgumentException When current node is empty
      */
-    public function html()
+    public function html(/* $default = null */)
     {
         if (!$this->nodes) {
+            if (0 < \func_num_args()) {
+                return \func_get_arg(0);
+            }
+
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -392,6 +392,8 @@ EOF
         } catch (\InvalidArgumentException $e) {
             $this->assertTrue(true, '->text() throws an \InvalidArgumentException if the node list is empty');
         }
+
+        $this->assertSame('my value', $this->createTestCrawler(null)->filterXPath('//ol')->text('my value'));
     }
 
     public function testHtml()
@@ -405,6 +407,8 @@ EOF
         } catch (\InvalidArgumentException $e) {
             $this->assertTrue(true, '->html() throws an \InvalidArgumentException if the node list is empty');
         }
+
+        $this->assertSame('my value', $this->createTestCrawler(null)->filterXPath('//ol')->html('my value'));
     }
 
     public function testExtract()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28313
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This changes the behavior when using text and html methods from the Crawler by returning null instead of throwing an exception.