### PR TITLE
[Travis] Bump ext-mongodb to 1.5.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,7 +159,7 @@ before_install:
               echo extension = $ext_cache >> $INI
           elif [[ $PHP = 7.* ]]; then
               tfold ext.apcu tpecl apcu-5.1.6 apcu.so $INI
-              tfold ext.mongodb tpecl mongodb-1.5.0 mongodb.so $INI
+              tfold ext.mongodb tpecl mongodb-1.5.2 mongodb.so $INI
           fi
       done
 
@@ -218,7 +218,7 @@ install:
           fi
           phpenv global ${PHP/hhvm*/hhvm}
           if [[ $PHP = 7.* ]]; then
-              ([[ $deps ]] && cd src/Symfony/Component/HttpFoundation; composer config platform.ext-mongodb 1.5.0; composer require --dev --no-update mongodb/mongodb)
+              ([[ $deps ]] && cd src/Symfony/Component/HttpFoundation; composer config platform.ext-mongodb 1.5.2; composer require --dev --no-update mongodb/mongodb)
           fi
           tfold 'composer update' $COMPOSER_UP
           if [[ $TRAVIS_PHP_VERSION = 5.* || $TRAVIS_PHP_VERSION = hhvm* ]]; then


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | https://travis-ci.org/symfony/symfony/jobs/451058906#L2679   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A

Should fix Travis builds after https://github.com/mongodb/mongo-php-library/commit/ba0b611acba37aeb43266a6ef01b836c56754a98 being merged (but not released yet).

And/or use `composer require --dev --no-update mongodb/mongodb:@stable`?