### PR TITLE
'yml' is not a format and shouldn't be visible as constant from 'YamlEncoder'

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -23,7 +23,7 @@ use Symfony\Component\Yaml\Parser;
 class YamlEncoder implements EncoderInterface, DecoderInterface
 {
     const FORMAT = 'yaml';
-    const ALTERNATIVE_FORMAT = 'yml';
+    private const ALTERNATIVE_FORMAT = 'yml';
 
     private $dumper;
     private $parser;


### PR DESCRIPTION
A little fix of my [previous PR](https://github.com/symfony/symfony/pull/28815)

This PR changes the constant visibility of the `yml` format as private. 

Because as @stof [mentionned](https://github.com/symfony/symfony/pull/28815#issuecomment-428941972) `yml` isn't a format, so the constant  shoudn't be public. 

Otherwise, this will be confusing while using autocomplete, you see two formats. The user can ask himself if there is a difference between `yaml` / `yml`. 

No need of that :) 


| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | - 
| License       | MIT
| Doc PR        | 

