### PR TITLE
[Messenger] Add possibility to define routing key when sending message throught amqp

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/Stamp/RoutingKeyStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/Stamp/RoutingKeyStampTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\AmqpExt\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Transport\AmqpExt\Stamp\RoutingKeyStamp;
+
+/**
+ * @author Vincent Touzet <vincent.touzet@gmail.com>
+ */
+class RoutingKeyStampTest extends TestCase
+{
+    public function testSerializable()
+    {
+        $stamp = new RoutingKeyStamp('dummy_routing');
+
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\AmqpExt\Stamp\RoutingKeyStamp;
 use Symfony\Component\Messenger\Transport\SenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -37,8 +38,13 @@ class AmqpSender implements SenderInterface
      */
     public function send(Envelope $envelope)
     {
+        $routingKey = null;
+        /** @var RoutingKeyStamp|null $routingKeyConfig */
+        if ($routingKeyConfig = $envelope->get(RoutingKeyStamp::class)) {
+            $routingKey = $routingKeyConfig->getRoutingKey();
+        }
         $encodedMessage = $this->serializer->encode($envelope);
 
-        $this->connection->publish($encodedMessage['body'], $encodedMessage['headers']);
+        $this->connection->publish($encodedMessage['body'], $encodedMessage['headers'], $routingKey);
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -94,13 +94,13 @@ class Connection
     /**
      * @throws \AMQPException
      */
-    public function publish(string $body, array $headers = array()): void
+    public function publish(string $body, array $headers = array(), string $routingKey = null): void
     {
         if ($this->debug && $this->shouldSetup()) {
             $this->setup();
         }
 
-        $this->exchange()->publish($body, null, AMQP_NOPARAM, array('headers' => $headers));
+        $this->exchange()->publish($body, $routingKey, AMQP_NOPARAM, array('headers' => $headers));
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Stamp/RoutingKeyStamp.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Stamp/RoutingKeyStamp.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\AmqpExt\Stamp;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * @author Vincent Touzet <vincent.touzet@gmail.com>
+ */
+final class RoutingKeyStamp implements StampInterface
+{
+    private $routingKey;
+
+    public function __construct(string $routingKey)
+    {
+        $this->routingKey = $routingKey;
+    }
+
+    public function getRoutingKey(): string
+    {
+        return $this->routingKey;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
 Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes    
| Fixed tickets | #28133
| License       | MIT

As describe in #28133 we can't actually define a custom routing key when sending message. It is now possible with the `Symfony\Component\Messenger\Stamp\AMQP\RoutingKeyStamp`

```php
$envelop = Envelop::wrap($message)->with(new RoutingKeyStamp('dummy_routing'));
```

