### PR TITLE
Allow integers as default console option value

### DIFF
--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -33,11 +33,11 @@ class InputOption
     private $description;
 
     /**
-     * @param string                    $name        The option name
-     * @param string|array              $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param int|null                  $mode        The option mode: One of the VALUE_* constants
-     * @param string                    $description A description text
-     * @param string|string[]|bool|null $default     The default value (must be null for self::VALUE_NONE)
+     * @param string                        $name        The option name
+     * @param string|array                  $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param int|null                      $mode        The option mode: One of the VALUE_* constants
+     * @param string                        $description A description text
+     * @param string|string[]|int|bool|null $default     The default value (must be null for self::VALUE_NONE)
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
      */
@@ -149,7 +149,7 @@ class InputOption
     /**
      * Sets the default value.
      *
-     * @param string|string[]|bool|null $default The default value
+     * @param string|string[]|int|bool|null $default The default value
      *
      * @throws LogicException When incorrect default value is given
      */
@@ -173,7 +173,7 @@ class InputOption
     /**
      * Returns the default value.
      *
-     * @return string|string[]|bool|null The default value
+     * @return string|string[]|int|bool|null The default value
      */
     public function getDefault()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

B/C break fix for static analysis tools.

Ref https://github.com/symfony/symfony/pull/28374#issuecomment-429319088
