### PR TITLE
[Config] Use intersection type when referring to ParentNodeDefinitionInterface

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -133,7 +133,7 @@ class NodeBuilder implements NodeParentInterface
     /**
      * Returns the parent node.
      *
-     * @return ParentNodeDefinitionInterface|NodeDefinition The parent node
+     * @return NodeDefinition&ParentNodeDefinitionInterface The parent node
      */
     public function end()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Allows PHPStan to understand it correctly (refs https://github.com/libero/content-api-bundle/pull/2#discussion_r226237763).

PHPStorm 2018.3 will add support for it too, but to help older versions I've reversed the order (so `NodeDefinition` is recognised).