### PR TITLE
[DomCrawler] Optionally use html5-php to parse HTML

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,7 @@
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/reflection": "~1.0",
         "doctrine/doctrine-bundle": "~1.4",
+        "masterminds/html5": "^2.6",
         "monolog/monolog": "~1.11",
         "nyholm/psr7": "^1.0",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
@@ -112,6 +113,7 @@
         "phpdocumentor/reflection-docblock": "^3.0|^4.0"
     },
     "conflict": {
+        "masterminds/html5": "<2.6",
         "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
         "phpdocumentor/type-resolver": "<0.3.0",
         "phpunit/phpunit": "<5.4.3"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SessionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SessionController.php
@@ -28,19 +28,19 @@ class SessionController implements ContainerAwareInterface
         // new session case
         if (!$session->has('name')) {
             if (!$name) {
-                return new Response('You are new here and gave no name.');
+                return new Response('<html><body>You are new here and gave no name.</body></html>');
             }
 
             // remember name
             $session->set('name', $name);
 
-            return new Response(sprintf('Hello %s, nice to meet you.', $name));
+            return new Response(sprintf('<html><body>Hello %s, nice to meet you.</body></html>', $name));
         }
 
         // existing session
         $name = $session->get('name');
 
-        return new Response(sprintf('Welcome back %s, nice to meet you.', $name));
+        return new Response(sprintf('<html><body>Welcome back %s, nice to meet you.</body></html>', $name));
     }
 
     public function cacheableAction()
@@ -55,7 +55,7 @@ class SessionController implements ContainerAwareInterface
     {
         $request->getSession()->invalidate();
 
-        return new Response('Session cleared.');
+        return new Response('<html><body>Session cleared.</body></html>');
     }
 
     public function setFlashAction(Request $request, $message)
@@ -76,6 +76,6 @@ class SessionController implements ContainerAwareInterface
             $output = 'No flash was set.';
         }
 
-        return new Response($output);
+        return new Response('<html><body>'.$output.'</body></html>');
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LocalizedController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LocalizedController.php
@@ -54,11 +54,11 @@ class LocalizedController implements ContainerAwareInterface
 
     public function profileAction()
     {
-        return new Response('Profile');
+        return new Response('<html><body>Profile</body></html>');
     }
 
     public function homepageAction()
     {
-        return new Response('Homepage');
+        return new Response('<html><body>Homepage</body></html>');
     }
 }

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
 * Added return of element name (`_name`) in `extract()` method.
 * Added ability to return a default value in `text()` and `html()` instead of throwing an exception when node is empty.
+* When available, the [html5-php library](https://github.com/Masterminds/html5-php) is used to
+  parse HTML added to a Crawler for better support of HTML5 tags.
 
 4.2.0
 -----

--- a/src/Symfony/Component/DomCrawler/Tests/Html5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Html5ParserCrawlerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+class Html5ParserCrawlerTest extends AbstractCrawlerTest
+{
+    public function createCrawler($node = null, string $uri = null, string $baseHref = null)
+    {
+        return new Crawler($node, $uri, $baseHref, true);
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/NativeParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/NativeParserCrawlerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+class NativeParserCrawlerTest extends AbstractCrawlerTest
+{
+    public function createCrawler($node = null, string $uri = null, string $baseHref = null)
+    {
+        return new Crawler($node, $uri, $baseHref, false);
+    }
+
+    public function testAddHtmlContentWithErrors()
+    {
+        $internalErrors = libxml_use_internal_errors(true);
+
+        $crawler = $this->createCrawler();
+        $crawler->addHtmlContent(<<<'EOF'
+<!DOCTYPE html>
+<html>
+    <head>
+    </head>
+    <body>
+        <nav><a href="#"><a href="#"></nav>
+    </body>
+</html>
+EOF
+            , 'UTF-8');
+
+        $errors = libxml_get_errors();
+        $this->assertCount(1, $errors);
+        $this->assertEquals("Tag nav invalid\n", $errors[0]->message);
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($internalErrors);
+    }
+
+    public function testAddXmlContentWithErrors()
+    {
+        $internalErrors = libxml_use_internal_errors(true);
+
+        $crawler = $this->createCrawler();
+        $crawler->addXmlContent(<<<'EOF'
+<!DOCTYPE html>
+<html>
+    <head>
+    </head>
+    <body>
+        <nav><a href="#"><a href="#"></nav>
+    </body>
+</html>
+EOF
+            , 'UTF-8');
+
+        $this->assertGreaterThan(1, libxml_get_errors());
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($internalErrors);
+    }
+}

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -21,7 +21,11 @@
         "symfony/polyfill-mbstring": "~1.0"
     },
     "require-dev": {
-        "symfony/css-selector": "~3.4|~4.0"
+        "symfony/css-selector": "~3.4|~4.0",
+        "masterminds/html5": "^2.6"
+    },
+    "conflict": {
+        "masterminds/html5": "<2.6"
     },
     "suggest": {
         "symfony/css-selector": ""


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | WIP
| Fixed tickets | https://github.com/symfony/symfony/issues/29280, https://github.com/symfony/symfony/issues/28596
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10700

This PR introduces the possibility to parse HTML content in the Crawler using the html5-php library (https://github.com/Masterminds/html5-php). This allows for better support of HTML5 and fix many unexpected behaviors and inconsistencies of the native DOM extension.