### PR TITLE
[FrameworkBundle] conflict with Dotenv <4.2 to simplify recipes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -66,6 +66,7 @@
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
         "symfony/asset": "<3.4",
         "symfony/console": "<3.4",
+        "symfony/dotenv": "<4.2",
         "symfony/form": "<4.2",
         "symfony/messenger": "<4.2",
         "symfony/property-info": "<3.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In the recipe for fwb 4.2, we already assume that if dotenv is installed, it will be at v4.2 or higher.
Let's enforce this.