### PR TITLE
[HttpKernel] Increase priority of AddRequestFormatsListener

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * increased the priority of `Symfony\Component\HttpKernel\EventListener\AddRequestFormatsListener`
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/EventListener/AddRequestFormatsListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AddRequestFormatsListener.php
@@ -45,6 +45,6 @@ class AddRequestFormatsListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(KernelEvents::REQUEST => array('onKernelRequest', 1));
+        return array(KernelEvents::REQUEST => array('onKernelRequest', 100));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
@@ -46,7 +46,7 @@ class AddRequestFormatsListenerTest extends TestCase
     public function testRegisteredEvent()
     {
         $this->assertEquals(
-            array(KernelEvents::REQUEST => array('onKernelRequest', 1)),
+            array(KernelEvents::REQUEST => array('onKernelRequest', 100)),
             AddRequestFormatsListener::getSubscribedEvents()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #19469
| License       | MIT
| Doc PR        | 

Currently `AddRequestFormatsListener` has a low priority, so it won't fire before others like `RouterListener` which can create problems (eg when listening for a HTTP exception thrown by the router you don't have access for any custom types).

IMO this map should be in the application rather than set on every request, but the same can be achieved by giving it a high priority. (Can't think of a reason for it to not be first...)