### PR TITLE
[Finder] fixed root directory access for ftp/sftp wrapper

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -732,12 +732,20 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Normalizes given directory names by removing trailing slashes.
      *
+     * Excluding: (s)ftp:// wrapper
+     *
      * @param string $dir
      *
      * @return string
      */
     private function normalizeDir($dir)
     {
-        return rtrim($dir, '/'.\DIRECTORY_SEPARATOR);
+        $dir = rtrim($dir, '/'.\DIRECTORY_SEPARATOR);
+
+        if (preg_match('#^s?ftp://#', $dir)) {
+            $dir .= '/';
+        }
+
+        return $dir;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #27423
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This fixes a flaw introduced in 3.4.7 by #26763

In order to access the root folder with ftp wrapper, there MUST BE a slash present. 
- Currently: from 3.4.7 on it just ```rtrim``` all seperators (```/```, ```\```) from directories
- Now: IF the directory is a (s)ftp:// wrapper (```#^s?ftp://#```) this fix just adds a slash (```/```) again
