### PR TITLE
[Console] Remove duplicate condition

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -303,14 +303,13 @@ class Command
 
         $this->definition->addOptions($this->application->getDefinition()->getOptions());
 
+        $this->applicationDefinitionMerged = true;
+
         if ($mergeArgs) {
             $currentArguments = $this->definition->getArguments();
             $this->definition->setArguments($this->application->getDefinition()->getArguments());
             $this->definition->addArguments($currentArguments);
-        }
 
-        $this->applicationDefinitionMerged = true;
-        if ($mergeArgs) {
             $this->applicationDefinitionMergedWithArgs = true;
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Inside the Command::mergeApplicationDefinition() method, the condition of $mergeArgs is checked twice now. Let's remove the second duplicate one.

See the capture below to review quickly!

```php
public function mergeApplicationDefinition($mergeArgs = true)
{
    if (null === $this->application || (true === $this->applicationDefinitionMerged && ($this->applicationDefinitionMergedWithArgs || !$mergeArgs))) {
        return;
    }

    $this->definition->addOptions($this->application->getDefinition()->getOptions());

    if ($mergeArgs) {
        $currentArguments = $this->definition->getArguments();
        $this->definition->setArguments($this->application->getDefinition()->getArguments());
        $this->definition->addArguments($currentArguments);
    }

    $this->applicationDefinitionMerged = true;
    if ($mergeArgs) {
        $this->applicationDefinitionMergedWithArgs = true;
    }
}
```
