### PR TITLE
Revert "fixed CS"

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -41,8 +41,8 @@ class ContainerAwareEventManager extends EventManager
      *
      * @param string    $eventName The name of the event to dispatch. The name of the event is
      *                             the name of the method that is invoked on listeners.
-     * @param EventArgs $eventArgs the event arguments to pass to the event handlers/listeners.
-     *                             If not supplied, the single empty EventArgs instance is used
+     * @param EventArgs $eventArgs The event arguments to pass to the event handlers/listeners.
+     *                             If not supplied, the single empty EventArgs instance is used.
      *
      * @return bool
      */

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -46,9 +46,9 @@ class ContainerAwareEventDispatcher extends EventDispatcher
      * @param string $eventName Event for which the listener is added
      * @param array  $callback  The service ID of the listener service & the method
      *                          name that has to be called
-     * @param int    $priority  the higher this value, the earlier an event listener
+     * @param int    $priority  The higher this value, the earlier an event listener
      *                          will be triggered in the chain.
-     *                          Defaults to 0
+     *                          Defaults to 0.
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -257,10 +257,10 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      *
      * Should be set to true only for root forms.
      *
-     * @param bool $initialize true to initialize the form automatically,
+     * @param bool $initialize True to initialize the form automatically,
      *                         false to suppress automatic initialization.
      *                         In the second case, you need to call
-     *                         {@link FormInterface::initialize()} manually
+     *                         {@link FormInterface::initialize()} manually.
      *
      * @return $this The configuration object
      */

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -127,9 +127,9 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the normalized data of the field.
      *
-     * @return mixed when the field is not submitted, the default data is returned.
+     * @return mixed When the field is not submitted, the default data is returned.
      *               When the field is submitted, the normalized submitted data is
-     *               returned if the field is valid, null otherwise
+     *               returned if the field is valid, null otherwise.
      */
     public function getNormData();
 

--- a/src/Symfony/Component/Form/FormRendererEngineInterface.php
+++ b/src/Symfony/Component/Form/FormRendererEngineInterface.php
@@ -36,10 +36,10 @@ interface FormRendererEngineInterface
      * The type of the resource is decided by the implementation. The resource
      * is later passed to {@link renderBlock()} by the rendering algorithm.
      *
-     * @param FormView $view      the view for determining the used themes.
+     * @param FormView $view      The view for determining the used themes.
      *                            First the themes attached directly to the
      *                            view with {@link setTheme()} are considered,
-     *                            then the ones of its parent etc
+     *                            then the ones of its parent etc.
      * @param string   $blockName The name of the block to render
      *
      * @return mixed the renderer resource or false, if none was found
@@ -68,10 +68,10 @@ interface FormRendererEngineInterface
      * The type of the resource is decided by the implementation. The resource
      * is later passed to {@link renderBlock()} by the rendering algorithm.
      *
-     * @param FormView $view               the view for determining the used themes.
+     * @param FormView $view               The view for determining the used themes.
      *                                     First the themes  attached directly to
      *                                     the view with {@link setTheme()} are
-     *                                     considered, then the ones of its parent etc
+     *                                     considered, then the ones of its parent etc.
      * @param array    $blockNameHierarchy The block name hierarchy, with the root block
      *                                     at the beginning
      * @param int      $hierarchyLevel     The level in the hierarchy at which to start
@@ -106,10 +106,10 @@ interface FormRendererEngineInterface
      * The type of the resource is decided by the implementation. The resource
      * is later passed to {@link renderBlock()} by the rendering algorithm.
      *
-     * @param FormView $view               the view for determining the used themes.
+     * @param FormView $view               The view for determining the used themes.
      *                                     First the themes  attached directly to
      *                                     the view with {@link setTheme()} are
-     *                                     considered, then the ones of its parent etc
+     *                                     considered, then the ones of its parent etc.
      * @param array    $blockNameHierarchy The block name hierarchy, with the root block
      *                                     at the beginning
      * @param int      $hierarchyLevel     The level in the hierarchy at which to start

--- a/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
@@ -62,11 +62,11 @@ class OrderedHashMapIterator implements \Iterator
      *                              keys
      * @param array $orderedKeys    The keys of the map in the order in which
      *                              they should be iterated
-     * @param array $managedCursors an array from which to reference the
+     * @param array $managedCursors An array from which to reference the
      *                              iterator's cursor as long as it is alive.
      *                              This array is managed by the corresponding
      *                              {@link OrderedHashMap} instance to support
-     *                              recognizing the deletion of elements
+     *                              recognizing the deletion of elements.
      */
     public function __construct(array &$elements, array &$orderedKeys, array &$managedCursors)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 class NativeFileSessionHandler extends NativeSessionHandler
 {
     /**
-     * @param string $savePath path of directory to save session files
+     * @param string $savePath Path of directory to save session files
      *                         Default null will leave setting as defined by PHP.
      *                         '/path', 'N;/path', or 'N;octal-mode;/path
      *

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -513,9 +513,9 @@ class IntlDateFormatter
     /**
      * Set the formatter's timezone identifier.
      *
-     * @param string $timeZoneId the time zone ID string of the time zone to use.
+     * @param string $timeZoneId The time zone ID string of the time zone to use.
      *                           If NULL or the empty string, the default time zone for the
-     *                           runtime is used
+     *                           runtime is used.
      *
      * @return bool true on success or false on failure
      *

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -242,9 +242,9 @@ class NumberFormatter
 
     /**
      * @param string $locale  The locale code. The only currently supported locale is "en" (or null using the default locale, i.e. "en")
-     * @param int    $style   style of the formatting, one of the format style constants.
+     * @param int    $style   Style of the formatting, one of the format style constants.
      *                        The only supported styles are NumberFormatter::DECIMAL
-     *                        and NumberFormatter::CURRENCY
+     *                        and NumberFormatter::CURRENCY.
      * @param string $pattern Not supported. A pattern string in case $style is NumberFormat::PATTERN_DECIMAL or
      *                        NumberFormat::PATTERN_RULEBASED. It must conform to  the syntax
      *                        described in the ICU DecimalFormat or ICU RuleBasedNumberFormat documentation
@@ -279,9 +279,9 @@ class NumberFormatter
      * Static constructor.
      *
      * @param string $locale  The locale code. The only supported locale is "en" (or null using the default locale, i.e. "en")
-     * @param int    $style   style of the formatting, one of the format style constants.
+     * @param int    $style   Style of the formatting, one of the format style constants.
      *                        The only currently supported styles are NumberFormatter::DECIMAL
-     *                        and NumberFormatter::CURRENCY
+     *                        and NumberFormatter::CURRENCY.
      * @param string $pattern Not supported. A pattern string in case $style is NumberFormat::PATTERN_DECIMAL or
      *                        NumberFormat::PATTERN_RULEBASED. It must conform to  the syntax
      *                        described in the ICU DecimalFormat or ICU RuleBasedNumberFormat documentation
@@ -340,8 +340,8 @@ class NumberFormatter
      * Format a number.
      *
      * @param int|float $value The value to format
-     * @param int       $type  type of the formatting, one of the format type constants.
-     *                         Only type NumberFormatter::TYPE_DEFAULT is currently supported
+     * @param int       $type  Type of the formatting, one of the format type constants.
+     *                         Only type NumberFormatter::TYPE_DEFAULT is currently supported.
      *
      * @return bool|string The formatted value or false on error
      *
@@ -547,9 +547,9 @@ class NumberFormatter
     /**
      * Set an attribute.
      *
-     * @param int $attr  an attribute specifier, one of the numeric attribute constants.
+     * @param int $attr  An attribute specifier, one of the numeric attribute constants.
      *                   The only currently supported attributes are NumberFormatter::FRACTION_DIGITS,
-     *                   NumberFormatter::GROUPING_USED and NumberFormatter::ROUNDING_MODE
+     *                   NumberFormatter::GROUPING_USED and NumberFormatter::ROUNDING_MODE.
      * @param int $value The attribute value
      *
      * @return bool true on success or false on failure


### PR DESCRIPTION
This reverts commit d48a3776fe0b425d41e3fa9f3ef8b14315c02a1f.

| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR reverts #28814 , that was caused as a bug of PHP CS Fixer fixed in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4027

After fix on PHP CS Fixer side, the rule is passing now at Symfony's codebase.

This PR only reverts wrong chances done by PHP CS Fixer,
it does not apply new rule requested in #28817 ( https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4045 )