### PR TITLE
[Form] reverse transform RFC 3339 formatted dates

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformer.php
@@ -81,7 +81,9 @@ class DateTimeToHtml5LocalDateTimeTransformer extends BaseDateTimeTransformer
             return;
         }
 
-        if (!preg_match('/^(\d{4})-(\d{2})-(\d{2})[T ]\d{2}:\d{2}(?::\d{2})?$/', $dateTimeLocal, $matches)) {
+        // to maintain backwards compatibility we do not strictly validate the submitted date
+        // see https://github.com/symfony/symfony/issues/28699
+        if (!preg_match('/^(\d{4})-(\d{2})-(\d{2})[T ]\d{2}:\d{2}(?::\d{2})?/', $dateTimeLocal, $matches)) {
             throw new TransformationFailedException(sprintf('The date "%s" is not a valid date.', $dateTimeLocal));
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
@@ -51,6 +51,10 @@ class DateTimeToHtml5LocalDateTimeTransformerTest extends TestCase
             array('UTC', 'UTC', '2010-02-03 04:05:00 UTC', '2010-02-03T04:05'),
             array('America/New_York', 'Asia/Hong_Kong', '2010-02-03 04:05:00 America/New_York', '2010-02-03T17:05'),
             array('Europe/Amsterdam', 'Europe/Amsterdam', '2013-08-21 10:30:00 Europe/Amsterdam', '2013-08-21T10:30:00'),
+            array('UTC', 'UTC', '2018-09-15T10:00:00Z', '2018-09-15T10:00:00Z'),
+            array('Europe/Berlin', 'Europe/Berlin', '2018-09-15T10:00:00+02:00', '2018-09-15T10:00:00+02:00'),
+            array('Europe/Berlin', 'Europe/Berlin', '2018-09-15T10:00:00+0200', '2018-09-15T10:00:00+0200'),
+            array('UTC', 'UTC', '2018-10-03T10:00:00.000Z', '2018-10-03T10:00:00.000Z'),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28699
| License       | MIT
| Doc PR        | 

Technically, dates formatted according to the HTML specifications do not
contain any timezone information. But since our DateTimeType used to
contain this information in the passed, users had configure their JS
libraries to accept (and create) dates in that format.

To not break BC we should accept these dates and silently ignore the
additional timezone information.