### PR TITLE
[Form] Hardened test suite for empty data (following for 3.4)

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1482,4 +1482,43 @@ class EntityTypeTest extends BaseTypeTest
         $this->assertEquals(array(), $form->getNormData());
         $this->assertSame(array(), $form->getViewData(), 'View data is always an array');
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = null)
+    {
+        $emptyData = '1';
+        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $this->persist(array($entity1));
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertSame($entity1, $form->getNormData());
+        $this->assertSame($entity1, $form->getData());
+    }
+
+    public function testSubmitNullMultipleUsesDefaultEmptyData()
+    {
+        $emptyData = array('1');
+        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $this->persist(array($entity1));
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'multiple' => true,
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        $collection = new ArrayCollection(array($entity1));
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertEquals($collection, $form->getNormData());
+        $this->assertEquals($collection, $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -145,6 +145,28 @@ abstract class BaseTypeTest extends TypeTestCase
         $this->assertSame($view, $form->getViewData());
     }
 
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = null)
+    {
+        $builder = $this->factory->createBuilder($this->getTestedType());
+
+        if ($builder->getCompound()) {
+            $emptyData = array();
+            foreach ($builder as $field) {
+                // empty children should map null (model data) in the compound view data
+                $emptyData[$field->getName()] = null;
+            }
+        } else {
+            // simple fields share the view and the model format, unless they use a transformer
+            $expectedData = $emptyData;
+        }
+
+        $form = $builder->setEmptyData($emptyData)->getForm()->submit(null);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
+
     protected function getTestedType()
     {
         return static::TESTED_TYPE;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ButtonTypeTest.php
@@ -22,4 +22,16 @@ class ButtonTypeTest extends BaseTypeTest
     {
         $this->assertInstanceOf('Symfony\Component\Form\Button', $this->factory->create(static::TESTED_TYPE));
     }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\BadMethodCallException
+     * @expectedExceptionMessage Buttons do not support empty data.
+     *
+     * @param string $emptyData
+     * @param null   $expectedData
+     */
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = null)
+    {
+        parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -177,4 +177,17 @@ class CheckboxTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull(false, false, null);
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = true)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        // view data is transformed to the string true value
+        $this->assertSame('1', $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -584,18 +584,19 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->assertTrue($form->isSynchronized());
     }
 
-    public function testSubmitSingleChoiceWithEmptyData()
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = null)
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, array(
             'multiple' => false,
             'expanded' => false,
-            'choices' => array('test'),
-            'empty_data' => 'test',
+            // empty data must match string choice value
+            'choices' => array($emptyData),
+            'empty_data' => $emptyData,
         ));
 
         $form->submit(null);
 
-        $this->assertSame('test', $form->getData());
+        $this->assertSame($emptyData, $form->getData());
     }
 
     public function testSubmitSingleChoiceWithEmptyDataAndInitialData()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -408,4 +408,10 @@ class CollectionTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull(array(), array(), array());
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = array(), $expectedData = array())
+    {
+        // resize form listener always set an empty array
+        parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -56,4 +56,9 @@ class CountryTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull($expected, $norm, '');
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'FR', $expectedData = 'FR')
+    {
+        parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -39,4 +39,9 @@ class CurrencyTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull($expected, $norm, '');
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'EUR', $expectedData = 'EUR')
+    {
+        parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
@@ -410,4 +410,17 @@ class DateIntervalTypeTest extends BaseTypeTest
             'days' => '',
         ));
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = array(), $expectedData = null)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        // view transformer writes back empty strings in the view data
+        $this->assertSame(array('years' => '', 'months' => '', 'days' => ''), $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -580,4 +580,20 @@ class DateTimeTypeTest extends BaseTypeTest
         $this->assertNull($form->getNormData());
         $this->assertSame('', $form->getViewData());
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = array(), $expectedData = null)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        // view transformer writes back empty strings in the view data
+        $this->assertSame(
+            array('date' => array('year' => '', 'month' => '', 'day' => ''), 'time' => array('hour' => '', 'minute' => '')),
+            $form->getViewData()
+        );
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -975,4 +975,33 @@ class DateTypeTest extends BaseTypeTest
         $this->assertNull($form->getNormData());
         $this->assertSame('', $form->getViewData());
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = array(), $expectedData = null)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        // view transformer write back empty strings in the view data
+        $this->assertSame(array('year' => '', 'month' => '', 'day' => ''), $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
+
+    public function testSingleTextSubmitNullUsesDefaultEmptyData()
+    {
+        $emptyData = '2018-11-11';
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'widget' => 'single_text',
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        $date = new \DateTime($emptyData);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertEquals($date, $form->getNormData());
+        $this->assertEquals($date, $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -170,6 +170,11 @@ class FormTypeTest extends BaseTypeTest
         ));
     }
 
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = array(), $expectedData = array())
+    {
+        parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
+    }
+
     public function testSubmitWithEmptyDataCreatesObjectIfClassAvailable()
     {
         $form = $this->factory->createBuilder(static::TESTED_TYPE, null, array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -38,4 +38,16 @@ class IntegerTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull($expected, $norm, '');
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = '10', $expectedData = 10)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -49,4 +49,9 @@ class LanguageTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull($expected, $norm, '');
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'en', $expectedData = 'en')
+    {
+        parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -39,4 +39,9 @@ class LocaleTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull($expected, $norm, '');
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'en', $expectedData = 'en')
+    {
+        parent::testSubmitNullUsesDefaultEmptyData($emptyData, $expectedData);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -70,4 +70,16 @@ class MoneyTypeTest extends BaseTypeTest
 
         $this->assertSame('{{ widget }}', $view->vars['money_pattern']);
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = '10.00', $expectedData = 10.0)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -63,4 +63,16 @@ class NumberTypeTest extends BaseTypeTest
     {
         parent::testSubmitNull($expected, $norm, '');
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = '10', $expectedData = 10.0)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -768,4 +768,17 @@ class TimeTypeTest extends BaseTypeTest
 
         parent::testSubmitNull($expected, $norm, $view);
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = array(), $expectedData = null)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        // view transformer write back empty strings in the view data
+        $this->assertSame(array('hour' => '', 'minute' => ''), $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -34,6 +34,18 @@ class TimezoneTypeTest extends BaseTypeTest
         parent::testSubmitNull($expected, $norm, '');
     }
 
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'Africa/Kinshasa', $expectedData = 'Africa/Kinshasa')
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
+
     public function testDateTimeZoneInput()
     {
         $form = $this->factory->create(static::TESTED_TYPE, new \DateTimeZone('America/New_York'), array('input' => 'datetimezone'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -90,4 +90,17 @@ class UrlTypeTest extends TextTypeTest
 
         $this->assertSame(array('domain.com', 'www.domain.com'), $form->getData());
     }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = 'http://empty')
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        // listener normalizes data on submit
+        $this->assertSame($expectedData, $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

Following #29179. This one fix conflicts (if cherry pick is needed, in any case needs rebasing here) and add fix the test for the introduced `DateIntervalType`.
Merging in 4.x has a small conflict but not a big deal, so no more PR for this scope unless I'm missing something.