### PR TITLE
Revert "bug #29154 [FrameworkBundle] Define APP_ENV/APP_DEBUG from argv via Application::bootstrapEnv()

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -177,27 +177,8 @@ FrameworkBundle
    with dependency injection instead.
  * The `--env` and `--no-debug` console options have been deprecated, define the `APP_ENV` and
    `APP_DEBUG` environment variables instead.
-   If you want to keep using `--env` and `--no-debug`, update your `bin/console` file to make it call
-   `Application::bootstrapEnv()`.
-
-   Before:
-   ```php
-   $input = new ArgvInput();
-   $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
-   $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
-   $kernel = new Kernel($env, $debug);
-   $application = new Application($kernel);
-   $application->run($input);
-   ```
-
-   After:
-   ```php
-   Application::bootstrapEnv($_SERVER['argv']);
-   $kernel = new Kernel($_SERVER['APP_ENV'], $_SERVER['APP_DEBUG']);
-   $application = new Application($kernel);
-   $application->run();
-   ```
-
+   If you want to keep using `--env` and `--no-debug`, you can take inspiration from
+   https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console
  * The `Templating\Helper\TranslatorHelper::transChoice()` method has been deprecated, use the `trans()` one instead with a `%count%` parameter.
  * Deprecated support for legacy translations directories `src/Resources/translations/` and `src/Resources/<BundleName>/translations/`, use `translations/` instead.
  * Support for the legacy directory structure in `translation:update` and `debug:translation` commands has been deprecated.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -166,27 +166,8 @@ FrameworkBundle
    with dependency injection instead.
  * The `--env` and `--no-debug` console options have been removed, define the `APP_ENV` and
    `APP_DEBUG` environment variables instead.
-   If you want to keep using `--env` and `--no-debug`, update your `bin/console` file to make it call
-   `Application::bootstrapEnv()`.
-
-   Before:
-   ```php
-   $input = new ArgvInput();
-   $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
-   $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
-   $kernel = new Kernel($env, $debug);
-   $application = new Application($kernel);
-   $application->run($input);
-   ```
-
-   After:
-   ```php
-   Application::bootstrapEnv($_SERVER['argv']);
-   $kernel = new Kernel($_SERVER['APP_ENV'], $_SERVER['APP_DEBUG']);
-   $application = new Application($kernel);
-   $application->run();
-   ```
-
+   If you want to keep using `--env` and `--no-debug`, you can take inspiration from
+   https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console
  * The `Templating\Helper\TranslatorHelper::transChoice()` method has been removed, use the `trans()` one instead with a `%count%` parameter.
  * Removed support for legacy translations directories `src/Resources/translations/` and `src/Resources/<BundleName>/translations/`, use `translations/` instead.
  * Support for the legacy directory structure in `translation:update` and `debug:translation` commands has been removed.

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -15,10 +15,8 @@ CHANGELOG
  * Removed the `framework.messenger.encoder` and `framework.messenger.decoder` options. Use the `framework.messenger.serializer.id` option to replace the Messenger serializer. 
  * Deprecated the `ContainerAwareCommand` class in favor of `Symfony\Component\Console\Command\Command`
  * Made `debug:container` and `debug:autowiring` ignore backslashes in service ids
- * Deprecated the `--env` console option and its "-e" shortcut, set the "APP_ENV" environment variable
-   or use `Application::bootstrapEnv()` instead.
- * Deprecated the `--no-debug` console option, set the "APP_DEBUG" environment variable to "0"
-   or use `Application::bootstrapEnv()` instead.
+ * Deprecated `--env` and `--no-debug` console options, define the `APP_ENV` and `APP_DEBUG` environment variables or
+   parse input arguments as done in https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console instead
  * Deprecated the `Templating\Helper\TranslatorHelper::transChoice()` method, use the `trans()` one instead with a `%count%` parameter
  * Deprecated `CacheCollectorPass`. Use `Symfony\Component\Cache\DependencyInjection\CacheCollectorPass` instead.
  * Deprecated `CachePoolClearerPass`. Use `Symfony\Component\Cache\DependencyInjection\CachePoolClearerPass` instead.

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -207,35 +207,6 @@ class Application extends BaseApplication
         }
     }
 
-    /**
-     * Defines the "APP_ENV" and "APP_DEBUG" environment variables by consuming --env and --no-debug from the command line arguments.
-     */
-    public static function bootstrapEnv(array &$argv)
-    {
-        for ($i = 0; $i < \count($argv) && '--' !== $v = $argv[$i]; ++$i) {
-            if ('--no-debug' === $v) {
-                putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
-                $argvUnset[$i] = true;
-                break;
-            }
-        }
-
-        for ($i = 0; $i < \count($argv) && '--' !== $v = $argv[$i]; ++$i) {
-            if (!$v || '-' !== $v[0] || !preg_match('/^-(?:-env(?:=|$)|e=?)(.*)$/D', $v, $v)) {
-                continue;
-            }
-            if (!empty($v[1]) || !empty($argv[1 + $i])) {
-                putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = empty($v[1]) ? $argv[1 + $i] : $v[1]);
-                $argvUnset[$i] = $argvUnset[$i + empty($v[1])] = true;
-            }
-            break;
-        }
-
-        if (!empty($argvUnset)) {
-            $argv = array_values(array_diff_key($argv, $argvUnset));
-        }
-    }
-
     private function renderRegistrationErrors(InputInterface $input, OutputInterface $output)
     {
         if ($output instanceof ConsoleOutputInterface) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -283,63 +283,6 @@ class ApplicationTest extends TestCase
 
         return $bundle;
     }
-
-    public function testBootstrapEnv()
-    {
-        $argv = array('--no-debug', '--env=testBootstrapEnv', 'foo=bar');
-        Application::bootstrapEnv($argv);
-
-        $this->assertSame($_SERVER['APP_DEBUG'], '0');
-        $this->assertSame($_ENV['APP_DEBUG'], '0');
-        $this->assertSame('0', getenv('APP_DEBUG'));
-        $this->assertSame('testBootstrapEnv', $_SERVER['APP_ENV']);
-        $this->assertSame('testBootstrapEnv', $_ENV['APP_ENV']);
-        $this->assertSame('testBootstrapEnv', getenv('APP_ENV'));
-        $this->assertSame(array('foo=bar'), $argv);
-
-        unset($_SERVER['APP_ENV']);
-        unset($_ENV['APP_ENV']);
-        putenv('APP_ENV');
-        unset($_SERVER['APP_DEBUG']);
-        unset($_ENV['APP_DEBUG']);
-        putenv('APP_DEBUG');
-
-        $argv = array('--env', 'testBootstrapEnv', 'foo=bar');
-        Application::bootstrapEnv($argv);
-
-        $this->assertSame('testBootstrapEnv', $_SERVER['APP_ENV']);
-        $this->assertSame('testBootstrapEnv', $_ENV['APP_ENV']);
-        $this->assertSame('testBootstrapEnv', getenv('APP_ENV'));
-        $this->assertSame(array('foo=bar'), $argv);
-
-        unset($_SERVER['APP_ENV']);
-        unset($_ENV['APP_ENV']);
-        putenv('APP_ENV');
-
-        $argv = array('-e', 'testBootstrapEnv', 'foo=bar');
-        Application::bootstrapEnv($argv);
-
-        $this->assertSame('testBootstrapEnv', $_SERVER['APP_ENV']);
-        $this->assertSame('testBootstrapEnv', $_ENV['APP_ENV']);
-        $this->assertSame('testBootstrapEnv', getenv('APP_ENV'));
-        $this->assertSame(array('foo=bar'), $argv);
-
-        unset($_SERVER['APP_ENV']);
-        unset($_ENV['APP_ENV']);
-        putenv('APP_ENV');
-
-        $argv = array('-e=testBootstrapEnv', 'foo=bar');
-        Application::bootstrapEnv($argv);
-
-        $this->assertSame('testBootstrapEnv', $_SERVER['APP_ENV']);
-        $this->assertSame('testBootstrapEnv', $_ENV['APP_ENV']);
-        $this->assertSame('testBootstrapEnv', getenv('APP_ENV'));
-        $this->assertSame(array('foo=bar'), $argv);
-
-        unset($_SERVER['APP_ENV']);
-        unset($_ENV['APP_ENV']);
-        putenv('APP_ENV');
-    }
 }
 
 class ThrowingCommand extends Command


### PR DESCRIPTION
This reverts commit 9253199de1d04ca591a051484bbdff861c1d542c, reversing
changes made to 664a032940a02ef9969345797cc3683ea56cf562.

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Replaced by https://github.com/symfony/recipes/pull/491, see description there.