### PR TITLE
[Validator] Add capability to use callable object (```__invoke()``` method) as callback validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -33,7 +33,7 @@ class CallbackValidator extends ConstraintValidator
         }
 
         $method = $constraint->callback;
-        if ($method instanceof \Closure) {
+        if (\is_callable($method)) {
             $method($object, $this->context, $constraint->payload);
         } elseif (\is_array($method)) {
             if (!\is_callable($method)) {
@@ -45,11 +45,8 @@ class CallbackValidator extends ConstraintValidator
 
             \call_user_func($method, $object, $this->context, $constraint->payload);
         } elseif (\method_exists($method, '__invoke')) {
-            if (!\is_object($method)) {
-                $method = new $method();
-            }
-
-            $method($object, $this->context, $constraint->payload);
+            $validator = new $method();
+            $validator($object, $this->context, $constraint->payload);
         } elseif (null !== $object) {
             if (!\method_exists($object, $method)) {
                 throw new ConstraintDefinitionException(sprintf('Method "%s" targeted by Callback constraint does not exist in class %s', $method, \get_class($object)));

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -44,8 +44,11 @@ class CallbackValidator extends ConstraintValidator
             }
 
             \call_user_func($method, $object, $this->context, $constraint->payload);
+        } elseif (\method_exists($method, '__invoke')) {
+            $validator = new $method();
+            $validator($object, $this->context, $constraint->payload);
         } elseif (null !== $object) {
-            if (!method_exists($object, $method)) {
+            if (!\method_exists($object, $method)) {
                 throw new ConstraintDefinitionException(sprintf('Method "%s" targeted by Callback constraint does not exist in class %s', $method, \get_class($object)));
             }
 

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -45,8 +45,11 @@ class CallbackValidator extends ConstraintValidator
 
             \call_user_func($method, $object, $this->context, $constraint->payload);
         } elseif (\method_exists($method, '__invoke')) {
-            $validator = new $method();
-            $validator($object, $this->context, $constraint->payload);
+            if (!is_object($method)) {
+                $method = new $method();
+            }
+
+            $method($object, $this->context, $constraint->payload);
         } elseif (null !== $object) {
             if (!\method_exists($object, $method)) {
                 throw new ConstraintDefinitionException(sprintf('Method "%s" targeted by Callback constraint does not exist in class %s', $method, \get_class($object)));

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -45,7 +45,7 @@ class CallbackValidator extends ConstraintValidator
 
             \call_user_func($method, $object, $this->context, $constraint->payload);
         } elseif (\method_exists($method, '__invoke')) {
-            if (!is_object($method)) {
+            if (!\is_object($method)) {
                 $method = new $method();
             }
 


### PR DESCRIPTION
Add capability to call __invoke(callable object) as validator callback

| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no   
| Deprecations? | no 
| License       | MIT

Add capability to use callable object as callback validator

Before:

```@Assert\Callback({"App\Validator\YourCustomValidator", "__invoke"})```

After:

```@Assert\Callback("App\Validator\YourCustomValidator")```