### PR TITLE
FileLocator service definition update: look for templates in /templates directory instead of deprecated /src/Resources

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -48,7 +48,7 @@
 
         <service id="file_locator" class="Symfony\Component\HttpKernel\Config\FileLocator">
             <argument type="service" id="kernel" />
-            <argument>%kernel.root_dir%/Resources</argument>
+            <argument>%kernel.root_dir%/../templates</argument>
             <argument type="collection">
                 <argument>%kernel.root_dir%</argument>
             </argument>


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | master for features / 2.8 up to 4.1 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


