### PR TITLE
[FrameworkBundle][WebServerBundle] Revert deprecation of --env and --no-debug console options

### DIFF
--- a/UPGRADE-4.2.md
+++ b/UPGRADE-4.2.md
@@ -175,10 +175,6 @@ FrameworkBundle
    ```
  * The `ContainerAwareCommand` class has been deprecated, use `Symfony\Component\Console\Command\Command`
    with dependency injection instead.
- * The `--env` and `--no-debug` console options have been deprecated, define the `APP_ENV` and
-   `APP_DEBUG` environment variables instead.
-   If you want to keep using `--env` and `--no-debug`, you can take inspiration from
-   https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console
  * The `Templating\Helper\TranslatorHelper::transChoice()` method has been deprecated, use the `trans()` one instead with a `%count%` parameter.
  * Deprecated support for legacy translations directories `src/Resources/translations/` and `src/Resources/<BundleName>/translations/`, use `translations/` instead.
  * Support for the legacy directory structure in `translation:update` and `debug:translation` commands has been deprecated.
@@ -381,9 +377,3 @@ Validator
  * Using the `Bic`, `Country`, `Currency`, `Language` and `Locale` constraints without `symfony/intl` is deprecated
  * Using the `Email` constraint in strict mode without `egulias/email-validator` is deprecated
  * Using the `Expression` constraint without `symfony/expression-language` is deprecated
-
-WebServerBundle
----------------
-
-* Omitting the `$environment` argument of the `ServerRunCommand` and 
-  `ServerStartCommand` constructors is deprecated.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -164,10 +164,6 @@ FrameworkBundle
  * Added support for the SameSite attribute for session cookies. It is highly recommended to set this setting (`framework.session.cookie_samesite`) to `lax` for increased security against CSRF attacks.
  * The `ContainerAwareCommand` class has been removed, use `Symfony\Component\Console\Command\Command`
    with dependency injection instead.
- * The `--env` and `--no-debug` console options have been removed, define the `APP_ENV` and
-   `APP_DEBUG` environment variables instead.
-   If you want to keep using `--env` and `--no-debug`, you can take inspiration from
-   https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console
  * The `Templating\Helper\TranslatorHelper::transChoice()` method has been removed, use the `trans()` one instead with a `%count%` parameter.
  * Removed support for legacy translations directories `src/Resources/translations/` and `src/Resources/<BundleName>/translations/`, use `translations/` instead.
  * Support for the legacy directory structure in `translation:update` and `debug:translation` commands has been removed.
@@ -286,9 +282,3 @@ Workflow
  * `add` method has been removed use `addWorkflow` method in `Workflow\Registry` instead.
  * `SupportStrategyInterface` has been removed, use `WorkflowSupportStrategyInterface` instead.
  * `ClassInstanceSupportStrategy` has been removed, use `InstanceOfSupportStrategy` instead.
-
-WebServerBundle
----------------
-
-* Omitting the `$environment` argument of  the `ServerRunCommand` and
-  `ServerStartCommand` constructors now throws a `\TypeError`.

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -15,8 +15,6 @@ CHANGELOG
  * Removed the `framework.messenger.encoder` and `framework.messenger.decoder` options. Use the `framework.messenger.serializer.id` option to replace the Messenger serializer. 
  * Deprecated the `ContainerAwareCommand` class in favor of `Symfony\Component\Console\Command\Command`
  * Made `debug:container` and `debug:autowiring` ignore backslashes in service ids
- * Deprecated `--env` and `--no-debug` console options, define the `APP_ENV` and `APP_DEBUG` environment variables or
-   parse input arguments as done in https://github.com/symfony/recipes/blob/master/symfony/console/3.3/bin/console instead
  * Deprecated the `Templating\Helper\TranslatorHelper::transChoice()` method, use the `trans()` one instead with a `%count%` parameter
  * Deprecated `CacheCollectorPass`. Use `Symfony\Component\Cache\DependencyInjection\CacheCollectorPass` instead.
  * Deprecated `CachePoolClearerPass`. Use `Symfony\Component\Cache\DependencyInjection\CachePoolClearerPass` instead.

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -62,19 +62,6 @@ class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        if ($input->hasParameterOption(array('-e', '--env'), true)) {
-            $notice = 'The "--env" option and its "-e" shortcut are deprecated since Symfony 4.2, set the "APP_ENV" environment variable instead.';
-            $io = (new SymfonyStyle($input, $output))->getErrorStyle();
-            $io->warning($notice);
-            @trigger_error($notice, E_USER_DEPRECATED);
-        }
-
-        if ($input->hasParameterOption('--no-debug', true)) {
-            $notice = 'The "--no-debug" option is deprecated since Symfony 4.2, set the "APP_DEBUG" environment variable to "0" instead.';
-            ($io ?? (new SymfonyStyle($input, $output))->getErrorStyle())->warning($notice);
-            @trigger_error($notice, E_USER_DEPRECATED);
-        }
-
         $this->kernel->boot();
 
         $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));

--- a/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebServerBundle/CHANGELOG.md
@@ -4,8 +4,6 @@ CHANGELOG
 4.2.0
 -----
 
-* Deprecated omitting the `$environment` argument of the `ServerRunCommand` and
- `ServerStartCommand` constructors
  * Added ability to display the current hostname address if available when binding to 0.0.0.0
 
 3.4.0

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
@@ -36,10 +36,6 @@ class ServerRunCommand extends Command
 
     public function __construct(string $documentRoot = null, string $environment = null)
     {
-        if (!$environment) {
-            @trigger_error(sprintf('Omitting the $environment argument of the "%s" constructor is deprecated since Symfony 4.2.', __CLASS__), E_USER_DEPRECATED);
-        }
-
         $this->documentRoot = $documentRoot;
         $this->environment = $environment;
 
@@ -103,7 +99,6 @@ EOF
             $documentRoot = $this->documentRoot;
         }
 
-        // @deprecated since Symfony 4.2
         if (!$env = $this->environment) {
             if ($input->hasOption('env') && !$env = $input->getOption('env')) {
                 $io->error('The environment must be either passed as second argument of the constructor or through the "--env" input option.');

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -36,10 +36,6 @@ class ServerStartCommand extends Command
 
     public function __construct(string $documentRoot = null, string $environment = null)
     {
-        if (!$environment) {
-            @trigger_error(sprintf('Omitting the $environment argument of the "%s" constructor is deprecated since Symfony 4.2.', __CLASS__), E_USER_DEPRECATED);
-        }
-
         $this->documentRoot = $documentRoot;
         $this->environment = $environment;
 
@@ -116,7 +112,6 @@ EOF
             $documentRoot = $this->documentRoot;
         }
 
-        // @deprecated since Symfony 4.2
         if (!$env = $this->environment) {
             if ($input->hasOption('env') && !$env = $input->getOption('env')) {
                 $io->error('The environment must be either passed as second argument of the constructor or through the "--env" input option.');


### PR DESCRIPTION
This reverts commit 9f60ff8a4d80e86dff4891874a2cf531bd5ed847.
This reverts commit 31b5615b51a338bf73c93b148f46c7a5f8fe3b0f.

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #28984
| License       | MIT
| Doc PR        | -

Working on recipes with @weaverryan, we figured out that this deprecation is just making our life more difficult. Let's revert it.

Same as #29126, reverts #28745 and #28653 