### PR TITLE
Update ValidationListener.php

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -51,7 +51,7 @@ class ValidationListener implements EventSubscriberInterface
         $form = $event->getForm();
 
         if ($form->isRoot()) {
-            // Validate the form in group "Default"
+            // Form groups are validated internally (FormValidator). Here we don't set groups as they are retrieved into the validator.
             foreach ($this->validator->validate($form) as $violation) {
                 // Allow the "invalid" constraint to be put onto
                 // non-synchronized forms


### PR DESCRIPTION
This comment was misleading.
It's true that no groups (ie.: `Default`) are setted into validation process but it's not clear from the comment.
I suppose that is better to be more explicit about this process.
BTW I'm still not sure if `FormValidator` reference is necessary as we can change it and we should remember to update this comment and this does not seems to fit.
WDYT, is better to leave `FormValidator` out of this comment?

For reference: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php#L46-L92

| Q             | A
| ------------- | ---
| Branch?       | 3.4 (careful when merging)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
