### PR TITLE
[HttpKernel][WebProfilerBundle] Getting the cached client mime type instead of guessing it again

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -131,31 +131,14 @@
                     {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: collector.requestrequest, maxDepth: 1 }, with_context = false) }}
                 {% endif %}
 
-                <h3>Uploaded files</h3>
+                <h4>Uploaded Files</h4>
 
                 {% if collector.requestfiles is empty %}
                     <div class="empty">
                         <p>No files were uploaded</p>
                     </div>
                 {% else %}
-                    <table>
-                        <thead>
-                            <tr>
-                                <th scope="col">File Name</th>
-                                <th scope="col">MIME Type</th>
-                                <th scope="col" class="text-right">Size (bytes)</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for file in collector.requestfiles %}
-                            <tr>
-                                <td>{{ file.name }}</td>
-                                <td>{{ file.mimetype }}</td>
-                                <td class="text-right">{{ file.size|number_format }}</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
+                    {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: collector.requestfiles, maxDepth: 1 }, with_context = false) }}
                 {% endif %}
 
                 <h3>Request Attributes</h3>

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpKernel\DataCollector;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -58,22 +57,6 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             $content = false;
         }
 
-        $requestFiles = array();
-        $extractFiles = function (array $files) use (&$extractFiles, &$requestFiles) {
-            foreach ($files as $file) {
-                if ($file instanceof UploadedFile) {
-                    $requestFiles[] = array(
-                        'name' => $file->getClientOriginalName(),
-                        'mimetype' => $file->getMimeType(),
-                        'size' => $file->getSize(),
-                    );
-                } elseif (\is_array($file)) {
-                    $extractFiles($file);
-                }
-            }
-        };
-        $extractFiles($request->files->all());
-
         $sessionMetadata = array();
         $sessionAttributes = array();
         $session = null;
@@ -112,7 +95,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             'status_code' => $statusCode,
             'request_query' => $request->query->all(),
             'request_request' => $request->request->all(),
-            'request_files' => $requestFiles,
+            'request_files' => $request->files->all(),
             'request_headers' => $request->headers->all(),
             'request_server' => $request->server->all(),
             'request_cookies' => $request->cookies->all(),
@@ -216,7 +199,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
 
     public function getRequestFiles()
     {
-        return $this->data['request_files']->getValue(true);
+        return new ParameterBag($this->data['request_files']->getValue());
     }
 
     public function getRequestHeaders()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (4.2)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29284
| License       | MIT
| Doc PR        | -

The 1st commit fixes the bug based on the current implementation. But I'd like to improve this new feature a little bit with the 2nd commit:
 * <del>Renaming "Uploaded files" title by "FILES Parameters" and</del> (sub-section of POST parameters) changing the table using key/value structure (being consistent with other sections).
 * The above allow us also to show nested paramaters. (It is useful to know where this file(s) comes from)
 * And show all info about the `UploadedFile` object. (It might be useful too) 

![files-parameters](https://user-images.githubusercontent.com/2028198/48918478-d3a3e100-ee5a-11e8-8ef7-a50ae4ee1550.png)

