### PR TITLE
[DomCrawler] Added return of element name in `extract()` method

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+* Added return of element name (`_name`) in `extract()` method.
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -658,6 +658,8 @@ class Crawler implements \Countable, \IteratorAggregate
             foreach ($attributes as $attribute) {
                 if ('_text' === $attribute) {
                     $elements[] = $node->nodeValue;
+                } elseif ('_name' === $attribute) {
+                    $elements[] = $node->nodeName;
                 } else {
                     $elements[] = $node->getAttribute($attribute);
                 }

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -416,6 +416,8 @@ EOF
         $this->assertEquals(array(array(), array(), array()), $crawler->extract(array()), '->extract() returns empty arrays if the attribute list is empty');
 
         $this->assertEquals(array(), $this->createTestCrawler()->filterXPath('//ol')->extract('_text'), '->extract() returns an empty array if the node list is empty');
+
+        $this->assertEquals(array(array('One', 'li'), array('Two', 'li'), array('Three', 'li')), $crawler->extract(array('_text', '_name')), '->extract() returns an array of extracted data from the node list');
     }
 
     public function testFilterXpathComplexQueries()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#10646

Situation: you need to get an array of keys and values.
The current package code does not allow this to be done easily.
The changes made to the code will allow you to return the required data set.
```php
use Symfony\Component\DomCrawler\Crawler;

$crawler = new Crawler($content);

$crawler
    ->filter('ItemsList > Item')
    ->each(function (Crawler $element) {
        $data = $element
            ->children()
            ->extract(['_name', '_text']);

        var_dump($data);
    });

// Result:
array:2 [
  0 => array:2 [
    0 => "id",
    1 => "1"
  ],
  1 => array:2 [
    0 => "title",
    1 => "Foo Bar"
  ]
]
```
