### PR TITLE
[TwigBridge] Fixed wrong DateTimeType error handling with bootstrap 4 layout

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -24,14 +24,6 @@
     {%- endif -%}
 {%- endblock money_widget %}
 
-{% block datetime_widget -%}
-    {%- if widget != 'single_text' and not valid -%}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) -%}
-        {% set valid = true %}
-    {%- endif -%}
-    {{- parent() -}}
-{%- endblock datetime_widget %}
-
 {% block date_widget -%}
     {%- if widget != 'single_text' and not valid -%}
         {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #29147   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Fixed wrong DateTimeType error handling with bootstrap_4_layout.html.twig with (`form-control` class removed)
