### PR TITLE
[Validator] use constraint options instead of properties

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -261,7 +261,7 @@ TwigBundle
 Validator
 ---------
 
- * The `checkMX` and `checkHost` properties of the Email constraint are deprecated
+ * The `checkMX` and `checkHost` options of the `Email` constraint are deprecated
  * The component is now decoupled from `symfony/translation` and uses `Symfony\Contracts\Translation\TranslatorInterface` instead
  * The `ValidatorBuilderInterface` has been deprecated and `ValidatorBuilder` made final
  * Deprecated validating instances of `\DateTimeInterface` in `DateTimeValidator`, `DateValidator` and `TimeValidator`. Use `Type` instead or remove the constraint if the underlying model is type hinted to `\DateTimeInterface` already.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -254,7 +254,7 @@ TwigBundle
 Validator
 --------
 
- * The `checkMX` and `checkHost` properties of the Email constraint were removed
+ * The `checkMX` and `checkHost` options of the `Email` constraint were removed
  * The `Email::__construct()` 'strict' property has been removed. Use 'mode'=>"strict" instead.
  * Calling `EmailValidator::__construct()` method with a boolean parameter has been removed, use `EmailValidator("strict")` instead.
  * Removed the `checkDNS` and `dnsMessage` options from the `Url` constraint.

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -81,11 +81,11 @@ class Email extends Constraint
         }
 
         if (\is_array($options) && array_key_exists('checkMX', $options)) {
-            @trigger_error('The "checkMX" property is deprecated since Symfony 4.2.', E_USER_DEPRECATED);
+            @trigger_error('The "checkMX" option is deprecated since Symfony 4.2.', E_USER_DEPRECATED);
         }
 
         if (\is_array($options) && array_key_exists('checkHost', $options)) {
-            @trigger_error('The "checkHost" property is deprecated since Symfony 4.2.', E_USER_DEPRECATED);
+            @trigger_error('The "checkHost" option is deprecated since Symfony 4.2.', E_USER_DEPRECATED);
         }
 
         if (\is_array($options) && array_key_exists('mode', $options) && !\in_array($options['mode'], self::$validationModes, true)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

For other constraints we always talk about "options" and that's how we name them in the documentation too. I think we should be consistent about the terminology being used here. What do you think?