### PR TITLE
[Messenger] Allow to override only a few of the abstract middleware definition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1548,7 +1548,7 @@ class FrameworkExtension extends Extension
             }
 
             if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {
-                array_unshift($middleware, array('id' => 'traceable', 'arguments' => array($busId)));
+                array_unshift($middleware, array('id' => 'traceable', 'arguments' => array(1 => $busId)));
             }
 
             $container->setParameter($busId.'.middleware', $middleware);

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -319,7 +319,8 @@ class MessengerPass implements CompilerPassInterface
             if (($definition = $container->findDefinition($messengerMiddlewareId))->isAbstract()) {
                 $childDefinition = new ChildDefinition($messengerMiddlewareId);
                 $count = \count($definition->getArguments());
-                foreach (array_values($arguments ?? array()) as $key => $argument) {
+
+                foreach (($arguments ?? array()) as $key => $argument) {
                     // Parent definition can provide default arguments.
                     // Replace each explicitly or add if not set:
                     $key < $count ? $childDefinition->replaceArgument($key, $argument) : $childDefinition->addArgument($argument);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29006
| License       | MIT
| Doc PR        | ø

The recent PR about the traceable middleware introduced an issue. This PR fixes it by enabling us to override only some parameters of the parent service.