### PR TITLE
Correct PHPDoc type for float ttl

### DIFF
--- a/src/Symfony/Component/Lock/Factory.php
+++ b/src/Symfony/Component/Lock/Factory.php
@@ -36,9 +36,9 @@ class Factory implements LoggerAwareInterface
     /**
      * Creates a lock for the given resource.
      *
-     * @param string $resource    The resource to lock
-     * @param float  $ttl         Maximum expected lock duration in seconds
-     * @param bool   $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
+     * @param string     $resource    The resource to lock
+     * @param float|null $ttl         Maximum expected lock duration in seconds
+     * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
      *
      * @return Lock
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

It can be null as the Lock instance accepts it.

It will fix that kind of PHPStan issue:

```
src/AppBundle/Command/AbstractCommand.php:45:Parameter #2 $ttl of method Symfony\Component\Lock\Factory::createLock() expects float, null given.
```