### PR TITLE
[Messenger] add welcome notice when running the command

### DIFF
--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -18,6 +18,8 @@ use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
  * @author Samuel Roze <samuel.roze@gmail.com>
  *
  * @experimental in 4.2
+ *
+ * @final
  */
 class Worker
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The current behavior of `./bin/console messenger:consume-messages` is totally silent: you run it and nothing visible happens.

Here is what is displayed with this PR:
![image](https://user-images.githubusercontent.com/243674/54235039-af0a6c80-4510-11e9-89d8-3c1c55e946c0.png)

Combined with #30539, it gives:
![image](https://user-images.githubusercontent.com/243674/54235156-ed079080-4510-11e9-9d4d-9f27c87e16e5.png)
