### PR TITLE
Remove redundant path check

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1120,7 +1120,7 @@ class Request
         }
 
         $sourceDirs = explode('/', isset($basePath[0]) && '/' === $basePath[0] ? substr($basePath, 1) : $basePath);
-        $targetDirs = explode('/', isset($path[0]) && '/' === $path[0] ? substr($path, 1) : $path);
+        $targetDirs = explode('/', substr($path, 1));
         array_pop($sourceDirs);
         $targetFile = array_pop($targetDirs);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | maybe?
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Commit 0ec852d79fb introduced this new method. As you can see, the code I'm removing always evaluates to `true` thanks to the first `if` statement in this method:

![image](https://user-images.githubusercontent.com/202034/46349212-70968a80-c61f-11e8-8360-7d6abc4d7414.png)

(I'm not sure if redundant code technically counts as a "bug", so I've assumed "yes it does" and targeted 2.8.)