### PR TITLE
[Workflow][FrameworkBundle] fixed guard event names for transitions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -300,6 +300,7 @@
         <xsd:sequence>
             <xsd:element name="from" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
             <xsd:element name="to" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
+            <xsd:element name="guard" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="required" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
@@ -1,0 +1,51 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+
+$container->loadFromExtension('framework', array(
+    'workflows' => array(
+        'article' => array(
+            'type' => 'workflow',
+            'marking_store' => array(
+                'type' => 'multiple_state',
+            ),
+            'supports' => array(
+                FrameworkExtensionTest::class,
+            ),
+            'initial_place' => 'draft',
+            'places' => array(
+                'draft',
+                'wait_for_journalist',
+                'approved_by_journalist',
+                'wait_for_spellchecker',
+                'approved_by_spellchecker',
+                'published',
+            ),
+            'transitions' => array(
+                'request_review' => array(
+                    'from' => 'draft',
+                    'to' => array('wait_for_journalist', 'wait_for_spellchecker'),
+                ),
+                'journalist_approval' => array(
+                    'from' => 'wait_for_journalist',
+                    'to' => 'approved_by_journalist',
+                ),
+                'spellchecker_approval' => array(
+                    'from' => 'wait_for_spellchecker',
+                    'to' => 'approved_by_spellchecker',
+                ),
+                'publish' => array(
+                    'from' => array('approved_by_journalist', 'approved_by_spellchecker'),
+                    'to' => 'published',
+                    'guard' => '!!true',
+                ),
+                'publish_editor_in_chief' => array(
+                    'name' => 'publish',
+                    'from' => 'draft',
+                    'to' => 'published',
+                    'guard' => '!!false',
+                ),
+            ),
+        ),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
@@ -13,12 +13,12 @@
                 <framework:argument>a</framework:argument>
             </framework:marking-store>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
-            <framework:place name="draft" />
-            <framework:place name="wait_for_journalist" />
-            <framework:place name="approved_by_journalist" />
-            <framework:place name="wait_for_spellchecker" />
-            <framework:place name="approved_by_spellchecker" />
-            <framework:place name="published" />
+            <framework:place>draft</framework:place>
+            <framework:place>wait_for_journalist</framework:place>
+            <framework:place>approved_by_journalist</framework:place>
+            <framework:place>wait_for_spellchecker</framework:place>
+            <framework:place>approved_by_spellchecker</framework:place>
+            <framework:place>published</framework:place>
             <framework:transition name="request_review">
                 <framework:from>draft</framework:from>
                 <framework:to>wait_for_journalist</framework:to>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:workflow name="article" type="workflow" initial-place="draft">
+            <framework:marking-store type="multiple_state">
+                <framework:argument>a</framework:argument>
+                <framework:argument>a</framework:argument>
+            </framework:marking-store>
+            <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
+            <framework:place name="draft" />
+            <framework:place name="wait_for_journalist" />
+            <framework:place name="approved_by_journalist" />
+            <framework:place name="wait_for_spellchecker" />
+            <framework:place name="approved_by_spellchecker" />
+            <framework:place name="published" />
+            <framework:transition name="request_review">
+                <framework:from>draft</framework:from>
+                <framework:to>wait_for_journalist</framework:to>
+                <framework:to>wait_for_spellchecker</framework:to>
+            </framework:transition>
+            <framework:transition name="journalist_approval">
+                <framework:from>wait_for_journalist</framework:from>
+                <framework:to>approved_by_journalist</framework:to>
+            </framework:transition>
+            <framework:transition name="spellchecker_approval">
+                <framework:from>wait_for_spellchecker</framework:from>
+                <framework:to>approved_by_spellchecker</framework:to>
+            </framework:transition>
+            <framework:transition name="publish">
+                <framework:from>approved_by_journalist</framework:from>
+                <framework:from>approved_by_spellchecker</framework:from>
+                <framework:to>published</framework:to>
+                <framework:guard>!!true</framework:guard>
+            </framework:transition>
+            <framework:transition name="publish">
+                <framework:from>draft</framework:from>
+                <framework:to>published</framework:to>
+                <framework:guard>!!false</framework:guard>
+            </framework:transition>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_guard_expression.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_guard_expression.yml
@@ -1,0 +1,35 @@
+framework:
+    workflows:
+        article:
+            type: workflow
+            marking_store:
+                type: multiple_state
+            supports:
+            - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest
+            initial_place: draft
+            places:
+            - draft
+            - wait_for_journalist
+            - approved_by_journalist
+            - wait_for_spellchecker
+            - approved_by_spellchecker
+            - published
+            transitions:
+                request_review:
+                    from: [draft]
+                    to: [wait_for_journalist, wait_for_spellchecker]
+                journalist_approval:
+                    from: [wait_for_journalist]
+                    to: [approved_by_journalist]
+                spellchecker_approval:
+                    from: [wait_for_spellchecker]
+                    to: [approved_by_spellchecker]
+                publish:
+                    from: [approved_by_journalist, approved_by_spellchecker]
+                    to: [published]
+                    guard: "!!true"
+                publish_editor_in_chief:
+                    name: publish
+                    from: [draft]
+                    to: [published]
+                    guard: "!!false"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -302,14 +302,84 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertCount(5, $transitions);
 
-        $this->assertSame('request_review', $transitions[0]->getArgument(0));
-        $this->assertSame('journalist_approval', $transitions[1]->getArgument(0));
-        $this->assertSame('spellchecker_approval', $transitions[2]->getArgument(0));
-        $this->assertSame('publish', $transitions[3]->getArgument(0));
-        $this->assertSame('publish', $transitions[4]->getArgument(0));
+        $this->assertSame('workflow.article.transition.0', (string) $transitions[0]);
+        $this->assertSame(array(
+            'request_review',
+            array(
+                'draft',
+            ),
+            array(
+                'wait_for_journalist', 'wait_for_spellchecker',
+            ),
+        ), $container->getDefinition($transitions[0])->getArguments());
 
-        $this->assertSame(array('approved_by_journalist', 'approved_by_spellchecker'), $transitions[3]->getArgument(1));
-        $this->assertSame(array('draft'), $transitions[4]->getArgument(1));
+        $this->assertSame('workflow.article.transition.1', (string) $transitions[1]);
+        $this->assertSame(array(
+            'journalist_approval',
+            array(
+                'wait_for_journalist',
+            ),
+            array(
+                'approved_by_journalist',
+            ),
+        ), $container->getDefinition($transitions[1])->getArguments());
+
+        $this->assertSame('workflow.article.transition.2', (string) $transitions[2]);
+        $this->assertSame(array(
+            'spellchecker_approval',
+            array(
+                'wait_for_spellchecker',
+            ),
+            array(
+                'approved_by_spellchecker',
+            ),
+        ), $container->getDefinition($transitions[2])->getArguments());
+
+        $this->assertSame('workflow.article.transition.3', (string) $transitions[3]);
+        $this->assertSame(array(
+            'publish',
+            array(
+                'approved_by_journalist',
+                'approved_by_spellchecker',
+            ),
+            array(
+                'published',
+            ),
+        ), $container->getDefinition($transitions[3])->getArguments());
+
+        $this->assertSame('workflow.article.transition.4', (string) $transitions[4]);
+        $this->assertSame(array(
+            'publish',
+            array(
+                'draft',
+            ),
+            array(
+                'published',
+            ),
+        ), $container->getDefinition($transitions[4])->getArguments());
+    }
+
+    public function testGuardExpressions()
+    {
+        $container = $this->createContainerFromFile('workflow_with_guard_expression');
+
+        $this->assertTrue($container->hasDefinition('workflow.article.listener.guard'), 'Workflow guard listener is registered as a service');
+        $this->assertTrue($container->hasParameter('workflow.has_guard_listeners'), 'Workflow guard listeners parameter exists');
+        $this->assertTrue(true === $container->getParameter('workflow.has_guard_listeners'), 'Workflow guard listeners parameter is enabled');
+        $guardDefinition = $container->getDefinition('workflow.article.listener.guard');
+        $this->assertSame(array(
+            array(
+                'event' => 'workflow.article.guard.publish',
+                'method' => 'onTransition',
+            ),
+        ), $guardDefinition->getTag('kernel.event_listener'));
+        $guardsConfiguration = $guardDefinition->getArgument(0);
+        $this->assertTrue(1 === \count($guardsConfiguration), 'Workflow guard configuration contains one element per transition name');
+        $transitionGuardExpressions = $guardsConfiguration['workflow.article.guard.publish'];
+        $this->assertSame('workflow.article.transition.3', (string) $transitionGuardExpressions[0]->getArgument(0));
+        $this->assertSame('!!true', $transitionGuardExpressions[0]->getArgument(1));
+        $this->assertSame('workflow.article.transition.4', (string) $transitionGuardExpressions[1]->getArgument(0));
+        $this->assertSame('!!false', $transitionGuardExpressions[1]->getArgument(1));
     }
 
     public function testWorkflowServicesCanBeEnabled()

--- a/src/Symfony/Component/Workflow/EventListener/GuardExpression.php
+++ b/src/Symfony/Component/Workflow/EventListener/GuardExpression.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\EventListener;
+
+use Symfony\Component\Workflow\Transition;
+
+class GuardExpression
+{
+    private $transition;
+
+    private $expression;
+
+    public function getTransition(): Transition
+    {
+        return $this->transition;
+    }
+
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    public function __construct(Transition $transition, string $expression)
+    {
+        $this->transition = $transition;
+        $this->expression = $expression;
+    }
+}

--- a/src/Symfony/Component/Workflow/EventListener/GuardExpression.php
+++ b/src/Symfony/Component/Workflow/EventListener/GuardExpression.php
@@ -19,19 +19,22 @@ class GuardExpression
 
     private $expression;
 
-    public function getTransition(): Transition
+    /**
+     * @param string $expression
+     */
+    public function __construct(Transition $transition, $expression)
+    {
+        $this->transition = $transition;
+        $this->expression = $expression;
+    }
+
+    public function getTransition()
     {
         return $this->transition;
     }
 
-    public function getExpression(): string
+    public function getExpression()
     {
         return $this->expression;
-    }
-
-    public function __construct(Transition $transition, string $expression)
-    {
-        $this->transition = $transition;
-        $this->expression = $expression;
     }
 }

--- a/src/Symfony/Component/Workflow/EventListener/GuardListener.php
+++ b/src/Symfony/Component/Workflow/EventListener/GuardListener.php
@@ -18,7 +18,6 @@ use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Workflow\Event\GuardEvent;
 use Symfony\Component\Workflow\Exception\InvalidTokenConfigurationException;
-use Symfony\Component\Workflow\TransitionBlocker;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
@@ -63,16 +62,15 @@ class GuardListener
         }
     }
 
-    private function validateGuardExpression(GuardEvent $event, string $expression)
+    private function validateGuardExpression(GuardEvent $event, $expression)
     {
         if (!$this->expressionLanguage->evaluate($expression, $this->getVariables($event))) {
-            $blocker = TransitionBlocker::createBlockedByExpressionGuardListener($expression);
-            $event->addTransitionBlocker($blocker);
+            $event->setBlocked(true);
         }
     }
 
     // code should be sync with Symfony\Component\Security\Core\Authorization\Voter\ExpressionVoter
-    private function getVariables(GuardEvent $event): array
+    private function getVariables(GuardEvent $event)
     {
         $token = $this->tokenStorage->getToken();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28018 https://github.com/symfony/symfony/pull/28007#issuecomment-40652420
| License       | MIT
| Doc PR        |

There is a bug when many transitions are defined with the same name.
I finished destillat's work and rebase against 3.4 as it's a bug fix.

There another point of failure, but it could not be fixed on 3.4. I will
be a need feature. The issue is related to `Workflow::can($subject, $transitionName)`.
Since the transitionName could be not unique, we will need to support
passing an instance of Transition. A new PR is incomming