### PR TITLE
[Translation] Use XLIFF source rather than resname when there's no target

### DIFF
--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -90,7 +90,7 @@ class XliffFileLoader implements LoaderInterface
             $source = isset($attributes['resname']) && $attributes['resname'] ? $attributes['resname'] : $translation->source;
             // If the xlf file has another encoding specified, try to convert it because
             // simple_xml will always return utf-8 encoded values
-            $target = $this->utf8ToCharset((string) (isset($translation->target) ? $translation->target : $source), $encoding);
+            $target = $this->utf8ToCharset((string) (isset($translation->target) ? $translation->target : $translation->source), $encoding);
 
             $catalogue->set((string) $source, $target, $domain);
 

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -66,7 +66,7 @@ class XliffFileLoaderTest extends TestCase
         $loader = new XliffFileLoader();
         $catalogue = $loader->load(__DIR__.'/../fixtures/resname.xlf', 'en', 'domain1');
 
-        $this->assertEquals(array('foo' => 'bar', 'bar' => 'baz', 'baz' => 'foo'), $catalogue->all('domain1'));
+        $this->assertEquals(array('foo' => 'bar', 'bar' => 'baz', 'baz' => 'foo', 'qux' => 'qux source'), $catalogue->all('domain1'));
     }
 
     public function testIncompleteResource()

--- a/src/Symfony/Component/Translation/Tests/fixtures/resname.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resname.xlf
@@ -14,6 +14,9 @@
         <source>baz</source>
         <target>foo</target>
       </trans-unit>
+      <trans-unit id="4" resname="qux">
+        <source>qux source</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed tickets | 
| License       | MIT
| Doc PR        |

Relates to https://github.com/symfony/symfony/issues/20076#issuecomment-251552328. If there's no `<target>` in an XLIFF but there is a `@resname` then that's used rather than the `<source>`.

If I'm using translation keys and my source locale is `en`, then it's a bit redundant to duplicate the `<source>` in the `<target>` in the `en` file (since there is no translation).

This isn't changing the behaviour when `<target>` is present but empty.

(Caveat: I'm definitely not an expert on XLIFF.)