### PR TITLE
[Validator] Added "G" for maxsize suffix

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -104,6 +104,8 @@ class File extends Constraint
             'ki' => 1 << 10,
             'm' => 1000000,
             'mi' => 1 << 20,
+            'g' => 1000000000,
+            'gi' => 1 << 30,
         );
         if (ctype_digit((string) $maxSize)) {
             $this->maxSize = (int) $maxSize;


### PR DESCRIPTION
This commit affect 3.3 up to 4.1

PHP allows shortcuts for byte values, including K (kilo), M (mega) and G (giga).

More info here: http://php.net/manual/en/ini.core.php
