### PR TITLE
Add support for complex expressions in twig globals

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+master
+------
+
+* add support for complex expressions in twig globals
+
 4.2.0
 -----
 

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-master
+4.3.0
 ------
 
 * add support for complex expressions in twig globals

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Translation\Translator;
 use Twig\Extension\ExtensionInterface;
@@ -132,7 +133,9 @@ class TwigExtension extends Extension
         if (!empty($config['globals'])) {
             $def = $container->getDefinition('twig');
             foreach ($config['globals'] as $key => $global) {
-                if (isset($global['type']) && 'service' === $global['type']) {
+                if (isset($global['type']) && 'expression' === $global['type']) {
+                    $def->addMethodCall('addGlobal', array($key, new Expression($global['expr'])));
+                } elseif (isset($global['type']) && 'service' === $global['type']) {
                     $def->addMethodCall('addGlobal', array($key, new Reference($global['id'])));
                 } else {
                     $def->addMethodCall('addGlobal', array($key, $global['value']));

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
@@ -49,10 +49,12 @@
         <xsd:attribute name="key" type="xsd:string" use="required" />
         <xsd:attribute name="type" type="global_type" />
         <xsd:attribute name="id" type="xsd:string" />
+        <xsd:attribute name="expr" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:simpleType name="global_type">
         <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="expression" />
             <xsd:enumeration value="service" />
         </xsd:restriction>
     </xsd:simpleType>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -8,6 +8,7 @@ $container->loadFromExtension('twig', array(
         'foo' => '@bar',
         'baz' => '@@qux',
         'pi' => 3.14,
+        'expr' => "@=service('bar')",
         'bad' => array('key' => 'foo'),
     ),
     'auto_reload' => true,

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -11,6 +11,7 @@
         <twig:global key="foo" id="bar" type="service" />
         <twig:global key="baz">@@qux</twig:global>
         <twig:global key="pi">3.14</twig:global>
+        <twig:global key="expr" expr="service('bar')" type="expression" />
         <twig:path>path1</twig:path>
         <twig:path>path2</twig:path>
         <twig:path namespace="namespace1">namespaced_path1</twig:path>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -5,6 +5,7 @@ twig:
         foo: "@bar"
         baz: "@@qux"
         pi:  3.14
+        expr: "@=service('bar')"
         bad: {key: foo}
     auto_reload:         true
     autoescape:          true

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 class TwigExtensionTest extends TestCase
 {
@@ -72,11 +73,12 @@ class TwigExtensionTest extends TestCase
         $this->assertEquals('@qux', $calls[3][1][1], '->load() allows escaping of service identifiers');
         $this->assertEquals('pi', $calls[4][1][0], '->load() registers variables as Twig globals');
         $this->assertEquals(3.14, $calls[4][1][1], '->load() registers variables as Twig globals');
+        $this->assertEquals(new Expression("service('bar')"), $calls[5][1][1], '->load() registers expression as Twig globals');
 
         // Yaml and Php specific configs
         if (\in_array($format, array('yml', 'php'))) {
-            $this->assertEquals('bad', $calls[5][1][0], '->load() registers variables as Twig globals');
-            $this->assertEquals(array('key' => 'foo'), $calls[5][1][1], '->load() registers variables as Twig globals');
+            $this->assertEquals('bad', $calls[6][1][0], '->load() registers variables as Twig globals');
+            $this->assertEquals(array('key' => 'foo'), $calls[6][1][1], '->load() registers variables as Twig globals');
         }
 
         // Twig options


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10601

This new feature add support to inject values based on complex expressions into twig globals.

Example:

```yaml

twig:
    globals:
        myvar: '@=service("App\Service").getMyVar()'

```