### PR TITLE
Undeprecate the single-colon controller notation

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -30,7 +30,7 @@ EventDispatcher
 FrameworkBundle
 ---------------
 
- * Removed support for `bundle:controller:action` and `service:action` syntaxes to reference controllers. Use `serviceOrFqcn::method`
+ * Removed support for `bundle:controller:action` syntax to reference controllers. Use `serviceOrFqcn::method`
    instead where `serviceOrFqcn` is either the service ID when using controllers as services or the FQCN of the controller.
 
    Before:
@@ -40,11 +40,6 @@ FrameworkBundle
        path: /
        defaults:
            _controller: FrameworkBundle:Redirect:redirect
-
-   service_controller:
-       path: /
-       defaults:
-           _controller: app.my_controller:myAction
    ```
 
    After:
@@ -54,11 +49,6 @@ FrameworkBundle
        path: /
        defaults:
            _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction
-
-   service_controller:
-       path: /
-       defaults:
-           _controller: app.my_controller::myAction
    ```
 
  * Removed `Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser`.

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * added orphaned events support to `EventDataCollector`
  * `ExceptionListener` now logs exceptions at priority `0` (previously logged at `-128`)
- * Deprecated `service:action` syntax with a single colon to reference controllers. Use `service::method` instead.
+ * Added support for using `service::method` to reference controllers, making it consistent with other cases. It is recommended over the `service:action` syntax with a single colon, which will be deprecated in the future.
  * Added the ability to profile individual argument value resolvers via the
    `Symfony\Component\HttpKernel\Controller\ArgumentResolver\TraceableValueResolver`
 

--- a/src/Symfony/Component/HttpKernel/Controller/ContainerControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ContainerControllerResolver.php
@@ -36,7 +36,7 @@ class ContainerControllerResolver extends ControllerResolver
     {
         if (1 === substr_count($controller, ':')) {
             $controller = str_replace(':', '::', $controller);
-            @trigger_error(sprintf('Referencing controllers with a single colon is deprecated since Symfony 4.1. Use %s instead.', $controller), E_USER_DEPRECATED);
+            // TODO deprecate this in 5.1
         }
 
         return parent::createController($controller);

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
@@ -19,10 +19,6 @@ use Symfony\Component\HttpKernel\Controller\ContainerControllerResolver;
 
 class ContainerControllerResolverTest extends ControllerResolverTest
 {
-    /**
-     * @group legacy
-     * @expectedDeprecation Referencing controllers with a single colon is deprecated since Symfony 4.1. Use foo::action instead.
-     */
     public function testGetControllerServiceWithSingleColon()
     {
         $service = new ControllerTestService('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a (in core)
| License       | MIT
| Doc PR        | n/a

This notation is the only way to support controllers as services in the 3.4 LTS version.
This deprecation has only a very small benefit for the Symfony codebase (the amount of code involved is very small), but has a huge cost for the community which cannot avoid this deprecation without dropping support for the LTS or making crazy logic to switch routing files (as they cannot switch things inline in YAML or XML files).
This deprecation will be delayed until a future 5.x version, when the current LTS will be 4.4 (which supports the new notation).

This PR is based on a discussion I had with @nicolas-grekas a few days ago about the cost of that deprecation for the community.

For instance, in FOSUserBundle, a [PR](https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2853) got merged which duplicates the routing files with new files using the new notation, allowing people to opt-out from the deprecation, while the original files cannot be migrated without dropping support for the LTS (which is bad for the concept of LTS, as its usefulness is severally impacted if the ecosystem does not support it). But that's a bad solution for the future, as the bundle would have to keep 2 files forever (well, until next major) to avoid breaking projects referencing the new files. And most open-source bundles providing routes are faced with this challenge.

This is sent to 4.1, so that projects using 4.1 can become deprecation-free for these community bundles when using the latest 4.1 release too (meaning FOSUserBundle could revert this PR before the next release for instance)
