### PR TITLE
[DoctrineBridge] catch errors while converting to db values in data collector

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\DataCollector;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -132,7 +133,14 @@ class DoctrineDataCollector extends DataCollector
                 }
                 if ($type instanceof Type) {
                     $query['types'][$j] = $type->getBindingType();
-                    $param = $type->convertToDatabaseValue($param, $this->registry->getConnection($connectionName)->getDatabasePlatform());
+                    try {
+                        $param = $type->convertToDatabaseValue($param, $this->registry->getConnection($connectionName)->getDatabasePlatform());
+                    } catch (\TypeError $e) {
+                        // Error thrown while processing params, query is not explainable.
+                        $query['explainable'] = false;
+                    } catch (ConversionException $e) {
+                        $query['explainable'] = false;
+                    }
                 }
             }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Tests\DataCollector;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Version;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Component\HttpFoundation\Request;
@@ -120,7 +121,7 @@ class DoctrineDataCollectorTest extends TestCase
 
     public function paramProvider()
     {
-        return array(
+        $tests = array(
             array('some value', array(), 'some value', true),
             array(1, array(), 1, true),
             array(true, array(), true, true),
@@ -129,6 +130,13 @@ class DoctrineDataCollectorTest extends TestCase
             array(fopen(__FILE__, 'r'), array(), 'Resource(stream)', false),
             array(new \SplFileInfo(__FILE__), array(), 'Object(SplFileInfo)', false),
         );
+
+        if (version_compare(Version::VERSION, '2.6', '>=')) {
+            $tests[] = array('this is not a date', array('date'), 'this is not a date', false);
+            $tests[] = array(new \stdClass(), array('date'), 'Object(stdClass)', false);
+        }
+
+        return $tests;
     }
 
     private function createCollector($queries)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

When the profiler is enabled and collecting doctrine queries data, if a query fails because of `ConversionException` or another error thrown while resolving parameters, the data collector is also throwing the same error.

This should fix this case. The tests for this case cannot be executed in 5.4 because Doctrine 2.5 fails with a fatal error in `DateType`.