### PR TITLE
Fix debug:container which crash when the service class has no doc comment

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -303,9 +303,11 @@ abstract class Descriptor implements DescriptorInterface
         try {
             $reflectionProperty = new \ReflectionClass($class);
 
-            return DocBlockFactory::createInstance()
-                ->create($reflectionProperty->getDocComment())
-                ->getSummary();
+            if ($docComment = $reflectionProperty->getDocComment()) {
+                return DocBlockFactory::createInstance()
+                    ->create($docComment)
+                    ->getSummary();
+            }
         } catch (\ReflectionException $e) {
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -69,6 +69,19 @@ abstract class AbstractDescriptorTest extends TestCase
         return $this->getContainerBuilderDescriptionTestData(ObjectsProvider::getContainerBuilders());
     }
 
+    /**
+     * @dataProvider getDescribeContainerExistingClassDefinitionTestData
+     */
+    public function testDescribeContainerExistingClassDefinition(Definition $definition, $expectedDescription)
+    {
+        $this->assertDescription($expectedDescription, $definition);
+    }
+
+    public function getDescribeContainerExistingClassDefinitionTestData()
+    {
+        return $this->getDescriptionTestData(ObjectsProvider::getContainerDefinitionsWithExistingClasses());
+    }
+
     /** @dataProvider getDescribeContainerDefinitionTestData */
     public function testDescribeContainerDefinition(Definition $definition, $expectedDescription)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -96,6 +96,14 @@ class ObjectsProvider
         return array('builder_1' => $builder1);
     }
 
+    public static function getContainerDefinitionsWithExistingClasses()
+    {
+        return array(
+            'existing_class_def_1' => new Definition(ClassWithDocComment::class),
+            'existing_class_def_2' => new Definition(ClassWithoutDocComment::class),
+        );
+    }
+
     public static function getContainerDefinitions()
     {
         $definition1 = new Definition('Full\\Qualified\\Class1');
@@ -195,4 +203,15 @@ class RouteStub extends Route
     {
         return new CompiledRoute('', '#PATH_REGEX#', array(), array(), '#HOST_REGEX#');
     }
+}
+
+class ClassWithoutDocComment
+{
+}
+
+/**
+ * This is a class with a doc comment.
+ */
+class ClassWithDocComment
+{
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_1.json
@@ -1,0 +1,13 @@
+{
+    "class": "Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\ClassWithDocComment",
+    "public": false,
+    "synthetic": false,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "autowire": false,
+    "autoconfigure": false,
+    "description": "This is a class with a doc comment.",
+    "file": null,
+    "tags": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_1.md
@@ -1,0 +1,10 @@
+- Description: `This is a class with a doc comment.`
+- Class: `Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\ClassWithDocComment`
+- Public: no
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_1.txt
@@ -1,0 +1,17 @@
+This is a class with a doc comment.
+
+ ---------------- ----------------------------------------------------------------------------- 
+ [32m Option         [39m [32m Value                                                                       [39m 
+ ---------------- ----------------------------------------------------------------------------- 
+  Service ID       -                                                                            
+  Class            Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\ClassWithDocComment  
+  Tags             -                                                                            
+  Public           no                                                                           
+  Synthetic        no                                                                           
+  Lazy             no                                                                           
+  Shared           yes                                                                          
+  Abstract         no                                                                           
+  Autowired        no                                                                           
+  Autoconfigured   no                                                                           
+ ---------------- -----------------------------------------------------------------------------
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\ClassWithDocComment" public="false" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file="">
+  <description><![CDATA[This is a class with a doc comment.]]></description>
+</definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_2.json
@@ -1,0 +1,12 @@
+{
+    "class": "Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\ClassWithoutDocComment",
+    "public": false,
+    "synthetic": false,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "autowire": false,
+    "autoconfigure": false,
+    "file": null,
+    "tags": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_2.md
@@ -1,0 +1,9 @@
+- Class: `Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\ClassWithoutDocComment`
+- Public: no
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_2.txt
@@ -1,0 +1,15 @@
+---------------- -------------------------------------------------------------------------------- 
+ [32m Option         [39m [32m Value                                                                          [39m 
+ ---------------- -------------------------------------------------------------------------------- 
+  Service ID       -                                                                               
+  Class            Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\ClassWithoutDocComment  
+  Tags             -                                                                               
+  Public           no                                                                              
+  Synthetic        no                                                                              
+  Lazy             no                                                                              
+  Shared           yes                                                                             
+  Abstract         no                                                                              
+  Autowired        no                                                                              
+  Autoconfigured   no                                                                              
+ ---------------- --------------------------------------------------------------------------------
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/existing_class_def_2.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\ClassWithoutDocComment" public="false" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file=""/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The console command container:debug have now the ability to display service description, based on phpdoc comments of the service class. But the command currently crash when selecting a service with a class without phpdoc description.

This PR fixes this issue.
