### PR TITLE
[FrameworkBundle] metadata_update_threshold default value must be an int

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -492,7 +492,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('gc_maxlifetime')->end()
                         ->scalarNode('save_path')->defaultValue('%kernel.cache_dir%/sessions')->end()
                         ->integerNode('metadata_update_threshold')
-                            ->defaultValue('0')
+                            ->defaultValue(0)
                             ->info('seconds to wait between 2 session metadata updates')
                         ->end()
                     ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -235,7 +235,7 @@ class ConfigurationTest extends TestCase
                 'cookie_samesite' => null,
                 'gc_probability' => 1,
                 'save_path' => '%kernel.cache_dir%/sessions',
-                'metadata_update_threshold' => '0',
+                'metadata_update_threshold' => 0,
             ),
             'request' => array(
                 'enabled' => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? |no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The type of the default config value is not in sync with the typehint added to `MetadataBag::__construct()`, so you get an error by default (at least when using strict types):

```
Type error: Argument 2 passed to Symfony\Component\HttpFoundation\Session\Storage\MetadataBag::__construct() must be of the type integer, string given, called in var/cache/test/ContainerEZ62jzd/getSession_Storage_MockFileService.php on line 23 (Behat\Testwork\Call\Exception\FatalThrowableError)
```