### PR TITLE
[Finder] Restore folder permissions after failed tests

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1211,7 +1211,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         if (false === ($couldRead = is_readable($testDir))) {
             try {
-                $this->assertIterator($this->toAbsolute([
+                $this->assertIterator($this->toAbsolute(array(
                         'foo bar',
                         'test.php',
                         'test.py',
@@ -1223,7 +1223,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
                         'qux_10_2.php',
                         'qux_12_0.php',
                         'qux_2_0.php',
-                    ]
+                    )
                 ), $finder->getIterator());
             } finally {
                 // restore original permissions

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1180,6 +1180,10 @@ class FinderTest extends Iterator\RealIteratorTestCase
                 }
 
                 $this->assertInstanceOf($expectedExceptionClass, $e);
+            } finally {
+                // restore original permissions
+                chmod($testDir, 0777);
+                clearstatcache($testDir);
             }
         }
 
@@ -1206,20 +1210,26 @@ class FinderTest extends Iterator\RealIteratorTestCase
         chmod($testDir, 0333);
 
         if (false === ($couldRead = is_readable($testDir))) {
-            $this->assertIterator($this->toAbsolute(array(
-                'foo bar',
-                'test.php',
-                'test.py',
-                'qux/baz_100_1.py',
-                'qux/baz_1_2.py',
-                'qux_0_1.php',
-                'qux_1000_1.php',
-                'qux_1002_0.php',
-                'qux_10_2.php',
-                'qux_12_0.php',
-                'qux_2_0.php',
-                )
-            ), $finder->getIterator());
+            try {
+                $this->assertIterator($this->toAbsolute([
+                        'foo bar',
+                        'test.php',
+                        'test.py',
+                        'qux/baz_100_1.py',
+                        'qux/baz_1_2.py',
+                        'qux_0_1.php',
+                        'qux_1000_1.php',
+                        'qux_1002_0.php',
+                        'qux_10_2.php',
+                        'qux_12_0.php',
+                        'qux_2_0.php',
+                    ]
+                ), $finder->getIterator());
+            } finally {
+                // restore original permissions
+                chmod($testDir, 0777);
+                clearstatcache($testDir);
+            }
         }
 
         // restore original permissions


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Allow teardown of created folders after failed assertions by restoring original folder permissions in `testAccessDeniedException()` and `testIgnoredAccessDeniedException()`
