### PR TITLE
 [TwigBridge] Remove $rootDir argument in CodeExtension

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
@@ -25,7 +25,7 @@ class CodeExtensionTest extends TestCase
 
     public function testFileRelative()
     {
-        $this->assertEquals('CodeExtensionTest.php', $this->getExtension()->getFileRelative(__FILE__));
+        $this->assertEquals('file.txt', $this->getExtension()->getFileRelative(\DIRECTORY_SEPARATOR.'project'.\DIRECTORY_SEPARATOR.'file.txt'));
     }
 
     /**
@@ -69,6 +69,6 @@ class CodeExtensionTest extends TestCase
 
     protected function getExtension()
     {
-        return new CodeExtension(new FileLinkFormatter('proto://%f#&line=%l&'.substr(__FILE__, 0, 5).'>foobar'), '/root', 'UTF-8', __DIR__);
+        return new CodeExtension(new FileLinkFormatter('proto://%f#&line=%l&'.substr(__FILE__, 0, 5).'>foobar'), \DIRECTORY_SEPARATOR.'project', 'UTF-8');
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -84,9 +84,8 @@
         <service id="twig.extension.code" class="Symfony\Bridge\Twig\Extension\CodeExtension">
             <tag name="twig.extension" />
             <argument type="service" id="debug.file_link_formatter" on-invalid="ignore" />
-            <argument>%kernel.root_dir%</argument>
-            <argument>%kernel.charset%</argument>
             <argument>%kernel.project_dir%</argument>
+            <argument>%kernel.charset%</argument>
         </service>
 
         <service id="twig.extension.routing" class="Symfony\Bridge\Twig\Extension\RoutingExtension">

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/config": "~4.2",
-        "symfony/twig-bridge": "^3.4.3|^4.0.3",
+        "symfony/twig-bridge": "^4.2",
         "symfony/http-foundation": "~4.1",
         "symfony/http-kernel": "~4.1",
         "symfony/polyfill-ctype": "~1.8",
@@ -33,6 +33,7 @@
         "symfony/form": "~3.4|~4.0",
         "symfony/routing": "~3.4|~4.0",
         "symfony/templating": "~3.4|~4.0",
+        "symfony/translation": "^4.2",
         "symfony/yaml": "~3.4|~4.0",
         "symfony/framework-bundle": "~4.1",
         "symfony/web-link": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://github.com/symfony/symfony-docs/pull/10547#issuecomment-432608538
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Forgotten in #28890 

cc @javiereguiluz 