### PR TITLE
[Form] Fixed empty data for compound date interval

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
@@ -423,4 +423,32 @@ class DateIntervalTypeTest extends BaseTypeTest
         $this->assertSame($expectedData, $form->getNormData());
         $this->assertSame($expectedData, $form->getData());
     }
+
+    /**
+     * @dataProvider provideEmptyData
+     */
+    public function testSubmitNullUsesDateEmptyData($widget, $emptyData, $expectedData)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, array(
+            'widget' => $widget,
+            'empty_data' => $emptyData,
+        ));
+        $form->submit(null);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertEquals($expectedData, $form->getNormData());
+        $this->assertEquals($expectedData, $form->getData());
+    }
+
+    public function provideEmptyData()
+    {
+        $expectedData = \DateInterval::createFromDateString('6 years and 4 months');
+
+        return array(
+            'Simple field' => array('single_text', 'P6Y4M0D', $expectedData),
+            'Compound text field' => array('text', array('years' => '06', 'months' => '04', 'days' => '00'), $expectedData),
+            'Compound integer field' => array('integer', array('years' => '6', 'months' => '4', 'days' => '0'), $expectedData),
+            'Compound choice field' => array('choice', array('years' => '6', 'months' => '4', 'days' => '0'), $expectedData),
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4715 (continuation)
| License       | MIT
| Doc PR        | ~


Following #29182, since this type has been introduced in Symfony 3 but with the same limitation explained in #4715.
So for consistency this needs to be fixed here as well.