### PR TITLE
[DI] Add an url EnvProcessor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * added `%env(trim:...)%` processor to trim a string value
  * added `%env(default:param_name:...)%` processor to fallback to a parameter or to null when using `%env(default::...)%`
+ * added `%env(url:...)%` processor to convert an URL or DNS into an array of components
+ * added `%env(query_string:...)%` processor to convert a query string into an array of key values
  * added support for deprecating aliases
  * made `ContainerParametersResource` final and not implement `Serializable` anymore
  * added ability to define an index for a tagged collection

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -39,6 +39,8 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'int' => ['int'],
             'json' => ['array'],
             'key' => ['bool', 'int', 'float', 'string', 'array'],
+            'url' => ['array'],
+            'query_string' => ['array'],
             'resolve' => ['string'],
             'default' => ['bool', 'int', 'float', 'string', 'array'],
             'string' => ['string'],

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
@@ -1,0 +1,124 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final since Symfony 3.3
+ */
+class Symfony_DI_PhpDumper_Test_QueryStringParameters extends Container
+{
+    private $parameters;
+    private $targetDirs = [];
+
+    public function __construct()
+    {
+        $this->parameters = $this->getDefaultParameters();
+
+        $this->services = $this->privates = [];
+
+        $this->aliases = [];
+    }
+
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped container that was already compiled.');
+    }
+
+    public function isCompiled()
+    {
+        return true;
+    }
+
+    public function getRemovedIds()
+    {
+        return [
+            'Psr\\Container\\ContainerInterface' => true,
+            'Symfony\\Component\\DependencyInjection\\ContainerInterface' => true,
+        ];
+    }
+
+    public function getParameter($name)
+    {
+        $name = (string) $name;
+
+        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || array_key_exists($name, $this->parameters))) {
+            throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
+        }
+        if (isset($this->loadedDynamicParameters[$name])) {
+            return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        return $this->parameters[$name];
+    }
+
+    public function hasParameter($name)
+    {
+        $name = (string) $name;
+
+        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || array_key_exists($name, $this->parameters);
+    }
+
+    public function setParameter($name, $value)
+    {
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
+    }
+
+    public function getParameterBag()
+    {
+        if (null === $this->parameterBag) {
+            $parameters = $this->parameters;
+            foreach ($this->loadedDynamicParameters as $name => $loaded) {
+                $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+            }
+            $this->parameterBag = new FrozenParameterBag($parameters);
+        }
+
+        return $this->parameterBag;
+    }
+
+    private $loadedDynamicParameters = [
+        'hello' => false,
+    ];
+    private $dynamicParameters = [];
+
+    /**
+     * Computes a dynamic parameter.
+     *
+     * @param string $name The name of the dynamic parameter to load
+     *
+     * @return mixed The value of the dynamic parameter
+     *
+     * @throws InvalidArgumentException When the dynamic parameter does not exist
+     */
+    private function getDynamicParameter($name)
+    {
+        switch ($name) {
+            case 'hello': $value = $this->getEnv('query_string:foo'); break;
+            default: throw new InvalidArgumentException(sprintf('The dynamic parameter "%s" must be defined.', $name));
+        }
+        $this->loadedDynamicParameters[$name] = true;
+
+        return $this->dynamicParameters[$name] = $value;
+    }
+
+    /**
+     * Gets the default parameters.
+     *
+     * @return array An array of the default parameters
+     */
+    protected function getDefaultParameters()
+    {
+        return [
+            'env(foo)' => 'foo=bar&baz[]=qux',
+        ];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
@@ -1,0 +1,124 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final since Symfony 3.3
+ */
+class Symfony_DI_PhpDumper_Test_UrlParameters extends Container
+{
+    private $parameters;
+    private $targetDirs = [];
+
+    public function __construct()
+    {
+        $this->parameters = $this->getDefaultParameters();
+
+        $this->services = $this->privates = [];
+
+        $this->aliases = [];
+    }
+
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped container that was already compiled.');
+    }
+
+    public function isCompiled()
+    {
+        return true;
+    }
+
+    public function getRemovedIds()
+    {
+        return [
+            'Psr\\Container\\ContainerInterface' => true,
+            'Symfony\\Component\\DependencyInjection\\ContainerInterface' => true,
+        ];
+    }
+
+    public function getParameter($name)
+    {
+        $name = (string) $name;
+
+        if (!(isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || array_key_exists($name, $this->parameters))) {
+            throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
+        }
+        if (isset($this->loadedDynamicParameters[$name])) {
+            return $this->loadedDynamicParameters[$name] ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+        }
+
+        return $this->parameters[$name];
+    }
+
+    public function hasParameter($name)
+    {
+        $name = (string) $name;
+
+        return isset($this->parameters[$name]) || isset($this->loadedDynamicParameters[$name]) || array_key_exists($name, $this->parameters);
+    }
+
+    public function setParameter($name, $value)
+    {
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
+    }
+
+    public function getParameterBag()
+    {
+        if (null === $this->parameterBag) {
+            $parameters = $this->parameters;
+            foreach ($this->loadedDynamicParameters as $name => $loaded) {
+                $parameters[$name] = $loaded ? $this->dynamicParameters[$name] : $this->getDynamicParameter($name);
+            }
+            $this->parameterBag = new FrozenParameterBag($parameters);
+        }
+
+        return $this->parameterBag;
+    }
+
+    private $loadedDynamicParameters = [
+        'hello' => false,
+    ];
+    private $dynamicParameters = [];
+
+    /**
+     * Computes a dynamic parameter.
+     *
+     * @param string $name The name of the dynamic parameter to load
+     *
+     * @return mixed The value of the dynamic parameter
+     *
+     * @throws InvalidArgumentException When the dynamic parameter does not exist
+     */
+    private function getDynamicParameter($name)
+    {
+        switch ($name) {
+            case 'hello': $value = $this->getEnv('url:foo'); break;
+            default: throw new InvalidArgumentException(sprintf('The dynamic parameter "%s" must be defined.', $name));
+        }
+        $this->loadedDynamicParameters[$name] = true;
+
+        return $this->dynamicParameters[$name] = $value;
+    }
+
+    /**
+     * Gets the default parameters.
+     *
+     * @return array An array of the default parameters
+     */
+    protected function getDefaultParameters()
+    {
+        return [
+            'env(foo)' => 'postgres://user@localhost:5432/database?sslmode=disable',
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/11128

This PR add a new env processor `url` to convert an URL (or DSN) into an array.

The main goal is to simplify the project configuration and reduce the number of env variable when working with bundle which are not able to deal with DSN
(pick some random project in symfony/recipes-contrib: https://github.com/symfony/recipes-contrib/blob/master/facile-it/mongodb-bundle/0.6/manifest.json or https://github.com/symfony/recipes-contrib/blob/master/wouterj/eloquent-bundle/1.0/manifest.json)

```yaml
# before
MONGODB_HOST=localhost
MONGODB_PORT=27017
MONGODB_USER=
MONGODB_PASSWORD=
MONGODB_DB=symfony

mongo_db_bundle:
    data_collection: '%kernel.debug%'
    clients:
        default:
            hosts:
            - { host: '%env(MONGODB_HOST)%', port: '%env(int:MONGODB_PORT)%' }
            username: '%env(MONGODB_USER)%'
            password: '%env(MONGODB_PASSWORD)%'
            connectTimeoutMS: 3000
    connections:
        default:
            database_name: '%env(MONGODB_DB)%'


# after
MONGODB_DSN=mongodb://localhost:27017/symfony

mongo_db_bundle:
    data_collection: '%kernel.debug%'
    clients:
        default:
            hosts:
            - { host: '%env(key:host:url:MONGODB_DSN)%', port: '%env(key:port:url:MONGODB_DSN)%' }
            username: '%env(key:user:url:MONGODB_DSN)%'
            password: '%env(key:pass:url:MONGODB_DSN)%'
            connectTimeoutMS: 3000
    connections:
        default:
            database_name: '%env(key:path:url:MONGODB_DSN)%'
```

Added also a `query_string` processor to parse query string

```
DATABASE_DSN=mysql://localhost/db?charset=utf8

foo:
  bar:
    charset: '%env(key:charset:query_string:key:query:url:DATABASE_DSN)%'
```