### PR TITLE
[HTTPKernel] Make it possible to set status code according to response

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -68,7 +68,7 @@ class ExceptionController
                 'logger' => $logger,
                 'currentContent' => $currentContent,
             )
-        ), 200, array('Content-Type' => $request->getMimeType($request->getRequestFormat()) ?: 'text/html'));
+        ), $exception->getStatusCode(), array('Content-Type' => $request->getMimeType($request->getRequestFormat()) ?: 'text/html'));
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -31,7 +31,7 @@ class ExceptionControllerTest extends TestCase
 
         $response = $controller->showAction($request, $exception, null);
 
-        $this->assertEquals(200, $response->getStatusCode()); // successful request
+        $this->assertEquals(404, $response->getStatusCode()); // successful request
         $this->assertEquals('<html>not found</html>', $response->getContent());
     }
 

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -232,11 +232,11 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         $response = $event->getResponse();
 
         // the developer asked for a specific status code
-        if (!$event->isAllowingCustomResponseCode() && !$response->isClientError() && !$response->isServerError() && !$response->isRedirect()) {
+        if (!$event->isAllowingCustomResponseCode()) {
             // ensure that we actually have an error response
             if ($e instanceof HttpExceptionInterface) {
                 // keep the HTTP status code and headers
-                $response->setStatusCode($e->getStatusCode());
+                $response->setStatusCode($response->getStatusCode());
                 $response->headers->add($e->getHeaders());
             } else {
                 $response->setStatusCode(500);

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -236,7 +236,6 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
             // ensure that we actually have an error response
             if ($e instanceof HttpExceptionInterface) {
                 // keep the HTTP status code and headers
-                $response->setStatusCode($response->getStatusCode());
                 $response->headers->add($e->getHeaders());
             } else {
                 $response->setStatusCode(500);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -102,7 +102,7 @@ class HttpKernelTest extends TestCase
     {
         $dispatcher = new EventDispatcher();
         $dispatcher->addListener(KernelEvents::EXCEPTION, function ($event) {
-            $event->setResponse(new Response($event->getException()->getMessage()));
+            $event->setResponse(new Response($event->getException()->getMessage(), $event->getException()->getStatusCode()));
         });
 
         $kernel = $this->getHttpKernel($dispatcher, function () { throw new MethodNotAllowedHttpException(array('POST')); });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | maybe
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | #28844 
| License       | MIT

This is related to issue #28844. It will allow the developers to set a status code according to their needs.

In my case I need to return a 200 HTTP Status code in case the route is not found.

Once I again I am not certain if it is a feature or a bug. Also I guess this might cause some BC issues... what do you think?