### PR TITLE
[Dotenv] skip loading "local" env twice

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -82,6 +82,10 @@ final class Dotenv
             $env = $_SERVER[$varName] ?? $_ENV[$varName] ?? $env;
         }
 
+        if ('local' === $env) {
+            return;
+        }
+
         if (file_exists($p = "$path.$env")) {
             $this->load($p);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

e.g. on homestead, APP_ENV defaults to "local" :)