### PR TITLE
[Request] [Documentation] clarify that isMethodCacheable() returns true only for GET & HEAD

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1475,7 +1475,7 @@ class Request
      *
      * @see https://tools.ietf.org/html/rfc7231#section-4.2.3
      *
-     * @return bool
+     * @return bool True for GET and HEAD, false otherwise
      */
     public function isMethodCacheable()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed tickets | na
| License       | MIT

The current documentation points to https://tools.ietf.org/html/rfc7231#section-4.2.3.

The spec says: "this specification defines GET, HEAD, and POST as cacheable, although the overwhelming majority of cache implementations only support GET and HEAD.". 

This fix to the documentation clarifies that Symfony follows majority (excluding POST) rather than the spec (including POST).
