### PR TITLE
Fix wrong loop in Process::wait() method

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -416,11 +416,8 @@ class Process implements \IteratorAggregate
             $this->checkTimeout();
             $running = '\\' === \DIRECTORY_SEPARATOR ? $this->isRunning() : $this->processPipes->areOpen();
             $this->readPipes($running, '\\' !== \DIRECTORY_SEPARATOR || !$running);
-        } while ($running);
-
-        while ($this->isRunning()) {
             usleep(1000);
-        }
+        } while ($running);
 
         if ($this->processInformation['signaled'] && $this->processInformation['termsig'] !== $this->latestSignal) {
             throw new ProcessSignaledException($this);


### PR DESCRIPTION
The while condition was the opposite of the previous while. This was obviously leading to the death of this loop. Loop which was useful according to some people (see #28940), so I just moved the code to the right position.

| Q             | A
| ------------- | ---
| Branch?       | 2.8 (want me to make it against 2.8 ?)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

I tested some process execution in order to be sure the code is never executed. I also noticed that there's no CPU issue without this sleep (kubuntu 18.04 / intel i7 2k):
![image](https://user-images.githubusercontent.com/972456/47686824-7743fd80-dbdd-11e8-8804-422293f72f47.png)
