### PR TITLE
[Form][DX] Add choice_filter option to ChoiceType

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1482,4 +1482,22 @@ class EntityTypeTest extends BaseTypeTest
         $this->assertEquals(array(), $form->getNormData());
         $this->assertSame(array(), $form->getViewData(), 'View data is always an array');
     }
+
+    public function testChoiceFilterOption()
+    {
+        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $entity2 = new SingleIntIdEntity(2, 'Bar');
+
+        $this->persist(array($entity1, $entity2));
+
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'choice_filter' => function (SingleIntIdEntity $entity) {
+                return 'Bar' === $entity->name;
+            },
+        ));
+
+        $this->assertEquals(array(2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
+    }
 }

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "symfony/stopwatch": "~3.4|~4.0",
         "symfony/dependency-injection": "~3.4|~4.0",
-        "symfony/form": "~3.4|~4.0",
+        "symfony/form": "^4.2",
         "symfony/http-kernel": "~3.4|~4.0",
         "symfony/property-access": "~3.4|~4.0",
         "symfony/property-info": "~3.4|~4.0",
@@ -45,7 +45,8 @@
     },
     "conflict": {
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-        "symfony/dependency-injection": "<3.4"
+        "symfony/dependency-injection": "<3.4",
+        "symfony/form": "<4.2"
     },
     "suggest": {
         "symfony/form": "",

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * added `Symfony\Component\Form\ClearableErrorsInterface`
  * deprecated calling `FormRenderer::searchAndRenderBlock` for fields which were already rendered
  * deprecated the `scale` option of the `IntegerType`
+ * added `Symfony\Component\Form\ChoiceList\Loader\ChoiceFilterInterface`
+ * added `choice_filter` option to `ChoiceType`
 
 4.1.0
 -----

--- a/src/Symfony/Component/Form/ChoiceList/Loader/CallbackChoiceLoader.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/CallbackChoiceLoader.php
@@ -18,9 +18,14 @@ use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
  *
  * @author Jules Pietri <jules@heahprod.com>
  */
-class CallbackChoiceLoader implements ChoiceLoaderInterface
+class CallbackChoiceLoader implements ChoiceLoaderInterface, ChoiceFilterInterface
 {
     private $callback;
+
+    /**
+     * @var callable
+     */
+    private $choiceFilter;
 
     /**
      * The loaded choice list.
@@ -46,7 +51,13 @@ class CallbackChoiceLoader implements ChoiceLoaderInterface
             return $this->choiceList;
         }
 
-        return $this->choiceList = new ArrayChoiceList(\call_user_func($this->callback), $value);
+        $choices = \call_user_func($this->callback);
+
+        if (null !== $this->choiceFilter) {
+            $choices = array_filter($choices, $this->choiceFilter, ARRAY_FILTER_USE_BOTH);
+        }
+
+        return $this->choiceList = new ArrayChoiceList($choices, $value);
     }
 
     /**
@@ -73,5 +84,13 @@ class CallbackChoiceLoader implements ChoiceLoaderInterface
         }
 
         return $this->loadChoiceList($value)->getValuesForChoices($choices);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setChoiceFilter(callable $choiceFilter)
+    {
+        $this->choiceFilter = $choiceFilter;
     }
 }

--- a/src/Symfony/Component/Form/ChoiceList/Loader/ChoiceFilterInterface.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/ChoiceFilterInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\ChoiceList\Loader;
+
+/**
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+interface ChoiceFilterInterface
+{
+    /**
+     * @param callable $choiceFilter The callable returning a filtered array of choices
+     */
+    public function setChoiceFilter(callable $choiceFilter);
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Author.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Author.php
@@ -42,9 +42,11 @@ class Author
         return 'foobar';
     }
 
-    public function setAustralian($australian)
+    public function setAustralian($australian): self
     {
         $this->australian = $australian;
+
+        return $this;
     }
 
     public function isAustralian()

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -4,6 +4,7 @@
     "options": {
         "own": [
             "choice_attr",
+            "choice_filter",
             "choice_label",
             "choice_loader",
             "choice_name",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -6,18 +6,18 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   Options                     Overridden options   Parent options            Extension options      
  --------------------------- -------------------- ------------------------- ----------------------- 
   choice_attr                 FormType             FormType                  FormTypeCsrfExtension  
-  choice_label               -------------------- ------------------------- ----------------------- 
-  choice_loader               compound             action                    csrf_field_name        
-  choice_name                 data_class           attr                      csrf_message           
-  choice_translation_domain   empty_data           auto_initialize           csrf_protection        
-  choice_value                error_bubbling       block_name                csrf_token_id          
-  choices                     trim                 by_reference              csrf_token_manager     
-  expanded                                         data                                             
-  group_by                                         disabled                                         
-  multiple                                         help                                             
-  placeholder                                      inherit_data                                     
-  preferred_choices                                label                                            
-                                                   label_attr                                       
+  choice_filter              -------------------- ------------------------- ----------------------- 
+  choice_label                compound             action                    csrf_field_name        
+  choice_loader               data_class           attr                      csrf_message           
+  choice_name                 empty_data           auto_initialize           csrf_protection        
+  choice_translation_domain   error_bubbling       block_name                csrf_token_id          
+  choice_value                trim                 by_reference              csrf_token_manager     
+  choices                                          data                                             
+  expanded                                         disabled                                         
+  group_by                                         help                                             
+  multiple                                         inherit_data                                     
+  placeholder                                      label                                            
+  preferred_choices                                label_attr                                       
                                                    label_format                                     
                                                    mapped                                           
                                                    method                                           


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #11847, #14072
| License       | MIT
| Doc PR        | TODO

Alternative of https://github.com/symfony/symfony/pull/18334 and https://github.com/symfony/symfony/pull/28542.

This is what we can do with this new option, before https://github.com/symfony/symfony/pull/28542#issuecomment-423616364, after https://github.com/symfony/symfony/pull/28542#issuecomment-423617861:
```php
$builder->add('locale', LocaleType::class, [
    'choice_filter' => function ($choice) use ($supportedLocales) {
        return \in_array($choice, $supportedLocales, true);
    },
]);
// or simply
$builder->add('locale', LocaleType::class, [
    'choice_filter' => $supportedLocales, // which does exactly the same as above
]);
```

In addition, we can use it with `EntityType`, to filter choices thanks to dynamic properties or methods that could not be used with a custom query builder.
```php
$builder->add('issues', EntityType::class, [
    'class' => Issue::class,
    'choice_filter' => function (Issue $issue) use ($user) {
        return $user->canHandle($issue);
    },
]);
```

This approach would filter the choices data just after loaded. This way, even filtered choice lists would be properly cached.