### PR TITLE
[Validator] Added the missing constraints instance checks

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * @author Michael Hirschler <michael.vhirsch@gmail.com>
@@ -26,6 +27,10 @@ class BicValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if (!$constraint instanceof Bic) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Bic');
+        }
+
         if (null === $value || '' === $value) {
             return;
         }

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -26,6 +26,10 @@ class CountValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if (!$constraint instanceof Count) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Count');
+        }
+
         if (null === $value) {
             return;
         }

--- a/src/Symfony/Component/Validator/Constraints/UuidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UuidValidator.php
@@ -83,12 +83,12 @@ class UuidValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (null === $value || '' === $value) {
-            return;
-        }
-
         if (!$constraint instanceof Uuid) {
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Uuid');
+        }
+
+        if (null === $value || '' === $value) {
+            return;
         }
 
         if (!is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This PR adds the constraints instance checks missing to limit the validators use.

This behavior is already implemented in all built-in validators, but it was missed in two validators.