### PR TITLE
[SecurityBundle] unhide debug security voter services

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
@@ -57,7 +57,7 @@ class AddSecurityVotersPass implements CompilerPassInterface
 
             if ($debug) {
                 // Decorate original voters with TraceableVoter
-                $debugVoterServiceId = '.debug.security.voter.'.$voterServiceId;
+                $debugVoterServiceId = 'debug.security.voter.'.$voterServiceId;
                 $container
                     ->register($debugVoterServiceId, TraceableVoter::class)
                     ->setDecoratedService($voterServiceId)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSecurityVotersPassTest.php
@@ -95,13 +95,13 @@ class AddSecurityVotersPassTest extends TestCase
         $compilerPass = new AddSecurityVotersPass();
         $compilerPass->process($container);
 
-        $def1 = $container->getDefinition('.debug.security.voter.voter1');
+        $def1 = $container->getDefinition('debug.security.voter.voter1');
         $this->assertEquals(array('voter1', null, 0), $def1->getDecoratedService(), 'voter1: wrong return from getDecoratedService');
-        $this->assertEquals(new Reference('.debug.security.voter.voter1.inner'), $def1->getArgument(0), 'voter1: wrong decorator argument');
+        $this->assertEquals(new Reference('debug.security.voter.voter1.inner'), $def1->getArgument(0), 'voter1: wrong decorator argument');
 
-        $def2 = $container->getDefinition('.debug.security.voter.voter2');
+        $def2 = $container->getDefinition('debug.security.voter.voter2');
         $this->assertEquals(array('voter2', null, 0), $def2->getDecoratedService(), 'voter2: wrong return from getDecoratedService');
-        $this->assertEquals(new Reference('.debug.security.voter.voter2.inner'), $def2->getArgument(0), 'voter2: wrong decorator argument');
+        $this->assertEquals(new Reference('debug.security.voter.voter2.inner'), $def2->getArgument(0), 'voter2: wrong decorator argument');
 
         $voters = $container->findTaggedServiceIds('security.voter');
         $this->assertCount(2, $voters, 'Incorrect count of voters');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

#27914 introduces `testThatVotersAreNotDecoratedWithoutDebugMode()` which tests if decorated services exist but uses a bad service name without starting dot.

Definition in the compiler pass :
https://github.com/symfony/symfony/blob/a4204cd685c02377e6e2fbfc7ece98b5563644d9/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php#L58-L66

The expected services are hidden and their name start with a dot. So the test will always pass, now it can fails :)