### PR TITLE
[WIP] Remove check for hardcoded message_bus service name

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -51,10 +51,6 @@ class MessengerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->has('message_bus')) {
-            return;
-        }
-
         $busIds = array();
         foreach ($container->findTaggedServiceIds($this->busTag) as $busId => $tags) {
             $busIds[] = $busId;

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -65,9 +65,11 @@ class MessengerPass implements CompilerPassInterface
             }
         }
 
-        $this->registerReceivers($container);
-        $this->registerSenders($container);
-        $this->registerHandlers($container, $busIds);
+        if (!empty($busIds)) {
+            $this->registerReceivers($container);
+            $this->registerSenders($container);
+            $this->registerHandlers($container, $busIds);
+        }
     }
 
     private function registerHandlers(ContainerBuilder $container, array $busIds)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes
| License       | MIT

There is no need to have a bus named `message_bus` for the `MessengerPass` to work.

