### PR TITLE
[Form] Deprecate TimezoneType regions option

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -104,6 +104,8 @@ Form
    {% endfor %}
    ```
 
+ * The `regions` option of the `TimezoneType` is deprecated.
+
 HttpFoundation
 --------------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -121,6 +121,8 @@ Form
    {% endfor %}
    ```
 
+ * The `regions` option was removed from the `TimezoneType`.
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -40,6 +40,7 @@ CHANGELOG
  * added a cause when a CSRF error has occurred
  * deprecated the `scale` option of the `IntegerType`
  * removed restriction on allowed HTTP methods
+ * deprecated the `regions` option of the `TimezoneType`
 
 4.1.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -37,7 +37,7 @@ class TimezoneType extends AbstractType
     {
         $resolver->setDefaults(array(
             'choice_loader' => function (Options $options) {
-                $regions = $options['regions'];
+                $regions = $options->offsetGet('regions', false);
 
                 return new CallbackChoiceLoader(function () use ($regions) {
                     return self::getTimezones($regions);
@@ -51,6 +51,7 @@ class TimezoneType extends AbstractType
         $resolver->setAllowedValues('input', array('string', 'datetimezone'));
 
         $resolver->setAllowedTypes('regions', 'int');
+        $resolver->setDeprecated('regions', 'The option "%name%" is deprecated since Symfony 4.2.');
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -45,7 +45,7 @@ class DebugCommandTest extends TestCase
 Built-in form types (Symfony\Component\Form\Extension\Core\Type)
 ----------------------------------------------------------------
 
- IntegerType
+ IntegerType, TimezoneType
 
 Service form types
 ------------------

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -53,6 +53,10 @@ class TimezoneTypeTest extends BaseTypeTest
         $this->assertEquals(array(new \DateTimeZone('Europe/Amsterdam'), new \DateTimeZone('Europe/Paris')), $form->getData());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The option "regions" is deprecated since Symfony 4.2.
+     */
     public function testFilterByRegions()
     {
         $choices = $this->factory->create(static::TESTED_TYPE, null, array('regions' => \DateTimeZone::EUROPE))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #28848
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I know i've added this option myself in 4.1, but given my recent development for #28624 i realized it's an opinionated feaure, which can/should be solved on user-side (`choice_filter/choice_loader` and/or `group_by`). 

- blocks translations as we dont have them (see #28831)
- blocks possibility of switching to Intl zones which doesnt really have this filter feature (see #28836)

~While at it, i solved a few issues with `OptionsResolver` that is able to deprecate options as of 4.2 also.~ Fixed in #28878

- when resolved trigger the deprecation
- allow to opt-out from triggering the deprecation
- dont trigger deprecation for default values (only given ones)