### PR TITLE
[FrameworkBundle][4.2] fix deps

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -69,7 +69,7 @@
         "symfony/form": "<4.2",
         "symfony/messenger": "<4.2",
         "symfony/property-info": "<3.4",
-        "symfony/serializer": "<4.1",
+        "symfony/serializer": "<4.2",
         "symfony/stopwatch": "<3.4",
         "symfony/translation": "<4.2",
         "symfony/twig-bridge": "<4.1.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The bundle requires the `MetadataAwareNameConverter` added in 4.2

https://github.com/symfony/symfony/blob/1fc577f2c7c1cff2857658537adf4f30a3ad60ac/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml#L122-L124

This PR fixes

```
Attempted to load interface "AdvancedNameConverterInterface" from namespace "Symfony\Component\Serializer\NameConverter".
Did you forget a "use" statement for another namespace?
```