### PR TITLE
[Serializer] CsvEncoder no header option (encode / decode)

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/CsvEncoderTest.php
@@ -309,6 +309,18 @@ CSV
             )));
     }
 
+    public function testEncodeWithoutHeader()
+    {
+        $this->assertSame(<<<'CSV'
+a,b
+c,d
+
+CSV
+            , $this->encoder->encode(array(array('a', 'b'), array('c', 'd')), 'csv', array(
+                CsvEncoder::NO_HEADERS_KEY => true,
+            )));
+    }
+
     public function testSupportsDecoding()
     {
         $this->assertTrue($this->encoder->supportsDecoding('csv'));
@@ -479,5 +491,17 @@ CSV
     public function testDecodeEmptyArray()
     {
         $this->assertEquals(array(), $this->encoder->decode('', 'csv'));
+    }
+
+    public function testDecodeWithoutHeader()
+    {
+        $this->assertEquals(array(array('a', 'b'), array('c', 'd')), $this->encoder->decode(<<<'CSV'
+a,b
+c,d
+
+CSV
+        , 'csv', array(
+            CsvEncoder::NO_HEADERS_KEY => true,
+        )));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | #27447
| License       | MIT
| Doc PR        | -

This PR wants to introduce a new context option for the CsvEncoder, `CsvEncoder::NO_HEADERS_KEY` (boolean), that allows CSV encoding/decoding when you don't have/need a header.

By default this is assumed to be false, so the headers are included in the CSV output or assumed to be present in the CSV input.

When the option is set to true, the following behaviour occurs.

Encoding 
===
The following PHP input
```php
array(array('a','b'), array('c', 'd'))
``` 
will generate this CSV output
```csv
a,b
c,d
```

Decoding 
===
Considering the CSV input to be
```csv
a,b
c,d
``` 
the following PHP array will be returned 
```php
array (
  0 => array (
    0 => 'a',
    1 => 'b',
  ),
  1 => array (
    0 => 'c',
    1 => 'd',
  ),
)
```
