### PR TITLE
[Serializer] Improve perf a bit by not using a signaling exception when not needed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -285,7 +285,7 @@ class Configuration implements ConfigurationInterface
                                         ->prototype('scalar')
                                             ->cannotBeEmpty()
                                             ->validate()
-                                                ->ifTrue(function ($v) { return !class_exists($v) && !interface_exists($v); })
+                                                ->ifTrue(function ($v) { return !class_exists($v) && !interface_exists($v, false); })
                                                 ->thenInvalid('The supported class or interface "%s" does not exist.')
                                             ->end()
                                         ->end()

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -179,7 +179,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     {
         self::validateName($name);
 
-        if (null !== $dataClass && !class_exists($dataClass) && !interface_exists($dataClass)) {
+        if (null !== $dataClass && !class_exists($dataClass) && !interface_exists($dataClass, false)) {
             throw new InvalidArgumentException(sprintf('Class "%s" not found. Is the "data_class" form option set correctly?', $dataClass));
         }
 

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -131,7 +131,7 @@ class MessengerPass implements CompilerPassInterface
                         $method = $method['method'] ?? '__invoke';
                     }
 
-                    if (!\class_exists($messageClass) && !\interface_exists($messageClass)) {
+                    if (!\class_exists($messageClass) && !\interface_exists($messageClass, false)) {
                         $messageClassLocation = isset($tag['handles']) ? 'declared in your tag attribute "handles"' : $r->implementsInterface(MessageSubscriberInterface::class) ? sprintf('returned by method "%s::getHandledMessages()"', $r->getName()) : sprintf('used as argument type in method "%s::%s()"', $r->getName(), $method);
 
                         throw new RuntimeException(sprintf('Invalid handler service "%s": message class "%s" %s does not exist.', $serviceId, $messageClass, $messageClassLocation));

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Mapping\Factory;
 
-use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
 
@@ -70,14 +69,6 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      */
     public function hasMetadataFor($value)
     {
-        try {
-            $this->getClass($value);
-
-            return true;
-        } catch (InvalidArgumentException $invalidArgumentException) {
-            // Return false in case of exception
-        }
-
-        return false;
+        return \is_object($value) || (\is_string($value) && (\class_exists($value) || \interface_exists($value, false)));
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassResolverTrait.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassResolverTrait.php
@@ -34,7 +34,7 @@ trait ClassResolverTrait
     private function getClass($value)
     {
         if (\is_string($value)) {
-            if (!class_exists($value) && !interface_exists($value)) {
+            if (!class_exists($value) && !interface_exists($value, false)) {
                 throw new InvalidArgumentException(sprintf('The class or interface "%s" does not exist.', $value));
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

And disabling unneeded autoload calls for interface_exists checks meanwhile.