### PR TITLE
[DI] Preserve placeholder exception for dynamic arrays

### DIFF
--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -332,7 +332,7 @@ abstract class BaseNode implements NodeInterface
 
         // run custom normalization closures
         foreach ($this->normalizationClosures as $closure) {
-            $value = $closure($value);
+            $value = $closure($value, $value !== self::resolvePlaceholderValue($value));
         }
 
         // resolve placeholder value

--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -238,7 +238,7 @@ class ExprBuilder
                 $if = $expr->ifPart;
                 $then = $expr->thenPart;
                 $expressions[$k] = function ($v) use ($if, $then) {
-                    return $if($v) ? $then($v) : $v;
+                    return $if(...\func_get_args()) ? $then(...\func_get_args()) : $v;
                 };
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Here's some initial work to deal with envs for array nodes in config.

From https://github.com/symfony/symfony/issues/27683#issuecomment-399404969 this would be a first step.

What's still needed is a way to know about the types, e.g. a env resolving to string should be preserved as `array($v)` to be really flexible.

cc @stof 