### PR TITLE
[CS] Enable phpdoc_types_order

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -19,6 +19,8 @@ return PhpCsFixer\Config::create()
         'self_accessor' => false,
         // Part of @Symfony:risky in PHP-CS-Fixer 2.13.0. To be removed from the config file once upgrading
         'native_function_invocation' => array('include' => array('@compiler_optimized'), 'scope' => 'namespaced'),
+        // Part of future @Symfony ruleset in PHP-CS-Fixer To be removed from the config file once upgrading
+        'phpdoc_types_order' => array('null_adjustment' => 'always_last', 'sort_algorithm' => 'none'),
     ))
     ->setRiskyAllowed(true)
     ->setFinder(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | -

As suggested by @jvasseur in https://github.com/symfony/symfony/pull/28675#issuecomment-427666988, we can use the `phpdoc_types_order` rule from PHP-CS-Fixer to ensure that `null` is always on the last position in phpDocs as proposed in #28675.