### PR TITLE
[Messenger] drop "handler." prefix from ContainerHandlerLocator

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 4.2.0
 -----
 
- * [BC BREAK] The signature of Amqp* classes changed to take a `Connection` as a first argument and an optional
+ * The component is not experimental anymore
+ * [BC BREAK] The signature of `Amqp*` classes changed to take a `Connection` as a first argument and an optional
    `Serializer` as a second argument.
  * [BC BREAK] `SenderLocator` has been renamed to `ContainerSenderLocator`
    Be careful as there is still a `SenderLocator` class, but it does not rely on a `ContainerInterface` to find senders.
@@ -16,3 +17,10 @@ CHANGELOG
  * [BC BREAK] The `ConsumeMessagesCommand` class now takes an instance of `Psr\Container\ContainerInterface` 
    as first constructor argument
  * [BC BREAK] The `EncoderInterface` and `DecoderInterface` have been replaced by a unified `Symfony\Component\Messenger\Transport\Serialization\SerializerInterface`.
+ * [BC BREAK] The locator passed to `ContainerHandlerLocator` should not prefix its keys by "handler." anymore
+ * [BC BREAK] The `AbstractHandlerLocator::getHandler()` method uses `?callable` as return type
+
+4.1.0
+-----
+
+ * Introduced the component as experimental

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -167,7 +167,7 @@ class MessengerPass implements CompilerPassInterface
         foreach ($handlersByBusAndMessage as $bus => $handlersByMessage) {
             foreach ($handlersByMessage as $message => $handlersIds) {
                 if (1 === \count($handlersIds)) {
-                    $handlersLocatorMappingByBus[$bus]['handler.'.$message] = new Reference(current($handlersIds));
+                    $handlersLocatorMappingByBus[$bus][$message] = new Reference(current($handlersIds));
                 } else {
                     $chainHandler = new Definition(ChainHandler::class, array(array_map(function (string $handlerId): Reference {
                         return new Reference($handlerId);
@@ -175,7 +175,7 @@ class MessengerPass implements CompilerPassInterface
                     $chainHandler->setPrivate(true);
                     $serviceId = '.messenger.chain_handler.'.ContainerBuilder::hash($bus.$message);
                     $definitions[$serviceId] = $chainHandler;
-                    $handlersLocatorMappingByBus[$bus]['handler.'.$message] = new Reference($serviceId);
+                    $handlersLocatorMappingByBus[$bus][$message] = new Reference($serviceId);
                 }
             }
         }

--- a/src/Symfony/Component/Messenger/Handler/Locator/AbstractHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/AbstractHandlerLocator.php
@@ -42,5 +42,5 @@ abstract class AbstractHandlerLocator implements HandlerLocatorInterface
         throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', $class));
     }
 
-    abstract protected function getHandler(string $class);
+    abstract protected function getHandler(string $class): ?callable;
 }

--- a/src/Symfony/Component/Messenger/Handler/Locator/ContainerHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/ContainerHandlerLocator.php
@@ -26,10 +26,11 @@ class ContainerHandlerLocator extends AbstractHandlerLocator
         $this->container = $container;
     }
 
-    protected function getHandler(string $class)
+    /**
+     * {@inheritdoc}
+     */
+    protected function getHandler(string $class): ?callable
     {
-        $handlerKey = 'handler.'.$class;
-
-        return $this->container->has($handlerKey) ? $this->container->get($handlerKey) : null;
+        return $this->container->has($class) ? $this->container->get($class) : null;
     }
 }

--- a/src/Symfony/Component/Messenger/Handler/Locator/HandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/HandlerLocator.php
@@ -26,7 +26,10 @@ class HandlerLocator extends AbstractHandlerLocator
         $this->messageToHandlerMapping = $messageToHandlerMapping;
     }
 
-    protected function getHandler(string $class)
+    /**
+     * {@inheritdoc}
+     */
+    protected function getHandler(string $class): ?callable
     {
         return $this->messageToHandlerMapping[$class] ?? null;
     }

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -69,8 +69,8 @@ class MessengerPassTest extends TestCase
         $this->assertSame(ServiceLocator::class, $handlerLocatorDefinition->getClass());
         $this->assertEquals(
             array(
-                'handler.'.DummyMessage::class => new ServiceClosureArgument(new Reference(DummyHandler::class)),
-                'handler.'.SecondMessage::class => new ServiceClosureArgument(new Reference(MissingArgumentTypeHandler::class)),
+                DummyMessage::class => new ServiceClosureArgument(new Reference(DummyHandler::class)),
+                SecondMessage::class => new ServiceClosureArgument(new Reference(MissingArgumentTypeHandler::class)),
             ),
             $handlerLocatorDefinition->getArgument(0)
         );
@@ -109,8 +109,8 @@ class MessengerPassTest extends TestCase
         $this->assertSame(ServiceLocator::class, $commandBusHandlerLocatorDefinition->getClass());
         $this->assertEquals(
             array(
-                'handler.'.DummyCommand::class => new ServiceClosureArgument(new Reference(DummyCommandHandler::class)),
-                'handler.'.MultipleBusesMessage::class => new ServiceClosureArgument(new Reference(MultipleBusesMessageHandler::class)),
+                DummyCommand::class => new ServiceClosureArgument(new Reference(DummyCommandHandler::class)),
+                MultipleBusesMessage::class => new ServiceClosureArgument(new Reference(MultipleBusesMessageHandler::class)),
             ),
             $commandBusHandlerLocatorDefinition->getArgument(0)
         );
@@ -119,8 +119,8 @@ class MessengerPassTest extends TestCase
         $this->assertSame(ServiceLocator::class, $queryBusHandlerLocatorDefinition->getClass());
         $this->assertEquals(
             array(
-                'handler.'.DummyQuery::class => new ServiceClosureArgument(new Reference(DummyQueryHandler::class)),
-                'handler.'.MultipleBusesMessage::class => new ServiceClosureArgument(new Reference(MultipleBusesMessageHandler::class)),
+                DummyQuery::class => new ServiceClosureArgument(new Reference(DummyQueryHandler::class)),
+                MultipleBusesMessage::class => new ServiceClosureArgument(new Reference(MultipleBusesMessageHandler::class)),
             ),
             $queryBusHandlerLocatorDefinition->getArgument(0)
         );
@@ -157,11 +157,11 @@ class MessengerPassTest extends TestCase
         $handlerLocatorDefinition = $container->getDefinition($container->getDefinition("$busId.messenger.handler_resolver")->getArgument(0));
         $handlerMapping = $handlerLocatorDefinition->getArgument(0);
 
-        $this->assertArrayHasKey('handler.'.DummyMessage::class, $handlerMapping);
-        $this->assertEquals(new ServiceClosureArgument(new Reference(HandlerWithMultipleMessages::class)), $handlerMapping['handler.'.DummyMessage::class]);
+        $this->assertArrayHasKey(DummyMessage::class, $handlerMapping);
+        $this->assertEquals(new ServiceClosureArgument(new Reference(HandlerWithMultipleMessages::class)), $handlerMapping[DummyMessage::class]);
 
-        $this->assertArrayHasKey('handler.'.SecondMessage::class, $handlerMapping);
-        $handlerReference = (string) $handlerMapping['handler.'.SecondMessage::class]->getValues()[0];
+        $this->assertArrayHasKey(SecondMessage::class, $handlerMapping);
+        $handlerReference = (string) $handlerMapping[SecondMessage::class]->getValues()[0];
         $definition = $container->getDefinition($handlerReference);
 
         $this->assertSame(ChainHandler::class, $definition->getClass());
@@ -185,16 +185,16 @@ class MessengerPassTest extends TestCase
         $handlerLocatorDefinition = $container->getDefinition($container->getDefinition("$busId.messenger.handler_resolver")->getArgument(0));
         $handlerMapping = $handlerLocatorDefinition->getArgument(0);
 
-        $this->assertArrayHasKey('handler.'.DummyMessage::class, $handlerMapping);
-        $this->assertArrayHasKey('handler.'.SecondMessage::class, $handlerMapping);
+        $this->assertArrayHasKey(DummyMessage::class, $handlerMapping);
+        $this->assertArrayHasKey(SecondMessage::class, $handlerMapping);
 
-        $dummyHandlerReference = (string) $handlerMapping['handler.'.DummyMessage::class]->getValues()[0];
+        $dummyHandlerReference = (string) $handlerMapping[DummyMessage::class]->getValues()[0];
         $dummyHandlerDefinition = $container->getDefinition($dummyHandlerReference);
         $this->assertSame('callable', $dummyHandlerDefinition->getClass());
         $this->assertEquals(array(new Reference(HandlerMappingMethods::class), 'dummyMethod'), $dummyHandlerDefinition->getArgument(0));
         $this->assertSame(array('Closure', 'fromCallable'), $dummyHandlerDefinition->getFactory());
 
-        $secondHandlerReference = (string) $handlerMapping['handler.'.SecondMessage::class]->getValues()[0];
+        $secondHandlerReference = (string) $handlerMapping[SecondMessage::class]->getValues()[0];
         $secondHandlerDefinition = $container->getDefinition($secondHandlerReference);
         $this->assertSame(ChainHandler::class, $secondHandlerDefinition->getClass());
         $this->assertEquals(new Reference(PrioritizedHandler::class), $secondHandlerDefinition->getArgument(0)[1]);
@@ -291,12 +291,12 @@ class MessengerPassTest extends TestCase
         $handlerLocatorDefinition = $container->getDefinition($container->getDefinition("$busId.messenger.handler_resolver")->getArgument(0));
         $handlerMapping = $handlerLocatorDefinition->getArgument(0);
 
-        $this->assertArrayHasKey('handler.'.DummyMessage::class, $handlerMapping);
-        $firstReference = $handlerMapping['handler.'.DummyMessage::class]->getValues()[0];
+        $this->assertArrayHasKey(DummyMessage::class, $handlerMapping);
+        $firstReference = $handlerMapping[DummyMessage::class]->getValues()[0];
         $this->assertEquals(array(new Reference(HandlerWithGenerators::class), 'dummyMethod'), $container->getDefinition($firstReference)->getArgument(0));
 
-        $this->assertArrayHasKey('handler.'.SecondMessage::class, $handlerMapping);
-        $secondReference = $handlerMapping['handler.'.SecondMessage::class]->getValues()[0];
+        $this->assertArrayHasKey(SecondMessage::class, $handlerMapping);
+        $secondReference = $handlerMapping[SecondMessage::class]->getValues()[0];
         $this->assertEquals(array(new Reference(HandlerWithGenerators::class), 'secondMessage'), $container->getDefinition($secondReference)->getArgument(0));
     }
 
@@ -315,15 +315,15 @@ class MessengerPassTest extends TestCase
         $eventsHandlerLocatorDefinition = $container->getDefinition($container->getDefinition($eventsBusId.'.messenger.handler_resolver')->getArgument(0));
         $eventsHandlerMapping = $eventsHandlerLocatorDefinition->getArgument(0);
 
-        $this->assertEquals(array('handler.'.DummyMessage::class), array_keys($eventsHandlerMapping));
-        $firstReference = $eventsHandlerMapping['handler.'.DummyMessage::class]->getValues()[0];
+        $this->assertEquals(array(DummyMessage::class), array_keys($eventsHandlerMapping));
+        $firstReference = $eventsHandlerMapping[DummyMessage::class]->getValues()[0];
         $this->assertEquals(array(new Reference(HandlerOnSpecificBuses::class), 'dummyMethodForEvents'), $container->getDefinition($firstReference)->getArgument(0));
 
         $commandsHandlerLocatorDefinition = $container->getDefinition($container->getDefinition($commandsBusId.'.messenger.handler_resolver')->getArgument(0));
         $commandsHandlerMapping = $commandsHandlerLocatorDefinition->getArgument(0);
 
-        $this->assertEquals(array('handler.'.DummyMessage::class), array_keys($commandsHandlerMapping));
-        $firstReference = $commandsHandlerMapping['handler.'.DummyMessage::class]->getValues()[0];
+        $this->assertEquals(array(DummyMessage::class), array_keys($commandsHandlerMapping));
+        $firstReference = $commandsHandlerMapping[DummyMessage::class]->getValues()[0];
         $this->assertEquals(array(new Reference(HandlerOnSpecificBuses::class), 'dummyMethodForCommands'), $container->getDefinition($firstReference)->getArgument(0));
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Handler/Locator/ContainerHandlerLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/Locator/ContainerHandlerLocatorTest.php
@@ -16,7 +16,7 @@ class ContainerHandlerLocatorTest extends TestCase
         $handler = function () {};
 
         $container = new Container();
-        $container->set('handler.'.DummyMessage::class, $handler);
+        $container->set(DummyMessage::class, $handler);
 
         $locator = new ContainerHandlerLocator($container);
         $resolvedHandler = $locator->resolve(new DummyMessage('Hey'));
@@ -39,7 +39,7 @@ class ContainerHandlerLocatorTest extends TestCase
         $handler = function () {};
 
         $container = new Container();
-        $container->set('handler.'.DummyMessageInterface::class, $handler);
+        $container->set(DummyMessageInterface::class, $handler);
 
         $locator = new ContainerHandlerLocator($container);
         $resolvedHandler = $locator->resolve(new DummyMessage('Hey'));
@@ -52,7 +52,7 @@ class ContainerHandlerLocatorTest extends TestCase
         $handler = function () {};
 
         $container = new Container();
-        $container->set('handler.'.DummyMessage::class, $handler);
+        $container->set(DummyMessage::class, $handler);
 
         $locator = new ContainerHandlerLocator($container);
         $resolvedHandler = $locator->resolve(new ChildDummyMessage('Hey'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28621
| License       | MIT
| Doc PR        | -

I fail to understand what this prefix is for. Looks like boilerplate to me, let's drop it, isn't it?
An alternative to #28621