### PR TITLE
[OptionsResolver] Trigger deprecation only if the option is used

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\OptionsResolver;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Tobias Schultze <http://tobion.de>
+ *
+ * @method mixed offsetGet(string $option, bool $triggerDeprecation = true)
  */
 interface Options extends \ArrayAccess, \Countable
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28848
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10496

It's true that showing a deprecation message when the option is not used is a bit annoying and it would be heavy to get rid of it.

Now, a deprecated option is triggered only when it's provided by the user or each time is being called from a lazy evaluation (except for deprecations based on the value, they're triggered only when provided by the user).