### PR TITLE
[DI] fix dumping inlined services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1388,6 +1388,8 @@ class ContainerBuilderTest extends TestCase
 
         $foo6 = $container->get('foo6');
         $this->assertEquals((object) array('bar6' => (object) array()), $foo6);
+
+        $this->assertInstanceOf(\stdClass::class, $container->get('root'));
     }
 
     public function provideAlmostCircular()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -833,6 +833,8 @@ class PhpDumperTest extends TestCase
 
         $foo6 = $container->get('foo6');
         $this->assertEquals((object) array('bar6' => (object) array()), $foo6);
+
+        $this->assertInstanceOf(\stdClass::class, $container->get('root'));
     }
 
     public function provideAlmostCircular()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooForCircularWithAddCalls.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooForCircularWithAddCalls.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooForCircularWithAddCalls
+{
+    public function call(\stdClass $argument)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_almost_circular.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_almost_circular.php
@@ -4,6 +4,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls;
 
 $public = 'public' === $visibility;
 $container = new ContainerBuilder();
@@ -114,5 +115,34 @@ $container->register('bar6', 'stdClass')
 $container->register('baz6', 'stdClass')
     ->setPublic(true)
     ->setProperty('bar6', new Reference('bar6'));
+
+// provided by Christian Schiffler
+
+$container
+    ->register('root', 'stdClass')
+    ->setArguments([new Reference('level2'), new Reference('multiuse1')])
+    ->setPublic(true);
+
+$container
+    ->register('level2', FooForCircularWithAddCalls::class)
+    ->addMethodCall('call', [new Reference('level3')]);
+
+$container->register('multiuse1', 'stdClass');
+
+$container
+    ->register('level3', 'stdClass')
+    ->addArgument(new Reference('level4'));
+
+$container
+    ->register('level4', 'stdClass')
+    ->setArguments([new Reference('multiuse1'), new Reference('level5')]);
+
+$container
+    ->register('level5', 'stdClass')
+    ->addArgument(new Reference('level6'));
+
+$container
+    ->register('level6', FooForCircularWithAddCalls::class)
+    ->addMethodCall('call', [new Reference('level5')]);
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -158,7 +158,6 @@ use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 $this->services['foo_with_inline'] = $instance = new \Foo();
 
 $a = new \Bar();
-
 $a->pub = 'pub';
 $a->setBaz(${($_ = isset($this->services['baz']) ? $this->services['baz'] : $this->load('getBazService.php')) && false ?: '_'});
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -264,7 +264,6 @@ class ProjectServiceContainer extends Container
         $this->services['foo_with_inline'] = $instance = new \Foo();
 
         $a = new \Bar();
-
         $a->pub = 'pub';
         $a->setBaz(${($_ = isset($this->services['baz']) ? $this->services['baz'] : $this->getBazService()) && false ?: '_'});
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -34,13 +34,26 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             'foo5' => 'getFoo5Service',
             'foo6' => 'getFoo6Service',
             'foobar4' => 'getFoobar4Service',
+            'level2' => 'getLevel2Service',
+            'level3' => 'getLevel3Service',
+            'level4' => 'getLevel4Service',
+            'level5' => 'getLevel5Service',
+            'level6' => 'getLevel6Service',
             'logger' => 'getLoggerService',
             'manager' => 'getManagerService',
             'manager2' => 'getManager2Service',
+            'multiuse1' => 'getMultiuse1Service',
+            'root' => 'getRootService',
             'subscriber' => 'getSubscriberService',
         );
         $this->privates = array(
             'bar6' => true,
+            'level2' => true,
+            'level3' => true,
+            'level4' => true,
+            'level5' => true,
+            'level6' => true,
+            'multiuse1' => true,
         );
 
         $this->aliases = array();
@@ -62,7 +75,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             'foobar' => true,
             'foobar2' => true,
             'foobar3' => true,
+            'level2' => true,
+            'level3' => true,
+            'level4' => true,
+            'level5' => true,
+            'level6' => true,
             'logger2' => true,
+            'multiuse1' => true,
             'subscriber2' => true,
         );
     }
@@ -141,9 +160,9 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
 
         $this->services['connection'] = $instance = new \stdClass($a, $b);
 
-        $a->subscriber = ${($_ = isset($this->services['subscriber']) ? $this->services['subscriber'] : $this->getSubscriberService()) && false ?: '_'};
-
         $b->logger = ${($_ = isset($this->services['logger']) ? $this->services['logger'] : $this->getLoggerService()) && false ?: '_'};
+
+        $a->subscriber = ${($_ = isset($this->services['subscriber']) ? $this->services['subscriber'] : $this->getSubscriberService()) && false ?: '_'};
 
         return $instance;
     }
@@ -157,19 +176,19 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     {
         $a = new \stdClass();
 
-        $c = new \stdClass();
+        $b = new \stdClass();
 
-        $this->services['connection2'] = $instance = new \stdClass($a, $c);
+        $this->services['connection2'] = $instance = new \stdClass($a, $b);
 
-        $b = ${($_ = isset($this->services['manager2']) ? $this->services['manager2'] : $this->getManager2Service()) && false ?: '_'};
+        $c = new \stdClass($instance);
 
-        $a->subscriber2 = new \stdClass($b);
+        $d = ${($_ = isset($this->services['manager2']) ? $this->services['manager2'] : $this->getManager2Service()) && false ?: '_'};
 
-        $d = new \stdClass($instance);
+        $c->handler2 = new \stdClass($d);
 
-        $d->handler2 = new \stdClass($b);
+        $b->logger2 = $c;
 
-        $c->logger2 = $d;
+        $a->subscriber2 = new \stdClass($d);
 
         return $instance;
     }
@@ -216,7 +235,6 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
         $this->services['foo5'] = $instance = new \stdClass();
 
         $a = new \stdClass($instance);
-
         $a->foo = $instance;
 
         $instance->bar = $a;
@@ -307,6 +325,16 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     }
 
     /**
+     * Gets the public 'root' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getRootService()
+    {
+        return $this->services['root'] = new \stdClass(${($_ = isset($this->services['level2']) ? $this->services['level2'] : $this->getLevel2Service()) && false ?: '_'}, ${($_ = isset($this->services['multiuse1']) ? $this->services['multiuse1'] : $this->services['multiuse1'] = new \stdClass()) && false ?: '_'});
+    }
+
+    /**
      * Gets the public 'subscriber' shared service.
      *
      * @return \stdClass
@@ -336,5 +364,79 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
         }
 
         return $this->services['bar6'] = new \stdClass($a);
+    }
+
+    /**
+     * Gets the private 'level2' shared service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls
+     */
+    protected function getLevel2Service()
+    {
+        $this->services['level2'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
+
+        $instance->call(${($_ = isset($this->services['level3']) ? $this->services['level3'] : $this->getLevel3Service()) && false ?: '_'});
+
+        return $instance;
+    }
+
+    /**
+     * Gets the private 'level3' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getLevel3Service()
+    {
+        return $this->services['level3'] = new \stdClass(${($_ = isset($this->services['level4']) ? $this->services['level4'] : $this->getLevel4Service()) && false ?: '_'});
+    }
+
+    /**
+     * Gets the private 'level4' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getLevel4Service()
+    {
+        return $this->services['level4'] = new \stdClass(${($_ = isset($this->services['multiuse1']) ? $this->services['multiuse1'] : $this->services['multiuse1'] = new \stdClass()) && false ?: '_'}, ${($_ = isset($this->services['level5']) ? $this->services['level5'] : $this->getLevel5Service()) && false ?: '_'});
+    }
+
+    /**
+     * Gets the private 'level5' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getLevel5Service()
+    {
+        $a = ${($_ = isset($this->services['level6']) ? $this->services['level6'] : $this->getLevel6Service()) && false ?: '_'};
+
+        if (isset($this->services['level5'])) {
+            return $this->services['level5'];
+        }
+
+        return $this->services['level5'] = new \stdClass($a);
+    }
+
+    /**
+     * Gets the private 'level6' shared service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls
+     */
+    protected function getLevel6Service()
+    {
+        $this->services['level6'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
+
+        $instance->call(${($_ = isset($this->services['level5']) ? $this->services['level5'] : $this->getLevel5Service()) && false ?: '_'});
+
+        return $instance;
+    }
+
+    /**
+     * Gets the private 'multiuse1' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getMultiuse1Service()
+    {
+        return $this->services['multiuse1'] = new \stdClass();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -41,13 +41,26 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             'foobar2' => 'getFoobar2Service',
             'foobar3' => 'getFoobar3Service',
             'foobar4' => 'getFoobar4Service',
+            'level2' => 'getLevel2Service',
+            'level3' => 'getLevel3Service',
+            'level4' => 'getLevel4Service',
+            'level5' => 'getLevel5Service',
+            'level6' => 'getLevel6Service',
             'logger' => 'getLoggerService',
             'manager' => 'getManagerService',
             'manager2' => 'getManager2Service',
+            'multiuse1' => 'getMultiuse1Service',
+            'root' => 'getRootService',
             'subscriber' => 'getSubscriberService',
         );
         $this->privates = array(
             'bar6' => true,
+            'level2' => true,
+            'level3' => true,
+            'level4' => true,
+            'level5' => true,
+            'level6' => true,
+            'multiuse1' => true,
         );
 
         $this->aliases = array();
@@ -62,7 +75,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
             'bar6' => true,
             'config' => true,
             'config2' => true,
+            'level2' => true,
+            'level3' => true,
+            'level4' => true,
+            'level5' => true,
+            'level6' => true,
             'logger2' => true,
+            'multiuse1' => true,
             'subscriber2' => true,
         );
     }
@@ -176,7 +195,6 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
         $this->services['connection2'] = $instance = new \stdClass(${($_ = isset($this->services['dispatcher2']) ? $this->services['dispatcher2'] : $this->getDispatcher2Service()) && false ?: '_'}, $a);
 
         $b = new \stdClass($instance);
-
         $b->handler2 = new \stdClass(${($_ = isset($this->services['manager2']) ? $this->services['manager2'] : $this->getManager2Service()) && false ?: '_'});
 
         $a->logger2 = $b;
@@ -397,6 +415,16 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
     }
 
     /**
+     * Gets the public 'root' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getRootService()
+    {
+        return $this->services['root'] = new \stdClass(${($_ = isset($this->services['level2']) ? $this->services['level2'] : $this->getLevel2Service()) && false ?: '_'}, ${($_ = isset($this->services['multiuse1']) ? $this->services['multiuse1'] : $this->services['multiuse1'] = new \stdClass()) && false ?: '_'});
+    }
+
+    /**
      * Gets the public 'subscriber' shared service.
      *
      * @return \stdClass
@@ -420,5 +448,79 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
         }
 
         return $this->services['bar6'] = new \stdClass($a);
+    }
+
+    /**
+     * Gets the private 'level2' shared service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls
+     */
+    protected function getLevel2Service()
+    {
+        $this->services['level2'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
+
+        $instance->call(${($_ = isset($this->services['level3']) ? $this->services['level3'] : $this->getLevel3Service()) && false ?: '_'});
+
+        return $instance;
+    }
+
+    /**
+     * Gets the private 'level3' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getLevel3Service()
+    {
+        return $this->services['level3'] = new \stdClass(${($_ = isset($this->services['level4']) ? $this->services['level4'] : $this->getLevel4Service()) && false ?: '_'});
+    }
+
+    /**
+     * Gets the private 'level4' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getLevel4Service()
+    {
+        return $this->services['level4'] = new \stdClass(${($_ = isset($this->services['multiuse1']) ? $this->services['multiuse1'] : $this->services['multiuse1'] = new \stdClass()) && false ?: '_'}, ${($_ = isset($this->services['level5']) ? $this->services['level5'] : $this->getLevel5Service()) && false ?: '_'});
+    }
+
+    /**
+     * Gets the private 'level5' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getLevel5Service()
+    {
+        $a = ${($_ = isset($this->services['level6']) ? $this->services['level6'] : $this->getLevel6Service()) && false ?: '_'};
+
+        if (isset($this->services['level5'])) {
+            return $this->services['level5'];
+        }
+
+        return $this->services['level5'] = new \stdClass($a);
+    }
+
+    /**
+     * Gets the private 'level6' shared service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls
+     */
+    protected function getLevel6Service()
+    {
+        $this->services['level6'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
+
+        $instance->call(${($_ = isset($this->services['level5']) ? $this->services['level5'] : $this->getLevel5Service()) && false ?: '_'});
+
+        return $instance;
+    }
+
+    /**
+     * Gets the private 'multiuse1' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getMultiuse1Service()
+    {
+        return $this->services['multiuse1'] = new \stdClass();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
@@ -81,8 +81,8 @@ class Symfony_DI_PhpDumper_Test_Deep_Graph extends Container
         if (isset($this->services['foo'])) {
             return $this->services['foo'];
         }
-
         $b = new \stdClass();
+
         $c = new \stdClass();
         $c->p3 = new \stdClass();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_self_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_self_ref.php
@@ -64,14 +64,14 @@ class Symfony_DI_PhpDumper_Test_Inline_Self_Ref extends Container
      */
     protected function getFooService()
     {
-        $b = new \App\Bar();
-        $a = new \App\Baz($b);
+        $a = new \App\Bar();
 
-        $this->services['App\Foo'] = $instance = new \App\Foo($a);
+        $b = new \App\Baz($a);
+        $b->bar = $a;
 
-        $b->foo = $instance;
+        $this->services['App\Foo'] = $instance = new \App\Foo($b);
 
-        $a->bar = $b;
+        $a->foo = $instance;
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tsantos.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tsantos.php
@@ -67,22 +67,20 @@ class ProjectServiceContainer extends Container
     {
         $a = new \TSantos\Serializer\NormalizerRegistry();
 
-        $d = new \TSantos\Serializer\EventDispatcher\EventDispatcher();
-        $d->addSubscriber(new \TSantos\SerializerBundle\EventListener\StopwatchListener(new \Symfony\Component\Stopwatch\Stopwatch(true)));
-
-        $this->services['tsantos_serializer'] = $instance = new \TSantos\Serializer\EventEmitterSerializer(new \TSantos\Serializer\Encoder\JsonEncoder(), $a, $d);
-
         $b = new \TSantos\Serializer\Normalizer\CollectionNormalizer();
 
+        $c = new \TSantos\Serializer\EventDispatcher\EventDispatcher();
+        $c->addSubscriber(new \TSantos\SerializerBundle\EventListener\StopwatchListener(new \Symfony\Component\Stopwatch\Stopwatch(true)));
+
+        $this->services['tsantos_serializer'] = $instance = new \TSantos\Serializer\EventEmitterSerializer(new \TSantos\Serializer\Encoder\JsonEncoder(), $a, $c);
+
         $b->setSerializer($instance);
-
-        $c = new \TSantos\Serializer\Normalizer\JsonNormalizer();
-
-        $c->setSerializer($instance);
+        $d = new \TSantos\Serializer\Normalizer\JsonNormalizer();
+        $d->setSerializer($instance);
 
         $a->add(new \TSantos\Serializer\Normalizer\ObjectNormalizer(new \TSantos\SerializerBundle\Serializer\CircularReferenceHandler()));
         $a->add($b);
-        $a->add($c);
+        $a->add($d);
 
         return $instance;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28824 #29078
| License       | MIT
| Doc PR        | -

Same as #29103 but for 3.4.

This PR dump inline services using the call-stack to sort the code for instantiating them.
This makes easier to follow and matches the behavior one would expect (and has when using `ContainerBuiler` directly to create services.)