### PR TITLE
SCA: consolidate non empty array checks across codebase

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -48,7 +48,7 @@ class FormValidator extends ConstraintValidator
 
             // Validate the data against its own constraints
             if ($form->isRoot() && (\is_object($data) || \is_array($data))) {
-                if (\is_array($groups) && \count($groups) > 0 || $groups instanceof GroupSequence && \count($groups->groups) > 0) {
+                if (($groups && \is_array($groups)) || ($groups instanceof GroupSequence && $groups->groups)) {
                     $validator->atPath('data')->validate($form->getData(), null, $groups);
                 }
             }

--- a/src/Symfony/Component/Translation/Util/ArrayConverter.php
+++ b/src/Symfony/Component/Translation/Util/ArrayConverter.php
@@ -69,7 +69,7 @@ class ArrayConverter
             $elem = &$elem[$part];
         }
 
-        if (\is_array($elem) && \count($elem) > 0 && $parentOfElem) {
+        if ($elem && \is_array($elem) && $parentOfElem) {
             /* Process next case:
              *    'foo.bar': 'test1'
              *    'foo': 'test2'

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -120,7 +120,7 @@ abstract class Constraint
         if (\is_array($options)) {
             reset($options);
         }
-        if (\is_array($options) && \count($options) > 0 && \is_string(key($options))) {
+        if ($options && \is_array($options) && \is_string(key($options))) {
             foreach ($options as $option => $value) {
                 if (array_key_exists($option, $knownOptions)) {
                     $this->$option = $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR replaces `is_array(...) && count(...) > 0` with `... && is_array(...)` construct used in the codebase.