### PR TITLE
[Form] FormErrorIterator do not filter only with Constraint causes 

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -39,6 +39,7 @@ CHANGELOG
  * deprecated calling `FormRenderer::searchAndRenderBlock` for fields which were already rendered
  * added a cause when a CSRF error has occurred
  * deprecated the `scale` option of the `IntegerType`
+ * findByCodes of `FormErrorIterator` is able to also filter causes that are string or objects that implement the `__toString` method
  * removed restriction on allowed HTTP methods
 
 4.1.0

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -267,6 +267,16 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
             $cause = $error->getCause();
             if ($cause instanceof ConstraintViolation && \in_array($cause->getCode(), $codes, true)) {
                 $errors[] = $error;
+                continue;
+            }
+
+            if (!is_scalar($cause) && !(\is_object($cause) && method_exists($cause, '__toString'))) {
+                continue;
+            }
+
+            $cause = (string) $cause;
+            if (\in_array($cause, $codes, true)) {
+                $errors[] = $error;
             }
         }
 

--- a/src/Symfony/Component/Form/Tests/FormErrorIteratorTest.php
+++ b/src/Symfony/Component/Form/Tests/FormErrorIteratorTest.php
@@ -23,7 +23,7 @@ class FormErrorIteratorTest extends TestCase
     /**
      * @dataProvider findByCodesProvider
      */
-    public function testFindByCodes($code, $violationsCount)
+    public function testFindByCodesWhenAllCausesAreViolationConstraints($code, $violationsCount)
     {
         if (!class_exists(ConstraintViolation::class)) {
             $this->markTestSkipped('Validator component required.');
@@ -45,6 +45,43 @@ class FormErrorIteratorTest extends TestCase
         $form->addError(new FormError('Error 2!', null, array(), null, $cause));
         $cause = new ConstraintViolation('Error 3!', null, array(), null, '', null, null, 'code2');
         $form->addError(new FormError('Error 3!', null, array(), null, $cause));
+        $formErrors = $form->getErrors();
+
+        $specificFormErrors = $formErrors->findByCodes($code);
+        $this->assertInstanceOf(FormErrorIterator::class, $specificFormErrors);
+        $this->assertCount($violationsCount, $specificFormErrors);
+    }
+
+    /**
+     * @dataProvider findByCodesProvider
+     */
+    public function testFindByCodesWhenAllCausesAreVariousObjectsOrSimpleStrings($code, $violationsCount)
+    {
+        if (!class_exists(ConstraintViolation::class)) {
+            $this->markTestSkipped('Validator component required.');
+        }
+
+        $formBuilder = new FormBuilder(
+            'form',
+            null,
+            new EventDispatcher(),
+            $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock(),
+            array()
+        );
+
+        $form = $formBuilder->getForm();
+
+        $cause = new ConstraintViolation('Error 1!', null, array(), null, '', null, null, 'code1');
+        $form->addError(new FormError('Error 1!', null, array(), null, $cause));
+        $cause = new class() {
+            public function __toString()
+            {
+                return 'code1';
+            }
+        };
+
+        $form->addError(new FormError('Error 2!', null, array(), null, $cause));
+        $form->addError(new FormError('Error 3!', null, array(), null, 'code2'));
         $formErrors = $form->getErrors();
 
         $specificFormErrors = $formErrors->findByCodes($code);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | symfony/symfony-docs

I made this PR based on [this](https://github.com/symfony/symfony/pull/28564#discussion_r219699798)

In general I believe that the FormError object should be strict on the type of the Cause. It should either be a `ConstraintViolation` object an object that implements `toString` function or a simple string and this should be checked during the construction of the FormError. For me it's too vague what a cause argument is and what `findByCodes` does.. Althought this PR does not check anything on the construction of the FormError object this can be the first step.

I will add tests later if you agree with this PR. Let me know. 😄 
