### PR TITLE
[Process] Fixes Typo in set*Timeout functions

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -960,7 +960,7 @@ class Process implements \IteratorAggregate
     /**
      * Sets the process timeout (max. runtime).
      *
-     * To disable the timeout, set this value to null.
+     * To disable the timeout, set this value to 0.
      *
      * @param int|float|null $timeout The timeout in seconds
      *
@@ -978,7 +978,7 @@ class Process implements \IteratorAggregate
     /**
      * Sets the process idle timeout (max. time since last output).
      *
-     * To disable the timeout, set this value to null.
+     * To disable the timeout, set this value to 0.
      *
      * @param int|float|null $timeout The timeout in seconds
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no  
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT


Comment for set*Timeout suggest `null` to disable Timeout, but fails with `The timeout value must be a valid positive integer or float number.` It has to be set to `0` to disable.
