### PR TITLE
[4.1][FrameworkBundle] fixed guard event names for transitions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -602,15 +602,40 @@ class FrameworkExtension extends Extension
                 @trigger_error(sprintf('The "type" option of the "framework.workflows.%s" configuration entry must be defined since Symfony 3.3. The default value will be "state_machine" in Symfony 4.0.', $name), E_USER_DEPRECATED);
             }
             $type = $workflow['type'];
+            $workflowId = sprintf('%s.%s', $type, $name);
 
+            // Create transitions
             $transitions = array();
-            foreach ($workflow['transitions'] as $transition) {
+            $guardsConfiguration = array();
+            // Global transition counter per workflow
+            $transitionCounter = 0;
+            foreach (array_values($workflow['transitions']) as $number => $transition) {
                 if ('workflow' === $type) {
-                    $transitions[] = new Definition(Workflow\Transition::class, array($transition['name'], $transition['from'], $transition['to']));
+                    $transitionDefinition = new Definition(Workflow\Transition::class, array($transition['name'], $transition['from'], $transition['to']));
+                    $transitionId = sprintf('%s.transition.%s', $workflowId, $transitionCounter++);
+                    $container->setDefinition($transitionId, $transitionDefinition);
+                    $transitions[] = new Reference($transitionId);
+                    if (isset($transition['guard'])) {
+                        $configuration = new Definition(Workflow\EventListener\GuardExpression::class);
+                        $configuration->addArgument(new Reference($transitionId));
+                        $configuration->addArgument($transition['guard']);
+                        $eventName = sprintf('workflow.%s.guard.%s', $name, $transition['name']);
+                        $guardsConfiguration[$eventName][] = $configuration;
+                    }
                 } elseif ('state_machine' === $type) {
                     foreach ($transition['from'] as $from) {
                         foreach ($transition['to'] as $to) {
-                            $transitions[] = new Definition(Workflow\Transition::class, array($transition['name'], $from, $to));
+                            $transitionDefinition = new Definition(Workflow\Transition::class, array($transition['name'], $from, $to));
+                            $transitionId = sprintf('%s.transition.%s', $workflowId, $transitionCounter++);
+                            $container->setDefinition($transitionId, $transitionDefinition);
+                            $transitions[] = new Reference($transitionId);
+                            if (isset($transition['guard'])) {
+                                $configuration = new Definition(Workflow\EventListener\GuardExpression::class);
+                                $configuration->addArgument(new Reference($transitionId));
+                                $configuration->addArgument($transition['guard']);
+                                $eventName = sprintf('workflow.%s.guard.%s', $name, $transition['name']);
+                                $guardsConfiguration[$eventName][] = $configuration;
+                            }
                         }
                     }
                 }
@@ -641,7 +666,6 @@ class FrameworkExtension extends Extension
             }
 
             // Create Workflow
-            $workflowId = sprintf('%s.%s', $type, $name);
             $workflowDefinition = new ChildDefinition(sprintf('%s.abstract', $type));
             $workflowDefinition->replaceArgument(0, new Reference(sprintf('%s.definition', $workflowId)));
             if (isset($markingStoreDefinition)) {
@@ -677,16 +701,7 @@ class FrameworkExtension extends Extension
             }
 
             // Add Guard Listener
-            $guard = new Definition(Workflow\EventListener\GuardListener::class);
-            $guard->setPrivate(true);
-            $configuration = array();
-            foreach ($workflow['transitions'] as $config) {
-                $transitionName = $config['name'];
-
-                if (!isset($config['guard'])) {
-                    continue;
-                }
-
+            if ($guardsConfiguration) {
                 if (!class_exists(ExpressionLanguage::class)) {
                     throw new LogicException('Cannot guard workflows as the ExpressionLanguage component is not installed. Try running "composer require symfony/expression-language".');
                 }
@@ -695,13 +710,11 @@ class FrameworkExtension extends Extension
                     throw new LogicException('Cannot guard workflows as the Security component is not installed. Try running "composer require symfony/security".');
                 }
 
-                $eventName = sprintf('workflow.%s.guard.%s', $name, $transitionName);
-                $guard->addTag('kernel.event_listener', array('event' => $eventName, 'method' => 'onTransition'));
-                $configuration[$eventName] = $config['guard'];
-            }
-            if ($configuration) {
+                $guard = new Definition(Workflow\EventListener\GuardListener::class);
+                $guard->setPrivate(true);
+
                 $guard->setArguments(array(
-                    $configuration,
+                    $guardsConfiguration,
                     new Reference('workflow.security.expression_language'),
                     new Reference('security.token_storage'),
                     new Reference('security.authorization_checker'),
@@ -709,6 +722,9 @@ class FrameworkExtension extends Extension
                     new Reference('security.role_hierarchy'),
                     new Reference('validator', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 ));
+                foreach ($guardsConfiguration as $eventName => $config) {
+                    $guard->addTag('kernel.event_listener', array('event' => $eventName, 'method' => 'onTransition'));
+                }
 
                 $container->setDefinition(sprintf('%s.listener.guard', $workflowId), $guard);
                 $container->setParameter('workflow.has_guard_listeners', true);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -300,6 +300,7 @@
         <xsd:sequence>
             <xsd:element name="from" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
             <xsd:element name="to" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
+            <xsd:element name="guard" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="required" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_guard_expression.php
@@ -1,0 +1,51 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+
+$container->loadFromExtension('framework', array(
+    'workflows' => array(
+        'article' => array(
+            'type' => 'workflow',
+            'marking_store' => array(
+                'type' => 'multiple_state',
+            ),
+            'supports' => array(
+                FrameworkExtensionTest::class,
+            ),
+            'initial_place' => 'draft',
+            'places' => array(
+                'draft',
+                'wait_for_journalist',
+                'approved_by_journalist',
+                'wait_for_spellchecker',
+                'approved_by_spellchecker',
+                'published',
+            ),
+            'transitions' => array(
+                'request_review' => array(
+                    'from' => 'draft',
+                    'to' => array('wait_for_journalist', 'wait_for_spellchecker'),
+                ),
+                'journalist_approval' => array(
+                    'from' => 'wait_for_journalist',
+                    'to' => 'approved_by_journalist',
+                ),
+                'spellchecker_approval' => array(
+                    'from' => 'wait_for_spellchecker',
+                    'to' => 'approved_by_spellchecker',
+                ),
+                'publish' => array(
+                    'from' => array('approved_by_journalist', 'approved_by_spellchecker'),
+                    'to' => 'published',
+                    'guard' => '!!true',
+                ),
+                'publish_editor_in_chief' => array(
+                    'name' => 'publish',
+                    'from' => 'draft',
+                    'to' => 'published',
+                    'guard' => '!!false',
+                ),
+            ),
+        ),
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
@@ -13,12 +13,12 @@
                 <framework:argument>a</framework:argument>
             </framework:marking-store>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
-            <framework:place name="draft" />
-            <framework:place name="wait_for_journalist" />
-            <framework:place name="approved_by_journalist" />
-            <framework:place name="wait_for_spellchecker" />
-            <framework:place name="approved_by_spellchecker" />
-            <framework:place name="published" />
+            <framework:place>draft</framework:place>
+            <framework:place>wait_for_journalist</framework:place>
+            <framework:place>approved_by_journalist</framework:place>
+            <framework:place>wait_for_spellchecker</framework:place>
+            <framework:place>approved_by_spellchecker</framework:place>
+            <framework:place>published</framework:place>
             <framework:transition name="request_review">
                 <framework:from>draft</framework:from>
                 <framework:to>wait_for_journalist</framework:to>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_guard_expression.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:workflow name="article" type="workflow" initial-place="draft">
+            <framework:marking-store type="multiple_state">
+                <framework:argument>a</framework:argument>
+                <framework:argument>a</framework:argument>
+            </framework:marking-store>
+            <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
+            <framework:place name="draft" />
+            <framework:place name="wait_for_journalist" />
+            <framework:place name="approved_by_journalist" />
+            <framework:place name="wait_for_spellchecker" />
+            <framework:place name="approved_by_spellchecker" />
+            <framework:place name="published" />
+            <framework:transition name="request_review">
+                <framework:from>draft</framework:from>
+                <framework:to>wait_for_journalist</framework:to>
+                <framework:to>wait_for_spellchecker</framework:to>
+            </framework:transition>
+            <framework:transition name="journalist_approval">
+                <framework:from>wait_for_journalist</framework:from>
+                <framework:to>approved_by_journalist</framework:to>
+            </framework:transition>
+            <framework:transition name="spellchecker_approval">
+                <framework:from>wait_for_spellchecker</framework:from>
+                <framework:to>approved_by_spellchecker</framework:to>
+            </framework:transition>
+            <framework:transition name="publish">
+                <framework:from>approved_by_journalist</framework:from>
+                <framework:from>approved_by_spellchecker</framework:from>
+                <framework:to>published</framework:to>
+                <framework:guard>!!true</framework:guard>
+            </framework:transition>
+            <framework:transition name="publish">
+                <framework:from>draft</framework:from>
+                <framework:to>published</framework:to>
+                <framework:guard>!!false</framework:guard>
+            </framework:transition>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_guard_expression.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_guard_expression.yml
@@ -1,0 +1,35 @@
+framework:
+    workflows:
+        article:
+            type: workflow
+            marking_store:
+                type: multiple_state
+            supports:
+            - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest
+            initial_place: draft
+            places:
+            - draft
+            - wait_for_journalist
+            - approved_by_journalist
+            - wait_for_spellchecker
+            - approved_by_spellchecker
+            - published
+            transitions:
+                request_review:
+                    from: [draft]
+                    to: [wait_for_journalist, wait_for_spellchecker]
+                journalist_approval:
+                    from: [wait_for_journalist]
+                    to: [approved_by_journalist]
+                spellchecker_approval:
+                    from: [wait_for_spellchecker]
+                    to: [approved_by_spellchecker]
+                publish:
+                    from: [approved_by_journalist, approved_by_spellchecker]
+                    to: [published]
+                    guard: "!!true"
+                publish_editor_in_chief:
+                    name: publish
+                    from: [draft]
+                    to: [published]
+                    guard: "!!false"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -302,14 +302,84 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertCount(5, $transitions);
 
-        $this->assertSame('request_review', $transitions[0]->getArgument(0));
-        $this->assertSame('journalist_approval', $transitions[1]->getArgument(0));
-        $this->assertSame('spellchecker_approval', $transitions[2]->getArgument(0));
-        $this->assertSame('publish', $transitions[3]->getArgument(0));
-        $this->assertSame('publish', $transitions[4]->getArgument(0));
+        $this->assertSame('workflow.article.transition.0', (string) $transitions[0]);
+        $this->assertSame(array(
+            'request_review',
+            array(
+                'draft',
+            ),
+            array(
+                'wait_for_journalist', 'wait_for_spellchecker',
+            ),
+        ), $container->getDefinition($transitions[0])->getArguments());
 
-        $this->assertSame(array('approved_by_journalist', 'approved_by_spellchecker'), $transitions[3]->getArgument(1));
-        $this->assertSame(array('draft'), $transitions[4]->getArgument(1));
+        $this->assertSame('workflow.article.transition.1', (string) $transitions[1]);
+        $this->assertSame(array(
+            'journalist_approval',
+            array(
+                'wait_for_journalist',
+            ),
+            array(
+                'approved_by_journalist',
+            ),
+        ), $container->getDefinition($transitions[1])->getArguments());
+
+        $this->assertSame('workflow.article.transition.2', (string) $transitions[2]);
+        $this->assertSame(array(
+            'spellchecker_approval',
+            array(
+                'wait_for_spellchecker',
+            ),
+            array(
+                'approved_by_spellchecker',
+            ),
+        ), $container->getDefinition($transitions[2])->getArguments());
+
+        $this->assertSame('workflow.article.transition.3', (string) $transitions[3]);
+        $this->assertSame(array(
+            'publish',
+            array(
+                'approved_by_journalist',
+                'approved_by_spellchecker',
+            ),
+            array(
+                'published',
+            ),
+        ), $container->getDefinition($transitions[3])->getArguments());
+
+        $this->assertSame('workflow.article.transition.4', (string) $transitions[4]);
+        $this->assertSame(array(
+            'publish',
+            array(
+                'draft',
+            ),
+            array(
+                'published',
+            ),
+        ), $container->getDefinition($transitions[4])->getArguments());
+    }
+
+    public function testGuardExpressions()
+    {
+        $container = $this->createContainerFromFile('workflow_with_guard_expression');
+
+        $this->assertTrue($container->hasDefinition('workflow.article.listener.guard'), 'Workflow guard listener is registered as a service');
+        $this->assertTrue($container->hasParameter('workflow.has_guard_listeners'), 'Workflow guard listeners parameter exists');
+        $this->assertTrue(true === $container->getParameter('workflow.has_guard_listeners'), 'Workflow guard listeners parameter is enabled');
+        $guardDefinition = $container->getDefinition('workflow.article.listener.guard');
+        $this->assertSame(array(
+            array(
+                'event' => 'workflow.article.guard.publish',
+                'method' => 'onTransition',
+            ),
+        ), $guardDefinition->getTag('kernel.event_listener'));
+        $guardsConfiguration = $guardDefinition->getArgument(0);
+        $this->assertTrue(1 === \count($guardsConfiguration), 'Workflow guard configuration contains one element per transition name');
+        $transitionGuardExpressions = $guardsConfiguration['workflow.article.guard.publish'];
+        $this->assertSame('workflow.article.transition.3', (string) $transitionGuardExpressions[0]->getArgument(0));
+        $this->assertSame('!!true', $transitionGuardExpressions[0]->getArgument(1));
+        $this->assertSame('workflow.article.transition.4', (string) $transitionGuardExpressions[1]->getArgument(0));
+        $this->assertSame('!!false', $transitionGuardExpressions[1]->getArgument(1));
     }
 
     public function testWorkflowServicesCanBeEnabled()

--- a/src/Symfony/Component/Workflow/EventListener/GuardExpression.php
+++ b/src/Symfony/Component/Workflow/EventListener/GuardExpression.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\EventListener;
+
+use Symfony\Component\Workflow\Transition;
+
+class GuardExpression
+{
+    private $transition;
+
+    private $expression;
+
+    public function getTransition(): Transition
+    {
+        return $this->transition;
+    }
+
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    public function __construct(Transition $transition, string $expression)
+    {
+        $this->transition = $transition;
+        $this->expression = $expression;
+    }
+}

--- a/src/Symfony/Component/Workflow/EventListener/GuardListener.php
+++ b/src/Symfony/Component/Workflow/EventListener/GuardListener.php
@@ -18,7 +18,6 @@ use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Workflow\Event\GuardEvent;
 use Symfony\Component\Workflow\Exception\InvalidTokenConfigurationException;
-use Symfony\Component\Workflow\TransitionBlocker;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
@@ -66,8 +65,7 @@ class GuardListener
     private function validateGuardExpression(GuardEvent $event, string $expression)
     {
         if (!$this->expressionLanguage->evaluate($expression, $this->getVariables($event))) {
-            $blocker = TransitionBlocker::createBlockedByExpressionGuardListener($expression);
-            $event->addTransitionBlocker($blocker);
+            $event->setBlocked(true);
         }
     }
 

--- a/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
+++ b/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
@@ -21,16 +21,16 @@ class GuardListenerTest extends TestCase
     private $authenticationChecker;
     private $validator;
     private $listener;
-    private $transition;
+    private $configuration;
 
     protected function setUp()
     {
-        $configuration = array(
+        $this->configuration = array(
             'test_is_granted' => 'is_granted("something")',
             'test_is_valid' => 'is_valid(subject)',
             'test_expression' => array(
-                new GuardExpression($this->getTransition(true), '!is_valid(subject)'),
-                new GuardExpression($this->getTransition(true), 'is_valid(subject)'),
+                new GuardExpression(new Transition('name', 'from', 'to'), '!is_valid(subject)'),
+                new GuardExpression(new Transition('name', 'from', 'to'), 'is_valid(subject)'),
             ),
         );
         $expressionLanguage = new ExpressionLanguage();
@@ -41,7 +41,7 @@ class GuardListenerTest extends TestCase
         $this->authenticationChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
         $trustResolver = $this->getMockBuilder(AuthenticationTrustResolverInterface::class)->getMock();
         $this->validator = $this->getMockBuilder(ValidatorInterface::class)->getMock();
-        $this->listener = new GuardListener($configuration, $expressionLanguage, $tokenStorage, $this->authenticationChecker, $trustResolver, null, $this->validator);
+        $this->listener = new GuardListener($this->configuration, $expressionLanguage, $tokenStorage, $this->authenticationChecker, $trustResolver, null, $this->validator);
     }
 
     protected function tearDown()
@@ -104,8 +104,8 @@ class GuardListenerTest extends TestCase
 
     public function testWithGuardExpressionWithNotSupportedTransition()
     {
-        $event = $this->createEvent(true);
-        $this->configureValidator(false, false);
+        $event = $this->createEvent();
+        $this->configureValidator(false);
         $this->listener->onTransition($event, 'test_expression');
 
         $this->assertFalse($event->isBlocked());
@@ -113,7 +113,7 @@ class GuardListenerTest extends TestCase
 
     public function testWithGuardExpressionWithSupportedTransition()
     {
-        $event = $this->createEvent();
+        $event = $this->createEvent($this->configuration['test_expression'][1]->getTransition());
         $this->configureValidator(true, true);
         $this->listener->onTransition($event, 'test_expression');
 
@@ -122,23 +122,23 @@ class GuardListenerTest extends TestCase
 
     public function testGuardExpressionBlocks()
     {
-        $event = $this->createEvent();
+        $event = $this->createEvent($this->configuration['test_expression'][1]->getTransition());
         $this->configureValidator(true, false);
         $this->listener->onTransition($event, 'test_expression');
 
         $this->assertTrue($event->isBlocked());
     }
 
-    private function createEvent($newTransition = false)
+    private function createEvent(Transition $transition = null)
     {
         $subject = new \stdClass();
         $subject->marking = new Marking();
-        $transition = $this->getTransition($newTransition);
+        $transition = $transition ?: new Transition('name', 'from', 'to');
 
         return new GuardEvent($subject, $subject->marking, $transition);
     }
 
-    private function configureAuthenticationChecker($isUsed, $granted = true)
+    private function configureAuthenticationChecker(bool $isUsed, bool $granted = true)
     {
         if (!$isUsed) {
             $this->authenticationChecker
@@ -156,7 +156,7 @@ class GuardListenerTest extends TestCase
         ;
     }
 
-    private function configureValidator($isUsed, $valid = true)
+    private function configureValidator(bool $isUsed, bool $valid = true)
     {
         if (!$isUsed) {
             $this->validator
@@ -172,14 +172,5 @@ class GuardListenerTest extends TestCase
             ->method('validate')
             ->willReturn($valid ? array() : array('a violation'))
         ;
-    }
-
-    private function getTransition($new = false)
-    {
-        if ($new || !$this->transition) {
-            $this->transition = new Transition('name', 'from', 'to');
-        }
-
-        return $this->transition;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

---

This PR is for the 4.1 branch.
After the merge of #29137, merging 3.4 in 4.1 will conflict.
This PR solves this conflict