### PR TITLE
YamlEncoder handle yml format

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 * `AbstractNormalizer::handleCircularReference` is now final, and receives two optional extra arguments: the format and the context
+* `YamlEncoder` now handle the `.yml` extension too
 
 4.1.0
 -----

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -23,6 +23,7 @@ use Symfony\Component\Yaml\Parser;
 class YamlEncoder implements EncoderInterface, DecoderInterface
 {
     const FORMAT = 'yaml';
+    const ALTERNATIVE_FORMAT = 'yml';
 
     private $dumper;
     private $parser;
@@ -54,7 +55,7 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
      */
     public function supportsEncoding($format)
     {
-        return self::FORMAT === $format;
+        return self::FORMAT === $format || self::ALTERNATIVE_FORMAT === $format;
     }
 
     /**
@@ -72,6 +73,6 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
      */
     public function supportsDecoding($format)
     {
-        return self::FORMAT === $format;
+        return self::FORMAT === $format || self::ALTERNATIVE_FORMAT === $format;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
@@ -35,6 +35,7 @@ class YamlEncoderTest extends TestCase
         $encoder = new YamlEncoder();
 
         $this->assertTrue($encoder->supportsEncoding('yaml'));
+        $this->assertTrue($encoder->supportsEncoding('yml'));
         $this->assertFalse($encoder->supportsEncoding('json'));
     }
 
@@ -51,6 +52,7 @@ class YamlEncoderTest extends TestCase
         $encoder = new YamlEncoder();
 
         $this->assertTrue($encoder->supportsDecoding('yaml'));
+        $this->assertTrue($encoder->supportsDecoding('yml'));
         $this->assertFalse($encoder->supportsDecoding('json'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | ?
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #28768
| License       | MIT

`Symfony\Component\Serializer\Encoder\YamlEncoder` now handle the `yml` format too

```
use Symfony\Component\Serializer\Serializer;
use Symfony\Component\Serializer\Encoder\YamlEncoder;

$serializer = new Serializer([], [new YamlEncoder()]);
$content = file_get_contents(__DIR__ . '/test.yml');
$data = $serializer->decode($content, YamlEncoder::ALTERNATIVE_FORMAT);
```

Let me know if something is wrong for you
