### PR TITLE
SCA: use 'yield from' where it does make sense

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -281,9 +281,7 @@ class PhpArrayAdapter implements AdapterInterface, CacheInterface, PruneableInte
         }
 
         if ($fallbackKeys) {
-            foreach ($this->pool->getItems($fallbackKeys) as $key => $item) {
-                yield $key => $item;
-            }
+            yield from $this->pool->getItems($fallbackKeys);
         }
     }
 

--- a/src/Symfony/Component/Cache/Simple/PhpArrayCache.php
+++ b/src/Symfony/Component/Cache/Simple/PhpArrayCache.php
@@ -242,9 +242,7 @@ class PhpArrayCache implements CacheInterface, PruneableInterface, ResettableInt
         }
 
         if ($fallbackKeys) {
-            foreach ($this->pool->getMultiple($fallbackKeys, $default) as $key => $item) {
-                yield $key => $item;
-            }
+            yield from $this->pool->getMultiple($fallbackKeys, $default);
         }
     }
 }

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -122,9 +122,7 @@ abstract class FileLoader extends Loader
         }
         $resource = new GlobResource($prefix, $pattern, $recursive, $forExclusion, $excluded);
 
-        foreach ($resource as $path => $info) {
-            yield $path => $info;
-        }
+        yield from $resource;
     }
 
     private function doImport($resource, $type = null, bool $ignoreErrors = false, $sourceResource = null)

--- a/src/Symfony/Component/Process/InputStream.php
+++ b/src/Symfony/Component/Process/InputStream.php
@@ -78,9 +78,7 @@ class InputStream implements \IteratorAggregate
             $current = array_shift($this->input);
 
             if ($current instanceof \Iterator) {
-                foreach ($current as $cur) {
-                    yield $cur;
-                }
+                yield from $current;
             } else {
                 yield $current;
             }

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -115,9 +115,7 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
             throw new \LogicException(sprintf('%s object holds non-iterable type "%s".', self::class, \gettype($value)));
         }
 
-        foreach ($value as $k => $v) {
-            yield $k => $v;
-        }
+        yield from $value;
     }
 
     public function __get($key)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Reduces amount of code by using generator delegation where possible (language level migration).