### PR TITLE
[Messenger][FrameworkBundle] Fix bus name on traceable middleware

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -34,6 +34,7 @@
         </service>
 
         <service id="messenger.middleware.traceable" class="Symfony\Component\Messenger\Middleware\TraceableMiddleware" abstract="true">
+            <argument type="string" /> <!-- Bus name -->
             <argument type="service" id="debug.stopwatch" />
         </service>
 

--- a/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
@@ -21,14 +21,14 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 class TraceableMiddleware implements MiddlewareInterface
 {
-    private $stopwatch;
     private $busName;
+    private $stopwatch;
     private $eventCategory;
 
-    public function __construct(Stopwatch $stopwatch, string $busName, string $eventCategory = 'messenger.middleware')
+    public function __construct(string $busName, Stopwatch $stopwatch, string $eventCategory = 'messenger.middleware')
     {
-        $this->stopwatch = $stopwatch;
         $this->busName = $busName;
+        $this->stopwatch = $stopwatch;
         $this->eventCategory = $eventCategory;
     }
 
@@ -37,7 +37,7 @@ class TraceableMiddleware implements MiddlewareInterface
      */
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        $stack = new TraceableStack($stack, $this->stopwatch, $this->busName, $this->eventCategory);
+        $stack = new TraceableStack($stack, $this->busName, $this->stopwatch, $this->eventCategory);
 
         try {
             return $stack->next()->handle($envelope, $stack);
@@ -53,16 +53,16 @@ class TraceableMiddleware implements MiddlewareInterface
 class TraceableStack implements StackInterface
 {
     private $stack;
-    private $stopwatch;
     private $busName;
+    private $stopwatch;
     private $eventCategory;
     private $currentEvent;
 
-    public function __construct(StackInterface $stack, Stopwatch $stopwatch, string $busName, string $eventCategory)
+    public function __construct(StackInterface $stack, string $busName, Stopwatch $stopwatch, string $eventCategory)
     {
         $this->stack = $stack;
-        $this->stopwatch = $stopwatch;
         $this->busName = $busName;
+        $this->stopwatch = $stopwatch;
         $this->eventCategory = $eventCategory;
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/TraceableMiddlewareTest.php
@@ -56,7 +56,7 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
             )
         ;
 
-        $traced = new TraceableMiddleware($stopwatch, $busId);
+        $traced = new TraceableMiddleware($busId, $stopwatch);
 
         $traced->handle($envelope, new StackMiddleware(new \ArrayIterator(array(null, $middleware))));
     }
@@ -87,7 +87,7 @@ class TraceableMiddlewareTest extends MiddlewareTestCase
             ->with($this->matches('"%sMiddlewareInterface%s" on "command_bus"'))
         ;
 
-        $traced = new TraceableMiddleware($stopwatch, $busId);
+        $traced = new TraceableMiddleware($busId, $stopwatch);
         $traced->handle(new Envelope(new DummyMessage('Hello')), new StackMiddleware(new \ArrayIterator(array(null, $middleware))));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #29034   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Supersedes #29034.

```sh
bin/console debug:container query_bus.middleware.traceable --show-arguments

Information for Service "query_bus.middleware.traceable"
========================================================

 ---------------- ------------------------------------------------------------ 
  Option           Value                                                       
 ---------------- ------------------------------------------------------------ 
  Service ID       query_bus.middleware.traceable                              
  Class            Symfony\Component\Messenger\Middleware\TraceableMiddleware                                                    
  Arguments        query_bus                                                   
                   Service(debug.stopwatch)                                    
 ---------------- ------------------------------------------------------------ 
```