### PR TITLE
[Debug] Mimic __toString php behavior in FlattenException

### DIFF
--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 -----
 
 * made the `ErrorHandler` and `ExceptionHandler` classes final
+* added `Exception\FlattenException::getAsString` and
+`Exception\FlattenException::getTraceAsString` to increase compatibility to php
+exception objects
 
 4.0.0
 -----

--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -27,6 +27,7 @@ class FlattenException
     private $code;
     private $previous;
     private $trace;
+    private $traceAsString;
     private $class;
     private $statusCode;
     private $headers;
@@ -239,6 +240,8 @@ class FlattenException
 
     public function setTraceFromThrowable(\Throwable $throwable)
     {
+        $this->traceAsString = $throwable->getTraceAsString();
+
         return $this->setTrace($throwable->getTrace(), $throwable->getFile(), $throwable->getLine());
     }
 
@@ -323,5 +326,34 @@ class FlattenException
         $array = new \ArrayObject($value);
 
         return $array['__PHP_Incomplete_Class_Name'];
+    }
+
+    public function getTraceAsString()
+    {
+        return $this->traceAsString;
+    }
+
+    public function getAsString()
+    {
+        $message = '';
+        $next = false;
+
+        foreach (array_reverse(array_merge([$this], $this->getAllPrevious())) as $exception) {
+            if ($next) {
+                $message .= 'Next ';
+            } else {
+                $next = true;
+            }
+            $message .= $exception->getClass();
+
+            if ('' != $exception->getMessage()) {
+                $message .= ': '.$exception->getMessage();
+            }
+
+            $message .= ' in '.$exception->getFile().':'.$exception->getLine().
+                "\nStack trace:\n".$exception->getTraceAsString()."\n\n";
+        }
+
+        return rtrim($message);
     }
 }

--- a/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
@@ -346,6 +346,41 @@ class FlattenExceptionTest extends TestCase
         $this->assertSame('Class "RuntimeException@anonymous" blah.', $flattened->getMessage());
     }
 
+    public function testToStringEmptyMessage()
+    {
+        $exception = new \RuntimeException();
+
+        $flattened = FlattenException::create($exception);
+
+        $this->assertSame($exception->getTraceAsString(), $flattened->getTraceAsString());
+        $this->assertSame($exception->__toString(), $flattened->getAsString());
+    }
+
+    public function testToString()
+    {
+        $test = function ($a, $b, $c, $d) {
+            return new \RuntimeException('This is a test message');
+        };
+
+        $exception = $test('foo123', 1, null, 1.5);
+
+        $flattened = FlattenException::create($exception);
+
+        $this->assertSame($exception->getTraceAsString(), $flattened->getTraceAsString());
+        $this->assertSame($exception->__toString(), $flattened->getAsString());
+    }
+
+    public function testToStringParent()
+    {
+        $exception = new \LogicException('This is message 1');
+        $exception = new \RuntimeException('This is messsage 2', 500, $exception);
+
+        $flattened = FlattenException::create($exception);
+
+        $this->assertSame($exception->getTraceAsString(), $flattened->getTraceAsString());
+        $this->assertSame($exception->__toString(), $flattened->getAsString());
+    }
+
     private function createException($foo)
     {
         return new \Exception();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | symfony/symfony-docs#

The `Symfony\Component\Debug\Exception\FlattenException` object is returned by `Symfony\Component\HttpKernel\DataCollector\ExceptionDataCollector::getException` method, but the docblock of this method indicates that it should return `\Exception` object.

As the `FlattenException` class should behave as much as possible like a php `\Exception` object, it should implement the same methods as `\Exception`.

This PR is adding `__toString` and `getTraceAsString` methods. Those methods are (in my opinion) the most useful methods of a `\Exception` object. A potential use case (where i am stumbled across this inconsistency) is to get the last exception of a request in a `WebTestCase` using the profiler and printing the trace.