### PR TITLE
[Messenger] Fix collecting messages

### DIFF
--- a/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
+++ b/src/Symfony/Component/Messenger/DataCollector/MessengerDataCollector.php
@@ -117,13 +117,15 @@ class MessengerDataCollector extends DataCollector implements LateDataCollectorI
         return $count;
     }
 
-    public function getMessages(string $bus = null): iterable
+    public function getMessages(string $bus = null): array
     {
-        foreach ($this->data['messages'] ?? array() as $message) {
-            if (null === $bus || $bus === $message['bus']) {
-                yield $message;
-            }
+        if (null === $bus) {
+            return $this->data['messages'];
         }
+
+        return array_filter($this->data['messages'], function ($message) use ($bus) {
+            return $bus === $message['bus'];
+        });
     }
 
     public function getBuses(): array

--- a/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DataCollector/MessengerDataCollectorTest.php
@@ -50,7 +50,7 @@ class MessengerDataCollectorTest extends TestCase
 
         $collector->lateCollect();
 
-        $messages = iterator_to_array($collector->getMessages());
+        $messages = $collector->getMessages();
         $this->assertCount(1, $messages);
 
         $file = __FILE__;
@@ -95,7 +95,7 @@ DUMP;
 
         $collector->lateCollect();
 
-        $messages = iterator_to_array($collector->getMessages());
+        $messages = $collector->getMessages();
         $this->assertCount(1, $messages);
 
         $file = __FILE__;
@@ -145,7 +145,7 @@ DUMP
 
         $collector->lateCollect();
 
-        $messages = iterator_to_array($collector->getMessages());
+        $messages = $collector->getMessages();
         $this->assertCount(5, $messages);
 
         $this->assertSame('#1', $messages[0]['message']['value']['message']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no-ish
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

In 4.2 there's always one dispatched message because we provide the template with a generator. Calling `{{ gen|length }}` always returns `1`

Before

![image](https://user-images.githubusercontent.com/1047696/48368788-f0028980-e6b4-11e8-91b0-54f755b9fb93.png)

After

![image](https://user-images.githubusercontent.com/1047696/48368817-0ad4fe00-e6b5-11e8-8215-54bfdb307c47.png)
