### PR TITLE
Minor fix: correct var nulled in tearDown()

### DIFF
--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -94,7 +94,7 @@ class FormLoginAuthenticatorTest extends TestCase
 
     protected function tearDown()
     {
-        $this->request = null;
+        $this->requestWithoutSession = null;
         $this->requestWithSession = null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8 (be careful when merging)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Minor fix within test.

`$this->request` doesn't exist in the test.