### PR TITLE
[CS] Enforces null type hint on last position in phpDocs

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -453,7 +453,7 @@ abstract class AbstractDoctrineExtension extends Extension
     /**
      * Search for a manager that is declared as 'auto_mapping' = true.
      *
-     * @return null|string The name of the manager. If no one manager is found, returns null
+     * @return string|null The name of the manager. If no one manager is found, returns null
      *
      * @throws \LogicException
      */

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
@@ -45,7 +45,7 @@ class DoctrineChoiceLoader implements ChoiceLoaderInterface
      * @param ObjectManager              $manager      The object manager
      * @param string                     $class        The class name of the loaded objects
      * @param IdReader                   $idReader     The reader for the object IDs
-     * @param null|EntityLoaderInterface $objectLoader The objects loader
+     * @param EntityLoaderInterface|null $objectLoader The objects loader
      */
     public function __construct(ChoiceListFactoryInterface $factory, ObjectManager $manager, $class, IdReader $idReader = null, EntityLoaderInterface $objectLoader = null)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
@@ -89,7 +89,7 @@ class PhpStringTokenParser
      * Parses escape sequences in strings (all string types apart from single quoted).
      *
      * @param string      $str   String without quotes
-     * @param null|string $quote Quote type
+     * @param string|null $quote Quote type
      *
      * @return string String with escape sequences parsed
      */

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -140,7 +140,7 @@ class Command
      * execute() method, you set the code to execute by passing
      * a Closure to the setCode() method.
      *
-     * @return null|int null or 0 if everything went fine, or an error code
+     * @return int|null null or 0 if everything went fine, or an error code
      *
      * @throws LogicException When this abstract method is not implemented
      *

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -109,7 +109,7 @@ class QuestionHelper extends Helper
      *
      * This method is public for PHP 5.3 compatibility, it should be private.
      *
-     * @return bool|mixed|null|string
+     * @return bool|mixed|string|null
      *
      * @throws RuntimeException In case the fallback is deactivated and the response cannot be hidden
      */

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -117,7 +117,7 @@ class Question
     /**
      * Gets values for the autocompleter.
      *
-     * @return null|iterable
+     * @return iterable|null
      */
     public function getAutocompleterValues()
     {
@@ -127,7 +127,7 @@ class Question
     /**
      * Sets values for the autocompleter.
      *
-     * @param null|iterable $values
+     * @param iterable|null $values
      *
      * @return $this
      *
@@ -156,7 +156,7 @@ class Question
     /**
      * Sets a validator for the question.
      *
-     * @param null|callable $validator
+     * @param callable|null $validator
      *
      * @return $this
      */
@@ -170,7 +170,7 @@ class Question
     /**
      * Gets the validator for the question.
      *
-     * @return null|callable
+     * @return callable|null
      */
     public function getValidator()
     {
@@ -182,7 +182,7 @@ class Question
      *
      * Null means an unlimited number of attempts.
      *
-     * @param null|int $attempts
+     * @param int|null $attempts
      *
      * @return $this
      *
@@ -204,7 +204,7 @@ class Question
      *
      * Null means an unlimited number of attempts.
      *
-     * @return null|int
+     * @return int|null
      */
     public function getMaxAttempts()
     {

--- a/src/Symfony/Component/CssSelector/Node/ElementNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ElementNode.php
@@ -37,7 +37,7 @@ class ElementNode extends AbstractNode
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getNamespace()
     {
@@ -45,7 +45,7 @@ class ElementNode extends AbstractNode
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getElement()
     {

--- a/src/Symfony/Component/CssSelector/Node/SelectorNode.php
+++ b/src/Symfony/Component/CssSelector/Node/SelectorNode.php
@@ -28,7 +28,7 @@ class SelectorNode extends AbstractNode
 
     /**
      * @param NodeInterface $tree
-     * @param null|string   $pseudoElement
+     * @param string|null   $pseudoElement
      */
     public function __construct(NodeInterface $tree, $pseudoElement = null)
     {
@@ -45,7 +45,7 @@ class SelectorNode extends AbstractNode
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getPseudoElement()
     {

--- a/src/Symfony/Component/CssSelector/Parser/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/Parser/TokenStream.php
@@ -142,7 +142,7 @@ class TokenStream
     /**
      * Returns nex identifier or star delimiter token.
      *
-     * @return null|string The identifier token value or null if star found
+     * @return string|null The identifier token value or null if star found
      *
      * @throws SyntaxErrorException If next token is not an identifier or a star delimiter
      */

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -115,7 +115,7 @@ class ErrorHandler
     /**
      * Registers the error handler.
      *
-     * @param self|null|int $handler The handler to register, or @deprecated (since version 2.6, to be removed in 3.0) bit field of thrown levels
+     * @param self|int|null $handler The handler to register, or @deprecated (since version 2.6, to be removed in 3.0) bit field of thrown levels
      * @param bool          $replace Whether to replace or not any existing handler
      *
      * @return self The registered error handler

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -142,8 +142,8 @@ class Definition
     /**
      * Sets the service that this service is decorating.
      *
-     * @param null|string $id        The decorated service id, use null to remove decoration
-     * @param null|string $renamedId The new decorated service id
+     * @param string|null $id        The decorated service id, use null to remove decoration
+     * @param string|null $renamedId The new decorated service id
      * @param int         $priority  The priority of decoration
      *
      * @return $this
@@ -168,7 +168,7 @@ class Definition
     /**
      * Gets the service that this service is decorating.
      *
-     * @return null|array An array composed of the decorated service id, the new id for it and the priority of decoration, null if no service is decorated
+     * @return array|null An array composed of the decorated service id, the new id for it and the priority of decoration, null if no service is decorated
      */
     public function getDecoratedService()
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -104,7 +104,7 @@ class Crawler extends \SplObjectStorage
      * HTTP 1.1 specification.
      *
      * @param string      $content A string to parse as HTML/XML
-     * @param null|string $type    The content type of the string
+     * @param string|null $type    The content type of the string
      */
     public function addContent($content, $type = null)
     {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -578,7 +578,7 @@ class Filesystem
      *
      * @param string   $filename The file to be written to
      * @param string   $content  The data to write into the file
-     * @param null|int $mode     The file mode (octal). If null, file permissions are not modified
+     * @param int|null $mode     The file mode (octal). If null, file permissions are not modified
      *                           Deprecated since version 2.3.12, to be removed in 3.0.
      *
      * @throws IOException if the file cannot be written to

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -368,7 +368,7 @@ class Button implements \IteratorAggregate, FormInterface
     /**
      * Submits data to the button.
      *
-     * @param null|string $submittedData The data
+     * @param string|null $submittedData The data
      * @param bool        $clearMissing  Not used
      *
      * @return $this

--- a/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php
@@ -32,7 +32,7 @@ interface ChoiceListFactoryInterface
      * argument.
      *
      * @param iterable      $choices The choices
-     * @param null|callable $value   The callable generating the choice
+     * @param callable|null $value   The callable generating the choice
      *                               values
      *
      * @return ChoiceListInterface The choice list
@@ -51,7 +51,7 @@ interface ChoiceListFactoryInterface
      * argument.
      *
      * @param array|\Traversable $choices The choices
-     * @param null|callable      $value   The callable generating the choice
+     * @param callable|null      $value   The callable generating the choice
      *                                    values
      *
      * @return ChoiceListInterface The choice list
@@ -69,7 +69,7 @@ interface ChoiceListFactoryInterface
      * argument.
      *
      * @param ChoiceLoaderInterface $loader The choice loader
-     * @param null|callable         $value  The callable generating the choice
+     * @param callable|null         $value  The callable generating the choice
      *                                      values
      *
      * @return ChoiceListInterface The choice list
@@ -103,14 +103,14 @@ interface ChoiceListFactoryInterface
      * attributes that should be added to the respective choice.
      *
      * @param ChoiceListInterface $list             The choice list
-     * @param null|array|callable $preferredChoices The preferred choices
-     * @param null|callable       $label            The callable generating the
+     * @param array|callable|null $preferredChoices The preferred choices
+     * @param callable|null       $label            The callable generating the
      *                                              choice labels
-     * @param null|callable       $index            The callable generating the
+     * @param callable|null       $index            The callable generating the
      *                                              view indices
-     * @param null|callable       $groupBy          The callable generating the
+     * @param callable|null       $groupBy          The callable generating the
      *                                              group names
-     * @param null|array|callable $attr             The callable generating the
+     * @param array|callable|null $attr             The callable generating the
      *                                              HTML attributes
      *
      * @return ChoiceListView The choice list view

--- a/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
@@ -60,7 +60,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
      * {@inheritdoc}
      *
      * @param iterable                          $choices The choices
-     * @param null|callable|string|PropertyPath $value   The callable or path for
+     * @param callable|string|PropertyPath|null $value   The callable or path for
      *                                                   generating the choice values
      *
      * @return ChoiceListInterface The choice list
@@ -91,7 +91,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
      * {@inheritdoc}
      *
      * @param array|\Traversable                $choices The choices
-     * @param null|callable|string|PropertyPath $value   The callable or path for
+     * @param callable|string|PropertyPath|null $value   The callable or path for
      *                                                   generating the choice values
      *
      * @return ChoiceListInterface The choice list
@@ -110,7 +110,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
      * {@inheritdoc}
      *
      * @param ChoiceLoaderInterface             $loader The choice loader
-     * @param null|callable|string|PropertyPath $value  The callable or path for
+     * @param callable|string|PropertyPath|null $value  The callable or path for
      *                                                  generating the choice values
      *
      * @return ChoiceListInterface The choice list
@@ -141,11 +141,11 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
      * {@inheritdoc}
      *
      * @param ChoiceListInterface                     $list             The choice list
-     * @param null|array|callable|string|PropertyPath $preferredChoices The preferred choices
-     * @param null|callable|string|PropertyPath       $label            The callable or path generating the choice labels
-     * @param null|callable|string|PropertyPath       $index            The callable or path generating the view indices
-     * @param null|callable|string|PropertyPath       $groupBy          The callable or path generating the group names
-     * @param null|array|callable|string|PropertyPath $attr             The callable or path generating the HTML attributes
+     * @param array|callable|string|PropertyPath|null $preferredChoices The preferred choices
+     * @param callable|string|PropertyPath|null       $label            The callable or path generating the choice labels
+     * @param callable|string|PropertyPath|null       $index            The callable or path generating the view indices
+     * @param callable|string|PropertyPath|null       $groupBy          The callable or path generating the group names
+     * @param array|callable|string|PropertyPath|null $attr             The callable or path generating the HTML attributes
      *
      * @return ChoiceListView The choice list view
      */

--- a/src/Symfony/Component/Form/ChoiceList/LazyChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/LazyChoiceList.php
@@ -34,7 +34,7 @@ class LazyChoiceList implements ChoiceListInterface
      *
      * If null, choices are simply cast to strings.
      *
-     * @var null|callable
+     * @var callable|null
      */
     private $value;
 
@@ -51,7 +51,7 @@ class LazyChoiceList implements ChoiceListInterface
      * argument.
      *
      * @param ChoiceLoaderInterface $loader The choice loader
-     * @param null|callable         $value  The callable generating the choice values
+     * @param callable|null         $value  The callable generating the choice values
      */
     public function __construct(ChoiceLoaderInterface $loader, $value = null)
     {

--- a/src/Symfony/Component/Form/ChoiceList/Loader/ChoiceLoaderInterface.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/ChoiceLoaderInterface.php
@@ -31,7 +31,7 @@ interface ChoiceLoaderInterface
      * The callable receives the choice as first and the array key as the second
      * argument.
      *
-     * @param null|callable $value The callable which generates the values
+     * @param callable|null $value The callable which generates the values
      *                             from choices
      *
      * @return ChoiceListInterface The loaded choice list
@@ -50,7 +50,7 @@ interface ChoiceLoaderInterface
      *
      * @param string[]      $values An array of choice values. Non-existing
      *                              values in this array are ignored
-     * @param null|callable $value  The callable generating the choice values
+     * @param callable|null $value  The callable generating the choice values
      *
      * @return array An array of choices
      */
@@ -68,7 +68,7 @@ interface ChoiceLoaderInterface
      *
      * @param array         $choices An array of choices. Non-existing choices in
      *                               this array are ignored
-     * @param null|callable $value   The callable generating the choice values
+     * @param callable|null $value   The callable generating the choice values
      *
      * @return string[] An array of choice values
      */

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfExtension.php
@@ -32,7 +32,7 @@ class CsrfExtension extends AbstractExtension
     /**
      * @param CsrfTokenManagerInterface $tokenManager      The CSRF token manager
      * @param TranslatorInterface       $translator        The translator for translating error messages
-     * @param null|string               $translationDomain The translation domain for translating
+     * @param string|null               $translationDomain The translation domain for translating
      */
     public function __construct($tokenManager, TranslatorInterface $translator = null, $translationDomain = null)
     {

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -51,7 +51,7 @@ class CsrfValidationListener implements EventSubscriberInterface
      *                                                     same session and with the same tokenId
      * @param string                    $errorMessage      The message displayed in case of an error
      * @param TranslatorInterface       $translator
-     * @param null|string               $translationDomain
+     * @param string|null               $translationDomain
      * @param ServerParams              $serverParams
      */
     public function __construct($fieldName, $tokenManager, $tokenId, $errorMessage, TranslatorInterface $translator = null, $translationDomain = null, ServerParams $serverParams = null)

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -47,7 +47,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
      * @param bool                                            $defaultEnabled
      * @param string                                          $defaultFieldName
      * @param TranslatorInterface                             $translator
-     * @param null|string                                     $translationDomain
+     * @param string|null                                     $translationDomain
      * @param ServerParams                                    $serverParams
      */
     public function __construct($defaultTokenManager, $defaultEnabled = true, $defaultFieldName = '_token', TranslatorInterface $translator = null, $translationDomain = null, ServerParams $serverParams = null)

--- a/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidatorExtension.php
@@ -27,7 +27,7 @@ class UploadValidatorExtension extends AbstractTypeExtension
 
     /**
      * @param TranslatorInterface $translator        The translator for translating error messages
-     * @param null|string         $translationDomain The translation domain for translating
+     * @param string|null         $translationDomain The translation domain for translating
      */
     public function __construct(TranslatorInterface $translator, $translationDomain = null)
     {

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
@@ -51,7 +51,7 @@ class MappingRule
      *
      * @param string $propertyPath The property path to match against the rule
      *
-     * @return null|FormInterface The mapped form or null
+     * @return FormInterface|null The mapped form or null
      */
     public function match($propertyPath)
     {

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -144,7 +144,7 @@ class ViolationMapper implements ViolationMapperInterface
      * @param FormInterface                 $form The form to search
      * @param PropertyPathIteratorInterface $it   The iterator at its current position
      *
-     * @return null|FormInterface The found match or null
+     * @return FormInterface|null The found match or null
      */
     private function matchChild(FormInterface $form, PropertyPathIteratorInterface $it)
     {

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -146,7 +146,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets the property path that the form should be mapped to.
      *
-     * @param null|string|PropertyPathInterface $propertyPath The property path or null if the path should be set
+     * @param string|PropertyPathInterface|null $propertyPath The property path or null if the path should be set
      *                                                        automatically based on the form's name
      *
      * @return $this The configuration object

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -38,7 +38,7 @@ interface FormConfigInterface
     /**
      * Returns the property path that the form should be mapped to.
      *
-     * @return null|PropertyPathInterface The property path
+     * @return PropertyPathInterface|null The property path
      */
     public function getPropertyPath();
 
@@ -167,7 +167,7 @@ interface FormConfigInterface
     /**
      * Returns the class of the form data or null if the data is scalar or an array.
      *
-     * @return null|string The data class or null
+     * @return string|null The data class or null
      */
     public function getDataClass();
 

--- a/src/Symfony/Component/Form/FormTypeInterface.php
+++ b/src/Symfony/Component/Form/FormTypeInterface.php
@@ -90,7 +90,7 @@ interface FormTypeInterface
      * Symfony 2.8 and will be unsupported as of Symfony 3.0. Return the
      * fully-qualified class name of the parent type instead.
      *
-     * @return string|null|FormTypeInterface The name of the parent type if any, null otherwise
+     * @return string|FormTypeInterface|null The name of the parent type if any, null otherwise
      */
     public function getParent();
 

--- a/src/Symfony/Component/Form/SubmitButton.php
+++ b/src/Symfony/Component/Form/SubmitButton.php
@@ -34,7 +34,7 @@ class SubmitButton extends Button implements ClickableInterface
     /**
      * Submits data to the button.
      *
-     * @param null|string $submittedData The data
+     * @param string|null $submittedData The data
      * @param bool        $clearMissing  Not used
      *
      * @return $this

--- a/src/Symfony/Component/Form/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Util/ServerParams.php
@@ -41,7 +41,7 @@ class ServerParams
     /**
      * Returns maximum post size in bytes.
      *
-     * @return null|int The maximum post size in bytes
+     * @return int|null The maximum post size in bytes
      */
     public function getPostMaxSize()
     {

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -40,7 +40,7 @@ class BinaryFileResponse extends Response
      * @param int                 $status             The response status code
      * @param array               $headers            An array of response headers
      * @param bool                $public             Files are public by default
-     * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
+     * @param string|null         $contentDisposition The type of Content-Disposition to set automatically with the filename
      * @param bool                $autoEtag           Whether the ETag header should be automatically set
      * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
      */
@@ -60,7 +60,7 @@ class BinaryFileResponse extends Response
      * @param int                 $status             The response status code
      * @param array               $headers            An array of response headers
      * @param bool                $public             Files are public by default
-     * @param null|string         $contentDisposition The type of Content-Disposition to set automatically with the filename
+     * @param string|null         $contentDisposition The type of Content-Disposition to set automatically with the filename
      * @param bool                $autoEtag           Whether the ETag header should be automatically set
      * @param bool                $autoLastModified   Whether the Last-Modified header should be automatically set
      *

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -197,7 +197,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      * @param string    $key     The parameter key
      * @param \DateTime $default The default value
      *
-     * @return null|\DateTime The parsed DateTime or the default value if the header does not exist
+     * @return \DateTime|null The parsed DateTime or the default value if the header does not exist
      *
      * @throws \RuntimeException When the HTTP header is not parseable
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -71,7 +71,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
     private $pdo;
 
     /**
-     * @var string|null|false DSN string or null for session.save_path or false when lazy connection disabled
+     * @var string|false|null DSN string or null for session.save_path or false when lazy connection disabled
      */
     private $dsn = false;
 

--- a/src/Symfony/Component/HttpKernel/Config/FileLocator.php
+++ b/src/Symfony/Component/HttpKernel/Config/FileLocator.php
@@ -26,7 +26,7 @@ class FileLocator extends BaseFileLocator
 
     /**
      * @param KernelInterface $kernel A KernelInterface instance
-     * @param null|string     $path   The path the global resource directory
+     * @param string|null     $path   The path the global resource directory
      * @param array           $paths  An array of paths where to look for resources
      */
     public function __construct(KernelInterface $kernel, $path = null, array $paths = array())

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -235,7 +235,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     /**
      * @param string $dsn
      *
-     * @return null|array Array($server, $database, $collection)
+     * @return array|null Array($server, $database, $collection)
      */
     private function parseDsn($dsn)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -92,7 +92,7 @@ class Profile
     /**
      * Returns the parent token.
      *
-     * @return null|string The parent token
+     * @return string|null The parent token
      */
     public function getParentToken()
     {

--- a/src/Symfony/Component/Intl/Intl.php
+++ b/src/Symfony/Component/Intl/Intl.php
@@ -187,7 +187,7 @@ final class Intl
     /**
      * Returns the version of the installed ICU library.
      *
-     * @return null|string The ICU version or NULL if it could not be determined
+     * @return string|null The ICU version or NULL if it could not be determined
      */
     public static function getIcuVersion()
     {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -567,7 +567,7 @@ class Process
     /**
      * Returns the exit code returned by the process.
      *
-     * @return null|int The exit status code, null if the Process is not terminated
+     * @return int|null The exit status code, null if the Process is not terminated
      *
      * @throws RuntimeException In case --enable-sigchild is activated and the sigchild compatibility mode is disabled
      */
@@ -588,7 +588,7 @@ class Process
      * This method relies on the Unix exit code status standardization
      * and might not be relevant for other operating systems.
      *
-     * @return null|string A string representation for the exit status code, null if the Process is not terminated
+     * @return string|null A string representation for the exit status code, null if the Process is not terminated
      *
      * @see http://tldp.org/LDP/abs/html/exitcodes.html
      * @see http://en.wikipedia.org/wiki/Unix_signal
@@ -1044,7 +1044,7 @@ class Process
     /**
      * Gets the Process input.
      *
-     * @return null|string The Process input
+     * @return string|null The Process input
      */
     public function getInput()
     {

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -99,7 +99,7 @@ class ProcessBuilder
     /**
      * Sets the working directory.
      *
-     * @param null|string $cwd The working directory
+     * @param string|null $cwd The working directory
      *
      * @return $this
      */
@@ -131,7 +131,7 @@ class ProcessBuilder
      * defined environment variable.
      *
      * @param string      $name  The variable name
-     * @param null|string $value The variable value
+     * @param string|null $value The variable value
      *
      * @return $this
      */

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1224,9 +1224,9 @@ class ProcessTest extends TestCase
 
     /**
      * @param string      $commandline
-     * @param null|string $cwd
-     * @param null|array  $env
-     * @param null|string $input
+     * @param string|null $cwd
+     * @param array|null  $env
+     * @param string|null $input
      * @param int         $timeout
      * @param array       $options
      *

--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -24,7 +24,7 @@ class PropertyPathBuilder
     /**
      * Creates a new property path builder.
      *
-     * @param null|PropertyPathInterface|string $path The path to initially store
+     * @param PropertyPathInterface|string|null $path The path to initially store
      *                                                in the builder. Optional.
      */
     public function __construct($path = null)

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -29,7 +29,7 @@ class Route implements \Serializable
     private $condition = '';
 
     /**
-     * @var null|CompiledRoute
+     * @var CompiledRoute|null
      */
     private $compiled;
 

--- a/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
@@ -31,7 +31,7 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
     private $namespace;
 
     /**
-     * @param null|string|RequestStack|callable $namespace
+     * @param string|RequestStack|callable|null $namespace
      *                                                     * null: generates a namespace using $_SERVER['HTTPS']
      *                                                     * string: uses the given string
      *                                                     * RequestStack: generates a namespace using the current master request

--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
@@ -73,7 +73,7 @@ class GuardAuthenticatorHandler
      * @param GuardAuthenticatorInterface $guardAuthenticator
      * @param string                      $providerKey        The provider (i.e. firewall) key
      *
-     * @return null|Response
+     * @return Response|null
      */
     public function handleAuthenticationSuccess(TokenInterface $token, Request $request, GuardAuthenticatorInterface $guardAuthenticator, $providerKey)
     {
@@ -118,7 +118,7 @@ class GuardAuthenticatorHandler
      * @param GuardAuthenticatorInterface $guardAuthenticator
      * @param string                      $providerKey             The key of the firewall
      *
-     * @return null|Response
+     * @return Response|null
      */
     public function handleAuthenticationFailure(AuthenticationException $authenticationException, Request $request, GuardAuthenticatorInterface $guardAuthenticator, $providerKey)
     {

--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -22,7 +22,7 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
     private $lowerCamelCase;
 
     /**
-     * @param null|array $attributes     The list of attributes to rename or null for all attributes
+     * @param array|null $attributes     The list of attributes to rename or null for all attributes
      * @param bool       $lowerCamelCase Use lowerCamelCase style
      */
     public function __construct(array $attributes = null, $lowerCamelCase = true)

--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -24,7 +24,7 @@ class Section
     private $events = array();
 
     /**
-     * @var null|float
+     * @var float|null
      */
     private $origin;
 

--- a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
@@ -29,7 +29,7 @@ abstract class AbstractOperation implements OperationInterface
     protected $result;
 
     /**
-     * @var null|array The domains affected by this operation
+     * @var array|null The domains affected by this operation
      */
     private $domains;
 

--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -41,7 +41,7 @@ class ExecutionContext implements ExecutionContextInterface
      *
      * @param GlobalExecutionContextInterface $globalContext     The global context storing node-independent state
      * @param TranslatorInterface             $translator        The translator for translating violation messages
-     * @param null|string                     $translationDomain The domain of the validation messages
+     * @param string|null                     $translationDomain The domain of the validation messages
      * @param MetadataInterface               $metadata          The metadata of the validated node
      * @param mixed                           $value             The value of the validated node
      * @param string                          $group             The current validation group
@@ -255,7 +255,7 @@ class ExecutionContext implements ExecutionContextInterface
     /**
      * Returns an array of group names.
      *
-     * @param null|string|string[] $groups The groups to resolve. If a single string is
+     * @param string|string[]|null $groups The groups to resolve. If a single string is
      *                                     passed, it is converted to an array. If null
      *                                     is passed, an array containing the current
      *                                     group of the context is returned.

--- a/src/Symfony/Component/Validator/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/ExecutionContextInterface.php
@@ -134,7 +134,7 @@ interface ExecutionContextInterface
      *
      * @param mixed                $value    The value to validate
      * @param string               $subPath  The path to append to the context's property path
-     * @param null|string|string[] $groups   The groups to validate in. If you don't pass any
+     * @param string|string[]|null $groups   The groups to validate in. If you don't pass any
      *                                       groups here, the current group of the context
      *                                       will be used.
      * @param bool                 $traverse Whether to traverse the value if it is an array
@@ -166,7 +166,7 @@ interface ExecutionContextInterface
      * @param mixed                   $value       The value to validate
      * @param Constraint|Constraint[] $constraints The constraint(s) to validate against
      * @param string                  $subPath     The path to append to the context's property path
-     * @param null|string|string[]    $groups      The groups to validate in. If you don't pass any
+     * @param string|string[]|null    $groups      The groups to validate in. If you don't pass any
      *                                             groups here, the current group of the context
      *                                             will be used.
      *

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -197,7 +197,7 @@ class Validator implements ValidatorInterface, Mapping\Factory\MetadataFactoryIn
     }
 
     /**
-     * @param null|string|string[] $groups
+     * @param string|string[]|null $groups
      *
      * @return string[]
      */

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -70,7 +70,7 @@ class ValidatorBuilder implements ValidatorBuilderInterface
     private $translator;
 
     /**
-     * @var null|string
+     * @var string|null
      */
     private $translationDomain;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

As a majority in our codebase, the `null` typehint usually comes in the last position in phpDocs.