### PR TITLE
[DoctrineBridge] Added support for boolean value in UniqueEntity

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added support for `boolean` field type in `UniqueEntityValidator`
+
 4.2.0
 -----
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdWithBooleanEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdWithBooleanEntity.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+/** @Entity */
+class SingleIntIdWithBooleanEntity
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /** @Column(type="boolean", nullable=true) */
+    public $enabled;
+
+    public function __construct($id, $enabled)
+    {
+        $this->id = $id;
+        $this->enabled = $enabled;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -33,6 +33,7 @@ class UniqueEntity extends Constraint
     public $fields = [];
     public $errorPath = null;
     public $ignoreNull = true;
+    public $ignoreFalse = false;
 
     protected static $errorNames = [
         self::NOT_UNIQUE_ERROR => 'NOT_UNIQUE_ERROR',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10404

Hi 👋,
little feature to allow to use `UniqueEntityValidator` with boolean type field (ex: `Entity::enabled` property) with `ignoreFalse` constraint option for allowing many entities with `false` value.




