### PR TITLE
[Messenger] allow to change the message name

### DIFF
--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -24,6 +24,7 @@ final class Envelope
 {
     private $stamps = array();
     private $message;
+    private $messageName;
 
     /**
      * @param object $message
@@ -38,6 +39,17 @@ final class Envelope
         foreach ($stamps as $stamp) {
             $this->stamps[\get_class($stamp)] = $stamp;
         }
+    }
+
+    /**
+     * @param object $message
+     */
+    public static function createNamed($message, string $name): self
+    {
+        $envelope = new self($message);
+        $envelope->messageName = $name;
+
+        return $envelope;
     }
 
     /**
@@ -77,6 +89,6 @@ final class Envelope
 
     public function getMessageName(): string
     {
-        return \get_class($this->message);
+        return $this->messageName ?? \get_class($this->message);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
@@ -30,6 +30,16 @@ class EnvelopeTest extends TestCase
         $this->assertSame($dummy, $envelope->getMessage());
         $this->assertArrayHasKey(ReceivedStamp::class, $stamps = $envelope->all());
         $this->assertSame($receivedStamp, $stamps[ReceivedStamp::class]);
+        $this->assertSame(DummyMessage::class, $envelope->getMessageName());
+    }
+
+    public function testCreateNamed()
+    {
+        $name = 'foobar';
+        $envelope = Envelope::createNamed($dummy = new DummyMessage('dummy'), $name);
+
+        $this->assertSame($dummy, $envelope->getMessage());
+        $this->assertSame($name, $envelope->getMessageName());
     }
 
     public function testWithReturnsNewInstance()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no    
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Having the class name as default for the message name is the best practice and usually does not need to be changed. But I think we need to provide a way to do so for just for flexibility. This allows people to opt-out of interface/parent class based routing (#28993) by manually calling `$bus->dispatch(Envelope::createNamed($message, 'foo'))`. IMO we don't need to add an optional name parameter to the `dispatch` method like originally proposed in #28944 since it's an edge case that does not need to be exposed at the primary entry point.

