### PR TITLE
[Messenger] Add `StackInterface`, allowing to unstack the call stack

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * The component is not experimental anymore
  * All the changes below are BC BREAKS
  * `MessageBusInterface::dispatch()` and `MiddlewareInterface::handle()` now return `void`
- * `MiddlewareInterface::handle()` now require an `Envelope` as first argument
+ * `MiddlewareInterface::handle()` now require an `Envelope` as first argument and a `StackInterface` as second
  * `EnvelopeAwareInterface` has been removed
  * The signature of `Amqp*` classes changed to take a `Connection` as a first argument and an optional
    `Serializer` as a second argument.
@@ -16,7 +16,6 @@ CHANGELOG
    Instead, it accepts the sender instance itself instead of its identifier in the container.
  * `MessageSubscriberInterface::getHandledMessages()` return value has changed. The value of an array item
    needs to be an associative array or the method name.
- * `ValidationMiddleware::handle()` and `SendMessageMiddleware::handle()` now require an `Envelope` object
  * `StampInterface` replaces `EnvelopeItemInterface` and doesn't extend `Serializable` anymore
  * The `ConsumeMessagesCommand` class now takes an instance of `Psr\Container\ContainerInterface`
    as first constructor argument

--- a/src/Symfony/Component/Messenger/MessageBus.php
+++ b/src/Symfony/Component/Messenger/MessageBus.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger;
 
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
@@ -64,14 +65,8 @@ class MessageBus implements MessageBusInterface
         if (!$middlewareIterator->valid()) {
             return;
         }
-        $next = static function (Envelope $envelope) use ($middlewareIterator, &$next) {
-            $middlewareIterator->next();
+        $stack = new StackMiddleware($middlewareIterator);
 
-            if ($middlewareIterator->valid()) {
-                $middlewareIterator->current()->handle($envelope, $next);
-            }
-        };
-
-        $middlewareIterator->current()->handle($message instanceof Envelope ? $message : new Envelope($message), $next);
+        $middlewareIterator->current()->handle($message instanceof Envelope ? $message : new Envelope($message), $stack);
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/ActivationMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/ActivationMiddleware.php
@@ -35,12 +35,12 @@ class ActivationMiddleware implements MiddlewareInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(Envelope $envelope, callable $next): void
+    public function handle(Envelope $envelope, StackInterface $stack): void
     {
         if (\is_callable($this->activated) ? ($this->activated)($envelope) : $this->activated) {
-            $this->inner->handle($envelope, $next);
+            $this->inner->handle($envelope, $stack);
         } else {
-            $next($envelope);
+            $stack->next()->handle($envelope, $stack);
         }
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -34,11 +34,11 @@ class HandleMessageMiddleware implements MiddlewareInterface
      *
      * @throws NoHandlerForMessageException When no handler is found and $allowNoHandlers is false
      */
-    public function handle(Envelope $envelope, callable $next): void
+    public function handle(Envelope $envelope, StackInterface $stack): void
     {
         if (null !== $handler = $this->messageHandlerLocator->getHandler($envelope)) {
             $handler($envelope->getMessage());
-            $next($envelope);
+            $stack->next()->handle($envelope, $stack);
         } elseif (!$this->allowNoHandlers) {
             throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', \get_class($envelope->getMessage())));
         }

--- a/src/Symfony/Component/Messenger/Middleware/LoggingMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/LoggingMiddleware.php
@@ -29,7 +29,7 @@ class LoggingMiddleware implements MiddlewareInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(Envelope $envelope, callable $next): void
+    public function handle(Envelope $envelope, StackInterface $stack): void
     {
         $message = $envelope->getMessage();
         $context = array(
@@ -39,7 +39,7 @@ class LoggingMiddleware implements MiddlewareInterface
         $this->logger->debug('Starting handling message {name}', $context);
 
         try {
-            $next($envelope);
+            $stack->next()->handle($envelope, $stack);
         } catch (\Throwable $e) {
             $context['exception'] = $e;
             $this->logger->warning('An exception occurred while handling message {name}', $context);

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -34,11 +34,11 @@ class SendMessageMiddleware implements MiddlewareInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(Envelope $envelope, callable $next): void
+    public function handle(Envelope $envelope, StackInterface $stack): void
     {
         if ($envelope->get(ReceivedStamp::class)) {
             // It's a received message. Do not send it back:
-            $next($envelope);
+            $stack->next()->handle($envelope, $stack);
 
             return;
         }
@@ -54,6 +54,6 @@ class SendMessageMiddleware implements MiddlewareInterface
             }
         }
 
-        $next($envelope);
+        $stack->next()->handle($envelope, $stack);
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/StackInterface.php
+++ b/src/Symfony/Component/Messenger/Middleware/StackInterface.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\Messenger\Middleware;
 
-use Symfony\Component\Messenger\Envelope;
-
 /**
- * @author Samuel Roze <samuel.roze@gmail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
  */
-interface MiddlewareInterface
+interface StackInterface
 {
-    public function handle(Envelope $envelope, StackInterface $stack): void;
+    /**
+     * Returns the next middleware to process a message.
+     */
+    public function next(): MiddlewareInterface;
 }

--- a/src/Symfony/Component/Messenger/Middleware/StackMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/StackMiddleware.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class StackMiddleware implements MiddlewareInterface, StackInterface
+{
+    private $middlewareIterator;
+
+    public function __construct(\Iterator $middlewareIterator = null)
+    {
+        $this->middlewareIterator = $middlewareIterator;
+    }
+
+    public function next(): MiddlewareInterface
+    {
+        if (null === $iterator = $this->middlewareIterator) {
+            return $this;
+        }
+        $iterator->next();
+
+        if (!$iterator->valid()) {
+            $this->middlewareIterator = null;
+
+            return $this;
+        }
+
+        return $iterator->current();
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): void
+    {
+        // no-op: this is the last null middleware
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
@@ -37,7 +37,7 @@ class TraceableMiddleware implements MiddlewareInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(Envelope $envelope, callable $next): void
+    public function handle(Envelope $envelope, StackInterface $stack): void
     {
         $class = \get_class($this->inner);
         $eventName = 'c' === $class[0] && 0 === strpos($class, "class@anonymous\0") ? get_parent_class($class).'@anonymous' : $class;
@@ -49,15 +49,52 @@ class TraceableMiddleware implements MiddlewareInterface
         $this->stopwatch->start($eventName, $this->eventCategory);
 
         try {
-            $this->inner->handle($envelope, function (Envelope $envelope) use ($next, $eventName) {
-                $this->stopwatch->stop($eventName);
-                $next($envelope);
-                $this->stopwatch->start($eventName, $this->eventCategory);
-            });
+            $this->inner->handle($envelope, new TraceableInnerMiddleware($stack, $this->stopwatch, $eventName, $this->eventCategory));
         } finally {
             if ($this->stopwatch->isStarted($eventName)) {
                 $this->stopwatch->stop($eventName);
             }
         }
+    }
+}
+
+/**
+ * @internal
+ */
+class TraceableInnerMiddleware implements MiddlewareInterface, StackInterface
+{
+    private $stack;
+    private $stopwatch;
+    private $eventName;
+    private $eventCategory;
+
+    public function __construct(StackInterface $stack, Stopwatch $stopwatch, string $eventName, string $eventCategory)
+    {
+        $this->stack = $stack;
+        $this->stopwatch = $stopwatch;
+        $this->eventName = $eventName;
+        $this->eventCategory = $eventCategory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Envelope $envelope, StackInterface $stack): void
+    {
+        $this->stopwatch->stop($this->eventName);
+        if ($this === $stack) {
+            $this->stack->next()->handle($envelope, $this->stack);
+        } else {
+            $stack->next()->handle($envelope, $stack);
+        }
+        $this->stopwatch->start($this->eventName, $this->eventCategory);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next(): MiddlewareInterface
+    {
+        return $this;
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/ValidationMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/ValidationMiddleware.php
@@ -31,7 +31,7 @@ class ValidationMiddleware implements MiddlewareInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(Envelope $envelope, callable $next): void
+    public function handle(Envelope $envelope, StackInterface $stack): void
     {
         $message = $envelope->getMessage();
         $groups = null;
@@ -45,6 +45,6 @@ class ValidationMiddleware implements MiddlewareInterface
             throw new ValidationFailedException($message, $violations);
         }
 
-        $next($envelope);
+        $stack->next()->handle($envelope, $stack);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommand;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
@@ -846,8 +847,8 @@ class HandlerOnUndefinedBus implements MessageSubscriberInterface
 
 class UselessMiddleware implements MiddlewareInterface
 {
-    public function handle(Envelope $message, callable $next): void
+    public function handle(Envelope $message, StackInterface $stack): void
     {
-        $next($message);
+        $stack->next()->handle($message, $stack);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/MessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/MessageBusTest.php
@@ -48,8 +48,8 @@ class MessageBusTest extends TestCase
         $firstMiddleware->expects($this->once())
             ->method('handle')
             ->with($envelope, $this->anything())
-            ->will($this->returnCallback(function ($envelope, $next) {
-                $next($envelope);
+            ->will($this->returnCallback(function ($envelope, $stack) {
+                $stack->next()->handle($envelope, $stack);
             }));
 
         $secondMiddleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
@@ -76,16 +76,16 @@ class MessageBusTest extends TestCase
         $firstMiddleware->expects($this->once())
             ->method('handle')
             ->with($envelope, $this->anything())
-            ->will($this->returnCallback(function ($envelope, $next) {
-                $next($envelope->with(new AnEnvelopeStamp()));
+            ->will($this->returnCallback(function ($envelope, $stack) {
+                $stack->next()->handle($envelope->with(new AnEnvelopeStamp()), $stack);
             }));
 
         $secondMiddleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
         $secondMiddleware->expects($this->once())
             ->method('handle')
             ->with($envelopeWithAnotherStamp, $this->anything())
-            ->will($this->returnCallback(function ($envelope, $next) {
-                $next($envelope);
+            ->will($this->returnCallback(function ($envelope, $stack) {
+                $stack->next()->handle($envelope, $stack);
             }));
 
         $thirdMiddleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
@@ -115,8 +115,8 @@ class MessageBusTest extends TestCase
         $firstMiddleware->expects($this->once())
             ->method('handle')
             ->with($envelope, $this->anything())
-            ->will($this->returnCallback(function ($message, $next) use ($expectedEnvelope) {
-                $next($expectedEnvelope);
+            ->will($this->returnCallback(function ($envelope, $stack) use ($expectedEnvelope) {
+                $stack->next()->handle($expectedEnvelope, $stack);
             }));
 
         $secondMiddleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\Messenger\Tests\Middleware;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Handler\Locator\HandlerLocator;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
-class HandleMessageMiddlewareTest extends TestCase
+class HandleMessageMiddlewareTest extends MiddlewareTestCase
 {
     public function testItCallsTheHandlerAndNextMiddleware()
     {
@@ -26,16 +26,13 @@ class HandleMessageMiddlewareTest extends TestCase
 
         $handler = $this->createPartialMock(\stdClass::class, array('__invoke'));
 
-        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
-
         $middleware = new HandleMessageMiddleware(new HandlerLocator(array(
             DummyMessage::class => $handler,
         )));
 
         $handler->expects($this->once())->method('__invoke')->with($message);
-        $next->expects($this->once())->method('__invoke')->with($envelope);
 
-        $middleware->handle($envelope, $next);
+        $middleware->handle($envelope, $this->getStackMock());
     }
 
     /**
@@ -46,13 +43,13 @@ class HandleMessageMiddlewareTest extends TestCase
     {
         $middleware = new HandleMessageMiddleware(new HandlerLocator(array()));
 
-        $middleware->handle(new Envelope(new DummyMessage('Hey')), function () {});
+        $middleware->handle(new Envelope(new DummyMessage('Hey')), new StackMiddleware());
     }
 
     public function testAllowNoHandlers()
     {
         $middleware = new HandleMessageMiddleware(new HandlerLocator(array()), true);
 
-        $this->assertNull($middleware->handle(new Envelope(new DummyMessage('Hey')), function () {}));
+        $this->assertNull($middleware->handle(new Envelope(new DummyMessage('Hey')), new StackMiddleware()));
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/LoggingMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/LoggingMiddlewareTest.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\Messenger\Tests\Middleware;
 
-use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\LoggingMiddleware;
+use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
-class LoggingMiddlewareTest extends TestCase
+class LoggingMiddlewareTest extends MiddlewareTestCase
 {
     public function testDebugLogAndNextMiddleware()
     {
@@ -29,14 +29,8 @@ class LoggingMiddlewareTest extends TestCase
             ->expects($this->exactly(2))
             ->method('debug')
         ;
-        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
-        $next
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($envelope)
-        ;
 
-        (new LoggingMiddleware($logger))->handle($envelope, $next);
+        (new LoggingMiddleware($logger))->handle($envelope, $this->getStackMock());
     }
 
     /**
@@ -56,14 +50,13 @@ class LoggingMiddlewareTest extends TestCase
             ->expects($this->once())
             ->method('warning')
         ;
-        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
-        $next
+        $stack = $this->createMock(StackInterface::class);
+        $stack
             ->expects($this->once())
-            ->method('__invoke')
-            ->with($envelope)
+            ->method('next')
             ->willThrowException(new \Exception())
         ;
 
-        (new LoggingMiddleware($logger))->handle($envelope, $next);
+        (new LoggingMiddleware($logger))->handle($envelope, $stack);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/MiddlewareTestCase.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/MiddlewareTestCase.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+abstract class MiddlewareTestCase extends TestCase
+{
+    protected function getStackMock(bool $nextIsCalled = true)
+    {
+        $nextMiddleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
+        $nextMiddleware
+            ->expects($nextIsCalled ? $this->once() : $this->never())
+            ->method('handle')
+        ;
+
+        $stack = $this->createMock(StackInterface::class);
+        $stack
+            ->expects($nextIsCalled ? $this->once() : $this->never())
+            ->method('next')
+            ->willReturn($nextMiddleware)
+        ;
+
+        return $stack;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/ValidationMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/ValidationMiddlewareTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Messenger\Tests\Middleware;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\ValidationMiddleware;
 use Symfony\Component\Messenger\Stamp\ValidationStamp;
@@ -19,7 +18,7 @@ use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-class ValidationMiddlewareTest extends TestCase
+class ValidationMiddlewareTest extends MiddlewareTestCase
 {
     public function testValidateAndNextMiddleware()
     {
@@ -33,14 +32,8 @@ class ValidationMiddlewareTest extends TestCase
             ->with($message)
             ->willReturn($this->createMock(ConstraintViolationListInterface::class))
         ;
-        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
-        $next
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($envelope)
-        ;
 
-        (new ValidationMiddleware($validator))->handle($envelope, $next);
+        (new ValidationMiddleware($validator))->handle($envelope, $this->getStackMock());
     }
 
     public function testValidateWithStampAndNextMiddleware()
@@ -54,14 +47,8 @@ class ValidationMiddlewareTest extends TestCase
             ->with($message, null, $groups)
             ->willReturn($this->createMock(ConstraintViolationListInterface::class))
         ;
-        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
-        $next
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($envelope)
-        ;
 
-        (new ValidationMiddleware($validator))->handle($envelope, $next);
+        (new ValidationMiddleware($validator))->handle($envelope, $this->getStackMock());
     }
 
     /**
@@ -86,12 +73,7 @@ class ValidationMiddlewareTest extends TestCase
             ->with($message)
             ->willReturn($violationList)
         ;
-        $next = $this->createPartialMock(\stdClass::class, array('__invoke'));
-        $next
-            ->expects($this->never())
-            ->method('__invoke')
-        ;
 
-        (new ValidationMiddleware($validator))->handle($envelope, $next);
+        (new ValidationMiddleware($validator))->handle($envelope, $this->getStackMock(false));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

At the moment, debugging an exception coming from a middleware is not as friendly as it could: each middleware is preceded by a noisy frame added by the `$next` callable indirection.

This PR allows removing this frame by using `$next()->handle($envelope, $next);` instead of `$next($envelope);` in a middleware. Note that this is optional so that the later continues to work. But if one wants to opt-in for the former, then the stack trace of exceptions will be freed from `$next`.

All core middleware should do this, so here they are, updated.