### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+* text=auto
+
+/.github export-ignore
+/src/Symfony/Component/**/Tests export-ignore
+.php_cs.dist export-ignore
+.travis.yml export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+CHANGELOG-* export-ignore
+CODE_OF_CONDUCT.md export-ignore
+CONTRIBUTING.md export-ignore
+CONTRIBUTORS.md export-ignore
+UPGRADE-* export-ignore
+link export-ignore
+phpunit export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Currently, when using a Symfony component as a dependency, Composer will download all the files from the source repository. In fact, there are a lot of unnecessary files. For example, Our PHP projects don't require .gitignore, CHANGELOG.md, .github,.. to run. Especially, we don't need the Tests directory, do we? 
          
/path/to/project/vendor/symfony/http-foundation/Tests are no-meaning.

In this pull request, I just add a .gitattributes file to ignore some files when exporting. 