### PR TITLE
[Cache] allow to skip saving the computed value when using CacheInterface::get()

### DIFF
--- a/src/Symfony/Contracts/Cache/CacheInterface.php
+++ b/src/Symfony/Contracts/Cache/CacheInterface.php
@@ -29,13 +29,13 @@ interface CacheInterface
      * requested key, that could be used e.g. for expiration control. It could also
      * be an ItemInterface instance when its additional features are needed.
      *
-     * @param string                             $key      The key of the item to retrieve from the cache
-     * @param callable(CacheItemInterface):mixed $callback Should return the computed value for the given key/item
-     * @param float|null                         $beta     A float that, as it grows, controls the likeliness of triggering
-     *                                                     early expiration. 0 disables it, INF forces immediate expiration.
-     *                                                     The default (or providing null) is implementation dependent but should
-     *                                                     typically be 1.0, which should provide optimal stampede protection.
-     *                                                     See https://en.wikipedia.org/wiki/Cache_stampede#Probabilistic_early_expiration
+     * @param string                     $key      The key of the item to retrieve from the cache
+     * @param callable|CallbackInterface $callback Should return the computed value for the given key/item
+     * @param float|null                 $beta     A float that, as it grows, controls the likeliness of triggering
+     *                                             early expiration. 0 disables it, INF forces immediate expiration.
+     *                                             The default (or providing null) is implementation dependent but should
+     *                                             typically be 1.0, which should provide optimal stampede protection.
+     *                                             See https://en.wikipedia.org/wiki/Cache_stampede#Probabilistic_early_expiration
      *
      * @return mixed The value corresponding to the provided key
      *

--- a/src/Symfony/Contracts/Cache/CacheTrait.php
+++ b/src/Symfony/Contracts/Cache/CacheTrait.php
@@ -59,7 +59,11 @@ trait CacheTrait
         }
 
         if ($recompute) {
-            $pool->save($item->set($callback($item)));
+            $save = true;
+            $item->set($callback($item, $save));
+            if ($save) {
+                $pool->save($item);
+            }
         }
 
         return $item->get();

--- a/src/Symfony/Contracts/Cache/CallbackInterface.php
+++ b/src/Symfony/Contracts/Cache/CallbackInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Cache;
+
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * Computes and returns the cached value of an item.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface CallbackInterface
+{
+    /**
+     * @param CacheItemInterface|ItemInterface $item  The item to compute the value for
+     * @param bool                             &$save Should be set to false when the value should not be saved in the pool
+     *
+     * @return mixed The computed value for the passed item
+     */
+    public function __invoke(CacheItemInterface $item, bool &$save);
+}

--- a/src/Symfony/Contracts/Cache/TagAwareCacheInterface.php
+++ b/src/Symfony/Contracts/Cache/TagAwareCacheInterface.php
@@ -22,8 +22,6 @@ interface TagAwareCacheInterface extends CacheInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @param callable(ItemInterface):mixed $callback Should return the computed value for the given key/item
      */
     public function get(string $key, callable $callback, float $beta = null);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

While trying to play with using Messenger and Cache together, I spotted a few issues related to the new `CacheInterface::get()` method:
- there must be a way to skip saving the computed value in the pool. This is needed in my (still local WIP) use case - and is also needed for `LockRegistry`: processes that wait for the lock to be released should not write the value back when the lock is over. This is addressed by adding a 2nd `bool &$save` argument to the computing callback. When the callback sets this reference to true, the returned value should not be written to the pool.
- in order to better document the signature of this callback, a new `CallbackInterface` is added in the `Contracts\Cache` namespace. This will help autocompletion and implementations.
- `ContractsTrait` was writing twice the value to the pool - now fixed
- `LockRegistry` did not retry locking when a waiting process wasn't able to fetch the fresh value - now fixed.