### PR TITLE
[Lock] Refine the contract and implementation for Stores to handle Not Expirable Store cases.

### DIFF
--- a/src/Symfony/Component/Lock/Exception/NotExpirableStoreException.php
+++ b/src/Symfony/Component/Lock/Exception/NotExpirableStoreException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Exception;
+
+/**
+ * NotExpirableStoreException is thrown when a store doesn't support expiration of locks.
+ *
+ * @author Ganesh Chandrasekaran <gchandrasekaran@wayfair.com>
+ */
+class NotExpirableStoreException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -19,6 +19,7 @@ use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockExpiredException;
 use Symfony\Component\Lock\Exception\LockReleasingException;
+use Symfony\Component\Lock\Exception\NotExpirableStoreException;
 
 /**
  * Lock is the default implementation of the LockInterface.
@@ -124,6 +125,8 @@ final class Lock implements LockInterface, LoggerAwareInterface
             }
 
             $this->logger->info('Expiration defined for "{resource}" lock for "{ttl}" seconds.', array('resource' => $this->key, 'ttl' => $ttl));
+        } catch (NotExpirableStoreException $e) {
+            $this->logger->notice('The store does not support expiration of locks.', array('store' => $this->store));
         } catch (LockConflictedException $e) {
             $this->dirty = false;
             $this->logger->notice('Failed to define an expiration for the "{resource}" lock, someone else acquired the lock.', array('resource' => $this->key));

--- a/src/Symfony/Component/Lock/Store/CombinedStore.php
+++ b/src/Symfony/Component/Lock/Store/CombinedStore.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockExpiredException;
+use Symfony\Component\Lock\Exception\NotExpirableStoreException;
 use Symfony\Component\Lock\Exception\NotSupportedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
@@ -114,6 +115,9 @@ class CombinedStore implements StoreInterface, LoggerAwareInterface
                 }
 
                 $store->putOffExpiration($key, $adjustedTtl);
+                ++$successCount;
+            } catch (NotExpirableStoreException $e) {
+                $this->logger->notice('The store does not support expiration of locks.', array('store' => $store));
                 ++$successCount;
             } catch (\Exception $e) {
                 $this->logger->warning('One store failed to put off the expiration of the "{resource}" lock.', array('resource' => $key, 'store' => $store, 'exception' => $e));

--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Store;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockStorageException;
+use Symfony\Component\Lock\Exception\NotExpirableStoreException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
 
@@ -108,7 +109,7 @@ class FlockStore implements StoreInterface
      */
     public function putOffExpiration(Key $key, $ttl)
     {
-        // do nothing, the flock locks forever.
+        throw new NotExpirableStoreException();
     }
 
     /**

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Lock\Store;
 
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\NotExpirableStoreException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
 
@@ -102,7 +103,7 @@ class SemaphoreStore implements StoreInterface
      */
     public function putOffExpiration(Key $key, $ttl)
     {
-        // do nothing, the semaphore locks forever.
+        throw new NotExpirableStoreException();
     }
 
     /**

--- a/src/Symfony/Component/Lock/Store/ZookeeperStore.php
+++ b/src/Symfony/Component/Lock/Store/ZookeeperStore.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock\Store;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockReleasingException;
+use Symfony\Component\Lock\Exception\NotExpirableStoreException;
 use Symfony\Component\Lock\Exception\NotSupportedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\StoreInterface;
@@ -91,7 +92,7 @@ class ZookeeperStore implements StoreInterface
      */
     public function putOffExpiration(Key $key, $ttl)
     {
-        throw new NotSupportedException();
+        throw new NotExpirableStoreException();
     }
 
     /**

--- a/src/Symfony/Component/Lock/StoreInterface.php
+++ b/src/Symfony/Component/Lock/StoreInterface.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Lock;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockReleasingException;
+use Symfony\Component\Lock\Exception\NotExpirableStoreException;
 use Symfony\Component\Lock\Exception\NotSupportedException;
 
 /**
@@ -49,6 +50,7 @@ interface StoreInterface
      * @param float $ttl amount of second to keep the lock in the store
      *
      * @throws LockConflictedException
+     * @throws NotExpirableStoreException
      * @throws NotSupportedException
      */
     public function putOffExpiration(Key $key, $ttl);

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\Store\CombinedStore;
 use Symfony\Component\Lock\Store\RedisStore;
+use Symfony\Component\Lock\Store\ZookeeperStore;
 use Symfony\Component\Lock\StoreInterface;
 use Symfony\Component\Lock\Strategy\StrategyInterface;
 use Symfony\Component\Lock\Strategy\UnanimousStrategy;
@@ -46,7 +47,10 @@ class CombinedStoreTest extends AbstractStoreTest
             self::markTestSkipped($e->getMessage());
         }
 
-        return new CombinedStore(array(new RedisStore($redis)), new UnanimousStrategy());
+        $zookeeper_server = getenv('ZOOKEEPER_HOST').':2181';
+        $zookeeper = new \Zookeeper(implode(',', array($zookeeper_server)));
+
+        return new CombinedStore(array(new RedisStore($redis), new ZookeeperStore($zookeeper)), new UnanimousStrategy());
     }
 
     /** @var \PHPUnit_Framework_MockObject_MockObject */

--- a/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Lock\Store\FlockStore;
 class FlockStoreTest extends AbstractStoreTest
 {
     use BlockingStoreTestTrait;
+    use NotExpiringStoreTestTrait;
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Lock/Tests/Store/NotExpiringStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/NotExpiringStoreTestTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use Symfony\Component\Lock\Key;
+
+/**
+ * @author Ganesh Chandrasekaran <gchandrasekaran@wayfair.com>
+ */
+trait NotExpiringStoreTestTrait
+{
+    /**
+     * @see AbstractStoreTest::getStore()
+     */
+    abstract protected function getStore();
+
+    /**
+     * @expectedException \Symfony\Component\Lock\Exception\NotExpirableStoreException
+     */
+    public function testPutOffExpirationThrowsException()
+    {
+        $store = $this->getStore();
+        $key = new Key(uniqid(__METHOD__, true));
+
+        $store->save($key);
+        $store->putOffExpiration($key, 10.0);
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Lock\Store\SemaphoreStore;
 class SemaphoreStoreTest extends AbstractStoreTest
 {
     use BlockingStoreTestTrait;
+    use NotExpiringStoreTestTrait;
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\Lock\Store\ZookeeperStore;
  */
 class ZookeeperStoreTest extends AbstractStoreTest
 {
+    use NotExpiringStoreTestTrait;
+
     public function getStore(): ZookeeperStore
     {
         $zookeeper_server = getenv('ZOOKEEPER_HOST').':2181';


### PR DESCRIPTION
The Stores contract and implementation doesn't clearly distinguish between stores that support expirable stores and ones which don't. This change attempts to improve that for better usage of the functions by the services without running into runtime issues.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #28696 
| License       | MIT
| Doc PR        | n/a

