### PR TITLE
[Messenger] Improved message when handler class does not exist

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -79,7 +79,12 @@ class MessengerPass implements CompilerPassInterface
                     throw new RuntimeException(sprintf('Invalid handler service "%s": bus "%s" specified on the tag "%s" does not exist (known ones are: %s).', $serviceId, $tag['bus'], $this->handlerTag, implode(', ', $busIds)));
                 }
 
-                $r = $container->getReflectionClass($container->getDefinition($serviceId)->getClass());
+                $className = $container->getDefinition($serviceId)->getClass();
+                $r = $container->getReflectionClass($className);
+
+                if (null === $r) {
+                    throw new RuntimeException(sprintf('Invalid service "%s": class "%s" does not exist.', $serviceId, $className));
+                }
 
                 if (isset($tag['handles'])) {
                     $handles = isset($tag['method']) ? array($tag['handles'] => $tag['method']) : array($tag['handles']);

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -196,6 +196,22 @@ class MessengerPassTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage Invalid service "NonExistentHandlerClass": class "NonExistentHandlerClass" does not exist.
+     */
+    public function testThrowsExceptionIfTheHandlerClassDoesNotExist()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('message_bus', MessageBusInterface::class)->addTag('messenger.bus');
+        $container
+            ->register('NonExistentHandlerClass', 'NonExistentHandlerClass')
+            ->addTag('messenger.message_handler')
+        ;
+
+        (new MessengerPass())->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      * @expectedExceptionMessage Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\HandlerMappingWithNonExistentMethod": method "Symfony\Component\Messenger\Tests\DependencyInjection\HandlerMappingWithNonExistentMethod::dummyMethod()" does not exist.
      */
     public function testThrowsExceptionIfTheHandlerMethodDoesNotExist()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

**Problem:**

When defining a non existing messenger handler class in the `services.yml` config file, we encounter this confusing error message:

```
services:
    App\Handler\NonExistentHandler:
        tags: [messenger.message_handler]
```

```
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Argument 1 passed to Symfony\Component\Messenger\DependencyInjection\MessengerPass::guessHandledClasses() must be an instance of ReflectionClass, null given, called in /app/vendor/symfony/messenger/DependencyInjection/MessengerPass.php on line 93 in /app/vendor/symfony/messenger/DependencyInjection/MessengerPass.php:189
Stack trace:
    #0 /app/vendor/symfony/messenger/DependencyInjection/MessengerPass.php(93): Symfony\Component\Messenger\DependencyInjection\MessengerPass->guessHandledClasses(NULL, 'App\\Application...')
    #1 /app/vendor/symfony/messenger/DependencyInjection/MessengerPass.php(74): Symfony\Component\Messenger\DependencyInjection\MessengerPass->registerHandlers(Object(Symfony\Component\DependencyInjection\ContainerBuilder), Array)
    #2 /app/vendor/symfony/dependency-injection/Compiler/Compiler.php(95): Symfony\Component\Messenger\DependencyInjection\MessengerPass->process(Object(Symfony\Component\DependencyInjection\ContainerBuilder))
    #3 / in /app/vendor/symfony/messenger/DependencyInjection/MessengerPass.php on line 189
```

**Proposal:**

We can throw a more relevant exception (RuntimeException) in this case to help the developer to have a better understanding of the issue.

```Invalid service "App\Handler\NonExistentHandler": class "App\Handler\NonExistentHandler" does not exist.```