### PR TITLE
[DI] Default undefined env to empty string during compile

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
@@ -48,7 +48,7 @@ class ValidateEnvPlaceholdersPass implements CompilerPassInterface
             foreach ($resolvingBag->getEnvPlaceholders() + $resolvingBag->getUnusedEnvPlaceholders() as $env => $placeholders) {
                 $values = array();
                 if (false === $i = strpos($env, ':')) {
-                    $default = $defaultBag->has("env($env)") ? $defaultBag->get("env($env)") : null;
+                    $default = $defaultBag->has("env($env)") ? $defaultBag->get("env($env)") : self::$typeFixtures['string'];
                     $defaultType = null !== $default ? self::getType($default) : 'string';
                     $values[$defaultType] = $default;
                 } else {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -48,6 +48,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $container->registerExtension($ext = new EnvExtension());
         $container->prependExtensionConfig('env_extension', $expected = array(
             'float_node' => '%env(FLOATISH)%',
+            'string_node' => '%env(UNDEFINED)%',
         ));
 
         $this->doProcess($container);
@@ -311,6 +312,14 @@ class EnvConfiguration implements ConfigurationInterface
                 ->arrayNode('simple_array_node')->end()
                 ->enumNode('enum_node')->values(array('a', 'b'))->end()
                 ->variableNode('variable_node')->end()
+                ->scalarNode('string_node')
+                    ->validate()
+                        ->ifTrue(function ($value) {
+                            return !\is_string($value);
+                        })
+                        ->thenInvalid('%s is not a string')
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #28827
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Instead of using `null` for undefined envs, use `""` instead. We already default the type to string, so actually providing a string value makes sense. During runtime it will always be string also.