### PR TITLE
[Debug] Mark ErrorHandler and ExceptionHandler classes as final

### DIFF
--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+* made the `ErrorHandler` and `ExceptionHandler` classes final
+
 4.0.0
 -----
 

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -45,6 +45,8 @@ use Symfony\Component\Debug\FatalErrorHandler\UndefinedMethodFatalErrorHandler;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @final since Symfony 4.3
  */
 class ErrorHandler
 {

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -26,6 +26,8 @@ use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @final since Symfony 4.3
  */
 class ExceptionHandler
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | not yet
| Deprecations? | yes
| Tests pass?   | yes 
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The goal of marking this method final is to be able to change the argument signature to `\Throwable` in Symfony 5.0

We will then be able to convert the incoming `\Throwable` to `\ErrorException` thanks to the `FatalThrowableError` class.

The use case is when you use the `ExceptionHandler::register()` method of the `Debug` component with a custom `set_error_handler()` that don't handle this conversion. This is for example the case of the `Drupal` one.