### PR TITLE
[FrameworkBundle] Added PhpFilesAdapter as a standard adapter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Deprecated the `--no-debug` console option, set the "APP_DEBUG" 
    environment variable to "0" instead.
  * Deprecated the `Templating\Helper\TranslatorHelper::transChoice()` method, use the `trans()` one instead with a `%count%` parameter
+ * Added `cache.adapter.php_files` cache pool that instantiates  `Symfony\Component\Cache\Adapter\PhpFilesAdapter`
 
 4.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -81,6 +81,18 @@
             </call>
         </service>
 
+        <service id="cache.adapter.php_files" class="Symfony\Component\Cache\Adapter\PhpFilesAdapter" abstract="true">
+            <tag name="cache.pool" clearer="cache.default_clearer" />
+            <tag name="monolog.logger" channel="cache" />
+            <argument /> <!-- namespace -->
+            <argument>0</argument> <!-- default lifetime -->
+            <argument>%kernel.cache_dir%/pools</argument>
+            <argument>false</argument> <!-- not append only, every use case must be possible -->
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore" />
+            </call>
+        </service>
+
         <service id="cache.adapter.psr6" class="Symfony\Component\Cache\Adapter\ProxyAdapter" abstract="true">
             <tag name="cache.pool" provider="cache.default_psr6_provider" clearer="cache.default_clearer" />
             <argument /> <!-- PSR-6 provider service -->

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
@@ -24,6 +24,10 @@ $container->loadFromExtension('framework', array(
             'cache.def' => array(
                 'default_lifetime' => 11,
             ),
+            'cache.foobaz' => array(
+                'adapter' => 'cache.adapter.php_files',
+                'default_lifetime' => 12,
+            ),
         ),
     ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
@@ -12,6 +12,7 @@
             <framework:pool name="cache.baz" adapter="cache.adapter.filesystem" default-lifetime="7" />
             <framework:pool name="cache.foobar" adapter="cache.adapter.psr6" default-lifetime="10" provider="app.cache_pool" />
             <framework:pool name="cache.def" default-lifetime="11" />
+            <framework:pool name="cache.foobaz" adapter="cache.adapter.php_files" default-lifetime="12" />
         </framework:cache>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
@@ -17,3 +17,6 @@ framework:
                 provider: app.cache_pool
             cache.def:
                 default_lifetime: 11
+            cache.foobaz:
+                adapter: cache.adapter.php_files
+                default_lifetime: 12

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -1202,6 +1203,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.baz', 'cache.adapter.filesystem', 7);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foobar', 'cache.adapter.psr6', 10);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.def', 'cache.app', 11);
+        $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foobaz', 'cache.adapter.php_files', 12);
     }
 
     public function testRemovesResourceCheckerConfigCacheFactoryArgumentOnlyIfNoDebug()
@@ -1358,6 +1360,9 @@ abstract class FrameworkExtensionTest extends TestCase
                 // no break
             case 'cache.adapter.filesystem':
                 $this->assertSame(FilesystemAdapter::class, $parentDefinition->getClass());
+                break;
+            case 'cache.adapter.php_files':
+                $this->assertSame(PhpFilesAdapter::class, $parentDefinition->getClass());
                 break;
             case 'cache.adapter.psr6':
                 $this->assertSame(ProxyAdapter::class, $parentDefinition->getClass());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | (none)
| License       | MIT
| Doc PR        | symfony/symfony-docs#10459

Added `Symfony\Component\Cache\Adapter\PhpFilesAdapter` also as a non-system adapter with the service ID `cache.adapter.php_files`.
