### PR TITLE
[PHPUnitBridge] Fix ClockMock microtime() format

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -66,7 +66,7 @@ class ClockMock
             return self::$now;
         }
 
-        return sprintf('%0.6f %d', self::$now - (int) self::$now, (int) self::$now);
+        return sprintf('%0.6f00 %d', self::$now - (int) self::$now, (int) self::$now);
     }
 
     public static function register($class)

--- a/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
+
+/**
+ * @author Dominic Tubach <dominic.tubach@to.com>
+ *
+ * @covers \Symfony\Bridge\PhpUnit\ClockMock
+ */
+class ClockMockTest extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        ClockMock::register(__CLASS__);
+    }
+
+    protected function setUp()
+    {
+        ClockMock::withClockMock(1234567890.125);
+    }
+
+    public function testTime()
+    {
+        $this->assertSame(1234567890, time());
+    }
+
+    public function testSleep()
+    {
+        sleep(2);
+        $this->assertSame(1234567892, time());
+    }
+
+    public function testMicrotime()
+    {
+        $this->assertSame('0.12500000 1234567890', microtime());
+    }
+
+    public function testMicrotimeAsFloat()
+    {
+        $this->assertSame(1234567890.125, microtime(true));
+    }
+
+    public function testUsleep()
+    {
+        usleep(2);
+        $this->assertSame(1234567890.125002, microtime(true));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is a follow-up PR to #27890 to fix the `microtime` precision, it should be 8 decimals instead of the current 6 (see https://3v4l.org/GYacF)

The problem now is that due to the new tests the whole testsuite will fail if run from the main directory, as hhvm and 5.4 targets are doing, due to phpunit using the wrong `ClockMock` class. Tests for 7.1 and 7.2 pass because they `cd` into the component directory.
