### PR TITLE
Revert "feature #27549 [Cache] Unconditionally use PhpFilesAdapter for system pools"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1601,6 +1601,7 @@ class FrameworkExtension extends Extension
 
         $version = new Parameter('container.build_id');
         $container->getDefinition('cache.adapter.apcu')->replaceArgument(2, $version);
+        $container->getDefinition('cache.adapter.system')->replaceArgument(2, $version);
         $container->getDefinition('cache.adapter.filesystem')->replaceArgument(2, $config['directory']);
 
         if (isset($config['prefix_seed'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -35,16 +35,15 @@
             <tag name="cache.pool" />
         </service>
 
-        <service id="cache.adapter.system" class="Symfony\Component\Cache\Adapter\PhpFilesAdapter" abstract="true">
+        <service id="cache.adapter.system" class="Symfony\Component\Cache\Adapter\AdapterInterface" abstract="true">
+            <factory class="Symfony\Component\Cache\Adapter\AbstractAdapter" method="createSystemCache" />
             <tag name="cache.pool" clearer="cache.system_clearer" />
             <tag name="monolog.logger" channel="cache" />
             <argument /> <!-- namespace -->
             <argument>0</argument> <!-- default lifetime -->
+            <argument /> <!-- version -->
             <argument>%kernel.cache_dir%/pools</argument>
-            <argument>true</argument>
-            <call method="setLogger">
-                <argument type="service" id="logger" on-invalid="ignore" />
-            </call>
+            <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
         <service id="cache.adapter.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" abstract="true">

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -12,7 +12,6 @@ CHANGELOG
  * added automatic table creation when using Doctrine DBAL with PDO-based backends
  * throw `LogicException` when `CacheItem::tag()` is called on an item coming from a non tag-aware pool
  * deprecated `CacheItem::getPreviousTags()`, use `CacheItem::getMetadata()` instead
- * deprecated the `AbstractAdapter::createSystemCache()` method
  * deprecated the `AbstractAdapter::unserialize()` and `AbstractCache::unserialize()` methods
  * added `CacheCollectorPass` (originally in `FrameworkBundle`)
  * added `CachePoolClearerPass` (originally in `FrameworkBundle`)


### PR DESCRIPTION
This reverts commit d4f5d46b132a83be32aa495907f9dd08c76ce305, reversing
changes made to 7e3b7b0b5069a6b791b577de19e72aaff4c7d26e.

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Reading #28800, I've just realized that #27549 breaks using system caches with read-only filesystem.
Using ApcuAdapter makes system caches compatible with read-only filesystems.
Note that this affects only non-warmed up pools, as the warmed-up ones use a faster `PhpArrayAdapter` in front.