### PR TITLE
[DependencyInjection] Fix tags on multiple decorated service

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -168,6 +168,29 @@ class DecoratorServicePassTest extends TestCase
         $this->assertEmpty($container->getDefinition('child.inner')->getAutowiringTypes());
     }
 
+    public function testProcessMovesTagsFromDecoratedDefinitionToDecoratingDefinitionMultipleTimes()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setPublic(true)
+            ->setTags(array('bar' => array('attr' => 'baz')))
+        ;
+        $container
+            ->register('deco1')
+            ->setDecoratedService('foo', null, 50)
+        ;
+        $container
+            ->register('deco2')
+            ->setDecoratedService('foo', null, 2)
+        ;
+
+        $this->process($container);
+
+        $this->assertEmpty($container->getDefinition('deco1')->getTags());
+        $this->assertEquals(array('bar' => array('attr' => 'baz')), $container->getDefinition('deco2')->getTags());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $repeatedPass = new DecoratorServicePass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28682
| License       | MIT
| Doc PR        | 

After the first run in the loop with the same decorated service it goes only in the hasAlias condition. The tags will be not set here, so the `ResolveTaggedIteratorArgumentPass` will handle only the first decoration.