### PR TITLE
[PropertyAccessor] Fix unable to write to singular property using setter while plural adder/remover exist

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -607,7 +607,6 @@ class PropertyAccessor implements PropertyAccessorInterface
         $camelized = $this->camelize($property);
         $singulars = (array) Inflector::singularize($camelized);
 
-
         if (!isset($access[self::ACCESS_TYPE])) {
             $setter = 'set'.$camelized;
             $getsetter = lcfirst($camelized); // jQuery style, e.g. read: last(), write: last($item)

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -607,15 +607,6 @@ class PropertyAccessor implements PropertyAccessorInterface
         $camelized = $this->camelize($property);
         $singulars = (array) Inflector::singularize($camelized);
 
-        if (\is_array($value) || $value instanceof \Traversable) {
-            $methods = $this->findAdderAndRemover($reflClass, $singulars);
-
-            if (null !== $methods) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_ADDER_AND_REMOVER;
-                $access[self::ACCESS_ADDER] = $methods[0];
-                $access[self::ACCESS_REMOVER] = $methods[1];
-            }
-        }
 
         if (!isset($access[self::ACCESS_TYPE])) {
             $setter = 'set'.$camelized;
@@ -638,16 +629,22 @@ class PropertyAccessor implements PropertyAccessorInterface
                 $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_MAGIC;
                 $access[self::ACCESS_NAME] = $setter;
             } elseif (null !== $methods = $this->findAdderAndRemover($reflClass, $singulars)) {
-                $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
-                $access[self::ACCESS_NAME] = sprintf(
-                    'The property "%s" in class "%s" can be defined with the methods "%s()" but '.
-                    'the new value must be an array or an instance of \Traversable, '.
-                    '"%s" given.',
-                    $property,
-                    $reflClass->name,
-                    implode('()", "', $methods),
-                    \is_object($value) ? \get_class($value) : \gettype($value)
-                );
+                if (\is_array($value) || $value instanceof \Traversable) {
+                    $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_ADDER_AND_REMOVER;
+                    $access[self::ACCESS_ADDER] = $methods[0];
+                    $access[self::ACCESS_REMOVER] = $methods[1];
+                } else {
+                    $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
+                    $access[self::ACCESS_NAME] = sprintf(
+                        'The property "%s" in class "%s" can be defined with the methods "%s()" but '.
+                        'the new value must be an array or an instance of \Traversable, '.
+                        '"%s" given.',
+                        $property,
+                        $reflClass->name,
+                        implode('()", "', $methods),
+                        \is_object($value) ? \get_class($value) : \gettype($value)
+                    );
+                }
             } else {
                 $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
                 $access[self::ACCESS_NAME] = sprintf(

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestSingularAndPluralProps.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestSingularAndPluralProps.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+/**
+ * Notice we don't have getter/setter for emails
+ * because we count on adder/remover
+ */
+class TestSingularAndPluralProps
+{
+    /** @var string|null */
+    private $email;
+
+    /** @var array */
+    private $emails = [];
+
+    /**
+     * @return null|string
+     */
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param null|string $email
+     */
+    public function setEmail(?string $email): void
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEmails(): array
+    {
+        return $this->emails;
+    }
+
+    /**
+     * @param string $email
+     */
+    public function addEmail(string $email): void
+    {
+        $this->emails[] = $email;
+    }
+
+    /**
+     * @param string $email
+     */
+    public function removeEmail(string $email): void
+    {
+        $this->emails = array_diff($this->emails, [$email]);
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestSingularAndPluralProps.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestSingularAndPluralProps.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
 
 /**
  * Notice we don't have getter/setter for emails
- * because we count on adder/remover
+ * because we count on adder/remover.
  */
 class TestSingularAndPluralProps
 {
@@ -21,10 +21,10 @@ class TestSingularAndPluralProps
     private $email;
 
     /** @var array */
-    private $emails = [];
+    private $emails = array();
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getEmail(): ?string
     {
@@ -32,7 +32,7 @@ class TestSingularAndPluralProps
     }
 
     /**
-     * @param null|string $email
+     * @param string|null $email
      */
     public function setEmail(?string $email): void
     {
@@ -60,6 +60,6 @@ class TestSingularAndPluralProps
      */
     public function removeEmail(string $email): void
     {
-        $this->emails = array_diff($this->emails, [$email]);
+        $this->emails = array_diff($this->emails, array($email));
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassSetValue;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassTypeErrorInsideCall;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\Ticket5775Object;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TypeHinted;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestSingularAndPluralProps;
 
 class PropertyAccessorTest extends TestCase
 {
@@ -674,5 +675,29 @@ class PropertyAccessorTest extends TestCase
         $object = new ReturnTyped();
 
         $this->propertyAccessor->setValue($object, 'name', 'foo');
+    }
+
+    public function testWriteToSingularPropertyWhilePluralOneExists()
+    {
+        $object = new TestSingularAndPluralProps();
+
+        if ($this->propertyAccessor->isWritable($object, 'email')) {
+            $this->propertyAccessor->setValue($object, 'email', 'test@email.com');
+        }
+
+        self::assertEquals('test@email.com', $object->getEmail());
+        self::assertEmpty($object->getEmails());
+    }
+
+    public function testWriteToPluralPropertyWhileSingularOneExists()
+    {
+        $object = new TestSingularAndPluralProps();
+
+        if ($this->propertyAccessor->isWritable($object, 'emails')) {
+            $this->propertyAccessor->setValue($object, 'emails', ['test@email.com']);
+        }
+
+        self::assertEquals(['test@email.com'], $object->getEmails());
+        self::assertNull($object->getEmail());
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -22,9 +22,9 @@ use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicCall;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassMagicGet;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassSetValue;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClassTypeErrorInsideCall;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\TestSingularAndPluralProps;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\Ticket5775Object;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TypeHinted;
-use Symfony\Component\PropertyAccess\Tests\Fixtures\TestSingularAndPluralProps;
 
 class PropertyAccessorTest extends TestCase
 {
@@ -694,10 +694,10 @@ class PropertyAccessorTest extends TestCase
         $object = new TestSingularAndPluralProps();
 
         if ($this->propertyAccessor->isWritable($object, 'emails')) {
-            $this->propertyAccessor->setValue($object, 'emails', ['test@email.com']);
+            $this->propertyAccessor->setValue($object, 'emails', array('test@email.com'));
         }
 
-        self::assertEquals(['test@email.com'], $object->getEmails());
+        self::assertEquals(array('test@email.com'), $object->getEmails());
         self::assertNull($object->getEmail());
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -681,9 +681,8 @@ class PropertyAccessorTest extends TestCase
     {
         $object = new TestSingularAndPluralProps();
 
-        if ($this->propertyAccessor->isWritable($object, 'email')) {
-            $this->propertyAccessor->setValue($object, 'email', 'test@email.com');
-        }
+        $this->propertyAccessor->isWritable($object, 'email'); //cache access info
+        $this->propertyAccessor->setValue($object, 'email', 'test@email.com');
 
         self::assertEquals('test@email.com', $object->getEmail());
         self::assertEmpty($object->getEmails());
@@ -693,9 +692,8 @@ class PropertyAccessorTest extends TestCase
     {
         $object = new TestSingularAndPluralProps();
 
-        if ($this->propertyAccessor->isWritable($object, 'emails')) {
-            $this->propertyAccessor->setValue($object, 'emails', array('test@email.com'));
-        }
+        $this->propertyAccessor->isWritable($object, 'emails'); //cache access info
+        $this->propertyAccessor->setValue($object, 'emails', array('test@email.com'));
 
         self::assertEquals(array('test@email.com'), $object->getEmails());
         self::assertNull($object->getEmail());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4, 4.1 and master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28961
| License       | MIT

Please take a look at the tests I added - they describe the issue. It has to do with the priorities: `findAdderAndRemover('User', 'email')` is called earlier than `$this->isMethodAccessible('User', 'setEmail', 1)`