### PR TITLE
[Cache] support configuring multiple Memcached servers in one DSN

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
@@ -133,7 +133,7 @@ class CachePoolPass implements CompilerPassInterface
     {
         $container->resolveEnvPlaceholders($name, null, $usedEnvs);
 
-        if ($usedEnvs || preg_match('#^[a-z]++://#', $name)) {
+        if ($usedEnvs || preg_match('#^[a-z]++:#', $name)) {
             $dsn = $name;
 
             if (!$container->hasDefinition($name = '.cache_connection.'.ContainerBuilder::hash($dsn))) {

--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -151,7 +151,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
         if (0 === strpos($dsn, 'redis://')) {
             return RedisAdapter::createConnection($dsn, $options);
         }
-        if (0 === strpos($dsn, 'memcached://')) {
+        if (0 === strpos($dsn, 'memcached:')) {
             return MemcachedAdapter::createConnection($dsn, $options);
         }
 

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.2.0
 -----
 
+ * added support for configuring multiple Memcached servers in one DSN
  * added `MarshallerInterface` and `DefaultMarshaller` to allow changing the serializer and provide one that automatically uses igbinary when available
  * added `CacheInterface`, which provides stampede protection via probabilistic early expiration and should become the preferred way to use a cache
  * added sub-second expiry accuracy for backends that support it

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -192,4 +192,46 @@ class MemcachedAdapterTest extends AdapterTestCase
             array(\Memcached::OPT_SOCKET_RECV_SIZE => 1, \Memcached::OPT_SOCKET_SEND_SIZE => 2, \Memcached::OPT_RETRY_TIMEOUT => 8),
         );
     }
+
+    public function testMultiServerDsn()
+    {
+        $dsn = 'memcached:?host[localhost]&host[localhost:12345]&host[/some/memcached.sock:]=3';
+        $client = MemcachedAdapter::createConnection($dsn);
+
+        $expected = array(
+            0 => array(
+                'host' => 'localhost',
+                'port' => 11211,
+                'type' => 'TCP',
+            ),
+            1 => array(
+                'host' => 'localhost',
+                'port' => 12345,
+                'type' => 'TCP',
+            ),
+            2 => array(
+                'host' => '/some/memcached.sock',
+                'port' => 0,
+                'type' => 'SOCKET',
+            ),
+        );
+        $this->assertSame($expected, $client->getServerList());
+
+        $dsn = 'memcached://localhost?host[foo.bar]=3';
+        $client = MemcachedAdapter::createConnection($dsn);
+
+        $expected = array(
+            0 => array(
+                'host' => 'localhost',
+                'port' => 11211,
+                'type' => 'TCP',
+            ),
+            1 => array(
+                'host' => 'foo.bar',
+                'port' => 11211,
+                'type' => 'TCP',
+            ),
+        );
+        $this->assertSame($expected, $client->getServerList());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27855
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/issues/10402

Useful to reconfigure dynamically an array of memcached servers (eg removing a dead one or adding a new one).
DSN format is e.g. `memcached://localhost?host[foo.bar]=3`.
To ease generating the DSN programmatically, it works also with `memcached:?host[localhost]&host[localhost:12345]&host[/some/memcached.sock:]=3`.

The key of the "host" parameter is a "host:port" pair, the value is the weight of the "host:port" pair.
Sockets need to be specified with the trailing `:` (as shown in the last example).