### PR TITLE
[OptionsResolver] Passing Options argument to deprecation closure

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
@@ -215,7 +215,7 @@ class OptionsResolverIntrospectorTest extends TestCase
     {
         $resolver = new OptionsResolver();
         $resolver->setDefined('foo');
-        $resolver->setDeprecated('foo', $closure = function ($value) {});
+        $resolver->setDeprecated('foo', $closure = function (Options $options, $value) {});
 
         $debug = new OptionsResolverIntrospector($resolver);
         $this->assertSame($closure, $debug->getDeprecationMessage('foo'));

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -486,14 +486,33 @@ class OptionsResolverTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Invalid type for deprecation message, expected string but got "boolean", returns an empty string to ignore.
+     * @expectedExceptionMessage Invalid type for deprecation message, expected string but got "boolean", return an empty string to ignore.
      */
     public function testLazyDeprecationFailsIfInvalidDeprecationMessageType()
     {
         $this->resolver
             ->setDefault('foo', true)
-            ->setDeprecated('foo', function ($value) {
+            ->setDeprecated('foo', function (Options $options, $value) {
                 return false;
+            })
+        ;
+        $this->resolver->resolve();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
+     * @expectedExceptionMessage The options "foo", "bar" have a cyclic dependency.
+     */
+    public function testFailsIfCyclicDependencyBetweenDeprecation()
+    {
+        $this->resolver
+            ->setDefault('foo', null)
+            ->setDefault('bar', null)
+            ->setDeprecated('foo', function (Options $options, $value) {
+                $options['bar'];
+            })
+            ->setDeprecated('bar', function (Options $options, $value) {
+                $options['foo'];
             })
         ;
         $this->resolver->resolve();
@@ -590,7 +609,7 @@ class OptionsResolverTest extends TestCase
                 $resolver
                     ->setDefault('foo', null)
                     ->setAllowedTypes('foo', array('null', 'string', \stdClass::class))
-                    ->setDeprecated('foo', function ($value) {
+                    ->setDeprecated('foo', function (Options $options, $value) {
                         if ($value instanceof \stdClass) {
                             return sprintf('Passing an instance of "%s" to option "foo" is deprecated, pass its FQCN instead.', \stdClass::class);
                         }
@@ -621,13 +640,34 @@ class OptionsResolverTest extends TestCase
             function (OptionsResolver $resolver) {
                 $resolver
                     ->setDefault('foo', null)
-                    ->setDeprecated('foo', function ($value) {
+                    ->setDeprecated('foo', function (Options $options, $value) {
                         return '';
                     })
                 ;
             },
             array('foo' => Bar::class),
             null,
+        );
+
+        yield 'It deprecates value depending on other option value' => array(
+            function (OptionsResolver $resolver) {
+                $resolver
+                    ->setDefault('widget', null)
+                    ->setDefault('date_format', null)
+                    ->setDeprecated('date_format', function (Options $options, $dateFormat) {
+                        if (null !== $dateFormat && 'single_text' === $options['widget']) {
+                            return 'Using the "date_format" option when the "widget" option is set to "single_text" is deprecated.';
+                        }
+
+                        return '';
+                    })
+                ;
+            },
+            array('widget' => 'single_text', 'date_format' => 2),
+            array(
+                'type' => E_USER_DEPRECATED,
+                'message' => 'Using the "date_format" option when the "widget" option is set to "single_text" is deprecated.',
+            ),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/28721#discussion_r222686221
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10439

As spotted here https://github.com/symfony/symfony/pull/28721, we sometimes need more advanced cases, where the deprecation of the value depends on another option:
```php
$resolver->setDeprecated('date_format', function (Options $options, $dateFormat) {
    if (null !== $options['date_format'] && 'single_text' === $options['widget']) {
         return sprintf('Using the "date_format" option of the %s when the "widget" option is set to "single_text" is deprecated since Symfony 4.2.', self::class);
    }

    return '';
});
```
There is still a decision to make:
> We're in time to change the arguments position (Options $options, $value) to be consistent with other closure signatures.

WDYT?

