### PR TITLE
[Yaml] deprecated parsing invalid unicode sequences

### DIFF
--- a/UPGRADE-4.3.md
+++ b/UPGRADE-4.3.md
@@ -1,0 +1,8 @@
+UPGRADE FROM 4.2 to 4.3
+=======================
+
+Yaml
+----
+
+ * Parsing YAML strings that contain any of the unicode sequences forbidden by the specification is deprecated and
+   will throw a `ParseException` in 5.0.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -282,3 +282,8 @@ Workflow
  * `add` method has been removed use `addWorkflow` method in `Workflow\Registry` instead.
  * `SupportStrategyInterface` has been removed, use `WorkflowSupportStrategyInterface` instead.
  * `ClassInstanceSupportStrategy` has been removed, use `InstanceOfSupportStrategy` instead.
+
+Yaml
+----
+
+ * Parsing YAML strings that contain any of the unicode sequences forbidden by the specification throws a `ParseException`.

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.3.0
+-----
+
+ * parsing YAML strings that contain any of the unicode sequences forbidden by the specification is deprecated and
+   will throw a `ParseException` in 5.0
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -160,6 +160,12 @@ class Parser
 
             Inline::initialize($flags, $this->getRealCurrentLineNb(), $this->filename);
 
+            if (preg_match('/([\x00-\x08\x0B-\x0C\x0E-\x1F\x7F])/', $this->currentLine, $matches)) {
+                @trigger_error(sprintf('Parsing YAML strings that contain the "0x%X" unicode sequence is deprecated since Symfony 4.3 and will throw a ParseException in 5.0.', $matches[1]), E_USER_DEPRECATED);
+                // to be thrown in 5.0
+                //throw new ParseException(sprintf('Unexpected character 0x%X', $matches[1]));
+            }
+
             $isRef = $mergeNode = false;
             if ('-' === $this->currentLine[0] && self::preg_match('#^\-((?P<leadspaces>\s+)(?P<value>.+))?$#u', rtrim($this->currentLine), $values)) {
                 if ($context && 'mapping' == $context) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Not being able to detect these invalid characters (see http://yaml.org/spec/1.2/spec.html#id2770814 in the specification) can lead to hard to debug issues when such invalid YAML is passed to third party services that use stricter parsers. We encountered this in a real project when handing over our translation files (containing invalid whitespaces coming from a Word document) to a translation service which then failed parsing the YAML files.

I failed to figure out how to create (and then detect) a string containing unicode sequences from the high surrogate block (`#xD800-#xDFFF`, `#xFFFE`, and `#xFFFF`). If someone has an idea how we can achieve that, I'll welcome and help.