### PR TITLE
[HttpFoundation] Fix trailing space for mime-type with parameters

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1326,7 +1326,7 @@ class Request
     {
         $canonicalMimeType = null;
         if (false !== $pos = strpos($mimeType, ';')) {
-            $canonicalMimeType = substr($mimeType, 0, $pos);
+            $canonicalMimeType = trim(substr($mimeType, 0, $pos));
         }
 
         if (null === static::$formats) {

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -323,6 +323,9 @@ class RequestTest extends TestCase
     {
         $request = new Request();
         $this->assertEquals('json', $request->getFormat('application/json; charset=utf-8'));
+        $this->assertEquals('json', $request->getFormat('application/json;charset=utf-8'));
+        $this->assertEquals('json', $request->getFormat('application/json ; charset=utf-8'));
+        $this->assertEquals('json', $request->getFormat('application/json ;charset=utf-8'));
     }
 
     public function testGetFormatWithCustomMimeType()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
This PR fixes a minor issue that we've discovered by exposing our API towards mobile applications which where sending the header as following `content-type: application/json ;charset=UTF-8`. Request is unable to determine the `getContentType -> getFormat` as **json** due to the whitespace at the end.

```php
$request = Request::createFromGlobals();
$request->headers->set('CONTENT_TYPE', 'application/json ;charset=UTF-8'); // Forcing header for test
if ($request->getContentType() !== 'json') {
    // Return 415 (Unsupported Media Type) status code..
}
```

When checking https://tools.ietf.org/html/rfc7231#section-3.1.1.1 it seems that a space is part of the RFC spec. (Where OWS is abbreviated for Optional WhiteSpace)
```
media-type = type "/" subtype *( OWS ";" OWS parameter )
```
Current the following cases are supported:
* application/json; charset=UTF-8
* application/json;charset=UTF-8

The following are failing:
* application/json ; charset=UTF-8
* application/json ;charset=UTF-8