### PR TITLE
[Routing] Remove duplicate schemes and methods for invokable controllers

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -120,12 +120,9 @@ abstract class AnnotationClassLoader implements LoaderInterface
         }
 
         if (0 === $collection->count() && $class->hasMethod('__invoke')) {
+            $globals = $this->resetGlobals();
             foreach ($this->reader->getClassAnnotations($class) as $annot) {
                 if ($annot instanceof $this->routeAnnotationClass) {
-                    $globals['path'] = '';
-                    $globals['name'] = '';
-                    $globals['localized_paths'] = array();
-
                     $this->addRoute($collection, $annot, $globals, $class, $class->getMethod('__invoke'));
                 }
             }
@@ -254,18 +251,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
 
     protected function getGlobals(\ReflectionClass $class)
     {
-        $globals = array(
-            'path' => null,
-            'localized_paths' => array(),
-            'requirements' => array(),
-            'options' => array(),
-            'defaults' => array(),
-            'schemes' => array(),
-            'methods' => array(),
-            'host' => '',
-            'condition' => '',
-            'name' => '',
-        );
+        $globals = $this->resetGlobals();
 
         if ($annot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass)) {
             if (null !== $annot->getName()) {
@@ -308,6 +294,22 @@ abstract class AnnotationClassLoader implements LoaderInterface
         }
 
         return $globals;
+    }
+
+    private function resetGlobals()
+    {
+        return array(
+            'path' => null,
+            'localized_paths' => array(),
+            'requirements' => array(),
+            'options' => array(),
+            'defaults' => array(),
+            'schemes' => array(),
+            'methods' => array(),
+            'host' => '',
+            'condition' => '',
+            'name' => '',
+        );
     }
 
     protected function createRoute($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition)

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/InvokableController.php
@@ -5,7 +5,7 @@ namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("/here", name="lol")
+ * @Route("/here", name="lol", methods={"GET", "POST"}, schemes={"https"})
  */
 class InvokableController
 {

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -92,6 +92,8 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $routes = $this->loader->load(InvokableController::class);
         $this->assertCount(1, $routes);
         $this->assertEquals('/here', $routes->get('lol')->getPath());
+        $this->assertEquals(array('GET', 'POST'), $routes->get('lol')->getMethods());
+        $this->assertEquals(array('https'), $routes->get('lol')->getSchemes());
     }
 
     public function testInvokableLocalizedControllerLoading()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no   
| Deprecations? |no 
| Tests pass?   | yes  
| Fixed tickets | 
| License       | MIT

Hi,

When we use annotation for invokable controller the http's methods and schemes are duplicate in ``Route`` instance.

This duplicity doesn't make bug but when we use ``bin/console debug:router`` the path's method and scheme are print twice. 

**To reproduce :**

``` php
/**
 * @Route("/here", name="lol", methods={"GET", "POST"}, schemes={"https"})
 */
class InvokableController
{
    public function __invoke()
    {
    }
}
```

``bin/console debug:router``

```
----------- ----------------------------- ------------------------------ --
  Name   Method           Scheme         Host   Path                                  
 ---------- ----------------------------- --------------- ------- ---------
  lol   GET|POST|GET|POST https|https    ANY  /here                                    
 ------------------------ ------------ -------- ------ ----------------------
