### PR TITLE
[VarExporter] fix handling of __sleep()

### DIFF
--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -184,6 +184,11 @@ class VarExporterTest extends TestCase
         yield array('final-array-iterator', new FinalArrayIterator());
 
         yield array('final-stdclass', new FinalStdClass());
+
+        $value = new MyWakeup();
+        $value->bis = new \ReflectionClass($value);
+
+         yield array('wakeup-refl', $value);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29118
| License       | MIT
| Doc PR        | -

Only the reproducer for now, fix on its way :)