### PR TITLE
[FWBundle] Add a new method AbstractController::addLink()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 4.2.0
 -----
 
+ * Added a `AbstractController::addLink()` method to add Link headers to the current response
  * Allowed configuring taggable cache pools via a new `framework.cache.pools.tags` option (bool|service-id)
  * Allowed configuring PDO-based cache pools via a new `cache.adapter.pdo` abstract service
  * Deprecated auto-injection of the container in AbstractController instances, register them as service subscribers instead

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 
+use Fig\Link\Link;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\DependencyInjection\Container;
@@ -528,6 +529,21 @@ abstract class ControllerTraitTest extends TestCase
 
         $this->assertEquals($doctrine, $controller->getDoctrine());
     }
+
+    public function testAddLink()
+    {
+        $request = new Request();
+        $link1 = new Link('mercure', 'https://demo.mercure.rocks');
+        $link2 = new Link('self', 'https://example.com/foo');
+
+        $controller = $this->createController();
+        $controller->addLink($request, $link1);
+        $controller->addLink($request, $link2);
+
+        $links = $request->attributes->get('_links')->getLinks();
+        $this->assertContains($link1, $links);
+        $this->assertContains($link2, $links);
+    }
 }
 
 trait TestControllerTrait
@@ -552,5 +568,6 @@ trait TestControllerTrait
         createForm as public;
         createFormBuilder as public;
         getDoctrine as public;
+        addLink as public;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      |no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | todo

This provides a convenient method to add `Link` headers to the current `Response` directly from the `Request` object.
It improves the developer experience and the discoverability of [the WebLink component](https://github.com/symfony/symfony-docs/pull/10309).

Usage:

```php
namespace App\Controller;

use Fig\Link\Link;
use Symfony\Component\HttpFoundation\Request;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

class MyAction extends AbstractController
{
    public function __invoke(Request $request): Response
    {
        $this->addLink($request, new Link('mercure', 'https://demo.mercure.rocks'));

        return $this->json(['foo' => 'bar']);
    }
}
```
