### PR TITLE
[FrameworkBundle] Deprecate the "--env" and "--no-debug" console options

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -110,6 +110,10 @@ FrameworkBundle
    ```
  * The `ContainerAwareCommand` class has been deprecated, use `Symfony\Component\Console\Command\Command`
    with dependency injection instead.
+ * The `--env` console option and its "-e" shortcut have been deprecated,
+   set the "APP_ENV" environment variable instead.
+ * The `--no-debug` console option has been deprecated,
+   set the "APP_DEBUG" environment variable to "0" instead.
 
 Messenger
 ---------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -116,6 +116,10 @@ FrameworkBundle
  * Added support for the SameSite attribute for session cookies. It is highly recommended to set this setting (`framework.session.cookie_samesite`) to `lax` for increased security against CSRF attacks.
  * The `ContainerAwareCommand` class has been removed, use `Symfony\Component\Console\Command\Command`
    with dependency injection instead.
+ * The `--env` console option and its "-e" shortcut have been removed,
+   set the "APP_ENV" environment variable instead.
+ * The `--no-debug` console option has been removed, 
+   set the "APP_DEBUG" environment variable to "0" instead.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -14,6 +14,10 @@ CHANGELOG
  * Removed the `framework.messenger.encoder` and `framework.messenger.decoder` options. Use the `framework.messenger.serializer.id` option to replace the Messenger serializer. 
  * Deprecated the `ContainerAwareCommand` class in favor of `Symfony\Component\Console\Command\Command`
  * Made `debug:container` and `debug:autowiring` ignore backslashes in service ids
+ * Deprecated the `--env` console option and its "-e" shortcut, set
+   the "APP_ENV" environment variable instead.
+ * Deprecated the `--no-debug` console option, set the "APP_DEBUG" 
+   environment variable to "0" instead.
 
 4.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -62,6 +62,14 @@ class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
+        if ($input->hasParameterOption(array('-e', '--env'), true)) {
+            @trigger_error('The "--env" option and its "-e" shortcut are deprecated since Symfony 4.2. Set the "APP_ENV" environment variable instead.', E_USER_DEPRECATED);
+        }
+
+        if ($input->hasParameterOption('--no-debug', true)) {
+            @trigger_error('The "--no-debug" option is deprecated since Symfony 4.2. Set the "APP_DEBUG" environment variable to "0" instead.', E_USER_DEPRECATED);
+        }
+
         $this->kernel->boot();
 
         $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | n/a
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

See https://github.com/symfony/symfony/issues/23343#issuecomment-345609612