### PR TITLE
[Messenger] Receiver and Bus Names Parameter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -73,9 +73,8 @@
             <argument /> <!-- Message bus locator -->
             <argument type="service" id="messenger.receiver_locator" />
             <argument type="service" id="logger" on-invalid="null" />
-            <argument type="collection" /> <!-- Receiver names -->
-            <argument type="collection" /> <!-- Message bus names -->
-
+            <argument>%messenger.receiver_names%</argument>
+            <argument>%messenger.bus_names%</argument>
             <tag name="console.command" command="messenger:consume-messages" />
         </service>
 

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -72,6 +72,8 @@ class MessengerPass implements CompilerPassInterface
             }
         }
 
+        $container->setParameter('messenger.bus_names', $busIds);
+
         $this->registerReceivers($container, $busIds);
         $this->registerSenders($container);
         $this->registerHandlers($container, $busIds);
@@ -254,20 +256,20 @@ class MessengerPass implements CompilerPassInterface
             }
         }
 
+        $receiverNames = array();
+        foreach ($receiverMapping as $name => $reference) {
+            $receiverNames[(string) $reference] = $name;
+        }
+        $container->setParameter('messenger.receiver_names', array_values($receiverNames));
+
         if ($container->hasDefinition('console.command.messenger_consume_messages')) {
-            $receiverNames = array();
-            foreach ($receiverMapping as $name => $reference) {
-                $receiverNames[(string) $reference] = $name;
-            }
             $buses = array();
             foreach ($busIds as $busId) {
                 $buses[$busId] = new Reference($busId);
             }
 
             $container->getDefinition('console.command.messenger_consume_messages')
-                ->replaceArgument(0, ServiceLocatorTagPass::register($container, $buses))
-                ->replaceArgument(3, array_values($receiverNames))
-                ->replaceArgument(4, $busIds);
+                ->replaceArgument(0, ServiceLocatorTagPass::register($container, $buses));
         }
 
         $container->getDefinition('messenger.receiver_locator')->replaceArgument(0, $receiverMapping);


### PR DESCRIPTION
- Register the receiver names and bus names as parameters
  instead of setting them directly to the messenger command

Signed-off-by: RJ Garcia <rj@bighead.net>

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

By setting the receiver and bus names as parameters, it allows for the ease of creating custom consume messages commands that might utilize custom receiver decorators. We might also want to register the bus locator as a server instead of directly into this command as well, but I didn't know if that was done for a specific reason.

I don't know how/what to test for the Framework Bundle changes, but i've tested this locally with my own CompilerPass on an SF repo I'm using.