### PR TITLE
[WebProfilerBundle] Extract server parameters into their own tab

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -186,17 +186,6 @@
                         <p>No content</p>
                     </div>
                 {% endif %}
-
-                <h3>Server Parameters</h3>
-                <h4>Defined in .env</h4>
-                {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: collector.dotenvvars }, with_context = false) }}
-
-                <h4>Defined as regular env variables</h4>
-                {% set requestserver = [] %}
-                {% for key, value in collector.requestserver if key not in collector.dotenvvars.keys %}
-                    {% set requestserver = requestserver|merge({(key): value}) %}
-                {% endfor %}
-                {{ include('@WebProfiler/Profiler/table.html.twig', { data: requestserver }, with_context = false) }}
             </div>
         </div>
 
@@ -275,6 +264,22 @@
                 {% else %}
                     {{ include('@WebProfiler/Profiler/table.html.twig', { data: collector.flashes }, with_context = false) }}
                 {% endif %}
+            </div>
+        </div>
+
+        <div class="tab">
+            <h3 class="tab-title">Server Parameters</h3>
+            <div class="tab-content">
+                <h3>Server Parameters</h3>
+                <h4>Defined in .env</h4>
+                {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: collector.dotenvvars }, with_context = false) }}
+
+                <h4>Defined as regular env variables</h4>
+                {% set requestserver = [] %}
+                {% for key, value in collector.requestserver if key not in collector.dotenvvars.keys %}
+                    {% set requestserver = requestserver|merge({(key): value}) %}
+                {% endfor %}
+                {{ include('@WebProfiler/Profiler/table.html.twig', { data: requestserver }, with_context = false) }}
             </div>
         </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes-ish
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

As using env vars is important as of Symfony 4, I think they deserves their own tab under the request section.


<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
