### PR TITLE
[EventDispatcher] Unwrap wrapped listeners internally

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -249,7 +249,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     {
         foreach ($this->dispatcher->getListeners($eventName) as $listener) {
             $priority = $this->getListenerPriority($eventName, $listener);
-            $wrappedListener = new WrappedListener($listener, null, $this->stopwatch, $this);
+            $wrappedListener = new WrappedListener($listener instanceof WrappedListener ? $listener->getWrappedListener() : $listener, null, $this->stopwatch, $this);
             $this->wrappedListeners[$eventName][] = $wrappedListener;
             $this->dispatcher->removeListener($eventName, $listener);
             $this->dispatcher->addListener($eventName, $wrappedListener, $priority);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | partially #24275
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I believe what happens is we re-register the listeners on the wrapped dispatcher, so in case of sub request we get those and wrap it again. The profiler seems to confirm this in case of an exception (default 404 here) and thus creates a sub-request.

## Before: (main request)

No exception: (OK)

![image](https://user-images.githubusercontent.com/1047696/48968597-295ec180-eff2-11e8-982c-756e9019e107.png)

Exception: (KO)

![image](https://user-images.githubusercontent.com/1047696/48968612-4abfad80-eff2-11e8-8556-37bfbd51bc3b.png)


## After (main request):

No exception: same

Exception: (OK)

![image](https://user-images.githubusercontent.com/1047696/48968636-9f632880-eff2-11e8-983e-b4099133600b.png)

I haven't furhter investigated if we should split events per request as done in #23659 for logs. It seems somewhere we deduplicate events.. so im not sure the profiler actually shows correct data.

