### PR TITLE
[DomCrawler] Change ->text() , ->html() and ->attr() methods to retur…

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -537,13 +537,11 @@ class Crawler implements \Countable, \IteratorAggregate
      * @param string $attribute The attribute name
      *
      * @return string|null The attribute value or null if the attribute does not exist
-     *
-     * @throws \InvalidArgumentException When current node is empty
      */
     public function attr($attribute)
     {
         if (!$this->nodes) {
-            throw new \InvalidArgumentException('The current node list is empty.');
+            return null;
         }
 
         $node = $this->getNode(0);
@@ -570,14 +568,12 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the node value of the first node of the list.
      *
-     * @return string The node value
-     *
-     * @throws \InvalidArgumentException When current node is empty
+     * @return string|null The node value
      */
     public function text()
     {
         if (!$this->nodes) {
-            throw new \InvalidArgumentException('The current node list is empty.');
+            return null;
         }
 
         return $this->getNode(0)->nodeValue;
@@ -586,14 +582,12 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns the first node of the list as HTML.
      *
-     * @return string The node html
-     *
-     * @throws \InvalidArgumentException When current node is empty
+     * @return string|null The node html
      */
     public function html()
     {
         if (!$this->nodes) {
-            throw new \InvalidArgumentException('The current node list is empty.');
+            return null;
         }
 
         $html = '';

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -350,13 +350,7 @@ EOF
     public function testAttr()
     {
         $this->assertEquals('first', $this->createTestCrawler()->filterXPath('//li')->attr('class'), '->attr() returns the attribute of the first element of the node list');
-
-        try {
-            $this->createTestCrawler()->filterXPath('//ol')->attr('class');
-            $this->fail('->attr() throws an \InvalidArgumentException if the node list is empty');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertTrue(true, '->attr() throws an \InvalidArgumentException if the node list is empty');
-        }
+        $this->assertEquals(null, $this->createTestCrawler()->filterXPath('//ol')->attr('class'), '->attr() returns null if the node list is empty');
     }
 
     public function testMissingAttrValueIsNull()
@@ -385,26 +379,14 @@ EOF
     public function testText()
     {
         $this->assertEquals('One', $this->createTestCrawler()->filterXPath('//li')->text(), '->text() returns the node value of the first element of the node list');
-
-        try {
-            $this->createTestCrawler()->filterXPath('//ol')->text();
-            $this->fail('->text() throws an \InvalidArgumentException if the node list is empty');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertTrue(true, '->text() throws an \InvalidArgumentException if the node list is empty');
-        }
+        $this->assertEquals(null, $this->createTestCrawler()->filterXPath('//ol')->text(), '->text() returns null if the node list is empty');
     }
 
     public function testHtml()
     {
         $this->assertEquals('<img alt="Bar">', $this->createTestCrawler()->filterXPath('//a[5]')->html());
         $this->assertEquals('<input type="text" value="TextValue" name="TextName"><input type="submit" value="FooValue" name="FooName" id="FooId"><input type="button" value="BarValue" name="BarName" id="BarId"><button value="ButtonValue" name="ButtonName" id="ButtonId"></button>', trim(preg_replace('~>\s+<~', '><', $this->createTestCrawler()->filterXPath('//form[@id="FooFormId"]')->html())));
-
-        try {
-            $this->createTestCrawler()->filterXPath('//ol')->html();
-            $this->fail('->html() throws an \InvalidArgumentException if the node list is empty');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertTrue(true, '->html() throws an \InvalidArgumentException if the node list is empty');
-        }
+        $this->assertEquals(null, $this->createTestCrawler()->filterXPath('//ol')->html(), '->html() returns null if the node list is empty');
     }
 
     public function testExtract()

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -350,7 +350,7 @@ EOF
     public function testAttr()
     {
         $this->assertEquals('first', $this->createTestCrawler()->filterXPath('//li')->attr('class'), '->attr() returns the attribute of the first element of the node list');
-        $this->assertEquals(null, $this->createTestCrawler()->filterXPath('//ol')->attr('class'), '->attr() returns null if the node list is empty');
+        $this->assertNull($this->createTestCrawler()->filterXPath('//ol')->attr('class'), '->attr() returns null if the node list is empty');
     }
 
     public function testMissingAttrValueIsNull()
@@ -379,14 +379,14 @@ EOF
     public function testText()
     {
         $this->assertEquals('One', $this->createTestCrawler()->filterXPath('//li')->text(), '->text() returns the node value of the first element of the node list');
-        $this->assertEquals(null, $this->createTestCrawler()->filterXPath('//ol')->text(), '->text() returns null if the node list is empty');
+        $this->assertNull($this->createTestCrawler()->filterXPath('//ol')->text(), '->text() returns null if the node list is empty');
     }
 
     public function testHtml()
     {
         $this->assertEquals('<img alt="Bar">', $this->createTestCrawler()->filterXPath('//a[5]')->html());
         $this->assertEquals('<input type="text" value="TextValue" name="TextName"><input type="submit" value="FooValue" name="FooName" id="FooId"><input type="button" value="BarValue" name="BarName" id="BarId"><button value="ButtonValue" name="ButtonName" id="ButtonId"></button>', trim(preg_replace('~>\s+<~', '><', $this->createTestCrawler()->filterXPath('//form[@id="FooFormId"]')->html())));
-        $this->assertEquals(null, $this->createTestCrawler()->filterXPath('//ol')->html(), '->html() returns null if the node list is empty');
+        $this->assertNull($this->createTestCrawler()->filterXPath('//ol')->html(), '->html() returns null if the node list is empty');
     }
 
     public function testExtract()


### PR DESCRIPTION
…n null if node list is empty

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28313 
| License       | MIT
| Doc PR        | symfony/symfony-docs

The ->text() , ->html() and ->attr() methods will return null if the node list is empty. Previous behavior was that they were throwing exceptions, which was inconvenient.