### PR TITLE
Update ContainerHandlerLocator to allow for arbitrary key patterns in containers

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/Locator/ContainerHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/ContainerHandlerLocator.php
@@ -20,15 +20,17 @@ use Psr\Container\ContainerInterface;
 class ContainerHandlerLocator extends AbstractHandlerLocator
 {
     private $container;
+    private $handlerKeyFormat;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, string $handlerKeyFormat = 'handler.%s')
     {
         $this->container = $container;
+        $this->handlerKeyFormat = $handlerKeyFormat;
     }
 
     protected function getHandler(string $class)
     {
-        $handlerKey = 'handler.'.$class;
+        $handlerKey = sprintf($this->handlerKeyFormat, $class);
 
         return $this->container->has($handlerKey) ? $this->container->get($handlerKey) : null;
     }

--- a/src/Symfony/Component/Messenger/Tests/Handler/Locator/ContainerHandlerLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/Locator/ContainerHandlerLocatorTest.php
@@ -59,4 +59,17 @@ class ContainerHandlerLocatorTest extends TestCase
 
         $this->assertSame($handler, $resolvedHandler);
     }
+
+    public function testLoctesHandlerWithSpecificKeyFormat()
+    {
+        $handler = function () {};
+
+        $container = new Container();
+        $container->set('messages.handler.'.DummyMessage::class, $handler);
+
+        $locator = new ContainerHandlerLocator($container, 'messages.handler.%s');
+        $resolvedHandler = $locator->resolve(new DummyMessage('Hey'));
+
+        $this->assertSame($handler, $resolvedHandler);
+    }
 }


### PR DESCRIPTION
… containers

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no     
| Deprecations? | no
| Tests pass?   | yes   
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Minor tweak to allow for arbitrary key patterns in containers while having a sensible non-breaking default. Discussed with @sroze at Symfony Live London
