### PR TITLE
[WebProfilerBundle] Replay referer URL

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -16,6 +16,10 @@
                                 <a href="{{ profile.url }}">{{ profile.url }}</a>
                             {% else %}
                                 {{ profile.url }}
+                                {% set referer = profile.collector('request').requestheaders.get('referer') %}
+                                {% if referer %}
+                                    <a href="{{ referer }}" class="referer">Replay referer URL</a>
+                                {% endif %}
                             {% endif %}
                         </h2>
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -585,9 +585,18 @@ tr.status-warning td {
     font-size: 21px;
     margin: 0;
     text-decoration: none;
+    vertical-align: middle;
 }
 #summary h2 a:hover {
     text-decoration: underline;
+}
+#summary h2 a.referer {
+    margin-left: .5em;
+    font-size: 75%;
+    color: rgba(255, 255, 255, 0.5);
+}
+#summary h2 a.referer:before {
+    content: '\1F503\00a0';
 }
 
 #summary .status-success { background: var(--color-success); }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26226
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

For non GET/HEAD requests (e.g. POST) that have a referer URL; allow to replay it. And thereby fix the missing navigation piece to get back to your application.

Default

![image](https://user-images.githubusercontent.com/1047696/47259042-3c86ea80-d4a4-11e8-99f7-c3941beaa72c.png)

On hover

![image](https://user-images.githubusercontent.com/1047696/47259048-54f70500-d4a4-11e8-9e44-e20121f5b04f.png)
