### PR TITLE
[Messenger] remove classifying sub-namespaces in favor of semantic ones

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -68,7 +68,7 @@ use Symfony\Component\Lock\StoreInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Transport\ChainSender;
+use Symfony\Component\Messenger\Transport\Sender\ChainSender;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -8,11 +8,11 @@
         <defaults public="false" />
 
         <!-- Asynchronous -->
-        <service id="messenger.asynchronous.routing.sender_locator" class="Symfony\Component\Messenger\Asynchronous\Routing\ContainerSenderLocator">
+        <service id="messenger.asynchronous.routing.sender_locator" class="Symfony\Component\Messenger\Transport\Sender\Locator\ContainerSenderLocator">
             <argument type="service" id="messenger.sender_locator" />
             <argument type="collection" /> <!-- Message to sender ID mapping -->
         </service>
-        <service id="messenger.middleware.route_messages" class="Symfony\Component\Messenger\Asynchronous\Middleware\SendMessageMiddleware">
+        <service id="messenger.middleware.route_messages" class="Symfony\Component\Messenger\Middleware\SendMessageMiddleware">
             <argument type="service" id="messenger.asynchronous.routing.sender_locator" />
             <argument type="collection" /> <!-- Message to send and handle mapping -->
         </service>

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -33,6 +33,12 @@ CHANGELOG
  * `HandlerLocatorInterface::resolve()` has been replaced by `getHandler(Envelope $envelope)`
  * `SenderLocatorInterface::getSenderForMessage()` has been replaced by `getSender(Envelope $envelope)`
  * `SenderInterface::send()` returns `void`
+ * Classes in the `Middleware\Enhancers` sub-namespace have been moved to the `Middleware` one
+ * Classes in the `Asynchronous\Routing` sub-namespace have been moved to the `Transport\Sender\Locator` sub-namespace
+ * The `Asynchronous/Middleware/SendMessageMiddleware` class has been moved to the `Middleware` namespace
+ * `SenderInterface` and `ChainSender` classes have been moved to the `Transport\Sender` sub-namespace
+ * `ReceiverInterface` and its implementations have been moved to the `Transport\Receiver` sub-namespace
+ * `ActivationMiddlewareDecorator` has been renamed `ActivationMiddleware`
 
 4.1.0
 -----

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -20,9 +20,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Messenger\Transport\Enhancers\StopWhenMemoryUsageIsExceededReceiver;
-use Symfony\Component\Messenger\Transport\Enhancers\StopWhenMessageCountIsExceededReceiver;
-use Symfony\Component\Messenger\Transport\Enhancers\StopWhenTimeLimitIsReachedReceiver;
+use Symfony\Component\Messenger\Transport\Receiver\StopWhenMemoryUsageIsExceededReceiver;
+use Symfony\Component\Messenger\Transport\Receiver\StopWhenMessageCountIsExceededReceiver;
+use Symfony\Component\Messenger\Transport\Receiver\StopWhenTimeLimitIsReachedReceiver;
 use Symfony\Component\Messenger\Worker;
 
 /**

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -22,10 +22,10 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\Handler\ChainHandler;
 use Symfony\Component\Messenger\Handler\Locator\ContainerHandlerLocator;
 use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
-use Symfony\Component\Messenger\Middleware\Enhancers\TraceableMiddleware;
+use Symfony\Component\Messenger\Middleware\TraceableMiddleware;
 use Symfony\Component\Messenger\TraceableMessageBus;
-use Symfony\Component\Messenger\Transport\ReceiverInterface;
-use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Messenger/Middleware/ActivationMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/ActivationMiddleware.php
@@ -9,17 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Middleware\Enhancers;
+namespace Symfony\Component\Messenger\Middleware;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 
 /**
  * Execute the inner middleware according to an activation strategy.
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
-class ActivationMiddlewareDecorator implements MiddlewareInterface
+class ActivationMiddleware implements MiddlewareInterface
 {
     private $inner;
     private $activated;

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -9,13 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Asynchronous\Middleware;
+namespace Symfony\Component\Messenger\Middleware;
 
-use Symfony\Component\Messenger\Asynchronous\Routing\AbstractSenderLocator;
-use Symfony\Component\Messenger\Asynchronous\Routing\SenderLocatorInterface;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Transport\Sender\Locator\AbstractSenderLocator;
+use Symfony\Component\Messenger\Transport\Sender\Locator\SenderLocatorInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
@@ -9,10 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Middleware\Enhancers;
+namespace Symfony\Component\Messenger\Middleware;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**

--- a/src/Symfony/Component/Messenger/Stamp/ReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ReceivedStamp.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Messenger\Stamp;
 
-use Symfony\Component\Messenger\Asynchronous\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
 
 /**
  * Marker config for a received message.

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -40,7 +40,7 @@ use Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler;
 use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
 use Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceiver;
 use Symfony\Component\Messenger\Transport\AmqpExt\AmqpSender;
-use Symfony\Component\Messenger\Transport\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 class MessengerPassTest extends TestCase
@@ -344,7 +344,7 @@ class MessengerPassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Invalid sender "app.messenger.sender": class "Symfony\Component\Messenger\Tests\DependencyInjection\InvalidSender" must implement interface "Symfony\Component\Messenger\Transport\SenderInterface".
+     * @expectedExceptionMessage Invalid sender "app.messenger.sender": class "Symfony\Component\Messenger\Tests\DependencyInjection\InvalidSender" must implement interface "Symfony\Component\Messenger\Transport\Sender\SenderInterface".
      */
     public function testItDoesNotRegisterInvalidSender()
     {

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/CallbackReceiver.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/CallbackReceiver.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\Messenger\Tests\Fixtures;
 
-use Symfony\Component\Messenger\Transport\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 class CallbackReceiver implements ReceiverInterface
 {

--- a/src/Symfony/Component/Messenger/Tests/Middleware/ActivationMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/ActivationMiddlewareTest.php
@@ -9,18 +9,18 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Middleware\Enhancers;
+namespace Symfony\Component\Messenger\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Middleware\Enhancers\ActivationMiddlewareDecorator;
+use Symfony\Component\Messenger\Middleware\ActivationMiddleware;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
 /**
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
-class ActivationMiddlewareDecoratorTest extends TestCase
+class ActivationMiddlewareTest extends TestCase
 {
     public function testExecuteMiddlewareOnActivated()
     {
@@ -33,7 +33,7 @@ class ActivationMiddlewareDecoratorTest extends TestCase
         $middleware = $this->createMock(MiddlewareInterface::class);
         $middleware->expects($this->once())->method('handle')->with($envelope, $next);
 
-        $decorator = new ActivationMiddlewareDecorator($middleware, true);
+        $decorator = new ActivationMiddleware($middleware, true);
 
         $decorator->handle($envelope, $next);
     }
@@ -52,7 +52,7 @@ class ActivationMiddlewareDecoratorTest extends TestCase
         $middleware = $this->createMock(MiddlewareInterface::class);
         $middleware->expects($this->once())->method('handle')->with($envelope, $next);
 
-        $decorator = new ActivationMiddlewareDecorator($middleware, $activated);
+        $decorator = new ActivationMiddleware($middleware, $activated);
 
         $decorator->handle($envelope, $next);
     }
@@ -68,7 +68,7 @@ class ActivationMiddlewareDecoratorTest extends TestCase
         $middleware = $this->createMock(MiddlewareInterface::class);
         $middleware->expects($this->never())->method('handle');
 
-        $decorator = new ActivationMiddlewareDecorator($middleware, false);
+        $decorator = new ActivationMiddleware($middleware, false);
 
         $decorator->handle($envelope, $next);
     }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Asynchronous\Middleware;
+namespace Symfony\Component\Messenger\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Messenger\Asynchronous\Middleware\SendMessageMiddleware;
-use Symfony\Component\Messenger\Asynchronous\Routing\SenderLocatorInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
-use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\Locator\SenderLocatorInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 class SendMessageMiddlewareTest extends TestCase
 {

--- a/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Middleware\Enhancers;
+namespace Symfony\Component\Messenger\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Middleware\Enhancers\TraceableMiddleware;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\TraceableMiddleware;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Stopwatch\Stopwatch;
 

--- a/src/Symfony/Component/Messenger/Tests/Stamp/SerializerStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/SerializerStampTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Asynchronous\Serialization;
+namespace Symfony\Component\Messenger\Tests\Stamp;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;

--- a/src/Symfony/Component/Messenger/Tests/Transport/Receiver/StopWhenMemoryUsageIsExceededReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Receiver/StopWhenMemoryUsageIsExceededReceiverTest.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Transport\Enhancers;
+namespace Symfony\Component\Messenger\Tests\Transport\Receiver;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Tests\Fixtures\CallbackReceiver;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
-use Symfony\Component\Messenger\Transport\Enhancers\StopWhenMemoryUsageIsExceededReceiver;
+use Symfony\Component\Messenger\Transport\Receiver\StopWhenMemoryUsageIsExceededReceiver;
 
 class StopWhenMemoryUsageIsExceededReceiverTest extends TestCase
 {

--- a/src/Symfony/Component/Messenger/Tests/Transport/Receiver/StopWhenMessageCountIsExceededReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Receiver/StopWhenMessageCountIsExceededReceiverTest.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Transport\Enhancers;
+namespace Symfony\Component\Messenger\Tests\Transport\Receiver;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Tests\Fixtures\CallbackReceiver;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
-use Symfony\Component\Messenger\Transport\Enhancers\StopWhenMessageCountIsExceededReceiver;
+use Symfony\Component\Messenger\Transport\Receiver\StopWhenMessageCountIsExceededReceiver;
 
 class StopWhenMessageCountIsExceededReceiverTest extends TestCase
 {

--- a/src/Symfony/Component/Messenger/Tests/Transport/Receiver/StopWhenTimeLimitIsReachedReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Receiver/StopWhenTimeLimitIsReachedReceiverTest.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Transport\Enhancers;
+namespace Symfony\Component\Messenger\Tests\Transport\Receiver;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Tests\Fixtures\CallbackReceiver;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
-use Symfony\Component\Messenger\Transport\Enhancers\StopWhenTimeLimitIsReachedReceiver;
+use Symfony\Component\Messenger\Transport\Receiver\StopWhenTimeLimitIsReachedReceiver;
 
 class StopWhenTimeLimitIsReachedReceiverTest extends TestCase
 {

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/Locator/ContainerSenderLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/Locator/ContainerSenderLocatorTest.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Asynchronous\Routing;
+namespace Symfony\Component\Messenger\Tests\Transport\Sender\Locator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\Messenger\Asynchronous\Routing\ContainerSenderLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
-use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\Locator\ContainerSenderLocator;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 class ContainerSenderLocatorTest extends TestCase
 {

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/Locator/SenderLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/Locator/SenderLocatorTest.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Tests\Asynchronous\Routing;
+namespace Symfony\Component\Messenger\Tests\Transport\Sender\Locator;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Messenger\Asynchronous\Routing\SenderLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\RuntimeException;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
-use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\Locator\SenderLocator;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 class SenderLocatorTest extends TestCase
 {

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpReceiver.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Transport\AmqpExt\Exception\RejectMessageExceptionInterface;
-use Symfony\Component\Messenger\Transport\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/AmqpSender.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Messenger\Transport\AmqpExt;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 

--- a/src/Symfony/Component/Messenger/Transport/Receiver/ReceiverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/ReceiverInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Transport;
+namespace Symfony\Component\Messenger\Transport\Receiver;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Messenger/Transport/Receiver/StopWhenMemoryUsageIsExceededReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/StopWhenMemoryUsageIsExceededReceiver.php
@@ -9,11 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Transport\Enhancers;
+namespace Symfony\Component\Messenger\Transport\Receiver;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\ReceiverInterface;
 
 /**
  * @author Simon Delicata <simon.delicata@free.fr>

--- a/src/Symfony/Component/Messenger/Transport/Receiver/StopWhenMessageCountIsExceededReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/StopWhenMessageCountIsExceededReceiver.php
@@ -9,11 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Transport\Enhancers;
+namespace Symfony\Component\Messenger\Transport\Receiver;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\ReceiverInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Messenger/Transport/Receiver/StopWhenTimeLimitIsReachedReceiver.php
+++ b/src/Symfony/Component/Messenger/Transport/Receiver/StopWhenTimeLimitIsReachedReceiver.php
@@ -9,11 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Transport\Enhancers;
+namespace Symfony\Component\Messenger\Transport\Receiver;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\ReceiverInterface;
 
 /**
  * @author Simon Delicata <simon.delicata@free.fr>

--- a/src/Symfony/Component/Messenger/Transport/Sender/ChainSender.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/ChainSender.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Transport;
+namespace Symfony\Component\Messenger\Transport\Sender;
 
 use Symfony\Component\Messenger\Envelope;
 

--- a/src/Symfony/Component/Messenger/Transport/Sender/Locator/AbstractSenderLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/Locator/AbstractSenderLocator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Asynchronous\Routing;
+namespace Symfony\Component\Messenger\Transport\Sender\Locator;
 
 use Symfony\Component\Messenger\Envelope;
 

--- a/src/Symfony/Component/Messenger/Transport/Sender/Locator/ContainerSenderLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/Locator/ContainerSenderLocator.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Asynchronous\Routing;
+namespace Symfony\Component\Messenger\Transport\Sender\Locator;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Messenger/Transport/Sender/Locator/SenderLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/Locator/SenderLocator.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Asynchronous\Routing;
+namespace Symfony\Component\Messenger\Transport\Sender\Locator;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\RuntimeException;
-use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/Messenger/Transport/Sender/Locator/SenderLocatorInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/Locator/SenderLocatorInterface.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Asynchronous\Routing;
+namespace Symfony\Component\Messenger\Transport\Sender\Locator;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>

--- a/src/Symfony/Component/Messenger/Transport/Sender/SenderInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SenderInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Messenger\Transport;
+namespace Symfony\Component\Messenger\Transport\Sender;
 
 use Symfony\Component\Messenger\Envelope;
 

--- a/src/Symfony/Component/Messenger/Transport/TransportInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/TransportInterface.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Messenger\Transport;
 
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Messenger;
 
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
-use Symfony\Component\Messenger\Transport\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

While working on the component, I found it hard to discover the meaning of the `Asynchronous` and `Enhancers` sub-namespaces. Now that I know the component better, I understand they're only classifying namespaces with no specific technical semantics.

I'd like to remove them to make the component easier to discover.
This PR introduces a few new semantic sub-namespaces instead.

From the changelog:
  * Classes in the `Middleware\Enhancers` sub-namespace have been moved to the `Middleware` one
 * Classes in the `Asynchronous\Routing` sub-namespace have been moved to the `Transport\Sender\Locator` sub-namespace
 * The `Asynchronous/Middleware/SendMessageMiddleware` class has been moved to the `Middleware` namespace
 * `SenderInterface` and `ChainSender` classes have been moved to the `Transport\Sender` sub-namespace
 * `ReceiverInterface` and its implementations have been moved to the `Transport\Receiver` sub-namespace 