### PR TITLE
[Messenger] add a transport that processes messages on kernel.terminate

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -59,5 +59,11 @@
             <argument type="service" id="messenger.transport.serializer" />
             <argument>%kernel.debug%</argument>
         </service>
+
+        <service id="messenger.transport.kernel_terminate.factory" class="Symfony\Component\Messenger\Transport\KernelTerminateTransportFactory">
+            <argument /> <!-- Message bus locator -->
+            <argument type="service" id="event_dispatcher" />
+            <tag name="messenger.transport_factory" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_no_default_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_no_default_bus.php
@@ -1,0 +1,16 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'messenger' => array(
+        'serializer' => false,
+        'buses' => array(
+            'a_bus' => null,
+            'another_bus' => null,
+        ),
+        'transports' => array(
+            'kernel_terminate' => array(
+                'dsn' => 'symfony://kernel.terminate',
+            ),
+        ),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_one_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_one_bus.php
@@ -1,0 +1,15 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'messenger' => array(
+        'serializer' => false,
+        'buses' => array(
+            'a_bus' => null,
+        ),
+        'transports' => array(
+            'kernel_terminate' => array(
+                'dsn' => 'symfony://kernel.terminate',
+            ),
+        ),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_transport_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_transport_bus.php
@@ -1,0 +1,17 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'messenger' => array(
+        'serializer' => false,
+        'buses' => array(
+            'a_bus' => null,
+            'another_bus' => null,
+        ),
+        'transports' => array(
+            'kernel_terminate' => array(
+                'dsn' => 'symfony://kernel.terminate',
+                'options' => array('bus' => 'a_bus'),
+            ),
+        ),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_transport_default_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_transport_default_bus.php
@@ -1,0 +1,13 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'messenger' => array(
+        'serializer' => false,
+        'transports' => array(
+            'kernel_terminate' => array(
+                'dsn' => 'symfony://kernel.terminate',
+                'options' => array('an_option' => 'an_option_value'),
+            ),
+        ),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_transport_missing_bus.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_kernel_terminate_transport_missing_bus.php
@@ -1,0 +1,13 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'messenger' => array(
+        'serializer' => false,
+        'transports' => array(
+            'kernel_terminate' => array(
+                'dsn' => 'symfony://kernel.terminate',
+                'options' => array('bus' => 'messenger.bus.commands'),
+            ),
+        ),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_no_default_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_no_default_bus.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:messenger>
+            <framework:serializer id="null" />
+            <framework:transport name="kernel_terminate" dsn="symfony://kernel.terminate" />
+            <framework:bus name="a_bus" />
+            <framework:bus name="another_bus" />
+        </framework:messenger>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_one_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_one_bus.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:messenger>
+            <framework:serializer id="null" />
+            <framework:transport name="kernel_terminate" dsn="symfony://kernel.terminate" />
+            <framework:bus name="a_bus" />
+        </framework:messenger>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_transport_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_transport_bus.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:messenger>
+            <framework:serializer id="null" />
+            <framework:transport name="kernel_terminate" dsn="symfony://kernel.terminate">
+                <framework:options>
+                    <framework:bus>a_bus</framework:bus>
+                </framework:options>
+            </framework:transport>
+            <framework:bus name="a_bus" />
+            <framework:bus name="another_bus" />
+        </framework:messenger>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_transport_default_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_transport_default_bus.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:messenger>
+            <framework:serializer id="null" />
+            <framework:transport name="kernel_terminate" dsn="symfony://kernel.terminate">
+                <framework:options>
+                    <framework:an_option>an_option_value</framework:an_option>
+                </framework:options>
+            </framework:transport>
+        </framework:messenger>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_transport_missing_bus.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_kernel_terminate_transport_missing_bus.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:messenger>
+            <framework:serializer id="null" />
+            <framework:transport name="kernel_terminate" dsn="symfony://kernel.terminate">
+                <framework:options>
+                    <framework:bus>messenger.bus.commands</framework:bus>
+                </framework:options>
+            </framework:transport>
+        </framework:messenger>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_no_default_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_no_default_bus.yml
@@ -1,0 +1,9 @@
+framework:
+    messenger:
+        serializer: false
+        buses:
+            a_bus: ~
+            another_bus: ~
+        transports:
+            kernel_terminate:
+                dsn: 'symfony://kernel.terminate'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_one_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_one_bus.yml
@@ -1,0 +1,8 @@
+framework:
+    messenger:
+        serializer: false
+        buses:
+            a_bus: ~
+        transports:
+            kernel_terminate:
+                dsn: 'symfony://kernel.terminate'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_transport_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_transport_bus.yml
@@ -1,0 +1,11 @@
+framework:
+    messenger:
+        serializer: false
+        buses:
+            a_bus: ~
+            another_bus: ~
+        transports:
+            kernel_terminate:
+                dsn: 'symfony://kernel.terminate'
+                options:
+                    bus: a_bus

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_transport_default_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_transport_default_bus.yml
@@ -1,0 +1,8 @@
+framework:
+    messenger:
+        serializer: false
+        transports:
+            kernel_terminate:
+                dsn: 'symfony://kernel.terminate'
+                options:
+                    an_option: an_option_value

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_transport_missing_bus.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_kernel_terminate_transport_missing_bus.yml
@@ -1,0 +1,8 @@
+framework:
+    messenger:
+        serializer: false
+        transports:
+            kernel_terminate:
+                dsn: 'symfony://kernel.terminate'
+                options:
+                    bus: messenger.bus.commands

--- a/src/Symfony/Component/Messenger/Tests/Transport/KernelTerminateTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/KernelTerminateTransportFactoryTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\KernelTerminateTransportFactory;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+class KernelTerminateTransportFactoryTest extends TestCase
+{
+    public function testItCreatesATransportWithBusInDsn()
+    {
+        $messageBus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+        $busLocator = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $busLocator->method('has')->with('aBus')->willReturn(true);
+        $busLocator->method('get')->with('aBus')->willReturn($messageBus);
+
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+
+        $kernelTerminateTransportFactory = new KernelTerminateTransportFactory($busLocator, $eventDispatcher);
+        $transport = $kernelTerminateTransportFactory->createTransport('symfony://kernel.terminate?bus=aBus', array());
+
+        $this->assertInstanceOf(TransportInterface::class, $transport);
+    }
+
+    public function testItCreatesATransportWithBusInOptions()
+    {
+        $messageBus = $this->getMockBuilder(MessageBusInterface::class)->getMock();
+        $busLocator = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $busLocator->method('has')->with('aBus')->willReturn(true);
+        $busLocator->method('get')->with('aBus')->willReturn($messageBus);
+
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+
+        $kernelTerminateTransportFactory = new KernelTerminateTransportFactory($busLocator, $eventDispatcher);
+        $transport = $kernelTerminateTransportFactory->createTransport('symfony://kernel.terminate', array('bus' => 'aBus'));
+
+        $this->assertInstanceOf(TransportInterface::class, $transport);
+    }
+
+    /**
+     * @dataProvider dsnProvider
+     */
+    public function testItSupportsKernelTerminateTransport(string $dsn, array $options, $expected)
+    {
+        $busLocator = $this->getMockBuilder(ContainerInterface::class)->getMock();
+
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+
+        $kernelTerminateTransportFactory = new KernelTerminateTransportFactory($busLocator, $eventDispatcher);
+        $supports = $kernelTerminateTransportFactory->supports($dsn, $options);
+
+        $this->assertEquals($expected, $supports);
+    }
+
+    public function dsnProvider()
+    {
+        yield array('symfony://kernel.terminate?x=y', array(), true);
+        yield array('symfony://kernel.terminate', array(), true);
+        yield array('aSymfony://kernel.terminate', array(), false);
+        yield array('symfony://kernel.exception', array(), false);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Messenger\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The given kernel.terminate DSN "http://" is invalid.
+     */
+    public function testItThrowsExceptionIfIncorrectDsnFormat()
+    {
+        $busLocator = $this->getMockBuilder(ContainerInterface::class)->getMock();
+
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+
+        $kernelTerminateTransportFactory = new KernelTerminateTransportFactory($busLocator, $eventDispatcher);
+        $kernelTerminateTransportFactory->createTransport('http://', array());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Messenger\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Missing mandatory "bus" option for kernel.terminate transport with DSN "symfony://kernel.terminate"
+     */
+    public function testItThrowsExceptionIfNoBusProvided()
+    {
+        $busLocator = $this->getMockBuilder(ContainerInterface::class)->getMock();
+
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+
+        $kernelTerminateTransportFactory = new KernelTerminateTransportFactory($busLocator, $eventDispatcher);
+        $kernelTerminateTransportFactory->createTransport('symfony://kernel.terminate', array());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Messenger\Exception\InvalidArgumentException
+     * @expectedExceptionMessage No bus was found with id "aBus" for kernel.terminate transport with DSN "symfony://kernel.terminate"
+     */
+    public function testItThrowsExceptionIfBusIsNotFound()
+    {
+        $busLocator = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $busLocator->method('has')->with('aBus')->willReturn(false);
+
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+
+        $kernelTerminateTransportFactory = new KernelTerminateTransportFactory($busLocator, $eventDispatcher);
+        $kernelTerminateTransportFactory->createTransport('symfony://kernel.terminate', array('bus' => 'aBus'));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/MemoryTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/MemoryTransportTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Transport\MemoryTransport;
+
+class MemoryTransportTest extends TestCase
+{
+    public function testItHandlesEnvelopes()
+    {
+        $transport = new MemoryTransport(new aBus());
+        $transport->send(new Envelope($aMessage = new aMessage()));
+        $transport->receive(function (Envelope $envelope) {
+            $envelope->getMessage()->setMessage('Lorem ipsum');
+        });
+
+        $this->assertEquals('Lorem ipsum', $aMessage->getMessage());
+    }
+
+    public function testItStopsReceivingMessages()
+    {
+        $transport = new MemoryTransport(new aBus());
+        $transport->send(new Envelope($aMessage = new aMessage()));
+        $transport->receive(function (Envelope $envelope) {
+            $envelope->getMessage()->setMessage('Lorem ipsum');
+        });
+
+        $transport->stop();
+        $transport->send(new Envelope($anotherMessage = new aMessage()));
+        $transport->receive(function (Envelope $envelope) {
+            $envelope->getMessage()->setMessage('Sic Amet');
+        });
+
+        $this->assertEquals('Lorem ipsum', $aMessage->getMessage());
+        $this->assertEquals('', $anotherMessage->getMessage());
+    }
+
+    public function testItFlushesMessages()
+    {
+        $transport = new MemoryTransport($aBus = new aBus());
+        $transport->send(new Envelope($aMessage = new aMessage('myId')));
+        $transport->flush();
+
+        $envelope = $aBus->getEnvelopes()[0];
+
+        $this->assertEquals($envelope->getMessage()->getId(), $aMessage->getId());
+        $stamps = $envelope->all();
+        $this->assertCount(1, $stamps);
+        $this->assertInstanceOf(ReceivedStamp::class, $stamps['Symfony\Component\Messenger\Stamp\ReceivedStamp'][0]);
+    }
+}
+
+class aMessage
+{
+    private $message = '';
+    private $id = '';
+
+    public function __construct(?string $id = '')
+    {
+        $this->id = $id;
+    }
+
+    public function setMessage(string $message): void
+    {
+        $this->message = $message;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}
+
+class aBus implements MessageBusInterface
+{
+    private $envelopes;
+
+    public function dispatch($envelope): Envelope
+    {
+        $this->envelopes[] = $envelope;
+
+        return $envelope;
+    }
+
+    public function getEnvelopes()
+    {
+        return $this->envelopes;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/KernelTerminateTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/KernelTerminateTransportFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+
+class KernelTerminateTransportFactory implements TransportFactoryInterface
+{
+    private $busLocator;
+    private $eventDispatcher;
+
+    public function __construct(ContainerInterface $busLocator, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->busLocator = $busLocator;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function createTransport(string $dsn, array $options): TransportInterface
+    {
+        if (false === $parsedUrl = parse_url($dsn)) {
+            throw new InvalidArgumentException(sprintf('The given kernel.terminate DSN "%s" is invalid.', $dsn));
+        }
+
+        $kernelTerminateBusId = $transport['options']['bus'] ?? null;
+        if ($kernelTerminateBusId && !$this->busLocator->has($kernelTerminateBusId)) {
+            throw new InvalidArgumentException(sprintf('No bus with id "%s" was found in framework.messenger.buses config for transport "%s". Known buses are %s.', $kernelTerminateBusId, $name, json_encode(array_keys($buses))));
+        }
+
+        $parsedQuery = array();
+        parse_str($parsedUrl['query'] ?? null, $parsedQuery);
+        $busId = $parsedQuery['bus'] ?? $options['bus'] ?? null;
+
+        if (null === $busId) {
+            throw new InvalidArgumentException(sprintf('Missing mandatory "bus" option for kernel.terminate transport with DSN "%s"', $dsn));
+        }
+
+        if (!$this->busLocator->has($busId)) {
+            throw new InvalidArgumentException(sprintf('No bus was found with id "%s" for kernel.terminate transport with DSN "%s"', $busId, $dsn));
+        }
+
+        $transport = new MemoryTransport($this->busLocator->get($busId));
+
+        $this->eventDispatcher->addListener(KernelEvents::TERMINATE, array($transport, 'flush'));
+        $this->eventDispatcher->addListener(KernelEvents::EXCEPTION, array($transport, 'stop'));
+
+        return $transport;
+    }
+
+    public function supports(string $dsn, array $options): bool
+    {
+        return 0 === strpos($dsn, 'symfony://kernel.terminate');
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/MemoryTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/MemoryTransport.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+
+class MemoryTransport implements TransportInterface
+{
+    private $envelopes = array();
+    private $bus;
+    private $stopped = false;
+
+    public function __construct(MessageBusInterface $bus)
+    {
+        $this->bus = $bus;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function receive(callable $handler): void
+    {
+        if (!$this->stopped) {
+            while (\count($this->envelopes) > 0) {
+                $handler(array_shift($this->envelopes));
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stop(): void
+    {
+        $this->stopped = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Envelope $envelope): Envelope
+    {
+        $this->envelopes[] = $envelope;
+
+        return $envelope;
+    }
+
+    public function flush(): void
+    {
+        $this->receive(function (Envelope $envelope) {
+            if (null === $envelope) {
+                return;
+            }
+
+            $this->bus->dispatch($envelope->with(new ReceivedStamp()));
+        });
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #28646
| License       | MIT
| Doc PR        | 

I'm not sure if this is what Nicolas was asking for in this issue: https://github.com/symfony/symfony/issues/28646#issuecomment-426417626
If it is, there are some questions that need general consensus:
* Is it worth splitting this file into a listener and a handler and inject the handler in the listener?
* Should the listener be in messenger component, in framework bundle or where?
* Should the service definition: eg: tags for being processed as a handler and as an event subscriber be documented and configured manually by the user or should we put some kind of automation in place?