### PR TITLE
[Messenger] Add support for "recording" events from entities

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/EntityMessage/EntityMessageCollectionInterface.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/EntityMessage/EntityMessageCollectionInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger\EntityMessage;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Matthias Noback <matthiasnoback@gmail.com>
+ */
+interface EntityMessageCollectionInterface
+{
+    /**
+     * Fetch recorded messages.
+     *
+     * @return object[]
+     */
+    public function getRecordedMessages(): array;
+
+    /**
+     * Remove all recorded messages.
+     */
+    public function resetRecordedMessages(): void;
+}

--- a/src/Symfony/Bridge/Doctrine/Messenger/EntityMessage/MessageRecorderTrait.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/EntityMessage/MessageRecorderTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger\EntityMessage;
+
+/**
+ * Use this trait in classes which implement EntityMessageCollectionInterface
+ * to privately record and later release Message instances, like events.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Matthias Noback <matthiasnoback@gmail.com>
+ */
+trait MessageRecorderTrait
+{
+    private $messages = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRecordedMessages(): array
+    {
+        return $this->messages;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resetRecordedMessages(): void
+    {
+        $this->messages = [];
+    }
+
+    /**
+     * Record a message.
+     *
+     * @param object $message
+     */
+    private function record($message): void
+    {
+        $this->messages[] = $message;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Messenger/EventSubscriber/EntityMessageCollector.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/EventSubscriber/EntityMessageCollector.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger\EventSubscriber;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Bridge\Doctrine\Messenger\EntityMessage\EntityMessageCollectionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
+
+/**
+ * Doctrine listener that listens to Persist, Update and Remove. Every time this is
+ * invoked we take messages from the entities.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Matthias Noback <matthiasnoback@gmail.com>
+ */
+class EntityMessageCollector implements EventSubscriber
+{
+    private $messageBus;
+
+    public function __construct(MessageBusInterface $messageBus)
+    {
+        $this->messageBus = $messageBus;
+    }
+
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::postFlush,
+        ];
+    }
+
+    public function postFlush(LifecycleEventArgs $event)
+    {
+        $this->collectEventsFromEntity($event);
+    }
+
+    private function collectEventsFromEntity(LifecycleEventArgs $message)
+    {
+        $entity = $message->getEntity();
+
+        if ($entity instanceof EntityMessageCollectionInterface) {
+            foreach ($entity->getRecordedMessages() as $message) {
+                $this->messageBus->dispatch($message, [new DispatchAfterCurrentBusStamp()]);
+            }
+
+            $entity->resetRecordedMessages();
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This is dependent of #28849. 



```yaml
services:
    messenger.doctrine.entity_message_collector:
        class: Symfony\Bridge\Doctrine\Messenger\EventSubscriber\EntityMessageCollector
        public: false
        arguments: ['@messenger.bus.event']
        tags:
          - { name: 'doctrine.event_subscriber', connection: 'default' }
```

```php

use Symfony\Bridge\Doctrine\EntityMessage\EntityMessageCollectionInterface;
use Symfony\Bridge\Doctrine\EntityMessage\MessageRecorderTrait;

class User implements EntityMessageCollectionInterface
{
    use MessageRecorderTrait;

    // ...
    
    public function setEmail(string $email)
    {
        $oldEmail = $this->email = $email;
        $this->email = $email;
        $this->record(new EmailChanged($this->id, $oldEmail, $email);
    }
```