### PR TITLE
[WebProfilerBundle] [VarDumper] Inject "unsafe-eval" into the CSP if the VarDumper was used

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\VarDumper\VarDumper;
 use Twig\Environment;
 
 /**
@@ -111,6 +112,14 @@ class WebDebugToolbarListener implements EventSubscriberInterface
         $this->injectToolbar($response, $request, $nonces);
     }
 
+    public function onKernelRequest(): void
+    {
+        // Because as of now the dumper embeds scripts they are evaluated in base_js.html.twig
+        VarDumper::setAfterDumpHandlerOnce(function () {
+            $this->cspHandler->setEvaluationEnabled(true);
+        });
+    }
+
     /**
      * Injects the web debug toolbar into the given Response.
      */
@@ -139,6 +148,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     {
         return [
             KernelEvents::RESPONSE => ['onKernelResponse', -128],
+            KernelEvents::REQUEST => ['onKernelRequest'],
         ];
     }
 }

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -27,6 +27,7 @@ require_once __DIR__.'/Resources/functions/dump.php';
 class VarDumper
 {
     private static $handler;
+    private static $afterDumpHandlerOnce;
 
     public static function dump($var)
     {
@@ -47,13 +48,28 @@ class VarDumper
             };
         }
 
-        return (self::$handler)($var);
+        $output = (self::$handler)($var);
+
+        if (null !== self::$afterDumpHandlerOnce) {
+            (self::$afterDumpHandlerOnce)($var);
+            self::$afterDumpHandlerOnce = null;
+        }
+
+        return $output;
     }
 
     public static function setHandler(callable $callable = null)
     {
         $prevHandler = self::$handler;
         self::$handler = $callable;
+
+        return $prevHandler;
+    }
+
+    public static function setAfterDumpHandlerOnce(callable $callable = null)
+    {
+        $prevHandler = self::$afterDumpHandlerOnce;
+        self::$afterDumpHandlerOnce = $callable;
 
         return $prevHandler;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #29084   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
Adapts the VarDumper so that it accepts a callable which is called after something has been dumped. This can be used by the ContentSecurityPolicyHandler in the WebProfilerBundle to modify CSPs to allow unsafe-eval which is needed for the profiler toolbar to evaluate injected JS.
This is kind of a small feature/extension to #18568. I ommited the changelog and doc changes because of that but they can be added of course if needed.
