### PR TITLE
Fix generated HTML code for file syntax highlighting

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -223,6 +223,8 @@ class CodeExtension extends AbstractExtension
 
     protected static function fixCodeMarkup($line)
     {
+        $line = trim($line);
+
         // </span> ending tag from previous line
         $opening = strpos($line, '<span');
         $closing = strpos($line, '</span>');
@@ -232,8 +234,7 @@ class CodeExtension extends AbstractExtension
 
         // missing </span> tag at the end of line
         $opening = strpos($line, '<span');
-        $closing = strpos($line, '</span>');
-        if (false !== $opening && (false === $closing || $closing > $opening)) {
+        if (false !== $opening && '</span>' !== substr($line, -7)) {
             $line .= '</span>';
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -211,6 +211,8 @@ class CodeHelper extends Helper
 
     protected static function fixCodeMarkup($line)
     {
+        $line = trim($line);
+
         // </span> ending tag from previous line
         $opening = strpos($line, '<span');
         $closing = strpos($line, '</span>');
@@ -220,8 +222,7 @@ class CodeHelper extends Helper
 
         // missing </span> tag at the end of line
         $opening = strpos($line, '<span');
-        $closing = strpos($line, '</span>');
-        if (false !== $opening && (false === $closing || $closing > $opening)) {
+        if (false !== $opening && '</span>' !== substr($line, -7)) {
             $line .= '</span>';
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | N/A

I realized that the syntax highlighting made of the code triggering an error is not HTML valid, as there are some extra closing `</span>` tags. If you look at the generated HTML code of this error shown in Symfony's profiler (I would appreciate if you don't make fun of my division by zero to trigger purposely an error 😅):

<img width="644" alt="ghost" src="https://user-images.githubusercontent.com/344445/47241076-fd776d00-d3af-11e8-9bc1-98d269594fdc.png">

You will see the invalid extra `</span>` tags (shown in red here):

<img width="1039" alt="span" src="https://user-images.githubusercontent.com/344445/47241080-00725d80-d3b0-11e8-9dff-cb18d2e0c9cc.png">

I tried to figure out why this code was written, in the `fixCodeMarkup` method. It leads to this commit of @fabpot : https://github.com/symfony/symfony/commit/eb7cbb77ec9ff4ca8143679ed66c0c9b94e08413#diff-bf4b3d6db506c41af5fa9306031e0a61R194

The commit message refers to an issue that was on the old Trac issue tracker (issue 9044) used back in the symfony 1 era. Which is fun actually, but doesn't help much on why this method was written, and I could not figure out any case when some missing `</span>` closing tags need to be added.

I supposed it was needed though, and just kept the purpose of the function and fixed it.


<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
