### PR TITLE
Revert "[HttpFoundation] Adds getAcceptableFormats() method for Request"

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,7 +4,6 @@ CHANGELOG
 4.2.0
 -----
 
- * added `getAcceptableFormats()` for reading acceptable formats based on Accept header
  * the default value of the "$secure" and "$samesite" arguments of Cookie's constructor
    will respectively change from "false" to "null" and from "null" to "lax" in Symfony
    5.0, you should define their values explicitly or use "Cookie::create()" instead.

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -171,11 +171,6 @@ class Request
     protected $format;
 
     /**
-     * @var array
-     */
-    private $acceptableFormats;
-
-    /**
      * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
      */
     protected $session;
@@ -268,7 +263,6 @@ class Request
         $this->charsets = null;
         $this->encodings = null;
         $this->acceptableContentTypes = null;
-        $this->acceptableFormats = null;
         $this->pathInfo = null;
         $this->requestUri = null;
         $this->baseUrl = null;
@@ -456,7 +450,6 @@ class Request
         $dup->charsets = null;
         $dup->encodings = null;
         $dup->acceptableContentTypes = null;
-        $dup->acceptableFormats = null;
         $dup->pathInfo = null;
         $dup->requestUri = null;
         $dup->baseUrl = null;
@@ -1366,18 +1359,6 @@ class Request
     public function getContentType()
     {
         return $this->getFormat($this->headers->get('CONTENT_TYPE'));
-    }
-
-    /**
-     * Gets the acceptable client formats associated with the request.
-     */
-    public function getAcceptableFormats(): array
-    {
-        if (null !== $this->acceptableFormats) {
-            return $this->acceptableFormats;
-        }
-
-        return $this->acceptableFormats = array_values(array_unique(array_filter(array_map(array($this, 'getFormat'), $this->getAcceptableContentTypes()))));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1432,16 +1432,6 @@ class RequestTest extends TestCase
         $this->assertEquals(array('application/vnd.wap.wmlscriptc', 'text/vnd.wap.wml', 'application/vnd.wap.xhtml+xml', 'application/xhtml+xml', 'text/html', 'multipart/mixed', '*/*'), $request->getAcceptableContentTypes());
     }
 
-    public function testGetAcceptableFormats()
-    {
-        $request = new Request();
-        $this->assertEquals(array(), $request->getAcceptableFormats());
-
-        $request = new Request();
-        $request->headers->set('Accept', 'text/html, application/xhtml+xml, application/xml;q=0.9, */*');
-        $this->assertEquals(array('html', 'xml'), $request->getAcceptableFormats());
-    }
-
     public function testGetLanguages()
     {
         $request = new Request();


### PR DESCRIPTION
This reverts commit 8a127ea34a8ca53d25de242dabe2e1e02745529e.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #26486
| License       | MIT
| Doc PR        | 

As I said in https://github.com/symfony/symfony/pull/26486#discussion_r228697658 and people wonder in https://symfony.com/blog/new-in-symfony-4-2-acceptable-request-formats#comment-22747, I don't think this method clear and generic enough to be added to the core.
I can't see where I would possibly use this method. What would be useful is a similar method that accepts formats as argument and would return the ones that are acceptable according to the accept header. This would then allow to make use of `*/*` and this is what people usually need in REST APIs etc.
But for now, we should revert it before it gets released like this.