### PR TITLE
[DI] fix GraphvizDumper ignoring inline definitions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -149,6 +149,14 @@ class GraphvizDumper extends Dumper
                 $edges[] = array('name' => $name, 'required' => $required, 'to' => $argument, 'lazy' => $lazyEdge);
             } elseif ($argument instanceof ArgumentInterface) {
                 $edges = array_merge($edges, $this->findEdges($id, $argument->getValues(), $required, $name, true));
+            } elseif ($argument instanceof Definition) {
+                $edges = array_merge($edges,
+                    $this->findEdges($id, $argument->getArguments(), $required, ''),
+                    $this->findEdges($id, $argument->getProperties(), false, '')
+                );
+                foreach ($argument->getMethodCalls() as $call) {
+                    $edges = array_merge($edges, $this->findEdges($id, $call[1], false, $call[0].'()'));
+                }
             } elseif (\is_array($argument)) {
                 $edges = array_merge($edges, $this->findEdges($id, $argument, $required, $name, $lazy));
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/GraphvizDumperTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Dumper\GraphvizDumper;
+use Symfony\Component\DependencyInjection\Reference;
 
 class GraphvizDumperTest extends TestCase
 {
@@ -32,11 +34,11 @@ class GraphvizDumperTest extends TestCase
 
         $container = include self::$fixturesPath.'/containers/container9.php';
         $dumper = new GraphvizDumper($container);
-        $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services9.dot')), $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services9.dot', $dumper->dump(), '->dump() dumps services');
 
         $container = include self::$fixturesPath.'/containers/container10.php';
         $dumper = new GraphvizDumper($container);
-        $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services10.dot')), $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services10.dot', $dumper->dump(), '->dump() dumps services');
 
         $container = include self::$fixturesPath.'/containers/container10.php';
         $dumper = new GraphvizDumper($container);
@@ -47,21 +49,21 @@ class GraphvizDumperTest extends TestCase
             'node.instance' => array('fillcolor' => 'green', 'style' => 'empty'),
             'node.definition' => array('fillcolor' => 'grey'),
             'node.missing' => array('fillcolor' => 'red', 'style' => 'empty'),
-        )), str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services10-1.dot')), '->dump() dumps services');
+        )), file_get_contents(self::$fixturesPath.'/graphviz/services10-1.dot'), '->dump() dumps services');
     }
 
     public function testDumpWithFrozenContainer()
     {
         $container = include self::$fixturesPath.'/containers/container13.php';
         $dumper = new GraphvizDumper($container);
-        $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services13.dot')), $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services13.dot', $dumper->dump(), '->dump() dumps services');
     }
 
     public function testDumpWithFrozenCustomClassContainer()
     {
         $container = include self::$fixturesPath.'/containers/container14.php';
         $dumper = new GraphvizDumper($container);
-        $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services14.dot')), $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services14.dot', $dumper->dump(), '->dump() dumps services');
     }
 
     public function testDumpWithUnresolvedParameter()
@@ -69,6 +71,18 @@ class GraphvizDumperTest extends TestCase
         $container = include self::$fixturesPath.'/containers/container17.php';
         $dumper = new GraphvizDumper($container);
 
-        $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services17.dot')), $dumper->dump(), '->dump() dumps services');
+        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services17.dot', $dumper->dump(), '->dump() dumps services');
+    }
+
+    public function testDumpWithInlineDefinition()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', 'stdClass')->addArgument(
+            (new Definition('stdClass'))->addArgument(new Reference('bar'))
+        );
+        $container->register('bar', 'stdClass');
+        $dumper = new GraphvizDumper($container);
+
+        $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services_inline.dot', $dumper->dump(), '->dump() dumps nested references');
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services_inline.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services_inline.dot
@@ -1,0 +1,10 @@
+digraph sc {
+  ratio="compress"
+  node [fontsize="11" fontname="Arial" shape="record"];
+  edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
+
+  node_service_container [label="service_container (Psr\Container\ContainerInterface, Symfony\Component\DependencyInjection\ContainerInterface)\nSymfony\\Component\\DependencyInjection\\ContainerInterface\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_foo [label="foo\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_bar [label="bar\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_foo -> node_bar [label="" style="filled"];
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Since SF3, inline definitions are first class citizen. I noticed that the GraphvizDumper does not inspect them. Here is the fix.