### PR TITLE
Fix GlobResource serialization

### DIFF
--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -83,12 +83,12 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface,
             $this->hash = $this->computeHash();
         }
 
-        return serialize(array($this->prefix, $this->pattern, $this->recursive, $this->hash));
+        return serialize(array($this->prefix, $this->pattern, $this->recursive, $this->hash, $this->forExclusion, $this->excludedPrefixes));
     }
 
     public function unserialize($serialized)
     {
-        list($this->prefix, $this->pattern, $this->recursive, $this->hash) = unserialize($serialized);
+        list($this->prefix, $this->pattern, $this->recursive, $this->hash, $this->forExclusion, $this->excludedPrefixes) = unserialize($serialized) + array(4 => false, array());
     }
 
     public function getIterator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | no    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #28200   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

Since @gonzalovilaseca improvement in PR #28200, I noticed that the container is being compiled systematically. This is caused by the two added properties (`forExclusion`, `excludedPrefixes`) not being serialized, and lead to wrong hash computing. I updated the `serialize` and `unserialize` methods in this PR. 

ping @nicolas-grekas