### PR TITLE
[DI] [HttpKernel] Add interfaces for Event listeners auto-configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Removed the `framework.messenger.encoder` and `framework.messenger.decoder` options. Use the `framework.messenger.serializer.id` option to replace the Messenger serializer. 
  * Deprecated the `ContainerAwareCommand` class in favor of `Symfony\Component\Console\Command\Command`
  * Made `debug:container` and `debug:autowiring` ignore backslashes in service ids
+ * Added interfaces to allow auto-configuration of Kernel events listeners
 
 4.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -388,7 +388,7 @@ class FrameworkExtension extends Extension
 
         foreach ($kernelEventsMapping as $class => $event) {
             $container->registerForAutoconfiguration($class)
-                ->addTag('kernel.event_listener', array('event' => $event, 'method' => '__invoke'));
+                ->addTag('kernel.event_listener', array('event' => $event));
         }
 
         if (!$container->getParameter('kernel.debug')) {

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelControllerListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelControllerListenerInterface.php
@@ -22,5 +22,5 @@ interface KernelControllerListenerInterface
     /**
      * @param FilterControllerEvent $event
      */
-    public function __invoke(FilterControllerEvent $event): void;
+    public function onKernelController(FilterControllerEvent $event): void;
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelControllerListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelControllerListenerInterface.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+
+/**
+ * Implement this interface to allow automatically add the "kernel.event_listener" tag with event "kernel.controller".
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+interface KernelControllerListenerInterface
+{
+    /**
+     * @param FilterControllerEvent $event
+     */
+    public function __invoke(FilterControllerEvent $event): void;
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelExceptionListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelExceptionListenerInterface.php
@@ -23,5 +23,5 @@ interface KernelExceptionListenerInterface
     /**
      * @param GetResponseForExceptionEvent $event
      */
-    public function __invoke(GetResponseForExceptionEvent $event): void;
+    public function onKernelException(GetResponseForExceptionEvent $event): void;
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelExceptionListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelExceptionListenerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+
+/**
+ * Implement this interface to allow automatically add the "kernel.event_listener" tag with event "kernel.exception".
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+interface KernelExceptionListenerInterface
+{
+    /**
+     * @param GetResponseForExceptionEvent $event
+     */
+    public function __invoke(GetResponseForExceptionEvent $event): void;
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelFinishRequestListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelFinishRequestListenerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+
+/**
+ * Implement this interface to allow automatically add the "kernel.event_listener" tag with event "kernel.finish_request".
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+interface KernelFinishRequestListenerInterface
+{
+    /**
+     * @param FinishRequestEvent $event
+     */
+    public function __invoke(FinishRequestEvent $event): void;
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelFinishRequestListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelFinishRequestListenerInterface.php
@@ -23,5 +23,5 @@ interface KernelFinishRequestListenerInterface
     /**
      * @param FinishRequestEvent $event
      */
-    public function __invoke(FinishRequestEvent $event): void;
+    public function onKernelFinishRequest(FinishRequestEvent $event): void;
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelRequestListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelRequestListenerInterface.php
@@ -23,5 +23,5 @@ interface KernelRequestListenerInterface
     /**
      * @param GetResponseEvent $event
      */
-    public function __invoke(GetResponseEvent $event): void;
+    public function onKernelRequest(GetResponseEvent $event): void;
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelRequestListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelRequestListenerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * Implement this interface to allow automatically add the "kernel.event_listener" tag with event "kernel.request".
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+interface KernelRequestListenerInterface
+{
+    /**
+     * @param GetResponseEvent $event
+     */
+    public function __invoke(GetResponseEvent $event): void;
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelResponseListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelResponseListenerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * Implement this interface to allow automatically add the "kernel.event_listener" tag with event "kernel.response".
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+interface KernelResponseListenerInterface
+{
+    /**
+     * @param FilterResponseEvent $event
+     */
+    public function __invoke(FilterResponseEvent $event): void;
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelResponseListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelResponseListenerInterface.php
@@ -23,5 +23,5 @@ interface KernelResponseListenerInterface
     /**
      * @param FilterResponseEvent $event
      */
-    public function __invoke(FilterResponseEvent $event): void;
+    public function onKernelResponse(FilterResponseEvent $event): void;
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelTerminateListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelTerminateListenerInterface.php
@@ -23,5 +23,5 @@ interface KernelTerminateListenerInterface
     /**
      * @param PostResponseEvent $event
      */
-    public function __invoke(PostResponseEvent $event): void;
+    public function onKernelTerminate(PostResponseEvent $event): void;
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelTerminateListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelTerminateListenerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+
+/**
+ * Implement this interface to allow automatically add the "kernel.event_listener" tag with event "kernel.terminate".
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+interface KernelTerminateListenerInterface
+{
+    /**
+     * @param PostResponseEvent $event
+     */
+    public function __invoke(PostResponseEvent $event): void;
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelViewListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelViewListenerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+
+/**
+ * Implement this interface to allow automatically add the "kernel.event_listener" tag with event "kernel.view".
+ *
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+interface KernelViewListenerInterface
+{
+    /**
+     * @param GetResponseForControllerResultEvent $event
+     */
+    public function __invoke(GetResponseForControllerResultEvent $event): void;
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/KernelViewListenerInterface.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/KernelViewListenerInterface.php
@@ -23,5 +23,5 @@ interface KernelViewListenerInterface
     /**
      * @param GetResponseForControllerResultEvent $event
      */
-    public function __invoke(GetResponseForControllerResultEvent $event): void;
+    public function onKernelView(GetResponseForControllerResultEvent $event): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | TODO

To register a *kernel event* listener:

### Before:
```php
namespace App\EventListener;

use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;

class ExceptionListener
{
    public function onKernelException(GetResponseForExceptionEvent $event)
    {
        // Whatever
    }
}
```

And then register it:
```yaml
# config/services.yaml
services:
    App\EventListener\ExceptionListener:
        tags:
            - { name: kernel.event_listener, event: kernel.exception }
```

### After:
```php
namespace App\EventListener;

use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
use Symfony\Component\HttpKernel\EventListener\KernelExceptionListenerInterface;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;

class ExceptionListener implements KernelExceptionListenerInterface
{
    public function onKernelException(GetResponseForExceptionEvent $event): void
    {
        // Whatever
    }
}
```

And that's it.

Available interfaces:
```
KernelControllerListenerInterface => KernelEvents::CONTROLLER
KernelExceptionListenerInterface => KernelEvents::EXCEPTION
KernelFinishRequestListenerInterface => KernelEvents::FINISH_REQUEST
KernelRequestListenerInterface => KernelEvents::REQUEST
KernelResponseListenerInterface => KernelEvents::RESPONSE
KernelTerminateListenerInterface => KernelEvents::TERMINATE
KernelViewListenerInterface => KernelEvents::VIEW
```