### PR TITLE
[Validator] Standardize constraint validators

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator;
 
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * Base class for constraint validators.
@@ -42,6 +43,40 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     public function initialize(ExecutionContextInterface $context)
     {
         $this->context = $context;
+    }
+
+    /**
+     * Test a constraint class for the current validator.
+     *
+     * @throws UnexpectedTypeException
+     */
+    final protected static function testConstraint(Constraint $constraint, string $expectedClass)
+    {
+        if (!$constraint instanceof $expectedClass) {
+            throw new UnexpectedTypeException($constraint, $expectedClass);
+        }
+    }
+
+    /**
+     * Get a string value.
+     *
+     * @throws UnexpectedTypeException
+     */
+    final protected static function toString($value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedTypeException($value, 'string or null');
+        }
+
+        if ('' === $value = (string) $value) {
+            return null;
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -9,12 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\Validator\Constraints\Bic;
+
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * @author Michael Hirschler <michael.vhirsch@gmail.com>
@@ -28,12 +29,11 @@ class BicValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (null === $value || '' === $value) {
-            return;
-        }
+        /* @var Bic $constraint */
+        self::testConstraint($constraint, Bic::class);
 
-        if (!is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
-            throw new UnexpectedTypeException($value, 'string');
+        if (null === $value = self::toString($value)) {
+            return;
         }
 
         $canonicalize = str_replace(' ', '', $value);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no-ish
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

there are subtle inconsistencies between constraint validators, esp. related to string values. I think we should tackle it, by taking away the boring stuff.

- constraint type isnt always checked
- casting objects to string doesnt always happen
- checking empty string after casting doesnt always happen
- the order of checks isnt always the same

This would help custom constraints, as well as core to e.g. deprecate empty string handling in a unified way (#28611).