### PR TITLE
[SecurityBundle] Fix remember-me cookie framework inheritance when session is disabled

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -65,7 +65,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             return;
         }
         foreach ($container->getExtensionConfig('framework') as $config) {
-            if (isset($config['session'])) {
+            if (isset($config['session']) && \is_array($config['session'])) {
                 $rememberMeSecureDefault = $config['session']['cookie_secure'] ?? $rememberMeSecureDefault;
                 $rememberMeSameSiteDefault = array_key_exists('cookie_samesite', $config['session']) ? $config['session']['cookie_samesite'] : $rememberMeSameSiteDefault;
             }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvider\DummyProvider;
@@ -341,6 +342,59 @@ class SecurityExtensionTest extends TestCase
         $container->compile();
 
         $this->assertFalse($container->has(UserProviderInterface::class));
+    }
+
+    /**
+     * @dataProvider sessionConfigurationProvider
+     */
+    public function testRememberMeCookieInheritFrameworkSessionCookie($config, $samesite, $secure)
+    {
+        $container = $this->getRawContainer();
+
+        $container->registerExtension(new FrameworkExtension());
+        $container->setParameter('kernel.bundles_metadata', array());
+        $container->setParameter('kernel.project_dir', __DIR__);
+        $container->setParameter('kernel.root_dir', __DIR__);
+        $container->setParameter('kernel.cache_dir', __DIR__);
+
+        $container->loadFromExtension('security', array(
+            'firewalls' => array(
+                'default' => array(
+                    'form_login' => null,
+                    'remember_me' => array('secret' => 'baz'),
+                ),
+            ),
+        ));
+        $container->loadFromExtension('framework', array(
+            'session' => $config,
+        ));
+
+        $container->compile();
+
+        $definition = $container->getDefinition('security.authentication.rememberme.services.simplehash.default');
+
+        $this->assertEquals($samesite, $definition->getArgument(3)['samesite']);
+        $this->assertEquals($secure, $definition->getArgument(3)['secure']);
+    }
+
+    public function sessionConfigurationProvider()
+    {
+        return array(
+            array(
+                false,
+                null,
+                false,
+            ),
+            array(
+                array(
+                    'cookie_secure' => true,
+                    'cookie_samesite' => 'lax',
+                    'save_path' => null,
+                ),
+                'lax',
+                true,
+            ),
+        );
     }
 
     protected function getRawContainer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29217 
| License       | MIT
| Doc PR        | N/A

When `framework.session` configuration key is not an array, we ignore it.
