### PR TITLE
[Security] Fix "exclude-from-classmap"

### DIFF
--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -55,7 +55,10 @@
     "autoload": {
         "psr-4": { "Symfony\\Component\\Security\\": "" },
         "exclude-from-classmap": [
-            "/Tests/"
+            "/Core/Tests/",
+            "/Csrf/Tests/",
+            "/Guard/Tests/",
+            "/Http/Tests/"
         ]
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The "/Tests/" directory doesn't exist in the Security Component, tests are located within the Security components folders and none of the tests were being excluded in an --classmap-authoritative dump of the autoload.
