### PR TITLE
[DI] fix taking lazy services into account when dumping the container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -91,11 +91,13 @@ class ServiceReferenceGraph
      * @param string $reference
      * @param bool   $lazy
      * @param bool   $weak
+     * @param bool   $byConstructor
      */
-    public function connect($sourceId, $sourceValue, $destId, $destValue = null, $reference = null/*, bool $lazy = false, bool $weak = false*/)
+    public function connect($sourceId, $sourceValue, $destId, $destValue = null, $reference = null/*, bool $lazy = false, bool $weak = false, bool $byConstructor = false*/)
     {
         $lazy = \func_num_args() >= 6 ? func_get_arg(5) : false;
         $weak = \func_num_args() >= 7 ? func_get_arg(6) : false;
+        $byConstructor = \func_num_args() >= 8 ? func_get_arg(7) : false;
 
         if (null === $sourceId || null === $destId) {
             return;
@@ -103,7 +105,7 @@ class ServiceReferenceGraph
 
         $sourceNode = $this->createNode($sourceId, $sourceValue);
         $destNode = $this->createNode($destId, $destValue);
-        $edge = new ServiceReferenceGraphEdge($sourceNode, $destNode, $reference, $lazy, $weak);
+        $edge = new ServiceReferenceGraphEdge($sourceNode, $destNode, $reference, $lazy, $weak, $byConstructor);
 
         $sourceNode->addOutEdge($edge);
         $destNode->addInEdge($edge);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphEdge.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphEdge.php
@@ -25,6 +25,7 @@ class ServiceReferenceGraphEdge
     private $value;
     private $lazy;
     private $weak;
+    private $byConstructor;
 
     /**
      * @param ServiceReferenceGraphNode $sourceNode
@@ -32,14 +33,16 @@ class ServiceReferenceGraphEdge
      * @param mixed                     $value
      * @param bool                      $lazy
      * @param bool                      $weak
+     * @param bool                      $byConstructor
      */
-    public function __construct(ServiceReferenceGraphNode $sourceNode, ServiceReferenceGraphNode $destNode, $value = null, $lazy = false, $weak = false)
+    public function __construct(ServiceReferenceGraphNode $sourceNode, ServiceReferenceGraphNode $destNode, $value = null, $lazy = false, $weak = false, $byConstructor = false)
     {
         $this->sourceNode = $sourceNode;
         $this->destNode = $destNode;
         $this->value = $value;
         $this->lazy = $lazy;
         $this->weak = $weak;
+        $this->byConstructor = $byConstructor;
     }
 
     /**
@@ -90,5 +93,15 @@ class ServiceReferenceGraphEdge
     public function isWeak()
     {
         return $this->weak;
+    }
+
+    /**
+     * Returns true if the edge links with a constructor argument.
+     *
+     * @return bool
+     */
+    public function isReferencedByConstructor()
+    {
+        return $this->byConstructor;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
@@ -133,7 +133,13 @@ class ProjectServiceContainer extends Container
      */
     protected function getHandler2Service()
     {
-        return $this->services['App\Handler2'] = new \App\Handler2(${($_ = isset($this->services['App\Db']) ? $this->services['App\Db'] : $this->getDbService()) && false ?: '_'}, ${($_ = isset($this->services['App\Schema']) ? $this->services['App\Schema'] : $this->getSchemaService()) && false ?: '_'}, ${($_ = isset($this->services['App\Processor']) ? $this->services['App\Processor'] : $this->getProcessorService()) && false ?: '_'});
+        $a = ${($_ = isset($this->services['App\Processor']) ? $this->services['App\Processor'] : $this->getProcessorService()) && false ?: '_'};
+
+        if (isset($this->services['App\Handler2'])) {
+            return $this->services['App\Handler2'];
+        }
+
+        return $this->services['App\Handler2'] = new \App\Handler2(${($_ = isset($this->services['App\Db']) ? $this->services['App\Db'] : $this->getDbService()) && false ?: '_'}, ${($_ = isset($this->services['App\Schema']) ? $this->services['App\Schema'] : $this->getSchemaService()) && false ?: '_'}, $a);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -174,11 +174,16 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected function getConnectionService()
     {
-        $a = new \stdClass();
+        $a = ${($_ = isset($this->services['dispatcher']) ? $this->services['dispatcher'] : $this->getDispatcherService()) && false ?: '_'};
 
-        $this->services['connection'] = $instance = new \stdClass(${($_ = isset($this->services['dispatcher']) ? $this->services['dispatcher'] : $this->getDispatcherService()) && false ?: '_'}, $a);
+        if (isset($this->services['connection'])) {
+            return $this->services['connection'];
+        }
+        $b = new \stdClass();
 
-        $a->logger = ${($_ = isset($this->services['logger']) ? $this->services['logger'] : $this->getLoggerService()) && false ?: '_'};
+        $this->services['connection'] = $instance = new \stdClass($a, $b);
+
+        $b->logger = ${($_ = isset($this->services['logger']) ? $this->services['logger'] : $this->getLoggerService()) && false ?: '_'};
 
         return $instance;
     }
@@ -190,14 +195,19 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected function getConnection2Service()
     {
-        $a = new \stdClass();
+        $a = ${($_ = isset($this->services['dispatcher2']) ? $this->services['dispatcher2'] : $this->getDispatcher2Service()) && false ?: '_'};
 
-        $this->services['connection2'] = $instance = new \stdClass(${($_ = isset($this->services['dispatcher2']) ? $this->services['dispatcher2'] : $this->getDispatcher2Service()) && false ?: '_'}, $a);
+        if (isset($this->services['connection2'])) {
+            return $this->services['connection2'];
+        }
+        $b = new \stdClass();
 
-        $b = new \stdClass($instance);
-        $b->handler2 = new \stdClass(${($_ = isset($this->services['manager2']) ? $this->services['manager2'] : $this->getManager2Service()) && false ?: '_'});
+        $this->services['connection2'] = $instance = new \stdClass($a, $b);
 
-        $a->logger2 = $b;
+        $c = new \stdClass($instance);
+        $c->handler2 = new \stdClass(${($_ = isset($this->services['manager2']) ? $this->services['manager2'] : $this->getManager2Service()) && false ?: '_'});
+
+        $b->logger2 = $c;
 
         return $instance;
     }
@@ -431,7 +441,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected function getSubscriberService()
     {
-        return $this->services['subscriber'] = new \stdClass(${($_ = isset($this->services['manager']) ? $this->services['manager'] : $this->getManagerService()) && false ?: '_'});
+        $a = ${($_ = isset($this->services['manager']) ? $this->services['manager'] : $this->getManagerService()) && false ?: '_'};
+
+        if (isset($this->services['subscriber'])) {
+            return $this->services['subscriber'];
+        }
+
+        return $this->services['subscriber'] = new \stdClass($a);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29246
| License       | MIT
| Doc PR        | -

This PR fixes issues found while working on #29246.
It *does* fix the infinite loop, ~but replaces it by an exception (reopening #29078)~:
> ~It's a requirement to specify a Metadata Driver and pass it to Doctrine\ORM\Configuration::setMetadataDriverImpl()~

The full fix is not immediately accessible as it needs some core changes to the dumping logic. Requiring `symfony/proxy-manager-bridge` works around the issue properly.

See #29251 for 4.2