### PR TITLE
Remove unused dependency in FrameworkExtensionTest

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -48,7 +48,6 @@ use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Translation\DependencyInjection\TranslatorPass;
 use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
-use Symfony\Component\Validator\Validation;
 use Symfony\Component\Workflow;
 
 abstract class FrameworkExtensionTest extends TestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no      
| Deprecations? |no
| Tests pass?   | yes    
| Fixed tickets |  
| License       | MIT
| Doc PR        |  

`Validation` is not used anywhere in the file, I can only see `new \ReflectionClass('Symfony\Component\Validator\Validation');`, maybe it's better to leave the `use` and replace with `new \ReflectionClass(Validation::class);`?
