### PR TITLE
[Serializer] Normalize constraint violation parameters

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * added the list of constraint violations' parameters in `ConstraintViolationListNormalizer`
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -49,6 +49,7 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
             $violationEntry = [
                 'propertyPath' => $propertyPath,
                 'title' => $violation->getMessage(),
+                'parameters' => $violation->getParameters(),
             ];
             if (null !== $code = $violation->getCode()) {
                 $violationEntry['type'] = sprintf('urn:uuid:%s', $code);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ConstraintViolationListNormalizerTest.php
@@ -38,7 +38,7 @@ class ConstraintViolationListNormalizerTest extends TestCase
     public function testNormalize()
     {
         $list = new ConstraintViolationList([
-            new ConstraintViolation('a', 'b', [], 'c', 'd', 'e', null, 'f'),
+            new ConstraintViolation('a', 'b', ['value' => 'foo'], 'c', 'd', 'e', null, 'f'),
             new ConstraintViolation('1', '2', [], '3', '4', '5', null, '6'),
         ]);
 
@@ -52,11 +52,15 @@ class ConstraintViolationListNormalizerTest extends TestCase
                         'propertyPath' => 'd',
                         'title' => 'a',
                         'type' => 'urn:uuid:f',
+                        'parameters' => [
+                            'value' => 'foo',
+                        ],
                     ],
                     [
                         'propertyPath' => '4',
                         'title' => '1',
                         'type' => 'urn:uuid:6',
+                        'parameters' => [],
                     ],
                 ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | N/A   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | N/A?

Adding violation constraints' parameters to the normalized data, as these are valuable for an API client.

I used `parameters` for now, as it's the name used in `ConstraintViolationInterface::getParameters()`, but what about `placeholders` or `context`?