### PR TITLE
[Messenger] Add middleware allowing just for a single handler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -29,6 +29,9 @@
         <service id="messenger.middleware.call_message_handler" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">
             <argument /> <!-- Bus handler resolver -->
         </service>
+        <service id="messenger.middleware.allow_single_handler" class="Symfony\Component\Messenger\Middleware\AllowSingleHandlerMiddleware" abstract="true">
+            <argument /> <!-- Bus handler resolver -->
+        </service>
 
         <service id="messenger.middleware.validation" class="Symfony\Component\Messenger\Middleware\ValidationMiddleware" abstract="true">
             <argument type="service" id="validator" />

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * [BC BREAK] The `EncoderInterface` and `DecoderInterface` have been replaced by a unified `Symfony\Component\Messenger\Transport\Serialization\SerializerInterface`.
  * [BC BREAK] The locator passed to `ContainerHandlerLocator` should not prefix its keys by "handler." anymore
  * [BC BREAK] The `AbstractHandlerLocator::getHandler()` method uses `?callable` as return type
+ * Added `AllowSingleHandlerMiddleware` for message buses which behave like command buses.
 
 4.1.0
 -----

--- a/src/Symfony/Component/Messenger/Exception/MoreThanOneHandlerForMessageException.php
+++ b/src/Symfony/Component/Messenger/Exception/MoreThanOneHandlerForMessageException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * @author Kamil Kokot <kamil@kokot.me>
+ */
+class MoreThanOneHandlerForMessageException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Messenger/Middleware/AllowSingleHandlerMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/AllowSingleHandlerMiddleware.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Exception\MoreThanOneHandlerForMessageException;
+use Symfony\Component\Messenger\Handler\ChainHandler;
+use Symfony\Component\Messenger\Handler\Locator\HandlerLocatorInterface;
+
+/**
+ * @author Kamil Kokot <kamil@kokot.me>
+ */
+class AllowSingleHandlerMiddleware implements MiddlewareInterface
+{
+    private $messageHandlerResolver;
+
+    public function __construct(HandlerLocatorInterface $messageHandlerResolver)
+    {
+        $this->messageHandlerResolver = $messageHandlerResolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($message, callable $next)
+    {
+        $handler = $this->messageHandlerResolver->resolve($message);
+
+        if ($handler instanceof ChainHandler) {
+            throw new MoreThanOneHandlerForMessageException(sprintf('More than one handler for message "%s".', \get_class($message)));
+        }
+
+        return $next($message);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/AllowSingleHandlerMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/AllowSingleHandlerMiddlewareTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Handler\ChainHandler;
+use Symfony\Component\Messenger\Handler\Locator\HandlerLocator;
+use Symfony\Component\Messenger\Middleware\AllowSingleHandlerMiddleware;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+class AllowSingleHandlerMiddlewareTest extends TestCase
+{
+    public function testItCallsNextMiddlewareAndReturnsItsResult(): void
+    {
+        $message = new DummyMessage('Hey');
+
+        $handler = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $handler->method('__invoke')->willReturn('Hello');
+
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next->expects($this->once())->method('__invoke')->with($message)->willReturn('Foo');
+
+        $middleware = new AllowSingleHandlerMiddleware(new HandlerLocator(array(
+            DummyMessage::class => $handler,
+        )));
+
+        $this->assertSame('Foo', $middleware->handle($message, $next));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Messenger\Exception\MoreThanOneHandlerForMessageException
+     * @expectedExceptionMessage More than one handler for message "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage".
+     */
+    public function testItThrowsAnExceptionIfHandlerIsChainHandler(): void
+    {
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+
+        $middleware = new AllowSingleHandlerMiddleware(new HandlerLocator(array(
+            DummyMessage::class => new ChainHandler(array(new \stdClass(), new \stdClass())),
+        )));
+
+        $middleware->handle(new DummyMessage('Hey'), $next);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | not yet

It's a quite common middleware, required for command buses.

PS. How do you manage to have autocompletion for PHPUnit classes when writing tests in Symfony since there is no PHPUnit in dependencies?
