### PR TITLE
[Cache] added support for connecting to Redis clusters via DSN

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
         "doctrine/doctrine-bundle": "~1.4",
         "monolog/monolog": "~1.11",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
-        "predis/predis": "~1.0",
+        "predis/predis": "~1.1",
         "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
         "symfony/phpunit-bridge": "~3.4|~4.0",
         "symfony/security-acl": "~2.8|~3.0",

--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -148,7 +148,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Logg
         if (!\is_string($dsn)) {
             throw new InvalidArgumentException(sprintf('The %s() method expect argument #1 to be string, %s given.', __METHOD__, \gettype($dsn)));
         }
-        if (0 === strpos($dsn, 'redis://')) {
+        if (0 === strpos($dsn, 'redis:')) {
             return RedisAdapter::createConnection($dsn, $options);
         }
         if (0 === strpos($dsn, 'memcached:')) {

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 4.2.0
 -----
 
- * added support for configuring multiple Memcached servers in one DSN
+ * added support for connecting to Redis clusters via DSN
+ * added support for configuring multiple Memcached servers via DSN
  * added `MarshallerInterface` and `DefaultMarshaller` to allow changing the serializer and provide one that automatically uses igbinary when available
  * added `CacheInterface`, which provides stampede protection via probabilistic early expiration and should become the preferred way to use a cache
  * added sub-second expiry accuracy for backends that support it

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -34,21 +34,13 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
 
         $params = array(
             'scheme' => 'tcp',
-            'host' => $redisHost,
-            'path' => '',
-            'dbindex' => '1',
+            'host' => 'localhost',
             'port' => 6379,
-            'class' => 'Predis\Client',
-            'timeout' => 3,
             'persistent' => 0,
-            'persistent_id' => null,
-            'read_timeout' => 0,
-            'retry_interval' => 0,
-            'compression' => true,
-            'tcp_keepalive' => 0,
-            'lazy' => false,
+            'timeout' => 3,
+            'read_write_timeout' => 0,
+            'tcp_nodelay' => true,
             'database' => '1',
-            'password' => null,
         );
         $this->assertSame($params, $connection->getParameters()->toArray());
     }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+
 class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
 {
     public static function setupBeforeClass()
@@ -18,7 +20,8 @@ class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
             self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
-        self::$redis = new \Predis\Client(explode(' ', $hosts), array('cluster' => 'redis'));
+
+        self::$redis = RedisAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', array('class' => \Predis\Client::class, 'redis_cluster' => true));
     }
 
     public static function tearDownAfterClass()

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -33,6 +33,11 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
 
     public function testCreateConnection()
     {
+        $redis = RedisAdapter::createConnection('redis:?host[h1]&host[h2]&host[/foo:]');
+        $this->assertInstanceOf(\RedisArray::class, $redis);
+        $this->assertSame(array('h1:6379', 'h2:6379', '/foo'), $redis->_hosts());
+        @$redis = null; // some versions of phpredis connect on destruct, let's silence the warning
+
         $redisHost = getenv('REDIS_HOST');
 
         $redis = RedisAdapter::createConnection('redis://'.$redisHost);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Traits\RedisClusterProxy;
+
 class RedisClusterAdapterTest extends AbstractRedisAdapterTest
 {
     public static function setupBeforeClass()
@@ -22,6 +26,33 @@ class RedisClusterAdapterTest extends AbstractRedisAdapterTest
             self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
 
-        self::$redis = new \RedisCluster(null, explode(' ', $hosts));
+        self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', array('lazy' => true, 'redis_cluster' => true));
+    }
+
+    public function createCachePool($defaultLifetime = 0)
+    {
+        $this->assertInstanceOf(RedisClusterProxy::class, self::$redis);
+        $adapter = new RedisAdapter(self::$redis, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+
+        return $adapter;
+    }
+
+    /**
+     * @dataProvider provideFailedCreateConnection
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Redis connection failed
+     */
+    public function testFailedCreateConnection($dsn)
+    {
+        RedisAdapter::createConnection($dsn);
+    }
+
+    public function provideFailedCreateConnection()
+    {
+        return array(
+            array('redis://localhost:1234?redis_cluster=1'),
+            array('redis://foo@localhost?redis_cluster=1'),
+            array('redis://localhost/123?redis_cluster=1'),
+        );
     }
 }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -32,7 +32,7 @@
         "cache/integration-tests": "dev-master",
         "doctrine/cache": "~1.6",
         "doctrine/dbal": "~2.5",
-        "predis/predis": "~1.0",
+        "predis/predis": "~1.1",
         "symfony/config": "~4.2",
         "symfony/dependency-injection": "~3.4",
         "symfony/var-dumper": "^4.1.1"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Replaces #28300 and #28175

This PR allows configuring a cluster of Redis servers using all available options of either the phpredis extension or the Predis package:
- the `redis_cluster=0/1` boolean option configures whether the client should use the Redis cluster protocol;
- several hosts can be provided using a syntax very similar to #28598, enabling consistent hashing distribution of keys;
- `failover=error/distribute/slaves` can be set to direct reads at slave servers;
- extra options are passed as is to the driver (e.g. `profile=2.8`)
- Predis per-server settings are also possible, using e.g. `host[localhost][alias]=foo` in the query string, or `host[localhost]=alias%3Dfoo` (ie PHP query arrays or urlencoded key/value pairs)