### PR TITLE
Add required key attribute

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -56,8 +56,8 @@
                 <array>
                     <element key="time-sensitive">
                         <array>
-                            <element><string>Symfony\Component\Console</string></element>
-                            <element><string>Symfony\Component\HttpFoundation</string></element>
+                            <element key="0"><string>Symfony\Component\Console</string></element>
+                            <element key="1"><string>Symfony\Component\HttpFoundation</string></element>
                         </array>
                     </element>
                 </array>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I am getting warnings when running tests with recent phpunit versions (since 7.2.0) :

> `- Element 'element': The attribute 'key' is required but missing.`

This requirement is far from being new, what is recent is phpunit
validating its configuration file against the XSD schema.

See https://github.com/sebastianbergmann/phpunit/commit/d4484be1a9c56c73353517510ce3b0690f6d738e

This is pedantic (not a bugfix), and might be a bit painful to merge upstream, so if you feel like I should target a more recent instead and let the old branches go on with their lives, please tell me.