### PR TITLE
Release v4.1.7

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -7,6 +7,32 @@ in 4.1 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.1.0...v4.1.1
 
+* 4.1.7 (2018-11-03)
+
+ * bug #28820 [DependencyInjection] Fix tags on multiple decorated service (Soner Sayakci)
+ * bug #29020 Fix ini_get() for boolean values (deguif)
+ * bug #28955 [Messenger] send using the routing_key for AMQP transport (nicolas-grekas)
+ * bug #28960 also clean away the NO_AUTO_CACHE_CONTROL_HEADER if we have no session (dbu)
+ * feature #28893 [TwigBundle] Fix usage of TwigBundle without FrameworkBundle (tgalopin)
+ * bug #28889 [Serializer] Reduce class discriminator overhead (fbourigault)
+ * bug #28861 [DependencyInjection] Skip empty proxy code (olvlvl)
+ * bug #28801 Convert InsufficientAuthenticationException to HttpException with 401 status code (vincentchalamon)
+ * bug #28840 add missing double-quotes to extra_fields output message (danielkay)
+ * bug #28838 [DI] Default undefined env to empty string during compile (ro0NL)
+ * bug #28863 [Process] Allow to pass non-string arguments to Process (vudaltsov)
+ * bug #28712 [Form] reverse transform RFC 3339 formatted dates (xabbuh)
+ * bug #28813 Fix for race condition in console output stream write (rudolfratusinski)
+ * bug #27772 [Console] Fixes multiselect choice question defaults in non-interactive mode (veewee)
+ * bug #28835 [FrameworkBundle] Setting missing default paths under BC layer (yceruto)
+ * bug #28760 [DI] fix dumping inline services again (nicolas-grekas)
+ * bug #28689 [Process] fix locking of pipe files on Windows (nicolas-grekas)
+ * bug #28704 [Form] fix multi-digit seconds fraction handling (xabbuh)
+ * bug #28793 [SecurityBundle] do not override custom access decision configs (xabbuh)
+ * bug #28783 [FrameworkBundle] add missing cache prefix seed attribute to XSD (xabbuh)
+ * bug #28072 [Security] Do not deauthenticate user when the first refreshed user has changed (gpekz)
+ * bug #28735 [FWBundle] Automatically enable PropertyInfo when using Flex (dunglas)
+ * bug #28751 [FrameworkBundle] Register messenger before the profiler (sroze)
+
 * 4.1.6 (2018-10-03)
 
  * bug #28604 [Finder] fixed root directory access for ftp/sftp wrapper (DerDu)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -63,12 +63,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private $requestStackSize = 0;
     private $resetServices = false;
 
-    const VERSION = '4.1.7-DEV';
+    const VERSION = '4.1.7';
     const VERSION_ID = 40107;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 1;
     const RELEASE_VERSION = 7;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2019';
     const END_OF_LIFE = '07/2019';


### PR DESCRIPTION
**Changelog** (since https://github.com/symfony/symfony/compare/v4.1.6...v4.1.7)

 * bug #28820 [DependencyInjection] Fix tags on multiple decorated service (@Soner Sayakci)
 * bug #29020 Fix ini_get() for boolean values (@deguif)
 * bug #28955 [Messenger] send using the routing_key for AMQP transport (@nicolas-grekas)
 * bug #28960 also clean away the NO_AUTO_CACHE_CONTROL_HEADER if we have no session (@dbu)
 * feature #28893 [TwigBundle] Fix usage of TwigBundle without FrameworkBundle (@tgalopin)
 * bug #28889 [Serializer] Reduce class discriminator overhead (@fbourigault)
 * bug #28861 [DependencyInjection] Skip empty proxy code (@olvlvl)
 * bug #28801 Convert InsufficientAuthenticationException to HttpException with 401 status code (@vincentchalamon)
 * bug #28840 add missing double-quotes to extra_fields output message (@danielkay)
 * bug #28838 [DI] Default undefined env to empty string during compile (@ro0NL)
 * bug #28863 [Process] Allow to pass non-string arguments to Process (@vudaltsov)
 * bug #28712 [Form] reverse transform RFC 3339 formatted dates (@xabbuh)
 * bug #28813 Fix for race condition in console output stream write (@rudolfratusinski)
 * bug #27772 [Console] Fixes multiselect choice question defaults in non-interactive mode (@veewee)
 * bug #28835 [FrameworkBundle] Setting missing default paths under BC layer (@yceruto)
 * bug #28760 [DI] fix dumping inline services again (@nicolas-grekas)
 * bug #28689 [Process] fix locking of pipe files on Windows (@nicolas-grekas)
 * bug #28704 [Form] fix multi-digit seconds fraction handling (@xabbuh)
 * bug #28793 [SecurityBundle] do not override custom access decision configs (@xabbuh)
 * bug #28783 [FrameworkBundle] add missing cache prefix seed attribute to XSD (@xabbuh)
 * bug #28072 [Security] Do not deauthenticate user when the first refreshed user has changed (@gpekz)
 * bug #28735 [FWBundle] Automatically enable PropertyInfo when using Flex (@dunglas)
 * bug #28751 [FrameworkBundle] Register messenger before the profiler (@sroze)
