### PR TITLE
[FrameworkBundle] Display a proper warning for deprecated --env and --no-debug options

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -63,11 +63,16 @@ class Application extends BaseApplication
     public function doRun(InputInterface $input, OutputInterface $output)
     {
         if ($input->hasParameterOption(array('-e', '--env'), true)) {
-            @trigger_error('The "--env" option and its "-e" shortcut are deprecated since Symfony 4.2. Set the "APP_ENV" environment variable instead.', E_USER_DEPRECATED);
+            $notice = 'The "--env" option and its "-e" shortcut are deprecated since Symfony 4.2, set the "APP_ENV" environment variable instead.';
+            $io = (new SymfonyStyle($input, $output))->getErrorStyle();
+            $io->warning($notice);
+            @trigger_error($notice, E_USER_DEPRECATED);
         }
 
         if ($input->hasParameterOption('--no-debug', true)) {
-            @trigger_error('The "--no-debug" option is deprecated since Symfony 4.2. Set the "APP_DEBUG" environment variable to "0" instead.', E_USER_DEPRECATED);
+            $notice = 'The "--no-debug" option is deprecated since Symfony 4.2, set the "APP_DEBUG" environment variable to "0" instead.';
+            ($io ?? (new SymfonyStyle($input, $output))->getErrorStyle())->warning($notice);
+            @trigger_error($notice, E_USER_DEPRECATED);
         }
 
         $this->kernel->boot();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Currently hidden (remember https://github.com/symfony/symfony/pull/23328)