### PR TITLE
[Validator] add number constraints

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -10,6 +10,10 @@ CHANGELOG
  * added `Json` constraint
  * added `Unique` constraint
  * added a new `normalizer` option to the string constraints and to the `NotBlank` constraint
+ * added `Positive` constraint
+ * added `PositiveOrZero` constraint
+ * added `Negative` constraint
+ * added `NegativeOrZero` constraint
 
 4.2.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/Negative.php
+++ b/src/Symfony/Component/Validator/Constraints/Negative.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class Negative extends LessThan
+{
+    use NumberConstraintTrait;
+
+    public $message = 'This value should be negative.';
+
+    public function __construct($options = null)
+    {
+        parent::__construct($this->configureNumberConstraintOptions($options));
+    }
+
+    public function validatedBy(): string
+    {
+        return LessThanValidator::class;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/NegativeOrZero.php
+++ b/src/Symfony/Component/Validator/Constraints/NegativeOrZero.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class NegativeOrZero extends LessThanOrEqual
+{
+    use NumberConstraintTrait;
+
+    public $message = 'This value should be either negative or zero.';
+
+    public function __construct($options = null)
+    {
+        parent::__construct($this->configureNumberConstraintOptions($options));
+    }
+
+    public function validatedBy(): string
+    {
+        return LessThanOrEqualValidator::class;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/NumberConstraintTrait.php
+++ b/src/Symfony/Component/Validator/Constraints/NumberConstraintTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+trait NumberConstraintTrait
+{
+    private function configureNumberConstraintOptions($options): array
+    {
+        if (null === $options) {
+            $options = [];
+        } elseif (!\is_array($options)) {
+            $options = [$this->getDefaultOption() => $options];
+        }
+
+        if (isset($options['propertyPath'])) {
+            throw new ConstraintDefinitionException(sprintf('The "propertyPath" option of the "%s" constraint cannot be set.', \get_class($this)));
+        }
+
+        if (isset($options['value'])) {
+            throw new ConstraintDefinitionException(sprintf('The "value" option of the "%s" constraint cannot be set.', \get_class($this)));
+        }
+
+        $options['value'] = 0;
+
+        return $options;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/Positive.php
+++ b/src/Symfony/Component/Validator/Constraints/Positive.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class Positive extends GreaterThan
+{
+    use NumberConstraintTrait;
+
+    public $message = 'This value should be positive.';
+
+    public function __construct($options = null)
+    {
+        parent::__construct($this->configureNumberConstraintOptions($options));
+    }
+
+    public function validatedBy(): string
+    {
+        return GreaterThanValidator::class;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/PositiveOrZero.php
+++ b/src/Symfony/Component/Validator/Constraints/PositiveOrZero.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class PositiveOrZero extends GreaterThanOrEqual
+{
+    use NumberConstraintTrait;
+
+    public $message = 'This value should be either positive or zero.';
+
+    public function __construct($options = null)
+    {
+        parent::__construct($this->configureNumberConstraintOptions($options));
+    }
+
+    public function validatedBy(): string
+    {
+        return GreaterThanOrEqualValidator::class;
+    }
+}

--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -330,6 +330,22 @@
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
                 <target>Diese internationale Bankleitzahl (BIC) ist nicht mit der IBAN {{ iban }} assoziiert.</target>
             </trans-unit>
+            <trans-unit id="87">
+                <source>This value should be positive.</source>
+                <target>Dieser Wert sollte positiv sein.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be either positive or zero.</source>
+                <target>Dieser Wert sollte entweder positiv oder 0 sein.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be negative.</source>
+                <target>Dieser Wert sollte negativ sein.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be either negative or zero.</source>
+                <target>Dieser Wert sollte entweder negativ oder 0 sein.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -334,6 +334,22 @@
                 <source>This value should be valid JSON.</source>
                 <target>This value should be valid JSON.</target>
             </trans-unit>
+            <trans-unit id="87">
+                <source>This value should be positive.</source>
+                <target>This value should be positive.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be either positive or zero.</source>
+                <target>This value should be either positive or zero.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be negative.</source>
+                <target>This value should be negative.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be either negative or zero.</source>
+                <target>This value should be either negative or zero.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
@@ -278,6 +278,22 @@
                 <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
                 <target>Giá trị không được phép giống như {{ compared_value_type }} {{ compared_value }}.</target>
             </trans-unit>
+            <trans-unit id="87">
+                <source>This value should be positive.</source>
+                <target>Giá trị này có thể thực hiện được.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be either positive or zero.</source>
+                <target>Giá trị này có thể thực hiện được hoặc bằng không.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be negative.</source>
+                <target>Giá trị này nên bị từ chối.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be either negative or zero.</source>
+                <target>Giá trị này nên bị từ chối hoặc bằng không.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\PositiveOrZero;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class GreaterThanOrEqualValidatorWithPositiveOrZeroConstraintTest extends GreaterThanOrEqualValidatorTest
+{
+    protected function createConstraint(array $options = null)
+    {
+        return new PositiveOrZero();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideValidComparisons()
+    {
+        return [
+            [0, 0],
+            [1, 0],
+            [2, 0],
+            [2.5, 0],
+            ['0', '0'],
+            ['333', '0'],
+            [null, 0],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return [
+            [-1, '-1', 0, '0', 'integer'],
+            [-2, '-2', 0, '0', 'integer'],
+            [-2.5, '-2.5', 0, '0', 'integer'],
+        ];
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "propertyPath" option of the "Symfony\Component\Validator\Constraints\PositiveOrZero" constraint cannot be set.
+     */
+    public function testThrowsConstraintExceptionIfPropertyPath()
+    {
+        return new PositiveOrZero(['propertyPath' => 'field']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "value" option of the "Symfony\Component\Validator\Constraints\PositiveOrZero" constraint cannot be set.
+     */
+    public function testThrowsConstraintExceptionIfValue()
+    {
+        return new PositiveOrZero(['value' => 0]);
+    }
+
+    /**
+     * @dataProvider provideInvalidConstraintOptions
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage requires either the "value" or "propertyPath" option to be set.
+     */
+    public function testThrowsConstraintExceptionIfNoValueOrPropertyPath($options)
+    {
+        $this->markTestSkipped('Value option always set for PositiveOrZero constraint');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage requires only one of the "value" or "propertyPath" options to be set, not both.
+     */
+    public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
+    {
+        $this->markTestSkipped('Value option is set for PositiveOrZero constraint automatically');
+    }
+
+    public function testInvalidValuePath()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
+    }
+
+    /**
+     * @dataProvider provideValidComparisonsToPropertyPath
+     */
+    public function testValidComparisonToPropertyPath($comparedValue)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in PositiveOrZero constraint');
+    }
+
+    /**
+     * @dataProvider provideValidComparisonsToPropertyPath
+     */
+    public function testValidComparisonToPropertyPathOnArray($comparedValue)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorWithPositiveConstraintTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Positive;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class GreaterThanValidatorWithPositiveConstraintTest extends GreaterThanValidatorTest
+{
+    protected function createConstraint(array $options = null)
+    {
+        return new Positive();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideValidComparisons()
+    {
+        return [
+            [2, 0],
+            [2.5, 0],
+            ['333', '0'],
+            [null, 0],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return [
+            [0, '0', 0, '0', 'integer'],
+            [-1, '-1', 0, '0', 'integer'],
+            [-2, '-2', 0, '0', 'integer'],
+            [-2.5, '-2.5', 0, '0', 'integer'],
+        ];
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "propertyPath" option of the "Symfony\Component\Validator\Constraints\Positive" constraint cannot be set.
+     */
+    public function testThrowsConstraintExceptionIfPropertyPath()
+    {
+        return new Positive(['propertyPath' => 'field']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "value" option of the "Symfony\Component\Validator\Constraints\Positive" constraint cannot be set.
+     */
+    public function testThrowsConstraintExceptionIfValue()
+    {
+        return new Positive(['value' => 0]);
+    }
+
+    /**
+     * @dataProvider provideInvalidConstraintOptions
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage requires either the "value" or "propertyPath" option to be set.
+     */
+    public function testThrowsConstraintExceptionIfNoValueOrPropertyPath($options)
+    {
+        $this->markTestSkipped('Value option always set for Positive constraint.');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage requires only one of the "value" or "propertyPath" options to be set, not both.
+     */
+    public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
+    {
+        $this->markTestSkipped('Value option is set for Positive constraint automatically');
+    }
+
+    public function testNoViolationOnNullObjectWithPropertyPath()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+    }
+
+    public function testInvalidValuePath()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+    }
+
+    /**
+     * @dataProvider provideValidComparisonsToPropertyPath
+     */
+    public function testValidComparisonToPropertyPath($comparedValue)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+    }
+
+    /**
+     * @dataProvider provideValidComparisonsToPropertyPath
+     */
+    public function testValidComparisonToPropertyPathOnArray($comparedValue)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\NegativeOrZero;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class LessThanOrEqualValidatorWithNegativeOrZeroConstraintTest extends LessThanOrEqualValidatorTest
+{
+    protected function createConstraint(array $options = null)
+    {
+        return new NegativeOrZero();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideValidComparisons()
+    {
+        return [
+            [0, 0],
+            [-1, 0],
+            [-2, 0],
+            [-2.5, 0],
+            [null, 0],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return [
+            [2, '2', 0, '0', 'integer'],
+            [2.5, '2.5', 0, '0', 'integer'],
+            [333, '333', 0, '0', 'integer'],
+        ];
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "propertyPath" option of the "Symfony\Component\Validator\Constraints\NegativeOrZero" constraint cannot be set.
+     */
+    public function testThrowsConstraintExceptionIfPropertyPath()
+    {
+        return new NegativeOrZero(['propertyPath' => 'field']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "value" option of the "Symfony\Component\Validator\Constraints\NegativeOrZero" constraint cannot be set.
+     */
+    public function testThrowsConstraintExceptionIfValue()
+    {
+        return new NegativeOrZero(['value' => 0]);
+    }
+
+    /**
+     * @dataProvider provideInvalidConstraintOptions
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage requires either the "value" or "propertyPath" option to be set.
+     */
+    public function testThrowsConstraintExceptionIfNoValueOrPropertyPath($options)
+    {
+        $this->markTestSkipped('Value option always set for NegativeOrZero constraint');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage requires only one of the "value" or "propertyPath" options to be set, not both.
+     */
+    public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
+    {
+        $this->markTestSkipped('Value option is set for NegativeOrZero constraint automatically');
+    }
+
+    public function testNoViolationOnNullObjectWithPropertyPath()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+    }
+
+    public function testInvalidValuePath()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+    }
+
+    /**
+     * @dataProvider provideValidComparisonsToPropertyPath
+     */
+    public function testValidComparisonToPropertyPath($comparedValue)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+    }
+
+    /**
+     * @dataProvider provideValidComparisonsToPropertyPath
+     */
+    public function testValidComparisonToPropertyPathOnArray($comparedValue)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in NegativeOrZero constraint');
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorWithNegativeConstraintTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Negative;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class LessThanValidatorWithNegativeConstraintTest extends LessThanValidatorTest
+{
+    protected function createConstraint(array $options = null)
+    {
+        return new Negative();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideValidComparisons()
+    {
+        return [
+            [-1, 0],
+            [-2, 0],
+            [-2.5, 0],
+            [null, 0],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return [
+            [0, '0', 0, '0', 'integer'],
+            [2, '2', 0, '0', 'integer'],
+            [2.5, '2.5', 0, '0', 'integer'],
+            [333, '333', 0, '0', 'integer'],
+        ];
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "propertyPath" option of the "Symfony\Component\Validator\Constraints\Negative" constraint cannot be set.
+     */
+    public function testThrowsConstraintExceptionIfPropertyPath()
+    {
+        return new Negative(['propertyPath' => 'field']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage The "value" option of the "Symfony\Component\Validator\Constraints\Negative" constraint cannot be set.
+     */
+    public function testThrowsConstraintExceptionIfValue()
+    {
+        return new Negative(['value' => 0]);
+    }
+
+    /**
+     * @dataProvider provideInvalidConstraintOptions
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage requires either the "value" or "propertyPath" option to be set.
+     */
+    public function testThrowsConstraintExceptionIfNoValueOrPropertyPath($options)
+    {
+        $this->markTestSkipped('Value option always set for Negative constraint');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     * @expectedExceptionMessage requires only one of the "value" or "propertyPath" options to be set, not both.
+     */
+    public function testThrowsConstraintExceptionIfBothValueAndPropertyPath()
+    {
+        $this->markTestSkipped('Value option is set for Negative constraint automatically');
+    }
+
+    public function testNoViolationOnNullObjectWithPropertyPath()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+    }
+
+    public function testInvalidValuePath()
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+    }
+
+    /**
+     * @dataProvider provideValidComparisonsToPropertyPath
+     */
+    public function testValidComparisonToPropertyPath($comparedValue)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Negative constraint');
+    }
+
+    /**
+     * @dataProvider provideValidComparisonsToPropertyPath
+     */
+    public function testValidComparisonToPropertyPathOnArray($comparedValue)
+    {
+        $this->markTestSkipped('PropertyPath option is not used in Positive constraint');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28608
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11254

I added the following constraints:
* `Positive`
* `PositiveOrZero`
* `Negative`
* `NegativeOrZero`