### PR TITLE
[Config] Fix @method annotation

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ParentNodeDefinitionInterface.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ParentNodeDefinitionInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Config\Definition\Builder;
  *
  * @author Victor Berchet <victor@suumit.com>
  *
- * @method NodeDefinition[] getChildNodeDefinitions() should be implemented since 4.1
+ * @method NodeDefinition[] getChildNodeDefinitions() Gets the child node definitions - not implementing it is deprecated since Symfony 4.2
  */
 interface ParentNodeDefinitionInterface extends BuilderAwareInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

```
@method [[static] return type] [name]([[type] [parameter]<, ...>]) [<description>]
```

I dont think this was intended to be the method description, which will be taken into account after #28902 

Let me know if there's a better description, other then `Gets the child node definitions` :)