### PR TITLE
 [Form] Add FilterChoiceLoader + choice_filter option

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
    option is set to `single_text`
  * added `block_prefix` option to `BaseType`.
  * added `help_html` option to display the `help` text as HTML.
+ * added `FilterChoiceLoader`
+ * added `choice_filter` option to `ChoiceType`
 
 4.2.0
 -----

--- a/src/Symfony/Component/Form/ChoiceList/Loader/FilterChoiceLoader.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/FilterChoiceLoader.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\ChoiceList\Loader;
+
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+
+/**
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class FilterChoiceLoader implements ChoiceLoaderInterface
+{
+    private $loader;
+    private $filter;
+    private $choiceList;
+
+    public function __construct(ChoiceLoaderInterface $loader, callable $filter)
+    {
+        $this->loader = $loader;
+        $this->filter = $filter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        if (null !== $this->choiceList) {
+            return $this->choiceList;
+        }
+
+        $choiceList = $this->loader->loadChoiceList($value);
+        $structured = $choiceList->getStructuredValues();
+        $choices = $choiceList->getChoices();
+        $visitor = function (array $list) use ($choices, &$visitor) {
+            foreach ($list as $k => $v) {
+                if (\is_array($v)) {
+                    if ($v = $visitor($v)) {
+                        $list[$k] = $v;
+                    } else {
+                        unset($list[$k]);
+                    }
+                    continue;
+                }
+
+                $choice = $choices[$v] ?? $v;
+                if (!\call_user_func($this->filter, $choice)) {
+                    unset($list[$k]);
+                    continue;
+                }
+
+                $list[$k] = $choice;
+            }
+
+            return $list;
+        };
+
+        return $this->choiceList = new ArrayChoiceList($visitor($structured), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        // Optimize
+        if (empty($values)) {
+            return [];
+        }
+        if (null !== $this->choiceList) {
+            return $this->choiceList->getChoicesForValues($values);
+        }
+
+        return array_filter($this->loader->loadChoicesForValues($values, $value), $this->filter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        // Optimize
+        if (empty($choices)) {
+            return [];
+        }
+        if (null !== $this->choiceList) {
+            return $this->choiceList->getValuesForChoices($choices);
+        }
+
+        return $this->loader->loadValuesForChoices(array_filter($choices, $this->filter), $value);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/FilterChoiceLoaderTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/FilterChoiceLoaderTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\ChoiceList\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
+use Symfony\Component\Form\ChoiceList\LazyChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+use Symfony\Component\Form\ChoiceList\Loader\FilterChoiceLoader;
+
+/**
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class FilterChoiceLoaderTest extends TestCase
+{
+    /**
+     * @var callable
+     */
+    private static $value;
+
+    /**
+     * @var array
+     */
+    private static $choices;
+
+    /**
+     * @var string[]
+     */
+    private static $choiceValues;
+
+    public static function setUpBeforeClass()
+    {
+        self::$value = function (\stdClass $choice) {
+            return $choice->value;
+        };
+        self::$choices = [
+            (object) ['value' => 'choice_one'],
+            (object) ['value' => 'choice_two'],
+            (object) ['value' => 'choice_three'],
+            (object) ['value' => 'choice_four'],
+        ];
+        self::$choiceValues = ['choice_one', 'choice_two', 'choice_three', 'choice_four'];
+    }
+
+    public function testLoadChoiceList()
+    {
+        $loader = $this->createLoader();
+
+        $this->assertInstanceOf(ChoiceListInterface::class, $loader->loadChoiceList(self::$value));
+    }
+
+    public function testLoadChoiceListOnlyOnce()
+    {
+        $loader = $this->createLoader();
+        $loadedChoiceList = $loader->loadChoiceList(self::$value);
+
+        $this->assertSame($loadedChoiceList, $loader->loadChoiceList(self::$value));
+    }
+
+    public function testLoadChoicesForValuesLoadsChoiceListOnFirstCall()
+    {
+        $loader = $this->createLoader();
+        $lazyList = new LazyChoiceList($loader, self::$value);
+
+        $this->assertSame(
+            $loader->loadChoicesForValues(self::$choiceValues, self::$value),
+            $lazyList->getChoicesForValues(self::$choiceValues),
+            'Choice list should not be reloaded.'
+        );
+    }
+
+    public function testLoadValuesForChoicesLoadsChoiceListOnFirstCall()
+    {
+        $loader = $this->createLoader();
+        $lazyList = new LazyChoiceList($loader, self::$value);
+
+        $this->assertSame(
+            $loader->loadValuesForChoices(self::$choices, self::$value),
+            $lazyList->getValuesForChoices(self::$choices),
+            'Choice list should not be reloaded.'
+        );
+    }
+
+    public function testLoadChoiceListFilters()
+    {
+        $choiceList = $this->createLoader()->loadChoiceList();
+
+        $this->assertSame([self::$choices[2], self::$choices[3]], $choiceList->getChoices());
+        $this->assertSame(['0', '1'], $choiceList->getValues());
+        $this->assertSame([1, 'key'], $choiceList->getOriginalKeys());
+        $this->assertSame([1 => '0', 'Group' => ['key' => '1']], $choiceList->getStructuredValues());
+        $this->assertSame([self::$choices[3]], $choiceList->getChoicesForValues(['1', '2']));
+        $this->assertSame([], $choiceList->getChoicesForValues(['foo']));
+        $this->assertSame([1 => '0'], $choiceList->getValuesForChoices([self::$choices[1], self::$choices[2]]));
+        $this->assertSame([], $choiceList->getValuesForChoices(['foo']));
+    }
+
+    public function testLoadChoicesForValuesFilters()
+    {
+        $loader = $this->createLoader();
+        $choices = $loader->loadChoicesForValues(['choice_one', 'choice_three'], self::$value);
+
+        $this->assertSame([1 => self::$choices[2]], $choices);
+    }
+
+    public function testLoadValuesForChoicesFilters()
+    {
+        $loader = $this->createLoader();
+        $values = $loader->loadValuesForChoices([
+            self::$choices[0],
+            self::$choices[2],
+        ], self::$value);
+
+        $this->assertSame([1 => 'choice_three'], $values);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$value = null;
+        self::$choices = [];
+        self::$choiceValues = [];
+    }
+
+    private function createLoader(): FilterChoiceLoader
+    {
+        return new FilterChoiceLoader(new CallbackChoiceLoader(function () {
+            return [
+                self::$choices[0],
+                self::$choices[2],
+                'Group' => [
+                    self::$choices[1],
+                    'key' => self::$choices[3],
+                ],
+            ];
+        }), function (\stdClass $choice) {
+            return \in_array($choice->value, ['choice_three', 'choice_four'], true);
+        });
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -4,6 +4,7 @@
     "options": {
         "own": [
             "choice_attr",
+            "choice_filter",
             "choice_label",
             "choice_loader",
             "choice_name",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -6,18 +6,18 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   Options                     Overridden options   Parent options            Extension options      
  --------------------------- -------------------- ------------------------- ----------------------- 
   choice_attr                 FormType             FormType                  FormTypeCsrfExtension  
-  choice_label               -------------------- ------------------------- ----------------------- 
-  choice_loader               compound             action                    csrf_field_name        
-  choice_name                 data_class           allow_file_upload         csrf_message           
-  choice_translation_domain   empty_data           attr                      csrf_protection        
-  choice_value                error_bubbling       auto_initialize           csrf_token_id          
-  choices                     trim                 block_name                csrf_token_manager     
-  expanded                                         block_prefix                                     
-  group_by                                         by_reference                                     
-  multiple                                         data                                             
-  placeholder                                      disabled                                         
-  preferred_choices                                help                                             
-                                                   help_attr                                        
+  choice_filter              -------------------- ------------------------- ----------------------- 
+  choice_label                compound             action                    csrf_field_name        
+  choice_loader               data_class           allow_file_upload         csrf_message           
+  choice_name                 empty_data           attr                      csrf_protection        
+  choice_translation_domain   error_bubbling       auto_initialize           csrf_token_id          
+  choice_value                trim                 block_name                csrf_token_manager     
+  choices                                          block_prefix                                     
+  expanded                                         by_reference                                     
+  group_by                                         data                                             
+  multiple                                         disabled                                         
+  placeholder                                      help                                             
+  preferred_choices                                help_attr                                        
                                                    help_html                                        
                                                    inherit_data                                     
                                                    label                                            


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #11847, #14072, #28607, #28542
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/issues/10413

I did it :) i understand form choice lists.. took me only 2 days :joy: 

But here it is, a `choice_filter` option for the `ChoiceType`. Allowing to filter the list of choices independent from any choice loader / array.

This is no magic bullet. To truly optimize one should always prefer a filtered choice list (e.g. passing a query builder to the doctrine choice loader). But for built-in / pre-defined choice loaders, e.g. Intl, this is convenient.

Thanks to @sstok and @yceruto also.

- [x] agree on approach (per https://github.com/symfony/symfony/issues/14072#issuecomment-190107007)
- [x] consider delegating array choices to `ArrayChoiceList` for sanity :)
- [x] update filtering array choices (see todo in code)
- [x] fix callable argument consistency (`choice` only)
- [x] add form integration/rendering tests