### PR TITLE
[DoctrineBridge] Custom entity repositories in EntityUserProvider

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added cause of UniqueEntity constraint violation
  * deprecated `DbalSessionHandler` and `DbalSessionHandlerSchema` in favor of
    `Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler`
+ * added custom entity repositories in `EntityUserProvider`
 
 3.1.0
 -----

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/Security/UserProvider/EntityFactory.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/Security/UserProvider/EntityFactory.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\User
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * EntityFactory creates services for Doctrine user provider.
@@ -40,6 +41,7 @@ class EntityFactory implements UserProviderFactoryInterface
             ->addArgument($config['class'])
             ->addArgument($config['property'])
             ->addArgument($config['manager_name'])
+            ->addArgument(new Reference($config['repository']))
         ;
     }
 
@@ -55,6 +57,7 @@ class EntityFactory implements UserProviderFactoryInterface
                 ->scalarNode('class')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('property')->defaultNull()->end()
                 ->scalarNode('manager_name')->defaultNull()->end()
+                ->scalarNode('repository')->defaultNull()->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -32,13 +32,15 @@ class EntityUserProvider implements UserProviderInterface
     private $classOrAlias;
     private $class;
     private $property;
+    private $repository;
 
-    public function __construct(ManagerRegistry $registry, $classOrAlias, $property = null, $managerName = null)
+    public function __construct(ManagerRegistry $registry, $classOrAlias, $property = null, $managerName = null, $repository = null)
     {
         $this->registry = $registry;
         $this->managerName = $managerName;
         $this->classOrAlias = $classOrAlias;
         $this->property = $property;
+        $this->repository = $repository;
     }
 
     /**
@@ -47,6 +49,7 @@ class EntityUserProvider implements UserProviderInterface
     public function loadUserByUsername($username)
     {
         $repository = $this->getRepository();
+
         if (null !== $this->property) {
             $user = $repository->findOneBy(array($this->property => $username));
         } else {
@@ -75,6 +78,7 @@ class EntityUserProvider implements UserProviderInterface
         }
 
         $repository = $this->getRepository();
+
         if ($repository instanceof UserProviderInterface) {
             $refreshedUser = $repository->refreshUser($user);
         } else {
@@ -114,7 +118,7 @@ class EntityUserProvider implements UserProviderInterface
 
     private function getRepository()
     {
-        return $this->getObjectManager()->getRepository($this->classOrAlias);
+        return (null !== $this->repository) ? $this->repository : $this->getObjectManager()->getRepository($this->classOrAlias);
     }
 
     private function getClass()

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomNotValidUserRepository.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomNotValidUserRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+class CustomNotValidUserRepository
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomUserRepository.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CustomUserRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
+
+class CustomUserRepository implements UserLoaderInterface
+{
+    public function loadUserByUsername($username)
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29257
| License       | MIT
| Doc PR        | pending 

This PR adds a new config option to the entity user provider in `security.yml` called `repository` that can be used to point to a custom entity repository class. This avoids calling Doctrine repository locator, which will return the wrong instance if the entity repository gets converted to a service.

If none is specified, Doctrine locator will be called, so BC is guaranteed.

Without this change, using entity repositories as services won't work with `EntityUserProvider`, which may be considered a bug.

Example:
```yaml
    # config/packages/security.yml
    # ...

    providers:
        our_db_provider:
            entity:
                class: App\Entity\User
                repository: App\Repository\UserRepository
    # ...
```