### PR TITLE
[Messenger] Envelope::stamp()

### DIFF
--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -41,7 +41,7 @@ final class Envelope
     /**
      * @return Envelope a new Envelope instance with additional stamp
      */
-    public function with(StampInterface ...$stamps): self
+    public function stamp(StampInterface ...$stamps): self
     {
         $cloned = clone $this;
 

--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -39,7 +39,7 @@ final class Envelope
     }
 
     /**
-     * @return Envelope a new Envelope instance with additional stamp
+     * @return Envelope a new stamped Envelope
      */
     public function stamp(StampInterface ...$stamps): self
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I'm wondering if stamping envelopes using `$envelope->stamp(...)` would be more intuitive API. And shouldnt we require at least one stamp?

yes/no?

s/all()/stamps() yes/no?

s/get()/getStamp() yes/no (to clearly differ with getMessage())