### PR TITLE
Remove reference to http digest authentication

### DIFF
--- a/src/Symfony/Component/Security/README.md
+++ b/src/Symfony/Component/Security/README.md
@@ -2,8 +2,8 @@ Security Component
 ==================
 
 The Security component provides a complete security system for your web
-application. It ships with facilities for authenticating using HTTP basic or
-digest authentication, interactive form login or X.509 certificate login, but
+application. It ships with facilities for authenticating using HTTP basic, 
+interactive form login or X.509 certificate login, but
 also allows you to implement your own authentication strategies. Furthermore,
 the component provides ways to authorize authenticated users based on their
 roles.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets |    <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
Seeing as HTTP Digest has been deprecated / removed, the README shouldn't be advertising it as a feature.

This is especially important seeing as sites such as packagist display the README to advertise the features/usage of a package. See https://packagist.org/packages/symfony/security
