### PR TITLE
[Serializer] Allow null values when denormalizing with constructor missing data

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -378,7 +378,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                     // Don't run set for a parameter passed to the constructor
                     $params[] = $parameterData;
                     unset($data[$key]);
-                } elseif (isset($context[static::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class][$key])) {
+                } elseif (array_key_exists($key, $context[static::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class] ?? array())) {
                     $params[] = $context[static::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class][$key];
                 } elseif ($constructorParameter->isDefaultValueAvailable()) {
                     $params[] = $constructorParameter->getDefaultValue();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -245,11 +245,11 @@ class ObjectNormalizerTest extends TestCase
 
         $result = $normalizer->denormalize($data, DummyValueObject::class, 'json', array(
             'default_constructor_arguments' => array(
-                DummyValueObject::class => array('foo' => '', 'bar' => ''),
+                DummyValueObject::class => array('foo' => '', 'bar' => '', 'baz' => null),
             ),
         ));
 
-        $this->assertEquals(new DummyValueObject(10, ''), $result);
+        $this->assertEquals(new DummyValueObject(10, '', null), $result);
     }
 
     public function testGroupsNormalize()
@@ -1117,11 +1117,13 @@ class DummyValueObject
 {
     private $foo;
     private $bar;
+    private $baz;
 
-    public function __construct($foo, $bar)
+    public function __construct($foo, $bar, $baz)
     {
         $this->foo = $foo;
         $this->bar = $bar;
+        $this->baz = $baz;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

When using `default_constructor_arguments` to denormalize objects, `null` values for a parameter weren't processed, so instantiating was failing.
