### PR TITLE
[Security][SecurityBundle] Add is_granted feature for impersonator on AuthorizationChecker

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/SwitchRoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/SwitchRoleVoter.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+
+/**
+ * SwitchRoleVoter votes if we check the impersonator roles.
+ *
+ * @author Fabien Papet <fabien.papet@gmail.com>
+ */
+class SwitchRoleVoter implements VoterInterface
+{
+    /**
+     * @var AccessDecisionManager
+     */
+    private $accessDecisionManager;
+    private $prefix;
+
+    public function __construct(AccessDecisionManager $accessDecisionManager, string $prefix = 'IMPERSONATOR_')
+    {
+        $this->accessDecisionManager = $accessDecisionManager;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function vote(TokenInterface $token, $subject, array $attributes)
+    {
+        $result = VoterInterface::ACCESS_ABSTAIN;
+
+        if (!$token instanceof SwitchUserToken) {
+            return VoterInterface::ACCESS_DENIED;
+        }
+
+        foreach ($attributes as $attribute) {
+            if (!\is_string($attribute) || 0 !== strpos($attribute, $this->prefix)) {
+                continue;
+            }
+
+            return $this->accessDecisionManager->decide($token->getOriginalToken(), [substr($attribute, \strlen($this->prefix))], $subject);
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes  <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | no test yet
| License       | MIT
| Doc PR        | Not yet

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->

This feature adds a new is*Granted function for the user impersonating another user. I may need some help for tests and also for the function naming. A twig extension may be added if you want to (or in another PR).


# Todo
- [ ] Add doc
- [ ] Add tests



