### PR TITLE
[Routing] Remove duplicate schemes and methods for invokable controllers

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -120,11 +120,9 @@ abstract class AnnotationClassLoader implements LoaderInterface
         }
 
         if (0 === $collection->count() && $class->hasMethod('__invoke')) {
+            $globals = $this->resetGlobals();
             foreach ($this->reader->getClassAnnotations($class) as $annot) {
                 if ($annot instanceof $this->routeAnnotationClass) {
-                    $globals['path'] = '';
-                    $globals['name'] = '';
-
                     $this->addRoute($collection, $annot, $globals, $class, $class->getMethod('__invoke'));
                 }
             }
@@ -212,17 +210,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
 
     protected function getGlobals(\ReflectionClass $class)
     {
-        $globals = array(
-            'path' => '',
-            'requirements' => array(),
-            'options' => array(),
-            'defaults' => array(),
-            'schemes' => array(),
-            'methods' => array(),
-            'host' => '',
-            'condition' => '',
-            'name' => '',
-        );
+        $globals = $this->resetGlobals();
 
         if ($annot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass)) {
             if (null !== $annot->getName()) {
@@ -263,6 +251,21 @@ abstract class AnnotationClassLoader implements LoaderInterface
         }
 
         return $globals;
+    }
+
+    private function resetGlobals()
+    {
+        return array(
+            'path' => '',
+            'requirements' => array(),
+            'options' => array(),
+            'defaults' => array(),
+            'schemes' => array(),
+            'methods' => array(),
+            'host' => '',
+            'condition' => '',
+            'name' => '',
+        );
     }
 
     protected function createRoute($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition)

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -181,7 +181,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         $this->assertEquals(array_merge($classRouteData['methods'], $methodRouteData['methods']), $route->getMethods(), '->load merges class and method route methods');
     }
 
-    public function testInvokableClassRouteLoad()
+    public function testInvokableClassRouteLoadWithMethodAnnotation()
     {
         $classRouteData = array(
             'name' => 'route1',
@@ -195,6 +195,41 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
             ->method('getClassAnnotations')
             ->will($this->returnValue(array($this->getAnnotatedRoute($classRouteData))))
         ;
+        $this->reader
+            ->expects($this->once())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue(array()))
+        ;
+
+        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BazClass');
+        $route = $routeCollection->get($classRouteData['name']);
+
+        $this->assertSame($classRouteData['path'], $route->getPath(), '->load preserves class route path');
+        $this->assertEquals($classRouteData['schemes'], $route->getSchemes(), '->load preserves class route schemes');
+        $this->assertEquals($classRouteData['methods'], $route->getMethods(), '->load preserves class route methods');
+    }
+
+    public function testInvokableClassRouteLoadWithClassAnnotation()
+    {
+        $classRouteData = array(
+            'name' => 'route1',
+            'path' => '/',
+            'schemes' => array('https'),
+            'methods' => array('GET'),
+        );
+
+        $this->reader
+            ->expects($this->exactly(1))
+            ->method('getClassAnnotation')
+            ->will($this->returnValue($this->getAnnotatedRoute($classRouteData)))
+        ;
+
+        $this->reader
+            ->expects($this->exactly(1))
+            ->method('getClassAnnotations')
+            ->will($this->returnValue(array($this->getAnnotatedRoute($classRouteData))))
+        ;
+
         $this->reader
             ->expects($this->once())
             ->method('getMethodAnnotations')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes   
| Fixed tickets | #29225
| License       | MIT

This PR backport for 3.4 branch the same issue than the PR #29225.

I add a test to check the fix when annotation are on the class and rename another one when the route annotation is on the invoke method.