### PR TITLE
add missing double-quotes to extra_fields output message

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -162,13 +162,13 @@ class FormValidator extends ConstraintValidator
             if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->setConstraint($constraint);
                 $this->context->buildViolation($config->getOption('extra_fields_message'))
-                    ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
+                    ->setParameter('{{ extra_fields }}', '"'.implode('", "', array_keys($form->getExtraData())).'"')
                     ->setInvalidValue($form->getExtraData())
                     ->setCode(Form::NO_SUCH_FIELD_ERROR)
                     ->addViolation();
             } else {
                 $this->buildViolation($config->getOption('extra_fields_message'))
-                    ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
+                    ->setParameter('{{ extra_fields }}', '"'.implode('", "', array_keys($form->getExtraData())).'"')
                     ->setInvalidValue($form->getExtraData())
                     ->setCode(Form::NO_SUCH_FIELD_ERROR)
                     ->addViolation();

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -620,8 +620,29 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($form, new Form());
 
         $this->buildViolation('Extra!')
-            ->setParameter('{{ extra_fields }}', 'foo')
+            ->setParameter('{{ extra_fields }}', '"foo"')
             ->setInvalidValue(array('foo' => 'bar'))
+            ->setCode(Form::NO_SUCH_FIELD_ERROR)
+            ->assertRaised();
+    }
+
+    public function testViolationFormatIfMultipleExtraFields()
+    {
+        $form = $this->getBuilder('parent', null, array('extra_fields_message' => 'Extra!'))
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->add($this->getBuilder('child'))
+            ->getForm();
+
+        $form->submit(array('foo' => 'bar', 'baz' => 'qux', 'quux' => 'quuz'));
+
+        $this->expectNoValidate();
+
+        $this->validator->validate($form, new Form());
+
+        $this->buildViolation('Extra!')
+            ->setParameter('{{ extra_fields }}', '"foo", "baz", "quux"')
+            ->setInvalidValue(array('foo' => 'bar', 'baz' => 'qux', 'quux' => 'quuz'))
             ->setCode(Form::NO_SUCH_FIELD_ERROR)
             ->assertRaised();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

When using the extra_fields_message option on FormTypes to include the extra_fields items in the message, the output included some superfluous (or, perhaps, missing?) quotes. This resulted in some strange output: `This form should not contain extra fields: notes1\", \"notes2\", \"notes3`.

This PR removes the quotes and instead implodes the extra_fields array using merely ', ' as the glue, resulting in the output: `This form should not contain extra fields: notes1, notes2, notes3`.