### PR TITLE
[VarDumper] Scroll into view when searching

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -504,6 +504,9 @@ return function (root, x) {
             if (currentNode) {
                 reveal(currentNode);
                 highlight(root, currentNode, state.nodes);
+                if ('scrollIntoView' in currentNode) {
+                    currentNode.scrollIntoView();
+                }
             }
             counter.textContent = (state.isEmpty() ? 0 : state.idx + 1) + ' of ' + state.count();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This jumps to the found element when using the javascript widget for searching HTML dumps. Inspired by Ctrl+F in Chrome :)

It's super convenient with long dumps, however i wasnt able to position the search input on the right in a fixed manner... because CSS :sweat: i was hoping @ogizanagi could add a patch for it.

Also see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView