### PR TITLE
[LDAP] Add TIMEOUT Option to LDAP Connection Options

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/ConnectionOptions.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/ConnectionOptions.php
@@ -38,6 +38,7 @@ final class ConnectionOptions
     const ERROR_STRING = 0x32;
     const MATCHED_DN = 0x33;
     const DEBUG_LEVEL = 0x5001;
+    const TIMEOUT = 0x5002;
     const NETWORK_TIMEOUT = 0x5005;
     const X_SASL_MECH = 0x6100;
     const X_SASL_REALM = 0x6101;

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `EntryManager::applyOperations`
+ * Added timeout option to `ConnectionOptions`
 
 4.1.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes 
| BC breaks?    | no    
| Deprecations? |no 
| Tests pass?   | yes    
| Fixed tickets | -  
| License       | MIT
| Doc PR        | -

This PR adds a TIMEOUT (Full name `LDAP_OPT_TIMEOUT`) option to the `ConnectionOptions.php` class in the LDAP Component. This option is not documented   in the PHP Docs for the LDAP component but is required to set a timeout for certain server configurations. One use case for this option is if the LDAP server has a whitelist the client is not approved to access. 
