### PR TITLE
[WebProfilerBundle] Remove application name

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -111,6 +111,15 @@ HttpFoundation
    will respectively change from "false" to "null" and from "null" to "lax" in Symfony
    5.0, you should define their values explicitly or use "Cookie::create()" instead.
 
+HttpKernel
+----------
+
+ * The `Kernel::getRootDir()` and the `kernel.root_dir` parameter have been deprecated
+ * The `KernelInterface::getName()` and the `kernel.name` parameter have been deprecated
+ * Deprecated the first and second constructor argument of `ConfigDataCollector` 
+ * Deprecated `ConfigDataCollector::getApplicationName()` 
+ * Deprecated `ConfigDataCollector::getApplicationVersion()`
+
 FrameworkBundle
 ---------------
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -182,6 +182,9 @@ HttpKernel
 
  * The `Kernel::getRootDir()` and the `kernel.root_dir` parameter have been removed
  * The `KernelInterface::getName()` and the `kernel.name` parameter have been removed
+ * Removed the first and second constructor argument of `ConfigDataCollector`
+ * Removed `ConfigDataCollector::getApplicationName()` 
+ * Removed `ConfigDataCollector::getApplicationVersion()`
 
 Monolog
 -------

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -10,12 +10,6 @@
         <service id="data_collector.config" class="Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector">
             <tag name="data_collector" template="@WebProfiler/Collector/config.html.twig" id="config" priority="-255" />
             <call method="setKernel"><argument type="service" id="kernel" on-invalid="ignore" /></call>
-            <argument type="service">
-                <service class="string">
-                    <factory function="basename" />
-                    <argument>%kernel.project_dir%</argument>
-                </service>
-            </argument>
         </service>
 
         <service id="data_collector.request" class="Symfony\Component\HttpKernel\DataCollector\RequestDataCollector">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -19,26 +19,14 @@
     {% endif %}
 
     {% set icon %}
-        {% if collector.applicationname %}
-            <span class="sf-toolbar-label">{{ collector.applicationname }}</span>
-            <span class="sf-toolbar-value">{{ collector.applicationversion }}</span>
-        {% elseif collector.symfonyState is defined %}
-            <span class="sf-toolbar-label">
-                {{ include('@WebProfiler/Icon/symfony.svg') }}
-            </span>
-            <span class="sf-toolbar-value">{{ collector.symfonyversion }}</span>
-        {% endif %}
+        <span class="sf-toolbar-label">
+            {{ include('@WebProfiler/Icon/symfony.svg') }}
+        </span>
+        <span class="sf-toolbar-value">{{ collector.symfonyState is defined ? collector.symfonyversion : 'n/a' }}</span>
     {% endset %}
 
     {% set text %}
         <div class="sf-toolbar-info-group">
-            {% if collector.applicationname %}
-                <div class="sf-toolbar-info-piece">
-                    <b>{{ collector.applicationname }}</b>
-                    <span>{{ collector.applicationversion }}</span>
-                </div>
-            {% endif %}
-
             <div class="sf-toolbar-info-piece">
                 <b>Profiler token</b>
                 <span>
@@ -92,15 +80,9 @@
                 <div class="sf-toolbar-info-piece">
                     <b>Resources</b>
                     <span>
-                        {% if 'Silex' == collector.applicationname %}
-                            <a href="https://silex.symfony.com/documentation" rel="help">
-                                Read Silex Docs
-                            </a>
-                        {% else %}
-                            <a href="https://symfony.com/doc/{{ collector.symfonyversion }}/index.html" rel="help">
-                                Read Symfony {{ collector.symfonyversion }} Docs
-                            </a>
-                        {% endif %}
+                        <a href="https://symfony.com/doc/{{ collector.symfonyversion }}/index.html" rel="help">
+                            Read Symfony {{ collector.symfonyversion }} Docs
+                        </a>
                     </span>
                 </div>
                 <div class="sf-toolbar-info-piece">
@@ -126,74 +108,53 @@
 {% endblock %}
 
 {% block panel %}
-    {% if collector.applicationname %}
-        {# this application is not the Symfony framework #}
-        <h2>Project Configuration</h2>
+    <h2>Symfony Configuration</h2>
 
-        <div class="metrics">
-            <div class="metric">
-                <span class="value">{{ collector.applicationname }}</span>
-                <span class="label">Application name</span>
-            </div>
-
-            <div class="metric">
-                <span class="value">{{ collector.applicationversion }}</span>
-                <span class="label">Application version</span>
-            </div>
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">{{ collector.symfonyversion }}</span>
+            <span class="label">Symfony version</span>
         </div>
 
-        <p>
-            Based on <a class="text-bold" href="https://symfony.com">Symfony {{ collector.symfonyversion }}</a>
-        </p>
-    {% else %}
-        <h2>Symfony Configuration</h2>
-
-        <div class="metrics">
+        {% if 'n/a' != collector.env %}
             <div class="metric">
-                <span class="value">{{ collector.symfonyversion }}</span>
-                <span class="label">Symfony version</span>
+                <span class="value">{{ collector.env }}</span>
+                <span class="label">Environment</span>
             </div>
+        {% endif %}
 
-            {% if 'n/a' != collector.env %}
-                <div class="metric">
-                    <span class="value">{{ collector.env }}</span>
-                    <span class="label">Environment</span>
-                </div>
-            {% endif %}
+        {% if 'n/a' != collector.debug %}
+            <div class="metric">
+                <span class="value">{{ collector.debug ? 'enabled' : 'disabled' }}</span>
+                <span class="label">Debug</span>
+            </div>
+        {% endif %}
+    </div>
 
-            {% if 'n/a' != collector.debug %}
-                <div class="metric">
-                    <span class="value">{{ collector.debug ? 'enabled' : 'disabled' }}</span>
-                    <span class="label">Debug</span>
-                </div>
-            {% endif %}
-        </div>
-
-        {% set symfony_status = { dev: 'Unstable Version', stable: 'Stable Version', eom: 'Maintenance Ended', eol: 'Version Expired' } %}
-        {% set symfony_status_class = { dev: 'warning', stable: 'success', eom: 'warning', eol: 'error' } %}
-        <table>
-            <thead class="small">
-                <tr>
-                    <th>Symfony Status</th>
-                    <th>Bugs {{ collector.symfonystate in ['eom', 'eol'] ? 'were' : 'are' }} fixed until</th>
-                    <th>Security issues {{ collector.symfonystate == 'eol' ? 'were' : 'are' }} fixed until</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td class="font-normal">
-                        <span class="label status-{{ symfony_status_class[collector.symfonystate] }}">{{ symfony_status[collector.symfonystate]|upper }}</span>
-                    </td>
-                    <td class="font-normal">{{ collector.symfonyeom }}</td>
-                    <td class="font-normal">{{ collector.symfonyeol }}</td>
-                    <td class="font-normal">
-                        <a href="https://symfony.com/roadmap?version={{ collector.symfonyminorversion }}#checker">View roadmap</a>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    {% endif %}
+    {% set symfony_status = { dev: 'Unstable Version', stable: 'Stable Version', eom: 'Maintenance Ended', eol: 'Version Expired' } %}
+    {% set symfony_status_class = { dev: 'warning', stable: 'success', eom: 'warning', eol: 'error' } %}
+    <table>
+        <thead class="small">
+            <tr>
+                <th>Symfony Status</th>
+                <th>Bugs {{ collector.symfonystate in ['eom', 'eol'] ? 'were' : 'are' }} fixed until</th>
+                <th>Security issues {{ collector.symfonystate == 'eol' ? 'were' : 'are' }} fixed until</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td class="font-normal">
+                    <span class="label status-{{ symfony_status_class[collector.symfonystate] }}">{{ symfony_status[collector.symfonystate]|upper }}</span>
+                </td>
+                <td class="font-normal">{{ collector.symfonyeom }}</td>
+                <td class="font-normal">{{ collector.symfonyeol }}</td>
+                <td class="font-normal">
+                    <a href="https://symfony.com/roadmap?version={{ collector.symfonyminorversion }}#checker">View roadmap</a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
 
     <h2>PHP Configuration</h2>
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 
  * deprecated `KernelInterface::getRootDir()` and the `kernel.root_dir` parameter
  * deprecated `KernelInterface::getName()` and the `kernel.name` parameter
+ * deprecated the first and second constructor argument of `ConfigDataCollector` 
+ * deprecated `ConfigDataCollector::getApplicationName()` 
+ * deprecated `ConfigDataCollector::getApplicationVersion()`
 
 4.1.0
 -----

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -30,12 +30,15 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
     private $version;
     private $hasVarDumper;
 
-    /**
-     * @param string $name    The name of the application using the web profiler
-     * @param string $version The version of the application using the web profiler
-     */
     public function __construct(string $name = null, string $version = null)
     {
+        if (1 <= \func_num_args()) {
+            @trigger_error(sprintf('The "$name" argument in method "%s()" is deprecated since Symfony 4.2.', __METHOD__), E_USER_DEPRECATED);
+        }
+        if (2 <= \func_num_args()) {
+            @trigger_error(sprintf('The "$version" argument in method "%s()" is deprecated since Symfony 4.2.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $this->name = $name;
         $this->version = $version;
         $this->hasVarDumper = class_exists(LinkStub::class);
@@ -105,13 +108,23 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
         $this->data = $this->cloneVar($this->data);
     }
 
+    /**
+     * @deprecated since Symfony 4.2
+     */
     public function getApplicationName()
     {
+        @trigger_error(sprintf('The method "%s()" is deprecated since Symfony 4.2.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->data['app_name'];
     }
 
+    /**
+     * @deprecated since Symfony 4.2
+     */
     public function getApplicationVersion()
     {
+        @trigger_error(sprintf('The method "%s()" is deprecated since Symfony 4.2.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->data['app_version'];
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -41,15 +41,26 @@ class ConfigDataCollectorTest extends TestCase
         $this->assertSame(\extension_loaded('Zend OPcache') && ini_get('opcache.enable'), $c->hasZendOpcache());
         $this->assertSame(\extension_loaded('apcu') && ini_get('apc.enabled'), $c->hasApcu());
     }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The "$name" argument in method "Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector::__construct()" is deprecated since Symfony 4.2.
+     * @expectedDeprecation The "$version" argument in method "Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector::__construct()" is deprecated since Symfony 4.2.
+     * @expectedDeprecation The method "Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector::getApplicationName()" is deprecated since Symfony 4.2.
+     * @expectedDeprecation The method "Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector::getApplicationVersion()" is deprecated since Symfony 4.2.
+     */
+    public function testLegacy()
+    {
+        $c = new ConfigDataCollector('name', null);
+        $c->collect(new Request(), new Response());
+
+        $this->assertSame('name', $c->getApplicationName());
+        $this->assertNull($c->getApplicationVersion());
+    }
 }
 
 class KernelForTest extends Kernel
 {
-    public function getName()
-    {
-        return 'testkernel';
-    }
-
     public function registerBundles()
     {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This fixes a regression in master, i think after #28809 (or something related)

There's still a "application name" concept out there today, and it's `ConfigDataCollector::getApplicationName()` :thinking: 

In my case the service resolved to 

```php
$e = new \Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector(\basename('/app'));
```

Causing the app name to be, well, `app` (again :P). It was really confusing.

Before:

![image](https://user-images.githubusercontent.com/1047696/47264761-fcb01980-d51c-11e8-9a3b-14a43d18b179.png)

(the "a" is from "app" here)

After:

![image](https://user-images.githubusercontent.com/1047696/47264767-16516100-d51d-11e8-8a5d-4c20d4911861.png)

or

![image](https://user-images.githubusercontent.com/1047696/47264774-28cb9a80-d51d-11e8-8fe6-de0f46b06a1d.png)

I think we need to deprecate the argument for real?

cc @fabpot 

