### PR TITLE
[HttpKernel] fix deprecating KernelInterface::getRootDir()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -128,13 +128,14 @@ EOF
         $domain = $input->getOption('domain');
         /** @var KernelInterface $kernel */
         $kernel = $this->getApplication()->getKernel();
+        $rootDir = $kernel->getContainer()->getParameter('kernel.root_dir');
 
         // Define Root Paths
-        $transPaths = array($kernel->getRootDir(false).'/Resources/translations');
+        $transPaths = array($rootDir.'/Resources/translations');
         if ($this->defaultTransPath) {
             $transPaths[] = $this->defaultTransPath;
         }
-        $viewsPaths = array($kernel->getRootDir(false).'/Resources/views');
+        $viewsPaths = array($rootDir.'/Resources/views');
         if ($this->defaultViewsPath) {
             $viewsPaths[] = $this->defaultViewsPath;
         }
@@ -147,12 +148,12 @@ EOF
                 if ($this->defaultTransPath) {
                     $transPaths[] = $this->defaultTransPath.'/'.$bundle->getName();
                 }
-                $transPaths[] = sprintf('%s/Resources/%s/translations', $kernel->getRootDir(false), $bundle->getName());
+                $transPaths[] = sprintf('%s/Resources/%s/translations', $rootDir, $bundle->getName());
                 $viewsPaths = array($bundle->getPath().'/Resources/views');
                 if ($this->defaultViewsPath) {
                     $viewsPaths[] = $this->defaultViewsPath.'/bundles/'.$bundle->getName();
                 }
-                $viewsPaths[] = sprintf('%s/Resources/%s/views', $kernel->getRootDir(false), $bundle->getName());
+                $viewsPaths[] = sprintf('%s/Resources/%s/views', $rootDir, $bundle->getName());
             } catch (\InvalidArgumentException $e) {
                 // such a bundle does not exist, so treat the argument as path
                 $transPaths = array($input->getArgument('bundle').'/Resources/translations');
@@ -168,12 +169,12 @@ EOF
                 if ($this->defaultTransPath) {
                     $transPaths[] = $this->defaultTransPath.'/'.$bundle->getName();
                 }
-                $transPaths[] = sprintf('%s/Resources/%s/translations', $kernel->getRootDir(false), $bundle->getName());
+                $transPaths[] = sprintf('%s/Resources/%s/translations', $rootDir, $bundle->getName());
                 $viewsPaths[] = $bundle->getPath().'/Resources/views';
                 if ($this->defaultViewsPath) {
                     $viewsPaths[] = $this->defaultViewsPath.'/bundles/'.$bundle->getName();
                 }
-                $viewsPaths[] = sprintf('%s/Resources/%s/views', $kernel->getRootDir(false), $bundle->getName());
+                $viewsPaths[] = sprintf('%s/Resources/%s/views', $rootDir, $bundle->getName());
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -118,13 +118,14 @@ EOF
         }
         /** @var KernelInterface $kernel */
         $kernel = $this->getApplication()->getKernel();
+        $rootDir = $kernel->getContainer()->getParameter('kernel.root_dir');
 
         // Define Root Paths
-        $transPaths = array($kernel->getRootDir(false).'/Resources/translations');
+        $transPaths = array($rootDir.'/Resources/translations');
         if ($this->defaultTransPath) {
             $transPaths[] = $this->defaultTransPath;
         }
-        $viewsPaths = array($kernel->getRootDir(false).'/Resources/views');
+        $viewsPaths = array($rootDir.'/Resources/views');
         if ($this->defaultViewsPath) {
             $viewsPaths[] = $this->defaultViewsPath;
         }
@@ -138,12 +139,12 @@ EOF
                 if ($this->defaultTransPath) {
                     $transPaths[] = $this->defaultTransPath.'/'.$foundBundle->getName();
                 }
-                $transPaths[] = sprintf('%s/Resources/%s/translations', $kernel->getRootDir(false), $foundBundle->getName());
+                $transPaths[] = sprintf('%s/Resources/%s/translations', $rootDir, $foundBundle->getName());
                 $viewsPaths = array($foundBundle->getPath().'/Resources/views');
                 if ($this->defaultViewsPath) {
                     $viewsPaths[] = $this->defaultViewsPath.'/bundles/'.$foundBundle->getName();
                 }
-                $viewsPaths[] = sprintf('%s/Resources/%s/views', $kernel->getRootDir(false), $foundBundle->getName());
+                $viewsPaths[] = sprintf('%s/Resources/%s/views', $rootDir, $foundBundle->getName());
                 $currentName = $foundBundle->getName();
             } catch (\InvalidArgumentException $e) {
                 // such a bundle does not exist, so treat the argument as path

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -17,18 +17,13 @@ use Symfony\Component\Templating\Helper\Helper;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @internal
+ * @internal since Symfony 4.2, all properties will be private in 5.0
  */
 class CodeHelper extends Helper
 {
     protected $fileLinkFormat;
-    /**
-     * @deprecated since Symfony 4.2
-     */
-    protected $rootDir;
+    protected $rootDir; // to be renamed $projectDir in 5.0
     protected $charset;
-
-    private $projectDir;
 
     /**
      * @param string|FileLinkFormatter $fileLinkFormat The format for links to source files
@@ -38,8 +33,7 @@ class CodeHelper extends Helper
     public function __construct($fileLinkFormat, string $projectDir, string $charset)
     {
         $this->fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
-        $this->projectDir = str_replace('\\', '/', $projectDir).'/';
-        $this->rootDir = $this->projectDir;
+        $this->rootDir = str_replace('\\', '/', $projectDir).'/';
         $this->charset = $charset;
     }
 
@@ -164,10 +158,10 @@ class CodeHelper extends Helper
         if (null === $text) {
             $file = trim($file);
             $fileStr = $file;
-            if (0 === strpos($fileStr, $this->projectDir)) {
-                $fileStr = str_replace(array('\\', $this->projectDir), array('/', ''), $fileStr);
+            if (0 === strpos($fileStr, $this->rootDir)) {
+                $fileStr = str_replace(array('\\', $this->rootDir), array('/', ''), $fileStr);
                 $fileStr = htmlspecialchars($fileStr, $flags, $this->charset);
-                $fileStr = sprintf('<abbr title="%s">kernel.project_dir</abbr>/%s', htmlspecialchars($this->projectDir, $flags, $this->charset), $fileStr);
+                $fileStr = sprintf('<abbr title="%s">kernel.project_dir</abbr>/%s', htmlspecialchars($this->rootDir, $flags, $this->charset), $fileStr);
             }
 
             $text = sprintf('%s at line %d', $fileStr, $line);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -27,20 +27,17 @@ class CacheClearCommandTest extends TestCase
     private $kernel;
     /** @var Filesystem */
     private $fs;
-    private $projectDir;
 
     protected function setUp()
     {
         $this->fs = new Filesystem();
         $this->kernel = new TestAppKernel('test', true);
-        $this->projectDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('sf_cache_', true);
-        $this->kernel->setProjectDir($this->projectDir);
-        $this->fs->mkdir($this->projectDir);
+        $this->fs->mkdir($this->kernel->getProjectDir());
     }
 
     protected function tearDown()
     {
-        $this->fs->remove($this->projectDir);
+        $this->fs->remove($this->kernel->getProjectDir());
     }
 
     public function testCacheIsFreshAfterCacheClearedWithWarmup()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
@@ -26,19 +26,9 @@ class TestAppKernel extends Kernel
         );
     }
 
-    public function setProjectDir($projectDir)
+    public function getProjectDir()
     {
-        $this->projectDir = $projectDir;
-    }
-
-    public function getCacheDir()
-    {
-        return $this->getProjectDir().'/Tests/Fixtures/cache.'.$this->environment;
-    }
-
-    public function getLogDir()
-    {
-        return $this->getProjectDir().'/Tests/Fixtures/logs';
+        return __DIR__.'/test';
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationDebugCommandTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel;
 
@@ -178,18 +179,16 @@ class TranslationDebugCommandTest extends TestCase
 
         $kernel
             ->expects($this->any())
-            ->method('getRootDir')
-            ->will($this->returnValue($this->translationDir));
-
-        $kernel
-            ->expects($this->any())
             ->method('getBundles')
             ->will($this->returnValue(array()));
+
+        $container = new Container();
+        $container->setParameter('kernel.root_dir', $this->translationDir);
 
         $kernel
             ->expects($this->any())
             ->method('getContainer')
-            ->will($this->returnValue($this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock()));
+            ->will($this->returnValue($container));
 
         $command = new TranslationDebugCommand($translator, $loader, $extractor, $this->translationDir.'/translations', $this->translationDir.'/templates');
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 4.2.0
 -----
 
- * deprecated `Kernel::getRootDir()` and the `kernel.root_dir` parameter
+ * deprecated `KernelInterface::getRootDir()` and the `kernel.root_dir` parameter
  * deprecated `KernelInterface::getName()` and the `kernel.name` parameter
 
 4.1.0

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -123,6 +123,8 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      * Gets the application root dir (path of the project's Kernel class).
      *
      * @return string The Kernel root dir
+     *
+     * @deprecated since Symfony 4.2
      */
     public function getRootDir();
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelWithoutBundles.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelWithoutBundles.php
@@ -26,6 +26,11 @@ class KernelWithoutBundles extends Kernel
     {
     }
 
+    public function getProjectDir()
+    {
+        return __DIR__;
+    }
+
     protected function build(ContainerBuilder $container)
     {
         $container->setParameter('test_executed', true);

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -521,7 +521,7 @@ EOF;
         $kernel->boot();
 
         $this->assertSame(__DIR__.'/Fixtures', $kernel->getProjectDir());
-        $this->assertSame(__DIR__.'/Fixtures', $kernel->getContainer()->getParameter('kernel.project_dir'));
+        $this->assertSame(__DIR__.\DIRECTORY_SEPARATOR.'Fixtures', $kernel->getContainer()->getParameter('kernel.project_dir'));
     }
 
     public function testKernelReset()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Follow up of #28810.
Did I get it right?