### PR TITLE
[WebProfilerBundle] Remove unused data attr

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/settings.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/settings.html.twig
@@ -104,7 +104,7 @@
 }
 </style>
 
-<a href="#" id="open-settings" data-triger="profiler-settings">Settings</a>
+<a href="#" id="open-settings">Settings</a>
 
 <div class="modal-wrap" id="profiler-settings">
     <div class="modal-container">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Actually spotted in #29192 when searching in master :)

The attribute is not used.