### PR TITLE
[Console] Don't return early as this bypasses the auto exit feature

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -162,8 +162,6 @@ class Application
             } else {
                 $exitCode = 1;
             }
-
-            return $exitCode;
         } finally {
             // if the exception handler changed, keep it
             // otherwise, unregister $renderException


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets |  #28666 
| License       | MIT

It looks like 8805cfdf8d4ba6776cfd74e290d8d17b0ae1b62d broke the auto exit feature by returning early.

I couldn't find any tests for this feature (presumably because it uses `exit()`), I was going to write one using uopz but didn't want to do this work if Symfony intentionally doesn't test the call to `exit()`