### PR TITLE
[Console] Fix clearing sections containing questions

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StreamableInputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
@@ -121,6 +122,10 @@ class QuestionHelper extends Helper
             }
         } else {
             $ret = trim($this->autocomplete($output, $question, $inputStream, \is_array($autocomplete) ? $autocomplete : iterator_to_array($autocomplete, false)));
+        }
+
+        if ($output instanceof ConsoleSectionOutput) {
+            $output->addContent($ret);
         }
 
         $ret = \strlen($ret) > 0 ? $ret : $question->getDefault();

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -78,6 +78,18 @@ class ConsoleSectionOutput extends StreamOutput
     }
 
     /**
+     * @internal
+     */
+    public function addContent(string $input)
+    {
+        foreach (explode(PHP_EOL, $input) as $lineContent) {
+            $this->lines += ceil($this->getDisplayLength($lineContent) / $this->terminal->getWidth()) ?: 1;
+            $this->content[] = $lineContent;
+            $this->content[] = PHP_EOL;
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function doWrite($message, $newline)
@@ -88,11 +100,7 @@ class ConsoleSectionOutput extends StreamOutput
 
         $erasedContent = $this->popStreamContentUntilCurrentSection();
 
-        foreach (explode(PHP_EOL, $message) as $lineContent) {
-            $this->lines += ceil($this->getDisplayLength($lineContent) / $this->terminal->getWidth()) ?: 1;
-            $this->content[] = $lineContent;
-            $this->content[] = PHP_EOL;
-        }
+        $this->addContent($message);
 
         parent::doWrite($message, true);
         parent::doWrite($erasedContent, false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28615 
| License       | MIT
| Doc PR        | n/a

Given:
```php
$section = $output->section();
$question = "What's your name?";
$name = (new QuestionHelper())->ask($input, $section, new Question($question));
$section->clear();
$section->writeln("$question (<info>$name</info>)");
```

Before:
![](https://i.imgur.com/nJdKXAo.gif)

After:
![](https://i.imgur.com/WdMtKvV.gif)