### PR TITLE
[HttpKernel] Introduce KernelInterface::getProjectDir()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -60,7 +60,6 @@ EOT
 
         /** @var KernelInterface $kernel */
         $kernel = $this->getApplication()->getKernel();
-        $projectDir = $kernel->getContainer()->getParameter('kernel.project_dir');
 
         $rows = array(
             array('<info>Symfony</>'),
@@ -75,8 +74,8 @@ EOT
             array('Environment', $kernel->getEnvironment()),
             array('Debug', $kernel->isDebug() ? 'true' : 'false'),
             array('Charset', $kernel->getCharset()),
-            array('Cache directory', self::formatPath($kernel->getCacheDir(), $projectDir).' (<comment>'.self::formatFileSize($kernel->getCacheDir()).'</>)'),
-            array('Log directory', self::formatPath($kernel->getLogDir(), $projectDir).' (<comment>'.self::formatFileSize($kernel->getLogDir()).'</>)'),
+            array('Cache directory', self::formatPath($kernel->getCacheDir(), $kernel->getProjectDir()).' (<comment>'.self::formatFileSize($kernel->getCacheDir()).'</>)'),
+            array('Log directory', self::formatPath($kernel->getLogDir(), $kernel->getProjectDir()).' (<comment>'.self::formatFileSize($kernel->getLogDir()).'</>)'),
             new TableSeparator(),
             array('<info>PHP</>'),
             new TableSeparator(),

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Command that places bundle web assets into a given directory.
@@ -89,11 +90,12 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        /** @var KernelInterface $kernel */
         $kernel = $this->getApplication()->getKernel();
         $targetArg = rtrim($input->getArgument('target'), '/');
 
         if (!is_dir($targetArg)) {
-            $targetArg = $kernel->getContainer()->getParameter('kernel.project_dir').'/'.$targetArg;
+            $targetArg = $kernel->getProjectDir().'/'.$targetArg;
 
             if (!is_dir($targetArg)) {
                 throw new InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $input->getArgument('target')));

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  * It manages an environment made of application kernel and bundles.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method string getProjectDir() Gets the project dir (path of the project's composer file) - not defining it is deprecated since Symfony 4.2
  */
 interface KernelInterface extends HttpKernelInterface, \Serializable
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | not yet
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://github.com/symfony/symfony/pull/28897#issuecomment-430523336
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Removes the last call to getParameter('kernel.project_dir') during runtime in core. Yay :)

cc @fabpot @nicolas-grekas 