### PR TITLE
[Console] Add missing null to input values allowed types

### DIFF
--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -31,10 +31,10 @@ class InputArgument
     private $description;
 
     /**
-     * @param string $name        The argument name
-     * @param int    $mode        The argument mode: self::REQUIRED or self::OPTIONAL
-     * @param string $description A description text
-     * @param mixed  $default     The default value (for self::OPTIONAL mode only)
+     * @param string               $name        The argument name
+     * @param int|null             $mode        The argument mode: self::REQUIRED or self::OPTIONAL
+     * @param string               $description A description text
+     * @param string|string[]|null $default     The default value (for self::OPTIONAL mode only)
      *
      * @throws InvalidArgumentException When argument mode is not valid
      */
@@ -86,7 +86,7 @@ class InputArgument
     /**
      * Sets the default value.
      *
-     * @param string|string[] $default The default value
+     * @param string|string[]|null $default The default value
      *
      * @throws LogicException When incorrect default value is given
      */
@@ -110,7 +110,7 @@ class InputArgument
     /**
      * Returns the default value.
      *
-     * @return string|string[] The default value
+     * @return string|string[]|null The default value
      */
     public function getDefault()
     {

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -83,7 +83,7 @@ interface InputInterface
      *
      * @param string $name The argument name
      *
-     * @return string|string[] The argument value
+     * @return string|string[]|null The argument value
      *
      * @throws InvalidArgumentException When argument given doesn't exist
      */
@@ -92,8 +92,8 @@ interface InputInterface
     /**
      * Sets an argument value by name.
      *
-     * @param string          $name  The argument name
-     * @param string|string[] $value The argument value
+     * @param string               $name  The argument name
+     * @param string|string[]|null $value The argument value
      *
      * @throws InvalidArgumentException When argument given doesn't exist
      */
@@ -120,7 +120,7 @@ interface InputInterface
      *
      * @param string $name The option name
      *
-     * @return string|string[]|bool The option value
+     * @return string|string[]|bool|null The option value
      *
      * @throws InvalidArgumentException When option given doesn't exist
      */
@@ -129,8 +129,8 @@ interface InputInterface
     /**
      * Sets an option value by name.
      *
-     * @param string               $name  The option name
-     * @param string|string[]|bool $value The option value
+     * @param string                    $name  The option name
+     * @param string|string[]|bool|null $value The option value
      *
      * @throws InvalidArgumentException When option given doesn't exist
      */

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -33,11 +33,11 @@ class InputOption
     private $description;
 
     /**
-     * @param string       $name        The option name
-     * @param string|array $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param int          $mode        The option mode: One of the VALUE_* constants
-     * @param string       $description A description text
-     * @param mixed        $default     The default value (must be null for self::VALUE_NONE)
+     * @param string                    $name        The option name
+     * @param string|array              $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param int|null                  $mode        The option mode: One of the VALUE_* constants
+     * @param string                    $description A description text
+     * @param string|string[]|bool|null $default     The default value (must be null for self::VALUE_NONE)
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
      */
@@ -149,7 +149,7 @@ class InputOption
     /**
      * Sets the default value.
      *
-     * @param string|string[]|bool $default The default value
+     * @param string|string[]|bool|null $default The default value
      *
      * @throws LogicException When incorrect default value is given
      */
@@ -173,7 +173,7 @@ class InputOption
     /**
      * Returns the default value.
      *
-     * @return string|string[]|bool The default value
+     * @return string|string[]|bool|null The default value
      */
     public function getDefault()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When switching from `mixed` in #28448 we forgot that input arguments/options are default `null` and can be set to null (e.g. when passed empty with mode `VALUE_OPTIONAL`).
Spotted by @ro0NL 