### PR TITLE
[Messenger] make TraceableMiddleware decorate a StackInterface instead of each middleware to free the callstack from noisy frames

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1542,9 +1542,13 @@ class FrameworkExtension extends Extension
             }
 
             foreach ($middleware as $middlewareItem) {
-                if (!$validationConfig['enabled'] && 'messenger.middleware.validation' === $middlewareItem['id']) {
+                if (!$validationConfig['enabled'] && \in_array($middlewareItem['id'], array('validation', 'messenger.middleware.validation'), true)) {
                     throw new LogicException('The Validation middleware is only available when the Validator component is installed and enabled. Try running "composer require symfony/validator".');
                 }
+            }
+
+            if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
+                array_unshift($middleware, array('id' => 'traceable', 'arguments' => array($busId)));
             }
 
             $container->setParameter($busId.'.middleware', $middleware);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -33,11 +33,14 @@
             <argument type="service" id="validator" />
         </service>
 
+        <service id="messenger.middleware.traceable" class="Symfony\Component\Messenger\Middleware\TraceableMiddleware" abstract="true">
+            <argument type="service" id="debug.stopwatch" />
+        </service>
+
         <!-- Logging -->
         <service id="messenger.middleware.logging" class="Symfony\Component\Messenger\Middleware\LoggingMiddleware" abstract="true">
-            <argument type="service" id="logger" />
-
             <tag name="monolog.logger" channel="messenger" />
+            <argument type="service" id="logger" />
         </service>
 
         <!-- Discovery -->
@@ -56,10 +59,9 @@
         </service>
 
         <service id="messenger.transport.amqp.factory" class="Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory">
+            <tag name="messenger.transport_factory" />
             <argument type="service" id="messenger.transport.serializer" />
             <argument>%kernel.debug%</argument>
-
-            <tag name="messenger.transport_factory" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
@@ -21,14 +21,12 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 class TraceableMiddleware implements MiddlewareInterface
 {
-    private $inner;
     private $stopwatch;
     private $busName;
     private $eventCategory;
 
-    public function __construct(MiddlewareInterface $inner, Stopwatch $stopwatch, string $busName = null, string $eventCategory = 'messenger.middleware')
+    public function __construct(Stopwatch $stopwatch, string $busName, string $eventCategory = 'messenger.middleware')
     {
-        $this->inner = $inner;
         $this->stopwatch = $stopwatch;
         $this->busName = $busName;
         $this->eventCategory = $eventCategory;
@@ -39,21 +37,12 @@ class TraceableMiddleware implements MiddlewareInterface
      */
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        $class = \get_class($this->inner);
-        $eventName = 'c' === $class[0] && 0 === strpos($class, "class@anonymous\0") ? get_parent_class($class).'@anonymous' : $class;
-
-        if ($this->busName) {
-            $eventName .= " (bus: {$this->busName})";
-        }
-
-        $this->stopwatch->start($eventName, $this->eventCategory);
+        $stack = new TraceableStack($stack, $this->stopwatch, $this->busName, $this->eventCategory);
 
         try {
-            return $this->inner->handle($envelope, new TraceableInnerMiddleware($stack, $this->stopwatch, $eventName, $this->eventCategory));
+            return $stack->next()->handle($envelope, $stack);
         } finally {
-            if ($this->stopwatch->isStarted($eventName)) {
-                $this->stopwatch->stop($eventName);
-            }
+            $stack->stop();
         }
     }
 }
@@ -61,35 +50,20 @@ class TraceableMiddleware implements MiddlewareInterface
 /**
  * @internal
  */
-class TraceableInnerMiddleware implements MiddlewareInterface, StackInterface
+class TraceableStack implements StackInterface
 {
     private $stack;
     private $stopwatch;
-    private $eventName;
+    private $busName;
     private $eventCategory;
+    private $currentEvent;
 
-    public function __construct(StackInterface $stack, Stopwatch $stopwatch, string $eventName, string $eventCategory)
+    public function __construct(StackInterface $stack, Stopwatch $stopwatch, string $busName, string $eventCategory)
     {
         $this->stack = $stack;
         $this->stopwatch = $stopwatch;
-        $this->eventName = $eventName;
+        $this->busName = $busName;
         $this->eventCategory = $eventCategory;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function handle(Envelope $envelope, StackInterface $stack): Envelope
-    {
-        $this->stopwatch->stop($this->eventName);
-        if ($this === $stack) {
-            $envelope = $this->stack->next()->handle($envelope, $this->stack);
-        } else {
-            $envelope = $stack->next()->handle($envelope, $stack);
-        }
-        $this->stopwatch->start($this->eventName, $this->eventCategory);
-
-        return $envelope;
     }
 
     /**
@@ -97,6 +71,28 @@ class TraceableInnerMiddleware implements MiddlewareInterface, StackInterface
      */
     public function next(): MiddlewareInterface
     {
-        return $this;
+        if (null !== $this->currentEvent) {
+            $this->stopwatch->stop($this->currentEvent);
+        }
+
+        if ($this->stack === $nextMiddleware = $this->stack->next()) {
+            $this->currentEvent = 'Tail';
+        } else {
+            $class = \get_class($nextMiddleware);
+            $this->currentEvent = sprintf('"%s"', 'c' === $class[0] && 0 === strpos($class, "class@anonymous\0") ? get_parent_class($class).'@anonymous' : $class);
+        }
+        $this->currentEvent .= sprintf(' on "%s"', $this->busName);
+
+        $this->stopwatch->start($this->currentEvent, $this->eventCategory);
+
+        return $nextMiddleware;
+    }
+
+    public function stop()
+    {
+        if (null !== $this->currentEvent && $this->stopwatch->isStarted($this->currentEvent)) {
+            $this->stopwatch->stop($this->currentEvent);
+        }
+        $this->currentEvent = null;
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Tests\Middleware;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
 use Symfony\Component\Messenger\Middleware\TraceableMiddleware;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
@@ -27,7 +28,7 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
     public function testHandle()
     {
         $busId = 'command_bus';
-        $envelope = new Envelope($message = new DummyMessage('Hello'));
+        $envelope = new Envelope(new DummyMessage('Hello'));
 
         $middleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
         $middleware->expects($this->once())
@@ -42,16 +43,22 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
         $stopwatch->expects($this->once())->method('isStarted')->willReturn(true);
         $stopwatch->expects($this->exactly(2))
             ->method('start')
-            ->with($this->matches('%sMiddlewareInterface%s (bus: command_bus)'), 'messenger.middleware')
+            ->withConsecutive(
+                array($this->matches('"%sMiddlewareInterface%s" on "command_bus"'), 'messenger.middleware'),
+                array('Tail on "command_bus"', 'messenger.middleware')
+            )
         ;
         $stopwatch->expects($this->exactly(2))
             ->method('stop')
-            ->with($this->matches('%sMiddlewareInterface%s (bus: command_bus)'))
+            ->withConsecutive(
+                array($this->matches('"%sMiddlewareInterface%s" on "command_bus"')),
+                array('Tail on "command_bus"')
+            )
         ;
 
-        $traced = new TraceableMiddleware($middleware, $stopwatch, $busId);
+        $traced = new TraceableMiddleware($stopwatch, $busId);
 
-        $traced->handle($envelope, $this->getStackMock());
+        $traced->handle($envelope, new StackMiddleware(new \ArrayIterator(array(null, $middleware))));
     }
 
     /**
@@ -61,32 +68,26 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
     public function testHandleWithException()
     {
         $busId = 'command_bus';
-        $envelope = new Envelope($message = new DummyMessage('Hello'));
 
         $middleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
         $middleware->expects($this->once())
             ->method('handle')
-            ->with($envelope, $this->anything())
-            ->will($this->returnCallback(function ($envelope, StackInterface $stack) {
-                return $stack->next()->handle($envelope, $stack);
-            }))
+            ->willThrowException(new \RuntimeException('Thrown from next middleware.'))
         ;
-
-        $stack = $this->getThrowingStackMock();
 
         $stopwatch = $this->createMock(Stopwatch::class);
         $stopwatch->expects($this->once())->method('isStarted')->willReturn(true);
-        // Start is only expected to be called once, as an exception is thrown by the next callable:
-        $stopwatch->expects($this->exactly(1))
+        // Start/stop are expected to be called once, as an exception is thrown by the next callable
+        $stopwatch->expects($this->once())
             ->method('start')
-            ->with($this->matches('%sMiddlewareInterface%s (bus: command_bus)'), 'messenger.middleware')
+            ->with($this->matches('"%sMiddlewareInterface%s" on "command_bus"'), 'messenger.middleware')
         ;
-        $stopwatch->expects($this->exactly(2))
+        $stopwatch->expects($this->once())
             ->method('stop')
-            ->with($this->matches('%sMiddlewareInterface%s (bus: command_bus)'))
+            ->with($this->matches('"%sMiddlewareInterface%s" on "command_bus"'))
         ;
 
-        $traced = new TraceableMiddleware($middleware, $stopwatch, $busId);
-        $traced->handle($envelope, $stack);
+        $traced = new TraceableMiddleware($stopwatch, $busId);
+        $traced->handle(new Envelope(new DummyMessage('Hello')), new StackMiddleware(new \ArrayIterator(array(null, $middleware))));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Right now, `TraceableMiddleware` works as a middleware decorator for the "handle" method. It means that *each middleware* frame in the call stack is wrapped between two noisy extra frames.
This is something we can remove by decorating the StackInterface instead: let's just stop/start events when the next middleware is fetched.
Thanks to this, only one frame *per bus* is added to measure middleware timings.