### PR TITLE
[Validator][minor] Fixed method in phpDoc

### DIFF
--- a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
@@ -88,7 +88,7 @@ interface ExecutionContextInterface extends LegacyExecutionContextInterface
      *     {
      *         $validator = $this->context->getValidator();
      *
-     *         $violations = $validator->validateValue($value, new Length(array('min' => 3)));
+     *         $violations = $validator->validate($value, new Length(array('min' => 3)));
      *
      *         if (count($violations) > 0) {
      *             // ...


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | >= 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

`ValidatorInterface` doesn't have a `validateValue` method, `validate` should be used.