### PR TITLE
[Process] Allow to pass null arguments to Process

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1530,13 +1530,13 @@ class Process implements \IteratorAggregate
     /**
      * Escapes a string to be used as a shell argument.
      */
-    private function escapeArgument(string $argument): string
+    private function escapeArgument(?string $argument): string
     {
+        if ('' === $argument || null === $argument) {
+            return '""';
+        }
         if ('\\' !== \DIRECTORY_SEPARATOR) {
             return "'".str_replace("'", "'\\''", $argument)."'";
-        }
-        if ('' === $argument = (string) $argument) {
-            return '""';
         }
         if (false !== strpos($argument, "\0")) {
             $argument = str_replace("\0", '?', $argument);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/28609
| License       | MIT
| Doc PR        | 

Sometimes you might pass integers, floats, nulls as command arguments to the Process constructor.
Before 4.0 and https://github.com/symfony/symfony/pull/24722 that worked fine. Now it throws because of an invalid type.

I think we can drop the type hint here safely and stringify the value implicitly in the method. That will be a little more convenient.