### PR TITLE
[Messenger] allow specifying the topic when calling dispatch()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -391,17 +391,19 @@ trait ControllerTrait
     /**
      * Dispatches a message to the bus.
      *
-     * @param object $message The message to dispatch
+     * @param object|Envelope $message The message or the message pre-wrapped in an envelope
+     * @param string|null     $topic   The topic that senders and/or handlers can subscribe to to get the message;
+     *                                 if not provided, the topic is the class of the message
      *
      * @final
      */
-    protected function dispatchMessage($message): Envelope
+    protected function dispatchMessage($message, string $topic = null): Envelope
     {
         if (!$this->container->has('message_bus')) {
             throw new \LogicException('The message bus is not enabled in your application. Try running "composer require symfony/messenger".');
         }
 
-        return $this->container->get('message_bus')->dispatch($message);
+        return $this->container->get('message_bus')->dispatch($message, $topic);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -12,7 +12,7 @@
             <argument type="service" id="messenger.sender_locator" />
             <argument type="collection" /> <!-- Message to sender ID mapping -->
         </service>
-        <service id="messenger.middleware.route_messages" class="Symfony\Component\Messenger\Middleware\SendMessageMiddleware">
+        <service id="messenger.middleware.send_message" class="Symfony\Component\Messenger\Middleware\SendMessageMiddleware">
             <argument type="service" id="messenger.asynchronous.routing.sender_locator" />
             <argument type="collection" /> <!-- Message to send and handle mapping -->
         </service>
@@ -25,7 +25,7 @@
         </service>
 
         <!-- Middleware -->
-        <service id="messenger.middleware.call_message_handler" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">
+        <service id="messenger.middleware.handle_message" class="Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" abstract="true">
             <argument /> <!-- Bus handler resolver -->
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_multiple_buses.php
@@ -13,8 +13,8 @@ $container->loadFromExtension('framework', array(
             'messenger.bus.queries' => array(
                 'default_middleware' => false,
                 'middleware' => array(
-                    'route_messages',
-                    'call_message_handler',
+                    'send_message',
+                    'handle_message',
                 ),
             ),
         ),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_multiple_buses.xml
@@ -18,8 +18,8 @@
                 </framework:middleware>
             </framework:bus>
             <framework:bus name="messenger.bus.queries" default-middleware="false">
-                <framework:middleware id="route_messages" />
-                <framework:middleware id="call_message_handler" />
+                <framework:middleware id="send_message" />
+                <framework:middleware id="handle_message" />
             </framework:bus>
         </framework:messenger>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_multiple_buses.yml
@@ -9,5 +9,5 @@ framework:
             messenger.bus.queries:
                 default_middleware: false
                 middleware:
-                    - "route_messages"
-                    - "call_message_handler"
+                    - "send_message"
+                    - "handle_message"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -564,7 +564,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('messenger_routing');
         $senderLocatorDefinition = $container->getDefinition('messenger.asynchronous.routing.sender_locator');
-        $sendMessageMiddlewareDefinition = $container->getDefinition('messenger.middleware.route_messages');
+        $sendMessageMiddlewareDefinition = $container->getDefinition('messenger.middleware.send_message');
 
         $messageToSenderIdsMapping = array(
             DummyMessage::class => '.messenger.chain_sender.'.DummyMessage::class,
@@ -619,22 +619,22 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(array(), $container->getDefinition('messenger.bus.commands')->getArgument(0));
         $this->assertEquals(array(
             array('id' => 'logging'),
-            array('id' => 'route_messages'),
-            array('id' => 'call_message_handler'),
+            array('id' => 'send_message'),
+            array('id' => 'handle_message'),
         ), $container->getParameter('messenger.bus.commands.middleware'));
         $this->assertTrue($container->has('messenger.bus.events'));
         $this->assertSame(array(), $container->getDefinition('messenger.bus.events')->getArgument(0));
         $this->assertEquals(array(
             array('id' => 'logging'),
             array('id' => 'with_factory', 'arguments' => array('foo', true, array('bar' => 'baz'))),
-            array('id' => 'route_messages'),
-            array('id' => 'call_message_handler'),
+            array('id' => 'send_message'),
+            array('id' => 'handle_message'),
         ), $container->getParameter('messenger.bus.events.middleware'));
         $this->assertTrue($container->has('messenger.bus.queries'));
         $this->assertSame(array(), $container->getDefinition('messenger.bus.queries')->getArgument(0));
         $this->assertEquals(array(
-            array('id' => 'route_messages', 'arguments' => array()),
-            array('id' => 'call_message_handler', 'arguments' => array()),
+            array('id' => 'send_message', 'arguments' => array()),
+            array('id' => 'handle_message', 'arguments' => array()),
         ), $container->getParameter('messenger.bus.queries.middleware'));
 
         $this->assertTrue($container->hasAlias('message_bus'));

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * The component is not experimental anymore
  * All the changes below are BC BREAKS
  * `MessageBusInterface::dispatch()`, `MiddlewareInterface::handle()` and `SenderInterface::send()` return `Envelope`
+ * `MessageBusInterface::dispatch()` now takes a second `string $topic = null` argument
  * `MiddlewareInterface::handle()` now require an `Envelope` as first argument and a `StackInterface` as second
  * `EnvelopeAwareInterface` has been removed
  * The signature of `Amqp*` classes changed to take a `Connection` as a first argument and an optional
@@ -21,16 +22,14 @@ CHANGELOG
    as first constructor argument
  * The `EncoderInterface` and `DecoderInterface` have been replaced by a unified `Symfony\Component\Messenger\Transport\Serialization\SerializerInterface`.
  * The locator passed to `ContainerHandlerLocator` should not prefix its keys by "handler." anymore
- * The `AbstractHandlerLocator::getHandler()` method uses `?callable` as return type
  * Renamed `EnvelopeItemInterface` to `StampInterface`
  * `Envelope`'s constructor and `with()` method now accept `StampInterface` objects as variadic parameters
  * Renamed and moved `ReceivedMessage`, `ValidationConfiguration` and `SerializerConfiguration` in the `Stamp` namespace
  * Removed the `WrapIntoReceivedMessage`
- * `SenderLocatorInterface::getSenderForMessage()` has been replaced by `getSender(Envelope $envelope)`
  * `MessengerDataCollector::getMessages()` returns an iterable, not just an array anymore
  * `AbstractHandlerLocator` is now internal
- * `HandlerLocatorInterface::resolve()` has been replaced by `getHandler(Envelope $envelope): ?callable` and shouldn't throw when no handlers are found
- * `SenderLocatorInterface::getSenderForMessage()` has been replaced by `getSender(Envelope $envelope)`
+ * `HandlerLocatorInterface::resolve()` has been replaced by `getHandler(string $topic): ?callable` and shouldn't throw when no handlers are found
+ * `SenderLocatorInterface::getSenderForMessage()` has been replaced by `getSender(string $topic): ?SenderInterface`
  * Classes in the `Middleware\Enhancers` sub-namespace have been moved to the `Middleware` one
  * Classes in the `Asynchronous\Routing` sub-namespace have been moved to the `Transport\Sender\Locator` sub-namespace
  * The `Asynchronous/Middleware/SendMessageMiddleware` class has been moved to the `Middleware` namespace

--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger;
 
 use Symfony\Component\Messenger\Stamp\StampInterface;
+use Symfony\Component\Messenger\Stamp\TopicStamp;
 
 /**
  * A message wrapped in an envelope with stamps (configurations, markers, ...).
@@ -36,6 +37,18 @@ final class Envelope
         foreach ($stamps as $stamp) {
             $this->stamps[\get_class($stamp)] = $stamp;
         }
+    }
+
+    /**
+     * Wraps a message into an envelope if not already wrapped.
+     *
+     * @param Envelope|object $message
+     */
+    public static function wrap($message, ?string $topic): self
+    {
+        $envelope = $message instanceof self ? $message : new self($message);
+
+        return null !== $topic ? $envelope->with(new TopicStamp($topic)) : $envelope;
     }
 
     /**
@@ -71,5 +84,14 @@ final class Envelope
     public function getMessage()
     {
         return $this->message;
+    }
+
+    public function getTopic(): string
+    {
+        if (null !== $topic = $this->stamps[TopicStamp::class] ?? null) {
+            return $topic->getName();
+        }
+
+        return \get_class($this->message);
     }
 }

--- a/src/Symfony/Component/Messenger/Handler/Locator/AbstractHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/AbstractHandlerLocator.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Messenger\Handler\Locator;
 
-use Symfony\Component\Messenger\Envelope;
-
 /**
  * @author Miha Vrhovnik <miha.vrhovnik@gmail.com>
  * @author Samuel Roze <samuel.roze@gmail.com>
@@ -21,21 +19,23 @@ use Symfony\Component\Messenger\Envelope;
  */
 abstract class AbstractHandlerLocator implements HandlerLocatorInterface
 {
-    public function getHandler(Envelope $envelope): ?callable
+    public function getHandler(string $topic): ?callable
     {
-        $class = \get_class($envelope->getMessage());
-
-        if ($handler = $this->getHandlerByName($class)) {
+        if ($handler = $this->getHandlerByName($topic)) {
             return $handler;
         }
 
-        foreach (class_parents($class) as $name) {
+        if (!class_exists($topic) && !interface_exists($topic, false)) {
+            return null;
+        }
+
+        foreach (class_parents($topic) as $name) {
             if ($handler = $this->getHandlerByName($name)) {
                 return $handler;
             }
         }
 
-        foreach (class_implements($class) as $name) {
+        foreach (class_implements($topic) as $name) {
             if ($handler = $this->getHandlerByName($name)) {
                 return $handler;
             }

--- a/src/Symfony/Component/Messenger/Handler/Locator/HandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/HandlerLocator.php
@@ -17,13 +17,13 @@ namespace Symfony\Component\Messenger\Handler\Locator;
 class HandlerLocator extends AbstractHandlerLocator
 {
     /**
-     * Maps a message (its class) to a given handler.
+     * Maps a topic to a given handler.
      */
-    private $messageToHandlerMapping;
+    private $topicToHandlerMapping;
 
-    public function __construct(array $messageToHandlerMapping = array())
+    public function __construct(array $topicToHandlerMapping = array())
     {
-        $this->messageToHandlerMapping = $messageToHandlerMapping;
+        $this->topicToHandlerMapping = $topicToHandlerMapping;
     }
 
     /**
@@ -31,6 +31,6 @@ class HandlerLocator extends AbstractHandlerLocator
      */
     protected function getHandlerByName(string $name): ?callable
     {
-        return $this->messageToHandlerMapping[$name] ?? null;
+        return $this->topicToHandlerMapping[$name] ?? null;
     }
 }

--- a/src/Symfony/Component/Messenger/Handler/Locator/HandlerLocatorInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/Locator/HandlerLocatorInterface.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Messenger\Handler\Locator;
 
-use Symfony\Component\Messenger\Envelope;
-
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
@@ -21,5 +19,5 @@ interface HandlerLocatorInterface
     /**
      * Returns the handler for the given message.
      */
-    public function getHandler(Envelope $envelope): ?callable;
+    public function getHandler(string $topic): ?callable;
 }

--- a/src/Symfony/Component/Messenger/MessageBus.php
+++ b/src/Symfony/Component/Messenger/MessageBus.php
@@ -50,12 +50,12 @@ class MessageBus implements MessageBusInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch($message): Envelope
+    public function dispatch($message, string $topic = null): Envelope
     {
         if (!\is_object($message)) {
             throw new \TypeError(sprintf('Invalid argument provided to "%s()": expected object, but got %s.', __METHOD__, \gettype($message)));
         }
-        $envelope = $message instanceof Envelope ? $message : new Envelope($message);
+        $envelope = Envelope::wrap($message, $topic);
         $middlewareIterator = $this->middlewareAggregate->getIterator();
 
         while ($middlewareIterator instanceof \IteratorAggregate) {

--- a/src/Symfony/Component/Messenger/MessageBusInterface.php
+++ b/src/Symfony/Component/Messenger/MessageBusInterface.php
@@ -20,6 +20,8 @@ interface MessageBusInterface
      * Dispatches the given message.
      *
      * @param object|Envelope $message The message or the message pre-wrapped in an envelope
+     * @param string|null     $topic   The topic that senders and/or handlers can subscribe to to get the message;
+     *                                 if not provided, the topic is the class of the message
      */
-    public function dispatch($message): Envelope;
+    public function dispatch($message, string $topic = null): Envelope;
 }

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -36,7 +36,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
      */
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        if (null !== $handler = $this->messageHandlerLocator->getHandler($envelope)) {
+        if (null !== $handler = $this->messageHandlerLocator->getHandler($envelope->getTopic())) {
             $handler($envelope->getMessage());
         } elseif (!$this->allowNoHandlers) {
             throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', \get_class($envelope->getMessage())));

--- a/src/Symfony/Component/Messenger/Middleware/LoggingMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/LoggingMiddleware.php
@@ -34,20 +34,20 @@ class LoggingMiddleware implements MiddlewareInterface
         $message = $envelope->getMessage();
         $context = array(
             'message' => $message,
-            'name' => \get_class($message),
+            'topic' => $envelope->getTopic(),
         );
-        $this->logger->debug('Starting handling message {name}', $context);
+        $this->logger->debug('Starting handling message "{topic}"', $context);
 
         try {
             $envelope = $stack->next()->handle($envelope, $stack);
         } catch (\Throwable $e) {
             $context['exception'] = $e;
-            $this->logger->warning('An exception occurred while handling message {name}', $context);
+            $this->logger->warning('An exception occurred while handling message "{topic}"', $context);
 
             throw $e;
         }
 
-        $this->logger->debug('Finished handling message {name}', $context);
+        $this->logger->debug('Finished handling message "{topic}"', $context);
 
         return $envelope;
     }

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -23,12 +23,12 @@ use Symfony\Component\Messenger\Transport\Sender\Locator\SenderLocatorInterface;
 class SendMessageMiddleware implements MiddlewareInterface
 {
     private $senderLocator;
-    private $messagesToSendAndHandleMapping;
+    private $topicsToSendAndHandle;
 
-    public function __construct(SenderLocatorInterface $senderLocator, array $messagesToSendAndHandleMapping = array())
+    public function __construct(SenderLocatorInterface $senderLocator, array $topicsToSendAndHandle = array())
     {
         $this->senderLocator = $senderLocator;
-        $this->messagesToSendAndHandleMapping = $messagesToSendAndHandleMapping;
+        $this->topicsToSendAndHandle = $topicsToSendAndHandle;
     }
 
     /**
@@ -41,13 +41,13 @@ class SendMessageMiddleware implements MiddlewareInterface
             return $stack->next()->handle($envelope, $stack);
         }
 
-        $sender = $this->senderLocator->getSender($envelope);
+        $sender = $this->senderLocator->getSender($envelope->getTopic());
 
         if ($sender) {
             $envelope = $sender->send($envelope);
 
-            if (!AbstractSenderLocator::getValueFromMessageRouting($this->messagesToSendAndHandleMapping, $envelope)) {
-                // message has no corresponding handler
+            if (!AbstractSenderLocator::getValueFromMessageRouting($this->topicsToSendAndHandle, $envelope->getTopic())) {
+                // message should only be sent and be not handled by the next middleware
                 return $envelope;
             }
         }

--- a/src/Symfony/Component/Messenger/Stamp/TopicStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/TopicStamp.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * A stamp that defines the topic that senders and/or handlers can subscribe to to get a message.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class TopicStamp implements StampInterface
+{
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Handler/Locator/ContainerHandlerLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/Locator/ContainerHandlerLocatorTest.php
@@ -4,7 +4,6 @@ namespace Symfony\Component\Messenger\Tests\Handler\Locator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Handler\Locator\ContainerHandlerLocator;
 use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
@@ -20,7 +19,7 @@ class ContainerHandlerLocatorTest extends TestCase
         $container->set(DummyMessage::class, $handler);
 
         $locator = new ContainerHandlerLocator($container);
-        $resolvedHandler = $locator->getHandler(new Envelope(new DummyMessage('Hey')));
+        $resolvedHandler = $locator->getHandler(DummyMessage::class);
 
         $this->assertSame($handler, $resolvedHandler);
     }
@@ -28,7 +27,7 @@ class ContainerHandlerLocatorTest extends TestCase
     public function testNoHandlersReturnsNull()
     {
         $locator = new ContainerHandlerLocator(new Container());
-        $this->assertNull($locator->getHandler(new Envelope(new DummyMessage('Hey'))));
+        $this->assertNull($locator->getHandler(DummyMessage::class));
     }
 
     public function testGetHandlerViaInterface()
@@ -39,7 +38,7 @@ class ContainerHandlerLocatorTest extends TestCase
         $container->set(DummyMessageInterface::class, $handler);
 
         $locator = new ContainerHandlerLocator($container);
-        $resolvedHandler = $locator->getHandler(new Envelope(new DummyMessage('Hey')));
+        $resolvedHandler = $locator->getHandler(DummyMessage::class);
 
         $this->assertSame($handler, $resolvedHandler);
     }
@@ -52,8 +51,22 @@ class ContainerHandlerLocatorTest extends TestCase
         $container->set(DummyMessage::class, $handler);
 
         $locator = new ContainerHandlerLocator($container);
-        $resolvedHandler = $locator->getHandler(new Envelope(new ChildDummyMessage('Hey')));
+        $resolvedHandler = $locator->getHandler(ChildDummyMessage::class);
 
         $this->assertSame($handler, $resolvedHandler);
+    }
+
+    public function testGetHandlerViaTopic()
+    {
+        $handler1 = function () {};
+        $handler2 = function () {};
+
+        $container = new Container();
+        $locator = new ContainerHandlerLocator($container);
+        $container->set(DummyMessage::class, $handler1);
+        $container->set('foo', $handler2);
+
+        $resolvedHandler = $locator->getHandler('foo');
+        $this->assertSame($handler2, $resolvedHandler);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
@@ -142,7 +142,7 @@ class InMemorySenderLocator implements SenderLocatorInterface
         $this->sender = $sender;
     }
 
-    public function getSender(Envelope $envelope): ?SenderInterface
+    public function getSender(string $topic): ?SenderInterface
     {
         return $this->sender;
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/Fixtures/long_receiver.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/Fixtures/long_receiver.php
@@ -30,9 +30,10 @@ $connection = Connection::fromDsn(getenv('DSN'));
 $receiver = new AmqpReceiver($connection, $serializer);
 
 $worker = new Worker($receiver, new class() implements MessageBusInterface {
-    public function dispatch($envelope): Envelope
+    public function dispatch($message, string $topic = null): Envelope
     {
-        echo 'Get envelope with message: '.get_class($envelope->getMessage())."\n";
+        $envelope = Envelope::wrap($message, $topic);
+        echo 'Get envelope with message: '.$envelope->getTopic()."\n";
         echo sprintf("with stamps: %s\n", json_encode(array_keys($envelope->all()), JSON_PRETTY_PRINT));
 
         sleep(30);

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/Locator/ContainerSenderLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/Locator/ContainerSenderLocatorTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Messenger\Tests\Transport\Sender\Locator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
@@ -33,8 +32,8 @@ class ContainerSenderLocatorTest extends TestCase
             DummyMessage::class => 'my_amqp_sender',
         ));
 
-        $this->assertSame($sender, $locator->getSender(new Envelope(new DummyMessage('Hello'))));
-        $this->assertNull($locator->getSender(new Envelope(new SecondMessage())));
+        $this->assertSame($sender, $locator->getSender(DummyMessage::class));
+        $this->assertNull($locator->getSender(SecondMessage::class));
     }
 
     public function testItReturnsTheSenderBasedOnTheMessageParentClass()
@@ -52,8 +51,8 @@ class ContainerSenderLocatorTest extends TestCase
             DummyMessage::class => 'my_amqp_sender',
         ));
 
-        $this->assertSame($sender, $locator->getSender(new Envelope(new ChildDummyMessage('Hello'))));
-        $this->assertNull($locator->getSender(new Envelope(new SecondMessage())));
+        $this->assertSame($sender, $locator->getSender(ChildDummyMessage::class));
+        $this->assertNull($locator->getSender(SecondMessage::class));
     }
 
     public function testItReturnsTheSenderBasedOnTheMessageInterface()
@@ -67,8 +66,21 @@ class ContainerSenderLocatorTest extends TestCase
             DummyMessageInterface::class => 'my_amqp_sender',
         ));
 
-        $this->assertSame($sender, $locator->getSender(new Envelope(new DummyMessage('Hello'))));
-        $this->assertNull($locator->getSender(new Envelope(new SecondMessage())));
+        $this->assertSame($sender, $locator->getSender(DummyMessage::class));
+        $this->assertNull($locator->getSender(SecondMessage::class));
+    }
+
+    public function testItReturnsTheSenderBasedOnTheTopic()
+    {
+        $container = new Container();
+        $container->set('my_amqp_sender1', $sender1 = $this->getMockBuilder(SenderInterface::class)->getMock());
+        $container->set('my_amqp_sender2', $sender2 = $this->getMockBuilder(SenderInterface::class)->getMock());
+
+        $locator = new ContainerSenderLocator($container, array(
+            DummyMessageInterface::class => 'my_amqp_sender1',
+            'foo' => 'my_amqp_sender2',
+        ));
+        $this->assertSame($sender2, $locator->getSender('foo'));
     }
 
     public function testItSupportsAWildcardInsteadOfTheMessageClass()
@@ -86,7 +98,7 @@ class ContainerSenderLocatorTest extends TestCase
             '*' => 'my_api_sender',
         ));
 
-        $this->assertSame($sender, $locator->getSender(new Envelope(new DummyMessage('Hello'))));
-        $this->assertSame($apiSender, $locator->getSender(new Envelope(new SecondMessage())));
+        $this->assertSame($sender, $locator->getSender(DummyMessage::class));
+        $this->assertSame($apiSender, $locator->getSender(SecondMessage::class));
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/Locator/SenderLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/Locator/SenderLocatorTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Messenger\Tests\Transport\Sender\Locator;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\RuntimeException;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
@@ -28,8 +27,8 @@ class SenderLocatorTest extends TestCase
             DummyMessage::class => $sender,
         ));
 
-        $this->assertSame($sender, $locator->getSender(new Envelope(new DummyMessage('Hello'))));
-        $this->assertNull($locator->getSender(new Envelope(new SecondMessage())));
+        $this->assertSame($sender, $locator->getSender(DummyMessage::class));
+        $this->assertNull($locator->getSender(SecondMessage::class));
     }
 
     public function testItThrowsExceptionIfConfigurationIsWrong()
@@ -39,6 +38,6 @@ class SenderLocatorTest extends TestCase
         ));
 
         $this->expectException(RuntimeException::class);
-        $locator->getSender(new Envelope(new DummyMessage('Hello')));
+        $locator->getSender(DummyMessage::class);
     }
 }

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -27,9 +27,9 @@ class TraceableMessageBus implements MessageBusInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch($message): Envelope
+    public function dispatch($message, string $topic = null): Envelope
     {
-        $envelope = $message instanceof Envelope ? $message : new Envelope($message);
+        $envelope = Envelope::wrap($message, $topic);
         $context = array(
             'stamps' => array_values($envelope->all()),
             'message' => $envelope->getMessage(),
@@ -38,7 +38,7 @@ class TraceableMessageBus implements MessageBusInterface
         );
 
         try {
-            return $this->decoratedBus->dispatch($message);
+            return $this->decoratedBus->dispatch($message, $topic);
         } catch (\Throwable $e) {
             $context['exception'] = $e;
 

--- a/src/Symfony/Component/Messenger/Transport/Sender/Locator/AbstractSenderLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/Locator/AbstractSenderLocator.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Messenger\Transport\Sender\Locator;
 
-use Symfony\Component\Messenger\Envelope;
-
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
  *
@@ -20,19 +18,23 @@ use Symfony\Component\Messenger\Envelope;
  */
 abstract class AbstractSenderLocator implements SenderLocatorInterface
 {
-    public static function getValueFromMessageRouting(array $mapping, Envelope $envelope)
+    public static function getValueFromMessageRouting(array $mapping, string $topic)
     {
-        if (isset($mapping[$class = \get_class($envelope->getMessage())])) {
-            return $mapping[$class];
+        if (isset($mapping[$topic])) {
+            return $mapping[$topic];
         }
 
-        foreach (class_parents($class) as $name) {
+        if (!class_exists($topic) && !interface_exists($topic, false)) {
+            return $mapping['*'] ?? null;
+        }
+
+        foreach (class_parents($topic) as $name) {
             if (isset($mapping[$name])) {
                 return $mapping[$name];
             }
         }
 
-        foreach (class_implements($class) as $name) {
+        foreach (class_implements($topic) as $name) {
             if (isset($mapping[$name])) {
                 return $mapping[$name];
             }

--- a/src/Symfony/Component/Messenger/Transport/Sender/Locator/ContainerSenderLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/Locator/ContainerSenderLocator.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Messenger\Transport\Sender\Locator;
 
 use Psr\Container\ContainerInterface;
-use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 /**
@@ -21,20 +20,20 @@ use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 class ContainerSenderLocator extends AbstractSenderLocator
 {
     private $senderServiceLocator;
-    private $messageToSenderIdMapping;
+    private $topicToSenderIdMapping;
 
-    public function __construct(ContainerInterface $senderServiceLocator, array $messageToSenderIdMapping)
+    public function __construct(ContainerInterface $senderServiceLocator, array $topicToSenderIdMapping)
     {
         $this->senderServiceLocator = $senderServiceLocator;
-        $this->messageToSenderIdMapping = $messageToSenderIdMapping;
+        $this->topicToSenderIdMapping = $topicToSenderIdMapping;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getSender(Envelope $envelope): ?SenderInterface
+    public function getSender(string $topic): ?SenderInterface
     {
-        $senderId = self::getValueFromMessageRouting($this->messageToSenderIdMapping, $envelope);
+        $senderId = self::getValueFromMessageRouting($this->topicToSenderIdMapping, $topic);
 
         return $senderId ? $this->senderServiceLocator->get($senderId) : null;
     }

--- a/src/Symfony/Component/Messenger/Transport/Sender/Locator/SenderLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/Locator/SenderLocator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Messenger\Transport\Sender\Locator;
 
-use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\RuntimeException;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
@@ -20,25 +19,25 @@ use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
  */
 class SenderLocator extends AbstractSenderLocator
 {
-    private $messageToSenderMapping;
+    private $topicToSenderMapping;
 
-    public function __construct(array $messageToSenderMapping)
+    public function __construct(array $topicToSenderMapping)
     {
-        $this->messageToSenderMapping = $messageToSenderMapping;
+        $this->topicToSenderMapping = $topicToSenderMapping;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getSender(Envelope $envelope): ?SenderInterface
+    public function getSender(string $topic): ?SenderInterface
     {
-        $sender = self::getValueFromMessageRouting($this->messageToSenderMapping, $envelope);
+        $sender = self::getValueFromMessageRouting($this->topicToSenderMapping, $topic);
         if (null === $sender) {
             return null;
         }
 
         if (!$sender instanceof SenderInterface) {
-            throw new RuntimeException(sprintf('The sender instance provided for message "%s" should be of type "%s" but got "%s".', \get_class($envelope->getMessage()), SenderInterface::class, \is_object($sender) ? \get_class($sender) : \gettype($sender)));
+            throw new RuntimeException(sprintf('The sender instance provided for message "%s" should be of type "%s" but got "%s".', $topic, SenderInterface::class, \is_object($sender) ? \get_class($sender) : \gettype($sender)));
         }
 
         return $sender;

--- a/src/Symfony/Component/Messenger/Transport/Sender/Locator/SenderLocatorInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/Locator/SenderLocatorInterface.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Messenger\Transport\Sender\Locator;
 
-use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 /**
@@ -23,5 +22,5 @@ interface SenderLocatorInterface
     /**
      * Gets the sender (if applicable) for the given message object.
      */
-    public function getSender(Envelope $envelope): ?SenderInterface;
+    public function getSender(string $topic): ?SenderInterface;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When dispatching a message, it's not always possible to know its "class" beforehand. Currently, the component suffers from this limitation of not allowing one to dispatch messages based on a string that would be provided at runtime.

Dispatching by parent classes + interfaces looks like a workaround for this limitation to me. Binding the type-system and configuration is what made autowiring clumsy in 2.8. The issue was that changing/refactoring some code would have unrelated and unwanted side effects. Here, that'd be the same on the way messages are dispatched. Adding a dispatch key fixes this issue by allowing one to opt-out from type-based dispatching, *without removing this strategy* (time will tell if I'm wrong)

Anyway, allowing to provide a runtime-computed dispatch key is a missing core feature.
It allows both:
 - dispatching several subclasses under the same key, allowing to use their type as useful info for a common set of handlers/senders
 - dispatching the same class under different keys, allowing one to provide more specialized dispatching than just the class when appropriate (when the key is known at runtime).

