### PR TITLE
[WIP][Serializer]Use PropertyInfo to extract properties

### DIFF
--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -1,11 +1,15 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+* added `exclude_static_properties` option to `ReflectionExtractor` to exclude public static properties when listing properties
+
 4.2.0
 -----
 
 * added `PropertyInitializableExtractorInterface` to test if a property can be initialized through the constructor (implemented by `ReflectionExtractor`)
-* added `exclude_static_properties` option to `ReflectionExtractor` to exclude public static properties when listing properties
 
 3.3.0
 -----

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 * added `PropertyInitializableExtractorInterface` to test if a property can be initialized through the constructor (implemented by `ReflectionExtractor`)
+* added `exclude_static_properties` option to `ReflectionExtractor` to exclude public static properties when listing properties
 
 3.3.0
 -----

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -27,6 +27,8 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface
 {
+    public const EXCLUDE_STATIC_PROPERTIES = 'exclude_static_properties';
+
     /**
      * @internal
      */
@@ -75,7 +77,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         $properties = array();
         foreach ($reflectionProperties as $reflectionProperty) {
-            if ($reflectionProperty->isPublic()) {
+            if ($reflectionProperty->isPublic() && (!($context[self::EXCLUDE_STATIC_PROPERTIES] ?? false) || !$reflectionProperty->isStatic())) {
                 $properties[$reflectionProperty->name] = $reflectionProperty->name;
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -46,8 +46,8 @@ class ReflectionExtractorTest extends TestCase
 
     public function getPropertiesProvider()
     {
-        return [
-            [
+        return array(
+            array(
                 'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy',
                 array(
                     'bal',
@@ -87,16 +87,16 @@ class ReflectionExtractorTest extends TestCase
                 null,
                 null,
                 array(),
-            ],
-            [
+            ),
+            array(
                 'Symfony\Component\PropertyInfo\Tests\Fixtures\NoProperties',
                 null,
                 null,
                 null,
                 null,
                 array(),
-            ],
-            [
+            ),
+            array(
                 'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy',
                 array(
                     'bal',
@@ -130,8 +130,8 @@ class ReflectionExtractorTest extends TestCase
                 array('is', 'can'),
                 null,
                 array(),
-            ],
-            [
+            ),
+            array(
                 'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy',
                 array(
                     'bal',
@@ -161,8 +161,8 @@ class ReflectionExtractorTest extends TestCase
                 array(),
                 array(),
                 array(),
-            ],
-            [
+            ),
+            array(
                 'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy',
                 array(
                     'bal',
@@ -202,9 +202,9 @@ class ReflectionExtractorTest extends TestCase
                 null,
                 array(
                     ReflectionExtractor::EXCLUDE_STATIC_PROPERTIES => true,
-                )
-            ]
-        ];
+                ),
+            ),
+        );
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -49,6 +49,7 @@ class ReflectionExtractorTest extends TestCase
                 'h',
                 'i',
                 'j',
+                'k',
                 'emptyVar',
                 'iteratorCollection',
                 'iteratorCollectionWithKey',
@@ -93,6 +94,7 @@ class ReflectionExtractorTest extends TestCase
                 'h',
                 'i',
                 'j',
+                'k',
                 'emptyVar',
                 'iteratorCollection',
                 'iteratorCollectionWithKey',
@@ -129,6 +131,7 @@ class ReflectionExtractorTest extends TestCase
                 'h',
                 'i',
                 'j',
+                'k',
                 'emptyVar',
                 'iteratorCollection',
                 'iteratorCollectionWithKey',
@@ -142,6 +145,50 @@ class ReflectionExtractorTest extends TestCase
             ),
             $noPrefixExtractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')
         );
+    }
+
+    public function testGetPropertiesWithoutStaticProperties()
+    {
+        $this->assertSame(
+            array(
+                'bal',
+                'parent',
+                'collection',
+                'nestedCollection',
+                'mixedCollection',
+                'B',
+                'Guid',
+                'g',
+                'h',
+                'i',
+                'j',
+                'emptyVar',
+                'iteratorCollection',
+                'iteratorCollectionWithKey',
+                'nestedIterators',
+                'foo',
+                'foo2',
+                'foo3',
+                'foo4',
+                'foo5',
+                'files',
+                'a',
+                'DOB',
+                'Id',
+                '123',
+                'self',
+                'realParent',
+                'c',
+                'd',
+                'e',
+                'f',
+            ),
+            $this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', array(
+                ReflectionExtractor::EXCLUDE_STATIC_PROPERTIES => true,
+            ))
+        );
+
+        $this->assertNull($this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\NoProperties'));
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -34,161 +34,177 @@ class ReflectionExtractorTest extends TestCase
         $this->extractor = new ReflectionExtractor();
     }
 
-    public function testGetProperties()
+    /**
+     * @dataProvider getPropertiesProvider
+     */
+    public function testGetProperties($class, $expected, $mutatorPrefixes, $accessorPrefixes, $arrayMutatorPrefixes, $context)
     {
-        $this->assertSame(
-            array(
-                'bal',
-                'parent',
-                'collection',
-                'nestedCollection',
-                'mixedCollection',
-                'B',
-                'Guid',
-                'g',
-                'h',
-                'i',
-                'j',
-                'k',
-                'emptyVar',
-                'iteratorCollection',
-                'iteratorCollectionWithKey',
-                'nestedIterators',
-                'foo',
-                'foo2',
-                'foo3',
-                'foo4',
-                'foo5',
-                'files',
-                'a',
-                'DOB',
-                'Id',
-                '123',
-                'self',
-                'realParent',
-                'c',
-                'd',
-                'e',
-                'f',
-            ),
-            $this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')
-        );
+        $extractor = new ReflectionExtractor($mutatorPrefixes, $accessorPrefixes, $arrayMutatorPrefixes);
 
-        $this->assertNull($this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\NoProperties'));
+        $this->assertSame($expected, $extractor->getProperties($class, $context));
     }
 
-    public function testGetPropertiesWithCustomPrefixes()
+    public function getPropertiesProvider()
     {
-        $customExtractor = new ReflectionExtractor(array('add', 'remove'), array('is', 'can'));
-
-        $this->assertSame(
-            array(
-                'bal',
-                'parent',
-                'collection',
-                'nestedCollection',
-                'mixedCollection',
-                'B',
-                'Guid',
-                'g',
-                'h',
-                'i',
-                'j',
-                'k',
-                'emptyVar',
-                'iteratorCollection',
-                'iteratorCollectionWithKey',
-                'nestedIterators',
-                'foo',
-                'foo2',
-                'foo3',
-                'foo4',
-                'foo5',
-                'files',
-                'c',
-                'd',
-                'e',
-                'f',
-            ),
-            $customExtractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')
-        );
-    }
-
-    public function testGetPropertiesWithNoPrefixes()
-    {
-        $noPrefixExtractor = new ReflectionExtractor(array(), array(), array());
-
-        $this->assertSame(
-            array(
-                'bal',
-                'parent',
-                'collection',
-                'nestedCollection',
-                'mixedCollection',
-                'B',
-                'Guid',
-                'g',
-                'h',
-                'i',
-                'j',
-                'k',
-                'emptyVar',
-                'iteratorCollection',
-                'iteratorCollectionWithKey',
-                'nestedIterators',
-                'foo',
-                'foo2',
-                'foo3',
-                'foo4',
-                'foo5',
-                'files',
-            ),
-            $noPrefixExtractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')
-        );
-    }
-
-    public function testGetPropertiesWithoutStaticProperties()
-    {
-        $this->assertSame(
-            array(
-                'bal',
-                'parent',
-                'collection',
-                'nestedCollection',
-                'mixedCollection',
-                'B',
-                'Guid',
-                'g',
-                'h',
-                'i',
-                'j',
-                'emptyVar',
-                'iteratorCollection',
-                'iteratorCollectionWithKey',
-                'nestedIterators',
-                'foo',
-                'foo2',
-                'foo3',
-                'foo4',
-                'foo5',
-                'files',
-                'a',
-                'DOB',
-                'Id',
-                '123',
-                'self',
-                'realParent',
-                'c',
-                'd',
-                'e',
-                'f',
-            ),
-            $this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', array(
-                ReflectionExtractor::EXCLUDE_STATIC_PROPERTIES => true,
-            ))
-        );
-
-        $this->assertNull($this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\NoProperties'));
+        return [
+            [
+                'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy',
+                array(
+                    'bal',
+                    'parent',
+                    'collection',
+                    'nestedCollection',
+                    'mixedCollection',
+                    'B',
+                    'Guid',
+                    'g',
+                    'h',
+                    'i',
+                    'j',
+                    'k',
+                    'emptyVar',
+                    'iteratorCollection',
+                    'iteratorCollectionWithKey',
+                    'nestedIterators',
+                    'foo',
+                    'foo2',
+                    'foo3',
+                    'foo4',
+                    'foo5',
+                    'files',
+                    'a',
+                    'DOB',
+                    'Id',
+                    '123',
+                    'self',
+                    'realParent',
+                    'c',
+                    'd',
+                    'e',
+                    'f',
+                ),
+                null,
+                null,
+                null,
+                array(),
+            ],
+            [
+                'Symfony\Component\PropertyInfo\Tests\Fixtures\NoProperties',
+                null,
+                null,
+                null,
+                null,
+                array(),
+            ],
+            [
+                'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy',
+                array(
+                    'bal',
+                    'parent',
+                    'collection',
+                    'nestedCollection',
+                    'mixedCollection',
+                    'B',
+                    'Guid',
+                    'g',
+                    'h',
+                    'i',
+                    'j',
+                    'k',
+                    'emptyVar',
+                    'iteratorCollection',
+                    'iteratorCollectionWithKey',
+                    'nestedIterators',
+                    'foo',
+                    'foo2',
+                    'foo3',
+                    'foo4',
+                    'foo5',
+                    'files',
+                    'c',
+                    'd',
+                    'e',
+                    'f',
+                ),
+                array('add', 'remove'),
+                array('is', 'can'),
+                null,
+                array(),
+            ],
+            [
+                'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy',
+                array(
+                    'bal',
+                    'parent',
+                    'collection',
+                    'nestedCollection',
+                    'mixedCollection',
+                    'B',
+                    'Guid',
+                    'g',
+                    'h',
+                    'i',
+                    'j',
+                    'k',
+                    'emptyVar',
+                    'iteratorCollection',
+                    'iteratorCollectionWithKey',
+                    'nestedIterators',
+                    'foo',
+                    'foo2',
+                    'foo3',
+                    'foo4',
+                    'foo5',
+                    'files',
+                ),
+                array(),
+                array(),
+                array(),
+                array(),
+            ],
+            [
+                'Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy',
+                array(
+                    'bal',
+                    'parent',
+                    'collection',
+                    'nestedCollection',
+                    'mixedCollection',
+                    'B',
+                    'Guid',
+                    'g',
+                    'h',
+                    'i',
+                    'j',
+                    'emptyVar',
+                    'iteratorCollection',
+                    'iteratorCollectionWithKey',
+                    'nestedIterators',
+                    'foo',
+                    'foo2',
+                    'foo3',
+                    'foo4',
+                    'foo5',
+                    'files',
+                    'a',
+                    'DOB',
+                    'Id',
+                    '123',
+                    'self',
+                    'realParent',
+                    'c',
+                    'd',
+                    'e',
+                    'f',
+                ),
+                null,
+                null,
+                null,
+                array(
+                    ReflectionExtractor::EXCLUDE_STATIC_PROPERTIES => true,
+                )
+            ]
+        ];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -94,6 +94,11 @@ class Dummy extends ParentDummy
     public $j;
 
     /**
+     * @var ?string
+     */
+    public static $k;
+
+    /**
      * This should not be removed.
      *
      * @var

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -36,7 +36,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
     private $propertyListExtractor;
 
-    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyAccessorInterface $propertyAccessor = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, callable $objectClassResolver = null, array $defaultContext = array())
+    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyAccessorInterface $propertyAccessor = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, callable $objectClassResolver = null, array $defaultContext = array(), PropertyListExtractorInterface $propertyListExtractor = null)
     {
         if (!\class_exists(PropertyAccess::class)) {
             throw new LogicException('The ObjectNormalizer class requires the "PropertyAccess" component. Install "symfony/property-access" to use it.');

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -61,11 +61,16 @@ class ObjectNormalizer extends AbstractObjectNormalizer
      */
     protected function extractAttributes($object, $format = null, array $context = array())
     {
-        $properties = $this->propertyListExtractor->getProperties(get_class($object), ['exclude_static_properties' => true]);
+        $properties = $this->propertyListExtractor->getProperties(\get_class($object), array(ReflectionExtractor::EXCLUDE_STATIC_PROPERTIES => true));
 
-        return array_filter($properties, function (string $attribute) use ($object, $format, $context) {
-            return $this->isAllowedAttribute($object, $attribute, $format, $context);
-        });
+        $allowedProperties = array();
+        foreach ($properties as $property) {
+            if ($this->isAllowedAttribute($object, $property, $format, $context)) {
+                $allowedProperties[] = $property;
+            }
+        }
+
+        return $allowedProperties;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -867,7 +867,7 @@ class ObjectNormalizerTest extends TestCase
         $data->setFoo('bar');
         $data->bar = 'foo';
 
-        $this->assertSame(array('foo' => 'bar', 'bar' => 'foo'), $normalizer->normalize($data, 'foo_and_bar_included'));
+        $this->assertSame(array('bar' => 'foo', 'foo' => 'bar'), $normalizer->normalize($data, 'foo_and_bar_included'));
     }
 
     public function testExtractAttributesRespectsContext()
@@ -878,7 +878,7 @@ class ObjectNormalizerTest extends TestCase
         $data->setFoo('bar');
         $data->bar = 'foo';
 
-        $this->assertSame(array('foo' => 'bar', 'bar' => 'foo'), $normalizer->normalize($data, null, array('include_foo_and_bar' => true)));
+        $this->assertSame(array('bar' => 'foo', 'foo' => 'bar'), $normalizer->normalize($data, null, array('include_foo_and_bar' => true)));
     }
 
     public function testAttributesContextNormalize()

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/polyfill-ctype": "~1.8"
+        "symfony/polyfill-ctype": "~1.8",
+        "symfony/property-info": "~4.2"
     },
     "require-dev": {
         "symfony/yaml": "~3.4|~4.0",
@@ -25,7 +26,6 @@
         "symfony/property-access": "~3.4|~4.0",
         "symfony/http-foundation": "~3.4|~4.0",
         "symfony/cache": "~3.4|~4.0",
-        "symfony/property-info": "~3.4|~4.0",
         "symfony/validator": "~3.4|~4.0",
         "doctrine/annotations": "~1.0",
         "symfony/dependency-injection": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ?
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10530

This is a small refactoring to reduce the complexity of the ObjectNormalizer. It now use a `PropertyListExtractorInterface` to get the class properties list.

To achieve this, I also added a `exclude_static_properties` option to the `ReflectionExtractor::getProperties` method.

Starting from this PR, `symfony/serializer` has a hard dependency on `symfony/property-info`.

This was exposed by @dunglas in https://github.com/symfony/symfony/pull/19374#issuecomment-418889589.

# To do
- [x] add a CHANGELOG.md entry.
- [x] documentation for `exclude_static_properties`.
- [x] check for performance regression.
