### PR TITLE
Fix for race condition in console output stream write

### DIFF
--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -70,7 +70,11 @@ class StreamOutput extends Output
      */
     protected function doWrite($message, $newline)
     {
-        if (false === @fwrite($this->stream, $message) || ($newline && (false === @fwrite($this->stream, PHP_EOL)))) {
+        if ($newline) {
+            $message .= PHP_EOL;
+        }
+
+        if (false === @fwrite($this->stream, $message)) {
             // should never happen
             throw new RuntimeException('Unable to write output.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

In high throughput environments writing `message` and `PHP_EOL` separately causes race condition issues, where messages might be written in order 

- message
- message
- EOL
- EOL

instead of

- message
- EOL
- message
- EOL

An example below is a laravel application log tail of queue workers  (multiple app instances writing to the same log file) handled by supervisor.

Before:
![ezgif-1-77388f9210cf](https://user-images.githubusercontent.com/2752769/46792349-bec13180-cd75-11e8-8f91-92f05762f964.gif)

After:
![ezgif-1-0b839d642644](https://user-images.githubusercontent.com/2752769/46792420-e617fe80-cd75-11e8-9414-4bfc85d9c569.gif)

