### PR TITLE
[HTTP Foundation] Fix useless space in docblock

### DIFF
--- a/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
@@ -65,7 +65,7 @@ class AcceptHeaderItem
     }
 
     /**
-     * Returns header  value's string representation.
+     * Returns header value's string representation.
      *
      * @return string
      */


### PR DESCRIPTION
I Just removed a useless space in PHP Doc, I don't know if target the 2.8 branch is enough to others SF versions
