### PR TITLE
Update EventSubscriberInterface.php

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeDoctrineCollectionListener.php
+++ b/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeDoctrineCollectionListener.php
@@ -27,7 +27,7 @@ use Symfony\Component\Form\FormEvents;
  */
 class MergeDoctrineCollectionListener implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         // Higher priority than core MergeCollectionListener so that this one
         // is called before

--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -129,7 +129,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             ConsoleEvents::COMMAND => array('onCommand', 255),

--- a/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
@@ -37,7 +37,7 @@ class WebProcessor extends BaseWebProcessor implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::REQUEST => array('onKernelRequest', 4096),

--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
@@ -41,7 +41,7 @@ class ResolveControllerNameSubscriber implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::REQUEST => array('onKernelRequest', 24),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/ConcreteMicroKernel.php
@@ -90,7 +90,7 @@ class ConcreteMicroKernel extends Kernel implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::EXCEPTION => 'onKernelException',

--- a/src/Symfony/Bundle/SecurityBundle/EventListener/VoteListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/EventListener/VoteListener.php
@@ -41,7 +41,7 @@ class VoteListener implements EventSubscriberInterface
         $this->traceableAccessDecisionManager->addVoterVote($event->getVoter(), $event->getAttributes(), $event->getVote());
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array('debug.security.authorization.vote' => 'onVoterVote');
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -134,7 +134,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::RESPONSE => array('onKernelResponse', -128),

--- a/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
@@ -168,7 +168,7 @@ class TestEventSubscriber implements EventSubscriberInterface
 {
     public static $subscribedEvents = array();
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return self::$subscribedEvents;
     }
@@ -178,7 +178,7 @@ class TestServiceSubscriber implements ServiceSubscriberInterface
 {
     public static $subscribedServices = array();
 
-    public static function getSubscribedServices()
+    public function getSubscribedServices() : array
     {
         return self::$subscribedServices;
     }

--- a/src/Symfony/Component/Console/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/Console/EventListener/ErrorListener.php
@@ -65,7 +65,7 @@ class ErrorListener implements EventSubscriberInterface
         $this->logger->debug('Command "{command}" exited with code "{code}"', array('command' => $inputString, 'code' => $exitCode));
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             ConsoleEvents::ERROR => array('onConsoleError', -128),

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -127,7 +127,7 @@ class ExtractingEventDispatcher extends EventDispatcher implements EventSubscrib
         $this->listeners[] = array($eventName, $listener[1], $priority);
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         $callback = array(self::$subscriber, 'getSubscribedEvents');
 

--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -42,5 +42,5 @@ interface EventSubscriberInterface
      *
      * @return array The event names to listen to
      */
-    public static function getSubscribedEvents();
+    public function getSubscribedEvents() : array;
 }

--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -42,5 +42,5 @@ interface EventSubscriberInterface
      *
      * @return array The event names to listen to
      */
-    public static function getSubscribedEvents();
+    public function getSubscribedEvents();
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
@@ -413,7 +413,7 @@ class TestWithDispatcher
 
 class TestEventSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array('pre.foo' => 'preFoo', 'post.foo' => 'postFoo');
     }
@@ -421,7 +421,7 @@ class TestEventSubscriber implements EventSubscriberInterface
 
 class TestEventSubscriberWithPriorities implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             'pre.foo' => array('preFoo', 10),
@@ -432,7 +432,7 @@ class TestEventSubscriberWithPriorities implements EventSubscriberInterface
 
 class TestEventSubscriberWithMultipleListeners implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array('pre.foo' => array(
             array('preFoo1'),

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -286,7 +286,7 @@ class TraceableEventDispatcherTest extends TestCase
 
 class EventSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array('foo' => 'call');
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -186,7 +186,7 @@ class RegisterListenersPassTest extends TestCase
 
 class SubscriberService implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             'event' => 'onEvent',

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
@@ -41,7 +41,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(FormEvents::SUBMIT => 'onSubmit');
     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -34,7 +34,7 @@ class MergeCollectionListener implements EventSubscriberInterface
         $this->allowDelete = $allowDelete;
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             FormEvents::SUBMIT => 'onSubmit',

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -47,7 +47,7 @@ class ResizeFormListener implements EventSubscriberInterface
         $this->deleteEmpty = $deleteEmpty;
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             FormEvents::PRE_SET_DATA => 'preSetData',

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
@@ -34,7 +34,7 @@ class TrimListener implements EventSubscriberInterface
         $event->setData(StringUtil::trim($data));
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(FormEvents::PRE_SUBMIT => 'preSubmit');
     }

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -34,7 +34,7 @@ class CsrfValidationListener implements EventSubscriberInterface
     private $translationDomain;
     private $serverParams;
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             FormEvents::PRE_SUBMIT => 'preSubmit',

--- a/src/Symfony/Component/Form/Extension/DataCollector/EventListener/DataCollectorListener.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/EventListener/DataCollectorListener.php
@@ -34,7 +34,7 @@ class DataCollectorListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             // High priority in order to be called as soon as possible

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -30,7 +30,7 @@ class ValidationListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(FormEvents::POST_SUBMIT => 'validateForm');
     }

--- a/src/Symfony/Component/Form/Tests/AbstractTypeExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTypeExtensionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpHierarchyChecksInspection */
 
 /*
  * This file is part of the Symfony package.

--- a/src/Symfony/Component/Form/Tests/Fixtures/FixedFilterListener.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FixedFilterListener.php
@@ -55,7 +55,7 @@ class FixedFilterListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             FormEvents::PRE_SUBMIT => 'preSubmit',

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -365,7 +365,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::CONTROLLER => 'onKernelController',

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -129,7 +129,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::REQUEST => array('onKernelRequest', 128),

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
@@ -96,7 +96,7 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::REQUEST => array('onKernelRequest', 192),

--- a/src/Symfony/Component/HttpKernel/EventListener/AddRequestFormatsListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AddRequestFormatsListener.php
@@ -43,7 +43,7 @@ class AddRequestFormatsListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(KernelEvents::REQUEST => array('onKernelRequest', 1));
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -143,7 +143,7 @@ class DebugHandlersListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         $events = array(KernelEvents::REQUEST => array('configure', 2048));
 

--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -51,7 +51,7 @@ class DumpListener implements EventSubscriberInterface
         });
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         if (!class_exists(ConsoleEvents::class)) {
             return array();

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -110,7 +110,7 @@ class ExceptionListener implements EventSubscriberInterface
         $this->isTerminating = false;
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::EXCEPTION => array(

--- a/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
@@ -90,7 +90,7 @@ class FragmentListener implements EventSubscriberInterface
         throw new AccessDeniedHttpException();
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::REQUEST => array(array('onKernelRequest', 48)),

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -72,7 +72,7 @@ class LocaleListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             // must be registered after the Router to have access to the _locale

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -117,7 +117,7 @@ class ProfilerListener implements EventSubscriberInterface
         $this->parents = new \SplObjectStorage();
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::RESPONSE => array('onKernelResponse', -100),

--- a/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
@@ -47,7 +47,7 @@ class ResponseListener implements EventSubscriberInterface
         $response->prepare($event->getRequest());
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -155,7 +155,7 @@ class RouterListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::REQUEST => array(array('onKernelRequest', 32)),

--- a/src/Symfony/Component/HttpKernel/EventListener/SaveSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SaveSessionListener.php
@@ -36,7 +36,7 @@ class SaveSessionListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             // low priority but higher than StreamedResponseListener

--- a/src/Symfony/Component/HttpKernel/EventListener/StreamedResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/StreamedResponseListener.php
@@ -40,7 +40,7 @@ class StreamedResponseListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::RESPONSE => array('onKernelResponse', -1024),

--- a/src/Symfony/Component/HttpKernel/EventListener/SurrogateListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SurrogateListener.php
@@ -56,7 +56,7 @@ class SurrogateListener implements EventSubscriberInterface
         $surrogate->addSurrogateControl($event->getResponse());
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/src/Symfony/Component/HttpKernel/EventListener/TranslatorListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TranslatorListener.php
@@ -56,7 +56,7 @@ class TranslatorListener implements EventSubscriberInterface
         $this->setLocale($parentRequest);
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             // must be registered after the Locale listener

--- a/src/Symfony/Component/HttpKernel/EventListener/ValidateRequestListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ValidateRequestListener.php
@@ -42,7 +42,7 @@ class ValidateRequestListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::REQUEST => array(

--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -103,7 +103,7 @@ class Firewall implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             KernelEvents::REQUEST => array('onKernelRequest', 8),

--- a/src/Symfony/Component/Security/Http/RememberMe/ResponseListener.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/ResponseListener.php
@@ -39,7 +39,7 @@ class ResponseListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(KernelEvents::RESPONSE => 'onKernelResponse');
     }

--- a/src/Symfony/Component/WebLink/EventListener/AddLinkHeaderListener.php
+++ b/src/Symfony/Component/WebLink/EventListener/AddLinkHeaderListener.php
@@ -50,7 +50,7 @@ class AddLinkHeaderListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(KernelEvents::RESPONSE => 'onKernelResponse');
     }

--- a/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
+++ b/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
@@ -46,7 +46,7 @@ class AuditTrailListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents() : array
     {
         return array(
             'workflow.leave' => array('onLeave'),

--- a/src/Symfony/Contracts/Service/ServiceSubscriberInterface.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberInterface.php
@@ -49,5 +49,5 @@ interface ServiceSubscriberInterface
      *
      * @return array The required service types, optionally keyed by service names
      */
-    public static function getSubscribedServices();
+    public function getSubscribedServices() : array;
 }


### PR DESCRIPTION
EventSubscriberInterface::getSubscribedEvents should not be static - every call to this method seems to be instance-based.

Problem:
Development of a "dynamic registration"-Subscriber based on Constructor-Params impossible.

Solution:
Change call-type of getSubscribedEvents to instance.

Side-Effects:
None known - all calls are instance-calls.

| Q             | A
| ------------- | ---
| Branch?       | master for features / 2.8 up to 4.1 for bug fixes <!-- see below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
