### PR TITLE
[OptionsResolver] Fixed explicitly ignores a depreciation

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -801,7 +801,7 @@ class OptionsResolver implements Options
 
         // Shortcut for resolved options
         if (array_key_exists($option, $this->resolved)) {
-            if ($triggerDeprecation && isset($this->deprecated[$option]) && \is_string($this->deprecated[$option])) {
+            if ($triggerDeprecation && isset($this->deprecated[$option]) && (isset($this->given[$option]) || $this->calling) && \is_string($this->deprecated[$option])) {
                 @trigger_error(strtr($this->deprecated[$option], array('%name%' => $option)), E_USER_DEPRECATED);
             }
 

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -754,6 +754,9 @@ class OptionsResolverTest extends TestCase
         yield 'It explicitly ignores a depreciation' => array(
             function (OptionsResolver $resolver) {
                 $resolver
+                    ->setDefault('baz', function (Options $options) {
+                        return $options->offsetGet('foo', false);
+                    })
                     ->setDefault('foo', null)
                     ->setDeprecated('foo')
                     ->setDefault('bar', function (Options $options) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/28860#issuecomment-432560319
| License       | MIT
| Doc PR        | -

When a deprecated option with default value was resolved (the first time it's called) in this case through a lazy evaluation, [the default resolution process](https://github.com/symfony/symfony/blob/8398947c9c1c1266aad0bea773d0b524e0d81643/src/Symfony/Component/OptionsResolver/OptionsResolver.php#L771-L773) takes the resolved value and here should also trigger only if the option was provided by the user or is being called from a lazy evaluation, otherwise ignore.