### PR TITLE
[Serializer] fix MetadataAwareNameConverter break denormalization

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -75,7 +75,12 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return null;
         }
 
-        return $this->metadataFactory->getMetadataFor($class)->getAttributesMetadata()[$propertyName]->getSerializedName() ?? null;
+        $attributesMetadata = $this->metadataFactory->getMetadataFor($class)->getAttributesMetadata();
+        if (!isset($attributesMetadata[$propertyName])) {
+            return null;
+        }
+
+        return $attributesMetadata[$propertyName]->getSerializedName() ?? null;
     }
 
     private function normalizeFallback(string $propertyName, string $class = null, string $format = null, array $context = array()): string

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NotSerializedConstructorArgumentDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NotSerializedConstructorArgumentDummy.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class NotSerializedConstructorArgumentDummy
+{
+    private $bar;
+
+    public function __construct($foo)
+    {
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  -
| License       | MIT
| Doc PR        |  -

During denormalization of an object, the `normalize` function of the `MetadataAwareNormalizer` is called to find the serialized name of constructor arguments. This do not work if the constructor argument is not in the serialized representation of the object (for example given with a `default_constructor_arguments` option ).

**Checklist**
- [x] Add test to cover the bug