### PR TITLE
[TwigBundle] Fix usage of TwigBundle without FrameworkBundle

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -64,6 +64,7 @@ class ExtensionPass implements CompilerPassInterface
 
         if ($container->has('fragment.handler')) {
             $container->getDefinition('twig.extension.httpkernel')->addTag('twig.extension');
+            $container->getDefinition('twig.runtime.httpkernel')->addTag('twig.runtime');
 
             // inject Twig in the hinclude service if Twig is the only registered templating engine
             if ((!$container->hasParameter('templating.engines') || array('twig') == $container->getParameter('templating.engines')) && $container->hasDefinition('fragment.renderer.hinclude')) {
@@ -72,6 +73,10 @@ class ExtensionPass implements CompilerPassInterface
                     ->replaceArgument(0, new Reference('twig'))
                 ;
             }
+        }
+
+        if (!$container->has('http_kernel')) {
+            $container->removeDefinition('twig.controller.preview_error');
         }
 
         if ($container->has('request_stack')) {

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -36,10 +36,13 @@ class TwigExtension extends Extension
         $loader->load('twig.xml');
 
         $container->getDefinition('twig.profile')->setPrivate(true);
-        $container->getDefinition('twig.runtime.httpkernel')->setPrivate(true);
         $container->getDefinition('twig.translation.extractor')->setPrivate(true);
         $container->getDefinition('workflow.twig_extension')->setPrivate(true);
         $container->getDefinition('twig.exception_listener')->setPrivate(true);
+
+        if ($container->has('fragment.handler')) {
+            $container->getDefinition('twig.runtime.httpkernel')->setPrivate(true);
+        }
 
         if (class_exists('Symfony\Component\Form\Form')) {
             $loader->load('form.xml');

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -105,7 +105,6 @@
 
         <service id="twig.runtime.httpkernel" class="Symfony\Bridge\Twig\Extension\HttpKernelRuntime">
             <argument type="service" id="fragment.handler" />
-            <tag name="twig.runtime" />
         </service>
 
         <service id="twig.extension.httpfoundation" class="Symfony\Bridge\Twig\Extension\HttpFoundationExtension">

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/EmptyAppTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Tests\Functional;
+
+use Symfony\Bundle\TwigBundle\Tests\TestCase;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+class EmptyAppTest extends TestCase
+{
+    public function testBootEmptyApp()
+    {
+        $kernel = new EmptyAppKernel('test', true);
+        $kernel->boot();
+
+        $this->assertTrue($kernel->getContainer()->hasParameter('twig.default_path'));
+        $this->assertNotEmpty($kernel->getContainer()->getParameter('twig.default_path'));
+    }
+}
+
+class EmptyAppKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        return array(new TwigBundle());
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel/cache/'.$this->environment;
+    }
+
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/'.Kernel::VERSION.'/EmptyAppKernel/logs';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

According to the composer.json (https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/TwigBundle/composer.json), the FrameworkBundle shouldn't be required to use the bundle (which can be useful in tests of other bundles for instance). However, it is not the case, mainly due to issues with direct references to unavailable services.

I target 3.4 because https://github.com/symfony/symfony/commit/812fbb444f1d1e4cafff5876ce7b22d5b8d4adf8 is the main reason for the issue. We may have added additional problems in 4.0 and 4.1.