### PR TITLE
[Form] add a convenience method to get the parent form in Twig templates

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added the `parent_form()` function that allows to reliably retrieve the parent form in Twig templates
+
 4.2.0
 -----
 

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -54,6 +54,7 @@ class FormExtension extends AbstractExtension
             new TwigFunction('form_start', null, ['node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => ['html']]),
             new TwigFunction('form_end', null, ['node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => ['html']]),
             new TwigFunction('csrf_token', ['Symfony\Component\Form\FormRenderer', 'renderCsrfToken']),
+            new TwigFunction('parent_form', 'Symfony\Bridge\Twig\Extension\twig_get_parent_form'),
         ];
     }
 
@@ -114,4 +115,12 @@ function twig_is_selected_choice(ChoiceView $choice, $selectedValue)
 function twig_is_root_form(FormView $formView)
 {
     return null === $formView->parent;
+}
+
+/**
+ * @internal
+ */
+function twig_get_parent_form(FormView $formView): ?FormView
+{
+    return $formView->parent;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28686
| License       | MIT
| Doc PR        | symfony/symfony-docs#10999