### PR TITLE
Added asset PackageJsonVersionStrategy

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.3.0
 -----
 
+ * Added asset `PackageJsonVersionStrategy`
  * Added `ControllerTrait::isFormValid()`
 
 4.2.0

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -617,6 +617,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('version')->defaultNull()->end()
                         ->scalarNode('version_format')->defaultValue('%%s?%%s')->end()
                         ->scalarNode('json_manifest_path')->defaultNull()->end()
+                        ->scalarNode('package_json_path')->defaultNull()->end()
                         ->scalarNode('base_path')->defaultValue('')->end()
                         ->arrayNode('base_urls')
                             ->requiresAtLeastOneElement()
@@ -635,15 +636,21 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->validate()
                         ->ifTrue(function ($v) {
-                            return isset($v['version_strategy']) && isset($v['json_manifest_path']);
+                            return isset($v['json_manifest_path']) && isset($v['package_json_path']);
                         })
-                        ->thenInvalid('You cannot use both "version_strategy" and "json_manifest_path" at the same time under "assets".')
+                        ->thenInvalid('You cannot use both "json_manifest_path" and "package_json_path" at the same time under "assets".')
                     ->end()
                     ->validate()
                         ->ifTrue(function ($v) {
-                            return isset($v['version']) && isset($v['json_manifest_path']);
+                            return isset($v['version_strategy']) && (isset($v['json_manifest_path']) || isset($v['package_json_path']));
                         })
-                        ->thenInvalid('You cannot use both "version" and "json_manifest_path" at the same time under "assets".')
+                        ->thenInvalid('You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets".')
+                    ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return isset($v['version']) && (isset($v['json_manifest_path']) || isset($v['package_json_path']));
+                        })
+                        ->thenInvalid('You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets".')
                     ->end()
                     ->fixXmlConfig('package')
                     ->children()
@@ -661,6 +668,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                     ->scalarNode('version_format')->defaultNull()->end()
                                     ->scalarNode('json_manifest_path')->defaultNull()->end()
+                                    ->scalarNode('package_json_path')->defaultNull()->end()
                                     ->scalarNode('base_path')->defaultValue('')->end()
                                     ->arrayNode('base_urls')
                                         ->requiresAtLeastOneElement()
@@ -679,15 +687,15 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return isset($v['version_strategy']) && isset($v['json_manifest_path']);
+                                        return isset($v['version_strategy']) && (isset($v['json_manifest_path']) || isset($v['package_json_path']));
                                     })
-                                    ->thenInvalid('You cannot use both "version_strategy" and "json_manifest_path" at the same time under "assets" packages.')
+                                    ->thenInvalid('You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.')
                                 ->end()
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return isset($v['version']) && isset($v['json_manifest_path']);
+                                        return isset($v['version']) && (isset($v['json_manifest_path']) || isset($v['package_json_path']));
                                     })
-                                    ->thenInvalid('You cannot use both "version" and "json_manifest_path" at the same time under "assets" packages.')
+                                    ->thenInvalid('You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.')
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -64,7 +64,7 @@ class Configuration implements ConfigurationInterface
             ->beforeNormalization()
                 ->ifTrue(function ($v) { return !isset($v['assets']) && isset($v['templating']) && class_exists(Package::class); })
                 ->then(function ($v) {
-                    $v['assets'] = array();
+                    $v['assets'] = [];
 
                     return $v;
                 })
@@ -79,7 +79,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('test')->end()
                 ->scalarNode('default_locale')->defaultValue('en')->end()
                 ->arrayNode('trusted_hosts')
-                    ->beforeNormalization()->ifString()->then(function ($v) { return array($v); })->end()
+                    ->beforeNormalization()->ifString()->then(function ($v) { return [$v]; })->end()
                     ->prototype('scalar')->end()
                 ->end()
             ->end()
@@ -117,9 +117,9 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('csrf_protection')
-                    ->treatFalseLike(array('enabled' => false))
-                    ->treatTrueLike(array('enabled' => true))
-                    ->treatNullLike(array('enabled' => true))
+                    ->treatFalseLike(['enabled' => false])
+                    ->treatTrueLike(['enabled' => true])
+                    ->treatNullLike(['enabled' => true])
                     ->addDefaultsIfNotSet()
                     ->children()
                         // defaults to framework.session.enabled && !class_exists(FullStack::class) && interface_exists(CsrfTokenManagerInterface::class)
@@ -139,9 +139,9 @@ class Configuration implements ConfigurationInterface
                     ->{!class_exists(FullStack::class) && class_exists(Form::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                     ->children()
                         ->arrayNode('csrf_protection')
-                            ->treatFalseLike(array('enabled' => false))
-                            ->treatTrueLike(array('enabled' => true))
-                            ->treatNullLike(array('enabled' => true))
+                            ->treatFalseLike(['enabled' => false])
+                            ->treatTrueLike(['enabled' => true])
+                            ->treatNullLike(['enabled' => true])
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->booleanNode('enabled')->defaultNull()->end() // defaults to framework.csrf_protection.enabled
@@ -224,10 +224,10 @@ class Configuration implements ConfigurationInterface
                                 unset($workflows['enabled']);
 
                                 if (1 === \count($workflows) && isset($workflows[0]['enabled']) && 1 === \count($workflows[0])) {
-                                    $workflows = array();
+                                    $workflows = [];
                                 }
 
-                                if (1 === \count($workflows) && isset($workflows['workflows']) && array_keys($workflows['workflows']) !== range(0, \count($workflows) - 1) && !empty(array_diff(array_keys($workflows['workflows']), array('audit_trail', 'type', 'marking_store', 'supports', 'support_strategy', 'initial_place', 'places', 'transitions')))) {
+                                if (1 === \count($workflows) && isset($workflows['workflows']) && array_keys($workflows['workflows']) !== range(0, \count($workflows) - 1) && !empty(array_diff(array_keys($workflows['workflows']), ['audit_trail', 'type', 'marking_store', 'supports', 'support_strategy', 'initial_place', 'places', 'transitions']))) {
                                     $workflows = $workflows['workflows'];
                                 }
 
@@ -239,10 +239,10 @@ class Configuration implements ConfigurationInterface
                                     unset($workflows[$key]['enabled']);
                                 }
 
-                                $v = array(
+                                $v = [
                                     'enabled' => true,
                                     'workflows' => $workflows,
-                                );
+                                ];
                             }
 
                             return $v;
@@ -260,19 +260,19 @@ class Configuration implements ConfigurationInterface
                                         ->canBeEnabled()
                                     ->end()
                                     ->enumNode('type')
-                                        ->values(array('workflow', 'state_machine'))
+                                        ->values(['workflow', 'state_machine'])
                                         ->defaultValue('state_machine')
                                     ->end()
                                     ->arrayNode('marking_store')
                                         ->fixXmlConfig('argument')
                                         ->children()
                                             ->enumNode('type')
-                                                ->values(array('multiple_state', 'single_state'))
+                                                ->values(['multiple_state', 'single_state'])
                                             ->end()
                                             ->arrayNode('arguments')
                                                 ->beforeNormalization()
                                                     ->ifString()
-                                                    ->then(function ($v) { return array($v); })
+                                                    ->then(function ($v) { return [$v]; })
                                                 ->end()
                                                 ->requiresAtLeastOneElement()
                                                 ->prototype('scalar')
@@ -294,7 +294,7 @@ class Configuration implements ConfigurationInterface
                                     ->arrayNode('supports')
                                         ->beforeNormalization()
                                             ->ifString()
-                                            ->then(function ($v) { return array($v); })
+                                            ->then(function ($v) { return [$v]; })
                                         ->end()
                                         ->prototype('scalar')
                                             ->cannotBeEmpty()
@@ -317,7 +317,7 @@ class Configuration implements ConfigurationInterface
                                                 // It's an indexed array of shape  ['place1', 'place2']
                                                 if (isset($places[0]) && \is_string($places[0])) {
                                                     return array_map(function (string $place) {
-                                                        return array('name' => $place);
+                                                        return ['name' => $place];
                                                     }, $places);
                                                 }
 
@@ -347,8 +347,8 @@ class Configuration implements ConfigurationInterface
                                                 ->end()
                                                 ->arrayNode('metadata')
                                                     ->normalizeKeys(false)
-                                                    ->defaultValue(array())
-                                                    ->example(array('color' => 'blue', 'description' => 'Workflow to manage article.'))
+                                                    ->defaultValue([])
+                                                    ->example(['color' => 'blue', 'description' => 'Workflow to manage article.'])
                                                     ->prototype('variable')
                                                     ->end()
                                                 ->end()
@@ -391,7 +391,7 @@ class Configuration implements ConfigurationInterface
                                                 ->arrayNode('from')
                                                     ->beforeNormalization()
                                                         ->ifString()
-                                                        ->then(function ($v) { return array($v); })
+                                                        ->then(function ($v) { return [$v]; })
                                                     ->end()
                                                     ->requiresAtLeastOneElement()
                                                     ->prototype('scalar')
@@ -401,7 +401,7 @@ class Configuration implements ConfigurationInterface
                                                 ->arrayNode('to')
                                                     ->beforeNormalization()
                                                         ->ifString()
-                                                        ->then(function ($v) { return array($v); })
+                                                        ->then(function ($v) { return [$v]; })
                                                     ->end()
                                                     ->requiresAtLeastOneElement()
                                                     ->prototype('scalar')
@@ -410,8 +410,8 @@ class Configuration implements ConfigurationInterface
                                                 ->end()
                                                 ->arrayNode('metadata')
                                                     ->normalizeKeys(false)
-                                                    ->defaultValue(array())
-                                                    ->example(array('color' => 'blue', 'description' => 'Workflow to manage article.'))
+                                                    ->defaultValue([])
+                                                    ->example(['color' => 'blue', 'description' => 'Workflow to manage article.'])
                                                     ->prototype('variable')
                                                     ->end()
                                                 ->end()
@@ -420,8 +420,8 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                     ->arrayNode('metadata')
                                         ->normalizeKeys(false)
-                                        ->defaultValue(array())
-                                        ->example(array('color' => 'blue', 'description' => 'Workflow to manage article.'))
+                                        ->defaultValue([])
+                                        ->example(['color' => 'blue', 'description' => 'Workflow to manage article.'])
                                         ->prototype('variable')
                                         ->end()
                                     ->end()
@@ -497,9 +497,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('cookie_lifetime')->end()
                         ->scalarNode('cookie_path')->end()
                         ->scalarNode('cookie_domain')->end()
-                        ->enumNode('cookie_secure')->values(array(true, false, 'auto'))->end()
+                        ->enumNode('cookie_secure')->values([true, false, 'auto'])->end()
                         ->booleanNode('cookie_httponly')->defaultTrue()->end()
-                        ->enumNode('cookie_samesite')->values(array(null, Cookie::SAMESITE_LAX, Cookie::SAMESITE_STRICT))->defaultNull()->end()
+                        ->enumNode('cookie_samesite')->values([null, Cookie::SAMESITE_LAX, Cookie::SAMESITE_STRICT])->defaultNull()->end()
                         ->booleanNode('use_cookies')->end()
                         ->scalarNode('gc_divisor')->end()
                         ->scalarNode('gc_probability')->defaultValue(1)->end()
@@ -533,7 +533,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->beforeNormalization()
                                     ->ifTrue(function ($v) { return !\is_array($v); })
-                                    ->then(function ($v) { return array($v); })
+                                    ->then(function ($v) { return [$v]; })
                                 ->end()
                                 ->prototype('scalar')->end()
                             ->end()
@@ -553,7 +553,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeEnabled()
                     ->beforeNormalization()
                         ->ifTrue(function ($v) { return false === $v || \is_array($v) && false === $v['enabled']; })
-                        ->then(function () { return array('enabled' => false, 'engines' => false); })
+                        ->then(function () { return ['enabled' => false, 'engines' => false]; })
                     ->end()
                     ->children()
                         ->scalarNode('hinclude_default_template')->defaultNull()->end()
@@ -568,7 +568,7 @@ class Configuration implements ConfigurationInterface
                                     ->validate()
                                         ->ifTrue(function ($v) {return !\in_array('FrameworkBundle:Form', $v); })
                                         ->then(function ($v) {
-                                            return array_merge(array('FrameworkBundle:Form'), $v);
+                                            return array_merge(['FrameworkBundle:Form'], $v);
                                         })
                                     ->end()
                                 ->end()
@@ -578,13 +578,13 @@ class Configuration implements ConfigurationInterface
                     ->fixXmlConfig('engine')
                     ->children()
                         ->arrayNode('engines')
-                            ->example(array('twig'))
+                            ->example(['twig'])
                             ->isRequired()
                             ->requiresAtLeastOneElement()
                             ->canBeUnset()
                             ->beforeNormalization()
                                 ->ifTrue(function ($v) { return !\is_array($v) && false !== $v; })
-                                ->then(function ($v) { return array($v); })
+                                ->then(function ($v) { return [$v]; })
                             ->end()
                             ->prototype('scalar')->end()
                         ->end()
@@ -594,7 +594,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('loaders')
                             ->beforeNormalization()
                                 ->ifTrue(function ($v) { return !\is_array($v); })
-                                ->then(function ($v) { return array($v); })
+                                ->then(function ($v) { return [$v]; })
                              ->end()
                             ->prototype('scalar')->end()
                         ->end()
@@ -623,7 +623,7 @@ class Configuration implements ConfigurationInterface
                             ->requiresAtLeastOneElement()
                             ->beforeNormalization()
                                 ->ifTrue(function ($v) { return !\is_array($v); })
-                                ->then(function ($v) { return array($v); })
+                                ->then(function ($v) { return [$v]; })
                             ->end()
                             ->prototype('scalar')->end()
                         ->end()
@@ -674,7 +674,7 @@ class Configuration implements ConfigurationInterface
                                         ->requiresAtLeastOneElement()
                                         ->beforeNormalization()
                                             ->ifTrue(function ($v) { return !\is_array($v); })
-                                            ->then(function ($v) { return array($v); })
+                                            ->then(function ($v) { return [$v]; })
                                         ->end()
                                         ->prototype('scalar')->end()
                                     ->end()
@@ -716,9 +716,9 @@ class Configuration implements ConfigurationInterface
                     ->fixXmlConfig('path')
                     ->children()
                         ->arrayNode('fallbacks')
-                            ->beforeNormalization()->ifString()->then(function ($v) { return array($v); })->end()
+                            ->beforeNormalization()->ifString()->then(function ($v) { return [$v]; })->end()
                             ->prototype('scalar')->end()
-                            ->defaultValue(array('en'))
+                            ->defaultValue(['en'])
                         ->end()
                         ->booleanNode('logging')->defaultValue(false)->end()
                         ->scalarNode('formatter')->defaultValue('translator.formatter.default')->end()
@@ -767,9 +767,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('cache')->end()
                         ->booleanNode('enable_annotations')->{!class_exists(FullStack::class) && class_exists(Annotation::class) ? 'defaultTrue' : 'defaultFalse'}()->end()
                         ->arrayNode('static_method')
-                            ->defaultValue(array('loadValidatorMetadata'))
+                            ->defaultValue(['loadValidatorMetadata'])
                             ->prototype('scalar')->end()
-                            ->treatFalseLike(array())
+                            ->treatFalseLike([])
                             ->validate()
                                 ->ifTrue(function ($v) { return !\is_array($v); })
                                 ->then(function ($v) { return (array) $v; })
@@ -777,7 +777,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('translation_domain')->defaultValue('validators')->end()
                         ->booleanNode('strict_email')->end()
-                        ->enumNode('email_validation_mode')->values(array('html5', 'loose', 'strict'))->end()
+                        ->enumNode('email_validation_mode')->values(['html5', 'loose', 'strict'])->end()
                         ->arrayNode('mapping')
                             ->addDefaultsIfNotSet()
                             ->fixXmlConfig('path')
@@ -954,7 +954,7 @@ class Configuration implements ConfigurationInterface
                     ->info('Lock configuration')
                     ->{!class_exists(FullStack::class) && class_exists(Lock::class) ? 'canBeDisabled' : 'canBeEnabled'}()
                     ->beforeNormalization()
-                        ->ifString()->then(function ($v) { return array('enabled' => true, 'resources' => $v); })
+                        ->ifString()->then(function ($v) { return ['enabled' => true, 'resources' => $v]; })
                     ->end()
                     ->beforeNormalization()
                         ->ifTrue(function ($v) { return \is_array($v) && !isset($v['resources']); })
@@ -962,7 +962,7 @@ class Configuration implements ConfigurationInterface
                             $e = $v['enabled'];
                             unset($v['enabled']);
 
-                            return array('enabled' => $e, 'resources' => $v);
+                            return ['enabled' => $e, 'resources' => $v];
                         })
                     ->end()
                     ->addDefaultsIfNotSet()
@@ -970,16 +970,16 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->arrayNode('resources')
                             ->requiresAtLeastOneElement()
-                            ->defaultValue(array('default' => array(class_exists(SemaphoreStore::class) && SemaphoreStore::isSupported() ? 'semaphore' : 'flock')))
+                            ->defaultValue(['default' => [class_exists(SemaphoreStore::class) && SemaphoreStore::isSupported() ? 'semaphore' : 'flock']])
                             ->beforeNormalization()
-                                ->ifString()->then(function ($v) { return array('default' => $v); })
+                                ->ifString()->then(function ($v) { return ['default' => $v]; })
                             ->end()
                             ->beforeNormalization()
                                 ->ifTrue(function ($v) { return \is_array($v) && array_keys($v) === range(0, \count($v) - 1); })
-                                ->then(function ($v) { return array('default' => $v); })
+                                ->then(function ($v) { return ['default' => $v]; })
                             ->end()
                             ->prototype('array')
-                                ->beforeNormalization()->ifString()->then(function ($v) { return array($v); })->end()
+                                ->beforeNormalization()->ifString()->then(function ($v) { return [$v]; })->end()
                                 ->prototype('scalar')->end()
                             ->end()
                         ->end()
@@ -1017,16 +1017,16 @@ class Configuration implements ConfigurationInterface
                                 ->always()
                                 ->then(function ($config) {
                                     if (!\is_array($config)) {
-                                        return array();
+                                        return [];
                                     }
 
-                                    $newConfig = array();
+                                    $newConfig = [];
                                     foreach ($config as $k => $v) {
                                         if (!\is_int($k)) {
-                                            $newConfig[$k] = array(
-                                                'senders' => $v['senders'] ?? (\is_array($v) ? array_values($v) : array($v)),
+                                            $newConfig[$k] = [
+                                                'senders' => $v['senders'] ?? (\is_array($v) ? array_values($v) : [$v]),
                                                 'send_and_handle' => $v['send_and_handle'] ?? false,
-                                            );
+                                            ];
                                         } else {
                                             $newConfig[$v['message-class']]['senders'] = array_map(
                                                 function ($a) {
@@ -1057,11 +1057,11 @@ class Configuration implements ConfigurationInterface
                                 ->always()
                                 ->then(function ($config) {
                                     if (false === $config) {
-                                        return array('id' => null);
+                                        return ['id' => null];
                                     }
 
                                     if (\is_string($config)) {
-                                        return array('id' => $config);
+                                        return ['id' => $config];
                                     }
 
                                     return $config;
@@ -1073,7 +1073,7 @@ class Configuration implements ConfigurationInterface
                                 ->arrayNode('context')
                                     ->normalizeKeys(false)
                                     ->useAttributeAsKey('name')
-                                    ->defaultValue(array())
+                                    ->defaultValue([])
                                     ->prototype('variable')->end()
                                 ->end()
                             ->end()
@@ -1084,7 +1084,7 @@ class Configuration implements ConfigurationInterface
                                 ->beforeNormalization()
                                     ->ifString()
                                     ->then(function (string $dsn) {
-                                        return array('dsn' => $dsn);
+                                        return ['dsn' => $dsn];
                                     })
                                 ->end()
                                 ->fixXmlConfig('option')
@@ -1092,7 +1092,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('dsn')->end()
                                     ->arrayNode('options')
                                         ->normalizeKeys(false)
-                                        ->defaultValue(array())
+                                        ->defaultValue([])
                                         ->prototype('variable')
                                         ->end()
                                     ->end()
@@ -1101,27 +1101,27 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('default_bus')->defaultNull()->end()
                         ->arrayNode('buses')
-                            ->defaultValue(array('messenger.bus.default' => array('default_middleware' => true, 'middleware' => array())))
+                            ->defaultValue(['messenger.bus.default' => ['default_middleware' => true, 'middleware' => []]])
                             ->useAttributeAsKey('name')
                             ->arrayPrototype()
                                 ->addDefaultsIfNotSet()
                                 ->children()
                                     ->enumNode('default_middleware')
-                                        ->values(array(true, false, 'allow_no_handlers'))
+                                        ->values([true, false, 'allow_no_handlers'])
                                         ->defaultTrue()
                                     ->end()
                                     ->arrayNode('middleware')
                                         ->beforeNormalization()
                                             ->ifTrue(function ($v) { return \is_string($v) || (\is_array($v) && !\is_int(key($v))); })
-                                            ->then(function ($v) { return array($v); })
+                                            ->then(function ($v) { return [$v]; })
                                         ->end()
-                                        ->defaultValue(array())
+                                        ->defaultValue([])
                                         ->arrayPrototype()
                                             ->beforeNormalization()
                                                 ->always()
                                                 ->then(function ($middleware): array {
                                                     if (!\is_array($middleware)) {
-                                                        return array('id' => $middleware);
+                                                        return ['id' => $middleware];
                                                     }
                                                     if (isset($middleware['id'])) {
                                                         return $middleware;
@@ -1130,10 +1130,10 @@ class Configuration implements ConfigurationInterface
                                                         throw new \InvalidArgumentException(sprintf('Invalid middleware at path "framework.messenger": a map with a single factory id as key and its arguments as value was expected, %s given.', json_encode($middleware)));
                                                     }
 
-                                                    return array(
+                                                    return [
                                                         'id' => key($middleware),
                                                         'arguments' => current($middleware),
-                                                    );
+                                                    ];
                                                 })
                                             ->end()
                                             ->fixXmlConfig('argument')
@@ -1141,7 +1141,7 @@ class Configuration implements ConfigurationInterface
                                                 ->scalarNode('id')->isRequired()->cannotBeEmpty()->end()
                                                 ->arrayNode('arguments')
                                                     ->normalizeKeys(false)
-                                                    ->defaultValue(array())
+                                                    ->defaultValue([])
                                                     ->prototype('variable')
                                                 ->end()
                                             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -181,7 +181,7 @@ class FrameworkExtension extends Extension
 
         if (!$container->hasParameter('debug.file_link_format')) {
             if (!$container->hasParameter('templating.helper.code.file_link_format')) {
-                $links = array(
+                $links = [
                     'textmate' => 'txmt://open?url=file://%%f&line=%%l',
                     'macvim' => 'mvim://open?url=file://%%f&line=%%l',
                     'emacs' => 'emacs://open?url=file://%%f&line=%%l',
@@ -189,7 +189,7 @@ class FrameworkExtension extends Extension
                     'phpstorm' => 'phpstorm://open?file=%%f&line=%%l',
                     'atom' => 'atom://core/open/file?filename=%%f&line=%%l',
                     'vscode' => 'vscode://file/%%f:%%l',
-                );
+                ];
                 $ide = $config['ide'];
 
                 $container->setParameter('templating.helper.code.file_link_format', str_replace('%', '%%', ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')) ?: (isset($links[$ide]) ? $links[$ide] : $ide));
@@ -302,13 +302,13 @@ class FrameworkExtension extends Extension
             $loader->load('web_link.xml');
         }
 
-        $this->addAnnotatedClassesToCompile(array(
+        $this->addAnnotatedClassesToCompile([
             '**\\Controller\\',
             '**\\Entity\\',
 
             // Added explicitly so that we don't rely on the class map being dumped to make it work
             'Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController',
-        ));
+        ]);
 
         $container->registerForAutoconfiguration(Command::class)
             ->addTag('console.command');
@@ -341,11 +341,11 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(EventSubscriberInterface::class)
             ->addTag('kernel.event_subscriber');
         $container->registerForAutoconfiguration(ResetInterface::class)
-            ->addTag('kernel.reset', array('method' => 'reset'));
+            ->addTag('kernel.reset', ['method' => 'reset']);
 
         if (!interface_exists(MarshallerInterface::class)) {
             $container->registerForAutoconfiguration(ResettableInterface::class)
-                ->addTag('kernel.reset', array('method' => 'reset'));
+                ->addTag('kernel.reset', ['method' => 'reset']);
         }
 
         $container->registerForAutoconfiguration(PropertyListExtractorInterface::class)
@@ -375,11 +375,11 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(TransportFactoryInterface::class)
             ->addTag('messenger.transport_factory');
         $container->registerForAutoconfiguration(LoggerAwareInterface::class)
-            ->addMethodCall('setLogger', array(new Reference('logger')));
+            ->addMethodCall('setLogger', [new Reference('logger')]);
 
         if (!$container->getParameter('kernel.debug')) {
             // remove tagged iterator argument for resource checkers
-            $container->getDefinition('config_cache_factory')->setArguments(array());
+            $container->getDefinition('config_cache_factory')->setArguments([]);
         }
     }
 
@@ -451,7 +451,7 @@ class FrameworkExtension extends Extension
     {
         if (!$this->isConfigEnabled($container, $config)) {
             // this is needed for the WebProfiler to work even if the profiler is disabled
-            $container->setParameter('data_collector.templates', array());
+            $container->setParameter('data_collector.templates', []);
 
             return;
         }
@@ -491,7 +491,7 @@ class FrameworkExtension extends Extension
 
         $container->getDefinition('profiler')
             ->addArgument($config['collect'])
-            ->addTag('kernel.reset', array('method' => 'reset'));
+            ->addTag('kernel.reset', ['method' => 'reset']);
     }
 
     private function registerWorkflowConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
@@ -515,11 +515,11 @@ class FrameworkExtension extends Extension
             $workflowId = sprintf('%s.%s', $type, $name);
 
             // Process Metadata (workflow + places (transition is done in the "create transition" block))
-            $metadataStoreDefinition = new Definition(Workflow\Metadata\InMemoryMetadataStore::class, array(array(), array(), null));
+            $metadataStoreDefinition = new Definition(Workflow\Metadata\InMemoryMetadataStore::class, [[], [], null]);
             if ($workflow['metadata']) {
                 $metadataStoreDefinition->replaceArgument(0, $workflow['metadata']);
             }
-            $placesMetadata = array();
+            $placesMetadata = [];
             foreach ($workflow['places'] as $place) {
                 if ($place['metadata']) {
                     $placesMetadata[$place['name']] = $place['metadata'];
@@ -530,14 +530,14 @@ class FrameworkExtension extends Extension
             }
 
             // Create transitions
-            $transitions = array();
-            $guardsConfiguration = array();
+            $transitions = [];
+            $guardsConfiguration = [];
             $transitionsMetadataDefinition = new Definition(\SplObjectStorage::class);
             // Global transition counter per workflow
             $transitionCounter = 0;
             foreach ($workflow['transitions'] as $transition) {
                 if ('workflow' === $type) {
-                    $transitionDefinition = new Definition(Workflow\Transition::class, array($transition['name'], $transition['from'], $transition['to']));
+                    $transitionDefinition = new Definition(Workflow\Transition::class, [$transition['name'], $transition['from'], $transition['to']]);
                     $transitionDefinition->setPublic(false);
                     $transitionId = sprintf('%s.transition.%s', $workflowId, $transitionCounter++);
                     $container->setDefinition($transitionId, $transitionDefinition);
@@ -551,15 +551,15 @@ class FrameworkExtension extends Extension
                         $guardsConfiguration[$eventName][] = $configuration;
                     }
                     if ($transition['metadata']) {
-                        $transitionsMetadataDefinition->addMethodCall('attach', array(
+                        $transitionsMetadataDefinition->addMethodCall('attach', [
                             new Reference($transitionId),
                             $transition['metadata'],
-                        ));
+                        ]);
                     }
                 } elseif ('state_machine' === $type) {
                     foreach ($transition['from'] as $from) {
                         foreach ($transition['to'] as $to) {
-                            $transitionDefinition = new Definition(Workflow\Transition::class, array($transition['name'], $from, $to));
+                            $transitionDefinition = new Definition(Workflow\Transition::class, [$transition['name'], $from, $to]);
                             $transitionDefinition->setPublic(false);
                             $transitionId = sprintf('%s.transition.%s', $workflowId, $transitionCounter++);
                             $container->setDefinition($transitionId, $transitionDefinition);
@@ -573,10 +573,10 @@ class FrameworkExtension extends Extension
                                 $guardsConfiguration[$eventName][] = $configuration;
                             }
                             if ($transition['metadata']) {
-                                $transitionsMetadataDefinition->addMethodCall('attach', array(
+                                $transitionsMetadataDefinition->addMethodCall('attach', [
                                     new Reference($transitionId),
                                     $transition['metadata'],
-                                ));
+                                ]);
                             }
                         }
                     }
@@ -596,11 +596,11 @@ class FrameworkExtension extends Extension
             $definitionDefinition->addArgument($transitions);
             $definitionDefinition->addArgument($workflow['initial_place'] ?? null);
             $definitionDefinition->addArgument($metadataStoreDefinition);
-            $definitionDefinition->addTag('workflow.definition', array(
+            $definitionDefinition->addTag('workflow.definition', [
                 'name' => $name,
                 'type' => $type,
                 'marking_store' => isset($workflow['marking_store']['type']) ? $workflow['marking_store']['type'] : null,
-            ));
+            ]);
 
             // Create MarkingStore
             if (isset($workflow['marking_store']['type'])) {
@@ -628,22 +628,22 @@ class FrameworkExtension extends Extension
             // Add workflow to Registry
             if ($workflow['supports']) {
                 foreach ($workflow['supports'] as $supportedClassName) {
-                    $strategyDefinition = new Definition(Workflow\SupportStrategy\InstanceOfSupportStrategy::class, array($supportedClassName));
+                    $strategyDefinition = new Definition(Workflow\SupportStrategy\InstanceOfSupportStrategy::class, [$supportedClassName]);
                     $strategyDefinition->setPublic(false);
-                    $registryDefinition->addMethodCall('addWorkflow', array(new Reference($workflowId), $strategyDefinition));
+                    $registryDefinition->addMethodCall('addWorkflow', [new Reference($workflowId), $strategyDefinition]);
                 }
             } elseif (isset($workflow['support_strategy'])) {
-                $registryDefinition->addMethodCall('addWorkflow', array(new Reference($workflowId), new Reference($workflow['support_strategy'])));
+                $registryDefinition->addMethodCall('addWorkflow', [new Reference($workflowId), new Reference($workflow['support_strategy'])]);
             }
 
             // Enable the AuditTrail
             if ($workflow['audit_trail']['enabled']) {
                 $listener = new Definition(Workflow\EventListener\AuditTrailListener::class);
                 $listener->setPrivate(true);
-                $listener->addTag('monolog.logger', array('channel' => 'workflow'));
-                $listener->addTag('kernel.event_listener', array('event' => sprintf('workflow.%s.leave', $name), 'method' => 'onLeave'));
-                $listener->addTag('kernel.event_listener', array('event' => sprintf('workflow.%s.transition', $name), 'method' => 'onTransition'));
-                $listener->addTag('kernel.event_listener', array('event' => sprintf('workflow.%s.enter', $name), 'method' => 'onEnter'));
+                $listener->addTag('monolog.logger', ['channel' => 'workflow']);
+                $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.leave', $name), 'method' => 'onLeave']);
+                $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.transition', $name), 'method' => 'onTransition']);
+                $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.enter', $name), 'method' => 'onEnter']);
                 $listener->addArgument(new Reference('logger'));
                 $container->setDefinition(sprintf('%s.listener.audit_trail', $workflowId), $listener);
             }
@@ -661,7 +661,7 @@ class FrameworkExtension extends Extension
                 $guard = new Definition(Workflow\EventListener\GuardListener::class);
                 $guard->setPrivate(true);
 
-                $guard->setArguments(array(
+                $guard->setArguments([
                     $guardsConfiguration,
                     new Reference('workflow.security.expression_language'),
                     new Reference('security.token_storage'),
@@ -669,9 +669,9 @@ class FrameworkExtension extends Extension
                     new Reference('security.authentication.trust_resolver'),
                     new Reference('security.role_hierarchy'),
                     new Reference('validator', ContainerInterface::NULL_ON_INVALID_REFERENCE),
-                ));
+                ]);
                 foreach ($guardsConfiguration as $eventName => $config) {
-                    $guard->addTag('kernel.event_listener', array('event' => $eventName, 'method' => 'onTransition'));
+                    $guard->addTag('kernel.event_listener', ['event' => $eventName, 'method' => 'onTransition']);
                 }
 
                 $container->setDefinition(sprintf('%s.listener.guard', $workflowId), $guard);
@@ -688,7 +688,7 @@ class FrameworkExtension extends Extension
             $container->register('debug.stopwatch', Stopwatch::class)
                 ->addArgument(true)
                 ->setPrivate(true)
-                ->addTag('kernel.reset', array('method' => 'reset'));
+                ->addTag('kernel.reset', ['method' => 'reset']);
             $container->setAlias(Stopwatch::class, new Alias('debug.stopwatch', false));
         }
 
@@ -737,7 +737,7 @@ class FrameworkExtension extends Extension
         $loader->load('routing.xml');
 
         if ($config['utf8']) {
-            $container->getDefinition('routing.loader')->replaceArgument(2, array('utf8' => true));
+            $container->getDefinition('routing.loader')->replaceArgument(2, ['utf8' => true]);
         }
 
         $container->setParameter('router.resource', $config['resource']);
@@ -756,24 +756,24 @@ class FrameworkExtension extends Extension
         if ($this->annotationsConfigEnabled) {
             $container->register('routing.loader.annotation', AnnotatedRouteControllerLoader::class)
                 ->setPublic(false)
-                ->addTag('routing.loader', array('priority' => -10))
+                ->addTag('routing.loader', ['priority' => -10])
                 ->addArgument(new Reference('annotation_reader'));
 
             $container->register('routing.loader.annotation.directory', AnnotationDirectoryLoader::class)
                 ->setPublic(false)
-                ->addTag('routing.loader', array('priority' => -10))
-                ->setArguments(array(
+                ->addTag('routing.loader', ['priority' => -10])
+                ->setArguments([
                     new Reference('file_locator'),
                     new Reference('routing.loader.annotation'),
-                ));
+                ]);
 
             $container->register('routing.loader.annotation.file', AnnotationFileLoader::class)
                 ->setPublic(false)
-                ->addTag('routing.loader', array('priority' => -10))
-                ->setArguments(array(
+                ->addTag('routing.loader', ['priority' => -10])
+                ->setArguments([
                     new Reference('file_locator'),
                     new Reference('routing.loader.annotation'),
-                ));
+                ]);
         }
     }
 
@@ -783,8 +783,8 @@ class FrameworkExtension extends Extension
 
         // session storage
         $container->setAlias('session.storage', $config['storage_id'])->setPrivate(true);
-        $options = array('cache_limiter' => '0');
-        foreach (array('name', 'cookie_lifetime', 'cookie_path', 'cookie_domain', 'cookie_secure', 'cookie_httponly', 'cookie_samesite', 'use_cookies', 'gc_maxlifetime', 'gc_probability', 'gc_divisor') as $key) {
+        $options = ['cache_limiter' => '0'];
+        foreach (['name', 'cookie_lifetime', 'cookie_path', 'cookie_domain', 'cookie_secure', 'cookie_httponly', 'cookie_samesite', 'use_cookies', 'gc_maxlifetime', 'gc_probability', 'gc_divisor'] as $key) {
             if (isset($config[$key])) {
                 $options[$key] = $config[$key];
             }
@@ -792,10 +792,10 @@ class FrameworkExtension extends Extension
 
         if ('auto' === ($options['cookie_secure'] ?? null)) {
             $locator = $container->getDefinition('session_listener')->getArgument(0);
-            $locator->setValues($locator->getValues() + array(
+            $locator->setValues($locator->getValues() + [
                 'session_storage' => new Reference('session.storage', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
                 'request_stack' => new Reference('request_stack'),
-            ));
+            ]);
         }
 
         $container->setParameter('session.storage.options', $options);
@@ -834,11 +834,11 @@ class FrameworkExtension extends Extension
             $logger = new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE);
 
             $container->getDefinition('templating.loader.cache')
-                ->addTag('monolog.logger', array('channel' => 'templating'))
-                ->addMethodCall('setLogger', array($logger));
+                ->addTag('monolog.logger', ['channel' => 'templating'])
+                ->addMethodCall('setLogger', [$logger]);
             $container->getDefinition('templating.loader.chain')
-                ->addTag('monolog.logger', array('channel' => 'templating'))
-                ->addMethodCall('setLogger', array($logger));
+                ->addTag('monolog.logger', ['channel' => 'templating'])
+                ->addMethodCall('setLogger', [$logger]);
         }
 
         if (!empty($config['loaders'])) {
@@ -872,13 +872,13 @@ class FrameworkExtension extends Extension
         } else {
             $templateEngineDefinition = $container->getDefinition('templating.engine.delegating');
             foreach ($engines as $engine) {
-                $templateEngineDefinition->addMethodCall('addEngine', array($engine));
+                $templateEngineDefinition->addMethodCall('addEngine', [$engine]);
             }
             $container->setAlias('templating', 'templating.engine.delegating')->setPublic(true);
         }
 
         $container->getDefinition('fragment.renderer.hinclude')
-            ->addTag('kernel.fragment_renderer', array('alias' => 'hinclude'))
+            ->addTag('kernel.fragment_renderer', ['alias' => 'hinclude'])
             ->replaceArgument(0, new Reference('templating'))
         ;
 
@@ -918,7 +918,7 @@ class FrameworkExtension extends Extension
         $defaultPackage = $this->createPackageDefinition($config['base_path'], $config['base_urls'], $defaultVersion);
         $container->setDefinition('assets._default_package', $defaultPackage);
 
-        $namedPackages = array();
+        $namedPackages = [];
         foreach ($config['packages'] as $name => $package) {
             if (null !== $package['version_strategy']) {
                 $version = new Reference($package['version_strategy']);
@@ -1012,13 +1012,13 @@ class FrameworkExtension extends Extension
         $container->setAlias('translator', 'translator.default')->setPublic(true);
         $container->setAlias('translator.formatter', new Alias($config['formatter'], false));
         $translator = $container->findDefinition('translator.default');
-        $translator->addMethodCall('setFallbackLocales', array($config['fallbacks']));
+        $translator->addMethodCall('setFallbackLocales', [$config['fallbacks']]);
 
         $container->setParameter('translator.logging', $config['logging']);
         $container->setParameter('translator.default_path', $config['default_path']);
 
         // Discover translation directories
-        $dirs = array();
+        $dirs = [];
         if (class_exists('Symfony\Component\Validator\Validation')) {
             $r = new \ReflectionClass('Symfony\Component\Validator\Validation');
 
@@ -1068,7 +1068,7 @@ class FrameworkExtension extends Extension
 
         // Register translation resources
         if ($dirs) {
-            $files = array();
+            $files = [];
             $finder = Finder::create()
                 ->followLinks()
                 ->files()
@@ -1082,7 +1082,7 @@ class FrameworkExtension extends Extension
             foreach ($finder as $file) {
                 list(, $locale) = explode('.', $file->getBasename(), 3);
                 if (!isset($files[$locale])) {
-                    $files[$locale] = array();
+                    $files[$locale] = [];
                 }
 
                 $files[$locale][] = (string) $file;
@@ -1090,7 +1090,7 @@ class FrameworkExtension extends Extension
 
             $options = array_merge(
                 $translator->getArgument(4),
-                array('resource_files' => $files)
+                ['resource_files' => $files]
             );
 
             $translator->replaceArgument(4, $options);
@@ -1117,15 +1117,15 @@ class FrameworkExtension extends Extension
 
         $container->setParameter('validator.translation_domain', $config['translation_domain']);
 
-        $files = array('xml' => array(), 'yml' => array());
+        $files = ['xml' => [], 'yml' => []];
         $this->registerValidatorMapping($container, $config, $files);
 
         if (!empty($files['xml'])) {
-            $validatorBuilder->addMethodCall('addXmlMappings', array($files['xml']));
+            $validatorBuilder->addMethodCall('addXmlMappings', [$files['xml']]);
         }
 
         if (!empty($files['yml'])) {
-            $validatorBuilder->addMethodCall('addYamlMappings', array($files['yml']));
+            $validatorBuilder->addMethodCall('addYamlMappings', [$files['yml']]);
         }
 
         $definition = $container->findDefinition('validator.email');
@@ -1136,17 +1136,17 @@ class FrameworkExtension extends Extension
                 throw new \LogicException('"enable_annotations" on the validator cannot be set as Annotations support is disabled.');
             }
 
-            $validatorBuilder->addMethodCall('enableAnnotationMapping', array(new Reference('annotation_reader')));
+            $validatorBuilder->addMethodCall('enableAnnotationMapping', [new Reference('annotation_reader')]);
         }
 
         if (array_key_exists('static_method', $config) && $config['static_method']) {
             foreach ($config['static_method'] as $methodName) {
-                $validatorBuilder->addMethodCall('addMethodMapping', array($methodName));
+                $validatorBuilder->addMethodCall('addMethodMapping', [$methodName]);
             }
         }
 
         if (!$container->getParameter('kernel.debug')) {
-            $validatorBuilder->addMethodCall('setMetadataCache', array(new Reference('validator.mapping.cache.symfony')));
+            $validatorBuilder->addMethodCall('setMetadataCache', [new Reference('validator.mapping.cache.symfony')]);
         }
     }
 
@@ -1226,7 +1226,7 @@ class FrameworkExtension extends Extension
 
         if (!method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
             $container->getDefinition('annotations.dummy_registry')
-                ->setMethodCalls(array(array('registerLoader', array('class_exists'))));
+                ->setMethodCalls([['registerLoader', ['class_exists']]]);
         }
 
         if ('none' !== $config['cache']) {
@@ -1337,7 +1337,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('serializer.encoder.yaml');
         }
 
-        $serializerLoaders = array();
+        $serializerLoaders = [];
         if (isset($config['enable_annotations']) && $config['enable_annotations']) {
             if (!$this->annotationsConfigEnabled) {
                 throw new \LogicException('"enable_annotations" on the serializer cannot be set as Annotations support is disabled.');
@@ -1345,7 +1345,7 @@ class FrameworkExtension extends Extension
 
             $annotationLoader = new Definition(
                 'Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader',
-                array(new Reference('annotation_reader'))
+                [new Reference('annotation_reader')]
             );
             $annotationLoader->setPublic(false);
 
@@ -1353,7 +1353,7 @@ class FrameworkExtension extends Extension
         }
 
         $fileRecorder = function ($extension, $path) use (&$serializerLoaders) {
-            $definition = new Definition(\in_array($extension, array('yaml', 'yml')) ? 'Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader' : 'Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader', array($path));
+            $definition = new Definition(\in_array($extension, ['yaml', 'yml']) ? 'Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader' : 'Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader', [$path]);
             $definition->setPublic(false);
             $serializerLoaders[] = $definition;
         };
@@ -1390,10 +1390,10 @@ class FrameworkExtension extends Extension
         if (!$container->getParameter('kernel.debug')) {
             $cacheMetadataFactory = new Definition(
                 CacheClassMetadataFactory::class,
-                array(
+                [
                     new Reference('serializer.mapping.cache_class_metadata_factory.inner'),
                     new Reference('serializer.mapping.cache.symfony'),
-                )
+                ]
             );
             $cacheMetadataFactory->setPublic(false);
             $cacheMetadataFactory->setDecoratedService('serializer.mapping.class_metadata_factory');
@@ -1406,11 +1406,11 @@ class FrameworkExtension extends Extension
         }
 
         if (isset($config['circular_reference_handler']) && $config['circular_reference_handler']) {
-            $container->getDefinition('serializer.normalizer.object')->addMethodCall('setCircularReferenceHandler', array(new Reference($config['circular_reference_handler'])));
+            $container->getDefinition('serializer.normalizer.object')->addMethodCall('setCircularReferenceHandler', [new Reference($config['circular_reference_handler'])]);
         }
 
         if ($config['max_depth_handler'] ?? false) {
-            $container->getDefinition('serializer.normalizer.object')->addMethodCall('setMaxDepthHandler', array(new Reference($config['max_depth_handler'])));
+            $container->getDefinition('serializer.normalizer.object')->addMethodCall('setMaxDepthHandler', [new Reference($config['max_depth_handler'])]);
         }
     }
 
@@ -1425,8 +1425,8 @@ class FrameworkExtension extends Extension
         if (interface_exists('phpDocumentor\Reflection\DocBlockFactoryInterface')) {
             $definition = $container->register('property_info.php_doc_extractor', 'Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor');
             $definition->setPrivate(true);
-            $definition->addTag('property_info.description_extractor', array('priority' => -1000));
-            $definition->addTag('property_info.type_extractor', array('priority' => -1001));
+            $definition->addTag('property_info.description_extractor', ['priority' => -1000]);
+            $definition->addTag('property_info.type_extractor', ['priority' => -1001]);
         }
     }
 
@@ -1440,7 +1440,7 @@ class FrameworkExtension extends Extension
             }
 
             // Generate stores
-            $storeDefinitions = array();
+            $storeDefinitions = [];
             foreach ($resourceStores as $storeDsn) {
                 $storeDsn = $container->resolveEnvPlaceholders($storeDsn, null, $usedEnvs);
                 switch (true) {
@@ -1462,15 +1462,15 @@ class FrameworkExtension extends Extension
                         if (!$container->hasDefinition($connectionDefinitionId = '.lock_connection.'.$container->hash($storeDsn))) {
                             $connectionDefinition = new Definition(\stdClass::class);
                             $connectionDefinition->setPublic(false);
-                            $connectionDefinition->setFactory(array(AbstractAdapter::class, 'createConnection'));
-                            $connectionDefinition->setArguments(array($storeDsn, array('lazy' => true)));
+                            $connectionDefinition->setFactory([AbstractAdapter::class, 'createConnection']);
+                            $connectionDefinition->setArguments([$storeDsn, ['lazy' => true]]);
                             $container->setDefinition($connectionDefinitionId, $connectionDefinition);
                         }
 
                         $storeDefinition = new Definition(StoreInterface::class);
                         $storeDefinition->setPublic(false);
-                        $storeDefinition->setFactory(array(StoreFactory::class, 'createStore'));
-                        $storeDefinition->setArguments(array(new Reference($connectionDefinitionId)));
+                        $storeDefinition->setFactory([StoreFactory::class, 'createStore']);
+                        $storeDefinition->setArguments([new Reference($connectionDefinitionId)]);
 
                         $container->setDefinition($storeDefinitionId = '.lock.'.$resourceName.'.store.'.$container->hash($storeDsn), $storeDefinition);
 
@@ -1500,8 +1500,8 @@ class FrameworkExtension extends Extension
             // Generate services for lock instances
             $lockDefinition = new Definition(Lock::class);
             $lockDefinition->setPublic(false);
-            $lockDefinition->setFactory(array(new Reference('lock.'.$resourceName.'.factory'), 'createLock'));
-            $lockDefinition->setArguments(array($resourceName));
+            $lockDefinition->setFactory([new Reference('lock.'.$resourceName.'.factory'), 'createLock']);
+            $lockDefinition->setArguments([$resourceName]);
             $container->setDefinition('lock.'.$resourceName, $lockDefinition);
 
             // provide alias for default resource
@@ -1554,16 +1554,16 @@ class FrameworkExtension extends Extension
             $config['default_bus'] = key($config['buses']);
         }
 
-        $defaultMiddleware = array(
-            'before' => array(array('id' => 'logging')),
-            'after' => array(array('id' => 'send_message'), array('id' => 'handle_message')),
-        );
+        $defaultMiddleware = [
+            'before' => [['id' => 'logging']],
+            'after' => [['id' => 'send_message'], ['id' => 'handle_message']],
+        ];
         foreach ($config['buses'] as $busId => $bus) {
             $middleware = $bus['middleware'];
 
             if ($bus['default_middleware']) {
                 if ('allow_no_handlers' === $bus['default_middleware']) {
-                    $defaultMiddleware['after'][1]['arguments'] = array(true);
+                    $defaultMiddleware['after'][1]['arguments'] = [true];
                 } else {
                     unset($defaultMiddleware['after'][1]['arguments']);
                 }
@@ -1571,17 +1571,17 @@ class FrameworkExtension extends Extension
             }
 
             foreach ($middleware as $middlewareItem) {
-                if (!$validationConfig['enabled'] && \in_array($middlewareItem['id'], array('validation', 'messenger.middleware.validation'), true)) {
+                if (!$validationConfig['enabled'] && \in_array($middlewareItem['id'], ['validation', 'messenger.middleware.validation'], true)) {
                     throw new LogicException('The Validation middleware is only available when the Validator component is installed and enabled. Try running "composer require symfony/validator".');
                 }
             }
 
             if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
-                array_unshift($middleware, array('id' => 'traceable', 'arguments' => array($busId)));
+                array_unshift($middleware, ['id' => 'traceable', 'arguments' => [$busId]]);
             }
 
             $container->setParameter($busId.'.middleware', $middleware);
-            $container->register($busId, MessageBus::class)->addArgument(array())->addTag('messenger.bus');
+            $container->register($busId, MessageBus::class)->addArgument([])->addTag('messenger.bus');
 
             if ($busId === $config['default_bus']) {
                 $container->setAlias('message_bus', $busId)->setPublic(true);
@@ -1591,28 +1591,28 @@ class FrameworkExtension extends Extension
             }
         }
 
-        $senderAliases = array();
+        $senderAliases = [];
         foreach ($config['transports'] as $name => $transport) {
             if (0 === strpos($transport['dsn'], 'amqp://') && !$container->hasDefinition('messenger.transport.amqp.factory')) {
                 throw new LogicException('The default AMQP transport is not available. Make sure you have installed and enabled the Serializer component. Try enabling it or running "composer require symfony/serializer-pack".');
             }
 
             $transportDefinition = (new Definition(TransportInterface::class))
-                ->setFactory(array(new Reference('messenger.transport_factory'), 'createTransport'))
-                ->setArguments(array($transport['dsn'], $transport['options']))
-                ->addTag('messenger.receiver', array('alias' => $name))
+                ->setFactory([new Reference('messenger.transport_factory'), 'createTransport'])
+                ->setArguments([$transport['dsn'], $transport['options']])
+                ->addTag('messenger.receiver', ['alias' => $name])
             ;
             $container->setDefinition($transportId = 'messenger.transport.'.$name, $transportDefinition);
             $senderAliases[$name] = $transportId;
         }
 
-        $messageToSendersMapping = array();
-        $messagesToSendAndHandle = array();
+        $messageToSendersMapping = [];
+        $messagesToSendAndHandle = [];
         foreach ($config['routing'] as $message => $messageConfiguration) {
             if ('*' !== $message && !class_exists($message) && !interface_exists($message, false)) {
                 throw new LogicException(sprintf('Invalid Messenger routing configuration: class or interface "%s" not found.', $message));
             }
-            $senders = array();
+            $senders = [];
             foreach ($messageConfiguration['senders'] as $sender) {
                 $senders[$sender] = new Reference($senderAliases[$sender] ?? $sender);
             }
@@ -1645,24 +1645,24 @@ class FrameworkExtension extends Extension
             // Inline any env vars referenced in the parameter
             $container->setParameter('cache.prefix.seed', $container->resolveEnvPlaceholders($container->getParameter('cache.prefix.seed'), true));
         }
-        foreach (array('doctrine', 'psr6', 'redis', 'memcached', 'pdo') as $name) {
+        foreach (['doctrine', 'psr6', 'redis', 'memcached', 'pdo'] as $name) {
             if (isset($config[$name = 'default_'.$name.'_provider'])) {
                 $container->setAlias('cache.'.$name, new Alias(CachePoolPass::getServiceProvider($container, $config[$name]), false));
             }
         }
-        foreach (array('app', 'system') as $name) {
-            $config['pools']['cache.'.$name] = array(
+        foreach (['app', 'system'] as $name) {
+            $config['pools']['cache.'.$name] = [
                 'adapter' => $config[$name],
                 'public' => true,
                 'tags' => false,
-            );
+            ];
         }
         foreach ($config['pools'] as $name => $pool) {
             if ($config['pools'][$pool['adapter']]['tags'] ?? false) {
                 $pool['adapter'] = '.'.$pool['adapter'].'.inner';
             }
             $definition = new ChildDefinition($pool['adapter']);
-            if (!\in_array($name, array('cache.app', 'cache.system'), true)) {
+            if (!\in_array($name, ['cache.app', 'cache.system'], true)) {
                 $container->registerAliasForArgument($name, CacheInterface::class);
                 $container->registerAliasForArgument($name, CacheItemPoolInterface::class);
             }
@@ -1693,13 +1693,13 @@ class FrameworkExtension extends Extension
             $propertyAccessDefinition->setPublic(false);
 
             if (!$container->getParameter('kernel.debug')) {
-                $propertyAccessDefinition->setFactory(array(PropertyAccessor::class, 'createCache'));
-                $propertyAccessDefinition->setArguments(array(null, null, $version, new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)));
-                $propertyAccessDefinition->addTag('cache.pool', array('clearer' => 'cache.system_clearer'));
-                $propertyAccessDefinition->addTag('monolog.logger', array('channel' => 'cache'));
+                $propertyAccessDefinition->setFactory([PropertyAccessor::class, 'createCache']);
+                $propertyAccessDefinition->setArguments([null, null, $version, new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)]);
+                $propertyAccessDefinition->addTag('cache.pool', ['clearer' => 'cache.system_clearer']);
+                $propertyAccessDefinition->addTag('monolog.logger', ['channel' => 'cache']);
             } else {
                 $propertyAccessDefinition->setClass(ArrayAdapter::class);
-                $propertyAccessDefinition->setArguments(array(0, false));
+                $propertyAccessDefinition->setArguments([0, false]);
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
@@ -50,5 +50,10 @@
         <service id="assets.json_manifest_version_strategy" class="Symfony\Component\Asset\VersionStrategy\JsonManifestVersionStrategy" abstract="true">
             <argument /> <!-- manifest path -->
         </service>
+
+        <service id="assets.package_json_version_strategy" class="Symfony\Component\Asset\VersionStrategy\PackageJsonVersionStrategy" abstract="true">
+            <argument /> <!-- package.json path -->
+            <argument /> <!-- format -->
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -148,6 +148,7 @@
         <xsd:attribute name="version" type="xsd:string" />
         <xsd:attribute name="version-format" type="xsd:string" />
         <xsd:attribute name="json-manifest-path" type="xsd:string" />
+        <xsd:attribute name="package-json-path" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="package">
@@ -161,6 +162,7 @@
         <xsd:attribute name="version" type="xsd:string" />
         <xsd:attribute name="version-format" type="xsd:string" />
         <xsd:attribute name="json-manifest-path" type="xsd:string" />
+        <xsd:attribute name="package-json-path" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="templating">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -26,35 +26,35 @@ class ConfigurationTest extends TestCase
     public function testDefaultConfig()
     {
         $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(true), array(array('secret' => 's3cr3t')));
+        $config = $processor->processConfiguration(new Configuration(true), [['secret' => 's3cr3t']]);
 
         $this->assertEquals(
-            array_merge(array('secret' => 's3cr3t', 'trusted_hosts' => array()), self::getBundleDefaultConfig()),
+            array_merge(['secret' => 's3cr3t', 'trusted_hosts' => []], self::getBundleDefaultConfig()),
             $config
         );
     }
 
     public function testDoNoDuplicateDefaultFormResources()
     {
-        $input = array('templating' => array(
-            'form' => array('resources' => array('FrameworkBundle:Form')),
-            'engines' => array('php'),
-        ));
+        $input = ['templating' => [
+            'form' => ['resources' => ['FrameworkBundle:Form']],
+            'engines' => ['php'],
+        ]];
 
         $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(true), array($input));
+        $config = $processor->processConfiguration(new Configuration(true), [$input]);
 
-        $this->assertEquals(array('FrameworkBundle:Form'), $config['templating']['form']['resources']);
+        $this->assertEquals(['FrameworkBundle:Form'], $config['templating']['form']['resources']);
     }
 
     public function getTestValidSessionName()
     {
-        return array(
-            array(null),
-            array('PHPSESSID'),
-            array('a&b'),
-            array(',_-!@#$%^*(){}:<>/?'),
-        );
+        return [
+            [null],
+            ['PHPSESSID'],
+            ['a&b'],
+            [',_-!@#$%^*(){}:<>/?'],
+        ];
     }
 
     /**
@@ -66,39 +66,39 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
         $processor->processConfiguration(
             new Configuration(true),
-            array(array('session' => array('name' => $sessionName)))
+            [['session' => ['name' => $sessionName]]]
         );
     }
 
     public function getTestInvalidSessionName()
     {
-        return array(
-            array('a.b'),
-            array('a['),
-            array('a[]'),
-            array('a[b]'),
-            array('a=b'),
-            array('a+b'),
-        );
+        return [
+            ['a.b'],
+            ['a['],
+            ['a[]'],
+            ['a[b]'],
+            ['a=b'],
+            ['a+b'],
+        ];
     }
 
     public function testAssetsCanBeEnabled()
     {
         $processor = new Processor();
         $configuration = new Configuration(true);
-        $config = $processor->processConfiguration($configuration, array(array('assets' => null)));
+        $config = $processor->processConfiguration($configuration, [['assets' => null]]);
 
-        $defaultConfig = array(
+        $defaultConfig = [
             'enabled' => true,
             'version_strategy' => null,
             'version' => null,
             'version_format' => '%%s?%%s',
             'base_path' => '',
-            'base_urls' => array(),
-            'packages' => array(),
+            'base_urls' => [],
+            'packages' => [],
             'json_manifest_path' => null,
             'package_json_path' => null,
-        );
+        ];
 
         $this->assertEquals($defaultConfig, $config['assets']);
     }
@@ -117,134 +117,134 @@ class ConfigurationTest extends TestCase
 
         $processor = new Processor();
         $configuration = new Configuration(true);
-        $processor->processConfiguration($configuration, array(
-                array(
+        $processor->processConfiguration($configuration, [
+                [
                     'assets' => $assetConfig,
-                ),
-            ));
+                ],
+            ]);
     }
 
     public function provideInvalidAssetConfigurationTests()
     {
         // helper to turn config into embedded package config
         $createPackageConfig = function (array $packageConfig) {
-            return array(
+            return [
                 'base_urls' => '//example.com',
                 'version' => 1,
-                'packages' => array(
+                'packages' => [
                     'foo' => $packageConfig,
-                ),
-            );
+                ],
+            ];
         };
 
-        $config = array(
+        $config = [
             'version' => 1,
             'version_strategy' => 'foo',
-        );
-        yield array($config, 'You cannot use both "version_strategy" and "version" at the same time under "assets".');
-        yield array($createPackageConfig($config), 'You cannot use both "version_strategy" and "version" at the same time under "assets" packages.');
+        ];
+        yield [$config, 'You cannot use both "version_strategy" and "version" at the same time under "assets".'];
+        yield [$createPackageConfig($config), 'You cannot use both "version_strategy" and "version" at the same time under "assets" packages.'];
 
-        $config = array(
+        $config = [
             'json_manifest_path' => '/foo.json',
             'version_strategy' => 'foo',
-        );
-        yield array($config, 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets".');
-        yield array($createPackageConfig($config), 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.');
+        ];
+        yield [$config, 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets".'];
+        yield [$createPackageConfig($config), 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.'];
 
-        $config = array(
+        $config = [
             'json_manifest_path' => '/foo.json',
             'version' => '1',
-        );
-        yield array($config, 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets".');
-        yield array($createPackageConfig($config), 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.');
+        ];
+        yield [$config, 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets".'];
+        yield [$createPackageConfig($config), 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.'];
 
-        $config = array(
+        $config = [
             'package_json_path' => '/package.json',
             'version_strategy' => 'foo',
-        );
-        yield array($config, 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets".');
-        yield array($createPackageConfig($config), 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.');
+        ];
+        yield [$config, 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets".'];
+        yield [$createPackageConfig($config), 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.'];
 
-        $config = array(
+        $config = [
             'package_json_path' => '/package.json',
             'version' => '1',
-        );
-        yield array($config, 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets".');
-        yield array($createPackageConfig($config), 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.');
+        ];
+        yield [$config, 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets".'];
+        yield [$createPackageConfig($config), 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.'];
     }
 
     protected static function getBundleDefaultConfig()
     {
-        return array(
+        return [
             'http_method_override' => true,
             'ide' => null,
             'default_locale' => 'en',
-            'csrf_protection' => array(
+            'csrf_protection' => [
                 'enabled' => false,
-            ),
-            'form' => array(
+            ],
+            'form' => [
                 'enabled' => !class_exists(FullStack::class),
-                'csrf_protection' => array(
+                'csrf_protection' => [
                     'enabled' => null, // defaults to csrf_protection.enabled
                     'field_name' => '_token',
-                ),
-            ),
-            'esi' => array('enabled' => false),
-            'ssi' => array('enabled' => false),
-            'fragments' => array(
+                ],
+            ],
+            'esi' => ['enabled' => false],
+            'ssi' => ['enabled' => false],
+            'fragments' => [
                 'enabled' => false,
                 'path' => '/_fragment',
-            ),
-            'profiler' => array(
+            ],
+            'profiler' => [
                 'enabled' => false,
                 'only_exceptions' => false,
                 'only_master_requests' => false,
                 'dsn' => 'file:%kernel.cache_dir%/profiler',
                 'collect' => true,
-            ),
-            'translator' => array(
+            ],
+            'translator' => [
                 'enabled' => !class_exists(FullStack::class),
-                'fallbacks' => array('en'),
+                'fallbacks' => ['en'],
                 'logging' => false,
                 'formatter' => 'translator.formatter.default',
-                'paths' => array(),
+                'paths' => [],
                 'default_path' => '%kernel.project_dir%/translations',
-            ),
-            'validation' => array(
+            ],
+            'validation' => [
                 'enabled' => !class_exists(FullStack::class),
                 'enable_annotations' => !class_exists(FullStack::class),
-                'static_method' => array('loadValidatorMetadata'),
+                'static_method' => ['loadValidatorMetadata'],
                 'translation_domain' => 'validators',
-                'mapping' => array(
-                    'paths' => array(),
-                ),
-            ),
-            'annotations' => array(
+                'mapping' => [
+                    'paths' => [],
+                ],
+            ],
+            'annotations' => [
                 'cache' => 'php_array',
                 'file_cache_dir' => '%kernel.cache_dir%/annotations',
                 'debug' => true,
                 'enabled' => true,
-            ),
-            'serializer' => array(
+            ],
+            'serializer' => [
                 'enabled' => !class_exists(FullStack::class),
                 'enable_annotations' => !class_exists(FullStack::class),
-                'mapping' => array('paths' => array()),
-            ),
-            'property_access' => array(
+                'mapping' => ['paths' => []],
+            ],
+            'property_access' => [
                 'magic_call' => false,
                 'throw_exception_on_invalid_index' => false,
-            ),
-            'property_info' => array(
+            ],
+            'property_info' => [
                 'enabled' => !class_exists(FullStack::class),
-            ),
-            'router' => array(
+            ],
+            'router' => [
                 'enabled' => false,
                 'http_port' => 80,
                 'https_port' => 443,
                 'strict_requirements' => true,
                 'utf8' => false,
-            ),
-            'session' => array(
+            ],
+            'session' => [
                 'enabled' => false,
                 'storage_id' => 'session.storage.native',
                 'handler_id' => 'session.handler.native_file',
@@ -253,71 +253,71 @@ class ConfigurationTest extends TestCase
                 'gc_probability' => 1,
                 'save_path' => '%kernel.cache_dir%/sessions',
                 'metadata_update_threshold' => 0,
-            ),
-            'request' => array(
+            ],
+            'request' => [
                 'enabled' => false,
-                'formats' => array(),
-            ),
-            'templating' => array(
+                'formats' => [],
+            ],
+            'templating' => [
                 'enabled' => false,
                 'hinclude_default_template' => null,
-                'form' => array(
-                    'resources' => array('FrameworkBundle:Form'),
-                ),
-                'engines' => array(),
-                'loaders' => array(),
-            ),
-            'assets' => array(
+                'form' => [
+                    'resources' => ['FrameworkBundle:Form'],
+                ],
+                'engines' => [],
+                'loaders' => [],
+            ],
+            'assets' => [
                 'enabled' => !class_exists(FullStack::class),
                 'version_strategy' => null,
                 'version' => null,
                 'version_format' => '%%s?%%s',
                 'base_path' => '',
-                'base_urls' => array(),
-                'packages' => array(),
+                'base_urls' => [],
+                'packages' => [],
                 'json_manifest_path' => null,
                 'package_json_path' => null,
-            ),
-            'cache' => array(
-                'pools' => array(),
+            ],
+            'cache' => [
+                'pools' => [],
                 'app' => 'cache.adapter.filesystem',
                 'system' => 'cache.adapter.system',
                 'directory' => '%kernel.cache_dir%/pools',
                 'default_redis_provider' => 'redis://localhost',
                 'default_memcached_provider' => 'memcached://localhost',
                 'default_pdo_provider' => class_exists(Connection::class) ? 'database_connection' : null,
-            ),
-            'workflows' => array(
+            ],
+            'workflows' => [
                 'enabled' => false,
-                'workflows' => array(),
-            ),
-            'php_errors' => array(
+                'workflows' => [],
+            ],
+            'php_errors' => [
                 'log' => true,
                 'throw' => true,
-            ),
-            'web_link' => array(
+            ],
+            'web_link' => [
                 'enabled' => !class_exists(FullStack::class),
-            ),
-            'lock' => array(
+            ],
+            'lock' => [
                 'enabled' => !class_exists(FullStack::class),
-                'resources' => array(
-                    'default' => array(
+                'resources' => [
+                    'default' => [
                         class_exists(SemaphoreStore::class) && SemaphoreStore::isSupported() ? 'semaphore' : 'flock',
-                    ),
-                ),
-            ),
-            'messenger' => array(
+                    ],
+                ],
+            ],
+            'messenger' => [
                 'enabled' => !class_exists(FullStack::class) && interface_exists(MessageBusInterface::class),
-                'routing' => array(),
-                'transports' => array(),
-                'serializer' => array(
+                'routing' => [],
+                'transports' => [],
+                'serializer' => [
                     'id' => !class_exists(FullStack::class) && class_exists(Serializer::class) ? 'messenger.transport.symfony_serializer' : null,
                     'format' => 'json',
-                    'context' => array(),
-                ),
+                    'context' => [],
+                ],
                 'default_bus' => null,
-                'buses' => array('messenger.bus.default' => array('default_middleware' => true, 'middleware' => array())),
-            ),
-        );
+                'buses' => ['messenger.bus.default' => ['default_middleware' => true, 'middleware' => []]],
+            ],
+        ];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -97,6 +97,7 @@ class ConfigurationTest extends TestCase
             'base_urls' => array(),
             'packages' => array(),
             'json_manifest_path' => null,
+            'package_json_path' => null,
         );
 
         $this->assertEquals($defaultConfig, $config['assets']);
@@ -147,15 +148,29 @@ class ConfigurationTest extends TestCase
             'json_manifest_path' => '/foo.json',
             'version_strategy' => 'foo',
         );
-        yield array($config, 'You cannot use both "version_strategy" and "json_manifest_path" at the same time under "assets".');
-        yield array($createPackageConfig($config), 'You cannot use both "version_strategy" and "json_manifest_path" at the same time under "assets" packages.');
+        yield array($config, 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets".');
+        yield array($createPackageConfig($config), 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.');
 
         $config = array(
             'json_manifest_path' => '/foo.json',
             'version' => '1',
         );
-        yield array($config, 'You cannot use both "version" and "json_manifest_path" at the same time under "assets".');
-        yield array($createPackageConfig($config), 'You cannot use both "version" and "json_manifest_path" at the same time under "assets" packages.');
+        yield array($config, 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets".');
+        yield array($createPackageConfig($config), 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.');
+
+        $config = array(
+            'package_json_path' => '/package.json',
+            'version_strategy' => 'foo',
+        );
+        yield array($config, 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets".');
+        yield array($createPackageConfig($config), 'You cannot use both "version_strategy" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.');
+
+        $config = array(
+            'package_json_path' => '/package.json',
+            'version' => '1',
+        );
+        yield array($config, 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets".');
+        yield array($createPackageConfig($config), 'You cannot use both "version" and "json_manifest_path" or "package_json_path" at the same time under "assets" packages.');
     }
 
     protected static function getBundleDefaultConfig()
@@ -261,6 +276,7 @@ class ConfigurationTest extends TestCase
                 'base_urls' => array(),
                 'packages' => array(),
                 'json_manifest_path' => null,
+                'package_json_path' => null,
             ),
             'cache' => array(
                 'pools' => array(),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
@@ -27,6 +27,10 @@ $container->loadFromExtension('framework', array(
             'json_manifest_strategy' => array(
                 'json_manifest_path' => '/path/to/manifest.json',
             ),
+            'package_json_strategy' => array(
+                'package_json_path' => '/path/to/package.json',
+                'version_format' => '%%s?v=%%s',
+            ),
         ),
     ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
@@ -1,36 +1,36 @@
 <?php
 
-$container->loadFromExtension('framework', array(
-    'assets' => array(
+$container->loadFromExtension('framework', [
+    'assets' => [
         'version' => 'SomeVersionScheme',
         'base_urls' => 'http://cdn.example.com',
         'version_format' => '%%s?version=%%s',
-        'packages' => array(
-            'images_path' => array(
+        'packages' => [
+            'images_path' => [
                 'base_path' => '/foo',
-            ),
-            'images' => array(
+            ],
+            'images' => [
                 'version' => '1.0.0',
-                'base_urls' => array('http://images1.example.com', 'http://images2.example.com'),
-            ),
-            'foo' => array(
+                'base_urls' => ['http://images1.example.com', 'http://images2.example.com'],
+            ],
+            'foo' => [
                 'version' => '1.0.0',
                 'version_format' => '%%s-%%s',
-            ),
-            'bar' => array(
-                'base_urls' => array('https://bar2.example.com'),
-            ),
-            'bar_version_strategy' => array(
-                'base_urls' => array('https://bar2.example.com'),
+            ],
+            'bar' => [
+                'base_urls' => ['https://bar2.example.com'],
+            ],
+            'bar_version_strategy' => [
+                'base_urls' => ['https://bar2.example.com'],
                 'version_strategy' => 'assets.custom_version_strategy',
-            ),
-            'json_manifest_strategy' => array(
+            ],
+            'json_manifest_strategy' => [
                 'json_manifest_path' => '/path/to/manifest.json',
-            ),
-            'package_json_strategy' => array(
+            ],
+            'package_json_strategy' => [
                 'package_json_path' => '/path/to/package.json',
                 'version_format' => '%%s?v=%%s',
-            ),
-        ),
-    ),
-));
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
@@ -22,6 +22,7 @@
                 <framework:base-url>https://bar_version_strategy.example.com</framework:base-url>
             </framework:package>
             <framework:package name="json_manifest_strategy" json-manifest-path="/path/to/manifest.json" />
+            <framework:package name="package_json_strategy" package-json-path="/path/to/package.json" version-format="%%s?v=%%s" />
         </framework:assets>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
@@ -19,3 +19,6 @@ framework:
                 version_strategy: assets.custom_version_strategy
             json_manifest_strategy:
                 json_manifest_path: '/path/to/manifest.json'
+            package_json_strategy:
+                package_json_path: '/path/to/package.json'
+                version_format: '%%s?v=%%s'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -564,7 +564,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         // packages
         $packages = $packages->getArgument(1);
-        $this->assertCount(6, $packages);
+        $this->assertCount(7, $packages);
 
         $package = $container->getDefinition((string) $packages['images_path']);
         $this->assertPathPackage($container, $package, '/foo', 'SomeVersionScheme', '%%s?version=%%s');
@@ -585,6 +585,12 @@ abstract class FrameworkExtensionTest extends TestCase
         $versionStrategy = $container->getDefinition((string) $package->getArgument(1));
         $this->assertEquals('assets.json_manifest_version_strategy', $versionStrategy->getParent());
         $this->assertEquals('/path/to/manifest.json', $versionStrategy->getArgument(0));
+
+        $package = $container->getDefinition((string) $packages['package_json_strategy']);
+        $versionStrategy = $container->getDefinition((string) $package->getArgument(1));
+        $this->assertEquals('assets.package_json_version_strategy', $versionStrategy->getParent());
+        $this->assertEquals('/path/to/package.json', $versionStrategy->getArgument(0));
+        $this->assertEquals('%%s?v=%%s', $versionStrategy->getArgument(1));
     }
 
     public function testAssetsDefaultVersionStrategyAsService()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -54,7 +54,7 @@ use Symfony\Component\Workflow;
 
 abstract class FrameworkExtensionTest extends TestCase
 {
-    private static $containerCache = array();
+    private static $containerCache = [];
 
     abstract protected function loadFromFile(ContainerBuilder $container, $file);
 
@@ -96,13 +96,13 @@ abstract class FrameworkExtensionTest extends TestCase
         }
 
         $cache = $container->getDefinition('cache.property_access');
-        $this->assertSame(array(PropertyAccessor::class, 'createCache'), $cache->getFactory(), 'PropertyAccessor::createCache() should be used in non-debug mode');
+        $this->assertSame([PropertyAccessor::class, 'createCache'], $cache->getFactory(), 'PropertyAccessor::createCache() should be used in non-debug mode');
         $this->assertSame(AdapterInterface::class, $cache->getClass());
     }
 
     public function testPropertyAccessCacheWithDebug()
     {
-        $container = $this->createContainerFromFile('property_accessor', array('kernel.debug' => true));
+        $container = $this->createContainerFromFile('property_accessor', ['kernel.debug' => true]);
 
         if (!method_exists(PropertyAccessor::class, 'createCache')) {
             return $this->assertFalse($container->hasDefinition('cache.property_access'));
@@ -204,18 +204,18 @@ abstract class FrameworkExtensionTest extends TestCase
         $workflowDefinition = $container->getDefinition('workflow.article.definition');
 
         $this->assertSame(
-            array(
+            [
                 'draft',
                 'wait_for_journalist',
                 'approved_by_journalist',
                 'wait_for_spellchecker',
                 'approved_by_spellchecker',
                 'published',
-            ),
+            ],
             $workflowDefinition->getArgument(0),
             'Places are passed to the workflow definition'
         );
-        $this->assertSame(array('workflow.definition' => array(array('name' => 'article', 'type' => 'workflow', 'marking_store' => 'multiple_state'))), $workflowDefinition->getTags());
+        $this->assertSame(['workflow.definition' => [['name' => 'article', 'type' => 'workflow', 'marking_store' => 'multiple_state']]], $workflowDefinition->getTags());
         $this->assertCount(4, $workflowDefinition->getArgument(1));
         $this->assertSame('draft', $workflowDefinition->getArgument(2));
 
@@ -226,18 +226,18 @@ abstract class FrameworkExtensionTest extends TestCase
         $stateMachineDefinition = $container->getDefinition('state_machine.pull_request.definition');
 
         $this->assertSame(
-            array(
+            [
                 'start',
                 'coding',
                 'travis',
                 'review',
                 'merged',
                 'closed',
-            ),
+            ],
             $stateMachineDefinition->getArgument(0),
             'Places are passed to the state machine definition'
         );
-        $this->assertSame(array('workflow.definition' => array(array('name' => 'pull_request', 'type' => 'state_machine', 'marking_store' => 'single_state'))), $stateMachineDefinition->getTags());
+        $this->assertSame(['workflow.definition' => [['name' => 'pull_request', 'type' => 'state_machine', 'marking_store' => 'single_state']]], $stateMachineDefinition->getTags());
         $this->assertCount(9, $stateMachineDefinition->getArgument(1));
         $this->assertSame('start', $stateMachineDefinition->getArgument(2));
 
@@ -246,11 +246,11 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(Workflow\Metadata\InMemoryMetadataStore::class, $metadataStoreDefinition->getClass());
 
         $workflowMetadata = $metadataStoreDefinition->getArgument(0);
-        $this->assertSame(array('title' => 'workflow title'), $workflowMetadata);
+        $this->assertSame(['title' => 'workflow title'], $workflowMetadata);
 
         $placesMetadata = $metadataStoreDefinition->getArgument(1);
         $this->assertArrayHasKey('start', $placesMetadata);
-        $this->assertSame(array('title' => 'place start title'), $placesMetadata['start']);
+        $this->assertSame(['title' => 'place start title'], $placesMetadata['start']);
 
         $transitionsMetadata = $metadataStoreDefinition->getArgument(2);
         $this->assertSame(\SplObjectStorage::class, $transitionsMetadata->getClass());
@@ -322,60 +322,60 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertCount(5, $transitions);
 
         $this->assertSame('workflow.article.transition.0', (string) $transitions[0]);
-        $this->assertSame(array(
+        $this->assertSame([
             'request_review',
-            array(
+            [
                 'draft',
-            ),
-            array(
+            ],
+            [
                 'wait_for_journalist', 'wait_for_spellchecker',
-            ),
-        ), $container->getDefinition($transitions[0])->getArguments());
+            ],
+        ], $container->getDefinition($transitions[0])->getArguments());
 
         $this->assertSame('workflow.article.transition.1', (string) $transitions[1]);
-        $this->assertSame(array(
+        $this->assertSame([
             'journalist_approval',
-            array(
+            [
                 'wait_for_journalist',
-            ),
-            array(
+            ],
+            [
                 'approved_by_journalist',
-            ),
-        ), $container->getDefinition($transitions[1])->getArguments());
+            ],
+        ], $container->getDefinition($transitions[1])->getArguments());
 
         $this->assertSame('workflow.article.transition.2', (string) $transitions[2]);
-        $this->assertSame(array(
+        $this->assertSame([
             'spellchecker_approval',
-            array(
+            [
                 'wait_for_spellchecker',
-            ),
-            array(
+            ],
+            [
                 'approved_by_spellchecker',
-            ),
-        ), $container->getDefinition($transitions[2])->getArguments());
+            ],
+        ], $container->getDefinition($transitions[2])->getArguments());
 
         $this->assertSame('workflow.article.transition.3', (string) $transitions[3]);
-        $this->assertSame(array(
+        $this->assertSame([
             'publish',
-            array(
+            [
                 'approved_by_journalist',
                 'approved_by_spellchecker',
-            ),
-            array(
+            ],
+            [
                 'published',
-            ),
-        ), $container->getDefinition($transitions[3])->getArguments());
+            ],
+        ], $container->getDefinition($transitions[3])->getArguments());
 
         $this->assertSame('workflow.article.transition.4', (string) $transitions[4]);
-        $this->assertSame(array(
+        $this->assertSame([
             'publish',
-            array(
+            [
                 'draft',
-            ),
-            array(
+            ],
+            [
                 'published',
-            ),
-        ), $container->getDefinition($transitions[4])->getArguments());
+            ],
+        ], $container->getDefinition($transitions[4])->getArguments());
     }
 
     public function testGuardExpressions()
@@ -386,12 +386,12 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->hasParameter('workflow.has_guard_listeners'), 'Workflow guard listeners parameter exists');
         $this->assertTrue(true === $container->getParameter('workflow.has_guard_listeners'), 'Workflow guard listeners parameter is enabled');
         $guardDefinition = $container->getDefinition('workflow.article.listener.guard');
-        $this->assertSame(array(
-            array(
+        $this->assertSame([
+            [
                 'event' => 'workflow.article.guard.publish',
                 'method' => 'onTransition',
-            ),
-        ), $guardDefinition->getTag('kernel.event_listener'));
+            ],
+        ], $guardDefinition->getTag('kernel.event_listener'));
         $guardsConfiguration = $guardDefinition->getArgument(0);
         $this->assertTrue(1 === \count($guardsConfiguration), 'Workflow guard configuration contains one element per transition name');
         $transitionGuardExpressions = $guardsConfiguration['workflow.article.guard.publish'];
@@ -470,7 +470,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainer();
         $loader = new FrameworkExtension();
-        $loader->load(array(array('router' => true)), $container);
+        $loader->load([['router' => true]], $container);
     }
 
     public function testSession()
@@ -505,7 +505,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertNull($container->getDefinition('session.storage.native')->getArgument(1));
         $this->assertNull($container->getDefinition('session.storage.php_bridge')->getArgument(0));
 
-        $expected = array('session', 'initialized_session');
+        $expected = ['session', 'initialized_session'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
     }
 
@@ -515,7 +515,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('request.add_request_formats_listener'), '->registerRequestConfiguration() loads request.xml');
         $listenerDef = $container->getDefinition('request.add_request_formats_listener');
-        $this->assertEquals(array('csv' => array('text/csv', 'text/plain'), 'pdf' => array('application/pdf')), $listenerDef->getArgument(0));
+        $this->assertEquals(['csv' => ['text/csv', 'text/plain'], 'pdf' => ['application/pdf']], $listenerDef->getArgument(0));
     }
 
     public function testEmptyRequestFormats()
@@ -540,9 +540,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('%templating.loader.cache.path%', $container->getDefinition('templating.loader.cache')->getArgument(1));
         $this->assertEquals('/path/to/cache', $container->getParameter('templating.loader.cache.path'));
 
-        $this->assertEquals(array('php', 'twig'), $container->getParameter('templating.engines'), '->registerTemplatingConfiguration() sets a templating.engines parameter');
+        $this->assertEquals(['php', 'twig'], $container->getParameter('templating.engines'), '->registerTemplatingConfiguration() sets a templating.engines parameter');
 
-        $this->assertEquals(array('FrameworkBundle:Form', 'theme1', 'theme2'), $container->getParameter('templating.helper.form.resources'), '->registerTemplatingConfiguration() registers the theme and adds the base theme');
+        $this->assertEquals(['FrameworkBundle:Form', 'theme1', 'theme2'], $container->getParameter('templating.helper.form.resources'), '->registerTemplatingConfiguration() registers the theme and adds the base theme');
         $this->assertEquals('global_hinclude_template', $container->getParameter('fragment.renderer.hinclude.global_template'), '->registerTemplatingConfiguration() registers the global hinclude.js template');
     }
 
@@ -560,7 +560,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         // default package
         $defaultPackage = $container->getDefinition((string) $packages->getArgument(0));
-        $this->assertUrlPackage($container, $defaultPackage, array('http://cdn.example.com'), 'SomeVersionScheme', '%%s?version=%%s');
+        $this->assertUrlPackage($container, $defaultPackage, ['http://cdn.example.com'], 'SomeVersionScheme', '%%s?version=%%s');
 
         // packages
         $packages = $packages->getArgument(1);
@@ -570,13 +570,13 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertPathPackage($container, $package, '/foo', 'SomeVersionScheme', '%%s?version=%%s');
 
         $package = $container->getDefinition((string) $packages['images']);
-        $this->assertUrlPackage($container, $package, array('http://images1.example.com', 'http://images2.example.com'), '1.0.0', '%%s?version=%%s');
+        $this->assertUrlPackage($container, $package, ['http://images1.example.com', 'http://images2.example.com'], '1.0.0', '%%s?version=%%s');
 
         $package = $container->getDefinition((string) $packages['foo']);
         $this->assertPathPackage($container, $package, '', '1.0.0', '%%s-%%s');
 
         $package = $container->getDefinition((string) $packages['bar']);
-        $this->assertUrlPackage($container, $package, array('https://bar2.example.com'), 'SomeVersionScheme', '%%s?version=%%s');
+        $this->assertUrlPackage($container, $package, ['https://bar2.example.com'], 'SomeVersionScheme', '%%s?version=%%s');
 
         $package = $container->getDefinition((string) $packages['bar_version_strategy']);
         $this->assertEquals('assets.custom_version_strategy', (string) $package->getArgument(1));
@@ -631,16 +631,16 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('messenger_transports');
         $this->assertTrue($container->hasDefinition('messenger.transport.default'));
         $this->assertTrue($container->getDefinition('messenger.transport.default')->hasTag('messenger.receiver'));
-        $this->assertEquals(array(array('alias' => 'default')), $container->getDefinition('messenger.transport.default')->getTag('messenger.receiver'));
+        $this->assertEquals([['alias' => 'default']], $container->getDefinition('messenger.transport.default')->getTag('messenger.receiver'));
 
         $this->assertTrue($container->hasDefinition('messenger.transport.customised'));
         $transportFactory = $container->getDefinition('messenger.transport.customised')->getFactory();
         $transportArguments = $container->getDefinition('messenger.transport.customised')->getArguments();
 
-        $this->assertEquals(array(new Reference('messenger.transport_factory'), 'createTransport'), $transportFactory);
+        $this->assertEquals([new Reference('messenger.transport_factory'), 'createTransport'], $transportFactory);
         $this->assertCount(2, $transportArguments);
         $this->assertSame('amqp://localhost/%2f/messages?exchange_name=exchange_name', $transportArguments[0]);
-        $this->assertSame(array('queue' => array('name' => 'Queue')), $transportArguments[1]);
+        $this->assertSame(['queue' => ['name' => 'Queue']], $transportArguments[1]);
 
         $this->assertTrue($container->hasDefinition('messenger.transport.amqp.factory'));
     }
@@ -650,18 +650,18 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('messenger_routing');
         $senderLocatorDefinition = $container->getDefinition('messenger.senders_locator');
 
-        $messageToSendAndHandleMapping = array(
+        $messageToSendAndHandleMapping = [
             DummyMessage::class => false,
             SecondMessage::class => true,
             '*' => false,
-        );
+        ];
 
         $this->assertSame($messageToSendAndHandleMapping, $senderLocatorDefinition->getArgument(1));
         $sendersMapping = $senderLocatorDefinition->getArgument(0);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'amqp' => new Reference('messenger.transport.amqp'),
             'audit' => new Reference('audit'),
-        ), $sendersMapping[DummyMessage::class]->getValues());
+        ], $sendersMapping[DummyMessage::class]->getValues());
     }
 
     /**
@@ -690,7 +690,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $serializerTransportDefinition = $container->getDefinition('messenger.transport.symfony_serializer');
         $this->assertSame('csv', $serializerTransportDefinition->getArgument(1));
-        $this->assertSame(array('enable_max_depth' => true), $serializerTransportDefinition->getArgument(2));
+        $this->assertSame(['enable_max_depth' => true], $serializerTransportDefinition->getArgument(2));
     }
 
     public function testMessengerWithMultipleBuses()
@@ -698,26 +698,26 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('messenger_multiple_buses');
 
         $this->assertTrue($container->has('messenger.bus.commands'));
-        $this->assertSame(array(), $container->getDefinition('messenger.bus.commands')->getArgument(0));
-        $this->assertEquals(array(
-            array('id' => 'logging'),
-            array('id' => 'send_message'),
-            array('id' => 'handle_message'),
-        ), $container->getParameter('messenger.bus.commands.middleware'));
+        $this->assertSame([], $container->getDefinition('messenger.bus.commands')->getArgument(0));
+        $this->assertEquals([
+            ['id' => 'logging'],
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ], $container->getParameter('messenger.bus.commands.middleware'));
         $this->assertTrue($container->has('messenger.bus.events'));
-        $this->assertSame(array(), $container->getDefinition('messenger.bus.events')->getArgument(0));
-        $this->assertEquals(array(
-            array('id' => 'logging'),
-            array('id' => 'with_factory', 'arguments' => array('foo', true, array('bar' => 'baz'))),
-            array('id' => 'send_message'),
-            array('id' => 'handle_message'),
-        ), $container->getParameter('messenger.bus.events.middleware'));
+        $this->assertSame([], $container->getDefinition('messenger.bus.events')->getArgument(0));
+        $this->assertEquals([
+            ['id' => 'logging'],
+            ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
+            ['id' => 'send_message'],
+            ['id' => 'handle_message'],
+        ], $container->getParameter('messenger.bus.events.middleware'));
         $this->assertTrue($container->has('messenger.bus.queries'));
-        $this->assertSame(array(), $container->getDefinition('messenger.bus.queries')->getArgument(0));
-        $this->assertEquals(array(
-            array('id' => 'send_message', 'arguments' => array()),
-            array('id' => 'handle_message', 'arguments' => array()),
-        ), $container->getParameter('messenger.bus.queries.middleware'));
+        $this->assertSame([], $container->getDefinition('messenger.bus.queries')->getArgument(0));
+        $this->assertEquals([
+            ['id' => 'send_message', 'arguments' => []],
+            ['id' => 'handle_message', 'arguments' => []],
+        ], $container->getParameter('messenger.bus.queries.middleware'));
 
         $this->assertTrue($container->hasAlias('message_bus'));
         $this->assertSame('messenger.bus.commands', (string) $container->getAlias('message_bus'));
@@ -770,7 +770,7 @@ abstract class FrameworkExtensionTest extends TestCase
         );
 
         $calls = $container->getDefinition('translator.default')->getMethodCalls();
-        $this->assertEquals(array('fr'), $calls[1][1][0]);
+        $this->assertEquals(['fr'], $calls[1][1][0]);
     }
 
     /**
@@ -779,7 +779,7 @@ abstract class FrameworkExtensionTest extends TestCase
      */
     public function testLegacyTranslationsDirectory()
     {
-        $container = $this->createContainerFromFile('full', array('kernel.root_dir' => __DIR__.'/Fixtures'));
+        $container = $this->createContainerFromFile('full', ['kernel.root_dir' => __DIR__.'/Fixtures']);
         $options = $container->getDefinition('translator.default')->getArgument(4);
         $files = array_map('realpath', $options['resource_files']['en']);
 
@@ -792,7 +792,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('translator_fallbacks');
 
         $calls = $container->getDefinition('translator.default')->getMethodCalls();
-        $this->assertEquals(array('en', 'fr'), $calls[1][1][0]);
+        $this->assertEquals(['en', 'fr'], $calls[1][1][0]);
     }
 
     /**
@@ -802,7 +802,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainer();
         $loader = new FrameworkExtension();
-        $loader->load(array(array('templating' => null)), $container);
+        $loader->load([['templating' => null]], $container);
     }
 
     public function testValidation()
@@ -811,10 +811,10 @@ abstract class FrameworkExtensionTest extends TestCase
         $projectDir = $container->getParameter('kernel.project_dir');
 
         $ref = new \ReflectionClass('Symfony\Component\Form\Form');
-        $xmlMappings = array(
+        $xmlMappings = [
             \dirname($ref->getFileName()).'/Resources/config/validation.xml',
             strtr($projectDir.'/config/validator/foo.xml', '/', \DIRECTORY_SEPARATOR),
-        );
+        ];
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
@@ -822,33 +822,33 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertCount($annotations ? 7 : 6, $calls);
         $this->assertSame('setConstraintValidatorFactory', $calls[0][0]);
-        $this->assertEquals(array(new Reference('validator.validator_factory')), $calls[0][1]);
+        $this->assertEquals([new Reference('validator.validator_factory')], $calls[0][1]);
         $this->assertSame('setTranslator', $calls[1][0]);
-        $this->assertEquals(array(new Reference('translator')), $calls[1][1]);
+        $this->assertEquals([new Reference('translator')], $calls[1][1]);
         $this->assertSame('setTranslationDomain', $calls[2][0]);
-        $this->assertSame(array('%validator.translation_domain%'), $calls[2][1]);
+        $this->assertSame(['%validator.translation_domain%'], $calls[2][1]);
         $this->assertSame('addXmlMappings', $calls[3][0]);
-        $this->assertSame(array($xmlMappings), $calls[3][1]);
+        $this->assertSame([$xmlMappings], $calls[3][1]);
         $i = 3;
         if ($annotations) {
             $this->assertSame('enableAnnotationMapping', $calls[++$i][0]);
         }
         $this->assertSame('addMethodMapping', $calls[++$i][0]);
-        $this->assertSame(array('loadValidatorMetadata'), $calls[$i][1]);
+        $this->assertSame(['loadValidatorMetadata'], $calls[$i][1]);
         $this->assertSame('setMetadataCache', $calls[++$i][0]);
-        $this->assertEquals(array(new Reference('validator.mapping.cache.symfony')), $calls[$i][1]);
+        $this->assertEquals([new Reference('validator.mapping.cache.symfony')], $calls[$i][1]);
     }
 
     public function testValidationService()
     {
-        $container = $this->createContainerFromFile('validation_annotations', array('kernel.charset' => 'UTF-8'), false);
+        $container = $this->createContainerFromFile('validation_annotations', ['kernel.charset' => 'UTF-8'], false);
 
         $this->assertInstanceOf('Symfony\Component\Validator\Validator\ValidatorInterface', $container->get('validator'));
     }
 
     public function testAnnotations()
     {
-        $container = $this->createContainerFromFile('full', array(), true, false);
+        $container = $this->createContainerFromFile('full', [], true, false);
         $container->addCompilerPass(new TestAnnotationsPass());
         $container->compile();
 
@@ -875,11 +875,11 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertCount(7, $calls);
         $this->assertSame('enableAnnotationMapping', $calls[4][0]);
-        $this->assertEquals(array(new Reference('annotation_reader')), $calls[4][1]);
+        $this->assertEquals([new Reference('annotation_reader')], $calls[4][1]);
         $this->assertSame('addMethodMapping', $calls[5][0]);
-        $this->assertSame(array('loadValidatorMetadata'), $calls[5][1]);
+        $this->assertSame(['loadValidatorMetadata'], $calls[5][1]);
         $this->assertSame('setMetadataCache', $calls[6][0]);
-        $this->assertEquals(array(new Reference('validator.mapping.cache.symfony')), $calls[6][1]);
+        $this->assertEquals([new Reference('validator.mapping.cache.symfony')], $calls[6][1]);
         // no cache this time
     }
 
@@ -887,10 +887,10 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         require_once __DIR__.'/Fixtures/TestBundle/TestBundle.php';
 
-        $container = $this->createContainerFromFile('validation_annotations', array(
-            'kernel.bundles' => array('TestBundle' => 'Symfony\\Bundle\\FrameworkBundle\\Tests\\TestBundle'),
-            'kernel.bundles_metadata' => array('TestBundle' => array('namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/TestBundle')),
-        ));
+        $container = $this->createContainerFromFile('validation_annotations', [
+            'kernel.bundles' => ['TestBundle' => 'Symfony\\Bundle\\FrameworkBundle\\Tests\\TestBundle'],
+            'kernel.bundles_metadata' => ['TestBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/TestBundle']],
+        ]);
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
 
@@ -899,9 +899,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame('addYamlMappings', $calls[4][0]);
         $this->assertSame('enableAnnotationMapping', $calls[5][0]);
         $this->assertSame('addMethodMapping', $calls[6][0]);
-        $this->assertSame(array('loadValidatorMetadata'), $calls[6][1]);
+        $this->assertSame(['loadValidatorMetadata'], $calls[6][1]);
         $this->assertSame('setMetadataCache', $calls[7][0]);
-        $this->assertEquals(array(new Reference('validator.mapping.cache.symfony')), $calls[7][1]);
+        $this->assertEquals([new Reference('validator.mapping.cache.symfony')], $calls[7][1]);
 
         $xmlMappings = $calls[3][1][0];
         $this->assertCount(3, $xmlMappings);
@@ -923,10 +923,10 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         require_once __DIR__.'/Fixtures/CustomPathBundle/src/CustomPathBundle.php';
 
-        $container = $this->createContainerFromFile('validation_annotations', array(
-            'kernel.bundles' => array('CustomPathBundle' => 'Symfony\\Bundle\\FrameworkBundle\\Tests\\CustomPathBundle'),
-            'kernel.bundles_metadata' => array('TestBundle' => array('namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/CustomPathBundle')),
-        ));
+        $container = $this->createContainerFromFile('validation_annotations', [
+            'kernel.bundles' => ['CustomPathBundle' => 'Symfony\\Bundle\\FrameworkBundle\\Tests\\CustomPathBundle'],
+            'kernel.bundles_metadata' => ['TestBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/CustomPathBundle']],
+        ]);
 
         $calls = $container->getDefinition('validator.builder')->getMethodCalls();
         $xmlMappings = $calls[3][1][0];
@@ -961,7 +961,7 @@ abstract class FrameworkExtensionTest extends TestCase
             $this->assertSame('enableAnnotationMapping', $calls[++$i][0]);
         }
         $this->assertSame('setMetadataCache', $calls[++$i][0]);
-        $this->assertEquals(array(new Reference('validator.mapping.cache.symfony')), $calls[$i][1]);
+        $this->assertEquals([new Reference('validator.mapping.cache.symfony')], $calls[$i][1]);
         // no cache, no annotations, no static methods
     }
 
@@ -1037,19 +1037,19 @@ abstract class FrameworkExtensionTest extends TestCase
 
     public function testStopwatchEnabledWithDebugModeEnabled()
     {
-        $container = $this->createContainerFromFile('default_config', array(
+        $container = $this->createContainerFromFile('default_config', [
             'kernel.container_class' => 'foo',
             'kernel.debug' => true,
-        ));
+        ]);
 
         $this->assertTrue($container->has('debug.stopwatch'));
     }
 
     public function testStopwatchEnabledWithDebugModeDisabled()
     {
-        $container = $this->createContainerFromFile('default_config', array(
+        $container = $this->createContainerFromFile('default_config', [
             'kernel.container_class' => 'foo',
-        ));
+        ]);
 
         $this->assertTrue($container->has('debug.stopwatch'));
     }
@@ -1072,8 +1072,8 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertNull($container->getDefinition('serializer.mapping.class_metadata_factory')->getArgument(1));
         $this->assertEquals(new Reference('serializer.name_converter.camel_case_to_snake_case'), $container->getDefinition('serializer.name_converter.metadata_aware')->getArgument(1));
         $this->assertEquals(new Reference('property_info', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE), $container->getDefinition('serializer.normalizer.object')->getArgument(3));
-        $this->assertEquals(array('setCircularReferenceHandler', array(new Reference('my.circular.reference.handler'))), $container->getDefinition('serializer.normalizer.object')->getMethodCalls()[0]);
-        $this->assertEquals(array('setMaxDepthHandler', array(new Reference('my.max.depth.handler'))), $container->getDefinition('serializer.normalizer.object')->getMethodCalls()[1]);
+        $this->assertEquals(['setCircularReferenceHandler', [new Reference('my.circular.reference.handler')]], $container->getDefinition('serializer.normalizer.object')->getMethodCalls()[0]);
+        $this->assertEquals(['setMaxDepthHandler', [new Reference('my.max.depth.handler')]], $container->getDefinition('serializer.normalizer.object')->getMethodCalls()[1]);
     }
 
     public function testRegisterSerializerExtractor()
@@ -1085,7 +1085,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('serializer.mapping.class_metadata_factory', $serializerExtractorDefinition->getArgument(0)->__toString());
         $this->assertFalse($serializerExtractorDefinition->isPublic());
         $tag = $serializerExtractorDefinition->getTag('property_info.list_extractor');
-        $this->assertEquals(array('priority' => -999), $tag[0]);
+        $this->assertEquals(['priority' => -999], $tag[0]);
     }
 
     public function testDataUriNormalizerRegistered()
@@ -1159,25 +1159,25 @@ abstract class FrameworkExtensionTest extends TestCase
 
     public function testSerializerCacheDisabled()
     {
-        $container = $this->createContainerFromFile('serializer_enabled', array('kernel.debug' => true, 'kernel.container_class' => __CLASS__));
+        $container = $this->createContainerFromFile('serializer_enabled', ['kernel.debug' => true, 'kernel.container_class' => __CLASS__]);
         $this->assertFalse($container->hasDefinition('serializer.mapping.cache_class_metadata_factory'));
     }
 
     public function testSerializerMapping()
     {
-        $container = $this->createContainerFromFile('serializer_mapping', array('kernel.bundles_metadata' => array('TestBundle' => array('namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/TestBundle'))));
+        $container = $this->createContainerFromFile('serializer_mapping', ['kernel.bundles_metadata' => ['TestBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle\\Tests', 'path' => __DIR__.'/Fixtures/TestBundle']]]);
         $projectDir = $container->getParameter('kernel.project_dir');
         $configDir = __DIR__.'/Fixtures/TestBundle/Resources/config';
-        $expectedLoaders = array(
-            new Definition(AnnotationLoader::class, array(new Reference('annotation_reader'))),
-            new Definition(XmlFileLoader::class, array($configDir.'/serialization.xml')),
-            new Definition(YamlFileLoader::class, array($configDir.'/serialization.yml')),
-            new Definition(YamlFileLoader::class, array($projectDir.'/config/serializer/foo.yml')),
-            new Definition(XmlFileLoader::class, array($configDir.'/serializer_mapping/files/foo.xml')),
-            new Definition(YamlFileLoader::class, array($configDir.'/serializer_mapping/files/foo.yml')),
-            new Definition(YamlFileLoader::class, array($configDir.'/serializer_mapping/serialization.yml')),
-            new Definition(YamlFileLoader::class, array($configDir.'/serializer_mapping/serialization.yaml')),
-        );
+        $expectedLoaders = [
+            new Definition(AnnotationLoader::class, [new Reference('annotation_reader')]),
+            new Definition(XmlFileLoader::class, [$configDir.'/serialization.xml']),
+            new Definition(YamlFileLoader::class, [$configDir.'/serialization.yml']),
+            new Definition(YamlFileLoader::class, [$projectDir.'/config/serializer/foo.yml']),
+            new Definition(XmlFileLoader::class, [$configDir.'/serializer_mapping/files/foo.xml']),
+            new Definition(YamlFileLoader::class, [$configDir.'/serializer_mapping/files/foo.yml']),
+            new Definition(YamlFileLoader::class, [$configDir.'/serializer_mapping/serialization.yml']),
+            new Definition(YamlFileLoader::class, [$configDir.'/serializer_mapping/serialization.yaml']),
+        ];
 
         foreach ($expectedLoaders as $definition) {
             if (is_file($arg = $definition->getArgument(0))) {
@@ -1247,9 +1247,9 @@ abstract class FrameworkExtensionTest extends TestCase
 
     public function testEventDispatcherService()
     {
-        $container = $this->createContainer(array('kernel.charset' => 'UTF-8', 'kernel.secret' => 'secret'));
+        $container = $this->createContainer(['kernel.charset' => 'UTF-8', 'kernel.secret' => 'secret']);
         $container->registerExtension(new FrameworkExtension());
-        $container->getCompilerPassConfig()->setBeforeOptimizationPasses(array(new LoggerPass()));
+        $container->getCompilerPassConfig()->setBeforeOptimizationPasses([new LoggerPass()]);
         $this->loadFromFile($container, 'default_config');
         $container
             ->register('foo', \stdClass::class)
@@ -1300,18 +1300,18 @@ abstract class FrameworkExtensionTest extends TestCase
 
     public function testRemovesResourceCheckerConfigCacheFactoryArgumentOnlyIfNoDebug()
     {
-        $container = $this->createContainer(array('kernel.debug' => true));
-        (new FrameworkExtension())->load(array(), $container);
+        $container = $this->createContainer(['kernel.debug' => true]);
+        (new FrameworkExtension())->load([], $container);
         $this->assertCount(1, $container->getDefinition('config_cache_factory')->getArguments());
 
-        $container = $this->createContainer(array('kernel.debug' => false));
-        (new FrameworkExtension())->load(array(), $container);
+        $container = $this->createContainer(['kernel.debug' => false]);
+        (new FrameworkExtension())->load([], $container);
         $this->assertEmpty($container->getDefinition('config_cache_factory')->getArguments());
     }
 
     public function testLoggerAwareRegistration()
     {
-        $container = $this->createContainerFromFile('full', array(), true, false);
+        $container = $this->createContainerFromFile('full', [], true, false);
         $container->addCompilerPass(new ResolveInstanceofConditionalsPass());
         $container->register('foo', LoggerAwareInterface::class)
             ->setAutoconfigured(true);
@@ -1329,15 +1329,15 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('session_cookie_secure_auto');
 
-        $expected = array('session', 'initialized_session', 'session_storage', 'request_stack');
+        $expected = ['session', 'initialized_session', 'session_storage', 'request_stack'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
     }
 
-    protected function createContainer(array $data = array())
+    protected function createContainer(array $data = [])
     {
-        return new ContainerBuilder(new ParameterBag(array_merge(array(
-            'kernel.bundles' => array('FrameworkBundle' => 'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle'),
-            'kernel.bundles_metadata' => array('FrameworkBundle' => array('namespace' => 'Symfony\\Bundle\\FrameworkBundle', 'path' => __DIR__.'/../..')),
+        return new ContainerBuilder(new ParameterBag(array_merge([
+            'kernel.bundles' => ['FrameworkBundle' => 'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle'],
+            'kernel.bundles_metadata' => ['FrameworkBundle' => ['namespace' => 'Symfony\\Bundle\\FrameworkBundle', 'path' => __DIR__.'/../..']],
             'kernel.cache_dir' => __DIR__,
             'kernel.project_dir' => __DIR__,
             'kernel.debug' => false,
@@ -1348,10 +1348,10 @@ abstract class FrameworkExtensionTest extends TestCase
             'container.build_hash' => 'Abc1234',
             'container.build_id' => hash('crc32', 'Abc123423456789'),
             'container.build_time' => 23456789,
-        ), $data)));
+        ], $data)));
     }
 
-    protected function createContainerFromFile($file, $data = array(), $resetCompilerPasses = true, $compile = true)
+    protected function createContainerFromFile($file, $data = [], $resetCompilerPasses = true, $compile = true)
     {
         $cacheKey = md5(\get_class($this).$file.serialize($data));
         if ($compile && isset(self::$containerCache[$cacheKey])) {
@@ -1362,12 +1362,12 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->loadFromFile($container, $file);
 
         if ($resetCompilerPasses) {
-            $container->getCompilerPassConfig()->setOptimizationPasses(array());
-            $container->getCompilerPassConfig()->setRemovingPasses(array());
+            $container->getCompilerPassConfig()->setOptimizationPasses([]);
+            $container->getCompilerPassConfig()->setRemovingPasses([]);
         }
-        $container->getCompilerPassConfig()->setBeforeOptimizationPasses(array(new LoggerPass()));
-        $container->getCompilerPassConfig()->setBeforeRemovingPasses(array(new AddConstraintValidatorsPass(), new TranslatorPass('translator.default', 'translation.reader')));
-        $container->getCompilerPassConfig()->setAfterRemovingPasses(array(new AddAnnotationsCachedReaderPass()));
+        $container->getCompilerPassConfig()->setBeforeOptimizationPasses([new LoggerPass()]);
+        $container->getCompilerPassConfig()->setBeforeRemovingPasses([new AddConstraintValidatorsPass(), new TranslatorPass('translator.default', 'translation.reader')]);
+        $container->getCompilerPassConfig()->setAfterRemovingPasses([new AddAnnotationsCachedReaderPass()]);
 
         if (!$compile) {
             return $container;
@@ -1377,15 +1377,15 @@ abstract class FrameworkExtensionTest extends TestCase
         return self::$containerCache[$cacheKey] = $container;
     }
 
-    protected function createContainerFromClosure($closure, $data = array())
+    protected function createContainerFromClosure($closure, $data = [])
     {
         $container = $this->createContainer($data);
         $container->registerExtension(new FrameworkExtension());
         $loader = new ClosureLoader($container);
         $loader->load($closure);
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         return $container;

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/PackageJsonVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/PackageJsonVersionStrategyTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Asset\Tests\VersionStrategy;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\VersionStrategy\PackageJsonVersionStrategy;
+
+class PackageJsonVersionStrategyTest extends TestCase
+{
+    public function testGetVersion()
+    {
+        $strategy = $this->createStrategy('package-valid.json');
+
+        $this->assertEquals('1.2.3', $strategy->getVersion('main.js'));
+    }
+
+    public function testApplyVersion()
+    {
+        $strategy = $this->createStrategy('package-valid.json');
+
+        $this->assertEquals('css/styles.css?1.2.3', $strategy->applyVersion('css/styles.css'));
+    }
+
+    public function testApplyVersionFormat()
+    {
+        $strategy = $this->createStrategy('package-valid.json', '%s?v=%s');
+
+        $this->assertEquals('css/styles.css?v=1.2.3', $strategy->applyVersion('css/styles.css'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testMissingPackageFileThrowsException()
+    {
+        $strategy = $this->createStrategy('non-existent-file.json');
+        $strategy->getVersion('main.js');
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Error parsing JSON
+     */
+    public function testManifestFileWithBadJSONThrowsException()
+    {
+        $strategy = $this->createStrategy('package-invalid.json');
+        $strategy->getVersion('main.js');
+    }
+
+    private function createStrategy($packageJsonFilename, $format = null)
+    {
+        return new PackageJsonVersionStrategy(__DIR__.'/../fixtures/'.$packageJsonFilename, $format);
+    }
+}

--- a/src/Symfony/Component/Asset/Tests/fixtures/package-invalid.json
+++ b/src/Symfony/Component/Asset/Tests/fixtures/package-invalid.json
@@ -1,0 +1,8 @@
+{
+    "version": 1.2.3",
+    "scripts": {
+        "build": "npm run build:assets && npm run version:patch",
+        "build:assets": "...",
+        "version:patch": "npm version patch --git-tag-version false"
+    }
+}

--- a/src/Symfony/Component/Asset/Tests/fixtures/package-valid.json
+++ b/src/Symfony/Component/Asset/Tests/fixtures/package-valid.json
@@ -1,0 +1,8 @@
+{
+    "version": "1.2.3",
+    "scripts": {
+        "build": "npm run build:assets && npm run version:patch",
+        "build:assets": "...",
+        "version:patch": "npm version patch --git-tag-version false"
+    }
+}

--- a/src/Symfony/Component/Asset/VersionStrategy/PackageJsonVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/PackageJsonVersionStrategy.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Asset\VersionStrategy;
+
+/**
+ * Reads the version from a package.json file.
+ *
+ * For example, the manifest file might look like this:
+ *     {
+ *         "version": "1.0.0",
+ *         "scripts": {
+ *             "build": "npm run build:assets && npm run version:patch",
+ *             "build:assets": "...",
+ *             "version:patch": "npm version patch --git-tag-version false"
+ *         }
+ *     }
+ */
+class PackageJsonVersionStrategy implements VersionStrategyInterface
+{
+    private $packagePath;
+    private $version;
+    private $format;
+
+    /**
+     * @param string $packagePath Absolute path to the package.json file
+     * @param string $format      Url format
+     */
+    public function __construct(string $packagePath, string $format = null)
+    {
+        $this->packagePath = $packagePath;
+        $this->format = $format ?: '%s?%s';
+    }
+
+    public function getVersion($path)
+    {
+        return $this->loadVersion();
+    }
+
+    public function applyVersion($path)
+    {
+        $versionized = sprintf($this->format, ltrim($path, '/'), $this->loadVersion());
+
+        if ($path && '/' == $path[0]) {
+            return '/'.$versionized;
+        }
+
+        return $versionized;
+    }
+
+    private function loadVersion()
+    {
+        if (null === $this->version) {
+            if (!file_exists($this->packagePath)) {
+                throw new \RuntimeException(sprintf('Asset manifest file "%s" does not exist.', $this->packagePath));
+            }
+
+            $json = json_decode(file_get_contents($this->packagePath), true);
+
+            if (0 < json_last_error() || !array_key_exists('version', $json)) {
+                throw new \RuntimeException(sprintf('Error parsing JSON from asset package file "%s" - %s', $this->packagePath, json_last_error_msg()));
+            }
+
+            $this->version = $json['version'];
+        }
+
+        return $this->version;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | symfony/symfony-docs#10431

In some cases where its not possible to implement a manifest file for asset versions you can use the version number from your package.json and increase this version number always when you build your assets e.g.:

```json
{
    "version": "1.2.3",
    "scripts": {
        "build": "npm run build:assets && npm run version:patch",
        "build:assets": "...",
        "version:patch": "npm version patch --git-tag-version false"
    }
}
```