### PR TITLE
Add a messenger middleware to enforce null results

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -29,6 +29,7 @@
         <service id="messenger.middleware.call_message_handler" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">
             <argument /> <!-- Bus handler resolver -->
         </service>
+        <service id="messenger.middleware.enforce_null_result" class="Symfony\Component\Messenger\Middleware\EnforceNullResultMiddleware" abstract="true" />
 
         <service id="messenger.middleware.validation" class="Symfony\Component\Messenger\Middleware\ValidationMiddleware" abstract="true">
             <argument type="service" id="validator" />

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * [BC BREAK] The `EncoderInterface` and `DecoderInterface` have been replaced by a unified `Symfony\Component\Messenger\Transport\Serialization\SerializerInterface`.
  * [BC BREAK] The locator passed to `ContainerHandlerLocator` should not prefix its keys by "handler." anymore
  * [BC BREAK] The `AbstractHandlerLocator::getHandler()` method uses `?callable` as return type
+ * Added a `EnforceNullResultMiddleware` middleware
 
 4.1.0
 -----

--- a/src/Symfony/Component/Messenger/Exception/NonNullResultException.php
+++ b/src/Symfony/Component/Messenger/Exception/NonNullResultException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * @author Paul Le Corre <paul@lecorre.me>
+ */
+class NonNullResultException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Messenger/Middleware/EnforceNullResultMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/EnforceNullResultMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Exception\NonNullResultException;
+
+/**
+ * @author Paul Le Corre <paul@lecorre.me>
+ */
+class EnforceNullResultMiddleware implements MiddlewareInterface
+{
+    public function handle($message, callable $next)
+    {
+        $result = $next($message);
+        if (null !== $result) {
+            throw new NonNullResultException(sprintf('Non null result for message %s.', \get_class($message)));
+        }
+
+        return $result;
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/EnforceNullResultMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/EnforceNullResultMiddleware.php
@@ -22,7 +22,7 @@ class EnforceNullResultMiddleware implements MiddlewareInterface
     {
         $result = $next($message);
         if (null !== $result) {
-            throw new NonNullResultException(sprintf('Non null result for message "%s": at least one handler returned something but this is prohibited by this middleware..', \get_class($message)));
+            throw new NonNullResultException(sprintf('Non null result for message "%s": at least one handler returned something but this is prohibited by this middleware.', \get_class($message)));
         }
 
         return $result;

--- a/src/Symfony/Component/Messenger/Middleware/EnforceNullResultMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/EnforceNullResultMiddleware.php
@@ -22,7 +22,7 @@ class EnforceNullResultMiddleware implements MiddlewareInterface
     {
         $result = $next($message);
         if (null !== $result) {
-            throw new NonNullResultException(sprintf('Non null result for message %s.', \get_class($message)));
+            throw new NonNullResultException(sprintf('Non null result for message "%s": at least one handler returned something but this is prohibited by this middleware..', \get_class($message)));
         }
 
         return $result;

--- a/src/Symfony/Component/Messenger/Tests/Middleware/EnforceNullResultMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/EnforceNullResultMiddlewareTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Middleware\EnforceNullResultMiddleware;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+class EnforceNullResultMiddlewareTest extends TestCase
+{
+    public function testItCallsNextMiddleware()
+    {
+        $message = new DummyMessage('Hey');
+
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next->expects($this->once())->method('__invoke')->with($message);
+
+        $middleware = new EnforceNullResultMiddleware();
+        $middleware->handle($message, $next);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Messenger\Exception\NonNullResultException
+     * @expectedExceptionMessage Non null result for message Symfony\Component\Messenger\Tests\Fixtures\DummyMessage.
+     */
+    public function testItThrowExceptionOnNonNullResult()
+    {
+        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
+        $next->expects($this->once())->method('__invoke')->will($this->returnValue('Non null value'));
+
+        $middleware = new EnforceNullResultMiddleware();
+        $middleware->handle(new DummyMessage('Hey'), $next);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/EnforceNullResultMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/EnforceNullResultMiddlewareTest.php
@@ -30,7 +30,7 @@ class EnforceNullResultMiddlewareTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\Messenger\Exception\NonNullResultException
-     * @expectedExceptionMessage Non null result for message Symfony\Component\Messenger\Tests\Fixtures\DummyMessage.
+     * @expectedExceptionMessage Non null result for message "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage": at least one handler returned something but this is prohibited by this middleware.
      */
     public function testItThrowExceptionOnNonNullResult()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #27839   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10442 <!-- required for new features -->

A little middleware to make sure a message bus doesn't return any result.