### PR TITLE
[Cache] add "setCallbackWrapper()" on adapters implementing CacheInterface for more flexibility

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ChainAdapter.php
@@ -100,7 +100,7 @@ class ChainAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
             if ($adapter instanceof CacheInterface) {
                 $value = $adapter->get($key, $callback, $beta);
             } else {
-                $value = $this->doGet($adapter, $key, $callback, $beta ?? 1.0);
+                $value = $this->doGet($adapter, $key, $callback, $beta);
             }
             if (null !== $item) {
                 ($this->syncItem)($lastItem = $lastItem ?? $item, $item);

--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -93,7 +93,7 @@ class PhpArrayAdapter implements AdapterInterface, CacheInterface, PruneableInte
                 return $this->pool->get($key, $callback, $beta);
             }
 
-            return $this->doGet($this->pool, $key, $callback, $beta ?? 1.0);
+            return $this->doGet($this->pool, $key, $callback, $beta);
         }
         $value = $this->values[$this->keys[$key]];
 

--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -94,7 +94,7 @@ class ProxyAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
     public function get(string $key, callable $callback, float $beta = null)
     {
         if (!$this->pool instanceof CacheInterface) {
-            return $this->doGet($this, $key, $callback, $beta ?? 1.0);
+            return $this->doGet($this, $key, $callback, $beta);
         }
 
         return $this->pool->get($this->getId($key), function ($innerItem) use ($key, $callback) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27730
| License       | MIT
| Doc PR        | -

Preparing my talk at SymfonyLive London, see you all there :)

This allows wrapping the callback passed to `->get($item, $callback, $beta)` in a callable that should at least return `$callback($item)`, but can do something around the call.
The default wrapper is locking the key to provide lock-based stampede protection.
That was already the case before this PR, but in a much dirtier way at the design level.
Fixes a few issues found meanwhile.