### PR TITLE
[Console] Make "warning" in SymfonyStyle different to "error" using commonly recognized orange color

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -154,7 +154,7 @@ class SymfonyStyle extends OutputStyle
      */
     public function warning($message)
     {
-        $this->block($message, 'WARNING', 'fg=white;bg=red', ' ', true);
+        $this->block($message, 'WARNING', 'fg=white;bg=yellow', ' ', true);
     }
 
     /**

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -154,7 +154,7 @@ class SymfonyStyle extends OutputStyle
      */
     public function warning($message)
     {
-        $this->block($message, 'WARNING', 'fg=white;bg=yellow', ' ', true);
+        $this->block($message, 'WARNING', 'fg=black;bg=yellow', ' ', true);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I love the `SymfonyStyle` since the [day 1 it was introduced in Symfony 2.8](https://symfony.com/blog/new-in-symfony-2-8-console-style-guide). The common approach to 


I just keep comming to one repeated confusion in every project I use it in. Current `SymfonyStyle` **uses the same colors style for "error" and "warning"**. The headline is different, but the design is not reflecting that.

Warning messages have lower servernity, but the red color signals it's critical/error.

<br>

This PR **suggests change color to orange, that is commonly recognized as "warning"**:

![image](https://user-images.githubusercontent.com/924196/48806000-44db7b00-ed19-11e8-943c-9c1c2ac3b1c3.png)

(Twitter bootstrap)


![image](https://user-images.githubusercontent.com/924196/48806094-984dc900-ed19-11e8-9c4d-af8fc6821d1e.png)

(Gitlab UI)



It originated in: https://github.com/Symplify/Symplify/pull/776 thanks to @OndraM 

<br>

### Before

- both look the same

![image](https://user-images.githubusercontent.com/924196/48805789-9fc0a280-ed18-11e8-8b39-174a6292022f.png)

### After 

- *error*
- *warning*

![image](https://user-images.githubusercontent.com/924196/48805758-83246a80-ed18-11e8-9488-d7198d21e21b.png)
