### PR TITLE
[Security] Deprecate simple_preauth and simple_form in favor of Guard

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -186,6 +186,9 @@ Security
    use custom tokens, extend the existing `Symfony\Component\Security\Core\Authentication\Token\AnonymousToken`
    or `Symfony\Component\Security\Core\Authentication\Token\RememberMeToken`.
  * Accessing the user object that is not an instance of `UserInterface` from `Security::getUser()` is deprecated.
+ * `SimpleAuthenticatorInterface`, `SimpleFormAuthenticatorInterface`, `SimplePreAuthenticatorInterface`,
+   `SimpleAuthenticationProvider`, `SimpleAuthenticationHandler`, `SimpleFormAuthenticationListener` and
+   `SimplePreAuthenticationListener` have been deprecated. Use Guard instead.
 
 SecurityBundle
 --------------
@@ -196,6 +199,10 @@ SecurityBundle
    `security.authentication.trust_resolver.rememberme_class` parameters to define
    the token classes is deprecated. To use
    custom tokens extend the existing AnonymousToken and RememberMeToken.
+ * The `simple_form` and `simple_preauth` authentication listeners have been deprecated,
+   use Guard instead.
+ * The `SimpleFormFactory` and `SimplePreAuthenticationFactory` classes have been deprecated,
+   use Guard instead.
 
 Serializer
 ----------

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -160,6 +160,9 @@ Security
    the 3rd one must be either a `LogoutListener` instance or `null`.
  * The `AuthenticationTrustResolver` constructor arguments have been removed.
  * A user object that is not an instance of `UserInterface` cannot be accessed from `Security::getUser()` anymore and returns `null` instead.
+ * `SimpleAuthenticatorInterface`, `SimpleFormAuthenticatorInterface`, `SimplePreAuthenticatorInterface`,
+   `SimpleAuthenticationProvider`, `SimpleAuthenticationHandler`, `SimpleFormAuthenticationListener` and
+   `SimplePreAuthenticationListener` have been removed. Use Guard instead.
 
 SecurityBundle
 --------------
@@ -171,6 +174,10 @@ SecurityBundle
    now throws a `\TypeError`, pass a `LogoutListener` instance instead.
  * The `security.authentication.trust_resolver.anonymous_class` parameter has been removed.
  * The `security.authentication.trust_resolver.rememberme_class` parameter has been removed.
+ * The `simple_form` and `simple_preauth` authentication listeners have been removed,
+   use Guard instead.
+ * The `SimpleFormFactory` and `SimplePreAuthenticationFactory` classes have been removed,
+   use Guard instead.
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -13,6 +13,8 @@ CHANGELOG
  * Added `json_login_ldap` authentication provider to use LDAP authentication with a REST API.
  * Made remember-me cookies inherit their default config from `framework.session.cookie_*`
    and added an "auto" mode to their "secure" config option to make them secure on HTTPS automatically.
+ * Deprecated the `simple_form` and `simple_preauth` authentication listeners, use Guard instead.
+ * Deprecated the `SimpleFormFactory` and `SimplePreAuthenticationFactory` classes, use Guard instead.
  
 4.1.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SimpleFormFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SimplePreAuthenticationFactory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -264,6 +266,10 @@ class MainConfiguration implements ConfigurationInterface
                 $factoryNode = $firewallNodeBuilder->arrayNode($name)
                     ->canBeUnset()
                 ;
+
+                if ($factory instanceof SimplePreAuthenticationFactory || $factory instanceof SimpleFormFactory) {
+                    $factoryNode->setDeprecated(sprintf('The "%s" security listener is deprecated Symfony 4.2, use Guard instead.', $name));
+                }
 
                 if ($factory instanceof AbstractFactory) {
                     $abstractFactoryKeys[] = $name;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimpleFormFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimpleFormFactory.php
@@ -18,14 +18,20 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since Symfony 4.2, use Guard instead.
  */
 class SimpleFormFactory extends FormLoginFactory
 {
-    public function __construct()
+    public function __construct(bool $triggerDeprecation = true)
     {
         parent::__construct();
 
         $this->addOption('authenticator', null);
+
+        if ($triggerDeprecation) {
+            @trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.2, use Guard instead.', __CLASS__), E_USER_DEPRECATED);
+        }
     }
 
     public function getKey()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimplePreAuthenticationFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SimplePreAuthenticationFactory.php
@@ -18,9 +18,18 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since Symfony 4.2, use Guard instead.
  */
 class SimplePreAuthenticationFactory implements SecurityFactoryInterface
 {
+    public function __construct(bool $triggerDeprecation = true)
+    {
+        if ($triggerDeprecation) {
+            @trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.2, use Guard instead.', __CLASS__), E_USER_DEPRECATED);
+        }
+    }
+
     public function getPosition()
     {
         return 'pre_auth';

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -114,6 +114,7 @@
                  parent="security.authentication.listener.abstract"
                  public="false"
                  abstract="true">
+            <deprecated>The "%service_id%" service is deprecated since Symfony 4.2.</deprecated>
         </service>
 
         <service id="security.authentication.simple_success_failure_handler" class="Symfony\Component\Security\Http\Authentication\SimpleAuthenticationHandler" abstract="true">
@@ -122,6 +123,7 @@
             <argument type="service" id="security.authentication.success_handler" />
             <argument type="service" id="security.authentication.failure_handler" />
             <argument type="service" id="logger" on-invalid="null" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 4.2.</deprecated>
         </service>
 
         <service id="security.authentication.listener.simple_preauth" class="Symfony\Component\Security\Http\Firewall\SimplePreAuthenticationListener" abstract="true">
@@ -133,6 +135,7 @@
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="event_dispatcher" on-invalid="null"/>
             <argument type="service" id="security.authentication.trust_resolver" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 4.2.</deprecated>
         </service>
 
         <service id="security.authentication.listener.x509" class="Symfony\Component\Security\Http\Firewall\X509AuthenticationListener" abstract="true">
@@ -201,6 +204,7 @@
             <argument /> <!-- User Provider -->
             <argument /> <!-- Provider-shared Key -->
             <argument>null</argument> <!-- UserChecker -->
+            <deprecated>The "%service_id%" service is deprecated since Symfony 4.2.</deprecated>
         </service>
 
         <service id="security.authentication.provider.pre_authenticated" class="Symfony\Component\Security\Core\Authentication\Provider\PreAuthenticatedAuthenticationProvider" abstract="true">

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -54,8 +54,8 @@ class SecurityBundle extends Bundle
         $extension->addSecurityListenerFactory(new RememberMeFactory());
         $extension->addSecurityListenerFactory(new X509Factory());
         $extension->addSecurityListenerFactory(new RemoteUserFactory());
-        $extension->addSecurityListenerFactory(new SimplePreAuthenticationFactory());
-        $extension->addSecurityListenerFactory(new SimpleFormFactory());
+        $extension->addSecurityListenerFactory(new SimplePreAuthenticationFactory(false));
+        $extension->addSecurityListenerFactory(new SimpleFormFactory(false));
         $extension->addSecurityListenerFactory(new GuardAuthenticationFactory());
 
         $extension->addUserProviderFactory(new InMemoryFactory());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -147,23 +147,6 @@ abstract class CompleteConfigurationTest extends TestCase
                 ),
                 null,
             ),
-            array(
-                'simple_auth',
-                'security.user_checker',
-                null,
-                true,
-                false,
-                'security.user.provider.concrete.default',
-                'simple_auth',
-                'security.authentication.form_entry_point.simple_auth',
-                null,
-                null,
-                array(
-                    'simple_form',
-                    'anonymous',
-                ),
-                null,
-            ),
         ), $configs);
 
         $this->assertEquals(array(
@@ -191,13 +174,6 @@ abstract class CompleteConfigurationTest extends TestCase
                 'security.context_listener.1',
                 'security.authentication.listener.basic.with_user_checker',
                 'security.authentication.listener.anonymous.with_user_checker',
-                'security.access_listener',
-            ),
-            array(
-                'security.channel_listener',
-                'security.context_listener.2',
-                'security.authentication.listener.simple_form.simple_auth',
-                'security.authentication.listener.anonymous.simple_auth',
                 'security.access_listener',
             ),
         ), $listeners);
@@ -473,6 +449,50 @@ abstract class CompleteConfigurationTest extends TestCase
     {
         $this->getContainer('listener_provider');
         $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The "simple_form" security listener is deprecated Symfony 4.2, use Guard instead.
+     */
+    public function testSimpleAuth()
+    {
+        $container = $this->getContainer('simple_auth');
+        $arguments = $container->getDefinition('security.firewall.map')->getArguments();
+        $listeners = array();
+        $configs = array();
+        foreach (array_keys($arguments[1]->getValues()) as $contextId) {
+            $contextDef = $container->getDefinition($contextId);
+            $arguments = $contextDef->getArguments();
+            $listeners[] = array_map('strval', $arguments['index_0']->getValues());
+
+            $configDef = $container->getDefinition((string) $arguments['index_3']);
+            $configs[] = array_values($configDef->getArguments());
+        }
+
+        $this->assertSame(array(array(
+            'simple_auth',
+            'security.user_checker',
+            null,
+            true,
+            false,
+            'security.user.provider.concrete.default',
+            'simple_auth',
+            'security.authentication.form_entry_point.simple_auth',
+            null,
+            null,
+            array('simple_form', 'anonymous',
+            ),
+            null,
+        )), $configs);
+
+        $this->assertSame(array(array(
+            'security.channel_listener',
+            'security.context_listener.0',
+            'security.authentication.listener.simple_form.simple_auth',
+            'security.authentication.listener.anonymous.simple_auth',
+            'security.access_listener',
+        )), $listeners);
     }
 
     protected function getContainer($file)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -87,11 +87,6 @@ $container->loadFromExtension('security', array(
             'anonymous' => true,
             'http_basic' => true,
         ),
-        'simple_auth' => array(
-            'provider' => 'default',
-            'anonymous' => true,
-            'simple_form' => array('authenticator' => 'simple_authenticator'),
-        ),
     ),
 
     'access_control' => array(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/simple_auth.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/simple_auth.php
@@ -1,0 +1,21 @@
+<?php
+
+$container->loadFromExtension('security', array(
+    'providers' => array(
+        'default' => array(
+            'memory' => array(
+                'users' => array(
+                    'foo' => array('password' => 'foo', 'roles' => 'ROLE_USER'),
+                ),
+            ),
+        ),
+    ),
+
+    'firewalls' => array(
+        'simple_auth' => array(
+            'provider' => 'default',
+            'anonymous' => true,
+            'simple_form' => array('authenticator' => 'simple_authenticator'),
+        ),
+    ),
+));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -68,11 +68,6 @@
             <user-checker>app.user_checker</user-checker>
         </firewall>
 
-        <firewall name="simple_auth" provider="default">
-            <anonymous />
-            <simple-form authenticator="simple_authenticator" />
-        </firewall>
-
         <role id="ROLE_ADMIN">ROLE_USER</role>
         <role id="ROLE_SUPER_ADMIN">ROLE_USER,ROLE_ADMIN,ROLE_ALLOWED_TO_SWITCH</role>
         <role id="ROLE_REMOTE">ROLE_USER,ROLE_ADMIN</role>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/simple_auth.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/simple_auth.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:sec="http://symfony.com/schema/dic/security"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <sec:config>
+        <sec:provider name="default">
+            <sec:memory>
+                <sec:user name="foo" password="foo" roles="ROLE_USER" />
+            </sec:memory>
+        </sec:provider>
+
+        <sec:firewall name="simple_auth">
+            <sec:simple_form authenticator="simple_authenticator"/>
+            <sec:anonymous/>
+        </sec:firewall>
+    </sec:config>
+
+</container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -70,11 +70,6 @@ security:
             http_basic: ~
             user_checker: app.user_checker
 
-        simple_auth:
-            provider: default
-            anonymous: ~
-            simple_form: { authenticator: simple_authenticator }
-
     role_hierarchy:
         ROLE_ADMIN:       ROLE_USER
         ROLE_SUPER_ADMIN: [ROLE_USER, ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH]

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/simple_auth.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/simple_auth.yml
@@ -1,0 +1,12 @@
+security:
+    providers:
+        default:
+            memory:
+                users:
+                    foo: { password: foo, roles: ROLE_USER }
+
+    firewalls:
+        simple_auth:
+            provider: default
+            anonymous: ~
+            simple_form: { authenticator: simple_authenticator }

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -13,6 +13,9 @@ CHANGELOG
   or `Symfony\Component\Security\Core\Authentication\Token\RememberMeToken`.
 * allow passing null as $filter in LdapUserProvider to get the default filter
 * accessing the user object that is not an instance of `UserInterface` from `Security::getUser()` is deprecated
+* Deprecated `SimpleAuthenticatorInterface`, `SimpleFormAuthenticatorInterface`,
+  `SimplePreAuthenticatorInterface`, `SimpleAuthenticationProvider`, `SimpleAuthenticationHandler`,
+  `SimpleFormAuthenticationListener` and `SimplePreAuthenticationListener`. Use Guard instead.
 
 4.1.0
 -----

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
@@ -19,8 +19,12 @@ use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.2, use Guard instead.', SimpleAuthenticationProvider::class), E_USER_DEPRECATED);
+
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since Symfony 4.2, use Guard instead.
  */
 class SimpleAuthenticationProvider implements AuthenticationProviderInterface
 {

--- a/src/Symfony/Component/Security/Core/Authentication/SimpleAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/SimpleAuthenticatorInterface.php
@@ -16,6 +16,8 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since Symfony 4.2, use Guard instead.
  */
 interface SimpleAuthenticatorInterface
 {

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/SimpleAuthenticationProviderTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\LockedException;
 use Symfony\Component\Security\Core\User\UserChecker;
 
+/**
+ * @group legacy
+ */
 class SimpleAuthenticationProviderTest extends TestCase
 {
     /**

--- a/src/Symfony/Component/Security/Http/Authentication/SimpleAuthenticationHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimpleAuthenticationHandler.php
@@ -18,6 +18,8 @@ use Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.2, use Guard instead.', SimpleAuthenticationHandler::class), E_USER_DEPRECATED);
+
 /**
  * Class to proxy authentication success/failure handlers.
  *
@@ -26,6 +28,8 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  * the default handlers are triggered.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since Symfony 4.2, use Guard instead.
  */
 class SimpleAuthenticationHandler implements AuthenticationFailureHandlerInterface, AuthenticationSuccessHandlerInterface
 {

--- a/src/Symfony/Component/Security/Http/Authentication/SimpleFormAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimpleFormAuthenticatorInterface.php
@@ -16,6 +16,8 @@ use Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since Symfony 4.2, use Guard instead.
  */
 interface SimpleFormAuthenticatorInterface extends SimpleAuthenticatorInterface
 {

--- a/src/Symfony/Component/Security/Http/Authentication/SimplePreAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimplePreAuthenticatorInterface.php
@@ -16,6 +16,8 @@ use Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since Symfony 4.2, use Guard instead.
  */
 interface SimplePreAuthenticatorInterface extends SimpleAuthenticatorInterface
 {

--- a/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
@@ -29,8 +29,12 @@ use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\ParameterBagUtils;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.2, use Guard instead.', SimpleFormAuthenticationListener::class), E_USER_DEPRECATED);
+
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since Symfony 4.2, use Guard instead.
  */
 class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
 {

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -31,10 +31,14 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 4.2, use Guard instead.', SimplePreAuthenticationListener::class), E_USER_DEPRECATED);
+
 /**
  * SimplePreAuthenticationListener implements simple proxying to an authenticator.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since Symfony 4.2, use Guard instead.
  */
 class SimplePreAuthenticationListener implements ListenerInterface
 {

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
@@ -19,6 +19,9 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\SimpleAuthenticationHandler;
 
+/**
+ * @group legacy
+ */
 class SimpleAuthenticationHandlerTest extends TestCase
 {
     private $successHandler;

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SimplePreAuthenticationListenerTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Firewall\SimplePreAuthenticationListener;
 use Symfony\Component\Security\Http\SecurityEvents;
 
+/**
+ * @group legacy
+ */
 class SimplePreAuthenticationListenerTest extends TestCase
 {
     private $authenticationManager;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a
