### PR TITLE
[Messenger] If `framework.messenger.buses.X.middleware` is empty, it will be `null`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1090,7 +1090,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                     ->arrayNode('middleware')
                                         ->beforeNormalization()
-                                            ->ifTrue(function ($v) { return \is_string($v) || !\is_int(key($v)); })
+                                            ->ifTrue(function ($v) { return \is_string($v) || (\is_array($v) && !\is_int(key($v))); })
                                             ->then(function ($v) { return array($v); })
                                         ->end()
                                         ->defaultValue(array())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28945
| License       | MIT
| Doc PR        | ø

Otherwise, it would fail with the following configuration:
```yaml
framework:
    messenger:
        buses:
            events_bus:
                middleware:
#                    - 'some_commented_middleware'
```