### PR TITLE
[Translation] marked getFallbackLocales() as internal

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -209,6 +209,7 @@ Translation
 
  * The `TranslatorInterface` has been deprecated in favor of `Symfony\Contracts\Translation\TranslatorInterface`
  * The `MessageSelector`, `Interval` and `PluralizationRules` classes have been deprecated, use `IdentityTranslator` instead
+ * The `Translator::getFallbackLocales()` and `TranslationDataCollector::getFallbackLocales()` method have been marked as internal
 
 Validator
 ---------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -184,6 +184,7 @@ Translation
  * The `TranslationWriter::disableBackup()` method has been removed.
  * The `TranslatorInterface` has been removed in favor of `Symfony\Contracts\Translation\TranslatorInterface`
  * The `MessageSelector`, `Interval` and `PluralizationRules` classes have been removed, use `IdentityTranslator` instead
+ * The `Translator::getFallbackLocales()` and `TranslationDataCollector::getFallbackLocales()` method are now internal
 
 TwigBundle
 ----------

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * deprecated `MessageSelector`, `Interval` and `PluralizationRules`; use `IdentityTranslator` instead
  * Added `IntlMessageFormatter` and `FallbackMessageFormatter`
  * added support for multiple files and directories in `XliffLintCommand`
+ * Marked `Translator::getFallbackLocales()` and `TranslationDataCollector::getFallbackLocales()` as internal
 
 4.1.0
 -----

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -97,6 +97,9 @@ class TranslationDataCollector extends DataCollector implements LateDataCollecto
         return !empty($this->data['locale']) ? $this->data['locale'] : null;
     }
 
+    /**
+     * @internal since Symfony 4.2
+     */
     public function getFallbackLocales()
     {
         return (isset($this->data['fallback_locales']) && \count($this->data['fallback_locales']) > 0) ? $this->data['fallback_locales'] : array();

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -176,6 +176,8 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     /**
      * Gets the fallback locales.
      *
+     * @internal since Symfony 4.2
+     *
      * @return array $locales The fallback locales
      */
     public function getFallbackLocales()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no 
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes    
| Fixed tickets | #28579   
| License       | MIT
| Doc PR        | 

Added the deprication trigger error function to getFallbackLocales in the Translation component.

(Its my first PR, please tell me if i need to change something)
